### PR TITLE
fix: filter out non-chat-compatible models from OpenAI model list

### DIFF
--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -164,6 +164,8 @@ describe("fetchProviderModels", () => {
             { id: "dall-e-3" },
             { id: "text-embedding-3-large" },
             { id: "whisper-1" },
+            { id: "omni-moderation-latest" },
+            { id: "gpt-3.5-turbo-instruct" },
           ],
         }),
         { status: 200 }
@@ -181,6 +183,8 @@ describe("fetchProviderModels", () => {
     expect(modelIds).not.toContain("openai/dall-e-3");
     expect(modelIds).not.toContain("openai/text-embedding-3-large");
     expect(modelIds).not.toContain("openai/whisper-1");
+    expect(modelIds).not.toContain("openai/omni-moderation-latest");
+    expect(modelIds).not.toContain("openai/gpt-3.5-turbo-instruct");
   });
 
   it("filters Google models to those supporting generateContent", async () => {

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -62,7 +62,9 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
     headers: (apiKey) => ({ Authorization: `Bearer ${apiKey}` }),
     transform: (data) =>
       (data.data as { id: string }[])
-        .filter((m) => m.id.startsWith("gpt-") || m.id.startsWith("o"))
+        .filter(
+          (m) => (m.id.startsWith("gpt-") && !m.id.endsWith("-instruct")) || /^o\d/.test(m.id)
+        )
         .map((m) => ({
           id: `openai/${m.id}`,
           name: m.id,


### PR DESCRIPTION
## Summary

- Tightens the OpenAI model filter in `/api/providers/models` to only return chat-compatible models
- Replaces the broad `startsWith("o")` check with `/^o\d/` regex, matching `o1`, `o3`, `o4`-series but excluding `omni-moderation-*`
- Excludes `-instruct`-suffixed models (e.g. `gpt-3.5-turbo-instruct`)
- All other providers unaffected (Anthropic already chat-only, Google already filters by `generateContent`)

## Test plan

- [ ] New assertions added to existing OpenAI filter test: `omni-moderation-latest` and `gpt-3.5-turbo-instruct` are excluded
- [ ] All 1053 existing tests continue to pass
- [ ] Verified new chat models (GPT-4.1, GPT-5, GPT-5.2, o3-pro, o4-mini) still pass through the filter

Closes #7