### PR TITLE
release: prepare v0.1.0

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,6 +5,8 @@ on:
     branches: [main]
     paths:
       - "docs/**"
+  release:
+    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,20 @@
+name: Release
+
+on:
+  push:
+    tags: ["v*"]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          generate_release_notes: true

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -2,7 +2,7 @@ FROM node:22-slim
 
 RUN apt-get update && apt-get install -y git inotify-tools && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@latest
+RUN npm install -g openclaw@2026.3.7
 
 COPY config/openclaw.json /root/.openclaw/openclaw.json
 COPY config/ensure-gateway-token.js /ensure-gateway-token.js

--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 
 <p align="center">
   <strong>Self-hosted AI agent platform built on OpenClaw.</strong><br/>
-  Enterprise-ready. Offline-capable. Open source. 🦞
+  Enterprise-ready. Offline-capable. Open source.
 </p>
 
 <p align="center">
@@ -38,33 +38,20 @@ You want AI agents in your company. But:
 
 Pinchy wraps OpenClaw into something enterprises can trust:
 
-- 🔌 **Plugin Architecture** — Agents get scoped tools, not raw shell access. A "Create Jira Ticket" plugin instead of `exec`.
-- 🔐 **Role-Based Access Control** — Who can use which agent. What each agent can do. Per team, per role.
-- 📋 **Audit Trail** — Every agent action logged. Who, what, when. Compliance-ready.
-- 🔀 **Cross-Channel Workflows** — Input on email, output on Slack. Properly routed, properly permissioned.
-- 🏠 **Self-Hosted & Offline** — Your server, your data, your models. Works without internet.
-- 🤖 **Model Agnostic** — OpenAI, Anthropic, local models via Ollama. Your choice.
+- **Plugin Architecture** — Agents get scoped tools, not raw shell access. A "Create Jira Ticket" plugin instead of `exec`.
+- **Role-Based Access Control** — Who can use which agent. What each agent can do. Per team, per role.
+- **Audit Trail** — Every agent action logged. Who, what, when. Compliance-ready.
+- **Cross-Channel Workflows** — Input on email, output on Slack. Properly routed, properly permissioned.
+- **Self-Hosted & Offline** — Your server, your data, your models. Works without internet.
+- **Model Agnostic** — OpenAI, Anthropic, local models via Ollama. Your choice.
 
-## Quick Start
+## Get Started
 
