### PR TITLE
fix: consistent multi-turn message handling

### DIFF
--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -182,6 +182,71 @@ describe("useWsRuntime", () => {
     expect(result.current.runtime.isRunning).toBe(false);
   });
 
+  it("should create separate messages for each turn in a multi-turn stream", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0];
+
+    act(() => {
+      ws.onopen?.();
+    });
+
+    // User sends a message
+    act(() => {
+      result.current.runtime.onNew({
+        content: [{ type: "text", text: "How big is the house?" }],
+        parentId: "root",
+      });
+    });
+
+    // Turn 1: agent searches
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "chunk", content: "Let me search...", messageId: "turn-1" }),
+      });
+    });
+
+    expect(result.current.runtime.isRunning).toBe(true);
+
+    // Turn 1 done
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "done", messageId: "turn-1" }),
+      });
+    });
+
+    // Turn 2: agent responds with new messageId
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({
+          type: "chunk",
+          content: "The house is 231m².",
+          messageId: "turn-2",
+        }),
+      });
+    });
+
+    // isRunning should be true again when new chunks arrive
+    expect(result.current.runtime.isRunning).toBe(true);
+
+    // Turn 2 done
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "done", messageId: "turn-2" }),
+      });
+    });
+
+    expect(result.current.runtime.isRunning).toBe(false);
+
+    // Should have 3 messages: user + 2 assistant turns
+    const messages = result.current.runtime.messages;
+    expect(messages).toHaveLength(3);
+    expect(messages[0].role).toBe("user");
+    expect(messages[1].role).toBe("assistant");
+    expect(messages[1].content[0].text).toBe("Let me search...");
+    expect(messages[2].role).toBe("assistant");
+    expect(messages[2].content[0].text).toBe("The house is 231m².");
+  });
+
   it("should send message without sessionKey", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -321,7 +321,7 @@ describe("ClientRouter", () => {
     expect(allText).toBe("Right away! How can I help?");
   });
 
-  it("should include consistent messageId in all chunks", async () => {
+  it("should include consistent messageId within a single turn", async () => {
     const clientWs = createMockClientWs();
     async function* fakeStream() {
       yield { type: "text" as const, text: "a" };
@@ -340,6 +340,45 @@ describe("ClientRouter", () => {
     const messageIds = messages.map((m: any) => m.messageId);
     expect(new Set(messageIds).size).toBe(1);
     expect(messageIds[0]).toBeTruthy();
+  });
+
+  it("should assign different messageIds to each agent turn in a multi-turn stream", async () => {
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      // Turn 1: agent searches documents
+      yield { type: "text" as const, text: "Let me search..." };
+      yield { type: "done" as const, text: "" };
+      // Turn 2: agent gives final answer
+      yield { type: "text" as const, text: "The house is 231m²." };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      content: "How big is the house?",
+      agentId: "agent-1",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const turn1Chunks = messages.filter(
+      (m: any) => m.type === "chunk" && m.content.includes("search")
+    );
+    const turn2Chunks = messages.filter(
+      (m: any) => m.type === "chunk" && m.content.includes("231")
+    );
+    const doneMessages = messages.filter((m: any) => m.type === "done");
+
+    // Each turn should have its own messageId
+    expect(turn1Chunks[0].messageId).not.toBe(turn2Chunks[0].messageId);
+
+    // Chunks within a turn share the same messageId
+    expect(turn1Chunks[0].messageId).toBe(doneMessages[0].messageId);
+    expect(turn2Chunks[0].messageId).toBe(doneMessages[1].messageId);
+
+    // Both messageIds should be truthy
+    expect(turn1Chunks[0].messageId).toBeTruthy();
+    expect(turn2Chunks[0].messageId).toBeTruthy();
   });
 
   it("should send a done message after stream completes", async () => {

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -158,6 +158,11 @@ export function useWsRuntime(agentId: string): {
           }
 
           if (data.type === "chunk") {
+            // Ensure isRunning stays true when new chunks arrive —
+            // critical for multi-turn agent responses where a "done"
+            // event between turns briefly sets isRunning to false.
+            setIsRunning(true);
+
             if (delayTimerRef.current) {
               clearTimeout(delayTimerRef.current);
               delayTimerRef.current = null;

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -84,7 +84,7 @@ export class ClientRouter {
 
     const sessionKey = this.computeSessionKey(message.agentId);
 
-    const messageId = crypto.randomUUID();
+    let messageId = crypto.randomUUID();
 
     try {
       await this.waitForConnection();
@@ -176,6 +176,10 @@ export class ClientRouter {
             type: "done",
             messageId,
           });
+          // Next agent turn gets a fresh messageId so the browser
+          // creates a separate assistant message — consistent with
+          // how OpenClaw stores them in history.
+          messageId = crypto.randomUUID();
         }
       }
     } catch (err) {


### PR DESCRIPTION
## Summary

OpenClaw agents produce multiple turns per user message (e.g. search documents → tool error → retry → final answer). Previously all turns shared one `messageId`, causing:

- **Text loss between turns**: `assistant-ui` finalizes the message on `done`, dropping subsequent chunks
- **Inconsistency**: streaming showed 1 merged message, but page reload showed N separate messages (from OpenClaw history)

## Fix

- **Server** (`client-router.ts`): Generate new `messageId` after each `done` event — each agent turn gets its own ID
- **Browser** (`use-ws-runtime.ts`): Set `isRunning=true` on every chunk — keeps typing indicator alive across turn boundaries

Now each agent turn creates a separate assistant message, consistent between streaming and history reload.

## Test plan

- [x] New test: multi-turn streams get separate messageIds (server)
- [x] New test: separate messages per turn + isRunning stays true (browser)
- [x] All 1569 tests passing
- [ ] Manual: multi-turn agent response shows separate messages during streaming