### PR TITLE
fix(deployment): secure-by-default port binding and secrets generation

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -471,6 +471,20 @@ jobs:
             exit 1
           fi
 
+      - name: Assert pinchy binds to 127.0.0.1 by default (not 0.0.0.0)
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          # Docker bypasses UFW — only 127.0.0.1 binding prevents external access.
+          # This assertion catches any regression that re-exposes port 7777 globally.
+          BINDING=$(docker inspect \
+            --format '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{.HostIp}}{{end}}{{end}}' \
+            "$(docker compose ps -q pinchy)")
+          echo "Pinchy port binding host IP: $BINDING"
+          if [ "$BINDING" != "127.0.0.1" ]; then
+            echo "::error::Pinchy must bind to 127.0.0.1 by default (got '$BINDING'). Docker bypasses UFW, so 0.0.0.0 exposes the port to the internet regardless of firewall rules."
+            exit 1
+          fi
+
       - name: Assert pinchy-docs is populated in openclaw container
         working-directory: ${{ steps.install-dir.outputs.path }}
         run: |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -2,7 +2,7 @@ services:
   pinchy:
     image: ghcr.io/heypinchy/pinchy:latest
     ports:
-      - "${PINCHY_PORT:-7777}:7777"
+      - "${PINCHY_PORT:-127.0.0.1:7777}:7777"
     environment:
       - DATABASE_URL=postgresql://pinchy:${DB_PASSWORD:-pinchy_dev}@db:5432/pinchy
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-}

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -152,7 +152,7 @@ Hetzner Cloud is an excellent choice for running Pinchy. Their servers run in EU
 
 ## Production setup
 
-The steps above get Pinchy running over plain HTTP. Before using it with real data, add HTTPS and pin your secrets.
+The steps above get Pinchy running over plain HTTP on port 80. Before using it with real data, add HTTPS and lock your domain.
 
 All commands below run **on your server**. You have two options to connect:
 
@@ -208,6 +208,31 @@ While connected, every command you type runs on your server. Type `exit` to disc
 
 ### Set up HTTPS with Caddy
 
+First, switch Pinchy from port 80 to a localhost-only binding so that Caddy can take over port 80 and 443:
+
+```bash
+nano /opt/pinchy/.env
+```
+
+Change the `PINCHY_PORT` line to:
+
+```bash
+PINCHY_PORT=127.0.0.1:7777
+```
+
+Restart Pinchy to apply:
+
+```bash
+cd /opt/pinchy && docker compose up -d
+```
+
+<Aside type="caution">
+  Docker manages its own iptables rules and can bypass host firewall tools like
+  UFW. The `127.0.0.1:` prefix ensures port 7777 is only reachable from
+  localhost — without it, the port is exposed to the internet regardless of
+  firewall settings.
+</Aside>
+
 Install Caddy, which handles SSL certificates automatically:
 
 ```bash
@@ -236,43 +261,16 @@ systemctl restart caddy
 
 After a few seconds, visit `https://pinchy.example.com` — Caddy automatically provisions a Let's Encrypt certificate.
 
-### Remove the port 80 redirect
+### Lock your domain
 
-The setup script added an iptables rule that redirected port 80 → 7777 for the initial HTTP access. Now that Caddy handles both port 80 and 443, remove it:
+Once HTTPS is working, open **Settings → Security** in the Pinchy web UI and enter your domain (e.g. `pinchy.example.com`).
 
-```bash
-iptables -t nat -D PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 7777
-iptables -t nat -D OUTPUT -p tcp -o lo --dport 80 -j REDIRECT --to-ports 7777
-netfilter-persistent save
-```
+After saving, Pinchy will reject requests from any other origin with a 403 error — including access via the raw server IP address.
 
