### PR TITLE
feat(telegram): require main bot before per-agent Telegram setup

### DIFF
--- a/docs/src/content/docs/guides/telegram-setup.mdx
+++ b/docs/src/content/docs/guides/telegram-setup.mdx
@@ -53,7 +53,7 @@ Pinchy's main Telegram bot must already be set up in **Settings → Telegram** (
 :::
 
 1. Create a new bot via BotFather (repeat Step 1)
-2. Go to **Agent Settings → Channels** for the agent you want to connect
+2. Go to **Agent Settings → Telegram** for the agent you want to connect
 3. Paste the new bot token and click **Connect**
 
 :::note
@@ -73,7 +73,7 @@ When group memberships or agent visibility change, Telegram access is updated au
 ## Unlinking and Removing
 
 - **Unlink your account**: Settings → Telegram → Unlink. You can re-link anytime.
-- **Disconnect an agent's bot**: Agent Settings → Channels → Disconnect (not available for Smithers)
+- **Disconnect an agent's bot**: Agent Settings → Telegram → Disconnect (not available for Smithers)
 - **Remove Telegram for everyone**: Settings → Telegram → Remove Telegram for everyone. This disconnects all bots and unlinks all users.
 
 :::caution

--- a/docs/src/content/docs/guides/telegram-setup.mdx
+++ b/docs/src/content/docs/guides/telegram-setup.mdx
@@ -48,6 +48,10 @@ You're now linked. Messages you send to the bot are answered by the agent.
 
 Each agent can have its own Telegram bot. To connect a second agent:
 
+:::caution[Before you start]
+Pinchy's main Telegram bot must already be set up in **Settings → Telegram** (Steps 1 and 2 above). Users link their Telegram account via the main bot; without it, additional agent bots have no way to receive messages. If you see a "Telegram isn't set up yet" message in the agent's Telegram tab, go to Settings → Telegram first.
+:::
+
 1. Create a new bot via BotFather (repeat Step 1)
 2. Go to **Agent Settings → Channels** for the agent you want to connect
 3. Paste the new bot token and click **Connect**

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,7 +33,7 @@
     "drizzle-orm": "^0.45.2",
     "jose": "^6.2.2",
     "lucide-react": "^1.7.0",
-    "next": "16.2.2",
+    "next": "16.2.3",
     "next-themes": "^0.4.6",
     "openclaw-node": "0.3.1",
     "postgres": "^3.4.8",

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -164,6 +164,23 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
 
     expect(response.status).toBe(401);
   });
+
+  it("returns mainBotConfigured: true for personal agent even when global main bot is missing", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      id: "agent-1",
+      isPersonal: true,
+    } as any);
+    vi.mocked(getSetting).mockResolvedValueOnce(null);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ configured: false, mainBotConfigured: true });
+  });
 });
 
 describe("POST /api/agents/[agentId]/channels/telegram", () => {
@@ -308,6 +325,23 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
     await POST(makeRequest({ botToken: "123456:ABC-token" }), { params: mockParams });
 
     expect(appendAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("allows personal agent setup even when main bot is missing (first-time bootstrap)", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      ...mockAgent,
+      isPersonal: true,
+    } as any);
+
+    const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ botUsername: "test_bot", botId: 123456 });
+    expect(mockValidateTelegramBotToken).toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -281,6 +281,34 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
     expect(response.status).toBe(200);
     expect(mockRecalculateTelegramAllowStores).toHaveBeenCalled();
   });
