### PR TITLE
fix(ollama-cloud): add reasoning, vision, and cost to every model entry

### DIFF
--- a/packages/web/src/__tests__/lib/model-vision.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.test.ts
@@ -27,8 +27,9 @@ describe("isModelVisionCapable", () => {
   });
 
   describe("Ollama cloud vision models", () => {
-    // Cloud model IDs are the bare names returned by https://ollama.com/v1/models
-    // — no ":cloud" / "-cloud" suffix since Ollama dropped them.
+    // Cloud vision IDs come from ollama-cloud-models.ts (tool-capable
+    // allowlist filtered by `vision: true`). Exact-match — no prefix-match
+    // — so `qwen3.5:397b` must be spelled out, not `qwen3.5`.
     it("should return true for kimi-k2.5", () => {
       expect(isModelVisionCapable("ollama-cloud/kimi-k2.5")).toBe(true);
     });
@@ -37,30 +38,52 @@ describe("isModelVisionCapable", () => {
       expect(isModelVisionCapable("ollama-cloud/gemini-3-flash-preview")).toBe(true);
     });
 
-    it("should return true for mistral-large-3", () => {
+    it("should return true for mistral-large-3:675b", () => {
       expect(isModelVisionCapable("ollama-cloud/mistral-large-3:675b")).toBe(true);
     });
 
-    it("should return true for qwen3.5", () => {
+    it("should return true for qwen3.5:397b", () => {
       expect(isModelVisionCapable("ollama-cloud/qwen3.5:397b")).toBe(true);
     });
 
-    it("should return true for ministral-3", () => {
+    it("should return true for every ministral-3 variant", () => {
+      expect(isModelVisionCapable("ollama-cloud/ministral-3:3b")).toBe(true);
+      expect(isModelVisionCapable("ollama-cloud/ministral-3:8b")).toBe(true);
       expect(isModelVisionCapable("ollama-cloud/ministral-3:14b")).toBe(true);
     });
 
-    it("should return true for qwen3-vl", () => {
+    it("should return true for both qwen3-vl variants", () => {
       expect(isModelVisionCapable("ollama-cloud/qwen3-vl:235b")).toBe(true);
+      expect(isModelVisionCapable("ollama-cloud/qwen3-vl:235b-instruct")).toBe(true);
     });
 
-    it("should return true for gemma3", () => {
-      expect(isModelVisionCapable("ollama-cloud/gemma3:27b")).toBe(true);
+    it("should return true for gemma4:31b", () => {
+      // Regression guard for a review finding: gemma4 is vision-capable per
+      // ollama.com/library/gemma4 but was missing from the hardcoded list.
+      expect(isModelVisionCapable("ollama-cloud/gemma4:31b")).toBe(true);
     });
 
-    it("should return false for non-vision Ollama cloud models", () => {
+    it("should return true for devstral-small-2:24b", () => {
+      // Devstral Small 2's library page lists "Text, Image" input type.
+      expect(isModelVisionCapable("ollama-cloud/devstral-small-2:24b")).toBe(true);
+    });
+
+    it("should return false for tool-capable cloud models that are text-only", () => {
       expect(isModelVisionCapable("ollama-cloud/deepseek-v3.2")).toBe(false);
       expect(isModelVisionCapable("ollama-cloud/glm-4.7")).toBe(false);
       expect(isModelVisionCapable("ollama-cloud/nemotron-3-nano:30b")).toBe(false);
+      expect(isModelVisionCapable("ollama-cloud/gpt-oss:20b")).toBe(false);
+      expect(isModelVisionCapable("ollama-cloud/kimi-k2-thinking")).toBe(false);
+      expect(isModelVisionCapable("ollama-cloud/qwen3-coder:480b")).toBe(false);
+      expect(isModelVisionCapable("ollama-cloud/qwen3-coder-next")).toBe(false);
+    });
+
+    it("should return false for models Pinchy doesn't surface (not in the tool-capable allowlist)", () => {
+      // gemma3 is vision-capable locally but not tool-capable on Ollama
+      // Cloud, so Pinchy filters it out and never shows it in the cloud
+      // model picker. It must not be reported as vision-capable under the
+      // ollama-cloud provider either.
+      expect(isModelVisionCapable("ollama-cloud/gemma3:27b")).toBe(false);
     });
   });
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -726,6 +726,108 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
   });
 
+  it("writes reasoning, input (vision), and cost fields for every Ollama Cloud model", async () => {
+    // OpenClaw's ModelDefinitionConfig requires `reasoning`, `input`, and
+    // `cost` alongside contextWindow/maxTokens/compat. Without these the
+    // runtime falls back to silent defaults — vision-capable models get
+    // treated as text-only, reasoning models can't advertise thinking, and
+    // estimatedCostUsd stays 0 for every session. Verified per model on
+    // ollama.com/library/<name>.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_cloud_api_key") return "sk-ollama-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const models = config.models.providers["ollama-cloud"].models as Array<{
+      id: string;
+      reasoning?: boolean;
+      input?: string[];
+      cost?: { input: number; output: number; cacheRead: number; cacheWrite: number };
+    }>;
+    const byId = Object.fromEntries(models.map((m) => [m.id, m]));
+
+    // Vision-capable cloud models per ollama.com/search?c=vision&c=cloud
+    const visionModels = [
+      "devstral-small-2:24b",
+      "gemini-3-flash-preview",
+      "gemma4:31b",
+      "kimi-k2.5",
+      "ministral-3:3b",
+      "ministral-3:8b",
+      "ministral-3:14b",
+      "mistral-large-3:675b",
+      "qwen3-vl:235b",
+      "qwen3-vl:235b-instruct",
+      "qwen3.5:397b",
+    ];
+    for (const id of visionModels) {
+      expect(byId[id].input).toEqual(["text", "image"]);
+    }
+    // Spot-check that text-only models stay text-only (gemma4 was the
+    // specific counter-example the user flagged during review)
+    expect(byId["rnj-1:8b"].input).toEqual(["text"]);
+    expect(byId["qwen3-coder:480b"].input).toEqual(["text"]);
+    expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
+
+    // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
+    const reasoningModels = [
+      "deepseek-v3.1:671b",
+      "deepseek-v3.2",
+      "gemini-3-flash-preview",
+      "gemma4:31b",
+      "glm-4.6",
+      "glm-4.7",
+      "glm-5",
+      "glm-5.1",
+      "gpt-oss:20b",
+      "gpt-oss:120b",
+      "kimi-k2-thinking",
+      "kimi-k2.5",
+      "minimax-m2",
+      "minimax-m2.5",
+      "minimax-m2.7",
+      "nemotron-3-nano:30b",
+      "nemotron-3-super",
+      "qwen3-next:80b",
+      "qwen3-vl:235b",
+      "qwen3-vl:235b-instruct",
+      "qwen3.5:397b",
+    ];
+    for (const id of reasoningModels) {
+      expect(byId[id].reasoning).toBe(true);
+    }
+    // Non-reasoning — qwen3-coder-next explicitly "Non-thinking mode only",
+    // ministral-3 / mistral-large-3 / devstral-* and rnj-1 not tagged,
+    // minimax-m2.1 absent from Ollama's thinking tag list.
+    const nonReasoningModels = [
+      "devstral-2:123b",
+      "devstral-small-2:24b",
+      "minimax-m2.1",
+      "ministral-3:3b",
+      "ministral-3:8b",
+      "ministral-3:14b",
+      "mistral-large-3:675b",
+      "qwen3-coder-next",
+      "qwen3-coder:480b",
+      "rnj-1:8b",
+    ];
+    for (const id of nonReasoningModels) {
+      expect(byId[id].reasoning).toBe(false);
+    }
+
+    // Ollama Cloud uses subscription pricing, not per-token billing (see
+    // ollama.com/pricing). Setting cost to zero is the honest value — a
+    // fabricated per-token rate would make the Usage dashboard lie about
+    // spend for users on the Free / Pro / Max plans.
+    for (const model of models) {
+      expect(model.cost).toEqual({ input: 0, output: 0, cacheRead: 0, cacheWrite: 0 });
+    }
+  });
+
   it("opts every Ollama Cloud model into streaming usage reporting", async () => {
     // Ollama Cloud's /v1/chat/completions only emits a final `usage` chunk
     // when the request carries `stream_options: { include_usage: true }`.

--- a/packages/web/src/lib/model-vision.ts
+++ b/packages/web/src/lib/model-vision.ts
@@ -1,26 +1,24 @@
 import type { ProviderName } from "@/lib/providers";
+import { VISION_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
 
 // Providers where all current chat models support vision
 export const VISION_CAPABLE_PROVIDERS: ProviderName[] = ["anthropic", "openai", "google"];
 
-// Known vision-capable Ollama model prefixes (local and cloud)
-const VISION_OLLAMA_MODELS = [
-  // Local models
+// Vision-capable LOCAL Ollama model prefixes. Kept as a prefix match because
+// local users pull arbitrary tags (e.g. `llava:7b`, `llava:13b-q4_0`) and the
+// prefix is the stable identifier. Cloud models go through
+// VISION_OLLAMA_CLOUD_MODEL_IDS (exact-ID match against the curated list).
+const VISION_OLLAMA_LOCAL_PREFIXES = [
   "llava",
   "llama3.2-vision",
   "bakllava",
   "qwen2-vl",
   "qwen2.5-vl",
+  "qwen3-vl",
   "moondream",
   "minicpm-v",
-  // Cloud models (verified via ollama.com/search?c=vision&c=cloud)
-  "gemini-3-flash-preview",
   "gemma3",
-  "kimi-k2.5",
-  "ministral-3",
-  "mistral-large-3",
-  "qwen3-vl",
-  "qwen3.5",
+  "gemma4",
 ];
 
 // Dynamic vision capability cache — populated by provider-models.ts when fetching local Ollama models.
@@ -45,11 +43,16 @@ export function isModelVisionCapable(modelId: string): boolean {
       return ollamaLocalVisionCache.has(modelName);
     }
     // Fallback to hardcoded prefix list
-    return VISION_OLLAMA_MODELS.some((prefix) => modelName.startsWith(prefix));
+    return VISION_OLLAMA_LOCAL_PREFIXES.some((prefix) => modelName.startsWith(prefix));
   }
 
   if (provider === "ollama-cloud") {
-    return VISION_OLLAMA_MODELS.some((prefix) => modelName.startsWith(prefix));
+    // Exact match against the curated cloud allowlist — see
+    // ollama-cloud-models.ts. We don't prefix-match here because cloud IDs
+    // carry parameter tags (e.g. `qwen3.5:397b`) and the wrong prefix match
+    // would mislabel `qwen3-coder-next` as vision-capable just because
+    // `qwen3.5` is.
+    return VISION_OLLAMA_CLOUD_MODEL_IDS.has(modelName);
   }
 
   return false;

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -1,19 +1,27 @@
 /**
  * The canonical list of tool-capable Ollama Cloud models Pinchy surfaces.
  *
- * Source of truth: each model's "tools" capability tag on its
- * ollama.com/library/<name> page. The aggregate page search?c=tools&c=cloud
- * is incomplete — it omits gpt-oss, qwen3-vl, mistral-large-3, and others —
- * so do NOT treat the search URL as the source of truth.
+ * Source of truth: each model's capability tags on its
+ * ollama.com/library/<name> page. The aggregate pages
+ * search?c=tools&c=cloud, search?c=vision&c=cloud, and search?c=thinking&c=cloud
+ * are useful starting points but are incomplete — they omit several
+ * genuinely tool/vision/thinking-capable cloud models that individual
+ * library pages confirm — so always cross-check against the library page
+ * before trusting the search listing.
  *
  * Context windows follow Ollama's "NK" = N * 1024 convention (verified by
  * cross-checking known models like "160K" → 163840). Pinchy writes these
  * hints into the OpenClaw config so context pruning can kick in before
  * requests bump into the real provider limit.
  *
+ * Cost is always zero: Ollama Cloud uses subscription pricing (Free / Pro /
+ * Max plans — see ollama.com/pricing), not per-token billing. A fabricated
+ * per-token rate would make Pinchy's Usage & Costs dashboard lie about
+ * spend, so we leave cost at zero and let the UI show tokens only.
+ *
  * When Ollama adds, removes, or resizes a model, update this file — the
- * ALLOWED_CLOUD_MODELS filter, the fallback list for the model picker, and
- * the OpenClaw config are all derived from it.
+ * ALLOWED_CLOUD_MODELS filter, the fallback list for the model picker, the
+ * vision check, and the OpenClaw config are all derived from it.
  */
 
 export interface OllamaCloudModel {
@@ -24,43 +32,124 @@ export interface OllamaCloudModel {
   /** Pinchy's max output tokens hint. Ollama doesn't publish this, so we use
    * the output-heavy value for Gemini Flash and a conservative 8192 elsewhere. */
   maxTokens: number;
+  /** True when the library page carries the "thinking" capability tag. */
+  reasoning: boolean;
+  /** True when the library page lists "Image" in the input types (vision). */
+  vision: boolean;
 }
 
+const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
+
 export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: readonly OllamaCloudModel[] = [
-  { id: "deepseek-v3.1:671b", contextWindow: 163840, maxTokens: 8192 },
-  { id: "deepseek-v3.2", contextWindow: 163840, maxTokens: 8192 },
-  { id: "devstral-2:123b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "devstral-small-2:24b", contextWindow: 393216, maxTokens: 8192 },
-  { id: "gemini-3-flash-preview", contextWindow: 1048576, maxTokens: 65536 },
-  { id: "gemma4:31b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "glm-4.6", contextWindow: 202752, maxTokens: 8192 },
-  { id: "glm-4.7", contextWindow: 202752, maxTokens: 8192 },
-  { id: "glm-5", contextWindow: 202752, maxTokens: 8192 },
-  { id: "glm-5.1", contextWindow: 202752, maxTokens: 8192 },
-  { id: "gpt-oss:20b", contextWindow: 131072, maxTokens: 8192 },
-  { id: "gpt-oss:120b", contextWindow: 131072, maxTokens: 8192 },
-  { id: "kimi-k2-thinking", contextWindow: 262144, maxTokens: 8192 },
-  { id: "kimi-k2.5", contextWindow: 262144, maxTokens: 8192 },
-  { id: "minimax-m2", contextWindow: 204800, maxTokens: 8192 },
-  { id: "minimax-m2.1", contextWindow: 204800, maxTokens: 8192 },
-  { id: "minimax-m2.5", contextWindow: 202752, maxTokens: 8192 },
-  { id: "minimax-m2.7", contextWindow: 204800, maxTokens: 8192 },
-  { id: "ministral-3:3b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "ministral-3:8b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "ministral-3:14b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "mistral-large-3:675b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "nemotron-3-nano:30b", contextWindow: 1048576, maxTokens: 8192 },
-  { id: "nemotron-3-super", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3-coder-next", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3-coder:480b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3-next:80b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3-vl:235b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3-vl:235b-instruct", contextWindow: 262144, maxTokens: 8192 },
-  { id: "qwen3.5:397b", contextWindow: 262144, maxTokens: 8192 },
-  { id: "rnj-1:8b", contextWindow: 32768, maxTokens: 8192 },
+  {
+    id: "deepseek-v3.1:671b",
+    contextWindow: 163840,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  { id: "deepseek-v3.2", contextWindow: 163840, maxTokens: 8192, reasoning: true, vision: false },
+  {
+    id: "devstral-2:123b",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: false,
+  },
+  {
+    id: "devstral-small-2:24b",
+    contextWindow: 393216,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: true,
+  },
+  {
+    id: "gemini-3-flash-preview",
+    contextWindow: 1048576,
+    maxTokens: 65536,
+    reasoning: true,
+    vision: true,
+  },
+  { id: "gemma4:31b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
+  { id: "glm-4.6", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "glm-4.7", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "glm-5", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "glm-5.1", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "gpt-oss:20b", contextWindow: 131072, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "gpt-oss:120b", contextWindow: 131072, maxTokens: 8192, reasoning: true, vision: false },
+  {
+    id: "kimi-k2-thinking",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  { id: "kimi-k2.5", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
+  { id: "minimax-m2", contextWindow: 204800, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "minimax-m2.1", contextWindow: 204800, maxTokens: 8192, reasoning: false, vision: false },
+  { id: "minimax-m2.5", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "minimax-m2.7", contextWindow: 204800, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "ministral-3:3b", contextWindow: 262144, maxTokens: 8192, reasoning: false, vision: true },
+  { id: "ministral-3:8b", contextWindow: 262144, maxTokens: 8192, reasoning: false, vision: true },
+  { id: "ministral-3:14b", contextWindow: 262144, maxTokens: 8192, reasoning: false, vision: true },
+  {
+    id: "mistral-large-3:675b",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: true,
+  },
+  {
+    id: "nemotron-3-nano:30b",
+    contextWindow: 1048576,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
+    id: "nemotron-3-super",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
+    id: "qwen3-coder-next",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: false,
+  },
+  {
+    id: "qwen3-coder:480b",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: false,
+  },
+  { id: "qwen3-next:80b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: false },
+  { id: "qwen3-vl:235b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
+  {
+    id: "qwen3-vl:235b-instruct",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: true,
+  },
+  { id: "qwen3.5:397b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
+  { id: "rnj-1:8b", contextWindow: 32768, maxTokens: 8192, reasoning: false, vision: false },
 ];
 
 /** Just the IDs — used by the `/v1/models` transform and fallback list. */
 export const TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map(
   (m) => m.id
 );
+
+/** Subset of IDs that accept image input. Used by the vision-capability check. */
+export const VISION_OLLAMA_CLOUD_MODEL_IDS = new Set(
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.filter((m) => m.vision).map((m) => m.id)
+);
+
+/** Zero-cost config written to the OpenClaw models list — Ollama Cloud is
+ * subscription-billed, not per-token, so per-token pricing would be misleading. */
+export const OLLAMA_CLOUD_COST = ZERO_COST;

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -13,7 +13,7 @@ import {
 import { getSetting } from "@/lib/settings";
 import { decrypt } from "@/lib/encryption";
 import { computeDeniedGroups } from "@/lib/tool-registry";
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
 import { getOpenClawWorkspacePath } from "@/lib/workspace";
 import { migrateExistingSmithers } from "@/lib/migrate-onboarding";
 
@@ -395,7 +395,7 @@ export async function regenerateOpenClawConfig() {
       apiKey: ollamaCloudKey,
       api: "openai-completions",
       // Derived from TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — see that file for
-      // the source of each context window (ollama.com/library/<name>).
+      // the source of each capability (ollama.com/library/<name>).
       //
       // `compat.supportsUsageInStreaming: true` is REQUIRED for usage
       // tracking. OpenClaw's default compat detection treats any configured
@@ -404,11 +404,19 @@ export async function regenerateOpenClawConfig() {
       // only emits the final usage chunk when that flag is present — without
       // this opt-in, every session has zero tracked tokens and Usage & Costs
       // stays empty. Verified live against https://ollama.com/v1/chat/completions.
+      //
+      // `reasoning`, `input`, and `cost` are required fields of OpenClaw's
+      // ModelDefinitionConfig. Cost is zero because Ollama Cloud bills by
+      // subscription plan, not per token — a fabricated rate would mislead
+      // users reading the Usage dashboard.
       models: TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => ({
         id: m.id,
         name: m.id,
         contextWindow: m.contextWindow,
         maxTokens: m.maxTokens,
+        reasoning: m.reasoning,
+        input: m.vision ? ["text", "image"] : ["text"],
+        cost: { ...OLLAMA_CLOUD_COST },
         compat: { supportsUsageInStreaming: true },
       })),
     };


### PR DESCRIPTION
## Summary

Review finding during v0.4.0 testing: `gemma4` showed up as text-only in the agent UI even though [ollama.com/library/gemma4](https://ollama.com/library/gemma4) lists "Text, Image" as input types. A broader audit of OpenClaw's `ModelDefinitionConfig` revealed three **required** per-model fields Pinchy never set:

- **`reasoning: boolean`** — thinking-capable models couldn't advertise it to the runtime
- **`input: Array<"text" | "image">`** — the real vision gate. Without it, multimodal models (`gemma4`, `devstral-small-2`, every `ministral-3` / `mistral-large-3` / `qwen3-vl` / `qwen3.5` variant) were effectively text-only in Pinchy
- **`cost: { input, output, cacheRead, cacheWrite }`** — required by the schema. Left at zero because Ollama Cloud bills by subscription plan (Free / Pro / Max, see [ollama.com/pricing](https://ollama.com/pricing)), not per token. A fabricated per-token rate would make the Usage dashboard lie about spend

## Research

Every flag was verified against `ollama.com/library/<name>` rather than the aggregate `search?c=…&c=cloud` pages, which under-report both vision and thinking tags in the cloud filter (e.g. `gpt-oss`, `qwen3-coder:480b`, and `qwen3-vl` only appear on their individual library pages).

Capability matrix is embedded in `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS` so the three consumer sites (`provider-models.ts` filter, `openclaw-config.ts` model list, `model-vision.ts` vision check) stay in sync by construction.

## Refactor

`model-vision.ts` now derives the cloud vision set from `VISION_OLLAMA_CLOUD_MODEL_IDS` (exact match against the tool-capable allowlist) instead of prefix-matching a hand-maintained list. Prefix matching was wrong on principle too — `"qwen3.5"` would have matched `"qwen3.5-coder-next"` if such a model appeared. Local Ollama still uses the prefix list because local users pull arbitrary tags the cloud allowlist doesn't enumerate.

## Test plan
- [x] Guard test in `openclaw-config.test.ts` asserts `reasoning`, `input`, and `cost` on every written entry — red-first, then green
- [x] `model-vision.test.ts` explicitly covers the regression: `gemma4:31b` and `devstral-small-2:24b` are vision-capable; `gemma3:27b` is **not** (gemma3 is vision-capable locally but isn't in Pinchy's tool-capable cloud allowlist, so it shouldn't pretend to be)
- [x] Full suite green (2687 tests)
- [x] Live: generated `openclaw.json` contains the full capability set per model, verified via `docker compose exec pinchy cat /openclaw-config/openclaw.json`