### PR TITLE
fix: password reset shows correct form at /reset/[token]

### DIFF
--- a/packages/web/e2e/08-password-reset.spec.ts
+++ b/packages/web/e2e/08-password-reset.spec.ts
@@ -1,0 +1,24 @@
+import { test, expect } from "@playwright/test";
+
+test.describe("Password reset page", () => {
+  test("/reset/[token] renders the reset form, not the invite form", async ({ page }) => {
+    await page.goto("/reset/some-token-value");
+
+    // Reset-specific copy
+    await expect(page.getByText("Reset your password")).toBeVisible();
+    await expect(page.getByText("Enter a new password for your account.")).toBeVisible();
+    await expect(page.getByRole("button", { name: /reset password/i })).toBeVisible();
+
+    // Must NOT render the invite-claim form (that was the bug)
+    await expect(page.getByText(/you've been invited to pinchy/i)).toHaveCount(0);
+    await expect(page.getByLabel(/^name$/i)).toHaveCount(0);
+  });
+
+  test("/invite/[token] still renders the invite form (regression guard)", async ({ page }) => {
+    await page.goto("/invite/some-token-value");
+
+    await expect(page.getByText("You've been invited to Pinchy")).toBeVisible();
+    await expect(page.getByLabel(/^name$/i)).toBeVisible();
+    await expect(page.getByRole("button", { name: /create account/i })).toBeVisible();
+  });
+});

--- a/packages/web/src/__tests__/app/invite-claim-page.test.tsx
+++ b/packages/web/src/__tests__/app/invite-claim-page.test.tsx
@@ -4,12 +4,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import InviteClaimPage from "@/app/invite/[token]/page";
 
-const pushMock = vi.fn();
-
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: pushMock,
-  }),
   useParams: () => ({
     token: "test-token-123",
   }),
@@ -161,7 +156,7 @@ describe("Invite Claim Page", () => {
     });
   });
 
-  it("should redirect to /login on success via 'Continue to sign in' button", async () => {
+  it("should link to /login on success via 'Continue to sign in'", async () => {
     const user = userEvent.setup();
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -176,10 +171,26 @@ describe("Invite Claim Page", () => {
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue to sign in/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /continue to sign in/i })).toHaveAttribute(
+        "href",
+        "/login"
+      );
     });
+  });
 
-    await user.click(screen.getByRole("button", { name: /continue to sign in/i }));
-    expect(pushMock).toHaveBeenCalledWith("/login");
+  it("should show generic error when fetch throws", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network down"));
+
+    render(<InviteClaimPage />);
+
+    await user.type(screen.getByLabelText(/name/i), "Test User");
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /create account/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/__tests__/app/reset-page.test.tsx
+++ b/packages/web/src/__tests__/app/reset-page.test.tsx
@@ -146,8 +146,8 @@ describe("Reset Password Page", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Password reset!")).toBeInTheDocument();
+      expect(screen.getByText("You can now sign in with your new password.")).toBeInTheDocument();
     });
