### PR TITLE
feat: usage dashboard improvements with poller and source breakdown

### DIFF
--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -16,10 +16,11 @@ Admins only. Non-admin users get redirected to the home page if they try to open
 Open **Usage** from the sidebar (or visit `/usage`).
 
 - **Total Tokens** — sum of input and output tokens for the selected period and agent filter
-- **Estimated Cost** — running USD estimate based on the per-token prices in your provider's model config
+- **Estimated Cost** — running USD estimate based on the per-token prices in your provider's model config. Shows "—" when pricing is unavailable (e.g. local Ollama models) so you can tell the difference between "free" and "no pricing data"
+- **Cache Tokens** — combined cache read and write tokens, shown when cache usage exists. Cache tokens reduce costs (reads are cheaper than fresh input tokens) and this card helps you see how much you're saving
 - **Source Breakdown** — how those tokens split across Chat, System, and Plugin use (see below)
-- **Daily Token Usage** chart — input vs output tokens over time
-- **Per-Agent Breakdown** — which agents consume what, sorted by cost
+- **Daily Token Usage** chart — input vs output tokens over time. Days with no usage show as zero instead of being skipped, so you see actual gaps rather than misleading interpolation. The chart groups days by your browser's timezone, not UTC
+- **Per-Agent Breakdown** — which agents consume what, sorted by cost. Deleted agents are marked with "(deleted)" so you can still see their historical usage
 - **Per-User Breakdown** — Enterprise only — same numbers split by who chatted with the agent
 
 ### Token sources
@@ -41,19 +42,22 @@ Both filters apply to every card and tab on the page.
 
 ## Where the numbers come from
 
-Pinchy writes a usage record whenever an LLM call completes — both for chat turns (captured by a background poller that reads OpenClaw session snapshots) and for plugin-internal LLM calls (reported directly by the plugin). Each record carries the input/output tokens the provider reported. Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals.
+Pinchy writes a usage record whenever an LLM call completes — both for chat turns (captured by a background poller that reads OpenClaw session snapshots) and for plugin-internal LLM calls (reported directly by the plugin). Each record carries the input/output tokens the provider reported, plus cache read and write tokens when the provider supports prompt caching.
+
+Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals. Cache tokens use Anthropic-style pricing ratios: cache reads at 10% of the input price, cache writes at 125%.
 
 A few honest caveats:
 
 - **It's an estimate.** Provider invoices are the source of truth. Pinchy uses the prices baked into the OpenClaw model config, which can drift from a provider's current published rates.
-- **Local Ollama is free.** Local models record token counts but their cost is always zero — you're paying in electricity and hardware, not API fees.
+- **Cache pricing is approximate.** The 10%/125% ratios match Anthropic's published pricing. If your provider uses different cache pricing, the estimate will be off. The token counts themselves are always accurate.
+- **Local Ollama shows "—" for cost.** Local models record token counts but have no pricing config. The dashboard shows a dash instead of $0.00 to make this clear.
 - **Tool execution time isn't tracked here.** Only the LLM tokens count. The Audit Trail at `/audit` is where you go for tool-use details.
 
 ## Export
 
 <Aside type="note">CSV export is an Enterprise feature.</Aside>
 
-With an active Enterprise license, the **Export CSV** button (top-right) downloads the current view — period and agent filter applied — as a CSV file. Useful for finance hand-offs or feeding the data into your own dashboards.
+With an active Enterprise license, the **Export CSV** button (top-right) downloads the current view — period and agent filter applied — as a CSV file. The export includes cache read and write tokens alongside the regular token columns. Useful for finance hand-offs or feeding the data into your own dashboards.
 
 Without a license, the button is disabled but stays visible so you know the feature exists.
 

--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -28,7 +28,7 @@ Not every token an agent burns comes from a user message. Pinchy labels each usa
 
 - **Chat** — tokens spent on direct conversations with the agent (user messages and the agent's replies).
 - **System** — tokens spent on background work Pinchy triggers on the agent's behalf, such as onboarding interviews or scheduled jobs. No human sent these messages.
-- **Plugin** — tokens spent *inside* a tool call. For example, when an agent asks the `pinchy-files` plugin to read a PDF, the plugin may call a vision model to extract text from scanned pages. Those vision calls are billed to the agent but show up under Plugin, not Chat.
+- **Plugin** — tokens spent _inside_ a tool call. For example, when an agent asks the `pinchy-files` plugin to read a PDF, the plugin may call a vision model to extract text from scanned pages. Those vision calls are billed to the agent but show up under Plugin, not Chat.
 
 Cards for each bucket only appear when that bucket has non-zero usage, so a fresh instance only shows Chat until background or plugin work kicks in.
 

--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -17,9 +17,20 @@ Open **Usage** from the sidebar (or visit `/usage`).
 
 - **Total Tokens** — sum of input and output tokens for the selected period and agent filter
 - **Estimated Cost** — running USD estimate based on the per-token prices in your provider's model config
+- **Source Breakdown** — how those tokens split across Chat, System, and Plugin use (see below)
 - **Daily Token Usage** chart — input vs output tokens over time
 - **Per-Agent Breakdown** — which agents consume what, sorted by cost
 - **Per-User Breakdown** — Enterprise only — same numbers split by who chatted with the agent
+
+### Token sources
+
+Not every token an agent burns comes from a user message. Pinchy labels each usage record with its source so you can see where the budget actually goes:
+
+- **Chat** — tokens spent on direct conversations with the agent (user messages and the agent's replies).
+- **System** — tokens spent on background work Pinchy triggers on the agent's behalf, such as onboarding interviews or scheduled jobs. No human sent these messages.
+- **Plugin** — tokens spent *inside* a tool call. For example, when an agent asks the `pinchy-files` plugin to read a PDF, the plugin may call a vision model to extract text from scanned pages. Those vision calls are billed to the agent but show up under Plugin, not Chat.
+
+Cards for each bucket only appear when that bucket has non-zero usage, so a fresh instance only shows Chat until background or plugin work kicks in.
 
 ### Filters
 
@@ -30,7 +41,7 @@ Both filters apply to every card and tab on the page.
 
 ## Where the numbers come from
 
-Every successful chat turn writes a usage record with the input/output tokens that the LLM provider reported. Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals.
+Pinchy writes a usage record whenever an LLM call completes — both for chat turns (captured by a background poller that reads OpenClaw session snapshots) and for plugin-internal LLM calls (reported directly by the plugin). Each record carries the input/output tokens the provider reported. Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals.
 
 A few honest caveats:
 

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -9,6 +9,7 @@ import { PdfCache } from "./pdf-cache";
 import { createVisionConfig, type VisionApiConfig } from "./pdf-vision-api";
 import { runVisionTasks, type AggregatedVisionUsage } from "./pdf-vision-runner";
 import { reportUsage } from "./usage-reporter";
+import { resolveAgentInfo } from "./resolve-agent-info";
 
 interface PluginToolContext {
   agentId?: string;
@@ -260,19 +261,20 @@ const plugin = {
 
               // PDF detection
               if (isPdf) {
-                // Build vision config from runtime APIs
+                // Resolve agent name + model from OpenClaw config in one walk.
+                // The model drives vision API calls; the name makes rows on
+                // the Usage Dashboard readable (agentId alone is opaque).
                 let visionConfig: VisionApiConfig | null = null;
+                let resolvedAgentName: string | undefined;
                 if (modelAuth && loadConfig) {
                   const cfg = loadConfig();
-                  const agents = (cfg as any)?.agents?.list as Array<{ id: string; model: string }> | undefined;
-                  const agentModel = agents?.find(
-                    (a) => a.id === agentId
-                  )?.model;
-                  if (agentModel) {
+                  const agentInfo = resolveAgentInfo(cfg, agentId);
+                  resolvedAgentName = agentInfo.name;
+                  if (agentInfo.model) {
                     visionConfig = createVisionConfig({
                       modelAuth,
                       cfg,
-                      model: agentModel,
+                      model: agentInfo.model,
                     });
                   }
                 }
@@ -286,7 +288,7 @@ const plugin = {
                   void reportUsage(
                     {
                       agentId,
-                      agentName: agentId,
+                      agentName: resolvedAgentName ?? agentId,
                       sessionKey: "plugin:pinchy-files",
                       model: visionConfig.model,
                       inputTokens: pdfResult.visionUsage.inputTokens,

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -6,7 +6,8 @@ import { validateAccess, MAX_FILE_SIZE, MAX_PDF_FILE_SIZE, type AgentFileConfig 
 import { extractPdfText } from "./pdf-extract";
 import { formatPdfResult } from "./pdf-format";
 import { PdfCache } from "./pdf-cache";
-import { createVisionConfig, describePageImage, type VisionApiConfig } from "./pdf-vision-api";
+import { createVisionConfig, type VisionApiConfig } from "./pdf-vision-api";
+import { runVisionTasks, type AggregatedVisionUsage } from "./pdf-vision-runner";
 
 interface PluginToolContext {
   agentId?: string;
@@ -70,13 +71,14 @@ async function readPdf(
   realPath: string,
   stats: { size: number; mtimeMs: number },
   visionConfig: VisionApiConfig | null,
-): Promise<{ content: ContentBlock[] }> {
+): Promise<{ content: ContentBlock[]; visionUsage: AggregatedVisionUsage }> {
   const pdfCache = getCache();
+  const zeroUsage: AggregatedVisionUsage = { inputTokens: 0, outputTokens: 0 };
 
   // Fast path: check cache with just size+mtime (no file read needed)
   const cachedFast = pdfCache.getFast(realPath, stats.size, stats.mtimeMs);
   if (cachedFast) {
-    return { content: [{ type: "text", text: cachedFast }] };
+    return { content: [{ type: "text", text: cachedFast }], visionUsage: zeroUsage };
   }
 
   // Cache miss or mtime changed — read file and compute hash
@@ -87,54 +89,17 @@ async function readPdf(
   const cachedSlow = pdfCache.getByHash(realPath, contentHash);
   if (cachedSlow) {
     pdfCache.updateMtime(realPath, stats.mtimeMs);
-    return { content: [{ type: "text", text: cachedSlow }] };
+    return { content: [{ type: "text", text: cachedSlow }], visionUsage: zeroUsage };
   }
 
   const extraction = await extractPdfText(fileBuffer);
 
   // Call the LLM vision API for scanned pages and embedded images.
-  // All calls run in parallel for maximum speed.
+  // All calls run in parallel for maximum speed and their token usage is
+  // aggregated so the caller can report it to the usage dashboard.
+  let visionUsage: AggregatedVisionUsage = zeroUsage;
   if (visionConfig) {
-    const visionTasks: Promise<void>[] = [];
-
-    // Scanned pages: render → vision API → replace text
-    for (const page of extraction.pages) {
-      if (page.isScanned && page.renderedImage) {
-        visionTasks.push(
-          (async () => {
-            const imageBase64 = page.renderedImage!.toString("base64");
-            page.renderedImage = undefined;
-            const extractedText = await describePageImage(imageBase64, visionConfig);
-            if (extractedText) {
-              page.text = extractedText;
-              page.isScanned = false;
-            }
-          })(),
-        );
-      }
-
-      // Embedded images: describe each and append [Figure: ...] to page text
-      for (const img of page.embeddedImages) {
-        visionTasks.push(
-          (async () => {
-            const imageBase64 = img.data.toString("base64");
-            const description = await describePageImage(imageBase64, visionConfig);
-            if (description) {
-              page.text += `\n\n[Figure: ${description}]`;
-            }
-          })(),
-        );
-      }
-    }
-
-    if (visionTasks.length > 0) {
-      const results = await Promise.allSettled(visionTasks);
-      for (const result of results) {
-        if (result.status === "rejected") {
-          console.error("[pinchy-files] Vision API failed:", result.reason);
-        }
-      }
-    }
+    visionUsage = await runVisionTasks(extraction.pages, visionConfig);
 
     // Free embedded image data after vision processing
     for (const page of extraction.pages) {
@@ -152,7 +117,7 @@ async function readPdf(
     pdfCache.set(realPath, stats.size, stats.mtimeMs, contentHash, formatted);
   }
 
-  return { content: [{ type: "text", text: formatted }] };
+  return { content: [{ type: "text", text: formatted }], visionUsage };
 }
 
 const plugin = {
@@ -306,7 +271,12 @@ const plugin = {
                     });
                   }
                 }
-                return await readPdf(realPath, stats, visionConfig);
+                const pdfResult = await readPdf(realPath, stats, visionConfig);
+                // visionUsage is captured here so Task 8 can report it to
+                // Pinchy's internal usage endpoint. Return only content
+                // to the OpenClaw tool runner.
+                void pdfResult.visionUsage;
+                return { content: pdfResult.content };
               }
 
               // Non-PDF: existing behavior

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -8,6 +8,7 @@ import { formatPdfResult } from "./pdf-format";
 import { PdfCache } from "./pdf-cache";
 import { createVisionConfig, type VisionApiConfig } from "./pdf-vision-api";
 import { runVisionTasks, type AggregatedVisionUsage } from "./pdf-vision-runner";
+import { reportUsage } from "./usage-reporter";
 
 interface PluginToolContext {
   agentId?: string;
@@ -21,6 +22,8 @@ interface ContentBlock {
 interface PluginApi {
   pluginConfig?: {
     agents?: Record<string, AgentFileConfig>;
+    apiBaseUrl?: string;
+    gatewayToken?: string;
   };
   registerTool: (
     factory: (ctx: PluginToolContext) => AgentTool | null,
@@ -135,6 +138,8 @@ const plugin = {
 
   register(api: PluginApi) {
     const agentConfigs = api.pluginConfig?.agents ?? {};
+    const apiBaseUrl = api.pluginConfig?.apiBaseUrl;
+    const gatewayToken = api.pluginConfig?.gatewayToken;
 
     // Capture runtime APIs for vision (direct LLM API calls for scanned pages)
     const modelAuth = (api as any).runtime?.modelAuth as {
@@ -272,10 +277,25 @@ const plugin = {
                   }
                 }
                 const pdfResult = await readPdf(realPath, stats, visionConfig);
-                // visionUsage is captured here so Task 8 can report it to
-                // Pinchy's internal usage endpoint. Return only content
-                // to the OpenClaw tool runner.
-                void pdfResult.visionUsage;
+
+                // Fire-and-forget: report any vision API tokens to Pinchy's
+                // internal usage endpoint so they show up on the Usage
+                // Dashboard. We intentionally do not await — telemetry must
+                // never block or fail a PDF read.
+                if (apiBaseUrl && gatewayToken && visionConfig) {
+                  void reportUsage(
+                    {
+                      agentId,
+                      agentName: agentId,
+                      sessionKey: "plugin:pinchy-files",
+                      model: visionConfig.model,
+                      inputTokens: pdfResult.visionUsage.inputTokens,
+                      outputTokens: pdfResult.visionUsage.outputTokens,
+                    },
+                    { apiBaseUrl, gatewayToken },
+                  );
+                }
+
                 return { content: pdfResult.content };
               }
 

--- a/packages/plugins/pinchy-files/pdf-vision-api.test.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.test.ts
@@ -21,7 +21,7 @@ describe("describePageImage", () => {
       resolveApiKey: async () => "test-key",
     });
 
-    expect(result).toBe("Extracted text from page");
+    expect(result?.text).toBe("Extracted text from page");
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "https://api.anthropic.com/v1/messages",
       expect.objectContaining({ method: "POST" }),
@@ -82,7 +82,7 @@ describe("describePageImage", () => {
       resolveApiKey: async () => "test-key",
     });
 
-    expect(result).toBe("Extracted after retry");
+    expect(result?.text).toBe("Extracted after retry");
     expect(mockFetch).toHaveBeenCalledTimes(2);
   });
 
@@ -116,7 +116,7 @@ describe("describePageImage", () => {
       resolveApiKey: async () => "test-key",
     });
 
-    expect(result).toBe("OpenAI extracted text");
+    expect(result?.text).toBe("OpenAI extracted text");
     expect(globalThis.fetch).toHaveBeenCalledWith(
       "https://api.openai.com/v1/chat/completions",
       expect.objectContaining({ method: "POST" }),
@@ -136,7 +136,7 @@ describe("describePageImage", () => {
       resolveApiKey: async () => "test-key",
     });
 
-    expect(result).toBe("Google extracted text");
+    expect(result?.text).toBe("Google extracted text");
     expect(globalThis.fetch).toHaveBeenCalledWith(
       expect.stringContaining("generativelanguage.googleapis.com"),
       expect.objectContaining({ method: "POST" }),
@@ -167,7 +167,7 @@ describe("describePageImage", () => {
         resolveApiKey: async () => null,
       });
 
-      expect(result).toBe("Extracted text from scanned page");
+      expect(result?.text).toBe("Extracted text from scanned page");
       expect(globalThis.fetch).toHaveBeenCalledWith(
         "http://localhost:11434/v1/chat/completions",
         expect.objectContaining({
@@ -220,6 +220,115 @@ describe("describePageImage", () => {
       });
       expect(result).toBeNull();
       expect(globalThis.fetch).not.toHaveBeenCalled();
+    });
+  });
+});
+
+describe("describePageImage usage extraction", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("returns usage tokens from Anthropic response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "Extracted text" }],
+        usage: { input_tokens: 1234, output_tokens: 56 },
+      }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "anthropic/claude-haiku-4-5-20251001",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result).toEqual({
+      text: "Extracted text",
+      usage: { inputTokens: 1234, outputTokens: 56 },
+    });
+  });
+
+  it("returns usage tokens from OpenAI response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "OpenAI text" } }],
+        usage: { prompt_tokens: 900, completion_tokens: 42 },
+      }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "openai/gpt-4o",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result).toEqual({
+      text: "OpenAI text",
+      usage: { inputTokens: 900, outputTokens: 42 },
+    });
+  });
+
+  it("returns usage tokens from Google response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "Google text" }] } }],
+        usageMetadata: { promptTokenCount: 500, candidatesTokenCount: 70 },
+      }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "google/gemini-2.5-flash",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result).toEqual({
+      text: "Google text",
+      usage: { inputTokens: 500, outputTokens: 70 },
+    });
+  });
+
+  it("returns usage tokens from Ollama response", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        choices: [{ message: { content: "Ollama text" } }],
+        usage: { prompt_tokens: 300, completion_tokens: 20 },
+      }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "ollama/llava:7b",
+      ollamaBaseUrl: "http://localhost:11434",
+      resolveApiKey: async () => null,
+    });
+
+    expect(result).toEqual({
+      text: "Ollama text",
+      usage: { inputTokens: 300, outputTokens: 20 },
+    });
+  });
+
+  it("defaults usage to zero when provider omits usage field", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "No usage provided" }],
+        // no usage field
+      }),
+    });
+
+    const result = await describePageImage("base64data", {
+      model: "anthropic/claude-haiku-4-5-20251001",
+      resolveApiKey: async () => "test-key",
+    });
+
+    expect(result).toEqual({
+      text: "No usage provided",
+      usage: { inputTokens: 0, outputTokens: 0 },
     });
   });
 });

--- a/packages/plugins/pinchy-files/pdf-vision-api.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-api.ts
@@ -38,6 +38,18 @@ export interface VisionApiInternalConfig {
   model: string;
 }
 
+/** Token usage returned from a vision API call. */
+export interface VisionUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+/** Result of a successful vision API call: extracted text plus token usage. */
+export interface VisionResult {
+  text: string;
+  usage: VisionUsage;
+}
+
 /** Validate model ID to prevent URL injection (e.g. path traversal in Google API URL). */
 function validateModelId(modelId: string): void {
   if (!modelId || /\.\./.test(modelId) || !/^[a-zA-Z0-9._:/-]+$/.test(modelId)) {
@@ -47,12 +59,12 @@ function validateModelId(modelId: string): void {
 
 /**
  * Describe a scanned page image using the configured LLM's vision API.
- * Returns extracted text, or null if vision is not available.
+ * Returns extracted text plus token usage, or null if vision is not available.
  */
 export async function describePageImage(
   imageBase64: string,
   config: VisionApiConfig,
-): Promise<string | null> {
+): Promise<VisionResult | null> {
   const [provider, ...modelParts] = config.model.split("/");
   const modelId = modelParts.join("/");
   validateModelId(modelId);
@@ -101,7 +113,7 @@ async function describeViaAnthropic(
   imageBase64: string,
   modelId: string,
   config: VisionApiConfig,
-): Promise<string | null> {
+): Promise<VisionResult | null> {
   const apiKey = await config.resolveApiKey("anthropic");
   if (!apiKey) return null;
 
@@ -142,20 +154,28 @@ async function describeViaAnthropic(
 
   const data = (await response.json()) as {
     content: Array<{ type: string; text?: string }>;
+    usage?: { input_tokens?: number; output_tokens?: number };
   };
-  return (
+  const text =
     data.content
       ?.filter((b) => b.type === "text" && b.text)
       .map((b) => b.text)
-      .join("\n") ?? null
-  );
+      .join("\n") ?? null;
+  if (text === null) return null;
+  return {
+    text,
+    usage: {
+      inputTokens: data.usage?.input_tokens ?? 0,
+      outputTokens: data.usage?.output_tokens ?? 0,
+    },
+  };
 }
 
 async function describeViaOpenAI(
   imageBase64: string,
   modelId: string,
   config: VisionApiConfig,
-): Promise<string | null> {
+): Promise<VisionResult | null> {
   const apiKey = await config.resolveApiKey("openai");
   if (!apiKey) return null;
 
@@ -191,15 +211,24 @@ async function describeViaOpenAI(
 
   const data = (await response.json()) as {
     choices: Array<{ message: { content: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
   };
-  return data.choices?.[0]?.message?.content ?? null;
+  const text = data.choices?.[0]?.message?.content ?? null;
+  if (text === null) return null;
+  return {
+    text,
+    usage: {
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+    },
+  };
 }
 
 async function describeViaGoogle(
   imageBase64: string,
   modelId: string,
   config: VisionApiConfig,
-): Promise<string | null> {
+): Promise<VisionResult | null> {
   const apiKey = await config.resolveApiKey("google");
   if (!apiKey) return null;
 
@@ -234,20 +263,28 @@ async function describeViaGoogle(
 
   const data = (await response.json()) as {
     candidates: Array<{ content: { parts: Array<{ text?: string }> } }>;
+    usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
   };
-  return (
+  const text =
     data.candidates?.[0]?.content?.parts
       ?.filter((p) => p.text)
       .map((p) => p.text)
-      .join("\n") ?? null
-  );
+      .join("\n") ?? null;
+  if (text === null) return null;
+  return {
+    text,
+    usage: {
+      inputTokens: data.usageMetadata?.promptTokenCount ?? 0,
+      outputTokens: data.usageMetadata?.candidatesTokenCount ?? 0,
+    },
+  };
 }
 
 async function describeViaOllama(
   imageBase64: string,
   modelId: string,
   config: VisionApiConfig,
-): Promise<string | null> {
+): Promise<VisionResult | null> {
   if (!config.ollamaBaseUrl) return null;
 
   const url = `${config.ollamaBaseUrl.replace(/\/$/, "")}/v1/chat/completions`;
@@ -280,6 +317,15 @@ async function describeViaOllama(
 
   const data = (await response.json()) as {
     choices: Array<{ message: { content: string } }>;
+    usage?: { prompt_tokens?: number; completion_tokens?: number };
   };
-  return data.choices?.[0]?.message?.content ?? null;
+  const text = data.choices?.[0]?.message?.content ?? null;
+  if (text === null) return null;
+  return {
+    text,
+    usage: {
+      inputTokens: data.usage?.prompt_tokens ?? 0,
+      outputTokens: data.usage?.completion_tokens ?? 0,
+    },
+  };
 }

--- a/packages/plugins/pinchy-files/pdf-vision-runner.test.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-runner.test.ts
@@ -1,0 +1,154 @@
+import { describe, it, expect, vi } from "vitest";
+import { runVisionTasks, type VisionRunnerPage } from "./pdf-vision-runner";
+import type { VisionApiConfig } from "./pdf-vision-api";
+
+function makeConfig(overrides: Partial<VisionApiConfig> = {}): VisionApiConfig {
+  return {
+    model: "anthropic/claude-haiku-4-5-20251001",
+    resolveApiKey: async () => "test-key",
+    ...overrides,
+  };
+}
+
+describe("runVisionTasks", () => {
+  it("returns zero usage when no pages need vision", async () => {
+    const pages: VisionRunnerPage[] = [
+      { text: "plain text", isScanned: false, embeddedImages: [] },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    expect(result).toEqual({ inputTokens: 0, outputTokens: 0 });
+  });
+
+  it("runs vision for each scanned page and aggregates usage", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "scanned page text" }],
+        usage: { input_tokens: 100, output_tokens: 20 },
+      }),
+    });
+
+    const pages: VisionRunnerPage[] = [
+      {
+        text: "",
+        isScanned: true,
+        renderedImage: Buffer.from("fake-image-1"),
+        embeddedImages: [],
+      },
+      {
+        text: "",
+        isScanned: true,
+        renderedImage: Buffer.from("fake-image-2"),
+        embeddedImages: [],
+      },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    expect(result).toEqual({ inputTokens: 200, outputTokens: 40 });
+    expect(pages[0]?.text).toBe("scanned page text");
+    expect(pages[0]?.isScanned).toBe(false);
+    expect(pages[1]?.text).toBe("scanned page text");
+    expect(pages[1]?.isScanned).toBe(false);
+  });
+
+  it("appends figure descriptions to page text and aggregates usage", async () => {
+    globalThis.fetch = vi
+      .fn()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "Description of figure A" }],
+          usage: { input_tokens: 50, output_tokens: 10 },
+        }),
+      })
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({
+          content: [{ type: "text", text: "Description of figure B" }],
+          usage: { input_tokens: 60, output_tokens: 15 },
+        }),
+      });
+
+    const pages: VisionRunnerPage[] = [
+      {
+        text: "Page with figures.",
+        isScanned: false,
+        embeddedImages: [
+          { data: Buffer.from("img-a") },
+          { data: Buffer.from("img-b") },
+        ],
+      },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    expect(result).toEqual({ inputTokens: 110, outputTokens: 25 });
+    expect(pages[0]?.text).toContain("Page with figures.");
+    expect(pages[0]?.text).toContain("[Figure: Description of figure A]");
+    expect(pages[0]?.text).toContain("[Figure: Description of figure B]");
+  });
+
+  it("combines scanned pages and embedded images in a single aggregated total", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        content: [{ type: "text", text: "ok" }],
+        usage: { input_tokens: 10, output_tokens: 2 },
+      }),
+    });
+
+    const pages: VisionRunnerPage[] = [
+      {
+        text: "",
+        isScanned: true,
+        renderedImage: Buffer.from("scan"),
+        embeddedImages: [{ data: Buffer.from("fig") }],
+      },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    // 2 vision calls × (10 input, 2 output) = 20 / 4
+    expect(result).toEqual({ inputTokens: 20, outputTokens: 4 });
+  });
+
+  it("ignores scanned pages without a rendered image", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+
+    const pages: VisionRunnerPage[] = [
+      { text: "", isScanned: true, embeddedImages: [] },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    expect(result).toEqual({ inputTokens: 0, outputTokens: 0 });
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("treats failed vision calls as zero usage without throwing", async () => {
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "error",
+    });
+
+    const pages: VisionRunnerPage[] = [
+      {
+        text: "",
+        isScanned: true,
+        renderedImage: Buffer.from("scan"),
+        embeddedImages: [],
+      },
+    ];
+
+    const result = await runVisionTasks(pages, makeConfig());
+
+    expect(result).toEqual({ inputTokens: 0, outputTokens: 0 });
+    // Scanned flag stays true because vision failed → caller must not cache
+    expect(pages[0]?.isScanned).toBe(true);
+  });
+});

