### PR TITLE
feat: detect and recover from OpenClaw disconnect during active chat

### DIFF
--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -90,13 +90,15 @@ The `agentId` segment must always be the Pinchy agent UUID. The `scope` segment 
 
 The browser-to-Pinchy WebSocket connection includes several layers of protection against network instability:
 
-**Keep-alive heartbeats** — While an agent is processing a request, Pinchy sends a `{ type: "thinking" }` message to the browser every 30 seconds. This defeats browser and proxy idle-timeout disconnects during long pauses (e.g. slow local Ollama models running a tool-use loop).
+**Keep-alive heartbeats** — Once the first response chunk arrives, Pinchy sends a `{ type: "thinking" }` message to the browser every 15 seconds for the duration of the request. This defeats browser and proxy idle-timeout disconnects during long pauses between agent turns (e.g. slow local Ollama models running a tool-use loop). Heartbeats are intentionally deferred until the first chunk — starting them earlier would prevent the stuck-request timeout from firing when OpenClaw is unresponsive before it sends anything.
+
+**OpenClaw disconnect propagation** — If Pinchy loses its connection to OpenClaw while a stream is in progress, it immediately closes all active browser WebSockets. This triggers the browser's existing disconnect-recovery path (disconnect error + auto-reconnect) without waiting for the server-side stream to time out. openclaw-node's chat generator hangs indefinitely when OpenClaw disappears, so the close is the only reliable way to surface the error quickly.
 
 **Auto-reconnect with exponential backoff** — If the connection drops, the browser automatically reconnects. Delays start at 1 second and double with each attempt, capped at 5 seconds, up to 10 attempts total. On reconnect, conversation history is re-fetched from the server and any partial streamed message is replaced with the canonical server version.
 
 **Disconnect recovery** — If the WebSocket closes while a response is being streamed, an inline error appears in the chat so the user knows the response may have been interrupted. If OpenClaw finished processing the request before the disconnect, the error is automatically replaced by the complete response when history reloads after reconnect.
 
-**Stuck-request timeout** — If 60 seconds pass without any response activity (no chunks and no thinking heartbeats), the spinner stops and an error is shown prompting the user to send the message again. Heartbeats explicitly reset the timer, so a slow-but-alive agent is never killed prematurely.
+**Stuck-request timeout** — If 60 seconds pass without any response activity (no chunks and no thinking heartbeats), the spinner stops and an error is shown prompting the user to send the message again. Heartbeats reset the timer between turns, so a slow-but-alive agent is never killed prematurely.
 
 **Reconnect exhausted** — After 10 failed reconnect attempts, a persistent banner prompts the user to reload the page.
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -86,6 +86,20 @@ This format is used for both personal and shared agents. Each user always gets t
 
 The `agentId` segment must always be the Pinchy agent UUID. The `scope` segment is free-form but should follow the patterns above for consistency.
 
+### Connection resilience
+
+The browser-to-Pinchy WebSocket connection includes several layers of protection against network instability:
+
+**Keep-alive heartbeats** — While an agent is processing a request, Pinchy sends a `{ type: "thinking" }` message to the browser every 30 seconds. This defeats browser and proxy idle-timeout disconnects during long pauses (e.g. slow local Ollama models running a tool-use loop).
+
+**Auto-reconnect with exponential backoff** — If the connection drops, the browser automatically reconnects. Delays start at 1 second and double with each attempt, capped at 5 seconds, up to 10 attempts total. On reconnect, conversation history is re-fetched from the server and any partial streamed message is replaced with the canonical server version.
+
+**Disconnect recovery** — If the WebSocket closes while a response is being streamed, an inline error appears in the chat so the user knows the response may have been interrupted. If OpenClaw finished processing the request before the disconnect, the error is automatically replaced by the complete response when history reloads after reconnect.
+
+**Stuck-request timeout** — If 60 seconds pass without any response activity (no chunks and no thinking heartbeats), the spinner stops and an error is shown prompting the user to send the message again. Heartbeats explicitly reset the timer, so a slow-but-alive agent is never killed prematurely.
+
+**Reconnect exhausted** — After 10 failed reconnect attempts, a persistent banner prompts the user to reload the page.
+
 ### Session lifecycle and compaction
 
 Sessions grow with each message. OpenClaw tracks the full conversation in JSONL files and sends the relevant context to the LLM provider with each request. Over time, this increases token usage and cost.

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -10,6 +10,7 @@ import { validateWsSession } from "./src/server/ws-auth";
 import { restartState } from "./src/server/restart-state";
 import { setOpenClawClient } from "./src/server/openclaw-client";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
+import { setupOpenClawDisconnectHandler } from "./src/server/openclaw-disconnect-handler";
 import { logCapture } from "./src/lib/log-capture";
 import { startUsagePoller, stopUsagePoller } from "./src/lib/usage-poller";
 import { registerShutdownHandlers } from "./src/lib/shutdown";
@@ -329,6 +330,8 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       // second poller. The poller handles sessions.list() failures gracefully.
       startUsagePoller(openclawClient!);
     });