-    expect(screen.getByText("You can now sign in with your new password.")).toBeInTheDocument();
   });
 
   it("should redirect to /login via 'Continue to sign in' button after success", async () => {

--- a/packages/web/src/__tests__/app/reset-page.test.tsx
+++ b/packages/web/src/__tests__/app/reset-page.test.tsx
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import ResetPasswordPage from "@/app/reset/[token]/page";
+
+const pushMock = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({
+    push: pushMock,
+  }),
+  useParams: () => ({
+    token: "reset-token-abc",
+  }),
+}));
+
+vi.mock("next/image", () => ({
+  default: ({
+    priority,
+    ...props
+  }: React.ImgHTMLAttributes<HTMLImageElement> & { priority?: boolean }) => {
+    // eslint-disable-next-line @next/next/no-img-element, jsx-a11y/alt-text
+    return <img {...props} />;
+  },
+}));
+
+global.fetch = vi.fn();
+
+describe("Reset Password Page", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("should render 'Reset your password' heading", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByText("Reset your password")).toBeInTheDocument();
+  });
+
+  it("should render description text", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByText("Enter a new password for your account.")).toBeInTheDocument();
+  });
+
+  it("should NOT render a Name field", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
+  });
+
+  it("should render Password and Confirm password fields", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+  });
+
+  it("should render a 'Reset password' submit button", () => {
+    render(<ResetPasswordPage />);
+    expect(screen.getByRole("button", { name: /reset password/i })).toBeInTheDocument();
+  });
+
+  it("should show validation error when password is too short", async () => {
+    const user = userEvent.setup();
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "short");
+    await user.type(screen.getByLabelText(/confirm password/i), "short");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Password must be at least 8 characters")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("should show validation error when passwords do not match", async () => {
+    const user = userEvent.setup();
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "different456");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).not.toHaveBeenCalled();
+  });
+
+  it("should submit to /api/invite/claim with token and password (no name)", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenCalledWith("/api/invite/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          token: "reset-token-abc",
+          password: "password123",
+        }),
+      });
+    });
+  });
+
+  it("should show error when API returns error", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Invalid or expired invite link" }),
+    });
+
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid or expired invite link")).toBeInTheDocument();
+    });
+  });
+
+  it("should show success screen with 'Password reset!' after successful submit", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Password reset!")).toBeInTheDocument();
+    });
+    expect(screen.getByText("You can now sign in with your new password.")).toBeInTheDocument();
+  });
+
+  it("should redirect to /login via 'Continue to sign in' button after success", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ success: true }),
+    });
+
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue to sign in/i })).toBeInTheDocument();
+    });
+
+    await user.click(screen.getByRole("button", { name: /continue to sign in/i }));
+    expect(pushMock).toHaveBeenCalledWith("/login");
+  });
+});

--- a/packages/web/src/__tests__/app/reset-page.test.tsx
+++ b/packages/web/src/__tests__/app/reset-page.test.tsx
@@ -4,12 +4,7 @@ import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import ResetPasswordPage from "@/app/reset/[token]/page";
 