--- a/packages/plugins/pinchy-files/pdf-vision-runner.ts
+++ b/packages/plugins/pinchy-files/pdf-vision-runner.ts
@@ -1,0 +1,80 @@
+/**
+ * Vision orchestration for PDF pages: runs vision API calls for every scanned
+ * page and every embedded image in parallel, mutates the page objects with
+ * extracted text, and returns the aggregated token usage across all calls.
+ *
+ * Kept in its own module so it can be unit-tested in isolation from
+ * pdf-extract/pdf-cache (which require native dependencies).
+ */
+import { describePageImage, type VisionApiConfig } from "./pdf-vision-api";
+
+export interface VisionRunnerEmbeddedImage {
+  data: Buffer;
+}
+
+export interface VisionRunnerPage {
+  text: string;
+  isScanned: boolean;
+  renderedImage?: Buffer;
+  embeddedImages: VisionRunnerEmbeddedImage[];
+}
+
+export interface AggregatedVisionUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export async function runVisionTasks(
+  pages: VisionRunnerPage[],
+  visionConfig: VisionApiConfig,
+): Promise<AggregatedVisionUsage> {
+  let inputTokens = 0;
+  let outputTokens = 0;
+
+  const tasks: Promise<void>[] = [];
+
+  for (const page of pages) {
+    // Scanned pages: render → vision API → replace text
+    if (page.isScanned && page.renderedImage) {
+      tasks.push(
+        (async () => {
+          const imageBase64 = page.renderedImage!.toString("base64");
+          page.renderedImage = undefined;
+          const visionResult = await describePageImage(imageBase64, visionConfig);
+          if (visionResult) {
+            page.text = visionResult.text;
+            page.isScanned = false;
+            inputTokens += visionResult.usage.inputTokens;
+            outputTokens += visionResult.usage.outputTokens;
+          }
+        })(),
+      );
+    }
+
+    // Embedded images: describe each and append [Figure: ...] to page text
+    for (const img of page.embeddedImages) {
+      tasks.push(
+        (async () => {
+          const imageBase64 = img.data.toString("base64");
+          const visionResult = await describePageImage(imageBase64, visionConfig);
+          if (visionResult) {
+            page.text += `\n\n[Figure: ${visionResult.text}]`;
+            inputTokens += visionResult.usage.inputTokens;
+            outputTokens += visionResult.usage.outputTokens;
+          }
+        })(),
+      );
+    }
+  }
+
+  if (tasks.length > 0) {
+    const results = await Promise.allSettled(tasks);
+    for (const result of results) {
+      if (result.status === "rejected") {
+        console.error("[pinchy-files] Vision API failed:", result.reason);
+      }
+    }
+  }
+
+  return { inputTokens, outputTokens };
+}

--- a/packages/plugins/pinchy-files/resolve-agent-info.test.ts
+++ b/packages/plugins/pinchy-files/resolve-agent-info.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect } from "vitest";
+import { resolveAgentInfo } from "./resolve-agent-info";
+
+describe("resolveAgentInfo", () => {
+  it("returns both name and model when the agent exists in the config", () => {
+    // The plugin needs BOTH name and model from the same cfg walk: the model
+    // drives vision API calls, the name makes the Usage Dashboard readable
+    // (without it, rows just show the opaque agent ID).
+    const cfg = {
+      agents: {
+        list: [
+          {
+            id: "agent-1",
+            name: "Knowledge Base",
+            model: "anthropic/claude-haiku-4-5-20251001",
+          },
+        ],
+      },
+    };
+
+    expect(resolveAgentInfo(cfg, "agent-1")).toEqual({
+      name: "Knowledge Base",
+      model: "anthropic/claude-haiku-4-5-20251001",
+    });
+  });
+
+  it("returns undefined fields when the agent is not in the list", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "other-agent", name: "Other", model: "some-model" }],
+      },
+    };
+
+    expect(resolveAgentInfo(cfg, "agent-1")).toEqual({
+      name: undefined,
+      model: undefined,
+    });
+  });
+
+  it("returns undefined fields when cfg has no agents at all", () => {
+    expect(resolveAgentInfo({}, "agent-1")).toEqual({
+      name: undefined,
+      model: undefined,
+    });
+  });
+
+  it("returns undefined fields when cfg is null or undefined", () => {
+    expect(resolveAgentInfo(null, "agent-1")).toEqual({
+      name: undefined,
+      model: undefined,
+    });
+    expect(resolveAgentInfo(undefined, "agent-1")).toEqual({
+      name: undefined,
+      model: undefined,
+    });
+  });
+
+  it("returns only name when model is missing on the matched agent", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "agent-1", name: "Knowledge Base" }],
+      },
+    };
+
+    expect(resolveAgentInfo(cfg, "agent-1")).toEqual({
+      name: "Knowledge Base",
+      model: undefined,
+    });
+  });
+
+  it("returns only model when name is missing on the matched agent", () => {
+    const cfg = {
+      agents: {
+        list: [{ id: "agent-1", model: "anthropic/claude-haiku-4-5-20251001" }],
+      },
+    };
+
+    expect(resolveAgentInfo(cfg, "agent-1")).toEqual({
+      name: undefined,
+      model: "anthropic/claude-haiku-4-5-20251001",
+    });
+  });
+});

--- a/packages/plugins/pinchy-files/resolve-agent-info.ts
+++ b/packages/plugins/pinchy-files/resolve-agent-info.ts
@@ -1,0 +1,24 @@
+/**
+ * Looks up an agent's `name` and `model` from the OpenClaw runtime config
+ * (`cfg.agents.list`).
+ *
+ * Used by the plugin at two different call sites — the vision API needs the
+ * model, the usage reporter needs a human-readable name for the Usage
+ * Dashboard. Doing both resolutions in one place prevents drift (e.g. name
+ * falling back to the ID while model is correctly resolved).
+ *
+ * Returns `undefined` for any field that isn't present so callers can decide
+ * on their own fallback (`name ?? agentId`, `model ?? undefined`, etc.).
+ */
+export function resolveAgentInfo(
+  cfg: unknown,
+  agentId: string
+): { name?: string; model?: string } {
+  const agents = (cfg as { agents?: { list?: Array<{ id?: string; name?: string; model?: string }> } } | null)
+    ?.agents?.list;
+  const agent = agents?.find((a) => a.id === agentId);
+  return {
+    name: agent?.name,
+    model: agent?.model,
+  };
+}

--- a/packages/plugins/pinchy-files/usage-reporter.test.ts
+++ b/packages/plugins/pinchy-files/usage-reporter.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { reportUsage } from "./usage-reporter";
+
+describe("reportUsage", () => {
+  const originalFetch = globalThis.fetch;
+
+  afterEach(() => {
+    globalThis.fetch = originalFetch;
+  });
+
+  it("skips the POST entirely when both token counts are zero", async () => {
+    const fetchSpy = vi.fn();
+    globalThis.fetch = fetchSpy;
+
+    await reportUsage(
+      {
+        agentId: "kb-agent",
+        agentName: "KB Agent",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 0,
+        outputTokens: 0,
+      },
+      { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" },
+    );
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it("posts aggregated usage to /api/internal/usage/record with gateway bearer auth", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({ success: true }) });
+    globalThis.fetch = fetchSpy;
+
+    await reportUsage(
+      {
+        agentId: "kb-agent",
+        agentName: "KB Agent",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 1234,
+        outputTokens: 56,
+      },
+      { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://pinchy:7777/api/internal/usage/record");
+    expect(init.method).toBe("POST");
+    const headers = init.headers as Record<string, string>;
+    expect(headers["Content-Type"]).toBe("application/json");
+    expect(headers["Authorization"]).toBe("Bearer gw-token");
+
+    const body = JSON.parse(init.body as string);
+    expect(body).toEqual({
+      agentId: "kb-agent",
+      agentName: "KB Agent",
+      userId: "system",
+      sessionKey: "plugin:pinchy-files",
+      model: "anthropic/claude-haiku-4-5-20251001",
+      inputTokens: 1234,
+      outputTokens: 56,
+    });
+  });
+
+  it("strips a trailing slash from apiBaseUrl so the URL stays well-formed", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    globalThis.fetch = fetchSpy;
+
+    await reportUsage(
+      {
+        agentId: "kb-agent",
+        agentName: "KB Agent",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 1,
+        outputTokens: 1,
+      },
+      { apiBaseUrl: "http://pinchy:7777/", gatewayToken: "gw-token" },
+    );
+
+    const [url] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("http://pinchy:7777/api/internal/usage/record");
+  });
+
+  it("still POSTs when only output tokens are present", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({ ok: true, json: async () => ({}) });
+    globalThis.fetch = fetchSpy;
+
+    await reportUsage(
+      {
+        agentId: "kb-agent",
+        agentName: "KB Agent",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: 0,
+        outputTokens: 10,
+      },
+      { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" },
+    );
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("logs without throwing when the endpoint responds with a non-2xx status", async () => {
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: false,
+      status: 500,
+      text: async () => "boom",
+    });
+    globalThis.fetch = fetchSpy;
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      reportUsage(
+        {
+          agentId: "kb-agent",
+          agentName: "KB Agent",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+        { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+
+  it("swallows fetch errors so PDF reads never fail on telemetry hiccups", async () => {
+    globalThis.fetch = vi.fn().mockRejectedValue(new Error("network down"));
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    await expect(
+      reportUsage(
+        {
+          agentId: "kb-agent",
+          agentName: "KB Agent",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 10,
+          outputTokens: 5,
+        },
+        { apiBaseUrl: "http://pinchy:7777", gatewayToken: "gw-token" },
+      ),
+    ).resolves.toBeUndefined();
+
+    expect(errorSpy).toHaveBeenCalled();
+    errorSpy.mockRestore();
+  });
+});

--- a/packages/plugins/pinchy-files/usage-reporter.ts
+++ b/packages/plugins/pinchy-files/usage-reporter.ts
@@ -1,0 +1,62 @@
+/**
+ * Fire-and-forget reporter that sends aggregated vision API token usage
+ * from the pinchy-files plugin to Pinchy's internal usage endpoint.
+ *
+ * Called after a PDF read that triggered one or more vision API calls.
+ * The endpoint writes the numbers directly into the usage_records table
+ * so they show up on the Usage Dashboard alongside chat tokens.
+ *
+ * Telemetry failures must never break PDF reads, so every error is caught
+ * and logged. The caller should ignore the returned promise or use `void`.
+ */
+
+export interface UsageReport {
+  agentId: string;
+  agentName: string;
+  sessionKey: string;
+  model?: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface UsageReportConfig {
+  apiBaseUrl: string;
+  gatewayToken: string;
+}
+
+export async function reportUsage(
+  report: UsageReport,
+  config: UsageReportConfig,
+): Promise<void> {
+  if (report.inputTokens === 0 && report.outputTokens === 0) return;
+
+  const url = `${config.apiBaseUrl.replace(/\/$/, "")}/api/internal/usage/record`;
+
+  try {
+    const response = await fetch(url, {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${config.gatewayToken}`,
+      },
+      body: JSON.stringify({
+        agentId: report.agentId,
+        agentName: report.agentName,
+        userId: "system",
+        sessionKey: report.sessionKey,
+        model: report.model,
+        inputTokens: report.inputTokens,
+        outputTokens: report.outputTokens,
+      }),
+    });
+
+    if (!response.ok) {
+      const text = await response.text().catch(() => "");
+      console.error(
+        `[pinchy-files] Usage report failed (${response.status}): ${text}`,
+      );
+    }
+  } catch (err) {
+    console.error("[pinchy-files] Usage report failed:", err);
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -33,7 +33,7 @@
     "drizzle-orm": "^0.45.2",
     "jose": "^6.2.2",
     "lucide-react": "^1.7.0",
-    "next": "16.2.2",
+    "next": "16.2.3",
     "next-themes": "^0.4.6",
     "openclaw-node": "0.3.1",
     "postgres": "^3.4.8",

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -11,7 +11,8 @@ import { restartState } from "./src/server/restart-state";
 import { setOpenClawClient } from "./src/server/openclaw-client";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
 import { logCapture } from "./src/lib/log-capture";
-import { startUsagePoller } from "./src/lib/usage-poller";
+import { startUsagePoller, stopUsagePoller } from "./src/lib/usage-poller";
+import { registerShutdownHandlers } from "./src/lib/shutdown";
 
 logCapture.install();
 
@@ -241,6 +242,18 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   server.listen(port, () => {
     console.log(`Pinchy ready on http://localhost:${port}`);
   });
+
+  // Graceful shutdown: stop the usage poller interval so Node can exit,
+  // then close the HTTP server. Without this, a SIGTERM (e.g. from Docker
+  // Compose) leaves the setInterval dangling and the process hangs until
+  // the container's kill-grace period expires.
+  registerShutdownHandlers([
+    () => stopUsagePoller(),
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  ]);
 
   // Connect to OpenClaw AFTER the server is listening so health checks pass
   // immediately and the setup wizard is available without waiting for OpenClaw.

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -11,6 +11,7 @@ import { restartState } from "./src/server/restart-state";
 import { setOpenClawClient } from "./src/server/openclaw-client";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
 import { logCapture } from "./src/lib/log-capture";
+import { startUsagePoller } from "./src/lib/usage-poller";
 
 logCapture.install();
 
@@ -295,6 +296,10 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       // config file at Pinchy startup, and OpenClaw reads it on its own startup.
       // Pushing via config.patch would cause an unnecessary internal restart
       // that breaks Telegram polling (openclaw/openclaw#47458).
+
+      // Start global usage poller. Idempotent — a reconnect won't spawn a
+      // second poller. The poller handles sessions.list() failures gracefully.
+      startUsagePoller(openclawClient!);
     });
 
     openclawClient.on("disconnected", () => {

--- a/packages/web/src/__tests__/api/internal-usage-record.test.ts
+++ b/packages/web/src/__tests__/api/internal-usage-record.test.ts
@@ -1,0 +1,67 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/gateway-auth", () => ({
+  validateGatewayToken: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/lib/usage-record-rate-limiter", () => ({
+  tryAcquireUsageRecordSlot: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: vi.fn().mockReturnValue({
+      values: vi.fn().mockResolvedValue(undefined),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  usageRecords: "usageRecords",
+}));
+
+import { validateGatewayToken } from "@/lib/gateway-auth";
+import { POST } from "@/app/api/internal/usage/record/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/internal/usage/record", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer gw-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+const validPayload = {
+  agentId: "a1",
+  agentName: "Bot",
+  userId: "u1",
+  sessionKey: "plugin:test",
+  inputTokens: 100,
+  outputTokens: 50,
+};
+
+describe("POST /api/internal/usage/record", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+  });
+
+  it("accepts valid payload", async () => {
+    const res = await POST(makeRequest(validPayload));
+    expect(res.status).toBe(200);
+  });
+
+  it("rejects negative inputTokens", async () => {
+    const res = await POST(makeRequest({ ...validPayload, inputTokens: -100 }));
+    expect(res.status).toBe(400);
+  });
+
+  it("rejects negative outputTokens", async () => {
+    const res = await POST(makeRequest({ ...validPayload, outputTokens: -50 }));
+    expect(res.status).toBe(400);
+  });
+});

--- a/packages/web/src/__tests__/api/internal/usage/record/route.test.ts
+++ b/packages/web/src/__tests__/api/internal/usage/record/route.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+
+vi.mock("@/lib/gateway-auth", () => ({
+  validateGatewayToken: vi.fn().mockReturnValue(true),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: (...args: unknown[]) => {
+      mockInsert(...args);
+      return { values: mockValues };
+    },
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  usageRecords: { _table: "usage_records" },
+}));
+
+import { validateGatewayToken } from "@/lib/gateway-auth";
+import { usageRecords } from "@/db/schema";
+import { POST } from "@/app/api/internal/usage/record/route";
+
+function makeRequest(body: Record<string, unknown>) {
+  return new NextRequest("http://localhost/api/internal/usage/record", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: "Bearer gw-token",
+    },
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/internal/usage/record", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    mockValues.mockResolvedValue(undefined);
+  });
+
+  it("returns 401 when gateway token is invalid", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(false);
+
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 100,
+        outputTokens: 20,
+      })
+    );
+
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when required fields are missing", async () => {
+    const res = await POST(
+      makeRequest({
+        // agentId missing
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: 100,
+        outputTokens: 20,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when token counts are not numbers", async () => {
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: "not-a-number",
+        outputTokens: 20,
+      })
+    );
+
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("inserts a usage record on a valid request", async () => {
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 123,
+        outputTokens: 45,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ success: true });
+
+    expect(mockInsert).toHaveBeenCalledWith(usageRecords);
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        inputTokens: 123,
+        outputTokens: 45,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+      })
+    );
+  });
+
+  it("allows model to be omitted", async () => {
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: 10,
+        outputTokens: 5,
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: null,
+      })
+    );
+  });
+});

--- a/packages/web/src/__tests__/api/internal/usage/record/route.test.ts
+++ b/packages/web/src/__tests__/api/internal/usage/record/route.test.ts
@@ -24,6 +24,7 @@ vi.mock("@/db/schema", () => ({
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { usageRecords } from "@/db/schema";
 import { POST } from "@/app/api/internal/usage/record/route";
+import { resetUsageRecordRateLimiterForTest } from "@/lib/usage-record-rate-limiter";
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/internal/usage/record", {
@@ -41,6 +42,7 @@ describe("POST /api/internal/usage/record", () => {
     vi.clearAllMocks();
     vi.mocked(validateGatewayToken).mockReturnValue(true);
     mockValues.mockResolvedValue(undefined);
+    resetUsageRecordRateLimiterForTest();
   });
 
   it("returns 401 when gateway token is invalid", async () => {
@@ -125,6 +127,135 @@ describe("POST /api/internal/usage/record", () => {
         cacheWriteTokens: 0,
       })
     );
+  });
+
+  it("rejects with 429 once the per-minute rate limit is exceeded", async () => {
+    // Defense-in-depth: even behind a gateway token, the endpoint should
+    // refuse to accept unbounded writes. A runaway plugin or a leaked token
+    // must not be able to flood usage_records at line-rate. The limit is
+    // generous enough for legitimate plugin traffic (many PDF vision calls
+    // at once), but still bounded.
+    const RATE_LIMIT_MAX = 300;
+
+    // Send RATE_LIMIT_MAX successful requests first
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      const res = await POST(
+        makeRequest({
+          agentId: "agent-1",
+          agentName: "Smithers",
+          userId: "system",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 1,
+          outputTokens: 1,
+        })
+      );
+      expect(res.status).toBe(200);
+    }
+
+    // The next one must be rejected
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: 1,
+        outputTokens: 1,
+      })
+    );
+
+    expect(res.status).toBe(429);
+    // Rate-limited requests must NOT hit the DB
+    expect(mockInsert).toHaveBeenCalledTimes(RATE_LIMIT_MAX);
+  });
+
+  it("allows requests again after the rate-limit window expires", async () => {
+    // Drive time forward via a fake clock so the test doesn't block on real
+    // time. Reset the limiter, burn through the limit, advance past the
+    // window, then confirm we can write again.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date("2026-04-11T12:00:00Z"));
+
+    try {
+      resetUsageRecordRateLimiterForTest();
+      const RATE_LIMIT_MAX = 300;
+
+      for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+        await POST(
+          makeRequest({
+            agentId: "agent-1",
+            agentName: "Smithers",
+            userId: "system",
+            sessionKey: "plugin:pinchy-files",
+            inputTokens: 1,
+            outputTokens: 1,
+          })
+        );
+      }
+
+      // At the limit — this call is blocked
+      const blocked = await POST(
+        makeRequest({
+          agentId: "agent-1",
+          agentName: "Smithers",
+          userId: "system",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 1,
+          outputTokens: 1,
+        })
+      );
+      expect(blocked.status).toBe(429);
+
+      // Advance past the 1-minute window
+      vi.setSystemTime(new Date("2026-04-11T12:01:01Z"));
+
+      const allowed = await POST(
+        makeRequest({
+          agentId: "agent-1",
+          agentName: "Smithers",
+          userId: "system",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 1,
+          outputTokens: 1,
+        })
+      );
+      expect(allowed.status).toBe(200);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("counts unauthorized (401) requests toward the rate limit to block brute-force token guessing", async () => {
+    // Without this, an attacker could guess gateway tokens at line rate.
+    // The rate limit must apply BEFORE the token check.
+    vi.mocked(validateGatewayToken).mockReturnValue(false);
+    const RATE_LIMIT_MAX = 300;
+
+    for (let i = 0; i < RATE_LIMIT_MAX; i++) {
+      const res = await POST(
+        makeRequest({
+          agentId: "agent-1",
+          agentName: "Smithers",
+          userId: "system",
+          sessionKey: "plugin:pinchy-files",
+          inputTokens: 1,
+          outputTokens: 1,
+        })
+      );
+      expect(res.status).toBe(401);
+    }
+
+    const res = await POST(
+      makeRequest({
+        agentId: "agent-1",
+        agentName: "Smithers",
+        userId: "system",
+        sessionKey: "plugin:pinchy-files",
+        inputTokens: 1,
+        outputTokens: 1,
+      })
+    );
+    expect(res.status).toBe(429);
   });
 
   it("allows model to be omitted", async () => {

--- a/packages/web/src/__tests__/api/usage-summary.test.ts
+++ b/packages/web/src/__tests__/api/usage-summary.test.ts
@@ -35,6 +35,14 @@ vi.mock("drizzle-orm", () => ({
   gte: vi.fn((col, val) => ({ col, val, op: "gte" })),
   eq: vi.fn((col, val) => ({ col, val })),
   and: vi.fn((...args) => args),
+  sql: Object.assign(
+    vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+      __sql: true,
+      strings,
+      values,
+    })),
+    { raw: vi.fn() }
+  ),
 }));
 
 import { requireAdmin } from "@/lib/api-auth";
@@ -73,6 +81,9 @@ describe("GET /api/usage/summary", () => {
     mockSelect.mockReturnValue({ from: mockFrom });
     mockFrom.mockReturnValue({ where: mockWhere });
     mockWhere.mockReturnValue({ groupBy: mockGroupBy });
+    // Default for the source-breakdown query (second groupBy call).
+    // Tests that care about the totals override with mockResolvedValueOnce.
+    mockGroupBy.mockResolvedValue([]);
 
     const mod = await import("@/app/api/usage/summary/route");
     GET = mod.GET;
@@ -198,5 +209,101 @@ describe("GET /api/usage/summary", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.agents).toEqual([]);
+  });
+
+  describe("source breakdown (totals)", () => {
+    it("returns totals split into chat/system/plugin based on sessionKey", async () => {
+      mockGroupBy.mockResolvedValueOnce(sampleAgents).mockResolvedValueOnce([
+        {
+          source: "chat",
+          inputTokens: "5000",
+          outputTokens: "2000",
+          cost: "0.045000",
+        },
+        {
+          source: "system",
+          inputTokens: "1000",
+          outputTokens: "500",
+          cost: "0.010000",
+        },
+        {
+          source: "plugin",
+          inputTokens: "2000",
+          outputTokens: "300",
+          cost: "0.015000",
+        },
+      ]);
+
+      const request = new NextRequest("http://localhost:7777/api/usage/summary");
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.totals).toEqual({
+        chat: {
+          inputTokens: "5000",
+          outputTokens: "2000",
+          cost: "0.045000",
+        },
+        system: {
+          inputTokens: "1000",
+          outputTokens: "500",
+          cost: "0.010000",
+        },
+        plugin: {
+          inputTokens: "2000",
+          outputTokens: "300",
+          cost: "0.015000",
+        },
+      });
+    });
+
+    it("defaults missing sources to zero tokens/cost", async () => {
+      // Only chat tokens exist — system and plugin should be zero
+      mockGroupBy.mockResolvedValueOnce(sampleAgents).mockResolvedValueOnce([
+        {
+          source: "chat",
+          inputTokens: "5000",
+          outputTokens: "2000",
+          cost: "0.045000",
+        },
+      ]);
+
+      const request = new NextRequest("http://localhost:7777/api/usage/summary");
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.totals.chat).toEqual({
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cost: "0.045000",
+      });
+      expect(body.totals.system).toEqual({
+        inputTokens: "0",
+        outputTokens: "0",
+        cost: "0",
+      });
+      expect(body.totals.plugin).toEqual({
+        inputTokens: "0",
+        outputTokens: "0",
+        cost: "0",
+      });
+    });
+
+    it("returns all-zero totals when there are no records at all", async () => {
+      mockGroupBy.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
+
+      const request = new NextRequest("http://localhost:7777/api/usage/summary");
+      const response = await GET(request);
+
+      expect(response.status).toBe(200);
+      const body = await response.json();
+      expect(body.totals).toEqual({
+        chat: { inputTokens: "0", outputTokens: "0", cost: "0" },
+        system: { inputTokens: "0", outputTokens: "0", cost: "0" },
+        plugin: { inputTokens: "0", outputTokens: "0", cost: "0" },
+      });
+    });
   });
 });

--- a/packages/web/src/__tests__/api/usage-summary.test.ts
+++ b/packages/web/src/__tests__/api/usage-summary.test.ts
@@ -7,10 +7,11 @@ vi.mock("@/lib/api-auth", () => ({
   requireAdmin: vi.fn(),
 }));
 
-// Build chainable mock: select().from().where().groupBy()
+// Build chainable mock: select().from().leftJoin().where().groupBy()
 const mockGroupBy = vi.fn();
 const mockWhere = vi.fn().mockReturnValue({ groupBy: mockGroupBy });
-const mockFrom = vi.fn().mockReturnValue({ where: mockWhere });
+const mockLeftJoin = vi.fn().mockReturnValue({ where: mockWhere });
+const mockFrom = vi.fn().mockReturnValue({ leftJoin: mockLeftJoin, where: mockWhere });
 
 const mockSelect = vi.fn().mockReturnValue({ from: mockFrom });
 
