### PR TITLE
fix: use PORT env var in plugin apiBaseUrl

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -571,6 +571,48 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
+  it("should use PORT env var in plugin apiBaseUrl when set", async () => {
+    const existingConfig = {
+      gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-123" } },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
+
+    // Simulate custom port
+    const originalPort = process.env.PORT;
+    process.env.PORT = "7778";
+
+    try {
+      mockedDb.select.mockReturnValue({
+        from: vi.fn().mockResolvedValue([
+          {
+            id: "smithers-1",
+            name: "Smithers",
+            model: "anthropic/claude-sonnet-4-20250514",
+            pluginConfig: null,
+            allowedTools: ["pinchy_save_user_context"],
+            ownerId: "user-1",
+            isPersonal: true,
+            createdAt: new Date(),
+          },
+        ]),
+      } as never);
+
+      await regenerateOpenClawConfig();
+
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+
+      expect(config.plugins.entries["pinchy-audit"].config.apiBaseUrl).toBe("http://pinchy:7778");
+      expect(config.plugins.entries["pinchy-context"].config.apiBaseUrl).toBe("http://pinchy:7778");
+    } finally {
+      if (originalPort === undefined) {
+        delete process.env.PORT;
+      } else {
+        process.env.PORT = originalPort;
+      }
+    }
+  });
+
   it("should include both pinchy-files and pinchy-context when agents use both", async () => {
     const existingConfig = {
       gateway: { mode: "local", bind: "lan", auth: { token: "gw-token" } },

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -194,7 +194,8 @@ export async function regenerateOpenClawConfig() {
     entries["pinchy-context"] = {
       enabled: true,
       config: {
-        apiBaseUrl: process.env.PINCHY_INTERNAL_URL || "http://pinchy:7777",
+        apiBaseUrl:
+          process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
         gatewayToken,
         agents: contextPluginAgents,
       },
@@ -206,7 +207,7 @@ export async function regenerateOpenClawConfig() {
   entries["pinchy-audit"] = {
     enabled: true,
     config: {
-      apiBaseUrl: process.env.PINCHY_INTERNAL_URL || "http://pinchy:7777",
+      apiBaseUrl: process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
       gatewayToken,
     },
   };


### PR DESCRIPTION
## Summary

When Pinchy runs on a custom port (`PORT=7778`), the internal URL for plugin callbacks (audit, context) was hardcoded to port 7777. OpenClaw's `pinchy-audit` plugin couldn't reach Pinchy → all tool audit events failed with `fetch failed`.

## Fix

Derive port from `process.env.PORT` with fallback to `7777`. Affects both `pinchy-audit` and `pinchy-context` plugin config generation.

## Test plan

- [x] New test: `PORT=7778` produces `http://pinchy:7778` in both plugin configs
- [x] Existing test: default port still produces `http://pinchy:7777`
- [x] All 1568 tests passing