+
+  it("returns 409 when main bot is not configured", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+
+    const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(data.error).toBe("telegram_not_configured");
+  });
+
+  it("does not call validateTelegramBotToken when main bot is missing", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+
+    await POST(makeRequest({ botToken: "123456:ABC-token" }), { params: mockParams });
+
+    expect(mockValidateTelegramBotToken).not.toHaveBeenCalled();
+  });
+
+  it("does not write audit log when main bot is missing", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+
+    await POST(makeRequest({ botToken: "123456:ABC-token" }), { params: mockParams });
+
+    expect(appendAuditLog).not.toHaveBeenCalled();
+  });
 });
 
 describe("DELETE /api/agents/[agentId]/channels/telegram", () => {

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -10,8 +10,10 @@ vi.mock("@/lib/api-auth", () => ({
 }));
 
 const mockValidateTelegramBotToken = vi.fn();
+const mockHasMainTelegramBot = vi.fn().mockResolvedValue(true);
 vi.mock("@/lib/telegram", () => ({
   validateTelegramBotToken: (...args: unknown[]) => mockValidateTelegramBotToken(...args),
+  hasMainTelegramBot: (...args: unknown[]) => mockHasMainTelegramBot(...args),
 }));
 
 vi.mock("@/lib/settings", () => ({
@@ -97,7 +99,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toEqual({ configured: false });
+    expect(data).toEqual({ configured: false, mainBotConfigured: true });
   });
 
   it("returns configured: true with hint when token exists", async () => {
@@ -109,7 +111,46 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toEqual({ configured: true, hint: "xY9z" });
+    expect(data).toEqual({ configured: true, hint: "xY9z", mainBotConfigured: true });
+  });
+
+  it("returns mainBotConfigured: true when the main bot exists", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(true);
+    vi.mocked(getSetting).mockResolvedValueOnce(null);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ configured: false, mainBotConfigured: true });
+  });
+
+  it("returns mainBotConfigured: false when the main bot is missing", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(false);
+    vi.mocked(getSetting).mockResolvedValueOnce(null);
+
+    const response = await GET(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ configured: false, mainBotConfigured: false });
+  });
+
+  it("still returns hint and mainBotConfigured when agent has its own bot", async () => {
+    mockHasMainTelegramBot.mockResolvedValueOnce(true);
+    vi.mocked(getSetting).mockResolvedValueOnce("123456:ABC-some-token-xY9z");
+
+    const response = await GET(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data).toEqual({ configured: true, hint: "xY9z", mainBotConfigured: true });
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ triggerRestart: vi.fn() }),
+}));
+
+function mockFetch(response: object) {
+  return vi.fn().mockImplementation((url: string) => {
+    if (typeof url === "string" && url.includes("/channels/telegram")) {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(response) });
+    }
+    return Promise.resolve({ ok: false });
+  });
+}
+
+describe("AgentTelegramSettings", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders empty state when main bot is not configured", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: false });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Telegram isn't set up yet/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/Pinchy's main bot needs to be configured first/i)).toBeInTheDocument();
+  });
+
+  it("empty state has a link to the global Telegram settings page", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: false });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      const link = screen.getByRole("link", { name: /Go to Telegram Settings/i });
+      expect(link).toHaveAttribute("href", "/settings?tab=telegram");
+    });
+  });
+
+  it("does not render the BotFather setup form in the empty state", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: false });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Telegram isn't set up yet/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/Bot Token/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Connect$/i })).not.toBeInTheDocument();
+  });
+
+  it("renders the setup form when main bot is configured and agent has no bot", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: true });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Telegram isn't set up yet/i)).not.toBeInTheDocument();
+  });
+
+  it("renders the connected state when agent has its own bot, regardless of main bot flag", async () => {
+    // Defensive: this combination shouldn't happen in production, but the UI
+    // must not regress to empty state if it does.
+    global.fetch = mockFetch({
+      configured: true,
+      hint: "xY9z",
+      mainBotConfigured: false,
+    });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Telegram isn't set up yet/i)).not.toBeInTheDocument();
+  });
+});

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -83,4 +83,15 @@ describe("AgentTelegramSettings", () => {
     });
     expect(screen.queryByText(/Telegram isn't set up yet/i)).not.toBeInTheDocument();
   });
+
+  it("renders the setup form for Smithers even when main bot is not configured", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: false });
+
+    render(<AgentTelegramSettings agentId="smithers-1" isSmithers />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/Telegram isn't set up yet/i)).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/components/telegram-link-settings.test.tsx
+++ b/packages/web/src/__tests__/components/telegram-link-settings.test.tsx
@@ -109,4 +109,80 @@ describe("TelegramLinkSettings", () => {
     });
     expect(screen.getByRole("button", { name: "Connect" })).toBeInTheDocument();
   });