@@ -27,6 +28,10 @@ vi.mock("@/db/schema", () => ({
     estimatedCostUsd: "estimated_cost_usd",
     timestamp: "timestamp",
   },
+  agents: {
+    id: "id",
+    deletedAt: "deleted_at",
+  },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -40,6 +45,7 @@ vi.mock("drizzle-orm", () => ({
       __sql: true,
       strings,
       values,
+      as: vi.fn().mockReturnThis(),
     })),
     { raw: vi.fn() }
   ),
@@ -79,7 +85,8 @@ describe("GET /api/usage/summary", () => {
 
     // Reset chainable mock defaults
     mockSelect.mockReturnValue({ from: mockFrom });
-    mockFrom.mockReturnValue({ where: mockWhere });
+    mockFrom.mockReturnValue({ leftJoin: mockLeftJoin, where: mockWhere });
+    mockLeftJoin.mockReturnValue({ where: mockWhere });
     mockWhere.mockReturnValue({ groupBy: mockGroupBy });
     // Default for the source-breakdown query (second groupBy call).
     // Tests that care about the totals override with mockResolvedValueOnce.
@@ -209,6 +216,36 @@ describe("GET /api/usage/summary", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.agents).toEqual([]);
+  });
+
+  it("returns deleted flag for soft-deleted agents", async () => {
+    mockGroupBy.mockResolvedValueOnce([
+      {
+        agentId: "a1",
+        agentName: "Smithers",
+        totalInputTokens: "5000",
+        totalOutputTokens: "2000",
+        totalCost: "0.045000",
+        deleted: false,
+      },
+      {
+        agentId: "a2",
+        agentName: "Old Bot",
+        totalInputTokens: "3000",
+        totalOutputTokens: "1000",
+        totalCost: "0.025000",
+        deleted: true,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/summary");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.agents).toHaveLength(2);
+    expect(body.agents[0].deleted).toBe(false);
+    expect(body.agents[1].deleted).toBe(true);
   });
 
   describe("source breakdown (totals)", () => {

--- a/packages/web/src/__tests__/api/usage-summary.test.ts
+++ b/packages/web/src/__tests__/api/usage-summary.test.ts
@@ -332,14 +332,14 @@ describe("GET /api/usage/summary", () => {
         outputTokens: "0",
         cacheReadTokens: "0",
         cacheWriteTokens: "0",
-        cost: "0",
+        cost: null,
       });
       expect(body.totals.plugin).toEqual({
         inputTokens: "0",
         outputTokens: "0",
         cacheReadTokens: "0",
         cacheWriteTokens: "0",
-        cost: "0",
+        cost: null,
       });
     });
 
@@ -357,21 +357,21 @@ describe("GET /api/usage/summary", () => {
           outputTokens: "0",
           cacheReadTokens: "0",
           cacheWriteTokens: "0",
-          cost: "0",
+          cost: null,
         },
         system: {
           inputTokens: "0",
           outputTokens: "0",
           cacheReadTokens: "0",
           cacheWriteTokens: "0",
-          cost: "0",
+          cost: null,
         },
         plugin: {
           inputTokens: "0",
           outputTokens: "0",
           cacheReadTokens: "0",
           cacheWriteTokens: "0",
-          cost: "0",
+          cost: null,
         },
       });
     });
@@ -397,6 +397,29 @@ describe("GET /api/usage/summary", () => {
     const body = await response.json();
     expect(body.agents[0].totalCacheReadTokens).toBe("50000");
     expect(body.agents[0].totalCacheWriteTokens).toBe("10000");
+  });
+
+  it("preserves null cost in source breakdown when pricing is unavailable", async () => {
+    mockGroupBy.mockResolvedValueOnce(sampleAgents).mockResolvedValueOnce([
+      {
+        source: "chat",
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cacheReadTokens: null,
+        cacheWriteTokens: null,
+        cost: null,
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/summary");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.totals.chat.cost).toBeNull();
+    // Token fields should still default to "0" when null
+    expect(body.totals.chat.inputTokens).toBe("5000");
+    expect(body.totals.chat.outputTokens).toBe("2000");
   });
 
   it("includes cache tokens in source breakdown totals", async () => {

--- a/packages/web/src/__tests__/api/usage-summary.test.ts
+++ b/packages/web/src/__tests__/api/usage-summary.test.ts
@@ -25,8 +25,11 @@ vi.mock("@/db/schema", () => ({
     agentName: "agent_name",
     inputTokens: "input_tokens",
     outputTokens: "output_tokens",
+    cacheReadTokens: "cache_read_tokens",
+    cacheWriteTokens: "cache_write_tokens",
     estimatedCostUsd: "estimated_cost_usd",
     timestamp: "timestamp",
+    sessionKey: "session_key",
   },
   agents: {
     id: "id",
@@ -280,16 +283,22 @@ describe("GET /api/usage/summary", () => {
         chat: {
           inputTokens: "5000",
           outputTokens: "2000",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
           cost: "0.045000",
         },
         system: {
           inputTokens: "1000",
           outputTokens: "500",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
           cost: "0.010000",
         },
         plugin: {
           inputTokens: "2000",
           outputTokens: "300",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
           cost: "0.015000",
         },
       });
@@ -314,16 +323,22 @@ describe("GET /api/usage/summary", () => {
       expect(body.totals.chat).toEqual({
         inputTokens: "5000",
         outputTokens: "2000",
+        cacheReadTokens: "0",
+        cacheWriteTokens: "0",
         cost: "0.045000",
       });
       expect(body.totals.system).toEqual({
         inputTokens: "0",
         outputTokens: "0",
+        cacheReadTokens: "0",
+        cacheWriteTokens: "0",
         cost: "0",
       });
       expect(body.totals.plugin).toEqual({
         inputTokens: "0",
         outputTokens: "0",
+        cacheReadTokens: "0",
+        cacheWriteTokens: "0",
         cost: "0",
       });
     });
@@ -337,10 +352,74 @@ describe("GET /api/usage/summary", () => {
       expect(response.status).toBe(200);
       const body = await response.json();
       expect(body.totals).toEqual({
-        chat: { inputTokens: "0", outputTokens: "0", cost: "0" },
-        system: { inputTokens: "0", outputTokens: "0", cost: "0" },
-        plugin: { inputTokens: "0", outputTokens: "0", cost: "0" },
+        chat: {
+          inputTokens: "0",
+          outputTokens: "0",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
+          cost: "0",
+        },
+        system: {
+          inputTokens: "0",
+          outputTokens: "0",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
+          cost: "0",
+        },
+        plugin: {
+          inputTokens: "0",
+          outputTokens: "0",
+          cacheReadTokens: "0",
+          cacheWriteTokens: "0",
+          cost: "0",
+        },
       });
     });
+  });
+
+  it("returns cache token totals per agent", async () => {
+    mockGroupBy.mockResolvedValueOnce([
+      {
+        agentId: "a1",
+        agentName: "Smithers",
+        totalInputTokens: "5000",
+        totalOutputTokens: "2000",
+        totalCacheReadTokens: "50000",
+        totalCacheWriteTokens: "10000",
+        totalCost: "0.045000",
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/summary");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.agents[0].totalCacheReadTokens).toBe("50000");
+    expect(body.agents[0].totalCacheWriteTokens).toBe("10000");
+  });
+
+  it("includes cache tokens in source breakdown totals", async () => {
+    mockGroupBy.mockResolvedValueOnce(sampleAgents).mockResolvedValueOnce([
+      {
+        source: "chat",
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cacheReadTokens: "30000",
+        cacheWriteTokens: "5000",
+        cost: "0.045000",
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/summary");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.totals.chat.cacheReadTokens).toBe("30000");
+    expect(body.totals.chat.cacheWriteTokens).toBe("5000");
+    // Missing sources default to zero
+    expect(body.totals.system.cacheReadTokens).toBe("0");
+    expect(body.totals.system.cacheWriteTokens).toBe("0");
   });
 });

--- a/packages/web/src/__tests__/api/usage-timeseries.test.ts
+++ b/packages/web/src/__tests__/api/usage-timeseries.test.ts
@@ -24,6 +24,8 @@ vi.mock("@/db/schema", () => ({
     agentName: "agent_name",
     inputTokens: "input_tokens",
     outputTokens: "output_tokens",
+    cacheReadTokens: "cache_read_tokens",
+    cacheWriteTokens: "cache_write_tokens",
     estimatedCostUsd: "estimated_cost_usd",
     timestamp: "timestamp",
   },
@@ -153,5 +155,26 @@ describe("GET /api/usage/timeseries", () => {
     expect(response.status).toBe(200);
     const body = await response.json();
     expect(body.data).toEqual([]);
+  });
+
+  it("returns cache tokens per day", async () => {
+    mockOrderBy.mockResolvedValueOnce([
+      {
+        date: "2026-03-01",
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cacheReadTokens: "40000",
+        cacheWriteTokens: "8000",
+        cost: "0.045000",
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/timeseries");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data[0].cacheReadTokens).toBe("40000");
+    expect(body.data[0].cacheWriteTokens).toBe("8000");
   });
 });

--- a/packages/web/src/__tests__/api/usage-timeseries.test.ts
+++ b/packages/web/src/__tests__/api/usage-timeseries.test.ts
@@ -157,6 +157,74 @@ describe("GET /api/usage/timeseries", () => {
     expect(body.data).toEqual([]);
   });
 
+  it("zero-fills gaps between data points", async () => {
+    mockOrderBy.mockResolvedValueOnce([
+      {
+        date: "2026-03-01",
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cacheReadTokens: "1000",
+        cacheWriteTokens: "500",
+        cost: "0.045000",
+      },
+      {
+        date: "2026-03-03",
+        inputTokens: "3000",
+        outputTokens: "1000",
+        cacheReadTokens: "800",
+        cacheWriteTokens: "200",
+        cost: "0.025000",
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/timeseries");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toHaveLength(3);
+    expect(body.data[0].date).toBe("2026-03-01");
+    expect(body.data[1]).toEqual({
+      date: "2026-03-02",
+      inputTokens: "0",
+      outputTokens: "0",
+      cacheReadTokens: "0",
+      cacheWriteTokens: "0",
+      cost: null,
+    });
+    expect(body.data[2].date).toBe("2026-03-03");
+  });
+
+  it("does not add extra days beyond data range", async () => {
+    mockOrderBy.mockResolvedValueOnce([
+      {
+        date: "2026-03-01",
+        inputTokens: "5000",
+        outputTokens: "2000",
+        cacheReadTokens: "1000",
+        cacheWriteTokens: "500",
+        cost: "0.045000",
+      },
+      {
+        date: "2026-03-02",
+        inputTokens: "3000",
+        outputTokens: "1000",
+        cacheReadTokens: "800",
+        cacheWriteTokens: "200",
+        cost: "0.025000",
+      },
+    ]);
+
+    const request = new NextRequest("http://localhost:7777/api/usage/timeseries");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toHaveLength(2);
+    expect(body.data[0].date).toBe("2026-03-01");
+    expect(body.data[1].date).toBe("2026-03-02");
+  });
+
   it("returns cache tokens per day", async () => {
     mockOrderBy.mockResolvedValueOnce([
       {

--- a/packages/web/src/__tests__/api/usage-timeseries.test.ts
+++ b/packages/web/src/__tests__/api/usage-timeseries.test.ts
@@ -225,6 +225,30 @@ describe("GET /api/usage/timeseries", () => {
     expect(body.data[1].date).toBe("2026-03-02");
   });
 
+  it("accepts tz parameter", async () => {
+    mockOrderBy.mockResolvedValueOnce(sampleTimeseries);
+
+    const request = new NextRequest(
+      "http://localhost:7777/api/usage/timeseries?tz=Europe/Vienna&days=30"
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    const body = await response.json();
+    expect(body.data).toHaveLength(2);
+  });
+
+  it("rejects invalid timezone", async () => {
+    const request = new NextRequest(
+      "http://localhost:7777/api/usage/timeseries?tz=../../etc/passwd"
+    );
+    const response = await GET(request);
+
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid timezone");
+  });
+
   it("returns cache tokens per day", async () => {
     mockOrderBy.mockResolvedValueOnce([
       {

--- a/packages/web/src/__tests__/api/usage-timeseries.test.ts
+++ b/packages/web/src/__tests__/api/usage-timeseries.test.ts
@@ -31,17 +31,24 @@ vi.mock("@/db/schema", () => ({
   },
 }));
 
-vi.mock("drizzle-orm", () => ({
-  sql: vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
+vi.mock("drizzle-orm", () => {
+  const sqlFn = vi.fn((strings: TemplateStringsArray, ...values: unknown[]) => ({
     _tag: "sql",
     strings,
     values,
-  })),
-  sum: vi.fn((col) => `sum(${col})`),
-  gte: vi.fn((col, val) => ({ col, val, op: "gte" })),
-  eq: vi.fn((col, val) => ({ col, val })),
-  and: vi.fn((...args) => args),
-}));
+  }));
+  (sqlFn as unknown as Record<string, unknown>).raw = (s: string) => ({
+    _tag: "sql.raw",
+    value: s,
+  });
+  return {
+    sql: sqlFn,
+    sum: vi.fn((col) => `sum(${col})`),
+    gte: vi.fn((col, val) => ({ col, val, op: "gte" })),
+    eq: vi.fn((col, val) => ({ col, val })),
+    and: vi.fn((...args) => args),
+  };
+});
 
 import { requireAdmin } from "@/lib/api-auth";
 import { eq, gte } from "drizzle-orm";

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -142,7 +142,7 @@ describe("UsageDashboard", () => {
       expect(screen.getByText("1.6M")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("$4.82")).toBeInTheDocument();
+    expect(screen.getAllByText("$4.82").length).toBeGreaterThanOrEqual(1);
   });
 
   describe("source breakdown cards", () => {

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { UsageDashboard } from "@/components/usage-dashboard";
+import { UsageDashboard, shouldShowDots } from "@/components/usage-dashboard";
 
 // recharts uses ResponsiveContainer which needs dimensions — mock it
 vi.mock("recharts", async () => {
@@ -354,6 +354,46 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(screen.getByTestId("chart-container")).toBeInTheDocument();
+    });
+  });
+
+  it("renders chart when only one data point exists", async () => {
+    const singlePointTimeseries = {
+      data: [
+        {
+          date: "2026-03-20",
+          inputTokens: "200000",
+          outputTokens: "300000",
+          cost: "1.50",
+        },
+      ],
+    };
+    mockBothEndpoints(undefined, singlePointTimeseries);
+    render(<UsageDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Daily Token Usage")).toBeInTheDocument();
+    });
+
+    // The chart renders (not stuck in empty/loading state) with a single data point
+    expect(screen.getByTestId("chart-container")).toBeInTheDocument();
+  });
+
+  describe("shouldShowDots", () => {
+    it("returns true for zero data points", () => {
+      expect(shouldShowDots(0)).toBe(true);
+    });
+
+    it("returns true for exactly one data point", () => {
+      expect(shouldShowDots(1)).toBe(true);
+    });
+
+    it("returns false for two data points", () => {
+      expect(shouldShowDots(2)).toBe(false);
+    });
+
+    it("returns false for many data points", () => {
+      expect(shouldShowDots(30)).toBe(false);
     });
   });
 

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -216,6 +216,37 @@ describe("UsageDashboard", () => {
       expect(screen.getByText("Plugin Tokens")).toBeInTheDocument();
     });
 
+    it("hides chat card when chat tokens are zero (same rule as system/plugin cards)", async () => {
+      // The source breakdown must stay internally consistent: all three
+      // cards follow the same "hide when zero" rule. Previously Chat was
+      // always rendered, which created an empty placeholder for the
+      // (admittedly unusual) system-only / plugin-only scenarios.
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: { inputTokens: "0", outputTokens: "0", cost: "0" },
+          system: {
+            inputTokens: "50000",
+            outputTokens: "10000",
+            cost: "0.40",
+          },
+          plugin: {
+            inputTokens: "100000",
+            outputTokens: "20000",
+            cost: "0.92",
+          },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("System Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Chat Tokens")).not.toBeInTheDocument();
+      expect(screen.getByText("Plugin Tokens")).toBeInTheDocument();
+    });
+
     it("hides plugin card when plugin tokens are zero", async () => {
       mockBothEndpoints({
         agents: mockSummaryResponse.agents,

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -620,6 +620,55 @@ describe("UsageDashboard", () => {
       expect(screen.getByText("$1.05")).toBeInTheDocument();
     });
 
+    it("shows error message when by-user API fails", async () => {
+      vi.mocked(global.fetch).mockImplementation((url) => {
+        const urlStr = String(url);
+        if (urlStr.includes("/api/enterprise/status")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => ({ enterprise: true }),
+          } as Response);
+        }
+        if (urlStr.includes("/api/usage/summary")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => mockSummaryResponse,
+          } as Response);
+        }
+        if (urlStr.includes("/api/usage/timeseries")) {
+          return Promise.resolve({
+            ok: true,
+            json: async () => mockTimeseriesResponse,
+          } as Response);
+        }
+        if (urlStr.includes("/api/usage/by-user")) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+          } as Response);
+        }
+        return Promise.resolve({ ok: false, json: async () => ({}) } as Response);
+      });
+
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+      const user = userEvent.setup();
+      render(<UsageDashboard isEnterprise />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Smithers").length).toBeGreaterThan(0);
+      });
+
+      await user.click(screen.getByRole("tab", { name: "By User" }));
+
+      await waitFor(() => {
+        expect(screen.getByText(/failed to load user data/i)).toBeInTheDocument();
+      });
+      expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+
+      consoleSpy.mockRestore();
+    });
+
     it("should show 'By User' tab even when not enterprise", async () => {
       mockBothEndpoints();
       render(<UsageDashboard />);

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -452,6 +452,57 @@ describe("UsageDashboard", () => {
     });
   });
 
+  it("displays cache tokens column in agent table and summary card", async () => {
+    mockBothEndpoints({
+      agents: [
+        {
+          agentId: "agent-1",
+          agentName: "Smithers",
+          totalInputTokens: "500000",
+          totalOutputTokens: "700000",
+          totalCacheReadTokens: "50000",
+          totalCacheWriteTokens: "10000",
+          totalCost: "3.50",
+        },
+      ],
+    });
+    render(<UsageDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Smithers").length).toBeGreaterThan(0);
+    });
+
+    // "Cache Tokens" appears in both summary card and table header
+    const cacheTokensElements = screen.getAllByText("Cache Tokens");
+    expect(cacheTokensElements.length).toBe(2);
+    // 50000 + 10000 = 60000 -> "60.0k" appears in both summary card and table cell
+    expect(screen.getAllByText("60.0k").length).toBeGreaterThanOrEqual(2);
+  });
+
+  it("hides cache tokens summary card when no cache tokens", async () => {
+    mockBothEndpoints({
+      agents: [
+        {
+          agentId: "agent-1",
+          agentName: "Smithers",
+          totalInputTokens: "500000",
+          totalOutputTokens: "700000",
+          totalCacheReadTokens: "0",
+          totalCacheWriteTokens: "0",
+          totalCost: "3.50",
+        },
+      ],
+    });
+    render(<UsageDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Smithers").length).toBeGreaterThan(0);
+    });
+
+    // "Cache Tokens" should NOT appear (no column header, no summary card)
+    expect(screen.queryByText("Cache Tokens")).not.toBeInTheDocument();
+  });
+
   it("should render all time period buttons", () => {
     mockBothEndpoints();
     render(<UsageDashboard />);

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -686,7 +686,7 @@ describe("UsageDashboard", () => {
     });
   });
 
-  it("should handle fetch errors gracefully and show no-data message", async () => {
+  it("shows error message when API fetch fails", async () => {
     vi.mocked(global.fetch).mockImplementation((url) => {
       const urlStr = String(url);
       if (urlStr.includes("/api/enterprise/status")) {
@@ -717,21 +717,72 @@ describe("UsageDashboard", () => {
     const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
     render(<UsageDashboard />);
 
-    // The component should not crash — it stays in loading state since the
-    // catch handler does not set summary/timeseries, so it will keep showing
-    // Loading... (which means it didn't crash). Eventually nothing is rendered
-    // as data — verify no crash by checking the heading still renders.
-    expect(screen.getByText("Usage & Costs")).toBeInTheDocument();
-
     await waitFor(() => {
-      expect(consoleSpy).toHaveBeenCalledWith(
-        "[usage] Failed to fetch usage data:",
-        expect.any(Error)
-      );
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
     });
 
-    // After error, summary remains null so Loading... is shown (graceful degradation)
-    expect(screen.getByText("Loading...")).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /retry/i })).toBeInTheDocument();
+    expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+
+    consoleSpy.mockRestore();
+  });
+
+  it("retries fetch when Retry button is clicked", async () => {
+    const user = userEvent.setup();
+
+    // First call: summary fails
+    let callCount = 0;
+    vi.mocked(global.fetch).mockImplementation((url) => {
+      const urlStr = String(url);
+      if (urlStr.includes("/api/enterprise/status")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => ({ enterprise: false }),
+        } as Response);
+      }
+      if (urlStr.includes("/api/usage/summary")) {
+        callCount++;
+        if (callCount <= 1) {
+          return Promise.resolve({
+            ok: false,
+            status: 500,
+            json: async () => ({}),
+          } as Response);
+        }
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockSummaryResponse,
+        } as Response);
+      }
+      if (urlStr.includes("/api/usage/timeseries")) {
+        return Promise.resolve({
+          ok: true,
+          json: async () => mockTimeseriesResponse,
+        } as Response);
+      }
+      return Promise.resolve({
+        ok: false,
+        json: async () => ({}),
+      } as Response);
+    });
+
+    const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    render(<UsageDashboard />);
+
+    // Wait for error state
+    await waitFor(() => {
+      expect(screen.getByText(/failed to load/i)).toBeInTheDocument();
+    });
+
+    // Click retry
+    await user.click(screen.getByRole("button", { name: /retry/i }));
+
+    // After retry, data should render (agent name appears in both dropdown and data area)
+    await waitFor(() => {
+      expect(screen.getAllByText("Smithers").length).toBeGreaterThanOrEqual(1);
+    });
+
+    expect(screen.queryByText(/failed to load/i)).not.toBeInTheDocument();
 
     consoleSpy.mockRestore();
   });

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -120,7 +120,9 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=30");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=30");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/usage/timeseries?days=30")
+      );
     });
   });
 
@@ -370,7 +372,9 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=7");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=7");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/usage/timeseries?days=7")
+      );
     });
   });
 
@@ -390,7 +394,9 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=0");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=0");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/usage/timeseries?days=0")
+      );
     });
   });
 
@@ -729,7 +735,9 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=30&agentId=agent-1");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=30&agentId=agent-1");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringMatching(/\/api\/usage\/timeseries\?days=30&agentId=agent-1/)
+      );
     });
   });
 
@@ -756,7 +764,9 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=30");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=30");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/usage/timeseries?days=30")
+      );
     });
   });
 
@@ -779,7 +789,21 @@ describe("UsageDashboard", () => {
 
     await waitFor(() => {
       expect(global.fetch).toHaveBeenCalledWith("/api/usage/summary?days=7");
-      expect(global.fetch).toHaveBeenCalledWith("/api/usage/timeseries?days=7");
+      expect(global.fetch).toHaveBeenCalledWith(
+        expect.stringContaining("/api/usage/timeseries?days=7")
+      );
+    });
+  });
+
+  it("sends tz parameter in timeseries fetch", async () => {
+    mockBothEndpoints();
+    render(<UsageDashboard />);
+
+    await waitFor(() => {
+      const calls = vi.mocked(global.fetch).mock.calls.map((c) => String(c[0]));
+      const tsCalls = calls.filter((u) => u.includes("/api/usage/timeseries"));
+      expect(tsCalls.length).toBeGreaterThan(0);
+      expect(tsCalls[0]).toMatch(/tz=.+/);
     });
   });
 

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -307,6 +307,52 @@ describe("UsageDashboard", () => {
     expect(screen.getByText("$1.32")).toBeInTheDocument();
   });
 
+  it("shows (deleted) label for deleted agents in dropdown and table", async () => {
+    mockBothEndpoints({
+      agents: [
+        {
+          agentId: "agent-1",
+          agentName: "Smithers",
+          totalInputTokens: "500000",
+          totalOutputTokens: "700000",
+          totalCost: "3.50",
+          deleted: false,
+        },
+        {
+          agentId: "agent-2",
+          agentName: "Old Bot",
+          totalInputTokens: "150000",
+          totalOutputTokens: "250000",
+          totalCost: "1.32",
+          deleted: true,
+        },
+      ],
+    });
+    render(<UsageDashboard />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText("Smithers").length).toBeGreaterThan(0);
+    });
+
+    // Agent filter dropdown should show "(deleted)" suffix
+    const agentSelect = screen.getByLabelText("Filter by agent");
+    const options = agentSelect.querySelectorAll("option");
+    expect(options[1]).toHaveTextContent("Smithers");
+    expect(options[1]).not.toHaveTextContent("(deleted)");
+    expect(options[2]).toHaveTextContent("Old Bot (deleted)");
+
+    // Agent table should show "(deleted)" suffix with muted styling
+    const oldBotCells = screen.getAllByText(/Old Bot/);
+    const oldBotTableCell = oldBotCells.find((el) => el.tagName === "TD")!;
+    expect(oldBotTableCell).toHaveTextContent("Old Bot (deleted)");
+    expect(oldBotTableCell).toHaveClass("text-muted-foreground");
+
+    // Smithers table cell should NOT have muted styling
+    const smithersCells = screen.getAllByText("Smithers");
+    const smithersTableCell = smithersCells.find((el) => el.tagName === "TD")!;
+    expect(smithersTableCell).not.toHaveClass("text-muted-foreground");
+  });
+
   it("should change fetch parameters when time period buttons are clicked", async () => {
     mockBothEndpoints();
     const user = userEvent.setup();

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -143,6 +143,122 @@ describe("UsageDashboard", () => {
     expect(screen.getByText("$4.82")).toBeInTheDocument();
   });
 
+  describe("source breakdown cards", () => {
+    it("renders chat/system/plugin cards when totals include all three", async () => {
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: {
+            inputTokens: "500000",
+            outputTokens: "700000",
+            cost: "3.50",
+          },
+          system: {
+            inputTokens: "50000",
+            outputTokens: "10000",
+            cost: "0.40",
+          },
+          plugin: {
+            inputTokens: "100000",
+            outputTokens: "20000",
+            cost: "0.92",
+          },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Chat Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("System Tokens")).toBeInTheDocument();
+      expect(screen.getByText("Plugin Tokens")).toBeInTheDocument();
+
+      // Chat: 500k + 700k = 1.2M
+      expect(screen.getByText("1.2M")).toBeInTheDocument();
+      // Plugin: 100k + 20k = 120k -> 120.0k
+      expect(screen.getByText("120.0k")).toBeInTheDocument();
+      // System: 50k + 10k = 60k -> 60.0k
+      expect(screen.getByText("60.0k")).toBeInTheDocument();
+
+      // Costs per bucket — $3.50 also appears in the Smithers agent table row
+      // (getAllByText handles both occurrences). $0.40 and $0.92 are unique to
+      // the source-breakdown cards.
+      expect(screen.getAllByText("$3.50").length).toBeGreaterThanOrEqual(1);
+      expect(screen.getByText("$0.40")).toBeInTheDocument();
+      expect(screen.getByText("$0.92")).toBeInTheDocument();
+    });
+
+    it("hides system card when system tokens are zero", async () => {
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: {
+            inputTokens: "500000",
+            outputTokens: "700000",
+            cost: "3.50",
+          },
+          system: { inputTokens: "0", outputTokens: "0", cost: "0" },
+          plugin: {
+            inputTokens: "100000",
+            outputTokens: "20000",
+            cost: "0.92",
+          },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Chat Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("System Tokens")).not.toBeInTheDocument();
+      expect(screen.getByText("Plugin Tokens")).toBeInTheDocument();
+    });
+
+    it("hides plugin card when plugin tokens are zero", async () => {
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: {
+            inputTokens: "500000",
+            outputTokens: "700000",
+            cost: "3.50",
+          },
+          system: {
+            inputTokens: "50000",
+            outputTokens: "10000",
+            cost: "0.40",
+          },
+          plugin: { inputTokens: "0", outputTokens: "0", cost: "0" },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Chat Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.getByText("System Tokens")).toBeInTheDocument();
+      expect(screen.queryByText("Plugin Tokens")).not.toBeInTheDocument();
+    });
+
+    it("does not render any source cards when totals is missing from response", async () => {
+      // Backward compat: summary responses without `totals` should still render
+      mockBothEndpoints(mockSummaryResponse);
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        // Main summary cards still render
+        expect(screen.getByText("Total Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Chat Tokens")).not.toBeInTheDocument();
+      expect(screen.queryByText("System Tokens")).not.toBeInTheDocument();
+      expect(screen.queryByText("Plugin Tokens")).not.toBeInTheDocument();
+    });
+  });
+
   it("should display agent table with agent names and formatted values", async () => {
     mockBothEndpoints();
     render(<UsageDashboard />);

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -686,6 +686,97 @@ describe("UsageDashboard", () => {
     });
   });
 
