### PR TITLE
fix: add rate limiting on WebSocket connections and messages

### DIFF
--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -7,6 +7,7 @@ import { OpenClawClient } from "openclaw-node";
 import { ClientRouter } from "./src/server/client-router";
 import { SessionCache } from "./src/server/session-cache";
 import { validateWsSession } from "./src/server/ws-auth";
+import { connectionLimiter, messageLimiter, getClientIp } from "./src/server/rate-limit";
 import { restartState } from "./src/server/restart-state";
 import { logCapture } from "./src/lib/log-capture";
 
@@ -98,6 +99,14 @@ app.prepare().then(async () => {
   server.on("upgrade", async (request, socket, head) => {
     const { pathname } = parse(request.url!, true);
     if (pathname === "/api/ws") {
+      // Rate limit connection attempts per IP
+      const clientIp = getClientIp(request);
+      if (!connectionLimiter.allow(clientIp)) {
+        socket.write("HTTP/1.1 429 Too Many Requests\r\n\r\n");
+        socket.destroy();
+        return;
+      }
+
       const sessionInfo = await validateWsSession(request.headers.cookie);
       if (!sessionInfo) {
         socket.write("HTTP/1.1 401 Unauthorized\r\n\r\n");
@@ -122,6 +131,12 @@ app.prepare().then(async () => {
       : null;
 
     clientWs.on("message", (data) => {
+      // Rate limit messages per user
+      if (!messageLimiter.allow(sessionInfo.userId)) {
+        clientWs.send(JSON.stringify({ type: "error", message: "Rate limit exceeded. Please slow down." }));
+        return;
+      }
+
       try {
         const parsed = JSON.parse(data.toString());
         if (!router) {

--- a/packages/web/src/server/rate-limit.test.ts
+++ b/packages/web/src/server/rate-limit.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { RateLimiter, getClientIp } from "./rate-limit";
+
+describe("RateLimiter", () => {
+  let limiter: RateLimiter;
+
+  afterEach(() => {
+    limiter?.destroy();
+  });
+
+  it("allows requests within the limit", () => {
+    limiter = new RateLimiter({ maxEvents: 3, windowMs: 60_000 });
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(true);
+  });
+
+  it("blocks requests exceeding the limit", () => {
+    limiter = new RateLimiter({ maxEvents: 2, windowMs: 60_000 });
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(false);
+    expect(limiter.allow("ip1")).toBe(false);
+  });
+
+  it("tracks different keys independently", () => {
+    limiter = new RateLimiter({ maxEvents: 1, windowMs: 60_000 });
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip2")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(false);
+    expect(limiter.allow("ip2")).toBe(false);
+  });
+
+  it("resets after window expires", async () => {
+    limiter = new RateLimiter({ maxEvents: 1, windowMs: 50 });
+    expect(limiter.allow("ip1")).toBe(true);
+    expect(limiter.allow("ip1")).toBe(false);
+
+    await new Promise((resolve) => setTimeout(resolve, 100));
+
+    expect(limiter.allow("ip1")).toBe(true);
+  });
+
+  it("remaining() returns correct count", () => {
+    limiter = new RateLimiter({ maxEvents: 3, windowMs: 60_000 });
+    expect(limiter.remaining("ip1")).toBe(3);
+    limiter.allow("ip1");
+    expect(limiter.remaining("ip1")).toBe(2);
+    limiter.allow("ip1");
+    expect(limiter.remaining("ip1")).toBe(1);
+    limiter.allow("ip1");
+    expect(limiter.remaining("ip1")).toBe(0);
+  });
+});
+
+describe("getClientIp", () => {
+  it("extracts IP from x-forwarded-for header", () => {
+    expect(getClientIp({ headers: { "x-forwarded-for": "1.2.3.4, 5.6.7.8" } })).toBe("1.2.3.4");
+  });
+
+  it("falls back to socket remoteAddress", () => {
+    expect(getClientIp({ headers: {}, socket: { remoteAddress: "10.0.0.1" } })).toBe("10.0.0.1");
+  });
+
+  it("returns 'unknown' when no IP available", () => {
+    expect(getClientIp({ headers: {} })).toBe("unknown");
+  });
+});

--- a/packages/web/src/server/rate-limit.ts
+++ b/packages/web/src/server/rate-limit.ts
@@ -1,0 +1,114 @@
+/**
+ * Rate limiter for WebSocket connections and messages.
+ *
+ * Uses a sliding window approach to track connection attempts per IP
+ * and message throughput per authenticated user.
+ */
+
+interface RateLimitEntry {
+  /** Timestamps of recent events within the window */
+  timestamps: number[];
+}
+
+interface RateLimiterConfig {
+  /** Maximum events allowed within the window */
+  maxEvents: number;
+  /** Window size in milliseconds */
+  windowMs: number;
+}
+
+export class RateLimiter {
+  private entries = new Map<string, RateLimitEntry>();
+  private config: RateLimiterConfig;
+  private cleanupInterval: ReturnType<typeof setInterval>;
+
+  constructor(config: RateLimiterConfig) {
+    this.config = config;
+    // Periodic cleanup of stale entries every 60s
+    this.cleanupInterval = setInterval(() => this.cleanup(), 60_000);
+    // Allow GC if server holds no other ref
+    if (this.cleanupInterval.unref) this.cleanupInterval.unref();
+  }
+
+  /**
+   * Check if a key is allowed to proceed.
+   * Returns true if within limits, false if rate limited.
+   */
+  allow(key: string): boolean {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+
+    let entry = this.entries.get(key);
+    if (!entry) {
+      entry = { timestamps: [] };
+      this.entries.set(key, entry);
+    }
+
+    // Remove timestamps outside the window
+    entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+
+    if (entry.timestamps.length >= this.config.maxEvents) {
+      return false;
+    }
+
+    entry.timestamps.push(now);
+    return true;
+  }
+
+  /** Get remaining attempts for a key */
+  remaining(key: string): number {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+    const entry = this.entries.get(key);
+    if (!entry) return this.config.maxEvents;
+
+    const active = entry.timestamps.filter((t) => t > cutoff).length;
+    return Math.max(0, this.config.maxEvents - active);
+  }
+
+  /** Clean up stale entries */
+  private cleanup(): void {
+    const now = Date.now();
+    const cutoff = now - this.config.windowMs;
+
+    for (const [key, entry] of this.entries.entries()) {
+      entry.timestamps = entry.timestamps.filter((t) => t > cutoff);
+      if (entry.timestamps.length === 0) {
+        this.entries.delete(key);
+      }
+    }
+  }
+
+  /** Stop the cleanup interval (for tests / shutdown) */
+  destroy(): void {
+    clearInterval(this.cleanupInterval);
+  }
+}
+
+// ─── Default rate limiters ───
+
+/** Rate limit WebSocket upgrade requests: 10 connections per IP per minute */
+export const connectionLimiter = new RateLimiter({
+  maxEvents: parseInt(process.env.WS_MAX_CONNECTIONS_PER_MIN || "10", 10),
+  windowMs: 60_000,
+});
+
+/** Rate limit messages per authenticated user: 60 messages per minute */
+export const messageLimiter = new RateLimiter({
+  maxEvents: parseInt(process.env.WS_MAX_MESSAGES_PER_MIN || "60", 10),
+  windowMs: 60_000,
+});
+
+/**
+ * Extract client IP from request, handling proxies.
+ */
+export function getClientIp(request: { headers: Record<string, string | string[] | undefined>; socket?: { remoteAddress?: string } }): string {
+  const forwarded = request.headers["x-forwarded-for"];
+  if (typeof forwarded === "string") {
+    return forwarded.split(",")[0]!.trim();
+  }
+  if (Array.isArray(forwarded) && forwarded.length > 0) {
+    return forwarded[0]!.split(",")[0]!.trim();
+  }
+  return request.socket?.remoteAddress || "unknown";
+}


### PR DESCRIPTION
## What does this PR do?

Add rate limiting for WebSocket connections (per IP) and message throughput (per authenticated user) to prevent resource exhaustion attacks.

Closes #45

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Details

### Implementation
- **`RateLimiter` class** — sliding window rate limiter with configurable max events and window size
- **Connection limiting** — 10 WebSocket upgrades per IP per minute (returns 429)
- **Message limiting** — 60 messages per user per minute (sends error JSON)
- **IP extraction** — handles `x-forwarded-for` for proxied setups
- **Cleanup** — periodic stale entry cleanup every 60s

### Configuration
```bash
WS_MAX_CONNECTIONS_PER_MIN=10   # default
WS_MAX_MESSAGES_PER_MIN=60     # default
```

### Tests
- Allow within limits / block when exceeded
- Independent tracking per key
- Window expiry reset
- Remaining count accuracy
- IP extraction (forwarded header, socket, fallback)