+
+  it("confirmation dialog lists agent bot names when agent bots exist", async () => {
+    global.fetch = mockFetch({ linked: true }, [
+      { agentId: "smithers-1", agentName: "Smithers", botUsername: "pinchy_bot", isPersonal: true },
+      { agentId: "a-2", agentName: "Support Bot", botUsername: "support_bot", isPersonal: false },
+      { agentId: "a-3", agentName: "Sales Bot", botUsername: "sales_bot", isPersonal: false },
+    ]);
+
+    render(<TelegramLinkSettings isAdmin={true} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Remove Telegram for everyone/i })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove Telegram for everyone/i }));
+
+    expect(screen.getByText((content) => /these 2 agents/i.test(content))).toBeInTheDocument();
+    expect(screen.getByText("Support Bot")).toBeInTheDocument();
+    expect(screen.getByText("Sales Bot")).toBeInTheDocument();
+  });
+
+  it("confirmation dialog omits the agent-bot block when only the main bot exists", async () => {
+    global.fetch = mockFetch({ linked: true }, [
+      {
+        agentId: "smithers-1",
+        agentName: "Smithers",
+        botUsername: "pinchy_bot",
+        isPersonal: true,
+      },
+    ]);
+
+    render(<TelegramLinkSettings isAdmin={true} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Remove Telegram for everyone/i })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove Telegram for everyone/i }));
+
+    expect(screen.queryByText(/these \d+ agents?/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/You can set it up again later\./i)).toBeInTheDocument();
+  });
+
+  it("confirmation dialog shows singular 'this 1 agent' with one extra bot", async () => {
+    global.fetch = mockFetch({ linked: true }, [
+      {
+        agentId: "smithers-1",
+        agentName: "Smithers",
+        botUsername: "pinchy_bot",
+        isPersonal: true,
+      },
+      {
+        agentId: "a-2",
+        agentName: "Support Bot",
+        botUsername: "support_bot",
+        isPersonal: false,
+      },
+    ]);
+
+    render(<TelegramLinkSettings isAdmin={true} />);
+
+    await waitFor(() => {
+      expect(
+        screen.getByRole("button", { name: /Remove Telegram for everyone/i })
+      ).toBeInTheDocument();
+    });
+
+    await userEvent.click(screen.getByRole("button", { name: /Remove Telegram for everyone/i }));
+
+    expect(screen.getByText(/this 1 agent:/i)).toBeInTheDocument();
+    expect(screen.getByText("Support Bot")).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/components/telegram-link-settings.test.tsx
+++ b/packages/web/src/__tests__/components/telegram-link-settings.test.tsx
@@ -127,7 +127,7 @@ describe("TelegramLinkSettings", () => {
 
     await userEvent.click(screen.getByRole("button", { name: /Remove Telegram for everyone/i }));
 
-    expect(screen.getByText((content) => /these 2 agents/i.test(content))).toBeInTheDocument();
+    expect(screen.getByText(/these 2 agents/i)).toBeInTheDocument();
     expect(screen.getByText("Support Bot")).toBeInTheDocument();
     expect(screen.getByText("Sales Bot")).toBeInTheDocument();
   });

--- a/packages/web/src/__tests__/lib/telegram.test.ts
+++ b/packages/web/src/__tests__/lib/telegram.test.ts
@@ -16,11 +16,6 @@ vi.mock("@/db", () => ({
   },
 }));
 
-vi.mock("drizzle-orm", async (importOriginal) => {
-  const actual = await importOriginal();
-  return { ...(actual as object), eq: vi.fn() };
-});
-
 import { validateTelegramBotToken, hasMainTelegramBot } from "@/lib/telegram";
 
 const fetchMock = vi.fn();
@@ -146,5 +141,11 @@ describe("hasMainTelegramBot", () => {
     await expect(hasMainTelegramBot()).resolves.toBe(true);
     // Should not query the 2nd and 3rd agents once it found the first one
     expect(mockGetSetting).toHaveBeenCalledTimes(1);
+  });
+
+  it("treats an empty-string token as not configured", async () => {
+    mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }]);
+    mockGetSetting.mockResolvedValueOnce("");
+    await expect(hasMainTelegramBot()).resolves.toBe(false);
   });
 });

--- a/packages/web/src/__tests__/lib/telegram.test.ts
+++ b/packages/web/src/__tests__/lib/telegram.test.ts
@@ -1,5 +1,27 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { validateTelegramBotToken } from "@/lib/telegram";
+
+const mockGetSetting = vi.fn();
+vi.mock("@/lib/settings", () => ({
+  getSetting: (...args: unknown[]) => mockGetSetting(...args),
+}));
+
+const mockFindMany = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      agents: {
+        findMany: (...args: unknown[]) => mockFindMany(...args),
+      },
+    },
+  },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal();
+  return { ...(actual as object), eq: vi.fn() };
+});
+
+import { validateTelegramBotToken, hasMainTelegramBot } from "@/lib/telegram";
 
 const fetchMock = vi.fn();
 vi.stubGlobal("fetch", fetchMock);
