### PR TITLE
fix: make audit logging failures non-silent (fail-closed)

### DIFF
--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -341,23 +341,103 @@ describe("pinchy-audit plugin", () => {
     });
   });
 
-  it("does not throw when audit endpoint fails", async () => {
-    vi.stubGlobal("fetch", vi.fn().mockRejectedValue(new Error("network down")));
+  describe("audit failure handling", () => {
+    it("retries on transient failure and succeeds on subsequent attempt", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockRejectedValueOnce(new Error("network down"))
+        .mockResolvedValueOnce({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
 
-    const { default: plugin } = await import("./index");
-    plugin.register?.(
-      createMockApi({
-        apiBaseUrl: "http://pinchy:7777",
-        gatewayToken: "gw-token",
-      }) as any
-    );
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
 
-    const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
-    await expect(
-      beforeHook(
-        { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
-        { toolName: "pinchy_read" }
-      )
-    ).resolves.toBeUndefined();
+      const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+      await expect(
+        beforeHook(
+          { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+          { toolName: "pinchy_read" }
+        )
+      ).resolves.toBeUndefined();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("retries on non-ok HTTP response", async () => {
+      const fetchMock = vi
+        .fn()
+        .mockResolvedValueOnce({ ok: false, status: 500 })
+        .mockResolvedValueOnce({ ok: true });
+      vi.stubGlobal("fetch", fetchMock);
+
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+      await expect(
+        afterHook(
+          { toolName: "pinchy_read", params: {}, result: "ok" },
+          { toolName: "pinchy_read", agentId: "agent-1" }
+        )
+      ).resolves.toBeUndefined();
+
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+    });
+
+    it("throws after all retries are exhausted (fail-closed)", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockRejectedValue(new Error("network down"))
+      );
+
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const beforeHook = mockOn.mock.calls.find((c) => c[0] === "before_tool_call")?.[1];
+      await expect(
+        beforeHook(
+          { toolName: "pinchy_read", params: {}, runId: "run-1", toolCallId: "tool-1" },
+          { toolName: "pinchy_read" }
+        )
+      ).rejects.toThrow("network down");
+    });
+
+    it("throws after all retries exhausted on non-ok HTTP responses", async () => {
+      vi.stubGlobal(
+        "fetch",
+        vi.fn().mockResolvedValue({ ok: false, status: 500 })
+      );
+
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+      await expect(
+        afterHook(
+          { toolName: "pinchy_read", params: {}, result: "ok" },
+          { toolName: "pinchy_read", agentId: "agent-1" }
+        )
+      ).rejects.toThrow(/audit endpoint returned 500/);
+    });
   });
 });

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -157,34 +157,44 @@ function cleanupRecentToolStarts(recentStarts: Map<string, RecentToolStart>): vo
   }
 }
 
+const MAX_RETRIES = 2;
+
 async function postToolAuditEvent(
   cfg: PluginConfig,
   logger: PluginLogger | undefined,
   payload: ToolAuditPayload
 ): Promise<void> {
   const endpoint = `${normalizeBaseUrl(cfg.apiBaseUrl)}/api/internal/audit/tool-use`;
+  let lastError: Error | undefined;
 
-  try {
-    const res = await fetch(endpoint, {
-      method: "POST",
-      headers: {
-        "Content-Type": "application/json",
-        Authorization: `Bearer ${cfg.gatewayToken}`,
-      },
-      body: JSON.stringify(payload),
-    });
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cfg.gatewayToken}`,
+        },
+        body: JSON.stringify(payload),
+      });
 
-    if (!res.ok) {
-      logger?.warn?.(
+      if (res.ok) return;
+
+      lastError = new Error(
         `[pinchy-audit] audit endpoint returned ${res.status} for ${payload.phase} ${payload.toolName}`
       );
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
     }
-  } catch (error) {
-    const message = error instanceof Error ? error.message : String(error);
-    logger?.warn?.(
-      `[pinchy-audit] failed to post ${payload.phase} event for ${payload.toolName}: ${message}`
-    );
+
+    if (attempt < MAX_RETRIES) {
+      logger?.warn?.(
+        `[pinchy-audit] audit failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying: ${lastError?.message}`
+      );
+    }
   }
+
+  throw lastError;
 }
 
 const plugin = {

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -209,6 +209,23 @@ describe("POST /api/internal/audit/tool-use", () => {
     });
   });
 
+  it("returns 500 with error message when appendAuditLog fails", async () => {
+    vi.mocked(appendAuditLog).mockRejectedValueOnce(new Error("DB connection lost"));
+
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "browser",
+        agentId: "agent-1",
+        result: "ok",
+      })
+    );
+
+    expect(res.status).toBe(500);
+    const body = await res.json();
+    expect(body.error).toBe("Audit logging failed");
+  });
+
   describe("sensitive data sanitization", () => {
     it("redacts sensitive key names in params before logging", async () => {
       await POST(

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -115,14 +115,18 @@ export async function POST(request: NextRequest) {
 
   const sanitizedDetail = sanitizeDetail(detail);
 
-  await appendAuditLog({
-    actorType,
-    actorId,
-    // Change 2: eventType becomes tool.<toolName>
-    eventType: `tool.${payload.toolName}`,
-    resource: `agent:${payload.agentId}`,
-    detail: sanitizedDetail,
-  });
+  try {
+    await appendAuditLog({
+      actorType,
+      actorId,
+      // Change 2: eventType becomes tool.<toolName>
+      eventType: `tool.${payload.toolName}`,
+      resource: `agent:${payload.agentId}`,
+      detail: sanitizedDetail,
+    });
+  } catch {
+    return NextResponse.json({ error: "Audit logging failed" }, { status: 500 });
+  }
 
   return NextResponse.json({ success: true });
 }


### PR DESCRIPTION
## Summary

- **Plugin**: Replace fire-and-forget audit logging with retry (up to 2 retries) + fail-closed — if all retries fail, the error propagates and blocks the tool call
- **API route**: Catch `appendAuditLog` errors and return proper 500 response instead of unhandled crash

## Context

Closes #47. Previously, when the audit endpoint was unreachable or the DB write failed, the plugin silently logged a warning and let the tool call proceed. This is a compliance gap — in regulated environments, unaudited agent actions are unacceptable.

Now the system is **fail-closed**: no audit record = no tool execution.

## Changes

- `packages/plugins/pinchy-audit/index.ts` — retry loop in `postToolAuditEvent`, throw on final failure
- `packages/plugins/pinchy-audit/index.test.ts` — 4 new tests for retry + fail-closed behavior
- `packages/web/src/app/api/internal/audit/tool-use/route.ts` — try/catch around `appendAuditLog` with 500 response
- `packages/web/src/__tests__/api/internal-audit-tool-use.test.ts` — test for 500 on DB failure

## Test plan

- [x] Plugin: retries on network failure, succeeds on subsequent attempt
- [x] Plugin: retries on non-ok HTTP response (500)
- [x] Plugin: throws after all retries exhausted (network error)
- [x] Plugin: throws after all retries exhausted (HTTP 500)
- [x] API route: returns 500 when appendAuditLog fails
- [x] All existing tests pass (1701 web + 12 plugin)