### PR TITLE
fix: bump openclaw-node to 0.4.0 for per-device-token lifecycle

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,15 +256,29 @@ jobs:
           fi
           echo "Clean startup verified (restarts=$RESTART_COUNT, connection_errors=$ERROR_COUNT)"
 
-      # Regression guard for the openclaw-node deviceToken bug: this is exactly
-      # the scenario that broke the v0.4.1 demo — Pinchy had been running fine,
-      # an upgrade recreated both containers, and Pinchy could no longer
-      # authenticate to OpenClaw because it was still sending the gateway
-      # bootstrap token instead of the per-device token issued at pairing.
-      # The named volumes persist across down/up, so paired.json survives while
-      # both containers get fresh processes — same state as a real upgrade.
-      - name: Simulate container recreate (regression guard)
+      # Regression guard for the openclaw-node deviceToken bug that broke the
+      # v0.4.1 demo. Pinchy had been running fine; an upgrade recreated both
+      # containers, gateway.auth.token got regenerated (race between Pinchy's
+      # regenerateOpenClawConfig and OpenClaw's ensure-gateway-token), and
+      # Pinchy could no longer authenticate because the old openclaw-node
+      # kept sending the bootstrap token instead of the per-device token
+      # issued at pairing. We force that rotation deterministically here by
+      # stripping gateway.auth.token from the persisted openclaw.json before
+      # the restart — OpenClaw will mint a fresh token on the way back up.
+      # Volumes are preserved, so paired.json (with the per-device token)
+      # survives — exactly the scenario that broke on demo.
+      - name: Force gateway.auth.token rotation + container recreate (regression guard)
         run: |
+          echo "=== Stripping gateway.auth.token to force rotation on next start ==="
+          docker compose exec -T openclaw node -e '
+            const fs = require("fs");
+            const p = "/root/.openclaw/openclaw.json";
+            const c = JSON.parse(fs.readFileSync(p, "utf8"));
+            const before = c.gateway?.auth?.token?.slice(0,12) ?? "<none>";
+            if (c.gateway?.auth) delete c.gateway.auth.token;
+            fs.writeFileSync(p, JSON.stringify(c, null, 2));
+            console.log("stripped auth.token; was:", before);
+          '
           echo "=== Stopping stack (volumes preserved) ==="
           docker compose down
           echo "=== Starting stack again ==="

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -256,6 +256,66 @@ jobs:
           fi
           echo "Clean startup verified (restarts=$RESTART_COUNT, connection_errors=$ERROR_COUNT)"
 
+      # Regression guard for the openclaw-node deviceToken bug: this is exactly
+      # the scenario that broke the v0.4.1 demo — Pinchy had been running fine,
+      # an upgrade recreated both containers, and Pinchy could no longer
+      # authenticate to OpenClaw because it was still sending the gateway
+      # bootstrap token instead of the per-device token issued at pairing.
+      # The named volumes persist across down/up, so paired.json survives while
+      # both containers get fresh processes — same state as a real upgrade.
+      - name: Simulate container recreate (regression guard)
+        run: |
+          echo "=== Stopping stack (volumes preserved) ==="
+          docker compose down
+          echo "=== Starting stack again ==="
+          docker compose up -d
+        env:
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Wait for health after recreate
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:7777/api/health; then
+              echo "Stack healthy after recreate"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "::error::Health check failed after container recreate"
+          docker compose ps
+          docker compose logs
+          exit 1
+
+      - name: Verify Pinchy reconnects to OpenClaw after recreate
+        run: |
+          # Watch the fresh logs (since this container start) for a successful
+          # connect. Any token_mismatch / token_missing means auth is broken.
+          for i in $(seq 1 60); do
+            RECENT=$(docker compose logs pinchy --since 120s 2>&1)
+            if echo "$RECENT" | grep -q "Connected to OpenClaw Gateway"; then
+              echo "Pinchy reconnected to OpenClaw (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::Pinchy did not reconnect to OpenClaw within 120s after recreate"
+              echo "--- pinchy logs ---"
+              docker compose logs pinchy | tail -40
+              echo "--- openclaw logs ---"
+              docker compose logs openclaw | tail -40
+              exit 1
+            fi
+            sleep 2
+          done
+          # OpenClaw side must show no auth failures in this window.
+          OC_RECENT=$(docker compose logs openclaw --since 120s 2>&1)
+          if echo "$OC_RECENT" | grep -qE "reason=(token_mismatch|token_missing)"; then
+            echo "::error::OpenClaw rejected Pinchy's auth after recreate"
+            echo "$OC_RECENT" | grep -E "reason=" | tail -5
+            exit 1
+          fi
+          echo "Auth clean on reconnect — no token_mismatch / token_missing"
+
       - name: Tear down production
         if: always()
         run: docker compose down -v

--- a/docs/public/llms-full.txt
+++ b/docs/public/llms-full.txt
@@ -14,7 +14,7 @@ We believe AI agents should run on **your** servers, with **your** data, under *
 
 ## Current Status
 
