### PR TITLE
fix: improve tool descriptions so OpenAI models use pinchy_ls correctly

### DIFF
--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -116,4 +116,58 @@ describe("pinchy-files plugin", () => {
     expect(plugin.name).toBe("Pinchy Files");
     expect(plugin.configSchema).toBeDefined();
   });
+
+  it("pinchy_ls path parameter description includes the allowed paths", async () => {
+    const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const lsFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_ls"
+    )?.[0];
+    const tool = lsFactory({ agentId: "agent-1" });
+
+    const pathParamDescription = tool.parameters.properties.path.description;
+    expect(pathParamDescription).toContain("/data/docs/");
+  });
+
+  it("pinchy_ls description instructs model to use it first", async () => {
+    const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const lsFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_ls"
+    )?.[0];
+    const tool = lsFactory({ agentId: "agent-1" });
+
+    expect(tool.description.toLowerCase()).toMatch(/first|start/);
+  });
+
+  it("pinchy_read path parameter description includes the allowed paths", async () => {
+    const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const readFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_read"
+    )?.[0];
+    const tool = readFactory({ agentId: "agent-1" });
+
+    const pathParamDescription = tool.parameters.properties.path.description;
+    expect(pathParamDescription).toContain("/data/docs/");
+  });
+
+  it("pinchy_read description tells model to use pinchy_ls first", async () => {
+    const api = createMockApi({ "agent-1": { allowed_paths: ["/data/docs/"] } });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const readFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_read"
+    )?.[0];
+    const tool = readFactory({ agentId: "agent-1" });
+
+    expect(tool.description).toContain("pinchy_ls");
+  });
 });

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -66,11 +66,11 @@ const plugin = {
         return {
           name: "pinchy_ls",
           label: "List Files",
-          description: `List files and directories. You have access to: ${pathList}`,
+          description: `List files and directories. Start here first to discover available files. Your knowledge base is at: ${pathList}`,
           parameters: {
             type: "object",
             properties: {
-              path: { type: "string", description: "Directory path to list" },
+              path: { type: "string", description: `Directory to list. Use one of these paths: ${pathList}` },
             },
             required: ["path"],
           },
@@ -127,13 +127,13 @@ const plugin = {
         return {
           name: "pinchy_read",
           label: "Read File",
-          description: `Read a file's content. You have access to: ${pathList}`,
+          description: `Read a file's content. Use pinchy_ls first to discover the exact file path. Your knowledge base is at: ${pathList}`,
           parameters: {
             type: "object",
             properties: {
               path: {
                 type: "string",
-                description: "File path to read",
+                description: `Full file path to read. Use pinchy_ls to discover available files in: ${pathList}`,
               },
             },
             required: ["path"],

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -382,6 +382,48 @@ describe("POST /api/agents", () => {
     );
   });
 
+  it("should include allowed paths in AGENTS.md for knowledge-base agents", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "HR Knowledge Base",
+        templateId: "knowledge-base",
+        pluginConfig: {
+          allowed_paths: ["/data/hr-docs/"],
+        },
+      }),
+    });
+
+    await POST(request);
+
+    expect(writeWorkspaceFile).toHaveBeenCalledWith(
+      "new-agent-id",
+      "AGENTS.md",
+      expect.stringContaining("/data/hr-docs/")
+    );
+  });
+
+  it("should include pinchy_ls instructions in AGENTS.md for knowledge-base agents", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "HR Knowledge Base",
+        templateId: "knowledge-base",
+        pluginConfig: {
+          allowed_paths: ["/data/hr-docs/"],
+        },
+      }),
+    });
+
+    await POST(request);
+
+    expect(writeWorkspaceFile).toHaveBeenCalledWith(
+      "new-agent-id",
+      "AGENTS.md",
+      expect.stringContaining("pinchy_ls")
+    );
+  });
+
   it("should not write AGENTS.md when template has null defaultAgentsMd", async () => {
     const request = new NextRequest("http://localhost:7777/api/agents", {
       method: "POST",

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { AGENT_TEMPLATES, getTemplate } from "@/lib/agent-templates";
+import { AGENT_TEMPLATES, getTemplate, generateAgentsMd } from "@/lib/agent-templates";
 
 describe("agent-templates", () => {
   it("should have a knowledge-base template", () => {
@@ -62,5 +62,45 @@ describe("agent-templates", () => {
 
   it("custom should have null defaultAgentsMd", () => {
     expect(AGENT_TEMPLATES["custom"].defaultAgentsMd).toBeNull();
+  });
+});
+
+describe("generateAgentsMd", () => {
+  it("should include allowed paths for knowledge-base template", () => {
+    const template = AGENT_TEMPLATES["knowledge-base"];
+    const content = generateAgentsMd(template, { allowed_paths: ["/data/hr-docs/"] });
+    expect(content).toContain("/data/hr-docs/");
+  });
+
+  it("should instruct the agent to use pinchy_ls before reading files", () => {
+    const template = AGENT_TEMPLATES["knowledge-base"];
+    const content = generateAgentsMd(template, { allowed_paths: ["/data/hr-docs/"] });
+    expect(content).toContain("pinchy_ls");
+  });
+
+  it("should preserve the base knowledge base instructions", () => {
+    const template = AGENT_TEMPLATES["knowledge-base"];
+    const content = generateAgentsMd(template, { allowed_paths: ["/data/hr-docs/"] });
+    expect(content).toContain("knowledge base agent");
+    expect(content).toContain("cite");
+  });
+
+  it("should include all provided paths when multiple paths given", () => {
+    const template = AGENT_TEMPLATES["knowledge-base"];
+    const content = generateAgentsMd(template, { allowed_paths: ["/data/docs/", "/data/hr/"] });
+    expect(content).toContain("/data/docs/");
+    expect(content).toContain("/data/hr/");
+  });
+
+  it("should return defaultAgentsMd unchanged for custom template", () => {
+    const template = AGENT_TEMPLATES["custom"];
+    const content = generateAgentsMd(template, undefined);
+    expect(content).toBe(template.defaultAgentsMd);
+  });
+
+  it("should return defaultAgentsMd when no pluginConfig provided for knowledge-base", () => {
+    const template = AGENT_TEMPLATES["knowledge-base"];
+    const content = generateAgentsMd(template, undefined);
+    expect(content).toBe(template.defaultAgentsMd);
   });
 });

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -4,7 +4,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { eq, or, and } from "drizzle-orm";
-import { getTemplate } from "@/lib/agent-templates";
+import { getTemplate, generateAgentsMd } from "@/lib/agent-templates";
 import { getPersonalityPreset, resolveGreetingMessage } from "@/lib/personality-presets";
 import { generateAvatarSeed } from "@/lib/avatar";
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
@@ -134,8 +134,12 @@ export async function POST(request: NextRequest) {
   ensureWorkspace(agent.id);
   writeWorkspaceFile(agent.id, "SOUL.md", preset?.soulMd ?? "");
   writeIdentityFile(agent.id, { name: agent.name, tagline: agent.tagline });
-  if (template.defaultAgentsMd) {
-    writeWorkspaceFile(agent.id, "AGENTS.md", template.defaultAgentsMd);
+  const agentsMd = generateAgentsMd(
+    template,
+    template.pluginId && pluginConfig ? pluginConfig : undefined
+  );
+  if (agentsMd) {
+    writeWorkspaceFile(agent.id, "AGENTS.md", agentsMd);
   }
   const context = await getContextForAgent({
     isPersonal: false,

--- a/packages/web/src/lib/agent-templates.ts
+++ b/packages/web/src/lib/agent-templates.ts
@@ -38,3 +38,28 @@ export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
 export function getTemplate(id: string): AgentTemplate | undefined {
   return AGENT_TEMPLATES[id];
 }
+
+/**
+ * Generate the AGENTS.md content for an agent.
+ *
+ * For knowledge-base agents, dynamically includes the allowed paths and
+ * explicit tool-use instructions so all models (including OpenAI) know
+ * exactly where to look for files instead of guessing paths.
+ */
+export function generateAgentsMd(
+  template: AgentTemplate,
+  pluginConfig: { allowed_paths?: string[] } | undefined
+): string | null {
+  if (!template.defaultAgentsMd) return template.defaultAgentsMd;
+
+  if (template.pluginId === "pinchy-files" && pluginConfig?.allowed_paths?.length) {
+    const paths = pluginConfig.allowed_paths;
+    const pathList = paths.map((p) => `- \`${p}\``).join("\n");
+    return (
+      template.defaultAgentsMd +
+      `\n\n## File Access\nYour knowledge base is stored at:\n${pathList}\n\nTool use workflow:\n1. Always start with \`pinchy_ls\` on one of the paths above to discover available files\n2. Use \`pinchy_read\` to read specific files\n3. Never guess file names — always discover them first`
+    );
+  }
+
+  return template.defaultAgentsMd;
+}


### PR DESCRIPTION
## Problem

Closes #4

Knowledge-base agents failed with "file not found" errors when using OpenAI models (e.g. gpt-4o-mini), while Anthropic models worked correctly.

**Root cause:** OpenAI models don't reliably extract base paths from tool descriptions and try to guess file paths directly instead of first calling `pinchy_ls` to discover available files. The `realpathSync()` call in the plugin then throws ENOENT for the guessed paths.

## Fix

### Primary fix — tool descriptions (non-user-editable)

The `pinchy-files` plugin's tool definitions now explicitly include the allowed paths and clear workflow instructions:

- `pinchy_ls`: *"Start here first to discover available files. Your knowledge base is at: /data/..."*
- `pinchy_ls` path parameter: *"Use one of these paths: /data/..."*
- `pinchy_read`: *"Use pinchy_ls first to discover the exact file path."*
- `pinchy_read` path parameter: *"Use pinchy_ls to discover available files in: /data/..."*

These descriptions are sent directly to the LLM as function definitions and cannot be removed by users editing AGENTS.md.

### Secondary fix — AGENTS.md at agent creation time

`generateAgentsMd()` now dynamically includes the allowed paths and a numbered tool-use workflow in the AGENTS.md written when a knowledge-base agent is created.

## Tests

- 4 new tests in `packages/plugins/pinchy-files/index.test.ts`
- 6 new tests in `packages/web/src/__tests__/lib/agent-templates.test.ts`
- 2 new tests in `packages/web/src/__tests__/api/agents-create.test.ts`