### PR TITLE
docs: deduplicate cloud-init script, use single canonical source

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -76,10 +76,13 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Generate versioned cloud-init.yml
+        run: sed "s/%%PINCHY_VERSION%%/${GITHUB_REF_NAME}/g" docs/src/snippets/cloud-init.yml > /tmp/cloud-init.yml
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
           files: |
             docs/public/installing.html
-            docs/public/cloud-init.yml
+            /tmp/cloud-init.yml

--- a/docs/.gitignore
+++ b/docs/.gitignore
@@ -2,3 +2,4 @@ node_modules/
 dist/
 .astro/
 .injected-version
+public/cloud-init.yml

--- a/docs/scripts/inject-version.sh
+++ b/docs/scripts/inject-version.sh
@@ -1,6 +1,7 @@
 #!/bin/sh
 # Reads the Pinchy version and replaces %%PINCHY_VERSION%% placeholders
-# in docs source files and public assets (e.g., cloud-init.yml).
+# in docs source files. Also generates public/cloud-init.yml from
+# src/snippets/cloud-init.yml (the canonical source).
 # Called automatically by the build/dev scripts — no manual step needed.
 #
 # Version sources (in priority order):
@@ -35,7 +36,7 @@ if [ -z "$TAG" ]; then
 fi
 
 # Count replacements for feedback
-COUNT=$(grep -r '%%PINCHY_VERSION%%' "$DOCS_DIR/src" "$DOCS_DIR/public" --include='*.mdx' --include='*.md' --include='*.yml' -l 2>/dev/null | wc -l | tr -d ' ')
+COUNT=$(grep -r '%%PINCHY_VERSION%%' "$DOCS_DIR/src" --include='*.mdx' --include='*.md' --include='*.yml' -l 2>/dev/null | wc -l | tr -d ' ')
 
 if [ "$COUNT" = "0" ]; then
   echo "[docs] No %%PINCHY_VERSION%% placeholders found (version: $TAG)"
@@ -46,7 +47,10 @@ fi
 echo "$TAG" > "$DOCS_DIR/.injected-version"
 
 # Replace in-place (works on both macOS and Linux)
-find "$DOCS_DIR/src" "$DOCS_DIR/public" \( -name '*.mdx' -o -name '*.md' -o -name '*.yml' \) -exec sed -i.bak "s/%%PINCHY_VERSION%%/$TAG/g" {} +
-find "$DOCS_DIR/src" "$DOCS_DIR/public" -name '*.bak' -delete
+find "$DOCS_DIR/src" \( -name '*.mdx' -o -name '*.md' -o -name '*.yml' \) -exec sed -i.bak "s/%%PINCHY_VERSION%%/$TAG/g" {} +
+find "$DOCS_DIR/src" -name '*.bak' -delete
+
+# Regenerate public/cloud-init.yml from the (now version-injected) source
+cp "$DOCS_DIR/src/snippets/cloud-init.yml" "$DOCS_DIR/public/cloud-init.yml"
 
 echo "[docs] Injected $TAG into $COUNT file(s)"

--- a/docs/scripts/restore-placeholders.sh
+++ b/docs/scripts/restore-placeholders.sh
@@ -21,8 +21,9 @@ if [ -z "$TAG" ]; then
   exit 0
 fi
 
-find "$DOCS_DIR/src" "$DOCS_DIR/public" \( -name '*.mdx' -o -name '*.md' -o -name '*.yml' \) -exec sed -i.bak "s/$TAG/%%PINCHY_VERSION%%/g" {} +
-find "$DOCS_DIR/src" "$DOCS_DIR/public" -name '*.bak' -delete
+find "$DOCS_DIR/src" \( -name '*.mdx' -o -name '*.md' -o -name '*.yml' \) -exec sed -i.bak "s/$TAG/%%PINCHY_VERSION%%/g" {} +
+find "$DOCS_DIR/src" -name '*.bak' -delete
+rm -f "$DOCS_DIR/public/cloud-init.yml"
 rm -f "$INJECTED_VERSION_FILE"
 
 echo "[docs] Restored %%PINCHY_VERSION%% placeholders (was: $TAG)"