-```bash
-git clone https://github.com/heypinchy/pinchy.git
-cd pinchy
-docker compose up --build
-```
-
-Then open [http://localhost:7777](http://localhost:7777) — the setup wizard will guide you through creating your admin account.
-
-> **Production:** Copy `.env.example` to `.env` and set secure values for `DB_PASSWORD` and `BETTER_AUTH_SECRET`. The defaults are for local evaluation only.
-
-### Prerequisites
-
-- Docker & Docker Compose
-- An OpenClaw-compatible model provider (e.g. Claude Max subscription via OpenClaw OAuth)
+See the **[Installation Guide](https://docs.heypinchy.com/guides/installation/)** for setup instructions, configuration, and development setup.
 
 ## Status
 
-> 🚧 **Pinchy is in early development.** The core is working — setup, auth, multi-user, agent chat, permissions, knowledge base agents, and audit trail. We're building the enterprise features (granular RBAC, plugin marketplace, cross-channel workflows) next.
+> Pinchy is in early development. The core is working — setup, auth, multi-user, agent chat, permissions, knowledge base agents, and audit trail. We're building the enterprise features (granular RBAC, plugin marketplace, cross-channel workflows) next.
 
 ### What works today
 
@@ -93,81 +80,15 @@ Follow our progress on [the blog](https://heypinchy.com/blog/building-pinchy-in-
 
 ## Tech Stack
 
-| Layer | Technology |
-|-------|-----------|
-| Frontend | Next.js 16, React 19, TailwindCSS v4, shadcn/ui |
-| Auth | Better Auth (email/password, DB sessions) |
-| Database | PostgreSQL 17, Drizzle ORM |
-| Agent Runtime | OpenClaw Gateway (WebSocket) |
-| Testing | Vitest, React Testing Library |
-| CI/CD | GitHub Actions, ESLint, Prettier, Husky |
-| Deployment | Docker Compose |
-
-## Development
-
-### Docker dev mode (recommended)
-
-Run the full stack with hot reload — code changes are reflected immediately in the browser:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build
-```
-
-After the initial build, subsequent starts only need:
-
-```bash
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up
-```
-
-What hot-reloads: React components, pages, styles. What doesn't: `server.ts` (restart container), dependencies (rebuild with `--build`).
-
-### Local development (without Docker for the app)
-
-```bash
-pnpm install
-
-# Start database and OpenClaw in Docker (dev override exposes port 5433)
-docker compose -f docker-compose.yml -f docker-compose.dev.yml up db openclaw -d
-
-export DATABASE_URL=postgresql://pinchy:pinchy_dev@localhost:5433/pinchy
-pnpm db:migrate
-pnpm dev
-```
-
-The app starts at [http://localhost:7777](http://localhost:7777).
-
-### Available commands
-
-```bash
-pnpm dev             # Start dev server
-pnpm build           # Production build
-pnpm test            # Run tests
-pnpm lint            # Run ESLint
-pnpm format          # Format code with Prettier
-pnpm db:generate     # Generate migration from schema changes
-pnpm db:migrate      # Apply pending migrations
-pnpm db:studio       # Open Drizzle Studio (database browser)
-```
-
-### Project structure
-
-```
-pinchy/
-├── packages/web/          # Next.js app
-│   ├── src/
-│   │   ├── app/           # Pages & API routes
-│   │   ├── components/    # React components
-│   │   ├── db/            # Schema & migrations
-│   │   ├── lib/           # Utilities (auth, setup, agents)
-│   │   ├── hooks/         # React hooks
-│   │   └── server/        # WebSocket bridge
-│   └── drizzle/           # Generated migrations
-├── config/                # OpenClaw config
-├── docs/                  # Documentation (Astro Starlight)
-├── docker-compose.yml     # Full stack definition (production)
-├── docker-compose.dev.yml # Dev override (hot reload, exposed DB port)
-└── .github/workflows/     # CI + docs deployment
-```
+| Layer         |                                      Technology |
+| ------------- | ----------------------------------------------: |
+| Frontend      | Next.js 16, React 19, TailwindCSS v4, shadcn/ui |
+| Auth          |       Better Auth (email/password, DB sessions) |
+| Database      |                      PostgreSQL 17, Drizzle ORM |
+| Agent Runtime |                    OpenClaw Gateway (WebSocket) |
+| Testing       |                   Vitest, React Testing Library |
+| CI/CD         |         GitHub Actions, ESLint, Prettier, Husky |
+| Deployment    |                                  Docker Compose |
 
 ## Origin Story
 
@@ -177,7 +98,7 @@ Read the full story on [heypinchy.com](https://heypinchy.com/blog/building-pinch
 
 ## Philosophy
 
-We care about how Pinchy *feels*, not just what it does. Security + Ease is our core tension — enterprise-grade protection that feels light, not intimidating. Smart defaults everywhere, personality templates instead of blank slates, zero-config setup, and full customization when you need it.
+We care about how Pinchy _feels_, not just what it does. Security + Ease is our core tension — enterprise-grade protection that feels light, not intimidating. Smart defaults everywhere, personality templates instead of blank slates, zero-config setup, and full customization when you need it.
 
 Read more in our [Philosophy docs](https://docs.heypinchy.com/concepts/philosophy) and [`PERSONALITY.md`](PERSONALITY.md).
 
@@ -189,10 +110,10 @@ Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a PR. If
 
 ## Community
 
-- 💬 [GitHub Discussions](https://github.com/heypinchy/pinchy/discussions) — Questions, ideas, show & tell
-- 🐛 [Issues](https://github.com/heypinchy/pinchy/issues) — Bug reports and feature requests
-- 📝 [Blog](https://heypinchy.com/blog) — Build in public updates
-- 💼 [LinkedIn](https://linkedin.com/in/clemenshelm) — Daily updates from the founder
+- [GitHub Discussions](https://github.com/heypinchy/pinchy/discussions) — Questions, ideas, show & tell
+- [Issues](https://github.com/heypinchy/pinchy/issues) — Bug reports and feature requests
+- [Blog](https://heypinchy.com/blog) — Build in public updates
+- [LinkedIn](https://linkedin.com/in/clemenshelm) — Daily updates from the founder
 
 ## License
 
@@ -204,4 +125,4 @@ This means you can use, modify, and distribute Pinchy freely — but if you run 
 
 Pinchy is built by [Clemens Helm](https://clemenshelm.com) — a software developer with 20+ years of experience, daily OpenClaw power user, and believer in self-hosted AI.
 
-Built in Vienna, Austria. ☕🦞
+Built in Vienna, Austria.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -3,6 +3,13 @@ title: Installation
 description: Environment variables, Docker services, and development setup.
 ---
 
+import { Aside } from "@astrojs/starlight/components";
+
+<Aside type="note">
+  This guide covers Pinchy v0.1.0. Check the [Releases
+  page](https://github.com/heypinchy/pinchy/releases) for newer versions.
+</Aside>
+
 ## System requirements
 
 - Docker Engine 20.10+ and Docker Compose v2+
@@ -16,6 +23,7 @@ The simplest way to run Pinchy. One command starts the full stack.
 ```bash
 git clone https://github.com/heypinchy/pinchy.git
 cd pinchy
+git checkout v0.1.0
 docker compose up --build
 ```
 


### PR DESCRIPTION
## Summary

- Pin OpenClaw to `2026.3.7` in `Dockerfile.openclaw` (instead of `@latest`)
- Shorten README — move installation/development/project structure to docs, add link to docs.heypinchy.com
- Add version note and `git checkout v0.1.0` to docs installation guide
- Add `release: types: [published]` trigger to docs deployment workflow
- Add release workflow (creates GitHub Release with auto-generated notes on `v*` tags)

## After merge

1. Wait for CI to pass on main
2. `git tag v0.1.0 && git push origin v0.1.0`
3. Release workflow creates GitHub Release automatically
4. Docs deploy triggered by release event

## Test plan

- [ ] CI passes (lint, test, build, docker-smoke, e2e)
- [ ] Review shortened README for completeness
- [ ] Review docs installation page renders correctly
- [ ] Verify release.yml and docs.yml workflow syntax