### PR TITLE
fix: use timingSafeEqual for gateway token validation

### DIFF
--- a/packages/web/src/lib/gateway-auth.ts
+++ b/packages/web/src/lib/gateway-auth.ts
@@ -1,4 +1,5 @@
 import { readFileSync } from "fs";
+import { timingSafeEqual } from "crypto";
 
 const CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
 
@@ -19,5 +20,8 @@ export function validateGatewayToken(headers: Headers): boolean {
   const gatewayToken = readGatewayToken();
   if (!gatewayToken) return false;
 
-  return token === gatewayToken;
+  const tokenBuf = Buffer.from(token);
+  const gatewayBuf = Buffer.from(gatewayToken);
+  if (tokenBuf.length !== gatewayBuf.length) return false;
+  return timingSafeEqual(tokenBuf, gatewayBuf);
 }


### PR DESCRIPTION
## What does this PR do?

Replace `===` with `crypto.timingSafeEqual()` in `gateway-auth.ts` to prevent timing attacks on gateway token comparison.

Closes #44

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Details

The previous implementation used `===` for token comparison, which is vulnerable to timing attacks. An attacker could theoretically determine the gateway token character by character by measuring response times.

The fix uses Node.js `crypto.timingSafeEqual()` with a length pre-check (since `timingSafeEqual` requires equal-length buffers).