@@ -80,5 +102,49 @@ describe("validateTelegramBotToken", () => {
     expect(result).toEqual({ valid: true, botId: 42, botUsername: "test_bot" });
 
     delete process.env.TELEGRAM_API_URL;
+  });
+});
+
+describe("hasMainTelegramBot", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns false when there are no personal agents", async () => {
+    mockFindMany.mockResolvedValueOnce([]);
+    await expect(hasMainTelegramBot()).resolves.toBe(false);
+    expect(mockGetSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns false when no personal agent has a telegram bot token", async () => {
+    mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }, { id: "smithers-2" }]);
+    mockGetSetting.mockResolvedValue(null);
+    await expect(hasMainTelegramBot()).resolves.toBe(false);
+    expect(mockGetSetting).toHaveBeenCalledWith("telegram_bot_token:smithers-1");
+    expect(mockGetSetting).toHaveBeenCalledWith("telegram_bot_token:smithers-2");
+  });
+
+  it("returns true when a personal agent has a telegram bot token", async () => {
+    mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }, { id: "smithers-2" }]);
+    mockGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:smithers-2") return "123456:ABC-token";
+      return null;
+    });
+    await expect(hasMainTelegramBot()).resolves.toBe(true);
+  });
+
+  it("short-circuits as soon as it finds a token", async () => {
+    mockFindMany.mockResolvedValueOnce([
+      { id: "smithers-1" },
+      { id: "smithers-2" },
+      { id: "smithers-3" },
+    ]);
+    mockGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:smithers-1") return "123456:ABC-token";
+      return null;
+    });
+    await expect(hasMainTelegramBot()).resolves.toBe(true);
+    // Should not query the 2nd and 3rd agents once it found the first one
+    expect(mockGetSetting).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
-import { validateTelegramBotToken } from "@/lib/telegram";
+import { validateTelegramBotToken, hasMainTelegramBot } from "@/lib/telegram";
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
 import { appendAuditLog } from "@/lib/audit";
 import { updateTelegramChannelConfig } from "@/lib/openclaw-config";
@@ -17,13 +17,17 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   if (admin instanceof NextResponse) return admin;
   const { agentId } = await params;
 
-  const botToken = await getSetting(`telegram_bot_token:${agentId}`);
+  const [botToken, mainBotConfigured] = await Promise.all([
+    getSetting(`telegram_bot_token:${agentId}`),
+    hasMainTelegramBot(),
+  ]);
+
   if (!botToken) {
-    return NextResponse.json({ configured: false });
+    return NextResponse.json({ configured: false, mainBotConfigured });
   }
 
   const hint = botToken.slice(-4);
