### PR TITLE
fix(integrations): isolate per-row decryption failures

### DIFF
--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -167,6 +167,76 @@ describe("GET /api/integrations", () => {
     expect(body[0].credentials).not.toHaveProperty("apiKey");
     expect(body[0].credentials).not.toHaveProperty("uid");
   });
+
+  it("flags a row instead of crashing when its credentials can't be decrypted", async () => {
+    // Regression: if the ENCRYPTION_KEY changes (deliberately or accidentally),
+    // existing rows can't be decrypted. The .map(decrypt) previously threw,
+    // returning 500 — so the UI silently rendered "No integrations configured yet"
+    // and ALL other rows disappeared too, including ones encrypted with the
+    // current key. The endpoint must degrade gracefully, one row at a time.
+    const unreadable = { ...mockConnection, id: "unreadable-1", name: "Old Odoo" };
+    const readable = { ...mockConnection, id: "readable-1", name: "New Odoo" };
+
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Promise.resolve([unreadable, readable]) as Promise<
+        (typeof mockConnection)[]
+      > & { where: ReturnType<typeof vi.fn> };
+      result.where = vi.fn().mockResolvedValue([unreadable, readable]);
+      return result;
+    });
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new Error("Unsupported state or unable to authenticate data");
+    });
+
+    const { GET } = await import("@/app/api/integrations/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body).toHaveLength(2);
+
+    const u = body.find((r: { id: string }) => r.id === "unreadable-1");
+    expect(u).toMatchObject({
+      id: "unreadable-1",
+      name: "Old Odoo",
+      cannotDecrypt: true,
+      credentials: null,
+    });
+
+    const r = body.find((r: { id: string }) => r.id === "readable-1");
+    expect(r).toMatchObject({
+      id: "readable-1",
+      name: "New Odoo",
+      cannotDecrypt: false,
+      credentials: { url: "https://odoo.example.com", db: "prod", login: "admin" },
+    });
+  });
+
+  it("never exposes credentials for an unreadable row", async () => {
+    // Defense in depth: even if decrypt fails, we must not return partial
+    // ciphertext or apiKey fragments. The row carries name/id only.
+    const unreadable = { ...mockConnection, id: "unreadable-1", credentials: "poisoned:data" };
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Promise.resolve([unreadable]) as Promise<(typeof mockConnection)[]> & {
+        where: ReturnType<typeof vi.fn>;
+      };
+      result.where = vi.fn().mockResolvedValue([unreadable]);
+      return result;
+    });
+    mockDecrypt.mockImplementationOnce(() => {
+      throw new Error("auth tag failed");
+    });
+
+    const { GET } = await import("@/app/api/integrations/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0].credentials).toBeNull();
+    const serialized = JSON.stringify(body);
+    expect(serialized).not.toContain("poisoned");
+    expect(serialized).not.toContain("apiKey");
+  });
 });
 
 describe("POST /api/integrations", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -41,8 +41,12 @@ vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
 }));
 
+const { mockDecrypt } = vi.hoisted(() => ({
+  mockDecrypt: vi.fn((val: string) => val),
+}));
+
 vi.mock("@/lib/encryption", () => ({
-  decrypt: (val: string) => val,
+  decrypt: (val: string) => mockDecrypt(val),
   encrypt: (val: string) => val,
   getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
 }));
