### PR TITLE
feat: dynamic default model selection from live API

### DIFF
--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -74,6 +74,10 @@ vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue("anthropic"),
 }));
 
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn().mockResolvedValue("anthropic/claude-haiku-4-5-20251001"),
+}));
+
 vi.mock("@/lib/personality-presets", () => ({
   getPersonalityPreset: vi.fn((id: string) => {
     const presets: Record<string, { greetingMessage: string | null; soulMd: string }> = {
@@ -101,6 +105,7 @@ import { POST } from "@/app/api/agents/route";
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
 import { validateAllowedPaths } from "@/lib/path-validation";
+import { getDefaultModel } from "@/lib/provider-models";
 import {
   ensureWorkspace,
   writeWorkspaceFile,
@@ -515,6 +520,27 @@ describe("POST /api/agents", () => {
     // visibility field — the DB default takes care of it.
     const insertedValues = insertValuesMock.mock.calls[0][0];
     expect(insertedValues).not.toHaveProperty("visibility");
+  });
+
+  it("should use getDefaultModel to select model dynamically", async () => {
+    vi.mocked(getDefaultModel).mockResolvedValueOnce("anthropic/claude-haiku-5-0");
+
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Test Agent",
+        templateId: "custom",
+      }),
+    });
+
+    await POST(request);
+
+    expect(getDefaultModel).toHaveBeenCalledWith("anthropic");
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "anthropic/claude-haiku-5-0",
+      })
+    );
   });
 
   it("should use template defaultTagline when tagline not provided", async () => {

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -279,6 +279,98 @@ describe("fetchProviderModels", () => {
   });
 });
 
