### PR TITLE
fix(ollama-cloud): opt into stream_options.include_usage so tokens track

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -726,6 +726,33 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
   });
 
+  it("opts every Ollama Cloud model into streaming usage reporting", async () => {
+    // Ollama Cloud's /v1/chat/completions only emits a final `usage` chunk
+    // when the request carries `stream_options: { include_usage: true }`.
+    // OpenClaw adds that flag only when the model config opts in via
+    // `compat.supportsUsageInStreaming: true` — its own auto-detection
+    // treats configured non-OpenAI endpoints as "not supported" by default.
+    // Without this opt-in, sessions have no inputTokens/outputTokens, the
+    // poller records nothing, and Usage & Costs stays empty.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_cloud_api_key") return "sk-ollama-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const models = config.models.providers["ollama-cloud"].models as Array<{
+      id: string;
+      compat?: { supportsUsageInStreaming?: boolean };
+    }>;
+
+    for (const model of models) {
+      expect(model.compat?.supportsUsageInStreaming).toBe(true);
+    }
+  });
+
   it("should not include models block when neither ollama provider is configured", async () => {
     mockedGetSetting.mockResolvedValue(null);
 

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -396,11 +396,20 @@ export async function regenerateOpenClawConfig() {
       api: "openai-completions",
       // Derived from TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — see that file for
       // the source of each context window (ollama.com/library/<name>).
+      //
+      // `compat.supportsUsageInStreaming: true` is REQUIRED for usage
+      // tracking. OpenClaw's default compat detection treats any configured
+      // non-OpenAI endpoint as not supporting usage-in-streaming, so it
+      // never sends `stream_options: { include_usage: true }`. Ollama Cloud
+      // only emits the final usage chunk when that flag is present — without
+      // this opt-in, every session has zero tracked tokens and Usage & Costs
+      // stays empty. Verified live against https://ollama.com/v1/chat/completions.
       models: TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => ({
         id: m.id,
         name: m.id,
         contextWindow: m.contextWindow,
         maxTokens: m.maxTokens,
+        compat: { supportsUsageInStreaming: true },
       })),
     };
   }


### PR DESCRIPTION
## Summary

Usage & Costs showed **"No usage data available"** for every chat that used an Ollama Cloud model, even with real traffic. Root cause: Ollama Cloud's `/v1/chat/completions` only emits the final `usage` chunk when the request carries `stream_options: { include_usage: true }`. OpenClaw's compat auto-detection treats any configured non-OpenAI endpoint as not supporting usage-in-streaming and never sends that flag — Ollama Cloud silently drops the usage chunk, session entries have no `inputTokens`/`outputTokens`, the poller finds nothing to record, dashboard stays empty.

**Fix:** set `compat: { supportsUsageInStreaming: true }` on every Ollama Cloud model entry in the generated OpenClaw config. OpenClaw then sends `stream_options.include_usage: true` and Ollama responds with the usage chunk.

Verified live:
- Direct calls to `https://ollama.com/v1/chat/completions`: without the flag the stream ends after `finish_reason: "stop"` with no usage chunk; with the flag a final chunk carries `{ prompt_tokens, completion_tokens, total_tokens }`.
- After the fix, a real test chat picks up tokens on the next poll tick and the `/usage` dashboard populates.

## Test plan
- [x] Guard unit test `opts every Ollama Cloud model into streaming usage reporting` — red-first, then green
- [x] Full suite green (2684 tests)
- [x] Live: Ollama Cloud chat → 60s → `usage_records` row appears, `/usage` dashboard shows data

## Release context

Release-blocker for v0.4.0 — a dashboard that silently stays empty for Ollama Cloud users violates the "no known bugs in releases" rule.