### PR TITLE
fix: polish startup (permissions, warning, duplicate log)

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -28,9 +28,11 @@ COPY packages/plugins/pinchy-audit /openclaw-extensions/pinchy-audit
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:7777/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
-# Run as non-root user
+# Create non-root user (entrypoint drops privileges after fixing volume permissions)
 RUN groupadd -r pinchy && useradd -r -g pinchy -d /app pinchy
 RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces
-USER pinchy
 
-CMD ["sh", "-c", "echo '[pinchy] Running database migrations...' && pnpm db:migrate && echo '[pinchy] Starting server...' && exec pnpm start"]
+COPY entrypoint.sh /entrypoint.sh
+RUN chmod +x /entrypoint.sh
+
+ENTRYPOINT ["/entrypoint.sh"]

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,13 @@
+#!/bin/sh
+set -e
+
+# Fix permissions on shared OpenClaw config volume.
+# OpenClaw runs as root and owns these files; Pinchy needs write access
+# to update openclaw.json when providers or agents change.
+chown -R pinchy:pinchy /openclaw-config
+
+echo '[pinchy] Running database migrations...'
+su -s /bin/sh pinchy -c 'cd /app/packages/web && pnpm db:migrate'
+
+echo '[pinchy] Starting server...'
+exec su -s /bin/sh pinchy -c 'cd /app/packages/web && exec pnpm start'

--- a/packages/web/server-preload.cjs
+++ b/packages/web/server-preload.cjs
@@ -24,6 +24,16 @@ if (!process.env.BETTER_AUTH_SECRET) {
   }
 }
 
+// Suppress InsecureTransportWarning for internal OpenClaw ws:// connection.
+// OpenClaw Gateway is never exposed publicly — ws:// is correct for container-internal traffic.
+{
+  const originalEmit = process.emit;
+  process.emit = function (event, ...args) {
+    if (event === "warning" && args[0]?.name === "InsecureTransportWarning") return false;
+    return originalEmit.call(this, event, ...args);
+  };
+}
+
 // Preload: set globalThis.AsyncLocalStorage before Next.js modules initialize.
 // Next.js 16 expects this global but tsx's module loader can cause
 // async-local-storage.js to run before Next.js's own require-hook sets it.

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -170,9 +170,8 @@ app.prepare().then(async () => {
     let hasConnected = false;
     let errorLogged = false;
 
-    openclawClient.connect().catch((err) => {
-      console.log("Waiting for OpenClaw Gateway...");
-      errorLogged = true;
+    openclawClient.connect().catch(() => {
+      // Swallow rejection — the error event handler logs once
     });
 
     openclawClient.on("connected", () => {

--- a/packages/web/src/__tests__/server/server-preload.test.ts
+++ b/packages/web/src/__tests__/server/server-preload.test.ts
@@ -1,0 +1,52 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+function nextTick(): Promise<void> {
+  return new Promise((resolve) => process.nextTick(resolve));
+}
+
+describe("server-preload warning filter", () => {
+  const originalEmit = process.emit.bind(process);
+
+  afterEach(() => {
+    // Restore original emit to avoid leaking between tests
+    process.emit = originalEmit;
+  });
+
+  it("suppresses InsecureTransportWarning", async () => {
+    await import("../../../server-preload.cjs");
+
+    const warningHandler = vi.fn();
+    process.on("warning", warningHandler);
+
+    try {
+      const warning = new Error(
+        "Connecting with authentication token over insecure ws:// transport."
+      );
+      warning.name = "InsecureTransportWarning";
+      process.emitWarning(warning);
+
+      await nextTick();
+
+      expect(warningHandler).not.toHaveBeenCalled();
+    } finally {
+      process.removeListener("warning", warningHandler);
+    }
+  });
+
+  it("passes through other warnings", async () => {
+    await import("../../../server-preload.cjs");
+
+    const warningHandler = vi.fn();
+    process.on("warning", warningHandler);
+
+    try {
+      process.emitWarning("Some other warning", "SomeWarning");
+
+      await nextTick();
+
+      expect(warningHandler).toHaveBeenCalledTimes(1);
+    } finally {
+      process.removeListener("warning", warningHandler);
+    }
+  });
+});


### PR DESCRIPTION
## Summary
- **EACCES fix**: Add `entrypoint.sh` that fixes openclaw-config volume permissions before dropping to `pinchy` user — fixes provider setup crashing with `EACCES: permission denied`
- **Warning suppression**: Suppress `InsecureTransportWarning` for internal ws:// OpenClaw connection (never exposed publicly)
- **Deduplicate log**: Remove duplicate "Waiting for OpenClaw Gateway..." message (race between `.catch()` and `error` event)

## Test plan
- [x] Unit tests for warning filter (suppress + pass-through)
- [x] Production Docker stack starts cleanly (no EACCES, no warning, single "Waiting..." line)
- [x] Dev Docker stack starts cleanly
- [x] All 1303 existing tests pass
- [x] CI smoke test covers startup regressions