+describe("selectDefaultModel", () => {
+  it("selects the smallest Anthropic model (haiku pattern)", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "anthropic/claude-opus-4-6", name: "Claude Opus 4.6" },
+      { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
+    ];
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("selects the mini OpenAI model (gpt-*-mini pattern)", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "openai/gpt-4o", name: "gpt-4o" },
+      { id: "openai/gpt-4o-mini", name: "gpt-4o-mini" },
+      { id: "openai/o1", name: "o1" },
+    ];
+    expect(selectDefaultModel("openai", models)).toBe("openai/gpt-4o-mini");
+  });
+
+  it("selects the flash Google model (gemini-*-flash pattern)", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro" },
+      { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
+    ];
+    expect(selectDefaultModel("google", models)).toBe("google/gemini-2.5-flash");
+  });
+
+  it("prefers stable versions over preview versions", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
+      { id: "anthropic/claude-haiku-4-5-20251001-preview", name: "Claude Haiku 4.5 Preview" },
+    ];
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("falls back to hardcoded default when no pattern matches", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [{ id: "anthropic/claude-opus-4-6", name: "Claude Opus 4.6" }];
+    // No haiku in the list — falls back to PROVIDERS[provider].defaultModel
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("falls back to hardcoded default when model list is empty", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    expect(selectDefaultModel("openai", [])).toBe("openai/gpt-4o-mini");
+  });
+});
+
+describe("getDefaultModel", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCache();
+    vi.mocked(getSetting).mockResolvedValue(null);
+  });
+
+  it("returns dynamically selected model from live model list", async () => {
+    vi.mocked(getSetting).mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test-key";
+      return null;
+    });
+
+    vi.mocked(fetch).mockResolvedValue(
+      new Response(
+        JSON.stringify({
+          data: [
+            { id: "claude-opus-4-6", display_name: "Claude Opus 4.6" },
+            { id: "claude-sonnet-4-6", display_name: "Claude Sonnet 4.6" },
+            { id: "claude-haiku-4-5-20251001", display_name: "Claude Haiku 4.5" },
+          ],
+        }),
+        { status: 200 }
+      )
+    );
+
+    const { getDefaultModel } = await import("@/lib/provider-models");
+    const model = await getDefaultModel("anthropic");
+    expect(model).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("falls back to hardcoded default when provider has no API key", async () => {
+    vi.mocked(getSetting).mockResolvedValue(null);
+
+    const { getDefaultModel } = await import("@/lib/provider-models");
+    const model = await getDefaultModel("openai");
+    expect(model).toBe("openai/gpt-4o-mini");
+  });
+});
+
 describe("vision capability detection", () => {
   it("marks anthropic, openai, google as vision-capable providers", async () => {
     const { VISION_CAPABLE_PROVIDERS } = await import("@/lib/provider-models");

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -18,7 +18,8 @@ import {
 import { getContextForAgent } from "@/lib/context-sync";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { getSetting } from "@/lib/settings";
-import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { type ProviderName } from "@/lib/providers";
+import { getDefaultModel } from "@/lib/provider-models";
 import { appendAuditLog } from "@/lib/audit";
 import { getVisibleAgents } from "@/lib/visible-agents";
 
@@ -85,10 +86,10 @@ export async function POST(request: NextRequest) {
   // Resolve personality preset from template
   const preset = getPersonalityPreset(template.defaultPersonality);
 
-  // Determine default model from current provider
+  // Determine default model dynamically from provider's live model list
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
   const model = defaultProvider
-    ? PROVIDERS[defaultProvider].defaultModel
+    ? await getDefaultModel(defaultProvider)
     : "anthropic/claude-haiku-4-5-20251001";
 
   const [agent] = await db

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -2,6 +2,7 @@ import { writeFileSync, readFileSync, existsSync, mkdirSync } from "fs";
 import { randomBytes } from "crypto";
 import { dirname } from "path";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { getDefaultModel } from "@/lib/provider-models";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { getSetting } from "@/lib/settings";
@@ -117,7 +118,7 @@ export async function regenerateOpenClawConfig() {
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
   const defaults: Record<string, unknown> = {};
   if (defaultProvider && PROVIDERS[defaultProvider]) {
-    defaults.model = { primary: PROVIDERS[defaultProvider].defaultModel };
+    defaults.model = { primary: await getDefaultModel(defaultProvider) };
   }
 
   // Build agents list with OpenClaw-side workspace paths, tools.deny, and plugin configs

--- a/packages/web/src/lib/personal-agent.ts
+++ b/packages/web/src/lib/personal-agent.ts
@@ -8,7 +8,8 @@ import {
 } from "@/lib/workspace";
 import { getContextForAgent } from "@/lib/context-sync";
 import { getSetting } from "@/lib/settings";
-import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { type ProviderName } from "@/lib/providers";
+import { getDefaultModel } from "@/lib/provider-models";
 import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
 import { getOnboardingPrompt, ONBOARDING_GREETING } from "@/lib/onboarding-prompt";
 
@@ -69,7 +70,7 @@ export async function seedPersonalAgent(userId: string, isAdmin = false) {
 
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
   const model = defaultProvider
-    ? PROVIDERS[defaultProvider].defaultModel
+    ? await getDefaultModel(defaultProvider)
     : "anthropic/claude-sonnet-4-20250514";
 
   return createSmithersAgent({ model, ownerId: userId, isPersonal: true, isAdmin });

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -103,6 +103,36 @@ async function fetchModelsForProvider(
   return config.transform(data);
 }
 
+const DEFAULT_MODEL_PATTERNS: Record<ProviderName, RegExp> = {
+  anthropic: /haiku/,
+  openai: /gpt-.*-mini/,
+  google: /gemini-.*-flash/,
+};
+
+const PREVIEW_PATTERN = /preview/i;
+
+export function selectDefaultModel(provider: ProviderName, models: ModelInfo[]): string {
+  const pattern = DEFAULT_MODEL_PATTERNS[provider];
+  const candidates = models.filter((m) => pattern.test(m.id) && !PREVIEW_PATTERN.test(m.id));
+
+  if (candidates.length > 0) {
+    return candidates[candidates.length - 1].id;
+  }
+
+  return PROVIDERS[provider].defaultModel;
+}
+
+export async function getDefaultModel(provider: ProviderName): Promise<string> {
+  const allProviders = await fetchProviderModels();
+  const providerModels = allProviders.find((p) => p.id === provider);
+
+  if (!providerModels || providerModels.models.length === 0) {
+    return PROVIDERS[provider].defaultModel;
+  }
+
+  return selectDefaultModel(provider, providerModels.models);
+}
+
 export async function fetchProviderModels(): Promise<ProviderModels[]> {
   const now = Date.now();
   if (cachedResult && now - cachedAt < CACHE_TTL_MS) {


### PR DESCRIPTION
## Summary

- Replace hardcoded `PROVIDERS[provider].defaultModel` with dynamic selection from the provider's live model list
- New `selectDefaultModel(provider, models)` picks the cheapest/smallest model per provider pattern (haiku, gpt-*-mini, gemini-*-flash), preferring stable over preview versions
- New `getDefaultModel(provider)` combines `fetchProviderModels()` (1h cache) with `selectDefaultModel()`
- Falls back to hardcoded defaults if API unreachable or no pattern match

## Context

Closes #65. When Google deprecated `gemini-2.0-flash`, Pinchy silently assigned an unavailable model to new agents. Now the model list is fetched dynamically, so deprecated models are automatically excluded and the best available model is selected.

## Changes

- [provider-models.ts](packages/web/src/lib/provider-models.ts) — `selectDefaultModel()`, `getDefaultModel()`
- [agents/route.ts](packages/web/src/app/api/agents/route.ts) — uses `getDefaultModel()`
- [personal-agent.ts](packages/web/src/lib/personal-agent.ts) — uses `getDefaultModel()`
- [openclaw-config.ts](packages/web/src/lib/openclaw-config.ts) — uses `getDefaultModel()`
- Tests: 8 new tests for selection logic + 1 integration test for agent creation

## Test plan

- [x] Selects haiku for Anthropic, gpt-*-mini for OpenAI, gemini-*-flash for Google
- [x] Prefers stable over preview versions
- [x] Falls back to hardcoded default when no pattern match
- [x] Falls back when model list is empty
- [x] getDefaultModel integrates with fetchProviderModels (cached)
- [x] Agent creation calls getDefaultModel
- [x] All 1710 tests pass