--- a/docs/src/content/docs/guides/deploy-digitalocean.mdx
+++ b/docs/src/content/docs/guides/deploy-digitalocean.mdx
@@ -4,7 +4,7 @@ description: Deploy a self-hosted AI agent platform on DigitalOcean. Step-by-ste
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import cloudInitScript from '../../../snippets/cloud-init.yml?raw';
+import cloudInitScript from "../../../snippets/cloud-init.yml?raw";
 
 DigitalOcean is a solid choice for running Pinchy — straightforward interface, predictable pricing, and data centers on multiple continents. If your team is distributed or you want to keep your AI agents close to your users, DigitalOcean's global footprint makes that easy.
 

--- a/docs/src/content/docs/guides/deploy-digitalocean.mdx
+++ b/docs/src/content/docs/guides/deploy-digitalocean.mdx
@@ -3,7 +3,8 @@ title: Deploy Pinchy on DigitalOcean
 description: Deploy a self-hosted AI agent platform on DigitalOcean. Step-by-step guide from Droplet creation to running Pinchy with Docker.
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Code, Steps } from "@astrojs/starlight/components";
+import cloudInitScript from '../../../snippets/cloud-init.yml?raw';
 
 DigitalOcean is a solid choice for running Pinchy — straightforward interface, predictable pricing, and data centers on multiple continents. If your team is distributed or you want to keep your AI agents close to your users, DigitalOcean's global footprint makes that easy.
 
@@ -66,42 +67,7 @@ A "Droplet" is DigitalOcean's name for a virtual server.
 
     Expand **Advanced Options** and check **Add Initialization scripts (free)**. Paste the following script into the text field. It automatically installs Docker, deploys Pinchy, sets up a firewall, and adds swap.
 
-    ```yaml
-    #cloud-config
-    runcmd:
-      - mkdir -p /opt/pinchy-loading
-      - curl -fsSL https://github.com/heypinchy/pinchy/releases/download/%%PINCHY_VERSION%%/installing.html -o /opt/pinchy-loading/index.html
-      - sed -i "s/INSTALL_START_TIME/$(date +%s)000/" /opt/pinchy-loading/index.html
-      - cd /opt/pinchy-loading && python3 -m http.server 80 &
-      - echo $! > /tmp/loading-server.pid
-      - apt-get update -qq
-      - apt-get install -y -qq docker.io docker-compose-v2 ufw
-      - echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
-      - echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
-      - apt-get install -y -qq iptables-persistent
-      - ufw allow OpenSSH
-      - ufw allow 80/tcp
-      - ufw allow 443/tcp
-      - ufw allow 7777/tcp
-      - ufw --force enable
-      - systemctl enable docker
-      - systemctl start docker
-      - fallocate -l 2G /swapfile
-      - chmod 600 /swapfile
-      - mkswap /swapfile
-      - swapon /swapfile
-      - echo '/swapfile none swap sw 0 0' >> /etc/fstab
-      - mkdir -p /opt/pinchy
-      - curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o /opt/pinchy/docker-compose.yml
-      - cd /opt/pinchy && docker compose pull
-      - cd /opt/pinchy && docker compose up -d
-      - for i in $(seq 1 90); do curl -sf http://localhost:7777/api/health > /dev/null 2>&1 && break; sleep 2; done
-      - kill $(cat /tmp/loading-server.pid) 2>/dev/null || true
-      - rm -rf /opt/pinchy-loading /tmp/loading-server.pid
-      - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 7777
-      - iptables -t nat -A OUTPUT -p tcp -o lo --dport 80 -j REDIRECT --to-ports 7777
-      - netfilter-persistent save
-    ```
+    <Code code={cloudInitScript} lang="yaml" title="cloud-init.yml" />
 
 7.  **Set the hostname and create the Droplet**
 

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -3,7 +3,8 @@ title: Deploy Pinchy on Hetzner Cloud
 description: Deploy a self-hosted AI agent platform on Hetzner Cloud. Step-by-step guide from server creation to running Pinchy with Docker.
 ---
 
-import { Aside, Steps } from "@astrojs/starlight/components";
+import { Aside, Code, Steps } from "@astrojs/starlight/components";
+import cloudInitScript from '../../../snippets/cloud-init.yml?raw';
 
 Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU data centers (Germany and Finland), which keeps your data under EU jurisdiction — no overseas transfers, no third-party cloud AI providers touching your conversations. Combined with strong price-to-performance ratios, it's the go-to option for European teams that take data sovereignty seriously.
 