@@ -1190,6 +1194,103 @@ describe("pinchy-odoo config size", () => {
     // Config should be small (no field definitions bloating it)
     const configSize = written.length;
     expect(configSize).toBeLessThan(5000); // Without schema: ~2-3KB. With schema it would be 100KB+
+  });
+
+  it("skips agents whose Odoo connection can't be decrypted instead of crashing the whole config regeneration", async () => {
+    // Regression: if ENCRYPTION_KEY changes, conn.credentials can't be decrypted.
+    // Previously the thrown error bubbled up and regenerateOpenClawConfig()
+    // crashed — which meant EVERY agent's config stopped regenerating, not just
+    // the one with the broken Odoo link. Now we skip the unreadable agent and
+    // keep the rest of the config alive.
+    const agentsData = [
+      {
+        id: "good-agent",
+        name: "Good Agent",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["odoo_read"],
+        createdAt: new Date(),
+      },
+      {
+        id: "broken-agent",
+        name: "Broken Agent",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["odoo_read"],
+        createdAt: new Date(),
+      },
+    ];
+
+    const permissionsData = [
+      {
+        agent_connection_permissions: {
+          agentId: "good-agent",
+          connectionId: "conn-good",
+          model: "sale.order",
+          operation: "read",
+        },
+        integration_connections: {
+          id: "conn-good",
+          type: "odoo",
+          name: "Readable Odoo",
+          description: "",
+          credentials: JSON.stringify({
+            url: "https://good.odoo",
+            db: "prod",
+            uid: 2,
+            apiKey: "good-key",
+          }),
+          data: { models: [], lastSyncAt: "2026-04-01T00:00:00Z" },
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+      {
+        agent_connection_permissions: {
+          agentId: "broken-agent",
+          connectionId: "conn-broken",
+          model: "sale.order",
+          operation: "read",
+        },
+        integration_connections: {
+          id: "conn-broken",
+          type: "odoo",
+          name: "Unreadable Odoo",
+          description: "",
+          credentials: "POISONED_BY_KEY_ROTATION",
+          data: null,
+          createdAt: new Date(),
+          updatedAt: new Date(),
+        },
+      },
+    ];
+
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockImplementation(() =>
+        Object.assign(Promise.resolve(agentsData), {
+          innerJoin: vi.fn().mockResolvedValue(permissionsData),
+        })
+      ),
+    } as never);
+
+    // Fail decryption only for the broken connection's ciphertext
+    mockDecrypt.mockImplementation((val: string) => {
+      if (val === "POISONED_BY_KEY_ROTATION") {
+        throw new Error("Unsupported state or unable to authenticate data");
+      }
+      return val;
+    });
+
+    await expect(regenerateOpenClawConfig()).resolves.toBeUndefined();
+
+    const written = mockedWriteFileSync.mock.calls.at(-1)?.[1] as string;
+    const config = JSON.parse(written);
+    const odooAgents = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents ?? {};
+
+    expect(odooAgents["good-agent"]).toBeDefined();
+    expect(odooAgents["good-agent"].connection.url).toBe("https://good.odoo");
+    expect(odooAgents["broken-agent"]).toBeUndefined();
+
+    // Reset for subsequent tests
+    mockDecrypt.mockImplementation((val: string) => val);
   });
 });
 

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -32,10 +32,37 @@ export async function GET() {
 
   const connections = await db.select().from(integrationConnections);
 
-  const masked = connections.map((conn) => ({
-    ...conn,
-    credentials: maskCredentials(conn.credentials, decrypt),
-  }));
+  // Decrypt per row and isolate failures: if ENCRYPTION_KEY changed (e.g. an
+  // admin accidentally overrode the persisted key via .env), some rows can no
+  // longer be decrypted. A single poison row must NOT crash the whole list —
+  // that used to silently hide all integrations, including freshly-added ones
+  // that would decrypt fine. Flag unreadable rows so the UI can offer Delete.
+  const masked = connections.map((conn) => {
+    try {
+      return {
+        ...conn,
+        credentials: maskCredentials(conn.credentials, decrypt),
+        cannotDecrypt: false,
+      };
+    } catch (err) {
+      console.warn(
+        `[integrations] Cannot decrypt credentials for connection ${conn.id} (${conn.name}). ` +
+          `ENCRYPTION_KEY may have changed. The admin can delete this row via the UI.`,
+        err
+      );
+      return {
+        id: conn.id,
+        type: conn.type,
+        name: conn.name,
+        description: conn.description,
+        data: null,
+        createdAt: conn.createdAt,
+        updatedAt: conn.updatedAt,
+        credentials: null,
+        cannotDecrypt: true,
+      };
+    }
+  });
 
   return NextResponse.json(masked);
 }