-Pinchy is in early development. The core is working — setup, authentication, provider configuration, agent chat via OpenClaw, and cryptographic audit trail. We're building the remaining enterprise features (RBAC, plugins) next.
+Pinchy is in early development. The core is working — setup, authentication, provider configuration, agent chat via OpenClaw, and cryptographic audit trail. We're building the remaining enterprise features (granular RBAC with custom roles and per-resource permissions, plugin marketplace) next.
 
 ---
 

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,7 +28,7 @@ We believe AI agents should run on **your** servers, with **your** data, under *
 
 ## Current Status
 
-Pinchy is in early development. The core is working — setup, authentication, provider configuration, agent chat via OpenClaw, agent permissions, knowledge base agents, user management, per-user/org context, Smithers onboarding interview, and cryptographic audit trail. We're building the remaining enterprise features (RBAC, plugin marketplace) next.
+Pinchy is in early development. The core is working — setup, authentication, provider configuration, agent chat via OpenClaw, agent permissions, knowledge base agents, user management, per-user/org context, Smithers onboarding interview, and cryptographic audit trail. We're building the remaining enterprise features (granular RBAC with custom roles and per-resource permissions, plugin marketplace) next.
 
 <CardGrid>
   <Card title="Quick Start" icon="rocket">

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -71,7 +71,7 @@ ENCRYPTION_KEY=
 # HMAC secret for audit trail signing (auto-generated if omitted)
 AUDIT_HMAC_SECRET=
 
-# Enterprise license key (optional — enables Groups, RBAC, agent access control)
+# Enterprise license key (optional — enables Groups, agent access control, basic RBAC)
 PINCHY_ENTERPRISE_KEY=
 ```
 
@@ -83,7 +83,7 @@ PINCHY_ENTERPRISE_KEY=
 
 **`AUDIT_HMAC_SECRET`** — Used to sign audit trail entries with HMAC-SHA256. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. Set explicitly if you need consistent signatures across deployments.
 
-**`PINCHY_ENTERPRISE_KEY`** — License key for enterprise features (Groups, RBAC, agent access control). Optional — can also be entered via **Settings → License** in the UI. See [Enterprise Setup](/guides/enterprise-setup/) for details.
+**`PINCHY_ENTERPRISE_KEY`** — License key for enterprise features (Groups, agent access control, basic RBAC — granular RBAC with custom roles is planned). Optional — can also be entered via **Settings → License** in the UI. See [Enterprise Setup](/guides/enterprise-setup/) for details.
 
 ### Data persistence
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -39,7 +39,7 @@
     "next": "16.2.3",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
-    "openclaw-node": "0.3.1",
+    "openclaw-node": "0.4.0",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",
     "qrcode.react": "^4.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -82,8 +82,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       openclaw-node:
-        specifier: 0.3.1
-        version: 0.3.1
+        specifier: 0.4.0
+        version: 0.4.0
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -4075,8 +4075,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openclaw-node@0.3.1:
-    resolution: {integrity: sha512-7Xk4WphXjNVQXzBXXjmGofDY8IGUctTzalNgPHg+tRGOuyOBRFSSs55j+Bn2/NJPax2W/Se63vKrGdIhCZHlNw==}
+  openclaw-node@0.4.0:
+    resolution: {integrity: sha512-Yd0OMGoYPFaHp/SP4AvNw7el4EGNrb77wuz2eKjA9kYn8MsRGW4muj9yUJix4ufHsYmsXo5GwAndJrdmI0fA1w==}
     engines: {node: '>=20.0.0'}
 
   optionator@0.9.4:
@@ -8870,7 +8870,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openclaw-node@0.3.1:
+  openclaw-node@0.4.0:
     optionalDependencies:
       ws: 8.20.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

Fixes the demo breakage surfaced during v0.4.1 upgrade: Pinchy ↔ OpenClaw auth loop (`reason=token_mismatch`) after a container recreate. Root cause was in `openclaw-node` (now fixed in 0.4.0 — see heypinchy/openclaw-node#14). This PR:

1. Adds a CI regression guard in the `docker-smoke` job that runs `docker compose down && up -d` with volumes persisted, then asserts Pinchy reconnects to OpenClaw without auth failure — catches the exact bug that slipped through v0.4.1.
2. Bumps `openclaw-node` dependency to 0.4.0 so the client honors the per-device-token lifecycle.

## TDD proof

- Commit 1 (this one): adds the CI step only — without the dep bump, CI must go RED on the new step (proving the guard actually fires).
- Commit 2: bumps openclaw-node → CI GREEN.

## Migration

No user-side migration needed. Already-paired devices persist a `deviceToken` on their next successful connect, fully transparent.

## Test plan

- [ ] Commit 1 fails `docker-smoke → Verify Pinchy reconnects to OpenClaw after recreate`
- [ ] Commit 2 passes all jobs