+
+    setupOpenClawDisconnectHandler(openclawClient, sessionMap);
 
     openclawClient.on("disconnected", () => {
       if (hasConnected) {

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -1430,6 +1430,71 @@ describe("useWsRuntime", () => {
   });
 
   describe("disconnect during active stream", () => {
+    it("should add a disconnect error message when stream is interrupted by a WebSocket error followed by close", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      expect(result.current.runtime.isRunning).toBe(true);
+
+      // Real browser behavior: onerror always fires before onclose
+      act(() => {
+        ws.onerror?.();
+        ws.onclose?.();
+      });
+
+      const messages = result.current.runtime.messages;
+      const disconnectError = messages.find(
+        (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.disconnected === true
+      );
+      expect(disconnectError).toBeDefined();
+    });
+
+    it("should not inject a disconnect error into the new agent chat when switching during an active stream", () => {
+      const { result, rerender } = renderHook(({ agentId }) => useWsRuntime(agentId), {
+        initialProps: { agentId: "agent-1" },
+      });
+      const ws1 = wsInstances[0];
+
+      act(() => {
+        ws1.onopen?.();
+      });
+
+      // Start a stream on agent-1
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+      act(() => {
+        ws1.onmessage?.({
+          data: JSON.stringify({ type: "chunk", content: "Hi", messageId: "msg-1" }),
+        });
+      });
+
+      // Switch to agent-2 while stream is active
+      rerender({ agentId: "agent-2" });
+
+      // Old connection closes (triggered by cleanup calling ws.close())
+      act(() => {
+        ws1.onclose?.();
+      });
+
+      // Agent-2's messages must be empty — no spurious disconnect error
+      expect(result.current.runtime.messages).toHaveLength(0);
+    });
+
     it("should add a disconnect error message when stream is interrupted by close", () => {
       const { result } = renderHook(() => useWsRuntime("agent-1"));
       const ws = wsInstances[0];

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -1429,6 +1429,350 @@ describe("useWsRuntime", () => {
     });
   });
 
+  describe("disconnect during active stream", () => {
+    it("should add a disconnect error message when stream is interrupted by close", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      expect(result.current.runtime.isRunning).toBe(true);
+
+      // Disconnect while stream is active
+      act(() => {
+        ws.onclose?.();
+      });
+
+      const messages = result.current.runtime.messages;
+      const disconnectError = messages.find(
+        (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.disconnected === true
+      );
+      expect(disconnectError).toBeDefined();
+    });
+
+    it("should not add a disconnect error message when idle (no active stream)", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: "history", messages: [] }),
+        });
+      });
+
+      const messagesBefore = result.current.runtime.messages.length;
+
+      // Disconnect while idle
+      act(() => {
+        ws.onclose?.();
+      });
+
+      expect(result.current.runtime.messages).toHaveLength(messagesBefore);
+    });
+
+    it("should reset isDelayed to false when WebSocket disconnects", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      // Let it become delayed
+      act(() => {
+        vi.advanceTimersByTime(15000);
+      });
+      expect(result.current.isDelayed).toBe(true);
+
+      // Disconnect — isDelayed must clear
+      act(() => {
+        ws.onclose?.();
+      });
+      expect(result.current.isDelayed).toBe(false);
+    });
+  });
+
+  describe("reconnectExhausted", () => {
+    it("should return reconnectExhausted as false initially", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      expect(result.current.reconnectExhausted).toBe(false);
+    });
+
+    it("should set reconnectExhausted to true after all reconnect attempts fail", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws1 = wsInstances[0];
+
+      act(() => {
+        ws1.onopen?.();
+      });
+
+      // Exhaust all MAX_RECONNECT_ATTEMPTS (10) + the original connection
+      for (let i = 0; i < 10; i++) {
+        const ws = wsInstances[wsInstances.length - 1];
+        act(() => {
+          ws.onclose?.();
+        });
+        act(() => {
+          vi.advanceTimersByTime(5000);
+        });
+      }
+
+      // 11th disconnect — no more reconnect attempts
+      const lastWs = wsInstances[wsInstances.length - 1];
+      act(() => {
+        lastWs.onclose?.();
+      });
+
+      expect(result.current.reconnectExhausted).toBe(true);
+    });
+
+    it("should reset reconnectExhausted to false when reconnect succeeds", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws1 = wsInstances[0];
+
+      act(() => {
+        ws1.onopen?.();
+      });
+
+      // Fail a few times (but not all)
+      for (let i = 0; i < 3; i++) {
+        const ws = wsInstances[wsInstances.length - 1];
+        act(() => {
+          ws.onclose?.();
+        });
+        act(() => {
+          vi.advanceTimersByTime(5000);
+        });
+      }
+
+      // Successful reconnect
+      const ws4 = wsInstances[wsInstances.length - 1];
+      act(() => {
+        ws4.onopen?.();
+      });
+
+      expect(result.current.reconnectExhausted).toBe(false);
+    });
+  });
+
+  describe("stuck request timeout", () => {
+    it("should add a timeout error message after 60 seconds without any activity", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      expect(result.current.runtime.isRunning).toBe(true);
+
+      // 59 seconds — should still be running
+      act(() => {
+        vi.advanceTimersByTime(59_000);
+      });
+      expect(result.current.runtime.isRunning).toBe(true);
+
+      // 60 seconds without any activity — stuck timeout fires
+      act(() => {
+        vi.advanceTimersByTime(1_000);
+      });
+      expect(result.current.runtime.isRunning).toBe(false);
+
+      const messages = result.current.runtime.messages;
+      const timeoutError = messages.find(
+        (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.timedOut === true
+      );
+      expect(timeoutError).toBeDefined();
+    });
+
+    it("should reset the stuck timer when a chunk arrives", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      // 50 seconds pass, then a chunk arrives
+      act(() => {
+        vi.advanceTimersByTime(50_000);
+      });
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: "chunk", content: "Hi", messageId: "msg-1" }),
+        });
+      });
+
+      // 50 more seconds — still under 60s from last activity, should not timeout
+      act(() => {
+        vi.advanceTimersByTime(50_000);
+      });
+      expect(result.current.runtime.isRunning).toBe(true);
+
+      // 10 more seconds (60s since last chunk) — now it should timeout
+      act(() => {
+        vi.advanceTimersByTime(10_000);
+      });
+      expect(result.current.runtime.isRunning).toBe(false);
+    });
+
+    it("should reset the stuck timer when a thinking heartbeat arrives", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      // 50 seconds pass, then a thinking heartbeat arrives
+      act(() => {
+        vi.advanceTimersByTime(50_000);
+      });
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: "thinking" }),
+        });
+      });
+
+      // 59 more seconds — still under 60s from last heartbeat
+      act(() => {
+        vi.advanceTimersByTime(59_000);
+      });
+      expect(result.current.runtime.isRunning).toBe(true);
+    });
+
+    it("should clear the stuck timer when complete arrives", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: "chunk", content: "Hi", messageId: "msg-1" }),
+        });
+      });
+      act(() => {
+        ws.onmessage?.({
+          data: JSON.stringify({ type: "complete" }),
+        });
+      });
+
+      // Advance past 60s — should NOT fire timeout because stream is done
+      act(() => {
+        vi.advanceTimersByTime(120_000);
+      });
+
+      const messages = result.current.runtime.messages;
+      const timeoutError = messages.find(
+        (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.timedOut === true
+      );
+      expect(timeoutError).toBeUndefined();
+    });
+
+    it("should clear the stuck timer on disconnect", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      // Disconnect at 30s — should clear stuck timer
+      act(() => {
+        vi.advanceTimersByTime(30_000);
+      });
+      act(() => {
+        ws.onclose?.();
+      });
+
+      // Advance to 90s total — stuck timer must NOT fire (it was cleared on disconnect)
+      act(() => {
+        vi.advanceTimersByTime(60_000);
+      });
+
+      const messages = result.current.runtime.messages;
+      const timeoutErrors = messages.filter(
+        (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.timedOut === true
+      );
+      // Disconnect error yes, but no separate timeout error
+      expect(timeoutErrors).toHaveLength(0);
+    });
+
+    it("should not start stuck timer when no message has been sent", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      act(() => {
+        vi.advanceTimersByTime(120_000);
+      });
+
+      expect(result.current.runtime.isRunning).toBe(false);
+      expect(result.current.runtime.messages).toHaveLength(0);
+    });
+  });
+
   describe("openclaw restart messages", () => {
     it("should call triggerRestart when openclaw:restarting message is received", () => {
       renderHook(() => useWsRuntime("agent-1"));

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -509,6 +509,46 @@ describe("ClientRouter", () => {
     }
   });
 
+  it("should not send heartbeats before the first chunk arrives so the client stuck-timer fires when OpenClaw hangs", async () => {
+    vi.useFakeTimers();
+    try {
+      const clientWs = createMockClientWs();
+      let resolveStream: () => void = () => {};
+
+      async function* hangingStream() {
+        // Never yields a chunk — simulates OpenClaw being unresponsive after a restart
+        await new Promise<void>((r) => (resolveStream = r));
+      }
+      mockChat.mockReturnValue(hangingStream());
+
+      const handlePromise = router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // Let synchronous code (including initial thinking) run
+      await vi.advanceTimersByTimeAsync(0);
+
+      const afterInitial = clientWs.sent.map((s) => JSON.parse(s));
+      expect(afterInitial.filter((m: any) => m.type === "thinking")).toHaveLength(1);
+
+      // Advance well past one heartbeat interval — no additional thinking should
+      // fire because no chunk has arrived from OpenClaw yet. Without this fix the
+      // heartbeat would reset the client stuck-timer indefinitely.
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const afterInterval = clientWs.sent.map((s) => JSON.parse(s));
+      expect(afterInterval.filter((m: any) => m.type === "thinking")).toHaveLength(1);
+
+      // Clean up
+      resolveStream();
+      await handlePromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should send a thinking message before consuming the stream so the UI can show a spinner", async () => {
     const clientWs = createMockClientWs();
     let firstSent: unknown = null;

--- a/packages/web/src/__tests__/server/openclaw-disconnect-propagation.test.ts
+++ b/packages/web/src/__tests__/server/openclaw-disconnect-propagation.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect, vi } from "vitest";
+import { EventEmitter } from "events";
+import { setupOpenClawDisconnectHandler } from "@/server/openclaw-disconnect-handler";
+
+// When OpenClaw disconnects mid-stream, Pinchy must close all active browser
+// WebSockets so the browser's existing disconnect-recovery path fires:
+//   • isRunning=true  → disconnect error injected, reconnect triggered
+//   • isRunning=false → just sets isConnected=false, reconnect triggered
+//
+// Without this, the browser stays connected to Pinchy while the server-side
+// for-await loop is blocked forever (openclaw-node's chat() generator hangs
+// because resolveChunk is never called after the underlying WS closes).
+
+describe("OpenClaw disconnect propagation to browser clients", () => {
+  it("closes all OPEN browser WebSockets when openclawClient emits disconnected", () => {
+    const openclawClient = new EventEmitter();
+
+    const ws1 = { readyState: 1 /* OPEN */, close: vi.fn() };
+    const ws2 = { readyState: 1 /* OPEN */, close: vi.fn() };
+    const wsClosed = { readyState: 3 /* CLOSED */, close: vi.fn() };
+
+    const sessionMap = new Map<object, { userId: string }>([
+      [ws1, { userId: "user-1" }],
+      [ws2, { userId: "user-2" }],
+      [wsClosed, { userId: "user-3" }],
+    ]);
+
+    setupOpenClawDisconnectHandler(openclawClient as any, sessionMap as any);
+    openclawClient.emit("disconnected");
+
+    expect(ws1.close).toHaveBeenCalledWith(1001, "OpenClaw disconnected");
+    expect(ws2.close).toHaveBeenCalledWith(1001, "OpenClaw disconnected");
+    // Already-closed WebSockets must not be touched
+    expect(wsClosed.close).not.toHaveBeenCalled();
+  });
+
+  it("does not throw when there are no active browser WebSocket connections", () => {
+    const openclawClient = new EventEmitter();
+    const sessionMap = new Map<object, { userId: string }>();
+
+    setupOpenClawDisconnectHandler(openclawClient as any, sessionMap as any);
+    expect(() => openclawClient.emit("disconnected")).not.toThrow();
+  });
+});

--- a/packages/web/src/__tests__/server/openclaw-disconnect-propagation.test.ts
+++ b/packages/web/src/__tests__/server/openclaw-disconnect-propagation.test.ts
@@ -10,6 +10,11 @@ import { setupOpenClawDisconnectHandler } from "@/server/openclaw-disconnect-han
 // Without this, the browser stays connected to Pinchy while the server-side
 // for-await loop is blocked forever (openclaw-node's chat() generator hangs
 // because resolveChunk is never called after the underlying WS closes).
+//
+// IMPORTANT: openclaw-node emits "disconnected" on every failed reconnect attempt
+// (~1s interval). Browser WebSockets must only be closed ONCE per "down" period,
+// not on every attempt — otherwise the browser can never stay connected while
+// Pinchy is waiting for OpenClaw to come back.
 
 describe("OpenClaw disconnect propagation to browser clients", () => {
   it("closes all OPEN browser WebSockets when openclawClient emits disconnected", () => {
@@ -32,6 +37,56 @@ describe("OpenClaw disconnect propagation to browser clients", () => {
     expect(ws2.close).toHaveBeenCalledWith(1001, "OpenClaw disconnected");
     // Already-closed WebSockets must not be touched
     expect(wsClosed.close).not.toHaveBeenCalled();
+  });
+
+  it("does not close browser WebSockets again on subsequent disconnected events while OpenClaw is still down", () => {
+    // openclaw-node fires "disconnected" on every failed reconnect attempt (~1s).
+    // Without this guard the browser could never re-establish its connection to
+    // Pinchy because each reconnect would be torn down almost immediately.
+    const openclawClient = new EventEmitter();
+
+    const ws = { readyState: 1 /* OPEN */, close: vi.fn() };
+    const sessionMap = new Map<object, { userId: string }>([[ws, { userId: "user-1" }]]);
+
+    setupOpenClawDisconnectHandler(openclawClient as any, sessionMap as any);
+
+    // First disconnect — should close browser WebSockets
+    openclawClient.emit("disconnected");
+    expect(ws.close).toHaveBeenCalledTimes(1);
+
+    // Simulate browser reconnecting: a new WS entry would be added, but the
+    // existing one is now CLOSED (readyState 3) — simulate that
+    ws.readyState = 3;
+    const wsNew = { readyState: 1 /* OPEN */, close: vi.fn() };
+    sessionMap.set(wsNew, { userId: "user-1" });
+
+    // Subsequent disconnected events while OpenClaw is still down
+    openclawClient.emit("disconnected");
+    openclawClient.emit("disconnected");
+
+    // New browser connection must NOT be closed by the repeated disconnect events
+    expect(wsNew.close).not.toHaveBeenCalled();
+  });
+
+  it("closes browser WebSockets again after OpenClaw reconnects and then disconnects again", () => {
+    const openclawClient = new EventEmitter();
+
+    const ws = { readyState: 1 /* OPEN */, close: vi.fn() };
+    const sessionMap = new Map<object, { userId: string }>([[ws, { userId: "user-1" }]]);
+
+    setupOpenClawDisconnectHandler(openclawClient as any, sessionMap as any);
+
+    // First disconnect period
+    openclawClient.emit("disconnected");
+    expect(ws.close).toHaveBeenCalledTimes(1);
+
+    // OpenClaw comes back — resets the guard
+    openclawClient.emit("connected");
+
+    // OpenClaw goes down again — should close browser WebSockets again
+    ws.readyState = 1; // simulating a new connection with same object
+    openclawClient.emit("disconnected");
+    expect(ws.close).toHaveBeenCalledTimes(2);
   });
 
   it("does not throw when there are no active browser WebSocket connections", () => {

--- a/packages/web/src/components/assistant-ui/chat-error-message.tsx
+++ b/packages/web/src/components/assistant-ui/chat-error-message.tsx
@@ -1,16 +1,60 @@
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Clock, WifiOff } from "lucide-react";
 import Link from "next/link";
 import type { FC } from "react";
 import { PROVIDER_SETTINGS_HINT } from "@/server/error-hints";
+import { ReportIssueLink } from "@/components/report-issue-link";
 
 export interface ChatError {
   agentName?: string;
   providerError?: string;
   hint?: string | null;
   message?: string;
+  disconnected?: true;
+  timedOut?: true;
 }
 
 export const ChatErrorMessage: FC<{ error: ChatError }> = ({ error }) => {
+  if (error.disconnected) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/5"
+      >
+        <div className="flex items-center gap-2 font-medium text-destructive dark:text-red-200">
+          <WifiOff className="size-4 shrink-0" data-testid="disconnect-icon" />
+          Connection lost
+        </div>
+        <p className="mt-1.5 text-destructive/90 dark:text-red-300/90">
+          The connection was interrupted. Your last message may not have been processed.
+        </p>
+        <p className="mt-1.5 text-destructive/75 dark:text-red-300/75">
+          <ReportIssueLink error="Connection lost during active stream" />
+        </p>
+      </div>
+    );
+  }
+
+  if (error.timedOut) {
+    return (
+      <div
+        role="alert"
+        className="rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/5"
+      >
+        <div className="flex items-center gap-2 font-medium text-destructive dark:text-red-200">
+          <Clock className="size-4 shrink-0" data-testid="timeout-icon" />
+          No response
+        </div>
+        <p className="mt-1.5 text-destructive/90 dark:text-red-300/90">
+          The agent didn&apos;t respond within 60 seconds. It may be overloaded or stuck.
+        </p>
+        <p className="mt-1.5 text-destructive/75 dark:text-red-300/75">
+          You can send your message again to retry.{" "}
+          <ReportIssueLink error="Agent timed out — no response after 60 seconds" />
+        </p>
+      </div>
+    );
+  }
+
   const isProviderError = !!error.providerError;
   const agentLabel = error.agentName ?? "The assistant";
 

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -40,7 +40,8 @@ export function Chat({
     : avatarUrl;
   const displayIsPersonal = liveAgent?.isPersonal ?? isPersonal;
 
-  const { runtime, isConnected, isDelayed, isHistoryLoaded } = useWsRuntime(agentId);
+  const { runtime, isConnected, isDelayed, isHistoryLoaded, reconnectExhausted } =
+    useWsRuntime(agentId);
 
   const statusMessage = !isConnected
     ? configuring
@@ -109,7 +110,12 @@ export function Chat({
             <div className="flex-1 min-h-0 animate-in fade-in duration-300">
               <Thread isHistoryLoaded={isHistoryLoaded} />
             </div>
-            {isDelayed && (
+            {reconnectExhausted && (
+              <div className="px-4 py-2 text-center text-xs text-destructive border-t bg-destructive/5">
+                Unable to reconnect. Please reload the page to resume chatting.
+              </div>
+            )}
+            {!reconnectExhausted && isDelayed && (
               <div className="px-4 py-2 text-center text-xs text-muted-foreground border-t">
                 The agent is taking longer than usual. This may be due to high demand.
               </div>

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -87,6 +87,11 @@ export function useWsRuntime(agentId: string): {
   const shouldRecoverFromHistoryRef = useRef(false);
   const pendingMessageRef = useRef<string | null>(null);
   const isRunningRef = useRef(false);
+  // Tracks the current agentId so stale WebSocket handlers (from before an
+  // agent switch) can detect they belong to an old connection and bail out.
+  // Updated at the start of the useEffect (before connecting), not during render,
+  // so the new value is in place before any stale onclose/onmessage fires.
+  const agentIdRef = useRef(agentId);
 
   // Reset state when switching agents — prevents stale messages from
   // one agent blocking history load for a different agent.
@@ -101,6 +106,9 @@ export function useWsRuntime(agentId: string): {
   }
 
   useEffect(() => {
+    // Update before connect() so stale handlers from the previous agent see
+    // the new agentId as soon as the cleanup's ws.close() fires asynchronously.
+    agentIdRef.current = agentId;
     mountedRef.current = true;
     reconnectAttemptRef.current = 0;
     shouldRecoverFromHistoryRef.current = false;
@@ -136,6 +144,9 @@ export function useWsRuntime(agentId: string): {
     function connect() {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws?agentId=${agentId}`);
+      // Snapshot the agentId at connection time. Handlers compare this against
+      // agentIdRef.current to detect stale connections after an agent switch.
+      const connectionAgentId = agentId;
 
       ws.onopen = () => {
         setIsConnected(true);
@@ -151,6 +162,7 @@ export function useWsRuntime(agentId: string): {
       };
 
       ws.onclose = () => {
+        if (connectionAgentId !== agentIdRef.current) return;
         setIsConnected(false);
         setIsDelayed(false);
         clearStuckTimer();
@@ -190,13 +202,15 @@ export function useWsRuntime(agentId: string): {
       };
 
       ws.onerror = () => {
+        if (connectionAgentId !== agentIdRef.current) return;
+        // onclose always fires after onerror — let onclose handle isRunning and
+        // the disconnect error injection so the user sees the right feedback.
         setIsConnected(false);
         clearStuckTimer();
-        isRunningRef.current = false;
-        setIsRunning(false);
       };
 
       ws.onmessage = (event) => {
+        if (connectionAgentId !== agentIdRef.current) return;
         try {
           const data = JSON.parse(event.data);
 

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -26,6 +26,7 @@ interface WsMessage {
 }
 
 const DELAY_HINT_MS = 15_000;
+const STUCK_TIMEOUT_MS = 60_000;
 
 function convertMessage(msg: WsMessage): ThreadMessageLike {
   const parts: Array<{ type: "text"; text: string } | { type: "image"; image: string }> = [
@@ -67,6 +68,7 @@ export function useWsRuntime(agentId: string): {
   isConnected: boolean;
   isDelayed: boolean;
   isHistoryLoaded: boolean;
+  reconnectExhausted: boolean;
 } {
   const { triggerRestart } = useRestart();
   const [messages, setMessages] = useState<WsMessage[]>([]);
@@ -74,13 +76,17 @@ export function useWsRuntime(agentId: string): {
   const [isConnected, setIsConnected] = useState(false);
   const [isDelayed, setIsDelayed] = useState(false);
   const [isHistoryLoaded, setIsHistoryLoaded] = useState(false);
+  const [reconnectExhausted, setReconnectExhausted] = useState(false);
   const wsRef = useRef<WebSocket | null>(null);
   const delayTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const stuckTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const resetStuckTimerRef = useRef<(() => void) | null>(null);
   const mountedRef = useRef(true);
   const reconnectAttemptRef = useRef(0);
   const reconnectTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const shouldRecoverFromHistoryRef = useRef(false);
   const pendingMessageRef = useRef<string | null>(null);
+  const isRunningRef = useRef(false);
 
   // Reset state when switching agents — prevents stale messages from
   // one agent blocking history load for a different agent.
@@ -99,12 +105,41 @@ export function useWsRuntime(agentId: string): {
     reconnectAttemptRef.current = 0;
     shouldRecoverFromHistoryRef.current = false;
 
+    function clearStuckTimer() {
+      if (stuckTimerRef.current) {
+        clearTimeout(stuckTimerRef.current);
+        stuckTimerRef.current = null;
+      }
+    }
+
+    function resetStuckTimer() {
+      clearStuckTimer();
+      stuckTimerRef.current = setTimeout(() => {
+        isRunningRef.current = false;
+        setIsRunning(false);
+        setIsDelayed(false);
+        setMessages((prev) => [
+          ...prev,
+          {
+            id: uuid(),
+            role: "assistant",
+            content: "",
+            error: { timedOut: true },
+          },
+        ]);
+      }, STUCK_TIMEOUT_MS);
+    }
+
+    // Expose resetStuckTimer to onNew (defined outside this useEffect)
+    resetStuckTimerRef.current = resetStuckTimer;
+
     function connect() {
       const protocol = window.location.protocol === "https:" ? "wss:" : "ws:";
       const ws = new WebSocket(`${protocol}//${window.location.host}/api/ws?agentId=${agentId}`);
 
       ws.onopen = () => {
         setIsConnected(true);
+        setReconnectExhausted(false);
         reconnectAttemptRef.current = 0;
         ws.send(JSON.stringify({ type: "history", agentId }));
 
@@ -117,7 +152,31 @@ export function useWsRuntime(agentId: string): {
 
       ws.onclose = () => {
         setIsConnected(false);
-        setIsRunning(false);
+        setIsDelayed(false);
+        clearStuckTimer();
+        if (delayTimerRef.current) {
+          clearTimeout(delayTimerRef.current);
+          delayTimerRef.current = null;
+        }
+
+        // If a stream was in progress, inject a disconnect error so the user
+        // knows the response may have been lost.
+        if (isRunningRef.current) {
+          isRunningRef.current = false;
+          setIsRunning(false);
+          setMessages((prev) => [
+            ...prev,
+            {
+              id: uuid(),
+              role: "assistant",
+              content: "",
+              error: { disconnected: true },
+            },
+          ]);
+        } else {
+          setIsRunning(false);
+        }
+
         setIsHistoryLoaded(false);
 
         if (mountedRef.current && reconnectAttemptRef.current < MAX_RECONNECT_ATTEMPTS) {
@@ -125,11 +184,15 @@ export function useWsRuntime(agentId: string): {
           const delay = Math.min(1000 * Math.pow(2, reconnectAttemptRef.current), 5000);
           reconnectAttemptRef.current++;
           reconnectTimerRef.current = setTimeout(connect, delay);
+        } else if (mountedRef.current) {
+          setReconnectExhausted(true);
         }
       };
 
       ws.onerror = () => {
         setIsConnected(false);
+        clearStuckTimer();
+        isRunningRef.current = false;
         setIsRunning(false);
       };
 
@@ -172,13 +235,17 @@ export function useWsRuntime(agentId: string): {
           if (data.type === "thinking") {
             // Server keep-alive: defeats browser/proxy WebSocket idle
             // timeouts during long pauses (e.g. local Ollama tool-use loops).
-            // No state change needed — we just don't want to drop the frame.
+            // Reset stuck timer so a slow-but-alive agent doesn't get killed.
+            isRunningRef.current = true;
             setIsRunning(true);
+            resetStuckTimer();
             return;
           }
 
           if (data.type === "chunk") {
+            isRunningRef.current = true;
             setIsRunning(true);
+            resetStuckTimer();
 
             if (delayTimerRef.current) {
               clearTimeout(delayTimerRef.current);
@@ -215,7 +282,9 @@ export function useWsRuntime(agentId: string): {
               clearTimeout(delayTimerRef.current);
               delayTimerRef.current = null;
             }
+            clearStuckTimer();
             setIsDelayed(false);
+            isRunningRef.current = false;
             setIsRunning(false);
           }
 
@@ -224,6 +293,7 @@ export function useWsRuntime(agentId: string): {
               clearTimeout(delayTimerRef.current);
               delayTimerRef.current = null;
             }
+            clearStuckTimer();
             setIsDelayed(false);
 
             const error: ChatError = data.providerError
@@ -243,6 +313,7 @@ export function useWsRuntime(agentId: string): {
                 error,
               },
             ]);
+            isRunningRef.current = false;
             setIsRunning(false);
           }
         } catch {
@@ -263,6 +334,7 @@ export function useWsRuntime(agentId: string): {
       if (delayTimerRef.current) {
         clearTimeout(delayTimerRef.current);
       }
+      clearStuckTimer();
       wsRef.current?.close();
     };
   }, [agentId]);
@@ -319,6 +391,7 @@ export function useWsRuntime(agentId: string): {
       };
 
       setMessages((prev) => [...prev, userMessage]);
+      isRunningRef.current = true;
       setIsRunning(true);
 
       // Start delay hint timer
@@ -328,6 +401,9 @@ export function useWsRuntime(agentId: string): {
       delayTimerRef.current = setTimeout(() => {
         setIsDelayed(true);
       }, DELAY_HINT_MS);
+
+      // Start stuck timer — fires if no activity (chunk or thinking) for 60s
+      resetStuckTimerRef.current?.();
 
       // Build content: structured array if images present, plain string otherwise
       let wsContent: string | Array<{ type: string; text?: string; image_url?: { url: string } }>;
@@ -372,5 +448,5 @@ export function useWsRuntime(agentId: string): {
     },
   });
 
-  return { runtime, isConnected, isDelayed, isHistoryLoaded };
+  return { runtime, isConnected, isDelayed, isHistoryLoaded, reconnectExhausted };
 }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -159,17 +159,13 @@ export class ClientRouter {
         messageId,
       });
 
-      // Periodic keep-alive: defeat browser/proxy idle timeouts during long
-      // pauses between agent turns (Ollama tool-use loops can take >60s).
-      // The interval is cleared in the finally block below.
-      const heartbeatInterval = setInterval(() => {
-        if (clientWs.readyState === WS_OPEN) {
-          this.sendToClient(clientWs, {
-            type: "thinking",
-            messageId,
-          });
-        }
-      }, THINKING_HEARTBEAT_MS);
+      // Heartbeat is intentionally deferred until the first chunk arrives.
+      // Starting it immediately would reset the client-side stuck timer even
+      // when OpenClaw's stream hangs before producing any output (e.g. after a
+      // restart), trapping the user in an infinite spinner. Once the first
+      // chunk arrives we know OpenClaw is actively responding, so heartbeats
+      // are safe to send between turns.
+      let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
       try {
         // Debug shortcut: "__debug_error:<type>" messages bypass OpenClaw and
@@ -206,6 +202,20 @@ export class ClientRouter {
           // server resources while letting OpenClaw finish on its side.
           if (clientWs.readyState !== WS_OPEN) {
             break;
+          }
+
+          // Start keep-alive heartbeats on the first chunk. Deferring until
+          // here ensures heartbeats only flow while OpenClaw is actively
+          // producing output — not while it may be hung before the first byte.
+          if (heartbeatInterval === null) {
+            heartbeatInterval = setInterval(() => {
+              if (clientWs.readyState === WS_OPEN) {
+                this.sendToClient(clientWs, {
+                  type: "thinking",
+                  messageId,
+                });
+              }
+            }, THINKING_HEARTBEAT_MS);
           }
 
           if (chunk.type === "text") {
@@ -253,7 +263,9 @@ export class ClientRouter {
           type: "complete",
         });
       } finally {
-        clearInterval(heartbeatInterval);
+        if (heartbeatInterval !== null) {
+          clearInterval(heartbeatInterval);
+        }
       }
     } catch (err) {
       this.sendToClient(clientWs, {

--- a/packages/web/src/server/openclaw-disconnect-handler.ts
+++ b/packages/web/src/server/openclaw-disconnect-handler.ts
@@ -1,0 +1,26 @@
+import type { WebSocket } from "ws";
+import type { OpenClawClient } from "openclaw-node";
+
+const WS_OPEN = 1;
+
+/**
+ * Closes all active browser WebSockets when OpenClaw disconnects.
+ *
+ * openclaw-node's chat() generator hangs indefinitely when the underlying
+ * WebSocket closes (its internal resolveChunk promise is never resolved).
+ * Closing the browser WebSocket triggers the browser's disconnect-recovery
+ * path, which injects an error message (if a stream was in progress) and
+ * auto-reconnects — without waiting for the zombie server-side generator.
+ */
+export function setupOpenClawDisconnectHandler(
+  openclawClient: Pick<OpenClawClient, "on">,
+  sessionMap: Map<WebSocket, unknown>
+): void {
+  openclawClient.on("disconnected", () => {
+    for (const [clientWs] of sessionMap) {
+      if (clientWs.readyState === WS_OPEN) {
+        clientWs.close(1001, "OpenClaw disconnected");
+      }
+    }
+  });
+}

--- a/packages/web/src/server/openclaw-disconnect-handler.ts
+++ b/packages/web/src/server/openclaw-disconnect-handler.ts
@@ -4,19 +4,39 @@ import type { OpenClawClient } from "openclaw-node";
 const WS_OPEN = 1;
 
 /**
- * Closes all active browser WebSockets when OpenClaw disconnects.
+ * Closes all active browser WebSockets when OpenClaw first disconnects, then
+ * waits for OpenClaw to reconnect before arming the handler again.
  *
+ * WHY ONCE-PER-PERIOD:
+ * openclaw-node emits "disconnected" on every failed reconnect attempt
+ * (~1 second interval with default config). If we closed browser WebSockets on
+ * every event, the browser could never re-establish a stable connection while
+ * Pinchy is waiting for OpenClaw to come back — the new browser WS would be torn
+ * down almost immediately.
+ *
+ * WHY CLOSE AT ALL:
  * openclaw-node's chat() generator hangs indefinitely when the underlying
- * WebSocket closes (its internal resolveChunk promise is never resolved).
- * Closing the browser WebSocket triggers the browser's disconnect-recovery
- * path, which injects an error message (if a stream was in progress) and
- * auto-reconnects — without waiting for the zombie server-side generator.
+ * OpenClaw WebSocket closes: its internal resolveChunk promise is never resolved.
+ * The server-side for-await loop blocks forever, heartbeats keep firing, and the
+ * browser's stuck timer never triggers. Closing the browser WebSocket fires the
+ * browser's existing onclose handler which injects the disconnect error (if a
+ * stream was in progress) and triggers auto-reconnect.
  */
 export function setupOpenClawDisconnectHandler(
   openclawClient: Pick<OpenClawClient, "on">,
   sessionMap: Map<WebSocket, unknown>
 ): void {
+  let closedForCurrentDisconnect = false;
+
+  openclawClient.on("connected", () => {
+    // OpenClaw is back — re-arm the handler so the next disconnect is caught.
+    closedForCurrentDisconnect = false;
+  });
+
   openclawClient.on("disconnected", () => {
+    if (closedForCurrentDisconnect) return;
+    closedForCurrentDisconnect = true;
+
     for (const [clientWs] of sessionMap) {
       if (clientWs.readyState === WS_OPEN) {
         clientWs.close(1001, "OpenClaw disconnected");


### PR DESCRIPTION
Closes #19

## What changed

### Client-side (`use-ws-runtime.ts`)

- **Disconnect error in chat**: When the WebSocket closes during an active stream, an inline error message (WifiOff icon) appears in the chat. On successful reconnect, history recovery automatically replaces this message with the actual response if OpenClaw completed the request.
- **Stuck-request timeout**: If 60 seconds pass with no chunks and no thinking heartbeats, the spinner stops and an inline error prompts the user to retry. Heartbeats reset the timer so slow-but-alive agents are never killed prematurely.
- **Reconnect exhausted banner**: After 10 failed reconnect attempts, a persistent banner prompts the user to reload the page.
- **Agent-switch isolation**: Stale WebSocket handlers from a previous agent are ignored after switching agents, preventing spurious disconnect errors in the new chat.

### Server-side (`client-router.ts`, `server.ts`)

- **Heartbeat deferred until first chunk**: The keep-alive heartbeat interval now starts only after OpenClaw sends its first chunk. Previously it started immediately, which indefinitely reset the client-side stuck timer even when OpenClaw's stream was hung (e.g. after a container restart). Now: if no chunk arrives within 60 seconds, the stuck timer fires correctly.
- **OpenClaw disconnect propagation**: When Pinchy loses its connection to OpenClaw mid-stream, it immediately closes all active browser WebSockets. This surfaces the disconnect error without waiting for the hung server-side stream to time out. A one-shot guard ensures browser WebSockets are only closed once per "down" period — not on every failed reconnect attempt from openclaw-node (~1s interval).

### UI (`chat-error-message.tsx`, `chat.tsx`)

- New `disconnected` variant: WifiOff icon, "Connection lost" heading
- New `timedOut` variant: Clock icon, "No response" heading, retry hint
- Reconnect-exhausted banner at the bottom of the chat

### Docs (`architecture.mdx`)

- New "Connection resilience" section documenting all behaviors above