### PR TITLE
fix: make audit logging failures fail-closed with retry

### DIFF
--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 
 const mockOn = vi.fn();
 
@@ -30,6 +30,11 @@ describe("pinchy-audit plugin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubGlobal("fetch", vi.fn().mockResolvedValue({ ok: true }));
+    delete process.env.AUDIT_FAIL_MODE;
+  });
+
+  afterEach(() => {
+    delete process.env.AUDIT_FAIL_MODE;
   });
 
   it("registers before_tool_call and after_tool_call hooks", async () => {
@@ -252,7 +257,8 @@ describe("pinchy-audit plugin", () => {
     });
   });
 
-  it("does not throw when audit endpoint fails", async () => {
+  it("does not throw when audit fails in AUDIT_FAIL_MODE=open", async () => {
+    process.env.AUDIT_FAIL_MODE = "open";
     vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
 
     const { default: plugin } = await import("./index");
@@ -270,5 +276,52 @@ describe("pinchy-audit plugin", () => {
         { toolName: "pinchy_read" }
       )
     ).resolves.toBeUndefined();
+  });
+
+  it("throws when audit fails in AUDIT_FAIL_MODE=closed (default)", async () => {
+    // closed is the default when env var is not set
+    delete process.env.AUDIT_FAIL_MODE;
+    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+
+    const { default: plugin } = await import("./index");
+    plugin.register?.(
+      createMockApi({
+        apiBaseUrl: "http://pinchy:7777",
+        gatewayToken: "gw-token",
+      }) as any
+    );
+
+    const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+    await expect(
+      beforeHook(
+        { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+        { toolName: "pinchy_read" }
+      )
+    ).rejects.toThrow("audit logging failed");
+  });
+
+  it("retries before failing", async () => {
+    delete process.env.AUDIT_FAIL_MODE;
+    const mockFetch = vi.fn().mockRejectedValue(new Error("network down"));
+    vi.stubGlobal("fetch", mockFetch);
+
+    const { default: plugin } = await import("./index");
+    plugin.register?.(
+      createMockApi({
+        apiBaseUrl: "http://pinchy:7777",
+        gatewayToken: "gw-token",
+      }) as any
+    );
+
+    const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+    await expect(
+      beforeHook(
+        { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+        { toolName: "pinchy_read" }
+      )
+    ).rejects.toThrow();
+
+    // Should have retried: 1 initial + 2 retries = 3 total calls
+    expect(mockFetch).toHaveBeenCalledTimes(3);
   });
 });

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -31,6 +31,7 @@ interface AfterToolCallEvent {
 
 interface PluginLogger {
   warn?: (message: string) => void;
+  error?: (message: string) => void;
 }
 
 interface PluginApi {
@@ -64,6 +65,15 @@ interface RecentToolStart {
   at: number;
 }
 
+/** Audit failure mode: "closed" blocks tool on failure, "open" warns and continues */
+type AuditFailMode = "closed" | "open";
+
+/** Maximum retry attempts for audit logging */
+const MAX_RETRIES = 2;
+
+/** Delay between retries in ms */
+const RETRY_DELAY_MS = 500;
+
 function normalizeBaseUrl(url: string): string {
   return url.replace(/\/+$/, "");
 }
@@ -85,34 +95,57 @@ function cleanupRecentToolStarts(recentStarts: Map<string, RecentToolStart>): vo
   }
 }
 
+function getAuditFailMode(): AuditFailMode {
+  const mode = process.env.AUDIT_FAIL_MODE?.toLowerCase();
+  if (mode === "open") return "open";
+  // Default to "closed" — fail-safe for compliance
+  return "closed";
+}
+
+function sleep(ms: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, ms));
+}
+
+/**
+ * Post an audit event with retry logic.
+ * Returns true on success, false on failure.
+ */
 async function postToolAuditEvent(
   cfg: PluginConfig,
   logger: PluginLogger | undefined,
   payload: ToolAuditPayload
-): Promise<void> {
+): Promise<boolean> {
   const endpoint = `${normalizeBaseUrl(cfg.apiBaseUrl)}/api/internal/audit/tool-use`;
 
-  try {
-    const res = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cfg.gatewayToken}`,
-      },
-      body: JSON.stringify(payload),
-    });
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cfg.gatewayToken}`,
+        },
+        body: JSON.stringify(payload),
+      });
 