-const pushMock = vi.fn();
-
 vi.mock("next/navigation", () => ({
-  useRouter: () => ({
-    push: pushMock,
-  }),
   useParams: () => ({
     token: "reset-token-abc",
   }),
@@ -150,7 +145,7 @@ describe("Reset Password Page", () => {
     });
   });
 
-  it("should redirect to /login via 'Continue to sign in' button after success", async () => {
+  it("should link to /login via 'Continue to sign in' after success", async () => {
     const user = userEvent.setup();
     (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
       ok: true,
@@ -164,10 +159,25 @@ describe("Reset Password Page", () => {
     await user.click(screen.getByRole("button", { name: /reset password/i }));
 
     await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue to sign in/i })).toBeInTheDocument();
+      expect(screen.getByRole("link", { name: /continue to sign in/i })).toHaveAttribute(
+        "href",
+        "/login"
+      );
     });
+  });
 
-    await user.click(screen.getByRole("button", { name: /continue to sign in/i }));
-    expect(pushMock).toHaveBeenCalledWith("/login");
+  it("should show generic error when fetch throws", async () => {
+    const user = userEvent.setup();
+    (global.fetch as ReturnType<typeof vi.fn>).mockRejectedValueOnce(new Error("network down"));
+
+    render(<ResetPasswordPage />);
+
+    await user.type(screen.getByLabelText(/^password$/i), "password123");
+    await user.type(screen.getByLabelText(/confirm password/i), "password123");
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Something went wrong. Please try again.")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -40,8 +40,14 @@ const allGroups = [
 ];
 
 describe("UserDetailSheet", () => {
+  const originalLocation = window.location;
+
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    Object.defineProperty(window, "location", { value: originalLocation, writable: true });
   });
 
   it("should render user name and email", () => {
@@ -329,12 +335,11 @@ describe("UserDetailSheet", () => {
 
   it("should show reset link with /reset/ path after clicking Reset Password", async () => {
     const user = userEvent.setup();
-    global.fetch = vi.fn().mockResolvedValueOnce({
+    vi.spyOn(global, "fetch").mockResolvedValueOnce({
       ok: true,
       json: async () => ({ token: "abc123" }),
-    });
+    } as Response);
 
-    const originalLocation = window.location;
     Object.defineProperty(window, "location", {
       value: { origin: "https://demo.heypinchy.com" },
       writable: true,
@@ -357,7 +362,5 @@ describe("UserDetailSheet", () => {
     await waitFor(() => {
       expect(screen.getByText("https://demo.heypinchy.com/reset/abc123")).toBeInTheDocument();
     });
-
-    Object.defineProperty(window, "location", { value: originalLocation, writable: true });
   });
 });

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -334,6 +334,7 @@ describe("UserDetailSheet", () => {
       json: async () => ({ token: "abc123" }),
     });
 
+    const originalLocation = window.location;
     Object.defineProperty(window, "location", {
       value: { origin: "https://demo.heypinchy.com" },
       writable: true,
@@ -356,5 +357,7 @@ describe("UserDetailSheet", () => {
     await waitFor(() => {
       expect(screen.getByText("https://demo.heypinchy.com/reset/abc123")).toBeInTheDocument();
     });
+
+    Object.defineProperty(window, "location", { value: originalLocation, writable: true });
   });
 });

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { UserDetailSheet } from "@/components/user-detail-sheet";
@@ -325,5 +325,36 @@ describe("UserDetailSheet", () => {
     await user.click(screen.getByRole("button", { name: "Copy" }));
 
     await screen.findByRole("button", { name: "Copied!" });
+  });
+
+  it("should show reset link with /reset/ path after clicking Reset Password", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi.fn().mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ token: "abc123" }),
+    });
+
+    Object.defineProperty(window, "location", {
+      value: { origin: "https://demo.heypinchy.com" },
+      writable: true,
+    });
+
+    render(
+      <UserDetailSheet
+        user={mockUser}
+        allGroups={allGroups}
+        isEnterprise={true}
+        currentUserId="admin-1"
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+
+    await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+    await waitFor(() => {
+      expect(screen.getByText("https://demo.heypinchy.com/reset/abc123")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -1,4 +1,7 @@
-// audit-exempt: invite claim is a self-service action by the invited user, not an admin action
+// Handles BOTH new-user invite claims AND admin-issued password resets:
+// the token's `type` field discriminates between them. The reset frontend
+// lives at /reset/[token] and posts here too — see invite.type === "reset".
+// audit-exempt: self-service action by the invited/reset user, not an admin action
 import { NextRequest, NextResponse } from "next/server";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -19,6 +19,7 @@ import {
 } from "@/components/ui/form";
 import { CheckCircle2 } from "lucide-react";
 import { PasswordInput } from "@/components/password-input";
+import { useTokenParam } from "@/hooks/use-token-param";
 
 const inviteClaimSchema = z
   .object({
@@ -34,9 +35,7 @@ const inviteClaimSchema = z
 type InviteClaimValues = z.infer<typeof inviteClaimSchema>;
 
 export default function InviteClaimPage() {
-  const params = useParams();
-  const token = Array.isArray(params.token) ? params.token[0] : params.token;
-  const router = useRouter();
+  const token = useTokenParam();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -87,8 +86,8 @@ export default function InviteClaimPage() {
                 <CardDescription>You can now sign in with your credentials.</CardDescription>
               </CardHeader>
               <CardContent>
-                <Button onClick={() => router.push("/login")} className="w-full">
-                  Continue to sign in
+                <Button asChild className="w-full">
+                  <Link href="/login">Continue to sign in</Link>
                 </Button>
               </CardContent>
             </>

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -34,7 +34,8 @@ const inviteClaimSchema = z
 type InviteClaimValues = z.infer<typeof inviteClaimSchema>;
 
 export default function InviteClaimPage() {
-  const { token } = useParams();
+  const params = useParams();
+  const token = Array.isArray(params.token) ? params.token[0] : params.token;
   const router = useRouter();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -100,7 +100,7 @@ export default function InviteClaimPage() {
               <CardContent>
                 <Form {...form}>
                   <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                    {error && <p className="text-destructive">{error}</p>}
+                    {error && <p className="text-sm text-destructive">{error}</p>}
 
                     <FormField
                       control={form.control}

--- a/packages/web/src/app/reset/[token]/page.tsx
+++ b/packages/web/src/app/reset/[token]/page.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState } from "react";
-import { useParams, useRouter } from "next/navigation";
+import Link from "next/link";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
@@ -11,6 +11,7 @@ import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/com
 import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
 import { CheckCircle2 } from "lucide-react";
 import { PasswordInput } from "@/components/password-input";
+import { useTokenParam } from "@/hooks/use-token-param";
 
 const resetSchema = z
   .object({
@@ -25,9 +26,7 @@ const resetSchema = z
 type ResetValues = z.infer<typeof resetSchema>;
 
 export default function ResetPasswordPage() {
-  const params = useParams();
-  const token = Array.isArray(params.token) ? params.token[0] : params.token;
-  const router = useRouter();
+  const token = useTokenParam();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
@@ -78,8 +77,8 @@ export default function ResetPasswordPage() {
                 <CardDescription>You can now sign in with your new password.</CardDescription>
               </CardHeader>
               <CardContent>
-                <Button onClick={() => router.push("/login")} className="w-full">
-                  Continue to sign in
+                <Button asChild className="w-full">
+                  <Link href="/login">Continue to sign in</Link>
                 </Button>
               </CardContent>
             </>

--- a/packages/web/src/app/reset/[token]/page.tsx
+++ b/packages/web/src/app/reset/[token]/page.tsx
@@ -1,0 +1,132 @@
+"use client";
+
+import { useState } from "react";
+import { useParams, useRouter } from "next/navigation";
+import Image from "next/image";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { z } from "zod";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Form, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
+import { CheckCircle2 } from "lucide-react";
+import { PasswordInput } from "@/components/password-input";
+
+const resetSchema = z
+  .object({
+    password: z.string().min(8, "Password must be at least 8 characters"),
+    confirmPassword: z.string(),
+  })
+  .refine((data) => data.password === data.confirmPassword, {
+    message: "Passwords do not match",
+    path: ["confirmPassword"],
+  });
+
+type ResetValues = z.infer<typeof resetSchema>;
+
+export default function ResetPasswordPage() {
+  const { token } = useParams();
+  const router = useRouter();
+  const [error, setError] = useState("");
+  const [loading, setLoading] = useState(false);
+  const [success, setSuccess] = useState(false);
+
+  const form = useForm<ResetValues>({
+    resolver: zodResolver(resetSchema),
+    defaultValues: { password: "", confirmPassword: "" },
+  });
+
+  async function onSubmit(values: ResetValues) {
+    setLoading(true);
+    setError("");
+
+    try {
+      const res = await fetch("/api/invite/claim", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ token, password: values.password }),
+      });
+
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to reset password");
+        return;
+      }
+
+      setSuccess(true);
+    } catch {
+      setError("Something went wrong. Please try again.");
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-md flex flex-col items-center gap-6">
+        <Image src="/pinchy-logo.png" alt="Pinchy" width={80} height={85} priority />
+
+        <Card className="w-full">
+          {success ? (
+            <>
+              <CardHeader className="text-center">
+                <div className="flex justify-center mb-2">
+                  <CheckCircle2 className="size-12 text-primary" />
+                </div>
+                <CardTitle>Password reset!</CardTitle>
+                <CardDescription>You can now sign in with your new password.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Button onClick={() => router.push("/login")} className="w-full">
+                  Continue to sign in
+                </Button>
+              </CardContent>
+            </>
+          ) : (
+            <>
+              <CardHeader>
+                <CardTitle>Reset your password</CardTitle>
+                <CardDescription>Enter a new password for your account.</CardDescription>
+              </CardHeader>
+              <CardContent>
+                <Form {...form}>
+                  <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+                    {error && <p className="text-destructive">{error}</p>}
+
+                    <FormField
+                      control={form.control}
+                      name="password"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Password</FormLabel>
+                          <PasswordInput {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <FormField
+                      control={form.control}
+                      name="confirmPassword"
+                      render={({ field }) => (
+                        <FormItem>
+                          <FormLabel>Confirm password</FormLabel>
+                          <PasswordInput {...field} />
+                          <FormMessage />
+                        </FormItem>
+                      )}
+                    />
+
+                    <Button type="submit" disabled={loading} className="w-full">
+                      {loading ? "Resetting password..." : "Reset password"}
+                    </Button>
+                  </form>
+                </Form>
+              </CardContent>
+            </>
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/app/reset/[token]/page.tsx
+++ b/packages/web/src/app/reset/[token]/page.tsx
@@ -25,7 +25,8 @@ const resetSchema = z
 type ResetValues = z.infer<typeof resetSchema>;
 
 export default function ResetPasswordPage() {
-  const { token } = useParams();
+  const params = useParams();
+  const token = Array.isArray(params.token) ? params.token[0] : params.token;
   const router = useRouter();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);

--- a/packages/web/src/app/reset/[token]/page.tsx
+++ b/packages/web/src/app/reset/[token]/page.tsx
@@ -91,7 +91,7 @@ export default function ResetPasswordPage() {
               <CardContent>
                 <Form {...form}>
                   <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                    {error && <p className="text-destructive">{error}</p>}
+                    {error && <p className="text-sm text-destructive">{error}</p>}
 
                     <FormField
                       control={form.control}

--- a/packages/web/src/components/user-detail-sheet.tsx
+++ b/packages/web/src/components/user-detail-sheet.tsx
@@ -139,7 +139,7 @@ export function UserDetailSheet({
     const res = await fetch(`/api/users/${user.id}/reset`, { method: "POST" });
     if (res.ok) {
       const data = await res.json();
-      setResetLink(`${window.location.origin}/invite/${data.token}`);
+      setResetLink(`${window.location.origin}/reset/${data.token}`);
     } else {
       toast.error("Failed to reset password");
     }

--- a/packages/web/src/hooks/use-token-param.ts
+++ b/packages/web/src/hooks/use-token-param.ts
@@ -1,0 +1,14 @@
+"use client";
+
+import { useParams } from "next/navigation";
+
+/**
+ * Reads the `[token]` route param from a dynamic page (e.g. `/invite/[token]`,
+ * `/reset/[token]`) and narrows it to a single string. Next.js types the param
+ * as `string | string[]`, but our routes only have a single segment.
+ */
+export function useTokenParam(): string | undefined {
+  const params = useParams();
+  const raw = params.token;
+  return Array.isArray(raw) ? raw[0] : raw;
+}


### PR DESCRIPTION
## Summary

- Add new `/reset/[token]` page with password-only form ("Reset your password" heading, no name field) that submits to the existing `/api/invite/claim` endpoint
- Fix `user-detail-sheet.tsx` to generate reset links pointing to `/reset/` instead of `/invite/`
- Add `text-sm` to inline error paragraphs on both the reset and invite pages (project standard)

## Root Cause

When an admin triggered a password reset, the generated link pointed to `/invite/<token>` — which showed the account-creation form (name + password, "You've been invited to Pinchy") instead of a password reset form. No `/reset/[token]` page existed.

The backend (`/api/invite/claim`) already handled `type: "reset"` correctly — this was a pure frontend fix.

## Test Plan

- [ ] All 2,781 tests pass (`cd packages/web && npx vitest run`)
- [ ] Build succeeds with `/reset/[token]` as a dynamic route (`npx next build`)
- [ ] Admin triggers password reset → link shows `https://<host>/reset/<token>`
- [ ] Visiting `/reset/<token>` shows "Reset your password" form with Password + Confirm password fields (no Name field)
- [ ] Submitting valid matching passwords resets the password and shows "Password reset!" success screen
- [ ] "Continue to sign in" button redirects to `/login`
- [ ] Short password or mismatched passwords show inline validation errors