### PR TITLE
fix: deploy docs only on release

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,12 +1,6 @@
 name: Deploy Docs
 
 on:
-  push:
-    branches: [main]
-    paths:
-      - "docs/**"
-  release:
-    types: [published]
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -6,6 +6,12 @@ on:
 
 permissions:
   contents: write
+  pages: write
+  id-token: write
+
+concurrency:
+  group: pages
+  cancel-in-progress: false
 
 jobs:
   release:
@@ -18,3 +24,47 @@ jobs:
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+
+  docs-build:
+    name: Build Docs
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 22
+          cache: pnpm
+          cache-dependency-path: docs/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: docs
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        working-directory: docs
+        run: pnpm build
+        env:
+          UMAMI_WEBSITE_ID: ${{ vars.UMAMI_DOCS_WEBSITE_ID }}
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: docs/dist
+
+  docs-deploy:
+    name: Deploy Docs
+    needs: docs-build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -84,6 +84,21 @@ All new features require tests. We practice TDD — write the failing test first
 
 By participating in this project, you agree to our [Code of Conduct](CODE_OF_CONDUCT.md). Be kind, be respectful, assume good intentions.
 
+## Releasing
+
+Pinchy uses [Semantic Versioning](https://semver.org/) and tags on `main`.
+
+1. Ensure all changes are merged to `main` and CI is green.
+2. Update `docs/src/content/docs/installation.mdx` with the new version (checkout tag + version note).
+3. If upgrading OpenClaw, update the version in `Dockerfile.openclaw`.
+4. Merge the release preparation PR.
+5. Tag and push:
+   ```bash
+   git tag v0.2.0
+   git push origin v0.2.0
+   ```
+6. The release workflow automatically creates a GitHub Release with auto-generated release notes and deploys the docs.
+
 ## Questions?
 
 Open a [Discussion](https://github.com/heypinchy/pinchy/discussions). We're happy to help.


### PR DESCRIPTION
## Summary

- Move docs build+deploy into the release workflow so docs always match the latest released version
- Reduce `docs.yml` to manual-only (`workflow_dispatch`) for hotfixes
- Document the release process in `CONTRIBUTING.md`

Previously, docs deployed on every push to main — which could publish documentation for unreleased features.

## Test plan

- [ ] CI passes
- [ ] Verify release.yml has correct pages permissions and docs build steps
- [ ] After merge + next release tag: confirm docs deploy runs as part of release workflow