### PR TITLE
fix: resolve container script execution failure due to CRLF line endings

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -7,7 +7,7 @@ RUN npm install -g openclaw@2026.3.7
 COPY config/openclaw.json /root/.openclaw/openclaw.json
 COPY config/ensure-gateway-token.js /ensure-gateway-token.js
 COPY config/start-openclaw.sh /start-openclaw.sh
-RUN chmod +x /start-openclaw.sh
+RUN sed -i 's/\r$//' /start-openclaw.sh && chmod +x /start-openclaw.sh
 
 EXPOSE 18789
 

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -33,6 +33,6 @@ RUN groupadd -r pinchy && useradd -r -g pinchy -d /app pinchy
 RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+RUN sed -i 's/\r$//' /entrypoint.sh && chmod +x /entrypoint.sh
 
 ENTRYPOINT ["/entrypoint.sh"]


### PR DESCRIPTION
### Problem
When developing on **Windows** hosts, shell scripts like `entrypoint.sh` and `config/start-openclaw.sh` are often saved with **CRLF** line endings. When these files are copied
      into a Linux-based Docker container, the shell fails to execute them, resulting in an `exit code 127` (Command not found). This happens because the Linux kernel cannot interpret
      the `\r` character in the `#!/bin/bash\r` shebang line.

 ### Solution
 This PR adds a `sed` command in the `Dockerfile` build process to strip carriage returns (`\r`) from the affected shell scripts before they are executed. This ensures that the
      containers can start successfully even when built on a Windows machine.

 ### Changes
 - **Dockerfile.openclaw**: Added `sed -i 's/\r$//'` for `start-openclaw.sh` before `chmod +x`.
 - **Dockerfile.pinchy**: Added `sed -i 's/\r$//'` for `entrypoint.sh` before `chmod +x`.

 ### Verification
 - Confirmed that `docker compose up --build` now starts both `openclaw` and `pinchy` services without the 127 exit error on a Windows host.
 - Verified that both scripts are correctly converted to LF line endings within the container.