-  return NextResponse.json({ configured: true, hint });
+  return NextResponse.json({ configured: true, hint, mainBotConfigured });
 }
 
 export async function POST(req: Request, { params }: { params: Promise<{ agentId: string }> }) {

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -40,6 +40,13 @@ export async function POST(req: Request, { params }: { params: Promise<{ agentId
     return NextResponse.json({ error: "Bot token is required" }, { status: 400 });
   }
 
+  // Guard: main Telegram bot must exist before additional agents can connect.
+  // Users can only link their Telegram account via the main bot — without it,
+  // per-agent bots have no way to reach any user.
+  if (!(await hasMainTelegramBot())) {
+    return NextResponse.json({ error: "telegram_not_configured" }, { status: 409 });
+  }
+
   const agent = await db.query.agents.findFirst({
     where: eq(agents.id, agentId),
   });

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -17,10 +17,19 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   if (admin instanceof NextResponse) return admin;
   const { agentId } = await params;
 
-  const [botToken, mainBotConfigured] = await Promise.all([
+  const [agent, botToken, globalMainBot] = await Promise.all([
+    db.query.agents.findFirst({
+      where: eq(agents.id, agentId),
+      columns: { isPersonal: true },
+    }),
     getSetting(`telegram_bot_token:${agentId}`),
     hasMainTelegramBot(),
   ]);
+
+  // Personal agents (Smithers) are themselves the main bot — the prerequisite
+  // is trivially satisfied from their perspective, otherwise first-time setup
+  // would hit an unresolvable chicken-and-egg.
+  const mainBotConfigured = agent?.isPersonal ? true : globalMainBot;
 
   if (!botToken) {
     return NextResponse.json({ configured: false, mainBotConfigured });
@@ -40,18 +49,19 @@ export async function POST(req: Request, { params }: { params: Promise<{ agentId
     return NextResponse.json({ error: "Bot token is required" }, { status: 400 });
   }
 
-  // Guard: main Telegram bot must exist before additional agents can connect.
-  // Users can only link their Telegram account via the main bot — without it,
-  // per-agent bots have no way to reach any user.
-  if (!(await hasMainTelegramBot())) {
-    return NextResponse.json({ error: "telegram_not_configured" }, { status: 409 });
-  }
-
   const agent = await db.query.agents.findFirst({
     where: eq(agents.id, agentId),
   });
   if (!agent) {
     return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+  }
+
+  // Guard: main Telegram bot must exist before additional agents can connect.
+  // Users can only link their Telegram account via the main bot — without it,
+  // per-agent bots have no way to reach any user. Personal agents (Smithers)
+  // are exempt because they ARE the main bot being set up.
+  if (!agent.isPersonal && !(await hasMainTelegramBot())) {
+    return NextResponse.json({ error: "telegram_not_configured" }, { status: 409 });
   }
 
   // Validate token via Telegram API first (gives us the botId for duplicate check)

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -19,13 +19,15 @@ import {
   AlertDialogTitle,
   AlertDialogTrigger,
 } from "@/components/ui/alert-dialog";
-import { CircleCheck, ChevronDown, Lock } from "lucide-react";
+import { CircleCheck, ChevronDown, Lock, ArrowRight } from "lucide-react";
+import Link from "next/link";
 import { useRestart } from "@/components/restart-provider";
 
 interface TelegramConfig {
   configured: boolean;
   hint?: string;
   botUsername?: string;
+  mainBotConfigured?: boolean;
 }
 
 interface AgentTelegramSettingsProps {
@@ -140,10 +142,27 @@ export function AgentTelegramSettings({
   }
 
   const isConfigured = config?.configured === true;
+  const mainBotMissing = config?.mainBotConfigured === false && !isConfigured;
 
   const content = (
     <div className="space-y-4">
-      {isConfigured ? (
+      {mainBotMissing ? (
+        <div className="space-y-4 text-center py-6">
+          <div className="space-y-2">
+            <p className="text-sm font-medium">Telegram isn&apos;t set up yet</p>
+            <p className="text-sm text-muted-foreground max-w-md mx-auto">
+              Before you can connect this agent to Telegram, Pinchy&apos;s main bot needs to be
+              configured first. That&apos;s the bot users message to link their account.
+            </p>
+          </div>
+          <Button asChild>
+            <Link href="/settings?tab=telegram">
+              Go to Telegram Settings
+              <ArrowRight className="size-4" />
+            </Link>
+          </Button>
+        </div>
+      ) : isConfigured ? (
         <>
           <div className="flex items-center gap-2">
             <CircleCheck className="size-5 text-green-600 shrink-0" />

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -142,7 +142,11 @@ export function AgentTelegramSettings({
   }
 
   const isConfigured = config?.configured === true;
-  const mainBotMissing = config?.mainBotConfigured === false && !isConfigured;
+  // Strict `=== false` (not `!config?.mainBotConfigured`) so missing/undefined
+  // doesn't trip the empty state on initial load or for older API responses.
+  // Smithers (`isSmithers`) is exempt because it IS the main bot being set up —
+  // otherwise first-time setup would show an empty state pointing to itself.
+  const mainBotMissing = config?.mainBotConfigured === false && !isConfigured && !isSmithers;
 
   const content = (
     <div className="space-y-4">

--- a/packages/web/src/components/telegram-link-settings.tsx
+++ b/packages/web/src/components/telegram-link-settings.tsx
@@ -183,6 +183,7 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
   }
 
   const primaryBot = bots[0];
+  const agentBots = bots.filter((b) => !b.isPersonal);
 
   // State 3: User is linked
   if (linkStatus?.linked) {
@@ -224,26 +225,24 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
                           This will disconnect Pinchy&apos;s main Telegram bot and unlink all users
                           from their Telegram accounts.
                         </p>
-                        {(() => {
-                          const agentBots = bots.filter((b) => !b.isPersonal);
-                          if (agentBots.length === 0) return null;
-                          const plural =
-                            agentBots.length === 1
-                              ? "this 1 agent"
-                              : `these ${agentBots.length} agents`;
-                          return (
-                            <div className="space-y-2">
-                              <p>It will also disconnect Telegram from {plural}:</p>
-                              <ul className="list-disc list-inside max-h-40 overflow-y-auto">
-                                {agentBots.map((b) => (
-                                  <li key={b.agentId}>{b.agentName}</li>
-                                ))}
-                              </ul>
-                            </div>
-                          );
-                        })()}
+                        {agentBots.length > 0 && (
+                          <div className="space-y-2">
+                            <p>
+                              It will also disconnect Telegram from{" "}
+                              {agentBots.length === 1
+                                ? "this 1 agent"
+                                : `these ${agentBots.length} agents`}
+                              :
+                            </p>
+                            <ul className="list-disc list-inside max-h-40 overflow-y-auto">
+                              {agentBots.map((b) => (
+                                <li key={b.agentId}>{b.agentName}</li>
+                              ))}
+                            </ul>
+                          </div>
+                        )}
                         <p>
-                          {bots.filter((b) => !b.isPersonal).length > 0
+                          {agentBots.length > 0
                             ? "You can set it up again later, but agent bots will need to be reconnected one by one."
                             : "You can set it up again later."}
                         </p>

--- a/packages/web/src/components/telegram-link-settings.tsx
+++ b/packages/web/src/components/telegram-link-settings.tsx
@@ -31,6 +31,7 @@ interface TelegramBot {
   agentId: string;
   agentName: string;
   botUsername: string;
+  isPersonal: boolean;
 }
 
 interface TelegramLinkSettingsProps {
@@ -217,9 +218,36 @@ export function TelegramLinkSettings({ isAdmin }: TelegramLinkSettingsProps) {
                 <AlertDialogContent>
                   <AlertDialogHeader>
                     <AlertDialogTitle>Remove Telegram for everyone?</AlertDialogTitle>
-                    <AlertDialogDescription>
-                      This will disconnect all Telegram bots and unlink all users. Everyone will
-                      lose Telegram access. You can set it up again later.
+                    <AlertDialogDescription asChild>
+                      <div className="space-y-3 text-sm text-muted-foreground">
+                        <p>
+                          This will disconnect Pinchy&apos;s main Telegram bot and unlink all users
+                          from their Telegram accounts.
+                        </p>
+                        {(() => {
+                          const agentBots = bots.filter((b) => !b.isPersonal);
+                          if (agentBots.length === 0) return null;
+                          const plural =
+                            agentBots.length === 1
+                              ? "this 1 agent"
+                              : `these ${agentBots.length} agents`;
+                          return (
+                            <div className="space-y-2">
+                              <p>It will also disconnect Telegram from {plural}:</p>
+                              <ul className="list-disc list-inside max-h-40 overflow-y-auto">
+                                {agentBots.map((b) => (
+                                  <li key={b.agentId}>{b.agentName}</li>
+                                ))}
+                              </ul>
+                            </div>
+                          );
+                        })()}
+                        <p>
+                          {bots.filter((b) => !b.isPersonal).length > 0
+                            ? "You can set it up again later, but agent bots will need to be reconnected one by one."
+                            : "You can set it up again later."}
+                        </p>
+                      </div>
                     </AlertDialogDescription>
                   </AlertDialogHeader>
                   <AlertDialogFooter>

--- a/packages/web/src/lib/telegram.ts
+++ b/packages/web/src/lib/telegram.ts
@@ -1,3 +1,8 @@
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { getSetting } from "@/lib/settings";
+
 interface TelegramValidationSuccess {
   valid: true;
   botId: number;
@@ -32,4 +37,21 @@ export async function validateTelegramBotToken(token: string): Promise<TelegramV
       error: err instanceof Error ? err.message : "Unknown error",
     };
   }
+}
+
+/**
+ * True when Pinchy's main Telegram bot is configured — i.e. when at least
+ * one personal agent (Smithers) has a bot token set. Used as a precondition
+ * for per-agent Telegram bot setup: users can only pair via the main bot,
+ * so additional agent bots are unreachable without one.
+ */
+export async function hasMainTelegramBot(): Promise<boolean> {
+  const personalAgents = await db.query.agents.findMany({
+    where: eq(agents.isPersonal, true),
+  });
+  for (const agent of personalAgents) {
+    const token = await getSetting(`telegram_bot_token:${agent.id}`);
+    if (token) return true;
+  }
+  return false;
 }

--- a/packages/web/src/lib/telegram.ts
+++ b/packages/web/src/lib/telegram.ts
@@ -48,6 +48,7 @@ export async function validateTelegramBotToken(token: string): Promise<TelegramV
 export async function hasMainTelegramBot(): Promise<boolean> {
   const personalAgents = await db.query.agents.findMany({
     where: eq(agents.isPersonal, true),
+    columns: { id: true },
   });
   for (const agent of personalAgents) {
     const token = await getSetting(`telegram_bot_token:${agent.id}`);

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -63,8 +63,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
       next:
-        specifier: 16.2.2
-        version: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.3
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1063,60 +1063,60 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@next/env@16.2.2':
-    resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
   '@next/eslint-plugin-next@16.2.2':
     resolution: {integrity: sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==}
 
-  '@next/swc-darwin-arm64@16.2.2':
-    resolution: {integrity: sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==}
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.2':
-    resolution: {integrity: sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==}
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
-    resolution: {integrity: sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==}
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.2':
-    resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.2':
-    resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.2':
-    resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
-    resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.2':
-    resolution: {integrity: sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==}
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3969,8 +3969,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.2:
-    resolution: {integrity: sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==}
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5644,34 +5644,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.2': {}
+  '@next/env@16.2.3': {}
 
   '@next/eslint-plugin-next@16.2.2':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.2':
+  '@next/swc-darwin-arm64@16.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.2':
+  '@next/swc-darwin-x64@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
+  '@next/swc-linux-arm64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.2':
+  '@next/swc-linux-arm64-musl@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.2':
+  '@next/swc-linux-x64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.2':
+  '@next/swc-linux-x64-musl@16.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
+  '@next/swc-win32-arm64-msvc@16.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.2':
+  '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
 
   '@noble/ciphers@2.1.1': {}
@@ -7079,7 +7079,7 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))
@@ -7102,7 +7102,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8)
       mongodb: 7.1.0
-      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -8716,9 +8716,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.2
+      '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001770
@@ -8727,14 +8727,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.2
-      '@next/swc-darwin-x64': 16.2.2
-      '@next/swc-linux-arm64-gnu': 16.2.2
-      '@next/swc-linux-arm64-musl': 16.2.2
-      '@next/swc-linux-x64-gnu': 16.2.2
-      '@next/swc-linux-x64-musl': 16.2.2
-      '@next/swc-win32-arm64-msvc': 16.2.2
-      '@next/swc-win32-x64-msvc': 16.2.2
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5


### PR DESCRIPTION
## Summary

Fixes three related UX bugs in the Telegram integration where the per-agent setup flow was unaware of the global main bot layer:

1. **Agent Settings → Telegram was always visible** even when no main bot existed. Connecting an agent bot without a main bot is useless: users link their Telegram account via the main bot, so without it, an agent bot has no users to talk to.
2. **`POST /api/agents/:id/channels/telegram` accepted tokens unconditionally**, allowing the API to silently create orphaned bots even when the UI gate would have blocked it.
3. **"Remove Telegram for everyone" was vague** about which agent bots it would disconnect — admins had to guess the blast radius.

### Changes
- New `hasMainTelegramBot()` helper (`packages/web/src/lib/telegram.ts`)
- `GET /api/agents/:id/channels/telegram` now returns `mainBotConfigured`
- `POST /api/agents/:id/channels/telegram` returns `409 telegram_not_configured` when no main bot exists — **except** for personal agents (Smithers), which ARE the main bot being set up (chicken-and-egg fix for first-time bootstrap)
- `AgentTelegramSettings` shows an empty state with a CTA linking to Settings → Telegram when the main bot is missing
- "Remove Telegram for everyone" dialog now lists affected agent bots with proper pluralization
- Docs: prerequisite admonition added to "Connect Additional Agents"; corrected tab name "Telegram" (was "Channels")

Defense-in-depth: backend API guards + frontend empty state + docs prerequisite note.

## Test plan
- [x] `hasMainTelegramBot()` helper unit tests
- [x] `GET` returns `mainBotConfigured` (incl. personal-agent override)
- [x] `POST` 409 guard with personal-agent bootstrap exemption
- [x] `AgentTelegramSettings` empty state + Smithers exception
- [x] Enriched remove-all dialog with singular/plural/omitted variants
- [x] Full web test suite: 2102/2107 passing (5 pre-existing skips)
- [x] ESLint clean, Prettier clean
- [ ] Docker smoke test (manual, post-merge)