-### Pin secrets
-
-By default, Pinchy auto-generates secrets on first start and stores them in Docker volumes. Pin your own secrets so they survive volume recreation:
-
-```bash
-nano /opt/pinchy/.env
-```
-
-Add these lines (generate each value with `openssl rand -hex 32`, run it three times):
-
-```bash
-DB_PASSWORD=<output of openssl rand -hex 32>
-BETTER_AUTH_SECRET=<output of openssl rand -hex 32>
-ENCRYPTION_KEY=<output of openssl rand -hex 32>
-```
-
-Then restart Pinchy to apply:
-
-```bash
-cd /opt/pinchy
-docker compose up -d
-```
-
-<Aside type="caution">
-  Changing `DB_PASSWORD` after the database is already running requires also
-  updating the password inside PostgreSQL. For a fresh setup, do this before
-  completing the setup wizard.
+<Aside type="note">
+  Secrets (database password, session secret, encryption key) were automatically
+  generated and saved to `/opt/pinchy/.env` when your server was first created.
+  They are already pinned — no manual step needed.
 </Aside>
 
 ## Point your domain (optional but recommended)

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -204,6 +204,21 @@ Never commit `.env` files or secrets to version control. The `.gitignore` in the
 
 Pinchy's Docker Compose setup uses an internal network. PostgreSQL and OpenClaw are not exposed to the host network.
 
+### Localhost binding (default since v0.4.3)
+
+Pinchy's default port binding is `127.0.0.1:7777`, which means it only accepts connections from localhost. A reverse proxy (Caddy, nginx) running on the same host forwards traffic from ports 80/443 to Pinchy on 7777.
+
+:::caution
+Docker manages its own iptables rules and bypasses host firewall tools like UFW. A binding of `0.0.0.0:7777` (without the `127.0.0.1:` prefix) exposes the port to the internet regardless of UFW rules. Always use the localhost binding when a reverse proxy is in front of Pinchy.
+:::
+
+If you need to override the binding temporarily (e.g. for initial setup without a reverse proxy), set `PINCHY_PORT` in your `.env`:
+
+```bash
+# Expose on all interfaces — only for initial setup, remove before production
+PINCHY_PORT=0.0.0.0:7777
+```
+
 ### Verify network isolation
 
 ```bash
@@ -211,7 +226,7 @@ Pinchy's Docker Compose setup uses an internal network. PostgreSQL and OpenClaw 
 docker compose ps --format "table {{.Name}}\t{{.Ports}}"
 ```
 
-Only the `pinchy` service should show a published port (7777 by default). The `db` and `openclaw` services should show no published ports, or only `127.0.0.1:PORT` bindings.
+The `pinchy` service should show `127.0.0.1:7777->7777/tcp`. The `db` and `openclaw` services should show no published ports.
 
 ### Custom Docker network
 
@@ -240,9 +255,7 @@ services:
 
 The `internal: true` flag prevents containers on that network from reaching the internet. The `pinchy` service bridges both networks — it can reach the database and OpenClaw internally, while also serving HTTP traffic.
 