@@ -77,42 +78,7 @@ Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU
 
     Scroll down past Volumes, Firewalls, Backups, Placement groups, and Labels until you reach **Cloud config** — it's near the very bottom. Paste the following script into the "Cloud-init configuration" text area:
 
-    ```yaml
-    #cloud-config
-    runcmd:
-      - mkdir -p /opt/pinchy-loading
-      - curl -fsSL https://github.com/heypinchy/pinchy/releases/download/%%PINCHY_VERSION%%/installing.html -o /opt/pinchy-loading/index.html
-      - sed -i "s/INSTALL_START_TIME/$(date +%s)000/" /opt/pinchy-loading/index.html
-      - cd /opt/pinchy-loading && python3 -m http.server 80 &
-      - echo $! > /tmp/loading-server.pid
-      - apt-get update -qq
-      - apt-get install -y -qq docker.io docker-compose-v2 ufw
-      - echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
-      - echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
-      - apt-get install -y -qq iptables-persistent
-      - ufw allow OpenSSH
-      - ufw allow 80/tcp
-      - ufw allow 443/tcp
-      - ufw allow 7777/tcp
-      - ufw --force enable
-      - systemctl enable docker
-      - systemctl start docker
-      - fallocate -l 2G /swapfile
-      - chmod 600 /swapfile
-      - mkswap /swapfile
-      - swapon /swapfile
-      - echo '/swapfile none swap sw 0 0' >> /etc/fstab
-      - mkdir -p /opt/pinchy
-      - curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o /opt/pinchy/docker-compose.yml
-      - cd /opt/pinchy && docker compose pull
-      - cd /opt/pinchy && docker compose up -d
-      - for i in $(seq 1 90); do curl -sf http://localhost:7777/api/health > /dev/null 2>&1 && break; sleep 2; done
-      - kill $(cat /tmp/loading-server.pid) 2>/dev/null || true
-      - rm -rf /opt/pinchy-loading /tmp/loading-server.pid
-      - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 7777
-      - iptables -t nat -A OUTPUT -p tcp -o lo --dport 80 -j REDIRECT --to-ports 7777
-      - netfilter-persistent save
-    ```
+    <Code code={cloudInitScript} lang="yaml" title="cloud-init.yml" />
 
     <details>
 

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -4,7 +4,7 @@ description: Deploy a self-hosted AI agent platform on Hetzner Cloud. Step-by-st
 ---
 
 import { Aside, Code, Steps } from "@astrojs/starlight/components";
-import cloudInitScript from '../../../snippets/cloud-init.yml?raw';
+import cloudInitScript from "../../../snippets/cloud-init.yml?raw";
 
 Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU data centers (Germany and Finland), which keeps your data under EU jurisdiction — no overseas transfers, no third-party cloud AI providers touching your conversations. Combined with strong price-to-performance ratios, it's the go-to option for European teams that take data sovereignty seriously.
 

--- a/docs/src/snippets/cloud-init.yml
+++ b/docs/src/snippets/cloud-init.yml
@@ -27,7 +27,6 @@ runcmd:
   - ufw allow OpenSSH
   - ufw allow 80/tcp
   - ufw allow 443/tcp
-  - ufw allow 7777/tcp
   - ufw --force enable
 
   # Docker


### PR DESCRIPTION
## Summary

- Extract `docs/src/snippets/cloud-init.yml` as single source of truth for the setup script
- Both `deploy-hetzner` and `deploy-digitalocean` guides now import it via Starlight's `<Code>` component instead of copy-pasting the same 35-line block
- Remove `ufw allow 7777/tcp` (port is only accessed via the 80→7777 iptables redirect, no need to expose it directly)

## Details

- `inject-version.sh` generates `public/cloud-init.yml` from the snippet after version injection — `public/cloud-init.yml` is now a build artifact (gitignored)
- **Fixes release workflow bug**: `%%PINCHY_VERSION%%` was previously uploaded as-is to GitHub release assets; now `sed` injects the tag before upload

## Test Plan

- [ ] Docs build passes in CI (requires Node.js 22, not available locally)
- [ ] Both deploy guides render the cloud-init block with syntax highlighting and title
- [ ] `pnpm dev` in `docs/` shows the correct script on both guide pages