### PR TITLE
ci: deploy docs from release workflow via workflow_call

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,13 @@
 name: Deploy Docs
 
 on:
-  # Fires automatically whenever the Release workflow publishes a new
-  # GitHub Release (softprops/action-gh-release in release.yml). Docs
-  # are kept in lockstep with releases, not main — edits to main between
-  # releases stay unpublished until the next tag. Manual runs stay
-  # available for one-off corrections (e.g. typo fix without a release).
-  release:
-    types: [published]
+  # Called from release.yml after a release is published, so docs stay in
+  # lockstep with releases. Edits to main between releases stay unpublished
+  # until the next tag. We can't use the `release: published` trigger here
+  # because releases created by GITHUB_TOKEN don't fire workflow events.
+  # Manual runs stay available for one-off corrections (e.g. typo fix
+  # without a release).
+  workflow_call:
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,8 @@ on:
 permissions:
   contents: write
   packages: write
+  pages: write
+  id-token: write
 
 jobs:
   docker:
@@ -86,3 +88,15 @@ jobs:
           files: |
             docs/public/installing.html
             /tmp/cloud-init.yml
+
+  docs:
+    name: Deploy Docs
+    needs: release
+    # Releases created by GITHUB_TOKEN don't fire `release: published`
+    # events, so we call the docs workflow directly from here instead
+    # of relying on a trigger in docs.yml.
+    uses: ./.github/workflows/docs.yml
+    permissions:
+      contents: read
+      pages: write
+      id-token: write


### PR DESCRIPTION
## Summary

- v0.4.1 shipped but docs.heypinchy.com stayed on v0.4.0 because the `release: published` trigger in `docs.yml` never fired. That's a known GitHub limitation: releases created by `GITHUB_TOKEN` (via `softprops/action-gh-release`) do not trigger downstream workflow events, to prevent recursive CI loops.
- Convert `docs.yml` into a reusable workflow (`workflow_call`) and invoke it from `release.yml` right after the `release` job.
- No PAT required, docs deploy is visible in the same pipeline run, and `workflow_dispatch` stays available for one-off typo fixes between releases.

## Test plan

- [ ] Merge this PR
- [ ] Tag v0.4.2 and confirm the Release workflow runs `docker → release → docs` end to end
- [ ] Verify docs.heypinchy.com updates automatically without a manual `workflow_dispatch`