-    if (!res.ok) {
+      if (res.ok) return true;
+
       logger?.warn?.(
-        `[pinchy-audit] audit endpoint returned ${res.status} for ${payload.phase} ${payload.toolName}`
+        `[pinchy-audit] audit endpoint returned ${res.status} for ${payload.phase} ${payload.toolName} (attempt ${attempt + 1}/${MAX_RETRIES + 1})`
+      );
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      logger?.warn?.(
+        `[pinchy-audit] failed to post ${payload.phase} event for ${payload.toolName}: ${message} (attempt ${attempt + 1}/${MAX_RETRIES + 1})`
       );
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger?.warn?.(
-      `[pinchy-audit] failed to post ${payload.phase} event for ${payload.toolName}: ${message}`
-    );
+
+    if (attempt < MAX_RETRIES) {
+      await sleep(RETRY_DELAY_MS);
+    }
   }
+
+  return false;
 }
 
 const plugin = {
@@ -141,6 +174,7 @@ const plugin = {
     }
 
     const recentStarts = new Map<string, RecentToolStart>();
+    const failMode = getAuditFailMode();
 
     api.on("before_tool_call", async (event, ctx) => {
       cleanupRecentToolStarts(recentStarts);
@@ -155,7 +189,7 @@ const plugin = {
         at: Date.now(),
       });
 
-      await postToolAuditEvent(cfg, api.logger, {
+      const success = await postToolAuditEvent(cfg, api.logger, {
         phase: "start",
         toolName: beforeEvent.toolName,
         params: beforeEvent.params,
@@ -165,6 +199,12 @@ const plugin = {
         sessionKey: ctx.sessionKey,
         sessionId: ctx.sessionId,
       });
+
+      if (!success && failMode === "closed") {
+        const msg = `[pinchy-audit] Blocking tool call "${beforeEvent.toolName}" — audit logging failed after ${MAX_RETRIES + 1} attempts (AUDIT_FAIL_MODE=closed)`;
+        api.logger?.error?.(msg);
+        throw new Error(msg);
+      }
     });
 
     api.on("after_tool_call", async (event, ctx) => {
@@ -179,7 +219,7 @@ const plugin = {
         extractAgentIdFromSessionKey(sessionKey) ??
         recent?.agentId;
 
-      await postToolAuditEvent(cfg, api.logger, {
+      const success = await postToolAuditEvent(cfg, api.logger, {
         phase: "end",
         toolName: afterEvent.toolName,
         params: afterEvent.params,
@@ -192,6 +232,13 @@ const plugin = {
         error: afterEvent.error,
         durationMs: afterEvent.durationMs,
       });
+
+      if (!success && failMode === "closed") {
+        api.logger?.error?.(
+          `[pinchy-audit] Failed to log "end" event for "${afterEvent.toolName}" after ${MAX_RETRIES + 1} attempts (AUDIT_FAIL_MODE=closed)`
+        );
+        // Don't throw on "end" — the tool already executed
+      }
     });
   },
 };


### PR DESCRIPTION
## What does this PR do?

Makes audit logging failures block tool execution by default, with configurable behavior via `AUDIT_FAIL_MODE` env var.

Closes #47

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Details

### Problem
When the audit endpoint fails, tool calls still execute — creating a compliance gap where agent actions happen without being audited.

### Solution
- **`AUDIT_FAIL_MODE=closed` (default)**: Block tool calls when audit logging fails. Fail-safe for compliance.
- **`AUDIT_FAIL_MODE=open`**: Warn and continue (previous behavior). For development or non-regulated environments.
- **Retry logic**: 2 retries with 500ms delay before failing — handles transient network issues without blocking unnecessarily.
- `before_tool_call` throws in closed mode to prevent unaudited execution.
- `after_tool_call` logs error but doesn't throw (tool already ran, blocking would be pointless).

### New tests
- Verify `open` mode doesn't throw on failure
- Verify `closed` mode throws on failure (default)
- Verify retry count (3 total attempts)