### PR TITLE
fix: resolve EACCES permission error during Docker setup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,6 +110,21 @@ jobs:
           docker compose logs pinchy
           exit 1
 
+      - name: Run setup wizard (production)
+        run: |
+          STATUS=$(curl -s -o /tmp/setup-response.json -w "%{http_code}" \
+            -X POST http://localhost:7777/api/setup \
+            -H "Content-Type: application/json" \
+            -d '{"name":"CI Admin","email":"ci@test.local","password":"CiTestPass123!"}')
+          echo "Setup response (HTTP $STATUS):"
+          cat /tmp/setup-response.json
+          if [ "$STATUS" -ne 201 ]; then
+            echo "Setup failed with status $STATUS"
+            docker compose logs pinchy
+            exit 1
+          fi
+          echo "Setup completed successfully"
+
       - name: Tear down production
         if: always()
         run: docker compose down -v
@@ -138,6 +153,21 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.dev.yml ps
           docker compose -f docker-compose.yml -f docker-compose.dev.yml logs pinchy
           exit 1
+
+      - name: Run setup wizard (dev)
+        run: |
+          STATUS=$(curl -s -o /tmp/setup-response.json -w "%{http_code}" \
+            -X POST http://localhost:7777/api/setup \
+            -H "Content-Type: application/json" \
+            -d '{"name":"CI Admin","email":"ci@test.local","password":"CiTestPass123!"}')
+          echo "Setup response (HTTP $STATUS):"
+          cat /tmp/setup-response.json
+          if [ "$STATUS" -ne 201 ]; then
+            echo "Setup failed with status $STATUS"
+            docker compose -f docker-compose.yml -f docker-compose.dev.yml logs pinchy
+            exit 1
+          fi
+          echo "Setup completed successfully"
 
       - name: Tear down
         if: always()

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -30,7 +30,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
 
 # Run as non-root user
 RUN groupadd -r pinchy && useradd -r -g pinchy -d /app pinchy
-RUN mkdir -p /app/secrets && chown -R pinchy:pinchy /app /app/secrets /openclaw-extensions
+RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-extensions /openclaw-config/workspaces
 USER pinchy
 
 CMD ["sh", "-c", "echo '[pinchy] Running database migrations...' && pnpm db:migrate && echo '[pinchy] Starting server...' && exec pnpm start"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,7 @@ services:
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
     volumes:
       - openclaw-config:/openclaw-config
+      - pinchy-workspaces:/openclaw-config/workspaces
       - openclaw-extensions:/openclaw-extensions
       - pinchy-secrets:/app/secrets
     restart: unless-stopped
@@ -30,6 +31,7 @@ services:
       - "18789"
     volumes:
       - openclaw-config:/root/.openclaw
+      - pinchy-workspaces:/root/.openclaw/workspaces
       - openclaw-extensions:/root/.openclaw/extensions
       - pinchy-data:/data
     restart: unless-stopped
@@ -52,6 +54,7 @@ services:
 volumes:
   pgdata:
   openclaw-config:
+  pinchy-workspaces:
   pinchy-data:
   pinchy-secrets:
   openclaw-extensions:


### PR DESCRIPTION
## Summary
- Fix `EACCES: permission denied, mkdir '/openclaw-config/workspaces/...'` error that occurs when running the setup wizard in the production Docker image
- Root cause: the `openclaw-config` volume is owned by root (from OpenClaw container), but the pinchy container runs as non-root user `pinchy`
- Add dedicated `pinchy-workspaces` volume with proper ownership, mounted at the workspaces subdirectory in both containers
- Add setup wizard API call to CI smoke tests so permission and setup errors are caught before release

## Test plan
- [ ] CI `docker-smoke` job passes — including the new setup wizard step
- [ ] Fresh `docker compose up --build` followed by setup wizard completes without error
- [ ] Existing dev workflow (`docker-compose.dev.yml`) still works