--- a/packages/web/src/components/new-agent-form.tsx
+++ b/packages/web/src/components/new-agent-form.tsx
@@ -188,7 +188,11 @@ export function NewAgentForm() {
         const res = await fetch("/api/integrations");
         if (res.ok) {
           const data = await res.json();
-          const odoo = (data as OdooConnection[]).filter((c: OdooConnection) => c.type === "odoo");
+          // Hide unreadable rows from the agent-creation flow — they can't be used
+          // and would show as "undefined URL". Admins clean them up in Settings.
+          const odoo = (data as OdooConnection[]).filter(
+            (c: OdooConnection) => c.type === "odoo" && !c.cannotDecrypt
+          );
           setOdooConnections(odoo);
 
           // Auto-select if only one connection

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -22,7 +22,7 @@ import {
 } from "@/components/ui/alert-dialog";
 import { Dialog, DialogContent, DialogHeader, DialogTitle } from "@/components/ui/dialog";
 import { Input } from "@/components/ui/input";
-import { MoreHorizontal, Plus, Plug, CheckCircle2, Loader2 } from "lucide-react";
+import { MoreHorizontal, Plus, Plug, CheckCircle2, Loader2, AlertTriangle } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 // toast is now handled by useIntegrationActions hook
 import { AddIntegrationDialog } from "./add-integration-dialog";
@@ -112,6 +112,37 @@ export function SettingsIntegrations() {
           ) : (
             <div className="space-y-3">
               {connections.map((conn) => {
+                if (conn.cannotDecrypt) {
+                  return (
+                    <div
+                      key={conn.id}
+                      className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 space-y-2"
+                    >
+                      <div className="flex items-center justify-between">
+                        <div className="flex items-center gap-3">
+                          <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+                          <span className="text-sm font-medium">{conn.name}</span>
+                        </div>
+                        <Button
+                          variant="outline"
+                          size="sm"
+                          className="text-destructive border-destructive/50 hover:bg-destructive/10"
+                          onClick={() => setDeleteTarget(conn)}
+                        >
+                          Delete
+                        </Button>
+                      </div>
+                      <p className="text-sm text-destructive/90">
+                        This integration can&apos;t be read. It was encrypted with a different{" "}
+                        <code className="rounded bg-destructive/10 px-1 py-0.5 text-xs">
+                          ENCRYPTION_KEY
+                        </code>{" "}
+                        than the one this server is using now. Delete it and re-add the connection
+                        to restore access.
+                      </p>
+                    </div>
+                  );
+                }
                 const categories = getAccessibleCategoryLabels(conn.data);
                 return (
                   <div key={conn.id} className="rounded-lg border p-4 space-y-2">

--- a/packages/web/src/lib/integrations/types.ts
+++ b/packages/web/src/lib/integrations/types.ts
@@ -7,11 +7,12 @@ export interface IntegrationConnection {
     url: string;
     db: string;
     login: string;
-  };
+  } | null;
   data: {
     lastSyncAt?: string;
     models?: Array<{ model: string; name: string }>;
   } | null;
   createdAt: string;
   updatedAt: string;
+  cannotDecrypt: boolean;
 }

--- a/packages/web/src/lib/odoo-connection-selection.ts
+++ b/packages/web/src/lib/odoo-connection-selection.ts
@@ -2,6 +2,7 @@ export interface OdooConnection {
   id: string;
   name: string;
   type: string;
+  cannotDecrypt?: boolean;
   data: {
     models: Array<{
       model: string;

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -322,7 +322,23 @@ export async function regenerateOpenClawConfig() {
     if (!firstConnection) continue;
 
     const conn = firstConnection.connection;
-    const decryptedCreds = JSON.parse(decrypt(conn.credentials));
+
+    // Robust against key rotation: if this connection's credentials can't be
+    // decrypted, skip it — the alternative is crashing the whole config
+    // regeneration, which leaves every agent broken. The admin can see and
+    // delete the orphaned row via Settings → Integrations.
+    let decryptedCreds: { url: string; db: string; uid: number; apiKey: string };
+    try {
+      decryptedCreds = JSON.parse(decrypt(conn.credentials));
+    } catch (err) {
+      console.warn(
+        `[openclaw-config] Skipping agent ${agentId}'s Odoo connection ${conn.id} ` +
+          `(${conn.name}) — credentials can't be decrypted. ENCRYPTION_KEY may have ` +
+          `changed. Admin must delete and re-add the integration.`,
+        err
+      );
+      continue;
+    }
     const permissions: Record<string, string[]> = {};
     for (const [model, ops] of firstConnection.ops) {
       permissions[model] = ops;


### PR DESCRIPTION
## Summary
- `GET /api/integrations` now decrypts per-row inside try/catch; unreadable rows come back with `cannotDecrypt: true` (no credentials payload) instead of throwing 500 and blanking the entire list.
- `regenerateOpenClawConfig()` wraps its `decrypt()` call the same way, so one unreadable connection no longer takes down config generation for every agent.
- UI: unreadable rows render as a destructive card with a Delete-only action; new-agent form hides them from the connection picker.

## Root cause
On demo an ENCRYPTION_KEY mismatch (volume file vs. `.env` env var) left one pre-mismatch row un-decryptable. The endpoint's `.map(decrypt)` threw on that row, Next.js returned 500, the frontend silently fell back to the empty state — so the user saw "No integrations configured yet" and "No Odoo connections yet" while the template gallery (bare EXISTS query, no decrypt) kept showing Odoo templates as available. Inconsistent and invisible to the admin. Server logs confirmed the exact stack: `Error: Unsupported state or unable to authenticate data` at `odoo-schema.ts:49` → `route.ts:37` → `route.ts:35`.

## Recovery path after this ships
Admins hit by the same issue open Settings → Integrations, see the unreadable row as a red warning card, click Delete, and re-add the integration. No DB access required.

## Test plan
- [x] Unit: unreadable row is flagged, readable rows returned normally, credentials field is null, apiKey never leaks into JSON
- [x] Unit: `regenerateOpenClawConfig` skips agents with unreadable Odoo connections instead of crashing
- [ ] Manual on demo: navigate to Settings → Integrations, expect the 2026-04-16 `Odoo-demo` row to appear as a red warning card; click Delete; rows 2 and 3 render normally; agent creation sees the two usable connections
- [ ] Manual: hit `/api/integrations` directly — expect `200` with a mix of `cannotDecrypt: true/false` entries, never `500`