+  describe("null cost vs $0.00", () => {
+    it("displays dash when all agent costs are null", async () => {
+      mockBothEndpoints({
+        agents: [
+          {
+            agentId: "agent-1",
+            agentName: "Ollama Bot",
+            totalInputTokens: "100000",
+            totalOutputTokens: "200000",
+            totalCost: null,
+          },
+        ],
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Ollama Bot").length).toBeGreaterThan(0);
+      });
+
+      // The Estimated Cost card should show em dash, not "$0.00"
+      const costCard = screen.getByText("Estimated Cost").closest("[data-slot='card']")!;
+      expect(costCard).toHaveTextContent("\u2014");
+      expect(costCard).not.toHaveTextContent("$0.00");
+    });
+
+    it("displays $0.00 when agent cost is explicitly zero", async () => {
+      mockBothEndpoints({
+        agents: [
+          {
+            agentId: "agent-1",
+            agentName: "Zero Cost Bot",
+            totalInputTokens: "100000",
+            totalOutputTokens: "200000",
+            totalCost: "0",
+          },
+        ],
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Zero Cost Bot").length).toBeGreaterThan(0);
+      });
+
+      const costCard = screen.getByText("Estimated Cost").closest("[data-slot='card']")!;
+      expect(costCard).toHaveTextContent("$0.00");
+    });
+
+    it("displays dash for individual agent cost when null", async () => {
+      mockBothEndpoints({
+        agents: [
+          {
+            agentId: "agent-1",
+            agentName: "Ollama Bot",
+            totalInputTokens: "100000",
+            totalOutputTokens: "200000",
+            totalCost: null,
+          },
+          {
+            agentId: "agent-2",
+            agentName: "Claude Bot",
+            totalInputTokens: "50000",
+            totalOutputTokens: "80000",
+            totalCost: "2.50",
+          },
+        ],
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getAllByText("Ollama Bot").length).toBeGreaterThan(0);
+      });
+
+      // Find the Ollama Bot row via its table cell and check the cost cell shows em dash
+      const ollamaCells = screen.getAllByText("Ollama Bot");
+      const ollamaCell = ollamaCells.find((el) => el.tagName === "TD")!;
+      const ollamaRow = ollamaCell.closest("tr")!;
+      const ollamaCostCells = ollamaRow.querySelectorAll("td");
+      const ollamaCostCell = ollamaCostCells[ollamaCostCells.length - 1];
+      expect(ollamaCostCell).toHaveTextContent("\u2014");
+      expect(ollamaCostCell).not.toHaveTextContent("$0.00");
+
+      // Claude Bot should still show its cost
+      const claudeCells = screen.getAllByText("Claude Bot");
+      const claudeCell = claudeCells.find((el) => el.tagName === "TD")!;
+      const claudeRow = claudeCell.closest("tr")!;
+      const claudeCostCells = claudeRow.querySelectorAll("td");
+      const claudeCostCell = claudeCostCells[claudeCostCells.length - 1];
+      expect(claudeCostCell).toHaveTextContent("$2.50");
+    });
+  });
+
   it("shows error message when API fetch fails", async () => {
     vi.mocked(global.fetch).mockImplementation((url) => {
       const urlStr = String(url);

--- a/packages/web/src/__tests__/integration/fake-llm-server.ts
+++ b/packages/web/src/__tests__/integration/fake-llm-server.ts
@@ -27,12 +27,9 @@ export interface FakeLlmConfig {
 export function startFakeLlmServer(config: FakeLlmConfig): Promise<Server> {
   return new Promise((resolve) => {
     const server = createServer((req, res) => {
-      // Consume the request body so the connection closes cleanly; we
-      // don't actually need it for the canned response.
-      let body = "";
-      req.on("data", (chunk) => {
-        body += chunk;
-      });
+      // Drain the request body so the connection closes cleanly; we
+      // don't actually need its contents for the canned response.
+      req.on("data", () => {});
       req.on("end", () => {
         res.writeHead(200, { "Content-Type": "application/json" });
         res.end(

--- a/packages/web/src/__tests__/integration/fake-llm-server.ts
+++ b/packages/web/src/__tests__/integration/fake-llm-server.ts
@@ -1,0 +1,65 @@
+/**
+ * Minimal OpenAI-compatible fake LLM server used by the usage-tracking
+ * integration test. It responds to any POST with a fixed chat-completion
+ * payload whose `usage` block carries known token counts — so the test
+ * can assert "X prompt_tokens in → X recorded on dashboard out" without
+ * depending on a real model provider.
+ *
+ * This file is a helper for `usage-tracking.integration.test.ts`; it is
+ * not itself a test suite. Vitest ignores files without `.test.ts` in
+ * the default run.
+ */
+
+import { createServer, type Server } from "http";
+
+export interface FakeLlmConfig {
+  port: number;
+  responseText: string;
+  promptTokens: number;
+  completionTokens: number;
+}
+
+/**
+ * Starts a fake OpenAI-compatible server on the given port and resolves
+ * with the underlying Node `Server` handle once it is listening. Call
+ * `server.close()` (typically in an `afterAll`) to release the port.
+ */
+export function startFakeLlmServer(config: FakeLlmConfig): Promise<Server> {
+  return new Promise((resolve) => {
+    const server = createServer((req, res) => {
+      // Consume the request body so the connection closes cleanly; we
+      // don't actually need it for the canned response.
+      let body = "";
+      req.on("data", (chunk) => {
+        body += chunk;
+      });
+      req.on("end", () => {
+        res.writeHead(200, { "Content-Type": "application/json" });
+        res.end(
+          JSON.stringify({
+            id: "fake-completion",
+            object: "chat.completion",
+            created: Math.floor(Date.now() / 1000),
+            model: "fake-model",
+            choices: [
+              {
+                index: 0,
+                message: {
+                  role: "assistant",
+                  content: config.responseText,
+                },
+                finish_reason: "stop",
+              },
+            ],
+            usage: {
+              prompt_tokens: config.promptTokens,
+              completion_tokens: config.completionTokens,
+              total_tokens: config.promptTokens + config.completionTokens,
+            },
+          })
+        );
+      });
+    });
+    server.listen(config.port, () => resolve(server));
+  });
+}

--- a/packages/web/src/__tests__/integration/usage-tracking.integration.test.ts
+++ b/packages/web/src/__tests__/integration/usage-tracking.integration.test.ts
@@ -1,0 +1,50 @@
+/**
+ * End-to-end usage tracking verification (Tier 2 from the design doc).
+ *
+ * This suite pipes real traffic through a fake LLM → OpenClaw → Pinchy
+ * and verifies the numbers that land in `usage_records` match the fake
+ * server's declared `usage` block. It's the only layer of our test
+ * pyramid that can prove the entire pipeline (chat event path + poller
+ * delta path) stays in sync with OpenClaw's cumulative counters.
+ *
+ * Runs only when `INTEGRATION_TEST=1` is set, because it needs:
+ *   - a running OpenClaw gateway (container or native)
+ *   - a reachable PostgreSQL with Pinchy's migrations applied
+ *   - port 9999 free on the host
+ *
+ * The skeleton below describes the steps; the full implementation is a
+ * follow-up once the poller has been exercised in the dev environment.
+ */
+
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import type { Server } from "http";
+import { startFakeLlmServer } from "./fake-llm-server";
+
+const FAKE_LLM_PORT = 9999;
+const PROMPT_TOKENS = 42;
+const COMPLETION_TOKENS = 17;
+
+describe.skipIf(!process.env.INTEGRATION_TEST)("usage tracking integration", () => {
+  let fakeLlm: Server;
+
+  beforeAll(async () => {
+    fakeLlm = await startFakeLlmServer({
+      port: FAKE_LLM_PORT,
+      responseText: "Hello from fake LLM",
+      promptTokens: PROMPT_TOKENS,
+      completionTokens: COMPLETION_TOKENS,
+    });
+  });
+
+  afterAll(() => {
+    fakeLlm?.close();
+  });
+
+  // Full implementation is a follow-up — wired in once the poller has
+  // been exercised against a real OpenClaw + DB in the dev environment.
+  it.todo("records correct token totals in usage_records after a chat + one poll cycle");
+
+  it.todo("records cumulative totals correctly across multiple chat turns in the same session");
+
+  it.todo("captures tokens added by vision/plugin calls via the internal usage endpoint");
+});

--- a/packages/web/src/__tests__/integration/usage-tracking.integration.test.ts
+++ b/packages/web/src/__tests__/integration/usage-tracking.integration.test.ts
@@ -16,7 +16,7 @@
  * follow-up once the poller has been exercised in the dev environment.
  */
 
-import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import { describe, it, beforeAll, afterAll } from "vitest";
 import type { Server } from "http";
 import { startFakeLlmServer } from "./fake-llm-server";
 

--- a/packages/web/src/__tests__/lib/fixed-window-rate-limiter.test.ts
+++ b/packages/web/src/__tests__/lib/fixed-window-rate-limiter.test.ts
@@ -1,0 +1,60 @@
+import { describe, it, expect } from "vitest";
+import { FixedWindowRateLimiter } from "@/lib/fixed-window-rate-limiter";
+
+describe("FixedWindowRateLimiter", () => {
+  it("allows calls up to the configured max", () => {
+    const limiter = new FixedWindowRateLimiter({ max: 3, windowMs: 1000 });
+    const now = 1_000_000;
+
+    expect(limiter.tryAcquire(now)).toBe(true);
+    expect(limiter.tryAcquire(now)).toBe(true);
+    expect(limiter.tryAcquire(now)).toBe(true);
+  });
+
+  it("rejects further calls once the window is full", () => {
+    const limiter = new FixedWindowRateLimiter({ max: 2, windowMs: 1000 });
+    const now = 1_000_000;
+
+    limiter.tryAcquire(now);
+    limiter.tryAcquire(now);
+
+    expect(limiter.tryAcquire(now)).toBe(false);
+    expect(limiter.tryAcquire(now + 500)).toBe(false);
+  });
+
+  it("opens a fresh window after windowMs elapses", () => {
+    // Fresh windows are the whole point of a fixed-window limiter —
+    // without this, a single burst would block the endpoint forever.
+    const limiter = new FixedWindowRateLimiter({ max: 2, windowMs: 1000 });
+    const start = 1_000_000;
+
+    limiter.tryAcquire(start);
+    limiter.tryAcquire(start);
+    expect(limiter.tryAcquire(start + 500)).toBe(false);
+
+    // One millisecond past the window — new window starts, call is allowed.
+    expect(limiter.tryAcquire(start + 1001)).toBe(true);
+  });
+
+  it("reset() empties the current window", () => {
+    // Reset exists purely for tests — keeps the singleton in route handlers
+    // deterministic between test cases without juggling fake timers.
+    const limiter = new FixedWindowRateLimiter({ max: 1, windowMs: 1000 });
+    const now = 1_000_000;
+
+    limiter.tryAcquire(now);
+    expect(limiter.tryAcquire(now)).toBe(false);
+
+    limiter.reset();
+    expect(limiter.tryAcquire(now)).toBe(true);
+  });
+
+  it("defaults `now` to Date.now() when called without arguments", () => {
+    // The route handler calls tryAcquire() without passing a clock —
+    // make sure that still works.
+    const limiter = new FixedWindowRateLimiter({ max: 1, windowMs: 1000 });
+
+    expect(limiter.tryAcquire()).toBe(true);
+    expect(limiter.tryAcquire()).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -344,6 +344,41 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
+  it("should include apiBaseUrl and gatewayToken in pinchy-files config so the plugin can report vision token usage", async () => {
+    const existingConfig = {
+      gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-files" } },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
+
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockResolvedValue([
+        {
+          id: "kb-agent-id",
+          name: "HR Knowledge Base",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          templateId: "knowledge-base",
+          pluginConfig: { allowed_paths: ["/data/hr-docs/"] },
+          allowedTools: ["pinchy_ls", "pinchy_read"],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    // apiBaseUrl and gatewayToken live at the plugin-level config (alongside `agents`),
+    // matching how pinchy-context and pinchy-audit expose them.
+    expect(config.plugins.entries["pinchy-files"].config.apiBaseUrl).toBe("http://pinchy:7777");
+    expect(config.plugins.entries["pinchy-files"].config.gatewayToken).toBe("gw-token-files");
+    // Per-agent allowed_paths is still nested under .agents
+    expect(config.plugins.entries["pinchy-files"].config.agents["kb-agent-id"]).toEqual({
+      allowed_paths: ["/data/hr-docs/"],
+    });
+  });
+
   it("should not keep stale env vars from previous config", async () => {
     const existingConfig = {
       gateway: {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -80,6 +80,30 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
+  it("should disable heartbeat per agent in agents.list", async () => {
+    // Rationale: Heartbeat fires LLM calls in the background and racks up
+    // tokens for every agent, even idle ones. Pinchy disables it by default
+    // (`heartbeat: { every: "0m" }`). We set it per-agent, NOT on agents.defaults,
+    // to avoid hot-reload races with Telegram (openclaw#47458).
+    const agentsData = [
+      { id: "a1", name: "Smithers", model: "anthropic/claude-opus-4-6", createdAt: new Date() },
+      { id: "a2", name: "Jeeves", model: "openai/gpt-4o", createdAt: new Date() },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockResolvedValue(agentsData),
+    } as never);
+    mockedGetSetting.mockResolvedValue(null);
+
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    for (const agent of config.agents.list) {
+      expect(agent.heartbeat).toEqual({ every: "0m" });
+    }
+    // Must NOT be in agents.defaults (would cause hot-reload loops)
+    expect(config.agents.defaults?.heartbeat).toBeUndefined();
+  });
+
   it("should write agents.list with all agents from DB", async () => {
     const agentsData = [
       {
@@ -113,6 +137,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "anthropic/claude-opus-4-6",
       workspace: "/root/.openclaw/workspaces/uuid-agent-1",
       tools: { deny: ["group:runtime", "group:fs", "group:web", "pdf", "image", "image_generate"] },
+      heartbeat: { every: "0m" },
     });
     expect(config.agents.list[1]).toEqual({
       id: "uuid-agent-2",
@@ -120,6 +145,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "openai/gpt-4o",
       workspace: "/root/.openclaw/workspaces/uuid-agent-2",
       tools: { deny: ["group:runtime", "group:fs", "group:web", "pdf", "image", "image_generate"] },
+      heartbeat: { every: "0m" },
     });
   });
 

--- a/packages/web/src/__tests__/lib/shutdown.test.ts
+++ b/packages/web/src/__tests__/lib/shutdown.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { registerShutdownHandlers } from "@/lib/shutdown";
+
+describe("registerShutdownHandlers", () => {
+  const disposers: Array<() => void> = [];
+
+  afterEach(() => {
+    while (disposers.length) {
+      const dispose = disposers.pop();
+      try {
+        dispose?.();
+      } catch {
+        // best-effort
+      }
+    }
+  });
+
+  it("calls every registered stopFn when a shutdown signal fires", async () => {
+    const stopA = vi.fn();
+    const stopB = vi.fn();
+    const exit = vi.fn();
+
+    const dispose = registerShutdownHandlers([stopA, stopB], { exit });
+    disposers.push(dispose);
+
+    process.emit("SIGTERM", "SIGTERM");
+    // Handlers are async — let the microtask queue drain
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(stopA).toHaveBeenCalledTimes(1);
+    expect(stopB).toHaveBeenCalledTimes(1);
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("runs every stopFn even if an earlier one throws (keeps shutdown best-effort)", async () => {
+    // Rationale: if stopUsagePoller throws, we still want to close the HTTP
+    // server and release DB handles. One broken shutdown step must not
+    // orphan the rest.
+    const stopA = vi.fn().mockImplementation(() => {
+      throw new Error("poller stop blew up");
+    });
+    const stopB = vi.fn();
+    const exit = vi.fn();
+
+    const dispose = registerShutdownHandlers([stopA, stopB], { exit });
+    disposers.push(dispose);
+
+    process.emit("SIGINT", "SIGINT");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(stopA).toHaveBeenCalled();
+    expect(stopB).toHaveBeenCalled();
+    expect(exit).toHaveBeenCalledWith(0);
+  });
+
+  it("awaits async stopFns before exiting", async () => {
+    const order: string[] = [];
+    const stopA = vi.fn().mockImplementation(async () => {
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      order.push("A");
+    });
+    const stopB = vi.fn().mockImplementation(() => {
+      order.push("B");
+    });
+    const exit = vi.fn().mockImplementation(() => {
+      order.push("exit");
+    });
+
+    const dispose = registerShutdownHandlers([stopA, stopB], { exit });
+    disposers.push(dispose);
+
+    process.emit("SIGTERM", "SIGTERM");
+    await new Promise((resolve) => setTimeout(resolve, 30));
+
+    // Exit must come strictly after both stop fns finished
+    expect(order).toEqual(["A", "B", "exit"]);
+  });
+
+  it("returns a disposer that removes the signal handlers", async () => {
+    const stopA = vi.fn();
+    const exit = vi.fn();
+
+    const dispose = registerShutdownHandlers([stopA], { exit });
+    dispose();
+
+    process.emit("SIGTERM", "SIGTERM");
+    await new Promise((resolve) => setImmediate(resolve));
+
+    expect(stopA).not.toHaveBeenCalled();
+    expect(exit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -1,5 +1,41 @@
-import { describe, it, expect } from "vitest";
-import { parseSessionKey } from "@/lib/usage-poller";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockRecordUsage = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+
+vi.mock("@/lib/usage", () => ({
+  recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return {
+        from: (...fArgs: unknown[]) => {
+          mockFrom(...fArgs);
+          return mockFrom._result;
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  agents: { _table: "agents", id: "id", name: "name" },
+  usageRecords: { _table: "usage_records" },
+}));
+
+import { parseSessionKey, pollAllSessions } from "@/lib/usage-poller";
+
+function makeOpenClawClient(sessions: unknown[] = []) {
+  return {
+    sessions: {
+      list: vi.fn().mockResolvedValue({ sessions }),
+    },
+  } as unknown as Parameters<typeof pollAllSessions>[0];
+}
 
 describe("parseSessionKey", () => {
   it("parses direct chat session key", () => {
@@ -43,5 +79,132 @@ describe("parseSessionKey", () => {
     expect(parseSessionKey("")).toBeNull();
     expect(parseSessionKey("agent:")).toBeNull();
     expect(parseSessionKey("notagent:foo:bar")).toBeNull();
+  });
+});
+
+describe("pollAllSessions", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordUsage.mockResolvedValue(undefined);
+    mockFrom._result = [{ id: "agent-1", name: "Smithers" }];
+  });
+
+  it("handles empty sessions list gracefully", async () => {
+    const client = makeOpenClawClient([]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+  });
+
+  it("calls recordUsage for each session with tokens", async () => {
+    mockFrom._result = [
+      { id: "agent-1", name: "Smithers" },
+      { id: "agent-2", name: "Burns" },
+    ];
+    const client = makeOpenClawClient([
+      {
+        key: "agent:agent-1:direct:user-1",
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "claude",
+      },
+      {
+        key: "agent:agent-2:direct:user-2",
+        inputTokens: 200,
+        outputTokens: 80,
+        model: "claude",
+      },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordUsage).toHaveBeenCalledWith({
+      openclawClient: client,
+      userId: "user-1",
+      agentId: "agent-1",
+      agentName: "Smithers",
+      sessionKey: "agent:agent-1:direct:user-1",
+    });
+    expect(mockRecordUsage).toHaveBeenCalledWith({
+      openclawClient: client,
+      userId: "user-2",
+      agentId: "agent-2",
+      agentName: "Burns",
+      sessionKey: "agent:agent-2:direct:user-2",
+    });
+  });
+
+  it("skips sessions with zero tokens", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 0, outputTokens: 0 },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+  });
+
+  it("skips sessions with unparseable keys", async () => {
+    const client = makeOpenClawClient([
+      { key: "something-else-entirely", inputTokens: 100, outputTokens: 50 },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+  });
+
+  it("records system sessions with userId='system'", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:main", inputTokens: 100, outputTokens: 50 },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "system",
+        agentId: "agent-1",
+        sessionKey: "agent:agent-1:main",
+      })
+    );
+  });
+
+  it("falls back to agentId when agent name is not in DB", async () => {
+    mockFrom._result = []; // empty agents table
+    const client = makeOpenClawClient([
+      { key: "agent:ghost-agent:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agentId: "ghost-agent",
+        agentName: "ghost-agent",
+      })
+    );
+  });
+
+  it("does not throw when sessions.list() fails", async () => {
+    const client = {
+      sessions: {
+        list: vi.fn().mockRejectedValue(new Error("OpenClaw unavailable")),
+      },
+    } as unknown as Parameters<typeof pollAllSessions>[0];
+
+    await expect(pollAllSessions(client)).resolves.toBeUndefined();
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+  });
+
+  it("continues processing remaining sessions when one recordUsage call throws", async () => {
+    mockFrom._result = [
+      { id: "agent-1", name: "A1" },
+      { id: "agent-2", name: "A2" },
+    ];
+    mockRecordUsage.mockRejectedValueOnce(new Error("db error")).mockResolvedValueOnce(undefined);
+
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:u1", inputTokens: 10, outputTokens: 5 },
+      { key: "agent:agent-2:direct:u2", inputTokens: 20, outputTokens: 8 },
+    ]);
+
+    await pollAllSessions(client);
+    // First call throws — the second should still be skipped because the
+    // loop body awaits and error is caught at the top level. We only assert
+    // that no exception escapes pollAllSessions.
+    expect(mockRecordUsage).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -15,12 +15,16 @@ vi.mock("@/db", () => ({
     select: (...args: unknown[]) => {
       mockSelect(...args);
       return {
-        from: (...fArgs: unknown[]) => {
-          mockFrom(...fArgs);
+        from: (table: { _table?: string }) => {
+          mockFrom(table);
+          if (table?._table === "users") {
+            // users query has no .where() — returns all users directly
+            return Promise.resolve(mockFrom._userResult);
+          }
           return {
             where: (...wArgs: unknown[]) => {
               mockWhere(...wArgs);
-              return mockFrom._result;
+              return mockFrom._agentResult;
             },
           };
         },
@@ -32,6 +36,7 @@ vi.mock("@/db", () => ({
 vi.mock("@/db/schema", () => ({
   agents: { _table: "agents", id: "id", name: "name", deletedAt: "deleted_at" },
   usageRecords: { _table: "usage_records" },
+  users: { _table: "users", id: "id" },
 }));
 
 const mockIsNull = vi.fn((col: unknown) => ({ _type: "isNull", col }));
@@ -104,7 +109,8 @@ describe("pollAllSessions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRecordUsage.mockResolvedValue(undefined);
-    mockFrom._result = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._userResult = [{ id: "user-1" }, { id: "user-2" }];
   });
 
   it("filters out soft-deleted agents from the name map", async () => {
@@ -129,7 +135,7 @@ describe("pollAllSessions", () => {
   });
 
   it("calls recordUsage for each session with tokens", async () => {
-    mockFrom._result = [
+    mockFrom._agentResult = [
       { id: "agent-1", name: "Smithers" },
       { id: "agent-2", name: "Burns" },
     ];
@@ -215,7 +221,7 @@ describe("pollAllSessions", () => {
   });
 
   it("falls back to agentId when agent name is not in DB", async () => {
-    mockFrom._result = []; // empty agents table
+    mockFrom._agentResult = []; // empty agents table
     const client = makeOpenClawClient([
       { key: "agent:ghost-agent:direct:user-1", inputTokens: 100, outputTokens: 50 },
     ]);
@@ -239,8 +245,49 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
+  it("resolves lowercased userId from session key to original-case DB id", async () => {
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._userResult = [{ id: "zLGhGKUwYqZeQfA4IMwG2oIDSxoYJVqz" }];
+
+    const client = makeOpenClawClient([
+      {
+        // Session key has lowercase userId (as OpenClaw normalizes)
+        key: "agent:agent-1:direct:zlghgkuwyqzeqfa4imwg2oidsxoyjvqz",
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+      },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        // userId should be the original-case DB id, not the lowercase from the key
+        userId: "zLGhGKUwYqZeQfA4IMwG2oIDSxoYJVqz",
+      })
+    );
+  });
+
+  it("does not resolve system userId through user lookup", async () => {
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._userResult = [{ id: "zLGhGKUwYqZeQfA4IMwG2oIDSxoYJVqz" }];
+
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:main", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "system",
+      })
+    );
+  });
+
   it("does not throw when a single recordUsage call rejects", async () => {
-    mockFrom._result = [
+    mockFrom._agentResult = [
       { id: "agent-1", name: "A1" },
       { id: "agent-2", name: "A2" },
     ];
@@ -260,7 +307,7 @@ describe("startUsagePoller / stopUsagePoller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRecordUsage.mockResolvedValue(undefined);
-    mockFrom._result = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     stopUsagePoller();
     vi.useFakeTimers();
   });

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockRecordUsage = vi.fn();
 const mockSelect = vi.fn();
@@ -27,7 +27,13 @@ vi.mock("@/db/schema", () => ({
   usageRecords: { _table: "usage_records" },
 }));
 
-import { parseSessionKey, pollAllSessions } from "@/lib/usage-poller";
+import {
+  parseSessionKey,
+  pollAllSessions,
+  startUsagePoller,
+  stopUsagePoller,
+  _isPollerRunning,
+} from "@/lib/usage-poller";
 
 function makeOpenClawClient(sessions: unknown[] = []) {
   return {
@@ -189,7 +195,7 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
-  it("continues processing remaining sessions when one recordUsage call throws", async () => {
+  it("does not throw when a single recordUsage call rejects", async () => {
     mockFrom._result = [
       { id: "agent-1", name: "A1" },
       { id: "agent-2", name: "A2" },
@@ -201,10 +207,77 @@ describe("pollAllSessions", () => {
       { key: "agent:agent-2:direct:u2", inputTokens: 20, outputTokens: 8 },
     ]);
 
-    await pollAllSessions(client);
-    // First call throws — the second should still be skipped because the
-    // loop body awaits and error is caught at the top level. We only assert
-    // that no exception escapes pollAllSessions.
+    await expect(pollAllSessions(client)).resolves.toBeUndefined();
     expect(mockRecordUsage).toHaveBeenCalled();
+  });
+});
+
+describe("startUsagePoller / stopUsagePoller", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockRecordUsage.mockResolvedValue(undefined);
+    mockFrom._result = [{ id: "agent-1", name: "Smithers" }];
+    stopUsagePoller();
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    stopUsagePoller();
+    vi.useRealTimers();
+  });
+
+  it("is not running before start", () => {
+    expect(_isPollerRunning()).toBe(false);
+  });
+
+  it("starts polling on startUsagePoller and marks as running", () => {
+    const client = makeOpenClawClient([]);
+    startUsagePoller(client);
+    expect(_isPollerRunning()).toBe(true);
+  });
+
+  it("calls pollAllSessions after each interval tick", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
+    ]);
+    startUsagePoller(client);
+
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+
+    // First tick at 60s
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+
+    // Second tick at 120s
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("stops polling on stopUsagePoller", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
+    ]);
+    startUsagePoller(client);
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+
+    stopUsagePoller();
+    expect(_isPollerRunning()).toBe(false);
+
+    await vi.advanceTimersByTimeAsync(120_000);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // no more calls after stop
+  });
+
+  it("is idempotent — multiple starts don't create duplicate intervals", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
+    ]);
+    startUsagePoller(client);
+    startUsagePoller(client);
+    startUsagePoller(client);
+
+    await vi.advanceTimersByTimeAsync(60_000);
+    // Three start calls, one tick → still only one recordUsage call
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -8,6 +8,8 @@ vi.mock("@/lib/usage", () => ({
   recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
 }));
 
+const mockWhere = vi.fn();
+
 vi.mock("@/db", () => ({
   db: {
     select: (...args: unknown[]) => {
@@ -15,7 +17,12 @@ vi.mock("@/db", () => ({
       return {
         from: (...fArgs: unknown[]) => {
           mockFrom(...fArgs);
-          return mockFrom._result;
+          return {
+            where: (...wArgs: unknown[]) => {
+              mockWhere(...wArgs);
+              return mockFrom._result;
+            },
+          };
         },
       };
     },
@@ -23,8 +30,13 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/db/schema", () => ({
-  agents: { _table: "agents", id: "id", name: "name" },
+  agents: { _table: "agents", id: "id", name: "name", deletedAt: "deleted_at" },
   usageRecords: { _table: "usage_records" },
+}));
+
+const mockIsNull = vi.fn((col: unknown) => ({ _type: "isNull", col }));
+vi.mock("drizzle-orm", () => ({
+  isNull: (col: unknown) => mockIsNull(col),
 }));
 
 import {
@@ -95,6 +107,21 @@ describe("pollAllSessions", () => {
     mockFrom._result = [{ id: "agent-1", name: "Smithers" }];
   });
 
+  it("filters out soft-deleted agents from the name map", async () => {
+    // Soft-deleted agents should not contribute to the poller's agent-name
+    // resolution. If a soft-deleted agent's ID happens to match a
+    // still-active OpenClaw session (e.g. because deletion is in-flight),
+    // we should NOT surface its name via the poller — the DB query must
+    // filter on `deleted_at IS NULL`.
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+    await pollAllSessions(client);
+
+    // The poller must have called .where(isNull(agents.deletedAt)).
+    expect(mockIsNull).toHaveBeenCalledWith("deleted_at");
+  });
+
   it("handles empty sessions list gracefully", async () => {
     const client = makeOpenClawClient([]);
     await pollAllSessions(client);
@@ -124,12 +151,22 @@ describe("pollAllSessions", () => {
     await pollAllSessions(client);
 
     expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    // The poller MUST pass sessionSnapshot so recordUsage does not issue a
+    // second sessions.list() round-trip per session. Check the full shape
+    // including the forwarded snapshot fields.
     expect(mockRecordUsage).toHaveBeenCalledWith({
       openclawClient: client,
       userId: "user-1",
       agentId: "agent-1",
       agentName: "Smithers",
       sessionKey: "agent:agent-1:direct:user-1",
+      sessionSnapshot: {
+        inputTokens: 100,
+        outputTokens: 50,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+        model: "claude",
+      },
     });
     expect(mockRecordUsage).toHaveBeenCalledWith({
       openclawClient: client,
@@ -137,6 +174,13 @@ describe("pollAllSessions", () => {
       agentId: "agent-2",
       agentName: "Burns",
       sessionKey: "agent:agent-2:direct:user-2",
+      sessionSnapshot: {
+        inputTokens: 200,
+        outputTokens: 80,
+        cacheReadTokens: undefined,
+        cacheWriteTokens: undefined,
+        model: "claude",
+      },
     });
   });
 

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { parseSessionKey } from "@/lib/usage-poller";
+
+describe("parseSessionKey", () => {
+  it("parses direct chat session key", () => {
+    const result = parseSessionKey("agent:my-agent:direct:user-123");
+    expect(result).toEqual({
+      agentId: "my-agent",
+      userId: "user-123",
+      type: "chat",
+    });
+  });
+
+  it("parses heartbeat/main session key as system", () => {
+    const result = parseSessionKey("agent:my-agent:main");
+    expect(result).toEqual({
+      agentId: "my-agent",
+      userId: "system",
+      type: "system",
+    });
+  });
+
+  it("parses cron session key as system", () => {
+    const result = parseSessionKey("agent:my-agent:cron:job-1");
+    expect(result).toEqual({
+      agentId: "my-agent",
+      userId: "system",
+      type: "system",
+    });
+  });
+
+  it("preserves userId with colons (e.g. OpenClaw lowercased UUIDs)", () => {
+    const result = parseSessionKey("agent:a1:direct:user-123:extra");
+    expect(result).toEqual({
+      agentId: "a1",
+      userId: "user-123:extra",
+      type: "chat",
+    });
+  });
+
+  it("returns null for unparseable keys", () => {
+    expect(parseSessionKey("random-string")).toBeNull();
+    expect(parseSessionKey("")).toBeNull();
+    expect(parseSessionKey("agent:")).toBeNull();
+    expect(parseSessionKey("notagent:foo:bar")).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -280,21 +280,39 @@ describe("startUsagePoller / stopUsagePoller", () => {
     expect(_isPollerRunning()).toBe(true);
   });
 
+  it("runs an immediate poll on startup before the interval fires", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
+    ]);
+
+    startUsagePoller(client);
+
+    // The immediate poll is fire-and-forget — flush its microtask
+    await vi.advanceTimersByTimeAsync(0);
+
+    // Should have polled once already (immediate), without waiting 60s
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+
+    stopUsagePoller();
+  });
+
   it("calls pollAllSessions after each interval tick", async () => {
     const client = makeOpenClawClient([
       { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
     ]);
     startUsagePoller(client);
 
-    expect(mockRecordUsage).not.toHaveBeenCalled();
-
-    // First tick at 60s
-    await vi.advanceTimersByTimeAsync(60_000);
+    // Immediate poll fires on startup (fire-and-forget)
+    await vi.advanceTimersByTimeAsync(0);
     expect(mockRecordUsage).toHaveBeenCalledTimes(1);
 
-    // Second tick at 120s
+    // First interval tick at 60s
     await vi.advanceTimersByTimeAsync(60_000);
     expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+
+    // Second interval tick at 120s
+    await vi.advanceTimersByTimeAsync(60_000);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(3);
   });
 
   it("stops polling on stopUsagePoller", async () => {
@@ -302,14 +320,15 @@ describe("startUsagePoller / stopUsagePoller", () => {
       { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
     ]);
     startUsagePoller(client);
+    await vi.advanceTimersByTimeAsync(0); // flush immediate poll
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2); // immediate + first tick
 
     stopUsagePoller();
     expect(_isPollerRunning()).toBe(false);
 
     await vi.advanceTimersByTimeAsync(120_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // no more calls after stop
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2); // no more calls after stop
   });
 
   it("is idempotent — multiple starts don't create duplicate intervals", async () => {
@@ -320,8 +339,9 @@ describe("startUsagePoller / stopUsagePoller", () => {
     startUsagePoller(client);
     startUsagePoller(client);
 
+    await vi.advanceTimersByTimeAsync(0); // flush immediate poll
     await vi.advanceTimersByTimeAsync(60_000);
-    // Three start calls, one tick → still only one recordUsage call
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    // Three start calls but only one immediate poll + one tick = 2
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
+++ b/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
@@ -97,6 +97,11 @@ vi.mock("@/db", () => ({
               },
             };
           }
+          if (table?._table === "users") {
+            // pollAllSessions fetches all user IDs to resolve lowercased
+            // session-key IDs back to original-case DB IDs.
+            return Promise.resolve([{ id: "user-1" }]);
+          }
           // usageRecords — chainable with where() to read the running sum
           return {
             where: (...wArgs: unknown[]) => {
@@ -120,6 +125,7 @@ vi.mock("@/db", () => ({
 vi.mock("@/db/schema", () => ({
   usageRecords: { _table: "usage_records" },
   agents: { _table: "agents", id: "id", name: "name" },
+  users: { _table: "users", id: "id" },
 }));
 
 vi.mock("drizzle-orm", () => ({

--- a/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
+++ b/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
@@ -1,0 +1,269 @@
+/**
+ * Integration-flavored timing tests for the poll-driven usage pipeline.
+ *
+ * These tests use the REAL `recordUsage` (not a spy) against a stateful
+ * in-memory DB mock, so they exercise:
+ *   - the cumulative-delta logic (subtract previously recorded sums from
+ *     the current OpenClaw snapshot)
+ *   - the per-session serialization via `pendingBySession` that prevents
+ *     concurrent recordUsage calls from double-counting
+ *
+ * They validate the design assumptions from the usage-dashboard-improvements
+ * plan — specifically that tokens added AFTER a "done" event are still
+ * captured on the next poll, and that a concurrent done-event + poll does
+ * not produce duplicate records for the same session window.
+ */
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockInsert = vi.fn();
+const mockValues = vi.fn();
+const mockSelect = vi.fn();
+const mockFrom = vi.fn();
+const mockWhere = vi.fn();
+
+// Stateful DB: tracks cumulative delta inserts so repeated recordUsage
+// calls see the same monotonically growing total that the real DB would
+// return from sum(inputTokens)/sum(outputTokens).
+interface DbState {
+  inputSum: number;
+  outputSum: number;
+  cacheReadSum: number;
+  cacheWriteSum: number;
+}
+const dbState: DbState = {
+  inputSum: 0,
+  outputSum: 0,
+  cacheReadSum: 0,
+  cacheWriteSum: 0,
+};
+
+function resetDbState(): void {
+  dbState.inputSum = 0;
+  dbState.outputSum = 0;
+  dbState.cacheReadSum = 0;
+  dbState.cacheWriteSum = 0;
+}
+
+vi.mock("@/db", () => ({
+  db: {
+    insert: (...args: unknown[]) => {
+      mockInsert(...args);
+      return {
+        values: (vals: {
+          inputTokens: number;
+          outputTokens: number;
+          cacheReadTokens: number;
+          cacheWriteTokens: number;
+        }) => {
+          mockValues(vals);
+          dbState.inputSum += vals.inputTokens ?? 0;
+          dbState.outputSum += vals.outputTokens ?? 0;
+          dbState.cacheReadSum += vals.cacheReadTokens ?? 0;
+          dbState.cacheWriteSum += vals.cacheWriteTokens ?? 0;
+          return Promise.resolve();
+        },
+      };
+    },
+    select: (...args: unknown[]) => {
+      mockSelect(...args);
+      return {
+        from: (table: { _table?: string }) => {
+          mockFrom(table);
+          if (table?._table === "agents") {
+            // pollAllSessions uses this to build its agent name map
+            return Promise.resolve([{ id: "agent-1", name: "Smithers" }]);
+          }
+          // usageRecords — chainable with where() to read the running sum
+          return {
+            where: (...wArgs: unknown[]) => {
+              mockWhere(...wArgs);
+              return Promise.resolve([
+                {
+                  totalInput: String(dbState.inputSum),
+                  totalOutput: String(dbState.outputSum),
+                  totalCacheRead: String(dbState.cacheReadSum),
+                  totalCacheWrite: String(dbState.cacheWriteSum),
+                },
+              ]);
+            },
+          };
+        },
+      };
+    },
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  usageRecords: { _table: "usage_records" },
+  agents: { _table: "agents", id: "id", name: "name" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((_col, val) => ({ _type: "eq", val })),
+  sum: vi.fn((col) => ({ _type: "sum", col })),
+}));
+
+import { recordUsage, _resetPricingCacheForTest, _resetPendingSessionsForTest } from "@/lib/usage";
+import { pollAllSessions } from "@/lib/usage-poller";
+
+interface MutableSession {
+  key: string;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+}
+
+function makeClient(sessionRef: { current: MutableSession }) {
+  return {
+    sessions: {
+      list: vi.fn().mockImplementation(() =>
+        Promise.resolve({
+          sessions: [sessionRef.current],
+        })
+      ),
+    },
+    config: {
+      get: vi.fn().mockResolvedValue({ config: { models: { providers: {} } } }),
+    },
+  } as unknown as Parameters<typeof pollAllSessions>[0];
+}
+
+const SESSION_KEY = "agent:agent-1:direct:user-1";
+const baseParams = {
+  userId: "user-1",
+  agentId: "agent-1",
+  agentName: "Smithers",
+  sessionKey: SESSION_KEY,
+};
+
+describe("polling timing scenarios", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetDbState();
+    _resetPricingCacheForTest();
+    _resetPendingSessionsForTest();
+  });
+
+  it("captures tokens added after 'done' event on next poll cycle", async () => {
+    // Scenario from the design doc: OpenClaw fires "done" when assistant
+    // text streaming finishes, but background tool calls (e.g. vision API,
+    // subagent spawn) can add tokens afterwards. Those tokens would be
+    // lost without the poller — this test proves the poller captures them.
+
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    // Step 1: "done" event fires, recordUsage inserts the initial snapshot.
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(mockValues).toHaveBeenCalledTimes(1);
+    expect(mockValues).toHaveBeenNthCalledWith(
+      1,
+      expect.objectContaining({ inputTokens: 100, outputTokens: 50 })
+    );
+    expect(dbState.inputSum).toBe(100);
+    expect(dbState.outputSum).toBe(50);
+
+    // Step 2: Background work bumps session tokens in OpenClaw — no event
+    // fires, nothing gets recorded yet.
+    sessionRef.current = {
+      ...sessionRef.current,
+      inputTokens: 250,
+      outputTokens: 80,
+    };
+
+    // Step 3: Poller runs. It sees the grown session and inserts the delta.
+    await pollAllSessions(client);
+
+    expect(mockValues).toHaveBeenCalledTimes(2);
+    expect(mockValues).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ inputTokens: 150, outputTokens: 30 })
+    );
+    // Running totals in DB now reflect the full OpenClaw snapshot
+    expect(dbState.inputSum).toBe(250);
+    expect(dbState.outputSum).toBe(80);
+  });
+
+  it("accumulates deltas correctly across multiple poll cycles", async () => {
+    // Simulate a long-running chat: tokens grow monotonically over 3 polls.
+    // The sum of all recorded deltas must equal the final OpenClaw total.
+
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 100,
+        outputTokens: 0,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    // Tick 1: 100 input tokens → delta 100
+    await pollAllSessions(client);
+    expect(mockValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({ inputTokens: 100, outputTokens: 0 })
+    );
+
+    // Tick 2: 200 input tokens (delta 100)
+    sessionRef.current = { ...sessionRef.current, inputTokens: 200 };
+    await pollAllSessions(client);
+    expect(mockValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({ inputTokens: 100, outputTokens: 0 })
+    );
+
+    // Tick 3: 350 input tokens (delta 150)
+    sessionRef.current = { ...sessionRef.current, inputTokens: 350 };
+    await pollAllSessions(client);
+    expect(mockValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({ inputTokens: 150, outputTokens: 0 })
+    );
+
+    // Final DB total must match OpenClaw's cumulative counter.
+    expect(dbState.inputSum).toBe(350);
+    expect(mockValues).toHaveBeenCalledTimes(3);
+  });
+
+  it("handles concurrent done-event and poll without double-counting", async () => {
+    // Two recordUsage calls are issued back-to-back for the same session
+    // (simulates a "done" event firing just as pollAllSessions wakes up).
+    // Without pendingBySession serialization, both would read sum=0 from
+    // the DB and each insert a full 100-token delta — doubling the real
+    // usage. The serialization chain must force the second call to see
+    // the first call's insert and skip its redundant delta.
+
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    // Kick off both calls without awaiting either — they race on the queue.
+    const call1 = recordUsage({ openclawClient: client, ...baseParams });
+    const call2 = recordUsage({ openclawClient: client, ...baseParams });
+
+    await Promise.all([call1, call2]);
+
+    // Exactly one insert: first call wrote delta 100/50, second call saw
+    // the resulting sum and computed delta 0/0 (skipped).
+    expect(mockValues).toHaveBeenCalledTimes(1);
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({ inputTokens: 100, outputTokens: 50 })
+    );
+    expect(dbState.inputSum).toBe(100);
+    expect(dbState.outputSum).toBe(50);
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
+++ b/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
@@ -3,15 +3,30 @@
  *
  * These tests use the REAL `recordUsage` (not a spy) against a stateful
  * in-memory DB mock, so they exercise:
- *   - the cumulative-delta logic (subtract previously recorded sums from
- *     the current OpenClaw snapshot)
+ *   - the per-session watermark delta logic (the last-seen OpenClaw
+ *     cumulative counter, which follows OpenClaw back down after a
+ *     compaction/reset so post-reset tokens are counted correctly)
  *   - the per-session serialization via `pendingBySession` that prevents
  *     concurrent recordUsage calls from double-counting
+ *   - the pendingBySession cleanup tail that prevents map leaks
+ *   - the sessionSnapshot handoff from poller → recordUsage that avoids
+ *     duplicate sessions.list() round-trips per poll tick
  *
  * They validate the design assumptions from the usage-dashboard-improvements
  * plan — specifically that tokens added AFTER a "done" event are still
- * captured on the next poll, and that a concurrent done-event + poll does
- * not produce duplicate records for the same session window.
+ * captured on the next poll, that a concurrent done-event + poll does
+ * not produce duplicate records for the same session window, and that
+ * OpenClaw counter resets do not silently drop post-reset tokens.
+ *
+ * LIMITATION — the DB mock serves reads from a shared JS object with no
+ * transaction isolation, which is strictly weaker than real Postgres. The
+ * concurrent-call scenarios pass here because our `pendingBySession`
+ * serialization avoids the race entirely before it ever reaches the DB,
+ * not because the mock simulates row-level locking. A real Postgres
+ * integration test (behind INTEGRATION_TEST=1, see
+ * ./integration/usage-tracking.integration.test.ts) is the layer that can
+ * catch actual transaction-ordering bugs. Changes to the pendingBySession
+ * logic or cross-row locking should be re-verified against the real DB.
  */
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
@@ -71,8 +86,16 @@ vi.mock("@/db", () => ({
         from: (table: { _table?: string }) => {
           mockFrom(table);
           if (table?._table === "agents") {
-            // pollAllSessions uses this to build its agent name map
-            return Promise.resolve([{ id: "agent-1", name: "Smithers" }]);
+            // pollAllSessions uses this to build its agent name map.
+            // Since the poller was hardened to filter soft-deleted agents
+            // via `.where(isNull(agents.deletedAt))`, the mock must also
+            // expose a chainable `.where()` on this branch.
+            return {
+              where: (..._wArgs: unknown[]) => {
+                mockWhere(..._wArgs);
+                return Promise.resolve([{ id: "agent-1", name: "Smithers" }]);
+              },
+            };
           }
           // usageRecords — chainable with where() to read the running sum
           return {
@@ -102,9 +125,16 @@ vi.mock("@/db/schema", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((_col, val) => ({ _type: "eq", val })),
   sum: vi.fn((col) => ({ _type: "sum", col })),
+  isNull: vi.fn((col) => ({ _type: "isNull", col })),
 }));
 
-import { recordUsage, _resetPricingCacheForTest, _resetPendingSessionsForTest } from "@/lib/usage";
+import {
+  recordUsage,
+  _resetPricingCacheForTest,
+  _resetPendingSessionsForTest,
+  _resetUsageWatermarksForTest,
+  _getPendingSessionsCountForTest,
+} from "@/lib/usage";
 import { pollAllSessions } from "@/lib/usage-poller";
 
 interface MutableSession {
@@ -145,6 +175,7 @@ describe("polling timing scenarios", () => {
     resetDbState();
     _resetPricingCacheForTest();
     _resetPendingSessionsForTest();
+    _resetUsageWatermarksForTest();
   });
 
   it("captures tokens added after 'done' event on next poll cycle", async () => {
@@ -231,6 +262,183 @@ describe("polling timing scenarios", () => {
     // Final DB total must match OpenClaw's cumulative counter.
     expect(dbState.inputSum).toBe(350);
     expect(mockValues).toHaveBeenCalledTimes(3);
+  });
+
+  it("never writes a negative delta on any token axis", async () => {
+    // Scenario: OpenClaw's cumulative counter drops on one or more axes —
+    // e.g. after context pruning, compaction, or a session restart. Without
+    // correct clamping, recordUsage would insert NEGATIVE values into
+    // usage_records, which corrupts sum(inputTokens) / sum(outputTokens) /
+    // sum(cacheReadTokens) / sum(cacheWriteTokens) aggregates on the dashboard.
+    //
+    // The original guard `deltaInput <= 0 && deltaOutput <= 0` only caught the
+    // full-reset case. It did not catch:
+    //   (a) mixed axis: input grows but output drops (or vice versa)
+    //   (b) cache axes: input/output grow positively, but cacheRead/cacheWrite
+    //       drop — no guard was checking them at all.
+
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 300,
+        outputTokens: 200,
+        cacheReadTokens: 100,
+        cacheWriteTokens: 50,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    // Baseline insert.
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(mockValues).toHaveBeenCalledTimes(1);
+    expect(dbState.inputSum).toBe(300);
+    expect(dbState.outputSum).toBe(200);
+    expect(dbState.cacheReadSum).toBe(100);
+    expect(dbState.cacheWriteSum).toBe(50);
+
+    // Case (a): input grows, output drops. Old guard: deltaInput=50 is NOT <=0,
+    // so the skip short-circuits and the insert goes through with deltaOutput=-20.
+    sessionRef.current = {
+      ...sessionRef.current,
+      inputTokens: 350, // +50
+      outputTokens: 180, // -20
+      cacheReadTokens: 100, // 0
+      cacheWriteTokens: 50, // 0
+    };
+    await recordUsage({ openclawClient: client, ...baseParams });
+    // dbState must never go backwards.
+    expect(dbState.outputSum).toBeGreaterThanOrEqual(200);
+    // And no inserted row may have a negative value on any axis.
+    for (const call of mockValues.mock.calls) {
+      const vals = call[0] as {
+        inputTokens: number;
+        outputTokens: number;
+        cacheReadTokens: number;
+        cacheWriteTokens: number;
+      };
+      expect(vals.inputTokens).toBeGreaterThanOrEqual(0);
+      expect(vals.outputTokens).toBeGreaterThanOrEqual(0);
+      expect(vals.cacheReadTokens).toBeGreaterThanOrEqual(0);
+      expect(vals.cacheWriteTokens).toBeGreaterThanOrEqual(0);
+    }
+
+    // Case (b): input AND output grow (guard does not skip), but cache axes
+    // drop. The insert must not contain negative cache deltas.
+    const insertsBefore = mockValues.mock.calls.length;
+    sessionRef.current = {
+      ...sessionRef.current,
+      inputTokens: 400, // +50 over prev dbState of 350 (or the guard reads sum=350)
+      outputTokens: 220, // +20 over prev dbState
+      cacheReadTokens: 60, // -40 vs dbState.cacheReadSum (was 100, never went up)
+      cacheWriteTokens: 30, // -20 vs dbState.cacheWriteSum
+    };
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    // A new insert should have happened (input/output both grew positively).
+    expect(mockValues.mock.calls.length).toBeGreaterThan(insertsBefore);
+    const lastCall = mockValues.mock.calls[mockValues.mock.calls.length - 1][0] as {
+      inputTokens: number;
+      outputTokens: number;
+      cacheReadTokens: number;
+      cacheWriteTokens: number;
+    };
+    expect(lastCall.inputTokens).toBeGreaterThanOrEqual(0);
+    expect(lastCall.outputTokens).toBeGreaterThanOrEqual(0);
+    expect(lastCall.cacheReadTokens).toBeGreaterThanOrEqual(0);
+    expect(lastCall.cacheWriteTokens).toBeGreaterThanOrEqual(0);
+  });
+
+  it("cleans up pending-session entries after recordUsage resolves", async () => {
+    // Without cleanup, pendingBySession grows unbounded — every unique
+    // session key ever seen by Pinchy stays in the map for the lifetime
+    // of the process. On a long-running deployment with many short chats
+    // this is a slow memory leak. The fix is a .finally() at the tail of
+    // the chain that deletes the map entry once it's safe (i.e. no later
+    // call has replaced it).
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    expect(_getPendingSessionsCountForTest()).toBe(0);
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(_getPendingSessionsCountForTest()).toBe(0);
+  });
+
+  it("poller avoids duplicate sessions.list calls on recordUsage", async () => {
+    // The poller already fetches sessions.list() to discover which sessions
+    // have tokens to record. recordUsage should consume the snapshot passed
+    // by the poller instead of making a second round-trip — otherwise every
+    // poll tick doubles the OpenClaw sessions.list traffic (and per-session
+    // that cost scales linearly with the number of active chat sessions).
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 100,
+        outputTokens: 50,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+    const listSpy = (client as unknown as { sessions: { list: ReturnType<typeof vi.fn> } }).sessions
+      .list;
+
+    await pollAllSessions(client);
+
+    expect(mockValues).toHaveBeenCalledTimes(1);
+    expect(listSpy).toHaveBeenCalledTimes(1);
+  });
+
+  it("recovers from OpenClaw counter reset (compaction)", async () => {
+    // Per upstream research (OpenClaw src/gateway/server-methods/sessions.ts
+    // ~line 1569, session-reset-service.ts ~line 639, and the auto-reply
+    // compaction path), a session's inputTokens/outputTokens/cacheRead/
+    // cacheWrite fields are NOT monotonic — they get cleared on compaction,
+    // session-reset, or checkpoint clone, then re-accumulate from zero.
+    //
+    // The old DB-sum baseline ALWAYS sees `current < historical sum` after
+    // a reset, so every per-axis delta clamps to 0 and we silently drop
+    // every post-reset token forever. The fix is a per-session watermark
+    // tracking the last observed OpenClaw counter (which moves backwards
+    // on reset), independent of the DB aggregate.
+    const sessionRef = {
+      current: {
+        key: SESSION_KEY,
+        inputTokens: 500,
+        outputTokens: 200,
+        model: "test-model",
+      } as MutableSession,
+    };
+    const client = makeClient(sessionRef);
+
+    // Pre-reset: 500/200 tokens get recorded normally.
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(dbState.inputSum).toBe(500);
+    expect(dbState.outputSum).toBe(200);
+
+    // OpenClaw compacts the session — cumulative counters drop to 0.
+    // No delta should be recorded (compaction reshuffles internal state,
+    // it doesn't undo already-billed tokens), but the watermark must
+    // follow OpenClaw back down to 0 so the next growth is recognized.
+    sessionRef.current = { ...sessionRef.current, inputTokens: 0, outputTokens: 0 };
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(dbState.inputSum).toBe(500);
+    expect(dbState.outputSum).toBe(200);
+
+    // New tokens accumulate after the reset: 300 input, 100 output.
+    sessionRef.current = { ...sessionRef.current, inputTokens: 300, outputTokens: 100 };
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    // These post-reset tokens MUST be counted. The old implementation
+    // would have computed max(0, 300-500)=0 and silently dropped them.
+    expect(dbState.inputSum).toBe(800);
+    expect(dbState.outputSum).toBe(300);
   });
 
   it("handles concurrent done-event and poll without double-counting", async () => {

--- a/packages/web/src/__tests__/lib/usage-source.test.ts
+++ b/packages/web/src/__tests__/lib/usage-source.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { classifyUsageSource } from "@/lib/usage-source";
+
+describe("classifyUsageSource", () => {
+  it("classifies direct chat sessions as 'chat'", () => {
+    expect(classifyUsageSource("agent:smithers:direct:user-1")).toBe("chat");
+  });
+
+  it("classifies direct chat sessions with complex userIds as 'chat'", () => {
+    expect(classifyUsageSource("agent:abc123:direct:user-with-dashes-42")).toBe("chat");
+  });
+
+  it("classifies plugin sessions as 'plugin'", () => {
+    expect(classifyUsageSource("plugin:pinchy-files")).toBe("plugin");
+  });
+
+  it("classifies other plugin namespaces as 'plugin'", () => {
+    expect(classifyUsageSource("plugin:pinchy-audit")).toBe("plugin");
+  });
+
+  it("classifies main sessions as 'system'", () => {
+    expect(classifyUsageSource("agent:smithers:main")).toBe("system");
+  });
+
+  it("classifies cron sessions as 'system'", () => {
+    expect(classifyUsageSource("agent:smithers:cron:job-1")).toBe("system");
+  });
+
+  it("classifies hook sessions as 'system'", () => {
+    expect(classifyUsageSource("agent:smithers:hook:webhook-1")).toBe("system");
+  });
+
+  it("classifies unknown formats as 'system'", () => {
+    expect(classifyUsageSource("something-else")).toBe("system");
+  });
+
+  it("classifies empty string as 'system'", () => {
+    expect(classifyUsageSource("")).toBe("system");
+  });
+
+  it("does not match partial 'direct' segment in the middle of another word", () => {
+    // e.g. a cron session whose job name happens to contain 'direct'
+    expect(classifyUsageSource("agent:smithers:cron:direct-deposit")).toBe("system");
+  });
+});

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -372,6 +372,72 @@ describe("recordUsage", () => {
     });
   });
 
+  it("does not advance watermark when DB insert fails", async () => {
+    const client = makeOpenClawClient([
+      {
+        key: "agent:agent-1:user-user-1",
+        inputTokens: 100,
+        outputTokens: 200,
+        cacheReadTokens: 0,
+        cacheWriteTokens: 0,
+        model: "test-model",
+      },
+    ]);
+
+    // First call succeeds — establishes watermark
+    await recordUsage({ openclawClient: client, ...baseParams });
+    expect(mockInsert).toHaveBeenCalledTimes(1);
+    mockInsert.mockClear();
+    mockValues.mockClear();
+
+    // Bump OpenClaw counters
+    (client.sessions.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessions: [
+        {
+          key: "agent:agent-1:user-user-1",
+          inputTokens: 300,
+          outputTokens: 400,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "test-model",
+        },
+      ],
+    });
+
+    // Make DB insert fail
+    mockValues.mockRejectedValueOnce(new Error("connection pool exhausted"));
+
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    // Reset mock to succeed again
+    mockValues.mockResolvedValue(undefined);
+
+    // Bump OpenClaw counters again
+    (client.sessions.list as ReturnType<typeof vi.fn>).mockResolvedValue({
+      sessions: [
+        {
+          key: "agent:agent-1:user-user-1",
+          inputTokens: 350,
+          outputTokens: 450,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+          model: "test-model",
+        },
+      ],
+    });
+
+    // Third call: should see delta from 100/200 (last SUCCESSFUL watermark),
+    // not from 300/400 (failed call's watermark)
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    expect(mockValues).toHaveBeenLastCalledWith(
+      expect.objectContaining({
+        inputTokens: 250, // 350 - 100, not 350 - 300
+        outputTokens: 250, // 450 - 200, not 450 - 400
+      })
+    );
+  });
+
   it("caches config and does not call config.get() again within 5 minutes", async () => {
     const configWithPricing = {
       config: {

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -38,7 +38,12 @@ vi.mock("drizzle-orm", () => ({
   sum: vi.fn((col) => ({ _type: "sum", col })),
 }));
 
-import { recordUsage, _resetPricingCacheForTest } from "@/lib/usage";
+import {
+  recordUsage,
+  _resetPricingCacheForTest,
+  _resetPendingSessionsForTest,
+  _resetUsageWatermarksForTest,
+} from "@/lib/usage";
 import { usageRecords } from "@/db/schema";
 
 const emptyConfig = { config: { models: { providers: {} } } };
@@ -65,6 +70,8 @@ describe("recordUsage", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     _resetPricingCacheForTest();
+    _resetPendingSessionsForTest();
+    _resetUsageWatermarksForTest();
     mockValues.mockResolvedValue(undefined);
     // Default: no previous records
     mockWhere._result = [

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -256,6 +256,91 @@ describe("recordUsage", () => {
     );
   });
 
+  it("includes cache read tokens at 10% of input price in cost estimation", async () => {
+    const configWithPricing = {
+      config: {
+        models: {
+          providers: {
+            anthropic: {
+              models: [
+                {
+                  id: "claude-sonnet-4-20250514",
+                  cost: { input: 3.0, output: 15.0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const client = makeOpenClawClient(
+      [
+        {
+          key: "agent:agent-1:user-user-1",
+          inputTokens: 1000,
+          outputTokens: 500,
+          cacheReadTokens: 2000,
+          cacheWriteTokens: 0,
+          model: "claude-sonnet-4-20250514",
+        },
+      ],
+      configWithPricing
+    );
+
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    // cost = (1000*3.0 + 500*15.0 + 2000*0.3) / 1_000_000
+    //      = (3000 + 7500 + 600) / 1_000_000 = 0.011100
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        estimatedCostUsd: "0.011100",
+      })
+    );
+  });
+
+  it("includes cache write tokens at 125% of input price in cost estimation", async () => {
+    const configWithPricing = {
+      config: {
+        models: {
+          providers: {
+            anthropic: {
+              models: [
+                {
+                  id: "claude-sonnet-4-20250514",
+                  cost: { input: 3.0, output: 15.0 },
+                },
+              ],
+            },
+          },
+        },
+      },
+    };
+
+    const client = makeOpenClawClient(
+      [
+        {
+          key: "agent:agent-1:user-user-1",
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 1000,
+          model: "claude-sonnet-4-20250514",
+        },
+      ],
+      configWithPricing
+    );
+
+    await recordUsage({ openclawClient: client, ...baseParams });
+
+    // cost = (1000 * 3.75) / 1_000_000 = 0.003750
+    expect(mockValues).toHaveBeenCalledWith(
+      expect.objectContaining({
+        estimatedCostUsd: "0.003750",
+      })
+    );
+  });
+
   it("sets estimatedCostUsd to null when no pricing configured for model", async () => {
     const configWithOtherModel = {
       config: {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -10,7 +10,6 @@ const {
   mockAppendAuditLog,
   mockGetUserGroupIds,
   mockGetAgentGroupIds,
-  mockRecordUsage,
 } = vi.hoisted(() => ({
   mockChat: vi.fn(),
   mockSessionsHistory: vi.fn(),
@@ -20,7 +19,6 @@ const {
   mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
   mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
   mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
-  mockRecordUsage: vi.fn().mockResolvedValue(undefined),
 }));
 
 vi.mock("@/lib/agent-access", async (importOriginal) => {
@@ -84,10 +82,6 @@ vi.mock("@/lib/audit", () => ({
 vi.mock("@/lib/groups", () => ({
   getUserGroupIds: (...args: unknown[]) => mockGetUserGroupIds(...args),
   getAgentGroupIds: (...args: unknown[]) => mockGetAgentGroupIds(...args),
-}));
-
-vi.mock("@/lib/usage", () => ({
-  recordUsage: mockRecordUsage,
 }));
 
 import { ClientRouter } from "@/server/client-router";
@@ -1733,61 +1727,6 @@ describe("ClientRouter", () => {
       const greeting = sent[0].messages[0].content;
       expect(greeting).not.toContain("{user}");
       expect(greeting).toContain("I'm Smithers");
-    });
-  });
-
-  describe("usage tracking", () => {
-    it("records usage after chat completes", async () => {
-      const clientWs = createMockClientWs();
-      async function* fakeStream() {
-        yield { type: "text" as const, text: "Hello!" };
-        yield { type: "done" as const, text: "" };
-      }
-      mockChat.mockReturnValue(fakeStream());
-
-      await router.handleMessage(clientWs as any, {
-        type: "message",
-        content: "Hi",
-        agentId: "agent-1",
-      });
-
-      expect(mockRecordUsage).toHaveBeenCalledWith(
-        expect.objectContaining({
-          openclawClient: expect.anything(),
-          userId: "user-1",
-          agentId: "agent-1",
-          agentName: "Smithers",
-          sessionKey: "agent:agent-1:direct:user-1",
-        })
-      );
-    });
-
-    it("does not block chat response when usage tracking fails", async () => {
-      mockRecordUsage.mockRejectedValueOnce(new Error("DB down"));
-      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
-
-      const clientWs = createMockClientWs();
-      async function* fakeStream() {
-        yield { type: "text" as const, text: "Hello!" };
-        yield { type: "done" as const, text: "" };
-      }
-      mockChat.mockReturnValue(fakeStream());
-
-      await router.handleMessage(clientWs as any, {
-        type: "message",
-        content: "Hi",
-        agentId: "agent-1",
-      });
-
-      const messages = clientWs.sent.map((s) => JSON.parse(s));
-      const doneMsg = messages.find((m: any) => m.type === "done");
-      expect(doneMsg).toBeDefined();
-
-      // Wait for the fire-and-forget promise to settle
-      await new Promise((resolve) => setTimeout(resolve, 0));
-      expect(consoleSpy).toHaveBeenCalledWith("Usage tracking failed:", expect.any(Error));
-
-      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/web/src/app/api/internal/usage/record/route.ts
+++ b/packages/web/src/app/api/internal/usage/record/route.ts
@@ -1,6 +1,7 @@
 // audit-exempt: internal telemetry sink for OpenClaw plugins reporting LLM token usage, not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
 import { validateGatewayToken } from "@/lib/gateway-auth";
+import { tryAcquireUsageRecordSlot } from "@/lib/usage-record-rate-limiter";
 import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
 
@@ -58,6 +59,13 @@ function parsePayload(value: unknown): UsagePayload | null {
 }
 
 export async function POST(request: NextRequest) {
+  // Defense-in-depth rate limit — runs BEFORE token validation so a brute
+  // forcer cannot guess the gateway token at line rate. See
+  // `src/lib/usage-record-rate-limiter.ts` for the window configuration.
+  if (!tryAcquireUsageRecordSlot()) {
+    return NextResponse.json({ error: "Too many requests" }, { status: 429 });
+  }
+
   if (!validateGatewayToken(request.headers)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }

--- a/packages/web/src/app/api/internal/usage/record/route.ts
+++ b/packages/web/src/app/api/internal/usage/record/route.ts
@@ -1,0 +1,84 @@
+// audit-exempt: internal telemetry sink for OpenClaw plugins reporting LLM token usage, not a user-facing action
+import { NextRequest, NextResponse } from "next/server";
+import { validateGatewayToken } from "@/lib/gateway-auth";
+import { db } from "@/db";
+import { usageRecords } from "@/db/schema";
+
+interface UsagePayload {
+  agentId: string;
+  agentName: string;
+  userId: string;
+  sessionKey: string;
+  model?: string;
+  inputTokens: number;
+  outputTokens: number;
+}
+
+function isObject(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null;
+}
+
+function parsePayload(value: unknown): UsagePayload | null {
+  if (!isObject(value)) return null;
+
+  const agentId = value.agentId;
+  const agentName = value.agentName;
+  const userId = value.userId;
+  const sessionKey = value.sessionKey;
+  const inputTokens = value.inputTokens;
+  const outputTokens = value.outputTokens;
+  const model = value.model;
+
+  if (
+    typeof agentId !== "string" ||
+    !agentId ||
+    typeof agentName !== "string" ||
+    !agentName ||
+    typeof userId !== "string" ||
+    !userId ||
+    typeof sessionKey !== "string" ||
+    !sessionKey ||
+    typeof inputTokens !== "number" ||
+    !Number.isFinite(inputTokens) ||
+    typeof outputTokens !== "number" ||
+    !Number.isFinite(outputTokens)
+  ) {
+    return null;
+  }
+
+  return {
+    agentId,
+    agentName,
+    userId,
+    sessionKey,
+    model: typeof model === "string" && model ? model : undefined,
+    inputTokens,
+    outputTokens,
+  };
+}
+
+export async function POST(request: NextRequest) {
+  if (!validateGatewayToken(request.headers)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const payload = parsePayload(await request.json());
+  if (!payload) {
+    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
+  }
+
+  await db.insert(usageRecords).values({
+    userId: payload.userId,
+    agentId: payload.agentId,
+    agentName: payload.agentName,
+    sessionKey: payload.sessionKey,
+    model: payload.model ?? null,
+    inputTokens: payload.inputTokens,
+    outputTokens: payload.outputTokens,
+    cacheReadTokens: 0,
+    cacheWriteTokens: 0,
+    estimatedCostUsd: null,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/web/src/app/api/internal/usage/record/route.ts
+++ b/packages/web/src/app/api/internal/usage/record/route.ts
@@ -41,8 +41,10 @@ function parsePayload(value: unknown): UsagePayload | null {
     !sessionKey ||
     typeof inputTokens !== "number" ||
     !Number.isFinite(inputTokens) ||
+    inputTokens < 0 ||
     typeof outputTokens !== "number" ||
-    !Number.isFinite(outputTokens)
+    !Number.isFinite(outputTokens) ||
+    outputTokens < 0
   ) {
     return null;
   }

--- a/packages/web/src/app/api/usage/by-user/route.ts
+++ b/packages/web/src/app/api/usage/by-user/route.ts
@@ -38,6 +38,8 @@ export async function GET(request: NextRequest) {
       userName: users.name,
       totalInputTokens: sum(usageRecords.inputTokens),
       totalOutputTokens: sum(usageRecords.outputTokens),
+      totalCacheReadTokens: sum(usageRecords.cacheReadTokens),
+      totalCacheWriteTokens: sum(usageRecords.cacheWriteTokens),
       totalCost: sum(usageRecords.estimatedCostUsd),
     })
     .from(usageRecords)

--- a/packages/web/src/app/api/usage/summary/route.ts
+++ b/packages/web/src/app/api/usage/summary/route.ts
@@ -9,12 +9,16 @@ import type { UsageSource } from "@/lib/usage-source";
 type SourceBucket = {
   inputTokens: string;
   outputTokens: string;
+  cacheReadTokens: string;
+  cacheWriteTokens: string;
   cost: string;
 };
 
 const ZERO_BUCKET: SourceBucket = {
   inputTokens: "0",
   outputTokens: "0",
+  cacheReadTokens: "0",
+  cacheWriteTokens: "0",
   cost: "0",
 };
 
@@ -49,6 +53,8 @@ export async function GET(request: NextRequest) {
       agentName: max(usageRecords.agentName),
       totalInputTokens: sum(usageRecords.inputTokens),
       totalOutputTokens: sum(usageRecords.outputTokens),
+      totalCacheReadTokens: sum(usageRecords.cacheReadTokens),
+      totalCacheWriteTokens: sum(usageRecords.cacheWriteTokens),
       totalCost: sum(usageRecords.estimatedCostUsd),
       deleted: sql<boolean>`bool_or(${agents.deletedAt} IS NOT NULL)`.as("deleted"),
     })
@@ -72,6 +78,8 @@ export async function GET(request: NextRequest) {
       source: sourceExpr,
       inputTokens: sum(usageRecords.inputTokens),
       outputTokens: sum(usageRecords.outputTokens),
+      cacheReadTokens: sum(usageRecords.cacheReadTokens),
+      cacheWriteTokens: sum(usageRecords.cacheWriteTokens),
       cost: sum(usageRecords.estimatedCostUsd),
     })
     .from(usageRecords)
@@ -87,6 +95,8 @@ export async function GET(request: NextRequest) {
     totals[row.source] = {
       inputTokens: row.inputTokens ?? "0",
       outputTokens: row.outputTokens ?? "0",
+      cacheReadTokens: row.cacheReadTokens ?? "0",
+      cacheWriteTokens: row.cacheWriteTokens ?? "0",
       cost: row.cost ?? "0",
     };
   }

--- a/packages/web/src/app/api/usage/summary/route.ts
+++ b/packages/web/src/app/api/usage/summary/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { parseDays } from "@/lib/usage-params";
 import { db } from "@/db";
-import { usageRecords } from "@/db/schema";
+import { usageRecords, agents } from "@/db/schema";
 import { max, sum, gte, eq, and, sql } from "drizzle-orm";
 import type { UsageSource } from "@/lib/usage-source";
 
@@ -43,15 +43,17 @@ export async function GET(request: NextRequest) {
   // max(agentName) returns the lexicographically greatest name.
   // If an agent is renamed, this may show either old or new name
   // until all old records age out. Acceptable trade-off for simplicity.
-  const agents = await db
+  const agentResults = await db
     .select({
       agentId: usageRecords.agentId,
       agentName: max(usageRecords.agentName),
       totalInputTokens: sum(usageRecords.inputTokens),
       totalOutputTokens: sum(usageRecords.outputTokens),
       totalCost: sum(usageRecords.estimatedCostUsd),
+      deleted: sql<boolean>`bool_or(${agents.deletedAt} IS NOT NULL)`.as("deleted"),
     })
     .from(usageRecords)
+    .leftJoin(agents, eq(agents.id, usageRecords.agentId))
     .where(where)
     .groupBy(usageRecords.agentId);
 
@@ -89,5 +91,5 @@ export async function GET(request: NextRequest) {
     };
   }
 
-  return NextResponse.json({ agents, totals });
+  return NextResponse.json({ agents: agentResults, totals });
 }

--- a/packages/web/src/app/api/usage/summary/route.ts
+++ b/packages/web/src/app/api/usage/summary/route.ts
@@ -3,7 +3,20 @@ import { requireAdmin } from "@/lib/api-auth";
 import { parseDays } from "@/lib/usage-params";
 import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
-import { max, sum, gte, eq, and } from "drizzle-orm";
+import { max, sum, gte, eq, and, sql } from "drizzle-orm";
+import type { UsageSource } from "@/lib/usage-source";
+
+type SourceBucket = {
+  inputTokens: string;
+  outputTokens: string;
+  cost: string;
+};
+
+const ZERO_BUCKET: SourceBucket = {
+  inputTokens: "0",
+  outputTokens: "0",
+  cost: "0",
+};
 
 export async function GET(request: NextRequest) {
   const sessionOrError = await requireAdmin();
@@ -42,5 +55,39 @@ export async function GET(request: NextRequest) {
     .where(where)
     .groupBy(usageRecords.agentId);
 
-  return NextResponse.json({ agents });
+  // Source breakdown — classify each row by its sessionKey shape and sum
+  // tokens/cost per bucket. SQL can't call our TypeScript classifier, so
+  // we mirror its rules as a CASE expression. Keep in sync with
+  // packages/web/src/lib/usage-source.ts.
+  const sourceExpr = sql<UsageSource>`CASE
+    WHEN ${usageRecords.sessionKey} LIKE 'plugin:%' THEN 'plugin'
+    WHEN ${usageRecords.sessionKey} LIKE 'agent:%:direct:%' THEN 'chat'
+    ELSE 'system'
+  END`;
+
+  const bySource = await db
+    .select({
+      source: sourceExpr,
+      inputTokens: sum(usageRecords.inputTokens),
+      outputTokens: sum(usageRecords.outputTokens),
+      cost: sum(usageRecords.estimatedCostUsd),
+    })
+    .from(usageRecords)
+    .where(where)
+    .groupBy(sourceExpr);
+
+  const totals: Record<UsageSource, SourceBucket> = {
+    chat: { ...ZERO_BUCKET },
+    system: { ...ZERO_BUCKET },
+    plugin: { ...ZERO_BUCKET },
+  };
+  for (const row of bySource) {
+    totals[row.source] = {
+      inputTokens: row.inputTokens ?? "0",
+      outputTokens: row.outputTokens ?? "0",
+      cost: row.cost ?? "0",
+    };
+  }
+
+  return NextResponse.json({ agents, totals });
 }

--- a/packages/web/src/app/api/usage/summary/route.ts
+++ b/packages/web/src/app/api/usage/summary/route.ts
@@ -11,7 +11,7 @@ type SourceBucket = {
   outputTokens: string;
   cacheReadTokens: string;
   cacheWriteTokens: string;
-  cost: string;
+  cost: string | null;
 };
 
 const ZERO_BUCKET: SourceBucket = {
@@ -19,7 +19,7 @@ const ZERO_BUCKET: SourceBucket = {
   outputTokens: "0",
   cacheReadTokens: "0",
   cacheWriteTokens: "0",
-  cost: "0",
+  cost: null,
 };
 
 export async function GET(request: NextRequest) {
@@ -97,7 +97,7 @@ export async function GET(request: NextRequest) {
       outputTokens: row.outputTokens ?? "0",
       cacheReadTokens: row.cacheReadTokens ?? "0",
       cacheWriteTokens: row.cacheWriteTokens ?? "0",
-      cost: row.cost ?? "0",
+      cost: row.cost ?? null,
     };
   }
 

--- a/packages/web/src/app/api/usage/timeseries/route.ts
+++ b/packages/web/src/app/api/usage/timeseries/route.ts
@@ -34,6 +34,8 @@ export async function GET(request: NextRequest) {
       date: dateExpr,
       inputTokens: sum(usageRecords.inputTokens),
       outputTokens: sum(usageRecords.outputTokens),
+      cacheReadTokens: sum(usageRecords.cacheReadTokens),
+      cacheWriteTokens: sum(usageRecords.cacheWriteTokens),
       cost: sum(usageRecords.estimatedCostUsd),
     })
     .from(usageRecords)

--- a/packages/web/src/app/api/usage/timeseries/route.ts
+++ b/packages/web/src/app/api/usage/timeseries/route.ts
@@ -36,8 +36,13 @@ export async function GET(request: NextRequest) {
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
+  // Use sql.raw for the timezone identifier — it's already validated above via
+  // Intl.DateTimeFormat and only contains [A-Za-z/_+-] characters. A parameterised
+  // ${tz} would create a fresh $N placeholder each time dateExpr is referenced
+  // (SELECT, GROUP BY, ORDER BY), making PostgreSQL see three different expressions
+  // and reject the query with "must appear in the GROUP BY clause".
   const dateExpr = tz
-    ? sql<string>`date_trunc('day', ${usageRecords.timestamp} AT TIME ZONE ${tz})::date`
+    ? sql<string>`date_trunc('day', ${usageRecords.timestamp} AT TIME ZONE '${sql.raw(tz)}')::date`
     : sql<string>`date_trunc('day', ${usageRecords.timestamp})::date`;
 
   const data = await db

--- a/packages/web/src/app/api/usage/timeseries/route.ts
+++ b/packages/web/src/app/api/usage/timeseries/route.ts
@@ -14,6 +14,15 @@ export async function GET(request: NextRequest) {
   if (daysOrError instanceof NextResponse) return daysOrError;
   const days = daysOrError;
   const agentId = url.searchParams.get("agentId");
+  const tz = url.searchParams.get("tz");
+
+  if (tz) {
+    try {
+      Intl.DateTimeFormat(undefined, { timeZone: tz });
+    } catch {
+      return NextResponse.json({ error: "Invalid timezone" }, { status: 400 });
+    }
+  }
 
   const conditions = [];
   if (days > 0) {
@@ -27,7 +36,9 @@ export async function GET(request: NextRequest) {
 
   const where = conditions.length > 0 ? and(...conditions) : undefined;
 
-  const dateExpr = sql<string>`date_trunc('day', ${usageRecords.timestamp})::date`;
+  const dateExpr = tz
+    ? sql<string>`date_trunc('day', ${usageRecords.timestamp} AT TIME ZONE ${tz})::date`
+    : sql<string>`date_trunc('day', ${usageRecords.timestamp})::date`;
 
   const data = await db
     .select({

--- a/packages/web/src/app/api/usage/timeseries/route.ts
+++ b/packages/web/src/app/api/usage/timeseries/route.ts
@@ -43,5 +43,38 @@ export async function GET(request: NextRequest) {
     .groupBy(dateExpr)
     .orderBy(dateExpr);
 
-  return NextResponse.json({ data });
+  return NextResponse.json({ data: zeroFill(data) });
+}
+
+function zeroFill(
+  rows: {
+    date: string;
+    inputTokens: string | null;
+    outputTokens: string | null;
+    cacheReadTokens: string | null;
+    cacheWriteTokens: string | null;
+    cost: string | null;
+  }[]
+) {
+  if (rows.length < 2) return rows;
+
+  const map = new Map(rows.map((r) => [String(r.date), r]));
+  const filled: typeof rows = [];
+  const start = new Date(String(rows[0].date));
+  const end = new Date(String(rows[rows.length - 1].date));
+
+  for (let d = new Date(start); d <= end; d.setDate(d.getDate() + 1)) {
+    const key = d.toISOString().slice(0, 10);
+    filled.push(
+      map.get(key) ?? {
+        date: key,
+        inputTokens: "0",
+        outputTokens: "0",
+        cacheReadTokens: "0",
+        cacheWriteTokens: "0",
+        cost: null,
+      }
+    );
+  }
+  return filled;
 }

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -101,6 +101,11 @@ const PERIOD_OPTIONS: { label: string; value: DaysOption }[] = [
   { label: "All", value: "all" },
 ];
 
+/** Show dots on chart lines when there is at most one data point (otherwise the single point is invisible). */
+export function shouldShowDots(dataLength: number): boolean {
+  return dataLength <= 1;
+}
+
 export function UsageDashboard({ isEnterprise: initialEnterprise = false }: UsageDashboardProps) {
   const [enterprise, setEnterprise] = useState(initialEnterprise);
   const [days, setDays] = useState<DaysOption>(30);
@@ -455,7 +460,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                     dataKey="inputTokens"
                     stroke="oklch(0.65 0.195 50)"
                     strokeWidth={2}
-                    dot={false}
+                    dot={shouldShowDots(chartData.length)}
                     name="Input Tokens"
                   />
                   <Line
@@ -463,7 +468,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                     dataKey="outputTokens"
                     stroke="oklch(0.62 0.1 230)"
                     strokeWidth={2}
-                    dot={false}
+                    dot={shouldShowDots(chartData.length)}
                     name="Output Tokens"
                   />
                 </LineChart>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -37,8 +37,21 @@ interface AgentSummary {
   totalCost: string | null;
 }
 
+interface SourceBucket {
+  inputTokens: string | null;
+  outputTokens: string | null;
+  cost: string | null;
+}
+
+interface SourceTotals {
+  chat: SourceBucket;
+  system: SourceBucket;
+  plugin: SourceBucket;
+}
+
 interface SummaryResponse {
   agents: AgentSummary[];
+  totals?: SourceTotals;
 }
 
 interface TimeseriesPoint {
@@ -192,6 +205,18 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   );
   const totalCost = (summary?.agents ?? []).reduce((acc, a) => acc + Number(a.totalCost ?? 0), 0);
 
+  function bucketTotals(b: SourceBucket | undefined): { tokens: number; cost: number } {
+    if (!b) return { tokens: 0, cost: 0 };
+    return {
+      tokens: Number(b.inputTokens ?? 0) + Number(b.outputTokens ?? 0),
+      cost: Number(b.cost ?? 0),
+    };
+  }
+
+  const chatBucket = bucketTotals(summary?.totals?.chat);
+  const systemBucket = bucketTotals(summary?.totals?.system);
+  const pluginBucket = bucketTotals(summary?.totals?.plugin);
+
   const chartData = (timeseries?.data ?? []).map((p) => ({
     date: p.date,
     inputTokens: Number(p.inputTokens ?? 0),
@@ -308,6 +333,48 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
               </CardContent>
             </Card>
           </div>
+
+          {summary?.totals && (
+            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
+              <Card>
+                <CardHeader className="pb-2">
+                  <CardTitle className="text-xs font-medium text-muted-foreground">
+                    Chat Tokens
+                  </CardTitle>
+                </CardHeader>
+                <CardContent className="pt-0">
+                  <p className="text-lg font-semibold">{formatTokens(chatBucket.tokens)}</p>
+                  <p className="text-xs text-muted-foreground">{formatCost(chatBucket.cost)}</p>
+                </CardContent>
+              </Card>
+              {systemBucket.tokens > 0 && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-xs font-medium text-muted-foreground">
+                      System Tokens
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <p className="text-lg font-semibold">{formatTokens(systemBucket.tokens)}</p>
+                    <p className="text-xs text-muted-foreground">{formatCost(systemBucket.cost)}</p>
+                  </CardContent>
+                </Card>
+              )}
+              {pluginBucket.tokens > 0 && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-xs font-medium text-muted-foreground">
+                      Plugin Tokens
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <p className="text-lg font-semibold">{formatTokens(pluginBucket.tokens)}</p>
+                    <p className="text-xs text-muted-foreground">{formatCost(pluginBucket.cost)}</p>
+                  </CardContent>
+                </Card>
+              )}
+            </div>
+          )}
 
           <Card>
             <CardHeader>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -35,6 +35,7 @@ interface AgentSummary {
   totalInputTokens: string | null;
   totalOutputTokens: string | null;
   totalCost: string | null;
+  deleted?: boolean;
 }
 
 interface SourceBucket {
@@ -297,6 +298,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
               {knownAgents.map((a) => (
                 <option key={a.agentId} value={a.agentId}>
                   {a.agentName}
+                  {a.deleted ? " (deleted)" : ""}
                 </option>
               ))}
             </select>
@@ -510,7 +512,10 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                         })
                         .map((agent) => (
                           <TableRow key={agent.agentId}>
-                            <TableCell>{agent.agentName}</TableCell>
+                            <TableCell className={agent.deleted ? "text-muted-foreground" : ""}>
+                              {agent.agentName}
+                              {agent.deleted ? " (deleted)" : ""}
+                            </TableCell>
                             <TableCell className="text-right">
                               {formatTokens(Number(agent.totalInputTokens ?? 0))}
                             </TableCell>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -109,6 +109,8 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   const [knownAgents, setKnownAgents] = useState<AgentSummary[]>([]);
   const [byUser, setByUser] = useState<ByUserResponse | null>(null);
   const [activeTab, setActiveTab] = useState("by-agent");
+  const [error, setError] = useState<string | null>(null);
+  const [retryKey, setRetryKey] = useState(0);
 
   // Fetch fresh enterprise status client-side (server value may be stale after dev toggle)
   useEffect(() => {
@@ -137,6 +139,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
     ])
       .then(([summaryData, timeseriesData]) => {
         if (!cancelled) {
+          setError(null);
           setSummary(summaryData);
           setTimeseries(timeseriesData);
           // Only update agent list when not filtering by agent (to keep full list)
@@ -147,12 +150,17 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
       })
       .catch((err) => {
         console.error("[usage] Failed to fetch usage data:", err);
+        if (!cancelled) {
+          setError("Failed to load usage data.");
+          setSummary(null);
+          setTimeseries(null);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [days, selectedAgent]);
+  }, [days, selectedAgent, retryKey]);
 
   useEffect(() => {
     if (!enterprise || activeTab !== "by-user") return;
@@ -180,6 +188,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   }, [enterprise, activeTab, days, selectedAgent]);
 
   function handleDaysChange(value: DaysOption) {
+    setError(null);
     setSummary(null);
     setTimeseries(null);
     setByUser(null);
@@ -187,6 +196,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   }
 
   function handleAgentChange(value: string) {
+    setError(null);
     setSummary(null);
     setTimeseries(null);
     setByUser(null);
@@ -224,6 +234,13 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   }));
 
   const hasData = (summary?.agents?.length ?? 0) > 0;
+
+  function handleRetry() {
+    setError(null);
+    setSummary(null);
+    setTimeseries(null);
+    setRetryKey((k) => k + 1);
+  }
 
   return (
     <div className="space-y-6">
@@ -305,7 +322,14 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
         </div>
       </div>
 
-      {loading ? (
+      {error ? (
+        <div className="text-center py-8">
+          <p className="text-muted-foreground mb-3">{error}</p>
+          <Button variant="outline" onClick={handleRetry}>
+            Retry
+          </Button>
+        </div>
+      ) : loading ? (
         <p>Loading...</p>
       ) : !hasData ? (
         <p>No usage data available.</p>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -34,6 +34,8 @@ interface AgentSummary {
   agentName: string;
   totalInputTokens: string | null;
   totalOutputTokens: string | null;
+  totalCacheReadTokens: string | null;
+  totalCacheWriteTokens: string | null;
   totalCost: string | null;
   deleted?: boolean;
 }
@@ -41,6 +43,8 @@ interface AgentSummary {
 interface SourceBucket {
   inputTokens: string | null;
   outputTokens: string | null;
+  cacheReadTokens: string | null;
+  cacheWriteTokens: string | null;
   cost: string | null;
 }
 
@@ -59,6 +63,8 @@ interface TimeseriesPoint {
   date: string;
   inputTokens: string | null;
   outputTokens: string | null;
+  cacheReadTokens: string | null;
+  cacheWriteTokens: string | null;
   cost: string | null;
 }
 
@@ -67,6 +73,8 @@ interface UserSummary {
   userName: string;
   totalInputTokens: string | null;
   totalOutputTokens: string | null;
+  totalCacheReadTokens: string | null;
+  totalCacheWriteTokens: string | null;
   totalCost: string | null;
 }
 
@@ -227,6 +235,10 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
     if (allNull) return null;
     return agents.reduce((acc, a) => acc + Number(a.totalCost ?? 0), 0);
   })();
+  const totalCacheTokens = (summary?.agents ?? []).reduce(
+    (acc, a) => acc + Number(a.totalCacheReadTokens ?? 0) + Number(a.totalCacheWriteTokens ?? 0),
+    0
+  );
 
   function bucketTotals(b: SourceBucket | undefined): { tokens: number; cost: number | null } {
     if (!b) return { tokens: 0, cost: null };
@@ -349,7 +361,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
         <p>No usage data available.</p>
       ) : (
         <>
-          <div className="grid grid-cols-2 gap-4">
+          <div className={`grid gap-4 ${totalCacheTokens > 0 ? "grid-cols-3" : "grid-cols-2"}`}>
             <Card>
               <CardHeader>
                 <CardTitle className="text-sm font-medium text-muted-foreground">
@@ -360,6 +372,18 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                 <p className="text-2xl font-bold">{formatTokens(totalTokens)}</p>
               </CardContent>
             </Card>
+            {totalCacheTokens > 0 && (
+              <Card>
+                <CardHeader>
+                  <CardTitle className="text-sm font-medium text-muted-foreground">
+                    Cache Tokens
+                  </CardTitle>
+                </CardHeader>
+                <CardContent>
+                  <p className="text-2xl font-bold">{formatTokens(totalCacheTokens)}</p>
+                </CardContent>
+              </Card>
+            )}
             <Card>
               <CardHeader>
                 <CardTitle className="text-sm font-medium text-muted-foreground">
@@ -495,6 +519,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                         <TableHead>Agent</TableHead>
                         <TableHead className="text-right">Input Tokens</TableHead>
                         <TableHead className="text-right">Output Tokens</TableHead>
+                        {totalCacheTokens > 0 && (
+                          <TableHead className="text-right">Cache Tokens</TableHead>
+                        )}
                         <TableHead className="text-right">Cost</TableHead>
                       </TableRow>
                     </TableHeader>
@@ -522,6 +549,14 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                             <TableCell className="text-right">
                               {formatTokens(Number(agent.totalOutputTokens ?? 0))}
                             </TableCell>
+                            {totalCacheTokens > 0 && (
+                              <TableCell className="text-right">
+                                {formatTokens(
+                                  Number(agent.totalCacheReadTokens ?? 0) +
+                                    Number(agent.totalCacheWriteTokens ?? 0)
+                                )}
+                              </TableCell>
+                            )}
                             <TableCell className="text-right">
                               {formatCost(
                                 agent.totalCost !== null ? Number(agent.totalCost) : null
@@ -550,6 +585,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                             <TableHead>User</TableHead>
                             <TableHead className="text-right">Input Tokens</TableHead>
                             <TableHead className="text-right">Output Tokens</TableHead>
+                            {totalCacheTokens > 0 && (
+                              <TableHead className="text-right">Cache Tokens</TableHead>
+                            )}
                             <TableHead className="text-right">Cost</TableHead>
                           </TableRow>
                         </TableHeader>
@@ -574,6 +612,14 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                                 <TableCell className="text-right">
                                   {formatTokens(Number(user.totalOutputTokens ?? 0))}
                                 </TableCell>
+                                {totalCacheTokens > 0 && (
+                                  <TableCell className="text-right">
+                                    {formatTokens(
+                                      Number(user.totalCacheReadTokens ?? 0) +
+                                        Number(user.totalCacheWriteTokens ?? 0)
+                                    )}
+                                  </TableCell>
+                                )}
                                 <TableCell className="text-right">
                                   {formatCost(
                                     user.totalCost !== null ? Number(user.totalCost) : null

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -336,17 +336,19 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
 
           {summary?.totals && (
             <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              <Card>
-                <CardHeader className="pb-2">
-                  <CardTitle className="text-xs font-medium text-muted-foreground">
-                    Chat Tokens
-                  </CardTitle>
-                </CardHeader>
-                <CardContent className="pt-0">
-                  <p className="text-lg font-semibold">{formatTokens(chatBucket.tokens)}</p>
-                  <p className="text-xs text-muted-foreground">{formatCost(chatBucket.cost)}</p>
-                </CardContent>
-              </Card>
+              {chatBucket.tokens > 0 && (
+                <Card>
+                  <CardHeader className="pb-2">
+                    <CardTitle className="text-xs font-medium text-muted-foreground">
+                      Chat Tokens
+                    </CardTitle>
+                  </CardHeader>
+                  <CardContent className="pt-0">
+                    <p className="text-lg font-semibold">{formatTokens(chatBucket.tokens)}</p>
+                    <p className="text-xs text-muted-foreground">{formatCost(chatBucket.cost)}</p>
+                  </CardContent>
+                </Card>
+              )}
               {systemBucket.tokens > 0 && (
                 <Card>
                   <CardHeader className="pb-2">

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -96,9 +96,11 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-function formatCost(n: number | null): string {
-  if (n === null) return "\u2014";
-  return `$${n.toFixed(2)}`;
+const NO_PRICING_HINT = "No pricing data available for this model";
+
+function FormattedCost({ value }: { value: number | null }) {
+  if (value === null) return <span title={NO_PRICING_HINT}>{"\u2014"}</span>;
+  return <>{`$${value.toFixed(2)}`}</>;
 }
 
 type DaysOption = 7 | 30 | 90 | "all";
@@ -113,6 +115,30 @@ const PERIOD_OPTIONS: { label: string; value: DaysOption }[] = [
 /** Show dots on chart lines when there is at most one data point (otherwise the single point is invisible). */
 export function shouldShowDots(dataLength: number): boolean {
   return dataLength <= 1;
+}
+
+function StatCard({
+  label,
+  value,
+  subtitle,
+}: {
+  label: string;
+  value: React.ReactNode;
+  subtitle?: React.ReactNode;
+}) {
+  return (
+    <Card>
+      <CardHeader className="p-3 pb-1 sm:p-4 sm:pb-1">
+        <CardTitle className="text-[10px] sm:text-xs font-medium text-muted-foreground">
+          {label}
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="p-3 pt-0 sm:p-4 sm:pt-0">
+        <p className="text-base sm:text-xl font-bold truncate">{value}</p>
+        {subtitle && <p className="text-[10px] sm:text-xs text-muted-foreground">{subtitle}</p>}
+      </CardContent>
+    </Card>
+  );
 }
 
 export function UsageDashboard({ isEnterprise: initialEnterprise = false }: UsageDashboardProps) {
@@ -290,10 +316,10 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   }
 
   return (
-    <div className="space-y-6">
-      <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
+    <div className="space-y-4">
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-center lg:justify-between">
         <h2 className="text-2xl font-bold">Usage & Costs</h2>
-        <div className="flex flex-wrap items-center gap-2 sm:gap-3">
+        <div className="flex flex-wrap items-center gap-2 lg:gap-3">
           <select
             aria-label="Select time period"
             value={String(days)}
@@ -301,7 +327,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
               const v = e.target.value;
               handleDaysChange(v === "all" ? "all" : (Number(v) as 7 | 30 | 90));
             }}
-            className="border-input bg-transparent text-sm rounded-md border px-3 py-1.5 h-8 sm:hidden"
+            className="border-input bg-transparent text-sm rounded-md border px-3 py-1.5 h-8 lg:hidden"
           >
             {PERIOD_OPTIONS.map((opt) => (
               <option key={opt.label} value={String(opt.value)}>
@@ -309,7 +335,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
               </option>
             ))}
           </select>
-          <div className="hidden sm:flex gap-1">
+          <div className="hidden lg:flex gap-1">
             {PERIOD_OPTIONS.map((opt) => (
               <Button
                 key={opt.label}
@@ -383,91 +409,45 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
         <p>No usage data available.</p>
       ) : (
         <>
-          <div className={`grid gap-4 ${totalCacheTokens > 0 ? "grid-cols-3" : "grid-cols-2"}`}>
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Total Tokens
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-bold">{formatTokens(totalTokens)}</p>
-              </CardContent>
-            </Card>
+          <div className="grid grid-cols-3 gap-2 sm:gap-3">
+            <StatCard
+              label="Total Tokens"
+              value={formatTokens(totalTokens)}
+              subtitle={<FormattedCost value={totalCost} />}
+            />
+            <StatCard label="Estimated Cost" value={<FormattedCost value={totalCost} />} />
             {totalCacheTokens > 0 && (
-              <Card>
-                <CardHeader>
-                  <CardTitle className="text-sm font-medium text-muted-foreground">
-                    Cache Tokens
-                  </CardTitle>
-                </CardHeader>
-                <CardContent>
-                  <p className="text-2xl font-bold">{formatTokens(totalCacheTokens)}</p>
-                </CardContent>
-              </Card>
+              <StatCard label="Cache Tokens" value={formatTokens(totalCacheTokens)} />
             )}
-            <Card>
-              <CardHeader>
-                <CardTitle className="text-sm font-medium text-muted-foreground">
-                  Estimated Cost
-                </CardTitle>
-              </CardHeader>
-              <CardContent>
-                <p className="text-2xl font-bold">{formatCost(totalCost)}</p>
-              </CardContent>
-            </Card>
+            {summary?.totals && chatBucket.tokens > 0 && (
+              <StatCard
+                label="Chat Tokens"
+                value={formatTokens(chatBucket.tokens)}
+                subtitle={<FormattedCost value={chatBucket.cost} />}
+              />
+            )}
+            {summary?.totals && systemBucket.tokens > 0 && (
+              <StatCard
+                label="System Tokens"
+                value={formatTokens(systemBucket.tokens)}
+                subtitle={<FormattedCost value={systemBucket.cost} />}
+              />
+            )}
+            {summary?.totals && pluginBucket.tokens > 0 && (
+              <StatCard
+                label="Plugin Tokens"
+                value={formatTokens(pluginBucket.tokens)}
+                subtitle={<FormattedCost value={pluginBucket.cost} />}
+              />
+            )}
           </div>
 
-          {summary?.totals && (
-            <div className="grid grid-cols-1 gap-3 sm:grid-cols-3">
-              {chatBucket.tokens > 0 && (
-                <Card>
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-xs font-medium text-muted-foreground">
-                      Chat Tokens
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <p className="text-lg font-semibold">{formatTokens(chatBucket.tokens)}</p>
-                    <p className="text-xs text-muted-foreground">{formatCost(chatBucket.cost)}</p>
-                  </CardContent>
-                </Card>
-              )}
-              {systemBucket.tokens > 0 && (
-                <Card>
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-xs font-medium text-muted-foreground">
-                      System Tokens
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <p className="text-lg font-semibold">{formatTokens(systemBucket.tokens)}</p>
-                    <p className="text-xs text-muted-foreground">{formatCost(systemBucket.cost)}</p>
-                  </CardContent>
-                </Card>
-              )}
-              {pluginBucket.tokens > 0 && (
-                <Card>
-                  <CardHeader className="pb-2">
-                    <CardTitle className="text-xs font-medium text-muted-foreground">
-                      Plugin Tokens
-                    </CardTitle>
-                  </CardHeader>
-                  <CardContent className="pt-0">
-                    <p className="text-lg font-semibold">{formatTokens(pluginBucket.tokens)}</p>
-                    <p className="text-xs text-muted-foreground">{formatCost(pluginBucket.cost)}</p>
-                  </CardContent>
-                </Card>
-              )}
-            </div>
-          )}
-
           <Card>
-            <CardHeader>
+            <CardHeader className="pb-2">
               <CardTitle>Daily Token Usage</CardTitle>
             </CardHeader>
-            <CardContent className="px-2 sm:px-6">
-              <ResponsiveContainer width="100%" height={250} className="sm:!h-[300px]">
+            <CardContent className="px-2 pb-2 sm:px-6 sm:pb-3">
+              <ResponsiveContainer width="100%" height={220}>
                 <LineChart data={chartData} margin={{ left: -10, right: 5, top: 5, bottom: 0 }}>
                   <CartesianGrid strokeDasharray="3 3" stroke="oklch(0.9 0 0)" />
                   <XAxis
@@ -580,9 +560,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                               </TableCell>
                             )}
                             <TableCell className="text-right">
-                              {formatCost(
-                                agent.totalCost !== null ? Number(agent.totalCost) : null
-                              )}
+                              <FormattedCost
+                                value={agent.totalCost !== null ? Number(agent.totalCost) : null}
+                              />
                             </TableCell>
                           </TableRow>
                         ))}
@@ -650,9 +630,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                                   </TableCell>
                                 )}
                                 <TableCell className="text-right">
-                                  {formatCost(
-                                    user.totalCost !== null ? Number(user.totalCost) : null
-                                  )}
+                                  <FormattedCost
+                                    value={user.totalCost !== null ? Number(user.totalCost) : null}
+                                  />
                                 </TableCell>
                               </TableRow>
                             ))}

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -126,6 +126,8 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   const [activeTab, setActiveTab] = useState("by-agent");
   const [error, setError] = useState<string | null>(null);
   const [retryKey, setRetryKey] = useState(0);
+  const [byUserError, setByUserError] = useState<string | null>(null);
+  const [byUserRetryKey, setByUserRetryKey] = useState(0);
 
   // Fetch fresh enterprise status client-side (server value may be stale after dev toggle)
   useEffect(() => {
@@ -196,19 +198,33 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
         return r.json();
       })
       .then((data) => {
-        if (!cancelled) setByUser(data);
+        if (!cancelled) {
+          setByUserError(null);
+          setByUser(data);
+        }
       })
       .catch((err) => {
         console.error("[usage] Failed to fetch by-user data:", err);
+        if (!cancelled) {
+          setByUserError("Failed to load user data.");
+          setByUser(null);
+        }
       });
 
     return () => {
       cancelled = true;
     };
-  }, [enterprise, activeTab, days, selectedAgent]);
+  }, [enterprise, activeTab, days, selectedAgent, byUserRetryKey]);
+
+  function handleByUserRetry() {
+    setByUserError(null);
+    setByUser(null);
+    setByUserRetryKey((k) => k + 1);
+  }
 
   function handleDaysChange(value: DaysOption) {
     setError(null);
+    setByUserError(null);
     setSummary(null);
     setTimeseries(null);
     setByUser(null);
@@ -217,6 +233,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
 
   function handleAgentChange(value: string) {
     setError(null);
+    setByUserError(null);
     setSummary(null);
     setTimeseries(null);
     setByUser(null);
@@ -581,7 +598,14 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                     <CardTitle>Per-User Breakdown</CardTitle>
                   </CardHeader>
                   <CardContent>
-                    {byUser === null ? (
+                    {byUserError ? (
+                      <div className="text-center py-8">
+                        <p className="text-muted-foreground mb-3">{byUserError}</p>
+                        <Button variant="outline" onClick={handleByUserRetry}>
+                          Retry
+                        </Button>
+                      </div>
+                    ) : byUser === null ? (
                       <p>Loading...</p>
                     ) : (
                       <Table>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -142,12 +142,17 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
     if (selectedAgent !== "all") params.set("agentId", selectedAgent);
     const qs = params.toString() ? `?${params.toString()}` : "";
 
+    const tsParams = new URLSearchParams(params);
+    const tz = Intl.DateTimeFormat().resolvedOptions().timeZone;
+    if (tz) tsParams.set("tz", tz);
+    const tsQs = tsParams.toString() ? `?${tsParams.toString()}` : "";
+
     Promise.all([
       fetch(`/api/usage/summary${qs}`).then((r) => {
         if (!r.ok) throw new Error(`Summary API error: ${r.status}`);
         return r.json();
       }),
-      fetch(`/api/usage/timeseries${qs}`).then((r) => {
+      fetch(`/api/usage/timeseries${tsQs}`).then((r) => {
         if (!r.ok) throw new Error(`Timeseries API error: ${r.status}`);
         return r.json();
       }),

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -87,7 +87,8 @@ function formatTokens(n: number): string {
   return String(n);
 }
 
-function formatCost(n: number): string {
+function formatCost(n: number | null): string {
+  if (n === null) return "\u2014";
   return `$${n.toFixed(2)}`;
 }
 
@@ -213,13 +214,19 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
     (acc, a) => acc + Number(a.totalInputTokens ?? 0) + Number(a.totalOutputTokens ?? 0),
     0
   );
-  const totalCost = (summary?.agents ?? []).reduce((acc, a) => acc + Number(a.totalCost ?? 0), 0);
+  const totalCost = (() => {
+    const agents = summary?.agents ?? [];
+    if (agents.length === 0) return null;
+    const allNull = agents.every((a) => a.totalCost === null);
+    if (allNull) return null;
+    return agents.reduce((acc, a) => acc + Number(a.totalCost ?? 0), 0);
+  })();
 
-  function bucketTotals(b: SourceBucket | undefined): { tokens: number; cost: number } {
-    if (!b) return { tokens: 0, cost: 0 };
+  function bucketTotals(b: SourceBucket | undefined): { tokens: number; cost: number | null } {
+    if (!b) return { tokens: 0, cost: null };
     return {
       tokens: Number(b.inputTokens ?? 0) + Number(b.outputTokens ?? 0),
-      cost: Number(b.cost ?? 0),
+      cost: b.cost !== null ? Number(b.cost) : null,
     };
   }
 
@@ -506,7 +513,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                               {formatTokens(Number(agent.totalOutputTokens ?? 0))}
                             </TableCell>
                             <TableCell className="text-right">
-                              {formatCost(Number(agent.totalCost ?? 0))}
+                              {formatCost(
+                                agent.totalCost !== null ? Number(agent.totalCost) : null
+                              )}
                             </TableCell>
                           </TableRow>
                         ))}
@@ -556,7 +565,9 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                                   {formatTokens(Number(user.totalOutputTokens ?? 0))}
                                 </TableCell>
                                 <TableCell className="text-right">
-                                  {formatCost(Number(user.totalCost ?? 0))}
+                                  {formatCost(
+                                    user.totalCost !== null ? Number(user.totalCost) : null
+                                  )}
                                 </TableCell>
                               </TableRow>
                             ))}

--- a/packages/web/src/lib/fixed-window-rate-limiter.ts
+++ b/packages/web/src/lib/fixed-window-rate-limiter.ts
@@ -1,0 +1,48 @@
+/**
+ * Minimal in-memory fixed-window rate limiter for single-process API routes.
+ *
+ * Used by internal endpoints (e.g. `/api/internal/usage/record`) as a
+ * defense-in-depth guard: token auth already gates writers, but an unbounded
+ * write path is still a liability if a plugin misbehaves or a token leaks.
+ *
+ * The implementation is deliberately tiny: one counter per limiter instance,
+ * with a window reset on the first call after `windowMs` elapses. Tracks are
+ * NOT per-client — each limiter is a single global bucket for the route
+ * that owns it. That's fine for internal endpoints where all traffic comes
+ * from one container; it's not sufficient for public, multi-tenant limits.
+ */
+
+export class FixedWindowRateLimiter {
+  private readonly max: number;
+  private readonly windowMs: number;
+  private windowStart = 0;
+  private count = 0;
+
+  constructor(options: { max: number; windowMs: number }) {
+    this.max = options.max;
+    this.windowMs = options.windowMs;
+  }
+
+  /**
+   * Returns `true` if the request is allowed, `false` if it would exceed
+   * the limit. Mutates the internal counter on every allowed call.
+   */
+  tryAcquire(now: number = Date.now()): boolean {
+    if (now - this.windowStart > this.windowMs) {
+      this.windowStart = now;
+      this.count = 1;
+      return true;
+    }
+    if (this.count >= this.max) {
+      return false;
+    }
+    this.count++;
+    return true;
+  }
+
+  /** Resets the window. Intended for tests. */
+  reset(): void {
+    this.windowStart = 0;
+    this.count = 0;
+  }
+}

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -104,6 +104,10 @@ export async function regenerateOpenClawConfig() {
       name: agent.name,
       model: agent.model,
       workspace: getOpenClawWorkspacePath(agent.id),
+      // Disable heartbeat by default: it fires LLM calls in the background
+      // and racks up tokens even for idle agents. Set per-agent (NOT in
+      // agents.defaults) to avoid hot-reload races with Telegram (openclaw#47458).
+      heartbeat: { every: "0m" },
     };
 
     // Compute denied tool groups from allowed tools

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -166,7 +166,33 @@ export async function regenerateOpenClawConfig() {
   }
 
   const entries: Record<string, unknown> = {};
+
+  const gatewayAuth = (gateway as Record<string, unknown>).auth as
+    | Record<string, unknown>
+    | undefined;
+  const gatewayToken = (gatewayAuth?.token as string) || "";
+
+  // pinchy-files needs apiBaseUrl/gatewayToken so it can report vision API
+  // token usage (from scanned-PDF processing) back to Pinchy via
+  // /api/internal/usage/record. Unlike pinchy-context which only exposes
+  // per-agent `agents`, pinchy-files adds the two top-level keys alongside.
+  if (pluginConfigs["pinchy-files"]) {
+    entries["pinchy-files"] = {
+      enabled: true,
+      config: {
+        apiBaseUrl:
+          process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
+        gatewayToken,
+        agents: pluginConfigs["pinchy-files"],
+      },
+    };
+  }
+
+  // Any additional plugins collected via pluginConfigs get the generic
+  // shape (no apiBaseUrl/gatewayToken). Today this branch is empty; it
+  // exists to keep the pluginConfigs abstraction for future per-agent plugins.
   for (const [pluginId, agentConfigs] of Object.entries(pluginConfigs)) {
+    if (pluginId === "pinchy-files") continue;
     entries[pluginId] = {
       enabled: true,
       config: {
@@ -174,11 +200,6 @@ export async function regenerateOpenClawConfig() {
       },
     };
   }
-
-  const gatewayAuth = (gateway as Record<string, unknown>).auth as
-    | Record<string, unknown>
-    | undefined;
-  const gatewayToken = (gatewayAuth?.token as string) || "";
 
   // Enable pinchy-docs for all personal agents (Smithers) so they can read
   // platform documentation on demand. The plugin scopes itself to listed agents.

--- a/packages/web/src/lib/shutdown.ts
+++ b/packages/web/src/lib/shutdown.ts
@@ -1,0 +1,48 @@
+/**
+ * Graceful-shutdown plumbing for the custom Next.js server.
+ *
+ * Registers SIGTERM/SIGINT handlers that run every supplied `stopFn`
+ * (e.g. `stopUsagePoller`, `server.close`, OpenClaw client disconnect) in
+ * order, then calls `exit`. Failures inside one stopFn must not prevent the
+ * others from running — a broken shutdown step is not a reason to orphan
+ * DB handles, timers, or network sockets.
+ *
+ * `exit` is injectable so tests don't actually terminate the process.
+ */
+
+type StopFn = () => void | Promise<void>;
+
+export interface ShutdownOptions {
+  exit?: (code: number) => void;
+  signals?: NodeJS.Signals[];
+}
+
+export function registerShutdownHandlers(
+  stopFns: StopFn[],
+  options: ShutdownOptions = {}
+): () => void {
+  const exit = options.exit ?? ((code: number) => process.exit(code));
+  const signals = options.signals ?? (["SIGTERM", "SIGINT"] as NodeJS.Signals[]);
+
+  const handler = async (signal: NodeJS.Signals) => {
+    console.log(`[pinchy] Received ${signal}, shutting down...`);
+    for (const fn of stopFns) {
+      try {
+        await fn();
+      } catch (err) {
+        console.error("[pinchy] Shutdown handler error:", err instanceof Error ? err.message : err);
+      }
+    }
+    exit(0);
+  };
+
+  for (const signal of signals) {
+    process.on(signal, handler);
+  }
+
+  return () => {
+    for (const signal of signals) {
+      process.off(signal, handler);
+    }
+  };
+}

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -1,0 +1,117 @@
+import type { OpenClawClient } from "openclaw-node";
+import { recordUsage } from "@/lib/usage";
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+
+const POLL_INTERVAL_MS = 60_000;
+
+export interface ParsedSessionKey {
+  agentId: string;
+  userId: string;
+  type: "chat" | "system";
+}
+
+/**
+ * Parses an OpenClaw session key into agentId, userId, and type.
+ *
+ * Key format: `agent:<agentId>:<scope>` where scope is either:
+ *   - `direct:<userId>` for browser chat sessions → type "chat"
+ *   - `main`, `cron:<jobId>`, `hook:<hookId>`, etc. → type "system"
+ *
+ * Returns null for unparseable keys.
+ */
+export function parseSessionKey(key: string): ParsedSessionKey | null {
+  const match = /^agent:([^:]+):(.+)$/.exec(key);
+  if (!match) return null;
+
+  const agentId = match[1];
+  const scope = match[2];
+  if (!agentId || !scope) return null;
+
+  // direct:<userId> → chat session. Preserve userId even if it contains colons.
+  const directMatch = /^direct:(.+)$/.exec(scope);
+  if (directMatch) {
+    return { agentId, userId: directMatch[1], type: "chat" };
+  }
+
+  // Everything else (main, cron:*, hook:*, etc.) → system usage
+  return { agentId, userId: "system", type: "system" };
+}
+
+interface SessionListEntry {
+  key: string;
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+}
+
+/**
+ * Polls all OpenClaw sessions once and records usage deltas for each
+ * session that has tokens. Unknown agent IDs fall back to the ID itself
+ * as the agent name. Failures are logged but never thrown — a failed poll
+ * just means we try again next tick.
+ */
+export async function pollAllSessions(openclawClient: OpenClawClient): Promise<void> {
+  try {
+    const listResult = (await openclawClient.sessions.list()) as {
+      sessions?: SessionListEntry[];
+    };
+    const sessions = listResult?.sessions ?? [];
+    if (sessions.length === 0) return;
+
+    // Pre-fetch agent names to avoid one DB round-trip per session.
+    const allAgents = await db.select({ id: agents.id, name: agents.name }).from(agents);
+    const agentNameMap = new Map(allAgents.map((a) => [a.id, a.name]));
+
+    for (const session of sessions) {
+      const hasTokens = (session.inputTokens ?? 0) > 0 || (session.outputTokens ?? 0) > 0;
+      if (!hasTokens) continue;
+
+      const parsed = parseSessionKey(session.key);
+      if (!parsed) continue;
+
+      const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
+
+      await recordUsage({
+        openclawClient,
+        userId: parsed.userId,
+        agentId: parsed.agentId,
+        agentName,
+        sessionKey: session.key,
+      });
+    }
+  } catch (error) {
+    console.error("[usage-poller] Poll failed:", error);
+  }
+}
+
+let pollInterval: ReturnType<typeof setInterval> | null = null;
+
+/**
+ * Starts the global usage poller. Idempotent — calling twice is a no-op.
+ * The poller gracefully handles disconnects: if sessions.list() fails, the
+ * next tick will try again, so no explicit stop is needed on OpenClaw
+ * reconnection.
+ */
+export function startUsagePoller(openclawClient: OpenClawClient): void {
+  if (pollInterval) return;
+  pollInterval = setInterval(() => {
+    pollAllSessions(openclawClient).catch((err) => {
+      console.error("[usage-poller] Unexpected error:", err);
+    });
+  }, POLL_INTERVAL_MS);
+}
+
+export function stopUsagePoller(): void {
+  if (pollInterval) {
+    clearInterval(pollInterval);
+    pollInterval = null;
+  }
+}
+
+/** Exported only for tests. */
+export function _isPollerRunning(): boolean {
+  return pollInterval !== null;
+}

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -1,4 +1,5 @@
 import type { OpenClawClient } from "openclaw-node";
+import { isNull } from "drizzle-orm";
 import { recordUsage } from "@/lib/usage";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
@@ -62,7 +63,12 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
     if (sessions.length === 0) return;
 
     // Pre-fetch agent names to avoid one DB round-trip per session.
-    const allAgents = await db.select({ id: agents.id, name: agents.name }).from(agents);
+    // Skip soft-deleted agents — a stale session key should fall through
+    // to the agentId fallback instead of surfacing a deleted agent's name.
+    const allAgents = await db
+      .select({ id: agents.id, name: agents.name })
+      .from(agents)
+      .where(isNull(agents.deletedAt));
     const agentNameMap = new Map(allAgents.map((a) => [a.id, a.name]));
 
     for (const session of sessions) {
@@ -80,6 +86,13 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
         agentId: parsed.agentId,
         agentName,
         sessionKey: session.key,
+        sessionSnapshot: {
+          inputTokens: session.inputTokens,
+          outputTokens: session.outputTokens,
+          cacheReadTokens: session.cacheReadTokens,
+          cacheWriteTokens: session.cacheWriteTokens,
+          model: session.model,
+        },
       });
     }
   } catch (error) {

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -2,7 +2,7 @@ import type { OpenClawClient } from "openclaw-node";
 import { isNull } from "drizzle-orm";
 import { recordUsage } from "@/lib/usage";
 import { db } from "@/db";
-import { agents } from "@/db/schema";
+import { agents, users } from "@/db/schema";
 
 const POLL_INTERVAL_MS = 60_000;
 
@@ -71,6 +71,13 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
       .where(isNull(agents.deletedAt));
     const agentNameMap = new Map(allAgents.map((a) => [a.id, a.name]));
 
+    // Pre-fetch user IDs to resolve lowercased session-key IDs back to
+    // the original-case DB ID. OpenClaw lowercases session keys, so
+    // parseSessionKey extracts a lowercase userId that won't match the
+    // users table on a case-sensitive join.
+    const allUsers = await db.select({ id: users.id }).from(users);
+    const userIdMap = new Map(allUsers.map((u) => [u.id.toLowerCase(), u.id]));
+
     for (const session of sessions) {
       const hasTokens = (session.inputTokens ?? 0) > 0 || (session.outputTokens ?? 0) > 0;
       if (!hasTokens) continue;
@@ -79,10 +86,14 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
       if (!parsed) continue;
 
       const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
+      const userId =
+        parsed.type === "chat"
+          ? (userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId)
+          : parsed.userId; // "system" stays as-is
 
       await recordUsage({
         openclawClient,
-        userId: parsed.userId,
+        userId,
         agentId: parsed.agentId,
         agentName,
         sessionKey: session.key,

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -110,6 +110,14 @@ let pollInterval: ReturnType<typeof setInterval> | null = null;
  */
 export function startUsagePoller(openclawClient: OpenClawClient): void {
   if (pollInterval) return;
+
+  // Immediate first poll to seed watermarks from current OpenClaw state
+  // before any user activity can create a gap between compaction baseline
+  // and the first interval tick.
+  pollAllSessions(openclawClient).catch((err) => {
+    console.error("[usage-poller] Initial poll failed:", err);
+  });
+
   pollInterval = setInterval(() => {
     pollAllSessions(openclawClient).catch((err) => {
       console.error("[usage-poller] Unexpected error:", err);

--- a/packages/web/src/lib/usage-record-rate-limiter.ts
+++ b/packages/web/src/lib/usage-record-rate-limiter.ts
@@ -1,0 +1,33 @@
+/**
+ * Module-private singleton rate limiter for POST /api/internal/usage/record.
+ *
+ * Lives outside the route file on purpose: Next.js 16 App Router route modules
+ * may only export HTTP method handlers and well-known config symbols. Keeping
+ * the limiter (and its test-only reset helper) here keeps the route file
+ * conformant while still letting tests drive the window deterministically.
+ *
+ * The limit is generous enough to absorb a burst of vision API calls from a
+ * single PDF read (tens of concurrent calls) but bounded enough to fail fast
+ * on abuse. The route applies it BEFORE token validation so brute-forcing the
+ * gateway token is also rate-limited.
+ */
+
+import { FixedWindowRateLimiter } from "./fixed-window-rate-limiter";
+
+const RATE_LIMIT_MAX_REQUESTS = 300;
+const RATE_LIMIT_WINDOW_MS = 60_000;
+
+const limiter = new FixedWindowRateLimiter({
+  max: RATE_LIMIT_MAX_REQUESTS,
+  windowMs: RATE_LIMIT_WINDOW_MS,
+});
+
+/** Returns `true` if the call is allowed, `false` if the window is full. */
+export function tryAcquireUsageRecordSlot(now: number = Date.now()): boolean {
+  return limiter.tryAcquire(now);
+}
+
+/** Resets the window. Intended for tests. */
+export function resetUsageRecordRateLimiterForTest(): void {
+  limiter.reset();
+}

--- a/packages/web/src/lib/usage-source.ts
+++ b/packages/web/src/lib/usage-source.ts
@@ -1,0 +1,20 @@
+/**
+ * Classify a usage record by its `sessionKey` into one of three buckets
+ * shown on the Usage Dashboard:
+ *
+ *   - "chat":   direct browser/Telegram chat with an agent
+ *               (sessionKey shape: `agent:<agentId>:direct:<userId>`)
+ *   - "plugin": LLM calls made by a plugin outside of agent sessions,
+ *               e.g. pinchy-files vision API for scanned PDFs
+ *               (sessionKey shape: `plugin:<pluginId>`)
+ *   - "system": everything else — main/heartbeat, cron jobs, webhooks,
+ *               and any unrecognized shape (fail-safe default).
+ */
+
+export type UsageSource = "chat" | "system" | "plugin";
+
+export function classifyUsageSource(sessionKey: string): UsageSource {
+  if (sessionKey.startsWith("plugin:")) return "plugin";
+  if (/^agent:[^:]+:direct:/.test(sessionKey)) return "chat";
+  return "system";
+}

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -3,12 +3,28 @@ import { usageRecords } from "@/db/schema";
 import { eq, sum } from "drizzle-orm";
 import type { OpenClawClient } from "openclaw-node";
 
+/**
+ * OpenClaw session token snapshot passed from callers that already have
+ * one in hand (notably the poller, which fetches sessions.list() once per
+ * tick and fans out to recordUsage for each session). If omitted, the
+ * implementation does its own sessions.list() round-trip — useful for
+ * one-off callers like the "done" event path from the chat route.
+ */
+export interface SessionTokenSnapshot {
+  inputTokens?: number;
+  outputTokens?: number;
+  cacheReadTokens?: number;
+  cacheWriteTokens?: number;
+  model?: string;
+}
+
 interface RecordUsageParams {
   openclawClient: OpenClawClient;
   userId: string;
   agentId: string;
   agentName: string;
   sessionKey: string;
+  sessionSnapshot?: SessionTokenSnapshot;
 }
 
 // Module-level cache for OpenClaw config pricing
@@ -30,6 +46,37 @@ const pendingBySession = new Map<string, Promise<void>>();
 /** Exported only for tests — resets the per-session serialization map. */
 export function _resetPendingSessionsForTest(): void {
   pendingBySession.clear();
+}
+
+/** Exported only for tests — reports the serialization map size for leak detection. */
+export function _getPendingSessionsCountForTest(): number {
+  return pendingBySession.size;
+}
+
+// Per-session watermark tracking the LAST OBSERVED OpenClaw cumulative
+// counter. This is deliberately distinct from the DB aggregate: OpenClaw
+// clears session.inputTokens/outputTokens/cacheRead/cacheWrite on
+// compaction, session-reset, and checkpoint clone (verified in
+// openclaw/src/gateway/server-methods/sessions.ts and
+// session-reset-service.ts). After a reset, `current < db_sum` forever,
+// which would make the old DB-sum baseline silently drop every post-reset
+// token. The watermark moves backwards with OpenClaw on a reset so the
+// next growth is detected correctly.
+//
+// Watermarks live in memory; after a Pinchy restart the first poll per
+// session seeds the watermark from the historical DB aggregate (best
+// effort — matches pre-refactor behaviour for the happy path).
+interface SessionWatermark {
+  input: number;
+  output: number;
+  cacheRead: number;
+  cacheWrite: number;
+}
+const sessionWatermarks = new Map<string, SessionWatermark>();
+
+/** Exported only for tests — resets the per-session OpenClaw watermark cache. */
+export function _resetUsageWatermarksForTest(): void {
+  sessionWatermarks.clear();
 }
 
 async function getModelPricing(
@@ -69,30 +116,45 @@ export async function recordUsage(params: RecordUsageParams): Promise<void> {
   // Normalize to lowercase to match OpenClaw's key format
   const normalizedKey = sessionKey.toLowerCase();
 
-  // Chain calls for the same session to prevent concurrent delta computation
+  // Chain calls for the same session to prevent concurrent delta computation.
+  // The .finally() tail deletes the map entry once this call is done — but
+  // only if no later call has already replaced it, otherwise we'd strand a
+  // chained follow-up with no serialization anchor.
   const prev = pendingBySession.get(normalizedKey) ?? Promise.resolve();
-  const next = prev.then(() => recordUsageImpl(params, normalizedKey)).catch(() => {});
+  const next: Promise<void> = prev
+    .then(() => recordUsageImpl(params, normalizedKey))
+    .catch(() => {})
+    .finally(() => {
+      if (pendingBySession.get(normalizedKey) === next) {
+        pendingBySession.delete(normalizedKey);
+      }
+    });
   pendingBySession.set(normalizedKey, next);
   return next;
 }
 
 async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string): Promise<void> {
   try {
-    const { openclawClient, userId, agentId, agentName } = params;
+    const { openclawClient, userId, agentId, agentName, sessionSnapshot } = params;
 
-    // Get current cumulative token counts from OpenClaw
-    const listResult = (await openclawClient.sessions.list()) as {
-      sessions?: Array<{
-        key: string;
-        inputTokens?: number;
-        outputTokens?: number;
-        cacheReadTokens?: number;
-        cacheWriteTokens?: number;
-        model?: string;
-      }>;
-    };
-    const sessions = listResult?.sessions ?? [];
-    const session = sessions.find((s) => s.key === normalizedKey);
+    // Prefer the caller-supplied snapshot (poller already fetched it) to
+    // avoid a duplicate sessions.list() round-trip. Fall back to fetching
+    // ourselves when called from one-off paths like the chat "done" event.
+    let session: SessionTokenSnapshot | undefined = sessionSnapshot;
+    if (!session) {
+      const listResult = (await openclawClient.sessions.list()) as {
+        sessions?: Array<{
+          key: string;
+          inputTokens?: number;
+          outputTokens?: number;
+          cacheReadTokens?: number;
+          cacheWriteTokens?: number;
+          model?: string;
+        }>;
+      };
+      const sessions = listResult?.sessions ?? [];
+      session = sessions.find((s) => s.key === normalizedKey);
+    }
 
     if (!session) {
       return;
@@ -103,30 +165,55 @@ async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string)
     const currentCacheRead = session.cacheReadTokens ?? 0;
     const currentCacheWrite = session.cacheWriteTokens ?? 0;
 
-    // Get sum of all previously recorded deltas for this session
-    // Use normalizedKey to match what we store (consistent casing)
-    const [prev] = await db
-      .select({
-        totalInput: sum(usageRecords.inputTokens),
-        totalOutput: sum(usageRecords.outputTokens),
-        totalCacheRead: sum(usageRecords.cacheReadTokens),
-        totalCacheWrite: sum(usageRecords.cacheWriteTokens),
-      })
-      .from(usageRecords)
-      .where(eq(usageRecords.sessionKey, normalizedKey));
+    // Resolve the baseline for this session. The watermark is the LAST
+    // OBSERVED OpenClaw cumulative counter — NOT the historical DB sum.
+    // On a cache miss (first poll for this session, or after a Pinchy
+    // restart), seed from the DB aggregate as a best-effort baseline: in
+    // the happy path that matches the pre-refactor behaviour; in the
+    // post-reset-during-downtime edge case we may miss a few tokens, but
+    // never double-count.
+    let watermark = sessionWatermarks.get(normalizedKey);
+    if (!watermark) {
+      const [prevSum] = await db
+        .select({
+          totalInput: sum(usageRecords.inputTokens),
+          totalOutput: sum(usageRecords.outputTokens),
+          totalCacheRead: sum(usageRecords.cacheReadTokens),
+          totalCacheWrite: sum(usageRecords.cacheWriteTokens),
+        })
+        .from(usageRecords)
+        .where(eq(usageRecords.sessionKey, normalizedKey));
 
-    const prevInput = Number(prev?.totalInput ?? 0);
-    const prevOutput = Number(prev?.totalOutput ?? 0);
-    const prevCacheRead = Number(prev?.totalCacheRead ?? 0);
-    const prevCacheWrite = Number(prev?.totalCacheWrite ?? 0);
+      watermark = {
+        input: Number(prevSum?.totalInput ?? 0),
+        output: Number(prevSum?.totalOutput ?? 0),
+        cacheRead: Number(prevSum?.totalCacheRead ?? 0),
+        cacheWrite: Number(prevSum?.totalCacheWrite ?? 0),
+      };
+    }
 
-    const deltaInput = currentInput - prevInput;
-    const deltaOutput = currentOutput - prevOutput;
-    const deltaCacheRead = currentCacheRead - prevCacheRead;
-    const deltaCacheWrite = currentCacheWrite - prevCacheWrite;
+    // Per-axis clamped delta. Clamping is the safety net for mixed-axis
+    // updates (input grows, output drops) where the watermark from one
+    // axis alone would otherwise produce a negative insert and corrupt
+    // downstream sum() aggregates on the dashboard.
+    const deltaInput = Math.max(0, currentInput - watermark.input);
+    const deltaOutput = Math.max(0, currentOutput - watermark.output);
+    const deltaCacheRead = Math.max(0, currentCacheRead - watermark.cacheRead);
+    const deltaCacheWrite = Math.max(0, currentCacheWrite - watermark.cacheWrite);
 
-    // Skip if no meaningful token usage
-    if (deltaInput <= 0 && deltaOutput <= 0) {
+    // Update the watermark BEFORE any early return. We always follow
+    // OpenClaw's counter, even when it drops (compaction/reset): if we
+    // left the watermark frozen at the pre-reset value, the next growth
+    // would still read `current < watermark` and clamp to 0 forever.
+    sessionWatermarks.set(normalizedKey, {
+      input: currentInput,
+      output: currentOutput,
+      cacheRead: currentCacheRead,
+      cacheWrite: currentCacheWrite,
+    });
+
+    // Skip if no axis grew — nothing new to record.
+    if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheWrite === 0) {
       return;
     }
 

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -221,8 +221,15 @@ async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string)
       if (model) {
         const pricing = await getModelPricing(openclawClient, model);
         if (pricing) {
+          // Cache pricing defaults: Anthropic-style ratios (OpenClaw config lacks cache-specific pricing)
+          const cacheReadPrice = pricing.input * 0.1;
+          const cacheWritePrice = pricing.input * 1.25;
           const cost =
-            (deltaInput * pricing.input) / 1_000_000 + (deltaOutput * pricing.output) / 1_000_000;
+            (deltaInput * pricing.input +
+              deltaOutput * pricing.output +
+              deltaCacheRead * cacheReadPrice +
+              deltaCacheWrite * cacheWritePrice) /
+            1_000_000;
           estimatedCostUsd = cost.toFixed(6);
         }
       }

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -201,19 +201,16 @@ async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string)
     const deltaCacheRead = Math.max(0, currentCacheRead - watermark.cacheRead);
     const deltaCacheWrite = Math.max(0, currentCacheWrite - watermark.cacheWrite);
 
-    // Update the watermark BEFORE any early return. We always follow
-    // OpenClaw's counter, even when it drops (compaction/reset): if we
-    // left the watermark frozen at the pre-reset value, the next growth
-    // would still read `current < watermark` and clamp to 0 forever.
-    sessionWatermarks.set(normalizedKey, {
-      input: currentInput,
-      output: currentOutput,
-      cacheRead: currentCacheRead,
-      cacheWrite: currentCacheWrite,
-    });
-
     // Skip if no axis grew — nothing new to record.
+    // Still follow OpenClaw's counter downward on compaction/reset so
+    // the next growth is detected correctly.
     if (deltaInput === 0 && deltaOutput === 0 && deltaCacheRead === 0 && deltaCacheWrite === 0) {
+      sessionWatermarks.set(normalizedKey, {
+        input: currentInput,
+        output: currentOutput,
+        cacheRead: currentCacheRead,
+        cacheWrite: currentCacheWrite,
+      });
       return;
     }
 
@@ -244,6 +241,15 @@ async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string)
       cacheReadTokens: deltaCacheRead,
       cacheWriteTokens: deltaCacheWrite,
       estimatedCostUsd,
+    });
+
+    // Advance watermark only AFTER successful DB insert. If the insert
+    // failed, the next call re-attempts with the same delta — no tokens lost.
+    sessionWatermarks.set(normalizedKey, {
+      input: currentInput,
+      output: currentOutput,
+      cacheRead: currentCacheRead,
+      cacheWrite: currentCacheWrite,
     });
   } catch (error) {
     console.error("[usage] Failed to record usage:", error);

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -4,7 +4,6 @@ import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { isEnterprise } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
-import { recordUsage } from "@/lib/usage";
 import { SessionCache } from "@/server/session-cache";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
@@ -205,17 +204,6 @@ export class ClientRouter {
             this.sendToClient(clientWs, {
               type: "done",
               messageId,
-            });
-
-            // Fire-and-forget usage tracking
-            recordUsage({
-              openclawClient: this.openclawClient,
-              userId: this.userId,
-              agentId: message.agentId,
-              agentName: agent.name,
-              sessionKey,
-            }).catch((err) => {
-              console.error("Usage tracking failed:", err);
             });
 
             // Next agent turn gets a fresh messageId so the browser

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -46,7 +46,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.5.6
-        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -63,8 +63,8 @@ importers:
         specifier: ^1.7.0
         version: 1.7.0(react@19.2.4)
       next:
-        specifier: 16.2.2
-        version: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+        specifier: 16.2.3
+        version: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
@@ -1063,60 +1063,60 @@ packages:
   '@napi-rs/wasm-runtime@1.1.1':
     resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
 
-  '@next/env@16.2.2':
-    resolution: {integrity: sha512-LqSGz5+xGk9EL/iBDr2yo/CgNQV6cFsNhRR2xhSXYh7B/hb4nePCxlmDvGEKG30NMHDFf0raqSyOZiQrO7BkHQ==}
+  '@next/env@16.2.3':
+    resolution: {integrity: sha512-ZWXyj4uNu4GCWQw9cjRxWlbD+33mcDszIo9iQxFnBX3Wmgq9ulaSJcl6VhuWx5pCWqqD+9W6Wfz7N0lM5lYPMA==}
 
   '@next/eslint-plugin-next@16.2.2':
     resolution: {integrity: sha512-IOPbWzDQ+76AtjZioaCjpIY72xNSDMnarZ2GMQ4wjNLvnJEJHqxQwGFhgnIWLV9klb4g/+amg88Tk5OXVpyLTw==}
 
-  '@next/swc-darwin-arm64@16.2.2':
-    resolution: {integrity: sha512-B92G3ulrwmkDSEJEp9+XzGLex5wC1knrmCSIylyVeiAtCIfvEJYiN3v5kXPlYt5R4RFlsfO/v++aKV63Acrugg==}
+  '@next/swc-darwin-arm64@16.2.3':
+    resolution: {integrity: sha512-u37KDKTKQ+OQLvY+z7SNXixwo4Q2/IAJFDzU1fYe66IbCE51aDSAzkNDkWmLN0yjTUh4BKBd+hb69jYn6qqqSg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.2':
-    resolution: {integrity: sha512-7ZwSgNKJNQiwW0CKhNm9B1WS2L1Olc4B2XY0hPYCAL3epFnugMhuw5TMWzMilQ3QCZcCHoYm9NGWTHbr5REFxw==}
+  '@next/swc-darwin-x64@16.2.3':
+    resolution: {integrity: sha512-gHjL/qy6Q6CG3176FWbAKyKh9IfntKZTB3RY/YOJdDFpHGsUDXVH38U4mMNpHVGXmeYW4wj22dMp1lTfmu/bTQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
-    resolution: {integrity: sha512-c3m8kBHMziMgo2fICOP/cd/5YlrxDU5YYjAJeQLyFsCqVF8xjOTH/QYG4a2u48CvvZZSj1eHQfBCbyh7kBr30Q==}
+  '@next/swc-linux-arm64-gnu@16.2.3':
+    resolution: {integrity: sha512-U6vtblPtU/P14Y/b/n9ZY0GOxbbIhTFuaFR7F4/uMBidCi2nSdaOFhA0Go81L61Zd6527+yvuX44T4ksnf8T+Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.2':
-    resolution: {integrity: sha512-VKLuscm0P/mIfzt+SDdn2+8TNNJ7f0qfEkA+az7OqQbjzKdBxAHs0UvuiVoCtbwX+dqMEL9U54b5wQ/aN3dHeg==}
+  '@next/swc-linux-arm64-musl@16.2.3':
+    resolution: {integrity: sha512-/YV0LgjHUmfhQpn9bVoGc4x4nan64pkhWR5wyEV8yCOfwwrH630KpvRg86olQHTwHIn1z59uh6JwKvHq1h4QEw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.2':
-    resolution: {integrity: sha512-kU3OPHJq6sBUjOk7wc5zJ7/lipn8yGldMoAv4z67j6ov6Xo/JvzA7L7LCsyzzsXmgLEhk3Qkpwqaq/1+XpNR3g==}
+  '@next/swc-linux-x64-gnu@16.2.3':
+    resolution: {integrity: sha512-/HiWEcp+WMZ7VajuiMEFGZ6cg0+aYZPqCJD3YJEfpVWQsKYSjXQG06vJP6F1rdA03COD9Fef4aODs3YxKx+RDQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.2':
-    resolution: {integrity: sha512-CKXRILyErMtUftp+coGcZ38ZwE/Aqq45VMCcRLr2I4OXKrgxIBDXHnBgeX/UMil0S09i2JXaDL3Q+TN8D/cKmg==}
+  '@next/swc-linux-x64-musl@16.2.3':
+    resolution: {integrity: sha512-Kt44hGJfZSefebhk/7nIdivoDr3Ugp5+oNz9VvF3GUtfxutucUIHfIO0ZYO8QlOPDQloUVQn4NVC/9JvHRk9hw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
-    resolution: {integrity: sha512-sS/jSk5VUoShUqINJFvNjVT7JfR5ORYj/+/ZpOYbbIohv/lQfduWnGAycq2wlknbOql2xOR0DoV0s6Xfcy49+g==}
+  '@next/swc-win32-arm64-msvc@16.2.3':
+    resolution: {integrity: sha512-O2NZ9ie3Tq6xj5Z5CSwBT3+aWAMW2PIZ4egUi9MaWLkwaehgtB7YZjPm+UpcNpKOme0IQuqDcor7BsW6QBiQBw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.2':
-    resolution: {integrity: sha512-aHaKceJgdySReT7qeck5oShucxWRiiEuwCGK8HHALe6yZga8uyFpLkPgaRw3kkF04U7ROogL/suYCNt/+CuXGA==}
+  '@next/swc-win32-x64-msvc@16.2.3':
+    resolution: {integrity: sha512-Ibm29/GgB/ab5n7XKqlStkm54qqZE8v2FnijUPBgrd67FWrac45o/RsNlaOWjme/B5UqeWt/8KM4aWBwA1D2Kw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -3969,8 +3969,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.2:
-    resolution: {integrity: sha512-i6AJdyVa4oQjyvX/6GeER8dpY/xlIV+4NMv/svykcLtURJSy/WzDnnUk/TM4d0uewFHK7xSQz4TbIwPgjky+3A==}
+  next@16.2.3:
+    resolution: {integrity: sha512-9V3zV4oZFza3PVev5/poB9g0dEafVcgNyQ8eTRop8GvxZjV2G15FC5ARuG1eFD42QgeYkzJBJzHghNP8Ad9xtA==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -5644,34 +5644,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.2': {}
+  '@next/env@16.2.3': {}
 
   '@next/eslint-plugin-next@16.2.2':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.2':
+  '@next/swc-darwin-arm64@16.2.3':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.2':
+  '@next/swc-darwin-x64@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.2':
+  '@next/swc-linux-arm64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.2':
+  '@next/swc-linux-arm64-musl@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.2':
+  '@next/swc-linux-x64-gnu@16.2.3':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.2':
+  '@next/swc-linux-x64-musl@16.2.3':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.2':
+  '@next/swc-win32-arm64-msvc@16.2.3':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.2':
+  '@next/swc-win32-x64-msvc@16.2.3':
     optional: true
 
   '@noble/ciphers@2.1.1': {}
@@ -7079,7 +7079,7 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.5.6(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))(mongodb@7.1.0)(next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4))(react-dom@19.2.4(react@19.2.4))(react@19.2.4)(vitest@4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.5.6(@better-auth/core@1.5.6(@better-auth/utils@0.3.1)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.2(zod@4.3.6))(jose@6.2.2)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.3.1)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8))
@@ -7102,7 +7102,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.8)
       mongodb: 7.1.0
-      next: 16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
+      next: 16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4)
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
       vitest: 4.1.2(@opentelemetry/api@1.9.1)(@types/node@25.5.2)(jsdom@29.0.1(@noble/hashes@2.0.1))(vite@8.0.5(@types/node@25.5.2)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -8716,9 +8716,9 @@ snapshots:
       react: 19.2.4
       react-dom: 19.2.4(react@19.2.4)
 
-  next@16.2.2(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
+  next@16.2.3(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.4(react@19.2.4))(react@19.2.4):
     dependencies:
-      '@next/env': 16.2.2
+      '@next/env': 16.2.3
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001770
@@ -8727,14 +8727,14 @@ snapshots:
       react-dom: 19.2.4(react@19.2.4)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.4)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.2
-      '@next/swc-darwin-x64': 16.2.2
-      '@next/swc-linux-arm64-gnu': 16.2.2
-      '@next/swc-linux-arm64-musl': 16.2.2
-      '@next/swc-linux-x64-gnu': 16.2.2
-      '@next/swc-linux-x64-musl': 16.2.2
-      '@next/swc-win32-arm64-msvc': 16.2.2
-      '@next/swc-win32-x64-msvc': 16.2.2
+      '@next/swc-darwin-arm64': 16.2.3
+      '@next/swc-darwin-x64': 16.2.3
+      '@next/swc-linux-arm64-gnu': 16.2.3
+      '@next/swc-linux-arm64-musl': 16.2.3
+      '@next/swc-linux-x64-gnu': 16.2.3
+      '@next/swc-linux-x64-musl': 16.2.3
+      '@next/swc-win32-arm64-msvc': 16.2.3
+      '@next/swc-win32-x64-msvc': 16.2.3
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5


### PR DESCRIPTION
## Summary
- Add a cumulative-delta **usage poller** that catches tokens OpenClaw adds after the chat `done` event (background tool calls, vision API, subagent spawns) — previously lost from the dashboard
- Disable OpenClaw's per-agent heartbeat by default to prevent hidden token costs
- Pipe **vision API** token usage from `pinchy-files` back to Pinchy via a new internal `/api/internal/usage/record` endpoint
- Classify every usage record as **chat / system / plugin** based on session key, expose the split in the summary API, and show breakdown cards on the dashboard (system/plugin cards only appear when non-zero)
- Integration-flavored timing tests for the poll pipeline (delta capture after `done`, multi-poll accumulation, concurrent `done`+poll dedup via `pendingBySession`)
- Fake OpenAI-compatible LLM server + integration test skeleton (`INTEGRATION_TEST=1`) to eventually verify the whole chain end-to-end against a real OpenClaw + Postgres

## Test Plan
- [x] `pnpm test` — 2126 passed, 5 skipped (Ollama), 3 todo (integration), 0 failures
- [x] `pnpm lint` — 0 errors
- [x] `pnpm build` — clean (verified via pre-push hook)
- [ ] Manual: spin up dev stack, send a chat that triggers a long-running tool call, confirm the extra tokens show up on `/usage` after one poll cycle
- [ ] Manual: open a PDF via `pinchy-files` in Smithers, verify vision tokens appear in the **Plugin** card
- [ ] Manual: verify the System/Plugin cards stay hidden when there's no non-chat usage