-:::note
-Binding to `127.0.0.1:7777` ensures the Pinchy Web service is only reachable from localhost. The reverse proxy running on the same host forwards traffic from port 443.
-:::
+See the [VPS Deployment guide](/guides/vps-deployment/#set-up-https-with-caddy) for the complete production setup walkthrough.
 
 ## AUDIT_HMAC_SECRET configuration
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -116,16 +116,37 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.4.1 to %%PINCHY_VERSION%%
-
-Standard upgrade — no breaking changes, no new required environment variables.
+## Upgrading from v0.4.2 to %%PINCHY_VERSION%%
 
 ```bash
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
 docker compose pull && docker compose up -d
 ```
 
-### What's fixed in %%PINCHY_VERSION%%
+### Port binding change — action required if you use direct port access
+
+The default port binding changed from `0.0.0.0:7777` to `127.0.0.1:7777`. After upgrading, Pinchy will only accept connections from localhost.
+
+**If you have a reverse proxy (Caddy, nginx):** No action needed — this is how it should be.
+
+**If you access Pinchy directly on port 7777** (no reverse proxy): Add this line to `/opt/pinchy/.env` to restore the previous behavior:
+
+```bash
+PINCHY_PORT=0.0.0.0:7777
+```
+
+We strongly recommend [setting up a reverse proxy](/guides/vps-deployment/#set-up-https-with-caddy) instead. Docker bypasses host firewall rules (UFW), so `0.0.0.0:7777` exposes the port to the internet regardless of your firewall configuration.
+
+## Upgrading from v0.4.1 to v0.4.2
+
+Standard upgrade — no breaking changes, no new required environment variables.
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.4.2/docker-compose.yml -o docker-compose.yml
+docker compose pull && docker compose up -d
+```
+
+### What's fixed in v0.4.2
 
 - **Pinchy reconnects cleanly after the OpenClaw container is recreated** — on upgrades that replaced the OpenClaw container, Pinchy would repeatedly log `token_mismatch` / `token_missing` and refuse to connect to the gateway. Root cause: once a device is paired, OpenClaw accepts only the per-device token it issued at pairing, not the gateway bootstrap token from `openclaw.json`. Pinchy's client library now persists that per-device token alongside the device identity and sends it on reconnect, and discards it automatically if OpenClaw ever rejects it so re-pairing just works. (`openclaw-node` bumped from 0.3.1 to 0.4.0.)
 

--- a/docs/src/content/docs/guides/vps-deployment.mdx
+++ b/docs/src/content/docs/guides/vps-deployment.mdx
@@ -60,11 +60,43 @@ You also need:
      together
    </details>
 
-2. **Download and start Pinchy**
+2. **Download the Docker Compose file**
 
    ```bash
    mkdir -p /opt/pinchy
    curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o /opt/pinchy/docker-compose.yml
+   ```
+
+3. **Pin your secrets before first start**
+
+   Pinchy uses three secrets: a database password, a session secret, and an encryption key for API keys at rest. By default these are auto-generated, but auto-generated secrets are tied to Docker volumes — if volumes are recreated the secrets change and encrypted data becomes unreadable. Pin them now, before the database is created, so they survive volume recreation.
+
+   ```bash
+   nano /opt/pinchy/.env
+   ```
+
+   Add these lines (run `openssl rand -hex 32` three times to generate each value):
+
+   ```bash
+   DB_PASSWORD=<output of openssl rand -hex 32>
+   BETTER_AUTH_SECRET=<output of openssl rand -hex 32>
+   ENCRYPTION_KEY=<output of openssl rand -hex 32>
+   ```
+
+   Save and lock down the file:
+
+   ```bash
+   chmod 600 /opt/pinchy/.env
+   ```
+
+   <Aside type="caution">
+     Set `DB_PASSWORD` before the database is created for the first time.
+     Changing it later requires updating the password inside PostgreSQL too.
+   </Aside>
+
+4. **Pull and start Pinchy**
+
+   ```bash
    cd /opt/pinchy
    docker compose pull
    docker compose up -d
@@ -73,13 +105,12 @@ You also need:
    Pulling the pre-built images takes about 30 seconds.
 
    <details>
-     <summary>What do these commands do?</summary>- `mkdir -p /opt/pinchy` —
-     creates the directory for Pinchy - `curl` — downloads the Docker Compose
-     file from GitHub - `docker compose pull` — downloads the pre-built Pinchy
-     images - `docker compose up -d` — starts all services in the background
+     <summary>What do these commands do?</summary>- `docker compose pull` —
+     downloads the pre-built Pinchy images - `docker compose up -d` — starts all
+     services in the background
    </details>
 
-3. **Verify all services are running**
+5. **Verify all services are running**
 
    ```bash
    docker compose ps
@@ -95,11 +126,22 @@ You also need:
 
    Look for: `Pinchy ready on http://localhost:7777`
 
-4. **Open the setup wizard**
+6. **Open the setup wizard**
 
-   Visit `http://<your-server-ip>:7777` in your browser. Replace `<your-server-ip>` with your server's actual IP address.
+   Pinchy binds to `127.0.0.1:7777` by default so it is only reachable from localhost. Open a temporary SSH tunnel from your local machine to reach it:
+
+   ```bash
+   ssh -L 7777:localhost:7777 root@<your-server-ip>
+   ```
+
+   Then visit `http://localhost:7777` in your browser while that SSH session is open.
 
    The setup wizard will guide you through creating your admin account and configuring your first LLM provider. You'll need your API key (from Anthropic, OpenAI, or Google) ready.
+
+   <Aside type="tip">
+     If you have a domain ready and want to skip straight to HTTPS, jump ahead
+     to **Production setup** — you can run the setup wizard over HTTPS instead.
+   </Aside>
 
 </Steps>
 
@@ -107,11 +149,36 @@ That's it — Pinchy is running! The rest of this guide covers production harden
 
 ## Production setup
 
-The steps above get Pinchy working, but for production use you should add HTTPS, a firewall, and pinned secrets.
+The steps above get Pinchy working, but for production use you should add HTTPS, a firewall, and a domain lock.
 
 ### Set up HTTPS with Caddy
 
-Never expose Pinchy directly on port 7777 in production. Use a reverse proxy that handles HTTPS for you. We recommend [Caddy](https://caddyserver.com/) because it automatically gets and renews SSL certificates — zero configuration.
+Use a reverse proxy that handles HTTPS for you. We recommend [Caddy](https://caddyserver.com/) because it automatically gets and renews SSL certificates — zero configuration.
+
+First, switch Pinchy to a localhost-only binding so that only Caddy can reach it. Open `/opt/pinchy/.env` and add (or update) the `PINCHY_PORT` line:
+
+```bash
+nano /opt/pinchy/.env
+```
+
+```bash
+PINCHY_PORT=127.0.0.1:7777
+```
+
+Then restart Pinchy to apply the change:
+
+```bash
+cd /opt/pinchy && docker compose up -d
+```
+
+<Aside type="caution">
+  Docker manages its own iptables rules and can bypass host firewall tools like
+  UFW. Without the `127.0.0.1:` prefix, port 7777 is reachable from the internet
+  regardless of firewall rules. Always use the localhost binding when a reverse
+  proxy is in front of Pinchy.
+</Aside>
+
+Install Caddy:
 
 ```bash
 apt-get install -y caddy
@@ -149,45 +216,17 @@ A reverse proxy sits between the internet and Pinchy. When someone visits your d
 3. Caddy forwards the request to **Pinchy** on port 7777 (internal only)
 4. Pinchy sends the response back through Caddy
 
-This way, Pinchy never needs to deal with SSL certificates, and port 7777 is never exposed to the internet.
+This way, Pinchy never needs to deal with SSL certificates directly.
 
 </details>
 
 See the [Hardening Guide](/guides/hardening/#reverse-proxy-with-tls) for nginx examples and advanced configuration.
 
-### Pin secrets
+### Lock your domain
 
-By default, Pinchy auto-generates secrets on first start and persists them in Docker volumes. For production, pin your own secrets so they don't depend on Docker volumes surviving. Add these lines to your `.env` file:
+Once HTTPS is working, lock Pinchy to your domain so it only responds to requests from your configured domain name. Open **Settings → Security** in the Pinchy web UI and enter your domain (e.g. `pinchy.example.com`).
 
-```bash
-nano /opt/pinchy/.env
-```
-
-```bash
-# Database password (default: pinchy_dev)
-DB_PASSWORD=<replace with output of the command below>
-
-# Session secret
-BETTER_AUTH_SECRET=<replace with output of the command below>
-
-# Encryption key for API keys at rest
-ENCRYPTION_KEY=<replace with output of the command below>
-```
-
-Generate each secret by running this command (run it three times, once for each secret):
-
-```bash
-openssl rand -hex 32
-```
-
-Copy each output and paste it as the value in your `.env` file. Then restart:
-
-```bash
-cd /opt/pinchy
-docker compose down && docker compose up -d
-```
-
-See [Installation — Environment variables](/installation/#environment-variables) for the full reference.
+After saving, Pinchy will reject requests from any other origin with a 403 error. This prevents someone from accessing your Pinchy instance by its raw IP address or via a different hostname.
 
 ### Configure a firewall
 

--- a/docs/src/snippets/cloud-init.yml
+++ b/docs/src/snippets/cloud-init.yml
@@ -19,9 +19,6 @@ runcmd:
   # Now install packages (loading page is already visible)
   - apt-get update -qq
   - apt-get install -y -qq docker.io docker-compose-v2 ufw
-  - echo iptables-persistent iptables-persistent/autosave_v4 boolean true | debconf-set-selections
-  - echo iptables-persistent iptables-persistent/autosave_v6 boolean true | debconf-set-selections
-  - apt-get install -y -qq iptables-persistent
 
   # Firewall
   - ufw allow OpenSSH
@@ -40,18 +37,22 @@ runcmd:
   - swapon /swapfile
   - echo '/swapfile none swap sw 0 0' >> /etc/fstab
 
-  # Download compose file and start Pinchy
+  # Generate pinned secrets before first start and bind Pinchy directly to port 80
   - mkdir -p /opt/pinchy
+  - echo "DB_PASSWORD=$(openssl rand -hex 32)" >> /opt/pinchy/.env
+  - echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)" >> /opt/pinchy/.env
+  - echo "ENCRYPTION_KEY=$(openssl rand -hex 32)" >> /opt/pinchy/.env
+  - echo "PINCHY_PORT=80:7777" >> /opt/pinchy/.env
+  - chmod 600 /opt/pinchy/.env
+
+  # Download compose file and pull images (loading page still visible during download)
   - curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o /opt/pinchy/docker-compose.yml
   - cd /opt/pinchy && docker compose pull
+
+  # Seamless switch — kill loading page, then start Pinchy on port 80 directly
+  - kill $(cat /tmp/loading-server.pid) 2>/dev/null || true
+  - rm -rf /opt/pinchy-loading /tmp/loading-server.pid
   - cd /opt/pinchy && docker compose up -d
 
   # Wait for Pinchy to be healthy
-  - for i in $(seq 1 90); do curl -sf http://localhost:7777/api/health > /dev/null 2>&1 && break; sleep 2; done
-
-  # Seamless switch — kill loading page, redirect port 80 to Pinchy
-  - kill $(cat /tmp/loading-server.pid) 2>/dev/null || true
-  - rm -rf /opt/pinchy-loading /tmp/loading-server.pid
-  - iptables -t nat -A PREROUTING -p tcp --dport 80 -j REDIRECT --to-ports 7777
-  - iptables -t nat -A OUTPUT -p tcp -o lo --dport 80 -j REDIRECT --to-ports 7777
-  - netfilter-persistent save
+  - for i in $(seq 1 90); do curl -sf http://localhost/api/health > /dev/null 2>&1 && break; sleep 2; done


### PR DESCRIPTION
Fixes #155

## Summary

- **`docker-compose.yml`**: Default `PINCHY_PORT` changed from `7777:7777` (binds to `0.0.0.0`) to `127.0.0.1:7777:7777` — Docker bypasses UFW, so explicit localhost binding is the only reliable way to keep port 7777 off the internet
- **`cloud-init.yml`**: Generates `DB_PASSWORD`, `BETTER_AUTH_SECRET`, and `ENCRYPTION_KEY` before first start; binds Pinchy directly to port 80 via `PINCHY_PORT=80:7777` instead of iptables NAT REDIRECT rules; removes `iptables-persistent` package and all NAT rules entirely
- **`vps-deployment.mdx`**: Secrets pinning moved to step 3 (before database creation); false "port 7777 is never exposed" claim corrected with Docker/UFW bypass explanation; `PINCHY_PORT=127.0.0.1:7777` step added before Caddy setup; domain-lock step added; SSH tunnel used for initial setup wizard access
- **`deploy-hetzner.mdx`**: Removes obsolete iptables redirect removal section; adds `PINCHY_PORT` localhost step before Caddy; adds domain-lock step; notes secrets are auto-pinned by cloud-init
- **`hardening.mdx`**: Documents localhost binding as default since v0.4.3, explains Docker/UFW bypass, adds override example for direct-access deployments
- **`upgrading.mdx`**: Freezes v0.4.2 section; adds v0.4.3 upgrade note explaining port binding change and required action for direct port 7777 users

## Breaking change

Users upgrading from v0.4.2 who access Pinchy directly on port 7777 (no reverse proxy) will lose access after upgrading. The upgrade guide documents the `PINCHY_PORT=0.0.0.0:7777` workaround and recommends switching to a reverse proxy.

## Test plan

- [ ] Cloud-init: paste into a fresh Hetzner VPS user-data field and verify Pinchy is accessible on port 80 after boot
- [ ] Cloud-init: verify `/opt/pinchy/.env` contains all three secrets and `PINCHY_PORT=80:7777`
- [ ] docker-compose.yml: `docker compose up -d` → `docker compose ps` shows `127.0.0.1:7777->7777/tcp`
- [ ] docker-compose.yml: setting `PINCHY_PORT=7777` in .env still works (override)
- [ ] Docs build: `cd docs && pnpm build` succeeds with no warnings
- [ ] vps-deployment.mdx: SSH tunnel step works for initial wizard access
- [ ] deploy-hetzner.mdx: no broken links, HTTPS section is self-consistent