### PR TITLE
fix: bake pinchy-docs into openclaw image (v0.4.0 deploy bug)

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -6,5 +6,9 @@ node_modules
 .env
 .env.*
 docs
+# …but ship the user-facing Markdown docs so Smithers' docs_list /
+# docs_read tools (pinchy-docs plugin in the openclaw image) can read
+# them without a repo-relative bind-mount.
+!docs/src/content/docs
 *.md
 !README.md

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,22 @@ jobs:
           docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .
           docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
 
+      - name: Verify end-user install assets are self-contained in the image
+        run: |
+          # End-users deploy by curl-ing docker-compose.yml into /opt/pinchy/
+          # — no git clone, no source tree. Any relative bind-mount to repo
+          # paths silently resolves to an empty directory in that scenario,
+          # and Pinchy boots with (e.g.) an empty /pinchy-docs that Smithers
+          # can't read from. This check runs the image in isolation,
+          # bypassing compose and its bind-mounts, to prove the image ships
+          # everything it needs at runtime.
+          DOC_COUNT=$(docker run --rm --entrypoint sh ghcr.io/heypinchy/pinchy-openclaw:latest -c 'find /pinchy-docs -name "*.mdx" 2>/dev/null | wc -l')
+          echo "Docs baked into openclaw image: $DOC_COUNT .mdx files"
+          if [ "$DOC_COUNT" -lt 10 ]; then
+            echo "::error::/pinchy-docs is missing or empty in the openclaw image ($DOC_COUNT .mdx files found). The docker-compose.yml must not rely on relative bind-mounts to source paths — they break in clean end-user installs."
+            exit 1
+          fi
+
       - name: Start production stack
         run: docker compose up -d
         env:

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -23,6 +23,13 @@ COPY config/ensure-gateway-token.js /ensure-gateway-token.js
 COPY config/start-openclaw.sh /start-openclaw.sh
 RUN chmod +x /start-openclaw.sh
 
+# Bake Pinchy's user-facing docs into the image so Smithers' docs_list /
+# docs_read tools (pinchy-docs plugin) work in every deploy. Previously
+# this path came from a relative bind-mount in docker-compose.yml, which
+# only exists when the full repo is checked out next to compose.yml —
+# broken for every clean end-user install (cloud-init, curl-and-go).
+COPY docs/src/content/docs /pinchy-docs
+
 EXPOSE 18789
 
 CMD ["/start-openclaw.sh"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -31,7 +31,6 @@ services:
       - openclaw-extensions:/root/.openclaw/extensions
       - pinchy-data:/data
       - pinchy-pdf-cache:/var/cache/pinchy-files
-      - ./docs/src/content/docs:/pinchy-docs:ro
     restart: unless-stopped
 
   db:


### PR DESCRIPTION
## Summary

Reported in #144 by @fbglv: on Podman Compose, the v0.4.0 release starts only the `db` container. Investigation showed this isn't a Podman quirk — it's a real compose-file bug that affects **every clean end-user deploy**, Docker included, just in a different (silent) way.

The `openclaw` service in `docker-compose.yml` bind-mounts a repo-relative path:

```yaml
- ./docs/src/content/docs:/pinchy-docs:ro
```

End-users `curl` `docker-compose.yml` into `/opt/pinchy/` via cloud-init — no repo checkout, so the path doesn't exist:

- **Docker Compose**: silently creates an empty directory and keeps going → Pinchy appears healthy but Smithers' `docs_list` / `docs_read` tools (pinchy-docs plugin) return nothing
- **Podman Compose**: refuses the mount → `pinchy` and `openclaw` services don't start (the report's symptom)

The production demo at `91.98.202.16` appeared to work only because the initial setup happened to create a full repo clone at `/opt/pinchy/`, not the standard `curl` install.

## Fix

- **`Dockerfile.openclaw`** — `COPY docs/src/content/docs /pinchy-docs` so the runtime asset ships with the image
- **`docker-compose.yml`** — drop the relative bind-mount (image supplies the content now)
- **`.dockerignore`** — add a `!docs/src/content/docs` exception to re-include the subtree while keeping `docs/node_modules`, `docs/dist` out

## How CI will catch this in the future

The `Docker smoke test` job previously ran against a full checkout, so the bind-mount resolved happily and the empty-dir failure mode was invisible. New step runs the openclaw image **directly via `docker run`**, bypassing compose and its bind-mounts — exactly the code path an end-user deploy takes. TDD-verified: the test was red on commit 21aa0bf4 (before the Dockerfile fix) and green after.

## Release

Should ship as **v0.4.1** since every v0.4.0 deploy outside the demo has a broken pinchy-docs plugin — Smithers can't answer any platform question until the image is re-pulled.

## Test plan
- [x] New CI step asserts `/pinchy-docs` in the openclaw image contains ≥10 `.mdx` files (red-first, then green)
- [x] Full CI green on this PR
- [ ] After merge + v0.4.1 tag: re-deploy the demo instance with a fresh compose, confirm pinchy-docs works (and no bind-mount errors on Podman)