### PR TITLE
fix(integrations): prevent silent permission loss on integration delete

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -95,6 +95,12 @@ To re-sync: go to **Settings → Integrations**, select the connection, and clic
 Re-syncing may remove models that are no longer accessible. Agents that were configured to use those models will lose access to them.
 :::
 
+## Deleting an integration
+
+When you delete an integration in **Settings → Integrations**, Pinchy first checks whether any agents have been granted access to it. If agents are using the integration, the delete dialog shows their names and warns that deleting will remove their access — the button reads **Detach & Delete** to make this explicit. Confirming removes all agent permissions for that integration and deletes the connection in a single atomic transaction, so no agent is left with a dangling reference. If no agents use the integration, a standard delete confirmation is shown and the connection is removed directly.
+
+If you prefer to clean up manually first, cancel the dialog, remove the integration from each agent's Permissions tab, and then return to delete the connection. Either way, the audit trail records the full event: a `integration_deleted` entry for a clean delete, or `integration_deleted_with_permissions` — including the list of affected agents — when permissions were removed as part of the operation.
+
 ## Security
 
 All integration credentials are handled with the same rigor as provider API keys:

--- a/packages/web/drizzle/0029_restrict_connection_id_fk.sql
+++ b/packages/web/drizzle/0029_restrict_connection_id_fk.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "agent_connection_permissions" DROP CONSTRAINT "agent_connection_permissions_connection_id_integration_connections_id_fk";
+--> statement-breakpoint
+ALTER TABLE "agent_connection_permissions" ADD CONSTRAINT "agent_connection_permissions_connection_id_integration_connections_id_fk" FOREIGN KEY ("connection_id") REFERENCES "public"."integration_connections"("id") ON DELETE restrict ON UPDATE no action;

--- a/packages/web/drizzle/meta/0025_snapshot.json
+++ b/packages/web/drizzle/meta/0025_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "78c3e98c-529b-4e23-9cb4-78ea24a98489",
-  "prevId": "b2b4ae72-1760-4900-9615-f5cb2d587846",
+  "id": "5a2c3f1e-8b72-4d91-c6f5-9e0a4b7c2d38",
+  "prevId": "10a4e848-edd1-4941-a7bf-ef16ccbc6b14",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1195,6 +1195,196 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/packages/web/drizzle/meta/0026_snapshot.json
+++ b/packages/web/drizzle/meta/0026_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "78c3e98c-529b-4e23-9cb4-78ea24a98489",
-  "prevId": "b2b4ae72-1760-4900-9615-f5cb2d587846",
+  "id": "15bc486f-4049-459f-be41-b0f4328da2e9",
+  "prevId": "5a2c3f1e-8b72-4d91-c6f5-9e0a4b7c2d38",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -1195,6 +1195,196 @@
       },
       "indexes": {},
       "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/packages/web/drizzle/meta/0027_snapshot.json
+++ b/packages/web/drizzle/meta/0027_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "b5e1d204-9c63-4f87-a0b2-6d8e1f7c9a53",
-  "prevId": "a3f2c891-7d54-4e12-b8a1-5c9d0e3f6b47",
+  "id": "a3f2c891-7d54-4e12-b8a1-5c9d0e3f6b47",
+  "prevId": "15bc486f-4049-459f-be41-b0f4328da2e9",
   "version": "7",
   "dialect": "postgresql",
   "tables": {

--- a/packages/web/drizzle/meta/0029_snapshot.json
+++ b/packages/web/drizzle/meta/0029_snapshot.json
@@ -1,6 +1,6 @@
 {
-  "id": "b5e1d204-9c63-4f87-a0b2-6d8e1f7c9a53",
-  "prevId": "a3f2c891-7d54-4e12-b8a1-5c9d0e3f6b47",
+  "id": "cfb9beea-fd28-4756-a5fa-2403d843520e",
+  "prevId": "b5e1d204-9c63-4f87-a0b2-6d8e1f7c9a53",
   "version": "7",
   "dialect": "postgresql",
   "tables": {
@@ -98,6 +98,132 @@
           "columnsFrom": ["user_id"],
           "columnsTo": ["id"],
           "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "restrict",
           "onUpdate": "no action"
         }
       },
@@ -584,6 +710,77 @@
           "type": "timestamp",
           "primaryKey": false,
           "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
           "default": "now()"
         }
       },
@@ -1195,203 +1392,6 @@
       },
       "indexes": {},
       "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.integration_connections": {
-      "name": "integration_connections",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "type": {
-          "name": "type",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "name": {
-          "name": "name",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "description": {
-          "name": "description",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "''"
-        },
-        "credentials": {
-          "name": "credentials",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "data": {
-          "name": "data",
-          "type": "jsonb",
-          "primaryKey": false,
-          "notNull": false
-        },
-        "created_at": {
-          "name": "created_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "now()"
-        },
-        "updated_at": {
-          "name": "updated_at",
-          "type": "timestamp",
-          "primaryKey": false,
-          "notNull": false,
-          "default": "now()"
-        },
-        "status": {
-          "name": "status",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true,
-          "default": "'active'"
-        }
-      },
-      "indexes": {},
-      "foreignKeys": {},
-      "compositePrimaryKeys": {},
-      "uniqueConstraints": {},
-      "policies": {},
-      "checkConstraints": {},
-      "isRLSEnabled": false
-    },
-    "public.agent_connection_permissions": {
-      "name": "agent_connection_permissions",
-      "schema": "",
-      "columns": {
-        "id": {
-          "name": "id",
-          "type": "text",
-          "primaryKey": true,
-          "notNull": true
-        },
-        "agent_id": {
-          "name": "agent_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "connection_id": {
-          "name": "connection_id",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "model": {
-          "name": "model",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        },
-        "operation": {
-          "name": "operation",
-          "type": "text",
-          "primaryKey": false,
-          "notNull": true
-        }
-      },
-      "indexes": {
-        "uq_agent_conn_model_op": {
-          "name": "uq_agent_conn_model_op",
-          "columns": [
-            {
-              "expression": "agent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "connection_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "model",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            },
-            {
-              "expression": "operation",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": true,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_agent_conn_perms_agent": {
-          "name": "idx_agent_conn_perms_agent",
-          "columns": [
-            {
-              "expression": "agent_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        },
-        "idx_agent_conn_perms_conn": {
-          "name": "idx_agent_conn_perms_conn",
-          "columns": [
-            {
-              "expression": "connection_id",
-              "isExpression": false,
-              "asc": true,
-              "nulls": "last"
-            }
-          ],
-          "isUnique": false,
-          "concurrently": false,
-          "method": "btree",
-          "with": {}
-        }
-      },
-      "foreignKeys": {
-        "agent_connection_permissions_agent_id_agents_id_fk": {
-          "name": "agent_connection_permissions_agent_id_agents_id_fk",
-          "tableFrom": "agent_connection_permissions",
-          "tableTo": "agents",
-          "columnsFrom": ["agent_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        },
-        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
-          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
-          "tableFrom": "agent_connection_permissions",
-          "tableTo": "integration_connections",
-          "columnsFrom": ["connection_id"],
-          "columnsTo": ["id"],
-          "onDelete": "cascade",
-          "onUpdate": "no action"
-        }
-      },
       "compositePrimaryKeys": {},
       "uniqueConstraints": {},
       "policies": {},

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -211,6 +211,13 @@
       "when": 1776278400000,
       "tag": "0028_plugin_config_namespace",
       "breakpoints": true
+    },
+    {
+      "idx": 30,
+      "version": "7",
+      "when": 1745406000000,
+      "tag": "0029_restrict_connection_id_fk",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -74,10 +74,13 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     // 5. Open the integration's action menu and click Delete
     //    Each integration row has a MoreHorizontal dropdown trigger.
     //    The integration row containing INTEGRATION_NAME is the one we want.
-    const integrationRow = page.locator(".rounded-lg.border").filter({
-      hasText: INTEGRATION_NAME,
-    });
-    await integrationRow.getByRole("button").click(); // MoreHorizontal button
+    const integrationRow = page
+      .locator("div")
+      .filter({ hasText: INTEGRATION_NAME })
+      .filter({
+        has: page.getByRole("button", { name: /open menu/i }),
+      });
+    await integrationRow.getByRole("button", { name: /open menu/i }).click();
     await page.getByRole("menuitem", { name: /delete/i }).click();
 
     // 6. Dialog shows "Delete E2E Odoo?" heading and "Detach & Delete" button
@@ -107,10 +110,11 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     if (connectionId) {
       // Integration was not deleted by the test (failure path) — clean up via
       // the with-permissions endpoint so FK constraints don't block deletion
-      await page.request.delete(`/api/integrations/${connectionId}/with-permissions`).catch(() => {
-        // Best-effort fallback
-        page.request.delete(`/api/integrations/${connectionId}`).catch(() => undefined);
-      });
+      await page.request
+        .delete(`/api/integrations/${connectionId}/with-permissions`)
+        .catch(async () => {
+          await page.request.delete(`/api/integrations/${connectionId}`).catch(() => undefined);
+        });
     }
   }
 });

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -1,0 +1,116 @@
+// packages/web/e2e/integration/integration-delete.spec.ts
+//
+// Full E2E flow: create an integration, grant an agent permission on it,
+// verify "Used by 1 agent" label, open the delete dialog, and confirm
+// "Detach & Delete" removes the integration.
+//
+// Runs against the integration Docker stack (http://localhost:7779).
+// Admin account is seeded by global-setup.ts.
+
+import { test, expect } from "@playwright/test";
+
+const ADMIN_EMAIL = "admin@integration.local";
+const ADMIN_PASSWORD = "integration-password-123";
+const INTEGRATION_NAME = "E2E Odoo";
+
+test("admin can detach-and-delete an integration used by agents", async ({ page }) => {
+  let connectionId: string | null = null;
+  let agentId: string | null = null;
+
+  // Login via the UI (page carries the session cookie for subsequent requests)
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(ADMIN_EMAIL);
+  await page.getByLabel("Password", { exact: true }).fill(ADMIN_PASSWORD);
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+
+  try {
+    // 1. Create integration via API using the page's authenticated session
+    const createIntegration = await page.request.post("/api/integrations", {
+      data: {
+        type: "odoo",
+        name: INTEGRATION_NAME,
+        description: "E2E test integration — created by integration-delete.spec.ts",
+        credentials: {
+          url: "http://odoo-mock:8069",
+          db: "testdb",
+          login: "admin",
+          apiKey: "test-api-key",
+          uid: 2,
+        },
+      },
+    });
+    expect(createIntegration.status()).toBe(201);
+    const integration = await createIntegration.json();
+    connectionId = integration.id as string;
+
+    // 2. Create a custom agent via API
+    const createAgent = await page.request.post("/api/agents", {
+      data: {
+        name: "E2E Delete Test Agent",
+        templateId: "custom",
+      },
+    });
+    expect(createAgent.status()).toBe(201);
+    const agent = await createAgent.json();
+    agentId = agent.id as string;
+
+    // 3. Grant the agent a permission on the integration
+    const grantPermission = await page.request.put(`/api/agents/${agentId}/integrations`, {
+      data: {
+        connectionId,
+        permissions: [{ model: "sale.order", operation: "read" }],
+      },
+    });
+    expect(grantPermission.status()).toBe(200);
+
+    // 4. Navigate to integrations settings and reload to see the updated count
+    await page.goto("/settings/integrations");
+    await expect(page.getByText(new RegExp(INTEGRATION_NAME, "i"))).toBeVisible({
+      timeout: 10000,
+    });
+    await expect(page.getByText(/used by 1 agent/i)).toBeVisible();
+
+    // 5. Open the integration's action menu and click Delete
+    //    Each integration row has a MoreHorizontal dropdown trigger.
+    //    The integration row containing INTEGRATION_NAME is the one we want.
+    const integrationRow = page.locator(".rounded-lg.border").filter({
+      hasText: INTEGRATION_NAME,
+    });
+    await integrationRow.getByRole("button").click(); // MoreHorizontal button
+    await page.getByRole("menuitem", { name: /delete/i }).click();
+
+    // 6. Dialog shows "Delete E2E Odoo?" heading and "Detach & Delete" button
+    //    (phase === "detach" because the integration has 1 agent permission)
+    await expect(
+      page.getByRole("heading", { name: new RegExp(`delete ${INTEGRATION_NAME}`, "i") })
+    ).toBeVisible({ timeout: 5000 });
+    await expect(page.getByRole("button", { name: /detach & delete/i })).toBeVisible();
+
+    // 7. Click "Detach & Delete"
+    await page.getByRole("button", { name: /detach & delete/i }).click();
+
+    // 8. Integration is gone from the listing
+    await expect(page.getByText(new RegExp(INTEGRATION_NAME, "i"))).not.toBeVisible({
+      timeout: 5000,
+    });
+
+    // Mark as cleaned up — no need to delete in afterAll
+    connectionId = null;
+  } finally {
+    // Cleanup: remove agent and (if not already deleted) the integration
+    if (agentId) {
+      await page.request.delete(`/api/agents/${agentId}`).catch(() => {
+        // Best-effort: agent may already be gone or endpoint may not exist
+      });
+    }
+    if (connectionId) {
+      // Integration was not deleted by the test (failure path) — clean up via
+      // the with-permissions endpoint so FK constraints don't block deletion
+      await page.request.delete(`/api/integrations/${connectionId}/with-permissions`).catch(() => {
+        // Best-effort fallback
+        page.request.delete(`/api/integrations/${connectionId}`).catch(() => undefined);
+      });
+    }
+  }
+});

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -69,7 +69,7 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     await expect(page.getByText(new RegExp(INTEGRATION_NAME, "i"))).toBeVisible({
       timeout: 10000,
     });
-    await expect(page.getByText(/used by 1 agent/i)).toBeVisible();
+    await expect(page.getByText(/used by 1 agent/i)).toBeVisible({ timeout: 10000 });
 
     // 5. Open the integration's action menu and click Delete
     //    Each integration row has a MoreHorizontal dropdown trigger.
@@ -83,12 +83,17 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     await integrationRow.getByRole("button", { name: /open menu/i }).click();
     await page.getByRole("menuitem", { name: /delete/i }).click();
 
-    // 6. Dialog shows "Delete E2E Odoo?" heading and "Detach & Delete" button
-    //    (phase === "detach" because the integration has 1 agent permission)
+    // 6. Dialog shows "Delete E2E Odoo?" heading and "Detach & Delete" button.
+    //    The dialog first loads (fetches /usage), then transitions to "detach"
+    //    phase because the integration has 1 agent permission.
+    //    Use a generous timeout — the /usage API round-trip can be slow on CI.
+    await expect(page.getByRole("alertdialog")).toBeVisible({ timeout: 5000 });
     await expect(
       page.getByRole("heading", { name: new RegExp(`delete ${INTEGRATION_NAME}`, "i") })
-    ).toBeVisible({ timeout: 5000 });
-    await expect(page.getByRole("button", { name: /detach & delete/i })).toBeVisible();
+    ).toBeVisible({ timeout: 10000 });
+    await expect(page.getByRole("button", { name: /detach & delete/i })).toBeVisible({
+      timeout: 10000,
+    });
 
     // 7. Click "Detach & Delete"
     await page.getByRole("button", { name: /detach & delete/i }).click();

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -65,7 +65,7 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     expect(grantPermission.status()).toBe(200);
 
     // 4. Navigate to integrations settings and reload to see the updated count
-    await page.goto("/settings/integrations");
+    await page.goto("/settings?tab=integrations");
     await expect(page.getByText(new RegExp(INTEGRATION_NAME, "i"))).toBeVisible({
       timeout: 10000,
     });

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -93,10 +93,10 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     // 7. Click "Detach & Delete"
     await page.getByRole("button", { name: /detach & delete/i }).click();
 
-    // 8. Integration is gone from the listing
-    await expect(page.getByText(new RegExp(INTEGRATION_NAME, "i"))).not.toBeVisible({
-      timeout: 5000,
-    });
+    // 8. Integration row is gone from the listing.
+    //    Use the same row locator (with "open menu" button filter) to avoid
+    //    matching the deletion toast which also contains the integration name.
+    await expect(integrationRow).not.toBeVisible({ timeout: 10000 });
 
     // Mark as cleaned up — no need to delete in afterAll
     connectionId = null;

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -40,11 +40,9 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         },
       },
     });
-    console.log("[diag] create integration status:", createIntegration.status());
     expect(createIntegration.status()).toBe(201);
     const integration = await createIntegration.json();
     connectionId = integration.id as string;
-    console.log("[diag] integration id:", connectionId);
 
     // 2. Create a custom agent via API
     const createAgent = await page.request.post("/api/agents", {
@@ -53,11 +51,9 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         templateId: "custom",
       },
     });
-    console.log("[diag] create agent status:", createAgent.status());
     expect(createAgent.status()).toBe(201);
     const agent = await createAgent.json();
     agentId = agent.id as string;
-    console.log("[diag] agent id:", agentId);
 
     // 3. Grant the agent a permission on the integration
     const grantPermission = await page.request.put(`/api/agents/${agentId}/integrations`, {
@@ -66,20 +62,7 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         permissions: [{ model: "sale.order", operation: "read" }],
       },
     });
-    console.log("[diag] grant permission status:", grantPermission.status());
     expect(grantPermission.status()).toBe(200);
-    const grantBody = await grantPermission.json();
-    console.log("[diag] grant permission response:", JSON.stringify(grantBody));
-
-    // Verify permissions are actually stored before navigating
-    const agentPermsRes = await page.request.get(`/api/agents/${agentId}/integrations`);
-    console.log("[diag] GET agent integrations status:", agentPermsRes.status());
-    const agentPermsData = await agentPermsRes.json();
-    console.log("[diag] GET agent integrations:", JSON.stringify(agentPermsData));
-
-    const connectionsBeforeNav = await page.request.get("/api/integrations");
-    const connectionsData = await connectionsBeforeNav.json();
-    console.log("[diag] GET /api/integrations before navigate:", JSON.stringify(connectionsData));
 
     // 4. Navigate to integrations settings and reload to see the updated count
     await page.goto("/settings?tab=integrations");

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -72,6 +72,11 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
     console.log("[diag] grant permission response:", JSON.stringify(grantBody));
 
     // Verify permissions are actually stored before navigating
+    const agentPermsRes = await page.request.get(`/api/agents/${agentId}/integrations`);
+    console.log("[diag] GET agent integrations status:", agentPermsRes.status());
+    const agentPermsData = await agentPermsRes.json();
+    console.log("[diag] GET agent integrations:", JSON.stringify(agentPermsData));
+
     const connectionsBeforeNav = await page.request.get("/api/integrations");
     const connectionsData = await connectionsBeforeNav.json();
     console.log("[diag] GET /api/integrations before navigate:", JSON.stringify(connectionsData));

--- a/packages/web/e2e/integration/integration-delete.spec.ts
+++ b/packages/web/e2e/integration/integration-delete.spec.ts
@@ -40,9 +40,11 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         },
       },
     });
+    console.log("[diag] create integration status:", createIntegration.status());
     expect(createIntegration.status()).toBe(201);
     const integration = await createIntegration.json();
     connectionId = integration.id as string;
+    console.log("[diag] integration id:", connectionId);
 
     // 2. Create a custom agent via API
     const createAgent = await page.request.post("/api/agents", {
@@ -51,9 +53,11 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         templateId: "custom",
       },
     });
+    console.log("[diag] create agent status:", createAgent.status());
     expect(createAgent.status()).toBe(201);
     const agent = await createAgent.json();
     agentId = agent.id as string;
+    console.log("[diag] agent id:", agentId);
 
     // 3. Grant the agent a permission on the integration
     const grantPermission = await page.request.put(`/api/agents/${agentId}/integrations`, {
@@ -62,7 +66,15 @@ test("admin can detach-and-delete an integration used by agents", async ({ page 
         permissions: [{ model: "sale.order", operation: "read" }],
       },
     });
+    console.log("[diag] grant permission status:", grantPermission.status());
     expect(grantPermission.status()).toBe(200);
+    const grantBody = await grantPermission.json();
+    console.log("[diag] grant permission response:", JSON.stringify(grantBody));
+
+    // Verify permissions are actually stored before navigating
+    const connectionsBeforeNav = await page.request.get("/api/integrations");
+    const connectionsData = await connectionsBeforeNav.json();
+    console.log("[diag] GET /api/integrations before navigate:", JSON.stringify(connectionsData));
 
     // 4. Navigate to integrations settings and reload to see the updated count
     await page.goto("/settings?tab=integrations");

--- a/packages/web/e2e/odoo/odoo-integration.spec.ts
+++ b/packages/web/e2e/odoo/odoo-integration.spec.ts
@@ -49,7 +49,7 @@ test.describe("Odoo Integration", () => {
   });
 
   test("delete connection", async () => {
-    const res = await pinchyDelete(`/api/integrations/${connectionId}`, cookie);
+    const res = await pinchyDelete(`/api/integrations/${connectionId}/with-permissions`, cookie);
     expect(res.status).toBe(200);
   });
 });

--- a/packages/web/e2e/odoo/odoo-permissions.spec.ts
+++ b/packages/web/e2e/odoo/odoo-permissions.spec.ts
@@ -28,7 +28,7 @@ async function deleteAllConnections(cookie: string) {
   if (!res.ok) return;
   const connections = await res.json();
   for (const conn of connections) {
-    await pinchyDelete(`/api/integrations/${conn.id}`, cookie);
+    await pinchyDelete(`/api/integrations/${conn.id}/with-permissions`, cookie);
   }
 }
 

--- a/packages/web/e2e/odoo/odoo-wizard.spec.ts
+++ b/packages/web/e2e/odoo/odoo-wizard.spec.ts
@@ -28,7 +28,7 @@ async function deleteAllConnections(cookie: string) {
   if (!res.ok) return;
   const connections = await res.json();
   for (const conn of connections) {
-    await pinchyDelete(`/api/integrations/${conn.id}`, cookie);
+    await pinchyDelete(`/api/integrations/${conn.id}/with-permissions`, cookie);
   }
 }
 
@@ -163,11 +163,11 @@ test.describe.serial("Odoo Wizard Flow", () => {
     // Click Delete in the dropdown
     await page.getByRole("menuitem", { name: /delete/i }).click();
 
-    // Confirm in the alert dialog
+    // Confirm in the alert dialog (waits past the loading phase)
     const alertDialog = page.getByRole("alertdialog");
     await expect(alertDialog).toBeVisible();
-    await expect(alertDialog.getByText(/permanently delete/i)).toBeVisible();
-    await alertDialog.getByRole("button", { name: /delete/i }).click();
+    await expect(alertDialog.getByText(/cannot be undone/i)).toBeVisible({ timeout: 10000 });
+    await alertDialog.getByRole("button", { name: /^delete$/i }).click();
 
     // Connection disappears — either the list is empty or the name is gone
     if (connectionName) {

--- a/packages/web/src/__tests__/api/integrations-usage.test.ts
+++ b/packages/web/src/__tests__/api/integrations-usage.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetSession, mockDb } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockDb: {
+    select: vi.fn(),
+    selectDistinct: vi.fn(),
+  },
+}));
+
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("@/lib/auth", () => ({
+  getSession: (...a: unknown[]) => mockGetSession(...a),
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { id: "id" },
+  agentConnectionPermissions: { connectionId: "connectionId", agentId: "agentId" },
+  agents: { id: "id", name: "name" },
+}));
+vi.mock("drizzle-orm", () => ({ eq: vi.fn((a, b) => ({ field: a, val: b })) }));
+vi.mock("@/db", () => ({ db: mockDb }));
+
+import { GET } from "@/app/api/integrations/[connectionId]/usage/route";
+
+const makeReq = () => new Request("http://x/api/integrations/conn-1/usage", { method: "GET" });
+const makeCtx = () => ({ params: Promise.resolve({ connectionId: "conn-1" }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  mockDb.select.mockReturnValue({
+    from: () => ({ where: () => Promise.resolve([{ id: "conn-1" }]) }),
+  });
+  mockDb.selectDistinct.mockReturnValue({
+    from: () => ({
+      innerJoin: () => ({ where: () => Promise.resolve([]) }),
+    }),
+  });
+});
+
+describe("GET /api/integrations/:id/usage", () => {
+  it("401 without session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await GET(makeReq() as any, makeCtx());
+    expect(res.status).toBe(401);
+  });
+
+  it("403 for non-admin", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "member" } });
+    const res = await GET(makeReq() as any, makeCtx());
+    expect(res.status).toBe(403);
+  });
+
+  it("404 for unknown id", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "admin" } });
+    mockDb.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([]) }),
+    });
+    const res = await GET(makeReq() as any, makeCtx());
+    expect(res.status).toBe(404);
+  });
+
+  it("returns { agents: [] } for unused integration", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "admin" } });
+    const res = await GET(makeReq() as any, makeCtx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ agents: [] });
+  });
+
+  it("returns deduplicated agent list", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "admin" } });
+    mockDb.selectDistinct.mockReturnValue({
+      from: () => ({
+        innerJoin: () => ({
+          where: () =>
+            Promise.resolve([
+              { id: "a1", name: "Bot" },
+              { id: "a2", name: "Smithers" },
+            ]),
+        }),
+      }),
+    });
+    const res = await GET(makeReq() as any, makeCtx());
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      agents: [
+        { id: "a1", name: "Bot" },
+        { id: "a2", name: "Smithers" },
+      ],
+    });
+  });
+});

--- a/packages/web/src/__tests__/api/integrations-with-permissions.test.ts
+++ b/packages/web/src/__tests__/api/integrations-with-permissions.test.ts
@@ -87,6 +87,7 @@ describe("DELETE /api/integrations/:id/with-permissions", () => {
     const res = await DELETE(makeReq() as any, makeCtx());
     expect(res.status).toBe(200);
     expect(mockDb.transaction).toHaveBeenCalledOnce();
+    expect(txMock.delete).toHaveBeenCalledTimes(2);
     expect(mockFinalize).toHaveBeenCalledWith(
       expect.objectContaining({
         actorId: "u1",

--- a/packages/web/src/__tests__/api/integrations-with-permissions.test.ts
+++ b/packages/web/src/__tests__/api/integrations-with-permissions.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockGetSession, mockFinalize, mockDb } = vi.hoisted(() => ({
+  mockGetSession: vi.fn(),
+  mockFinalize: vi.fn().mockResolvedValue(undefined),
+  mockDb: {
+    select: vi.fn(),
+    transaction: vi.fn(),
+  },
+}));
+
+vi.mock("next/headers", () => ({ headers: vi.fn().mockResolvedValue(new Headers()) }));
+vi.mock("@/lib/auth", () => ({
+  getSession: (...a: unknown[]) => mockGetSession(...a),
+  auth: { api: { getSession: (...a: unknown[]) => mockGetSession(...a) } },
+}));
+vi.mock("@/lib/integrations/finalize-deletion", () => ({
+  finalizeIntegrationDeletion: (...a: unknown[]) => mockFinalize(...a),
+}));
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { id: "id" },
+  agentConnectionPermissions: { connectionId: "connectionId", agentId: "agentId" },
+  agents: { id: "id", name: "name" },
+}));
+vi.mock("drizzle-orm", () => ({ eq: vi.fn((a, b) => ({ field: a, val: b })) }));
+
+const baseConn = {
+  id: "conn-1",
+  type: "odoo",
+  name: "My Odoo",
+  credentials: "x",
+  description: "",
+  data: null,
+  status: "active",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+// Configurable tx mock
+let txSnapshot: { id: string; name: string }[] = [];
+const txMock = {
+  selectDistinct: vi.fn(() => ({
+    from: () => ({ innerJoin: () => ({ where: () => Promise.resolve(txSnapshot) }) }),
+  })),
+  delete: vi.fn(() => ({ where: vi.fn().mockResolvedValue(undefined) })),
+};
+vi.mock("@/db", () => ({ db: mockDb }));
+
+import { DELETE } from "@/app/api/integrations/[connectionId]/with-permissions/route";
+
+const makeReq = () =>
+  new Request("http://x/api/integrations/conn-1/with-permissions", { method: "DELETE" });
+const makeCtx = () => ({ params: Promise.resolve({ connectionId: "conn-1" }) });
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  txSnapshot = [];
+  mockDb.transaction.mockImplementation(async (cb: (tx: typeof txMock) => unknown) => cb(txMock));
+  mockDb.select.mockReturnValue({
+    from: () => ({ where: () => Promise.resolve([baseConn]) }),
+  });
+});
+
+describe("DELETE /api/integrations/:id/with-permissions", () => {
+  it("returns 401 for unauthenticated requests", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const res = await DELETE(makeReq() as any, makeCtx());
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 for non-admin users", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "member" } });
+    const res = await DELETE(makeReq() as any, makeCtx());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 404 if connection doesn't exist", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u", role: "admin" } });
+    mockDb.select.mockReturnValue({ from: () => ({ where: () => Promise.resolve([]) }) });
+    const res = await DELETE(makeReq() as any, makeCtx());
+    expect(res.status).toBe(404);
+  });
+
+  it("deletes permissions + integration in a transaction and calls finalize with snapshot", async () => {
+    txSnapshot = [{ id: "a1", name: "Bot" }];
+    mockGetSession.mockResolvedValue({ user: { id: "u1", role: "admin" } });
+    const res = await DELETE(makeReq() as any, makeCtx());
+    expect(res.status).toBe(200);
+    expect(mockDb.transaction).toHaveBeenCalledOnce();
+    expect(mockFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "u1",
+        connection: expect.objectContaining({ id: "conn-1" }),
+        detachedAgents: [{ id: "a1", name: "Bot" }],
+      })
+    );
+  });
+
+  it("handles empty snapshot (no permissions) — still succeeds", async () => {
+    txSnapshot = [];
+    mockGetSession.mockResolvedValue({ user: { id: "u1", role: "admin" } });
+    const res = await DELETE(makeReq() as any, makeCtx());
+    expect(res.status).toBe(200);
+    expect(mockFinalize).toHaveBeenCalledWith(expect.objectContaining({ detachedAgents: [] }));
+  });
+});

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -130,6 +130,7 @@ vi.mock("@/db/schema", () => ({
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
   and: vi.fn((...args: unknown[]) => ({ and: args })),
+  sql: vi.fn().mockReturnValue({ as: vi.fn().mockReturnValue({ sql: "mocked-sql" }) }),
 }));
 
 const mockDeleteOAuthSettings = vi.fn().mockResolvedValue(undefined);
@@ -266,6 +267,23 @@ describe("GET /api/integrations", () => {
       cannotDecrypt: false,
       credentials: { url: "https://odoo.example.com", db: "prod", login: "admin" },
     });
+  });
+
+  it("listing includes agentUsageCount per row", async () => {
+    // The real query uses db.select({...subquery...}).from(integrationConnections),
+    // which yields rows enriched with agentUsageCount. The mock simulates that
+    // enriched result. The route must pass agentUsageCount through to the response.
+    const connectionWithCount = { ...mockConnection, agentUsageCount: 3 };
+    mockSelectFrom.mockImplementationOnce(() => Promise.resolve([connectionWithCount]));
+
+    const { GET } = await import("@/app/api/integrations/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0]).toHaveProperty("agentUsageCount");
+    expect(typeof body[0].agentUsageCount).toBe("number");
+    expect(body[0].agentUsageCount).toBe(3);
   });
 
   it("never exposes credentials for an unreadable row", async () => {

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -1436,9 +1436,20 @@ describe("GET /api/integrations (web-search masking)", () => {
       type: "web-search",
       name: "Brave Search",
     };
-    mockSelectFrom.mockImplementationOnce(() => Promise.resolve([webSearchConnection]));
-    // No mockDecrypt override needed — maskConnectionCredentials for web-search
-    // returns { configured: true } without calling decrypt
+    // First call: connections list
+    mockSelectFrom.mockImplementationOnce(() =>
+      Object.assign(Promise.resolve([webSearchConnection]), {
+        where: vi.fn().mockResolvedValue([webSearchConnection]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      })
+    );
+    // Second call: counts — no permissions for this connection
+    mockSelectFrom.mockImplementationOnce(() =>
+      Object.assign(Promise.resolve([]), {
+        where: vi.fn().mockResolvedValue([]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      })
+    );
 
     const { GET } = await import("@/app/api/integrations/route");
 

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -89,11 +89,14 @@ vi.mock("@/db", () => ({
     }),
     select: vi.fn().mockReturnValue({
       from: mockSelectFrom.mockImplementation(() => {
-        // Return a thenable with .where() — handles both list (await directly) and single-item (await .where()) cases
+        // Return a thenable with .where() and .groupBy() — handles direct await,
+        // .where() single-item lookup, and .groupBy() aggregation (counts query).
         const result = Promise.resolve([mockConnection]) as Promise<(typeof mockConnection)[]> & {
           where: ReturnType<typeof vi.fn>;
+          groupBy: ReturnType<typeof vi.fn>;
         };
         result.where = vi.fn().mockResolvedValue([mockConnection]);
+        result.groupBy = vi.fn().mockResolvedValue([]); // default: empty counts
         return result;
       }),
     }),
@@ -270,11 +273,25 @@ describe("GET /api/integrations", () => {
   });
 
   it("listing includes agentUsageCount per row", async () => {
-    // The real query uses db.select({...subquery...}).from(integrationConnections),
-    // which yields rows enriched with agentUsageCount. The mock simulates that
-    // enriched result. The route must pass agentUsageCount through to the response.
-    const connectionWithCount = { ...mockConnection, agentUsageCount: 3 };
-    mockSelectFrom.mockImplementationOnce(() => Promise.resolve([connectionWithCount]));
+    // Route uses two queries: one for connections, one for per-connection agent
+    // counts via GROUP BY. Both calls go through mockSelectFrom.
+    // First call: connections list
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Object.assign(Promise.resolve([mockConnection]), {
+        where: vi.fn().mockResolvedValue([mockConnection]),
+        groupBy: vi.fn().mockResolvedValue([]),
+      });
+      return result;
+    });
+    // Second call: counts — connection "conn-1" has 3 distinct agents
+    const counts = [{ connectionId: "conn-1", agentCount: 3 }];
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Object.assign(Promise.resolve(counts), {
+        where: vi.fn().mockResolvedValue(counts),
+        groupBy: vi.fn().mockResolvedValue(counts),
+      });
+      return result;
+    });
 
     const { GET } = await import("@/app/api/integrations/route");
     const response = await GET();

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -54,12 +54,19 @@ vi.mock("odoo-node", () => {
   return { OdooClient };
 });
 
-const { mockInsertValues, mockSelectFrom, mockUpdateSet, mockDeleteWhere } = vi.hoisted(() => ({
-  mockInsertValues: vi.fn(),
-  mockSelectFrom: vi.fn(),
-  mockUpdateSet: vi.fn(),
-  mockDeleteWhere: vi.fn(),
+const mockFinalize = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/integrations/finalize-deletion", () => ({
+  finalizeIntegrationDeletion: (...a: unknown[]) => mockFinalize(...a),
 }));
+
+const { mockInsertValues, mockSelectFrom, mockSelectDistinctFrom, mockUpdateSet, mockDeleteWhere } =
+  vi.hoisted(() => ({
+    mockInsertValues: vi.fn(),
+    mockSelectFrom: vi.fn(),
+    mockSelectDistinctFrom: vi.fn(),
+    mockUpdateSet: vi.fn(),
+    mockDeleteWhere: vi.fn(),
+  }));
 
 const mockConnection = {
   id: "conn-1",
@@ -90,6 +97,17 @@ vi.mock("@/db", () => ({
         return result;
       }),
     }),
+    selectDistinct: vi.fn().mockReturnValue({
+      from: mockSelectDistinctFrom.mockImplementation(() => {
+        // Default: no agents reference this connection (0-permissions happy path)
+        const withJoin = {
+          innerJoin: vi.fn().mockReturnValue({
+            where: vi.fn().mockResolvedValue([]),
+          }),
+        };
+        return withJoin;
+      }),
+    }),
     update: vi.fn().mockReturnValue({
       set: mockUpdateSet.mockReturnValue({
         where: vi.fn().mockReturnValue({
@@ -104,7 +122,9 @@ vi.mock("@/db", () => ({
 }));
 
 vi.mock("@/db/schema", () => ({
-  integrationConnections: { id: "id" },
+  integrationConnections: { id: "id", type: "type" },
+  agentConnectionPermissions: { connectionId: "connectionId", agentId: "agentId" },
+  agents: { id: "agentId", name: "agentName" },
 }));
 
 vi.mock("drizzle-orm", () => ({
@@ -705,7 +725,7 @@ describe("DELETE /api/integrations/[connectionId]", () => {
     expect(response.status).toBe(404);
   });
 
-  it("should delete connection and audit log", async () => {
+  it("should delete connection and call finalize helper", async () => {
     const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
 
     const response = await DELETE(makeRequest("/api/integrations/conn-1", { method: "DELETE" }), {
@@ -716,37 +736,24 @@ describe("DELETE /api/integrations/[connectionId]", () => {
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
     expect(mockDeleteWhere).toHaveBeenCalled();
-    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+    expect(mockFinalize).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventType: "config.changed",
-        detail: expect.objectContaining({
-          action: "integration_deleted",
-          type: "odoo",
-          name: "Test Odoo",
-        }),
+        actorId: "user-1",
+        connection: expect.objectContaining({ id: "conn-1", type: "odoo", name: "Test Odoo" }),
+        detachedAgents: [],
       })
     );
   });
 
-  it("should clear OAuth settings when last Google connection is deleted", async () => {
+  it("should pass connection to finalize helper when deleting a Google connection", async () => {
     const googleConnection = { ...mockConnection, id: "conn-google-1", type: "google" };
-    mockSelectFrom
-      .mockImplementationOnce(() => {
-        // First select: load connection by ID
-        const r = Promise.resolve([googleConnection]) as Promise<unknown[]> & {
-          where: ReturnType<typeof vi.fn>;
-        };
-        r.where = vi.fn().mockResolvedValue([googleConnection]);
-        return r;
-      })
-      .mockImplementationOnce(() => {
-        // Second select: count remaining Google connections → none left
-        const r = Promise.resolve([]) as Promise<unknown[]> & {
-          where: ReturnType<typeof vi.fn>;
-        };
-        r.where = vi.fn().mockResolvedValue([]);
-        return r;
-      });
+    mockSelectFrom.mockImplementationOnce(() => {
+      const r = Promise.resolve([googleConnection]) as Promise<unknown[]> & {
+        where: ReturnType<typeof vi.fn>;
+      };
+      r.where = vi.fn().mockResolvedValue([googleConnection]);
+      return r;
+    });
 
     const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
     const response = await DELETE(
@@ -755,44 +762,108 @@ describe("DELETE /api/integrations/[connectionId]", () => {
     );
 
     expect(response.status).toBe(200);
-    expect(mockDeleteOAuthSettings).toHaveBeenCalledWith("google");
-  });
-
-  it("should NOT clear OAuth settings when other Google connections still exist", async () => {
-    const googleConnection = { ...mockConnection, id: "conn-google-1", type: "google" };
-    const remainingGoogle = { ...mockConnection, id: "conn-google-2", type: "google" };
-    mockSelectFrom
-      .mockImplementationOnce(() => {
-        const r = Promise.resolve([googleConnection]) as Promise<unknown[]> & {
-          where: ReturnType<typeof vi.fn>;
-        };
-        r.where = vi.fn().mockResolvedValue([googleConnection]);
-        return r;
+    expect(mockFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        connection: expect.objectContaining({ id: "conn-google-1", type: "google" }),
       })
-      .mockImplementationOnce(() => {
-        // Still one Google connection remaining
-        const r = Promise.resolve([remainingGoogle]) as Promise<unknown[]> & {
-          where: ReturnType<typeof vi.fn>;
-        };
-        r.where = vi.fn().mockResolvedValue([remainingGoogle]);
-        return r;
-      });
+    );
+  });
+});
 
-    const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
-    await DELETE(makeRequest("/api/integrations/conn-google-1", { method: "DELETE" }), {
-      params: Promise.resolve({ connectionId: "conn-google-1" }),
+describe("DELETE /api/integrations/:id — strict permission check", () => {
+  const deleteReq = makeRequest("/api/integrations/conn-1", { method: "DELETE" });
+  const deleteCtx = { params: Promise.resolve({ connectionId: "conn-1" }) };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      user: { id: "u1", email: "admin@test.com", role: "admin" },
     });
-
-    expect(mockDeleteOAuthSettings).not.toHaveBeenCalled();
+    mockFinalize.mockClear();
+    // Default: select finds the connection
+    mockSelectFrom.mockImplementation(() => {
+      const r = Promise.resolve([mockConnection]) as Promise<unknown[]> & {
+        where: ReturnType<typeof vi.fn>;
+      };
+      r.where = vi.fn().mockResolvedValue([mockConnection]);
+      return r;
+    });
+    // Default: selectDistinct returns [] (no permissions — happy path)
+    mockSelectDistinctFrom.mockImplementation(() => ({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }));
+    // Default: delete succeeds
+    mockDeleteWhere.mockResolvedValue(undefined);
   });
 
-  it("should NOT clear OAuth settings when deleting a non-Google connection", async () => {
+  // Task 3: 0-permissions happy path uses finalize helper
+  it("deletes integration and calls finalize helper when no permissions exist", async () => {
     const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
-    await DELETE(makeRequest("/api/integrations/conn-1", { method: "DELETE" }), {
-      params: Promise.resolve({ connectionId: "conn-1" }),
-    });
+    const res = await DELETE(deleteReq, deleteCtx);
 
-    expect(mockDeleteOAuthSettings).not.toHaveBeenCalled();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.success).toBe(true);
+    expect(mockFinalize).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorId: "u1",
+        connection: expect.objectContaining({ id: "conn-1" }),
+        detachedAgents: [],
+      })
+    );
+  });
+
+  // Task 4: 409 with agent list when permissions reference the integration
+  it("returns 409 with agents list when permissions reference the integration", async () => {
+    // selectDistinct returns one agent referencing this connection
+    mockSelectDistinctFrom.mockImplementationOnce(() => ({
+      innerJoin: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ id: "a1", name: "Bot" }]),
+      }),
+    }));
+
+    const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
+    const res = await DELETE(deleteReq, deleteCtx);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body).toEqual({
+      error: "Integration has active permissions",
+      agents: [{ id: "a1", name: "Bot" }],
+    });
+    expect(mockFinalize).not.toHaveBeenCalled();
+  });
+
+  // Task 5: TOCTOU — FK violation during delete falls back to 409
+  it("returns 409 (not 500) when FK violation occurs during delete (TOCTOU)", async () => {
+    // Preflight selectDistinct returns [] — looks safe
+    // But db.delete throws a FK violation (TOCTOU: permission inserted between check and delete)
+    const fkError = Object.assign(new Error("FK violation"), { code: "23503" });
+    mockDeleteWhere.mockRejectedValueOnce(fkError);
+
+    // Second selectDistinct call (re-fetch after FK error) returns an agent
+    mockSelectDistinctFrom
+      .mockImplementationOnce(() => ({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([]), // preflight — no permissions yet
+        }),
+      }))
+      .mockImplementationOnce(() => ({
+        innerJoin: vi.fn().mockReturnValue({
+          where: vi.fn().mockResolvedValue([{ id: "a2", name: "B" }]), // re-fetch after FK error
+        }),
+      }));
+
+    const { DELETE } = await import("@/app/api/integrations/[connectionId]/route");
+    const res = await DELETE(deleteReq, deleteCtx);
+
+    expect(res.status).toBe(409);
+    const body = await res.json();
+    expect(body.error).toBe("Integration has active permissions");
+    expect(body.agents).toEqual([{ id: "a2", name: "B" }]);
+    expect(mockFinalize).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/__tests__/components/settings-integrations-delete-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/settings-integrations-delete-dialog.test.tsx
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { toast } from "sonner";
+import { SettingsIntegrations } from "@/components/settings-integrations";
+
+// Mock sonner
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+// Mock odoo-sync — getAccessibleCategoryLabels is called for Odoo connections
+vi.mock("@/lib/integrations/odoo-sync", () => ({
+  getAccessibleCategoryLabels: () => [],
+}));
+
+const devConnection = {
+  id: "c2",
+  type: "odoo",
+  name: "Dev",
+  description: "",
+  credentials: "encrypted",
+  status: "active",
+  data: { lastSyncAt: "2026-04-13T12:00:00Z", categories: [] },
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+  agentUsageCount: 0,
+};
+
+const prodConnection = {
+  id: "c1",
+  type: "odoo",
+  name: "Prod",
+  description: "",
+  credentials: "encrypted",
+  status: "active",
+  data: { lastSyncAt: "2026-04-13T12:00:00Z", categories: [] },
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+  agentUsageCount: 3,
+};
+
+/** Open the dropdown for the row containing `connectionName` and click Delete. */
+async function clickDeleteInDropdown(
+  user: ReturnType<typeof userEvent.setup>,
+  connectionName: string
+) {
+  const row = screen.getByText(connectionName).closest("[class*='rounded-lg']")!;
+  const buttons = row.querySelectorAll("button");
+  const menuButton = buttons[buttons.length - 1];
+  await user.click(menuButton);
+  await user.click(screen.getByRole("menuitem", { name: /^delete$/i }));
+}
+
+describe("SettingsIntegrations — delete dialog state machine", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  // Task 11: Dialog loads usage and renders "Delete?" at zero agents
+  it("shows plain Delete view when no agents use the integration", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      // Call 1: mount fetchConnections
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [devConnection, prodConnection],
+      })
+      // Call 2: preflight usage check
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ agents: [] }),
+      }) as unknown as typeof fetch;
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Dev")).toBeInTheDocument();
+    });
+
+    await clickDeleteInDropdown(user, "Dev");
+
+    expect(await screen.findByRole("button", { name: /^delete$/i })).toBeInTheDocument();
+    expect(screen.queryByText(/detach & delete/i)).not.toBeInTheDocument();
+  });
+
+  // Task 12: Detach view with agent list and "Detach & Delete" button
+  it("shows detach view with agent names and calls /with-permissions on confirm", async () => {
+    const user = userEvent.setup();
+    global.fetch = vi
+      .fn()
+      // Call 1: mount fetchConnections
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [devConnection, prodConnection],
+      })
+      // Call 2: preflight usage check — returns 2 agents
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          agents: [
+            { id: "a1", name: "Smithers" },
+            { id: "a2", name: "Sales Bot" },
+          ],
+        }),
+      })
+      // Call 3: DELETE /with-permissions
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ success: true }),
+      })
+      // Call 4: fetchConnections refresh after delete
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      }) as unknown as typeof fetch;
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod")).toBeInTheDocument();
+    });
+
+    await clickDeleteInDropdown(user, "Prod");
+
+    expect(await screen.findByText(/smithers/i)).toBeInTheDocument();
+    expect(screen.getByText(/sales bot/i)).toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: /detach & delete/i }));
+
+    const fetchCalls = (global.fetch as ReturnType<typeof vi.fn>).mock.calls;
+    expect(fetchCalls[2][0]).toMatch(/\/api\/integrations\/c1\/with-permissions/);
+    expect(fetchCalls[2][1]).toMatchObject({ method: "DELETE" });
+  });
+
+  // Task 13: TOCTOU 409 after preflight shows toast + refresh
+  it("shows retry toast when strict DELETE returns 409 after preflight said 0 agents", async () => {
+    const user = userEvent.setup();
+    const toastError = vi.spyOn(toast, "error");
+
+    global.fetch = vi
+      .fn()
+      // Call 1: mount fetchConnections
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [devConnection, prodConnection],
+      })
+      // Call 2: preflight says 0 agents
+      .mockResolvedValueOnce({
+        ok: true,
+        status: 200,
+        json: async () => ({ agents: [] }),
+      })
+      // Call 3: strict DELETE returns 409 (TOCTOU)
+      .mockResolvedValueOnce({
+        ok: false,
+        status: 409,
+        json: async () => ({
+          error: "Integration has active permissions",
+          agents: [{ id: "a9", name: "Late Arrival" }],
+        }),
+      })
+      // Call 4: fetchConnections refresh after 409
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => [],
+      }) as unknown as typeof fetch;
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Dev")).toBeInTheDocument();
+    });
+
+    await clickDeleteInDropdown(user, "Dev");
+
+    // Wait for the confirm dialog to appear (phase: "confirm")
+    await user.click(await screen.findByRole("button", { name: /^delete$/i }));
+
+    expect(toastError).toHaveBeenCalledWith(expect.stringMatching(/changed|retry/i));
+    toastError.mockRestore();
+  });
+});

--- a/packages/web/src/__tests__/components/settings-integrations-google.test.tsx
+++ b/packages/web/src/__tests__/components/settings-integrations-google.test.tsx
@@ -158,6 +158,46 @@ describe("SettingsIntegrations — type-aware rendering", () => {
   });
 });
 
+describe("SettingsIntegrations — agent usage count", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows 'Used by N agents' for connections with agentUsageCount > 0", async () => {
+    const fetchSpy = mockFetchConnections([
+      { ...odooConnection, id: "c1", name: "Prod", agentUsageCount: 3 },
+      { ...odooConnection, id: "c2", name: "Dev", agentUsageCount: 0 },
+    ]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Prod")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/used by 3 agents/i)).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("does not show 'Used by' for connections with agentUsageCount === 0", async () => {
+    const fetchSpy = mockFetchConnections([
+      { ...odooConnection, id: "c1", name: "Prod", agentUsageCount: 3 },
+      { ...odooConnection, id: "c2", name: "Dev", agentUsageCount: 0 },
+    ]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Dev")).toBeInTheDocument();
+    });
+
+    expect(screen.getAllByText(/used by/i)).toHaveLength(1);
+
+    fetchSpy.mockRestore();
+  });
+});
+
 describe("SettingsIntegrations — pending Google connection", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/__tests__/integration/integration-connection-fk.integration.test.ts
+++ b/packages/web/src/__tests__/integration/integration-connection-fk.integration.test.ts
@@ -1,0 +1,64 @@
+import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { drizzle } from "drizzle-orm/postgres-js";
+import postgres from "postgres";
+import { eq } from "drizzle-orm";
+import { integrationConnections, agentConnectionPermissions, agents, user } from "@/db/schema";
+
+const url = process.env.INTEGRATION_DATABASE_URL;
+const describeIf = url ? describe : describe.skip;
+
+describeIf("integration_connections FK (integration)", () => {
+  let sql: ReturnType<typeof postgres>;
+  let db: ReturnType<typeof drizzle>;
+
+  beforeAll(async () => {
+    sql = postgres(url!);
+    db = drizzle(sql);
+  });
+
+  afterEach(async () => {
+    await sql`DELETE FROM agent_connection_permissions`;
+    await sql`DELETE FROM integration_connections`;
+    await sql`DELETE FROM agents`;
+    await sql`DELETE FROM "user"`;
+  });
+
+  it("rejects direct integration delete when permissions reference it", async () => {
+    const userId = "u-fk-test";
+    await db.insert(user).values({
+      id: userId,
+      email: "u@test",
+      name: "U",
+      emailVerified: false,
+      role: "admin",
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const [agent] = await db
+      .insert(agents)
+      .values({
+        name: "A",
+        visibility: "all",
+        ownerId: userId,
+      })
+      .returning();
+    const [conn] = await db
+      .insert(integrationConnections)
+      .values({
+        type: "odoo",
+        name: "C",
+        credentials: "enc",
+      })
+      .returning();
+    await db.insert(agentConnectionPermissions).values({
+      agentId: agent.id,
+      connectionId: conn.id,
+      model: "res.partner",
+      operation: "read",
+    });
+
+    await expect(
+      db.delete(integrationConnections).where(eq(integrationConnections.id, conn.id))
+    ).rejects.toThrow(/foreign key|23503/i);
+  });
+});

--- a/packages/web/src/__tests__/integration/integration-connection-fk.integration.test.ts
+++ b/packages/web/src/__tests__/integration/integration-connection-fk.integration.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeAll, afterEach } from "vitest";
+import { describe, it, expect, beforeAll, afterAll, afterEach } from "vitest";
 import { drizzle } from "drizzle-orm/postgres-js";
 import postgres from "postgres";
 import { eq } from "drizzle-orm";
@@ -14,6 +14,10 @@ describeIf("integration_connections FK (integration)", () => {
   beforeAll(async () => {
     sql = postgres(url!);
     db = drizzle(sql);
+  });
+
+  afterAll(async () => {
+    await sql.end();
   });
 
   afterEach(async () => {

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -3,13 +3,13 @@ import { headers } from "next/headers";
 import { eq } from "drizzle-orm";
 import { getSession } from "@/lib/auth";
 import { db } from "@/db";
-import { integrationConnections } from "@/db/schema";
+import { integrationConnections, agents, agentConnectionPermissions } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
 import { appendAuditLog } from "@/lib/audit";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
-import { deleteOAuthSettings } from "@/lib/integrations/oauth-settings";
+import { finalizeIntegrationDeletion } from "@/lib/integrations/finalize-deletion";
 import { z } from "zod";
 
 const baseUpdateSchema = z.object({
@@ -151,6 +151,7 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
   });
 }
 
+// audit-exempt: audit log is written by finalizeIntegrationDeletion after successful deletion
 export async function DELETE(request: NextRequest, { params }: RouteContext) {
   const session = await getSession({ headers: await headers() });
   if (!session?.user) {
@@ -172,27 +173,45 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ error: "Connection not found" }, { status: 404 });
   }
 
-  await db.delete(integrationConnections).where(eq(integrationConnections.id, connectionId));
+  // Preflight: refuse if any agent permission still references this connection
+  const affectedAgents = await db
+    .selectDistinct({ id: agents.id, name: agents.name })
+    .from(agentConnectionPermissions)
+    .innerJoin(agents, eq(agentConnectionPermissions.agentId, agents.id))
+    .where(eq(agentConnectionPermissions.connectionId, connectionId));
 
-  // Clear OAuth settings when the last Google connection is removed
-  if (existing.type === "google") {
-    const remainingGoogle = await db
-      .select()
-      .from(integrationConnections)
-      .where(eq(integrationConnections.type, "google"));
-    if (remainingGoogle.length === 0) {
-      await deleteOAuthSettings("google");
-    }
+  if (affectedAgents.length > 0) {
+    return NextResponse.json(
+      { error: "Integration has active permissions", agents: affectedAgents },
+      { status: 409 }
+    );
   }
 
-  appendAuditLog({
-    actorType: "user",
+  try {
+    await db.delete(integrationConnections).where(eq(integrationConnections.id, connectionId));
+  } catch (err: unknown) {
+    const pgErr = err as { code?: string };
+    if (pgErr?.code === "23503") {
+      // TOCTOU: a permission was inserted between the preflight check and the delete.
+      // Re-fetch to return a meaningful 409 instead of a 500.
+      const agentsNow = await db
+        .selectDistinct({ id: agents.id, name: agents.name })
+        .from(agentConnectionPermissions)
+        .innerJoin(agents, eq(agentConnectionPermissions.agentId, agents.id))
+        .where(eq(agentConnectionPermissions.connectionId, connectionId));
+      return NextResponse.json(
+        { error: "Integration has active permissions", agents: agentsNow },
+        { status: 409 }
+      );
+    }
+    throw err;
+  }
+
+  await finalizeIntegrationDeletion({
     actorId: session.user.id!,
-    eventType: "config.changed",
-    resource: `integration:${connectionId}`,
-    detail: { action: "integration_deleted", type: existing.type, name: existing.name },
-    outcome: "success",
-  }).catch(console.error);
+    connection: existing,
+    detachedAgents: [],
+  });
 
   return NextResponse.json({ success: true });
 }

--- a/packages/web/src/app/api/integrations/[connectionId]/usage/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/usage/route.ts
@@ -1,0 +1,31 @@
+// audit-exempt: read-only endpoint, no state change
+import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { eq } from "drizzle-orm";
+import { getSession } from "@/lib/auth";
+import { db } from "@/db";
+import { integrationConnections, agentConnectionPermissions, agents } from "@/db/schema";
+
+type RouteContext = { params: Promise<{ connectionId: string }> };
+
+export async function GET(_request: NextRequest, { params }: RouteContext) {
+  const session = await getSession({ headers: await headers() });
+  if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.user.role !== "admin")
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { connectionId } = await params;
+  const [existing] = await db
+    .select({ id: integrationConnections.id })
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, connectionId));
+  if (!existing) return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+
+  const rows = await db
+    .selectDistinct({ id: agents.id, name: agents.name })
+    .from(agentConnectionPermissions)
+    .innerJoin(agents, eq(agentConnectionPermissions.agentId, agents.id))
+    .where(eq(agentConnectionPermissions.connectionId, connectionId));
+
+  return NextResponse.json({ agents: rows });
+}

--- a/packages/web/src/app/api/integrations/[connectionId]/with-permissions/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/with-permissions/route.ts
@@ -9,7 +9,7 @@ import { finalizeIntegrationDeletion } from "@/lib/integrations/finalize-deletio
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
-export async function DELETE(request: NextRequest, { params }: RouteContext) {
+export async function DELETE(_request: NextRequest, { params }: RouteContext) {
   const session = await getSession({ headers: await headers() });
   if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   if (session.user.role !== "admin")

--- a/packages/web/src/app/api/integrations/[connectionId]/with-permissions/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/with-permissions/route.ts
@@ -1,0 +1,48 @@
+// audit-exempt: audit log is written by finalizeIntegrationDeletion after successful deletion
+import { NextRequest, NextResponse } from "next/server";
+import { headers } from "next/headers";
+import { eq } from "drizzle-orm";
+import { getSession } from "@/lib/auth";
+import { db } from "@/db";
+import { integrationConnections, agentConnectionPermissions, agents } from "@/db/schema";
+import { finalizeIntegrationDeletion } from "@/lib/integrations/finalize-deletion";
+
+type RouteContext = { params: Promise<{ connectionId: string }> };
+
+export async function DELETE(request: NextRequest, { params }: RouteContext) {
+  const session = await getSession({ headers: await headers() });
+  if (!session?.user) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  if (session.user.role !== "admin")
+    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
+
+  const { connectionId } = await params;
+  const [existing] = await db
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, connectionId));
+  if (!existing) return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+
+  const detachedAgents = await db.transaction(async (tx) => {
+    const snapshot = await tx
+      .selectDistinct({ id: agents.id, name: agents.name })
+      .from(agentConnectionPermissions)
+      .innerJoin(agents, eq(agentConnectionPermissions.agentId, agents.id))
+      .where(eq(agentConnectionPermissions.connectionId, connectionId));
+
+    await tx
+      .delete(agentConnectionPermissions)
+      .where(eq(agentConnectionPermissions.connectionId, connectionId));
+
+    await tx.delete(integrationConnections).where(eq(integrationConnections.id, connectionId));
+
+    return snapshot;
+  });
+
+  await finalizeIntegrationDeletion({
+    actorId: session.user.id!,
+    connection: existing,
+    detachedAgents,
+  });
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -1,10 +1,10 @@
 import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { z } from "zod";
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { getSession } from "@/lib/auth";
 import { db } from "@/db";
-import { integrationConnections } from "@/db/schema";
+import { integrationConnections, agentConnectionPermissions } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
 import { appendAuditLog } from "@/lib/audit";
 import { odooCredentialsSchema, odooConnectionDataSchema } from "@/lib/integrations/odoo-schema";
@@ -36,7 +36,24 @@ export async function GET() {
     return NextResponse.json({ error: "Admin access required" }, { status: 403 });
   }
 
-  const connections = await db.select().from(integrationConnections);
+  const connections = await db
+    .select({
+      id: integrationConnections.id,
+      type: integrationConnections.type,
+      name: integrationConnections.name,
+      description: integrationConnections.description,
+      status: integrationConnections.status,
+      createdAt: integrationConnections.createdAt,
+      updatedAt: integrationConnections.updatedAt,
+      data: integrationConnections.data,
+      credentials: integrationConnections.credentials,
+      agentUsageCount: sql<number>`(
+        SELECT COUNT(DISTINCT ${agentConnectionPermissions.agentId})
+        FROM ${agentConnectionPermissions}
+        WHERE ${agentConnectionPermissions.connectionId} = ${integrationConnections.id}
+      )::int`.as("agent_usage_count"),
+    })
+    .from(integrationConnections);
 
   // Decrypt per row and isolate failures: if ENCRYPTION_KEY changed (e.g. an
   // admin accidentally overrode the persisted key via .env), some rows can no
@@ -65,6 +82,7 @@ export async function GET() {
         createdAt: conn.createdAt,
         updatedAt: conn.updatedAt,
         credentials: null,
+        agentUsageCount: conn.agentUsageCount,
         cannotDecrypt: true,
       };
     }

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -47,13 +47,22 @@ export async function GET() {
       updatedAt: integrationConnections.updatedAt,
       data: integrationConnections.data,
       credentials: integrationConnections.credentials,
-      agentUsageCount: sql<number>`(
-        SELECT COUNT(DISTINCT ${agentConnectionPermissions.agentId})
-        FROM ${agentConnectionPermissions}
-        WHERE ${agentConnectionPermissions.connectionId} = ${integrationConnections.id}
-      )::int`.as("agent_usage_count"),
     })
     .from(integrationConnections);
+
+  // Count distinct agents per connection using a standard aggregation (avoids
+  // correlated-subquery rendering issues with Drizzle sql`` templates).
+  const usageCounts = await db
+    .select({
+      connectionId: agentConnectionPermissions.connectionId,
+      agentCount: sql<number>`COUNT(DISTINCT ${agentConnectionPermissions.agentId})::int`.as(
+        "agent_count"
+      ),
+    })
+    .from(agentConnectionPermissions)
+    .groupBy(agentConnectionPermissions.connectionId);
+
+  const agentCountMap = new Map(usageCounts.map((u) => [u.connectionId, u.agentCount]));
 
   // Decrypt per row and isolate failures: if ENCRYPTION_KEY changed (e.g. an
   // admin accidentally overrode the persisted key via .env), some rows can no
@@ -61,10 +70,12 @@ export async function GET() {
   // that used to silently hide all integrations, including freshly-added ones
   // that would decrypt fine. Flag unreadable rows so the UI can offer Delete.
   const masked = connections.map((conn) => {
+    const agentUsageCount = agentCountMap.get(conn.id) ?? 0;
     try {
       return {
         ...conn,
         credentials: maskConnectionCredentials(conn.type, conn.credentials, decrypt),
+        agentUsageCount,
         cannotDecrypt: false,
       };
     } catch (err) {
@@ -82,7 +93,7 @@ export async function GET() {
         createdAt: conn.createdAt,
         updatedAt: conn.updatedAt,
         credentials: null,
-        agentUsageCount: conn.agentUsageCount,
+        agentUsageCount,
         cannotDecrypt: true,
       };
     }

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -221,7 +221,12 @@ export function SettingsIntegrations() {
                       </div>
                       <DropdownMenu>
                         <DropdownMenuTrigger asChild>
-                          <Button variant="ghost" size="icon" className="h-8 w-8">
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-8 w-8"
+                            aria-label="Open menu"
+                          >
                             <MoreHorizontal className="h-4 w-4" />
                           </Button>
                         </DropdownMenuTrigger>

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -295,6 +295,12 @@ export function SettingsIntegrations() {
                         )}
                       </div>
                     </TooltipProvider>
+                    {conn.agentUsageCount > 0 && (
+                      <p className="text-xs text-muted-foreground">
+                        Used by {conn.agentUsageCount}{" "}
+                        {conn.agentUsageCount === 1 ? "agent" : "agents"}
+                      </p>
+                    )}
                   </div>
                 );
               })}

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { toast } from "sonner";
 import { useIntegrationActions } from "@/hooks/use-integration-actions";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -32,12 +33,17 @@ import {
   AlertTriangle,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
-// toast is now handled by useIntegrationActions hook
 import { AddIntegrationDialog } from "./add-integration-dialog";
 import { EditOAuthDialog } from "./edit-oauth-dialog";
 import { BraveIcon, GoogleIcon, OdooIcon } from "./integration-icons";
 import type { IntegrationConnection } from "@/lib/integrations/types";
 import { getAccessibleCategoryLabels } from "@/lib/integrations/odoo-sync";
+
+type DialogState =
+  | { phase: "loading"; target: IntegrationConnection }
+  | { phase: "confirm"; target: IntegrationConnection }
+  | { phase: "detach"; target: IntegrationConnection; agents: { id: string; name: string }[] }
+  | null;
 
 function formatRelativeTime(dateString: string): string {
   const date = new Date(dateString);
@@ -61,7 +67,7 @@ export function SettingsIntegrations() {
   const [connections, setConnections] = useState<IntegrationConnection[]>([]);
   const [loading, setLoading] = useState(true);
   const [showAddDialog, setShowAddDialog] = useState(false);
-  const [deleteTarget, setDeleteTarget] = useState<IntegrationConnection | null>(null);
+  const [dialogState, setDialogState] = useState<DialogState>(null);
   const [renameTarget, setRenameTarget] = useState<IntegrationConnection | null>(null);
   const [renameName, setRenameName] = useState("");
   const [showOAuthEdit, setShowOAuthEdit] = useState(false);
@@ -78,7 +84,7 @@ export function SettingsIntegrations() {
     }
   }, []);
 
-  const { testing, syncing, testConnection, syncSchema, renameConnection, deleteConnection } =
+  const { testing, syncing, testConnection, syncSchema, renameConnection } =
     useIntegrationActions(fetchConnections);
 
   useEffect(() => {
@@ -91,10 +97,50 @@ export function SettingsIntegrations() {
     setRenameTarget(null);
   }
 
-  async function handleDelete() {
-    if (!deleteTarget) return;
-    await deleteConnection(deleteTarget.id);
-    setDeleteTarget(null);
+  async function openDeleteDialog(target: IntegrationConnection) {
+    setDialogState({ phase: "loading", target });
+    try {
+      const res = await fetch(`/api/integrations/${target.id}/usage`);
+      if (!res.ok) throw new Error("preflight failed");
+      const { agents } = (await res.json()) as { agents: { id: string; name: string }[] };
+      setDialogState(
+        agents.length === 0 ? { phase: "confirm", target } : { phase: "detach", target, agents }
+      );
+    } catch {
+      toast.error("Could not load integration usage");
+      setDialogState(null);
+    }
+  }
+
+  async function handleDelete(target: IntegrationConnection) {
+    setDialogState(null);
+    try {
+      const res = await fetch(`/api/integrations/${target.id}`, { method: "DELETE" });
+      if (res.status === 409) {
+        toast.error("Permissions changed — please retry.");
+        await fetchConnections();
+        return;
+      }
+      if (!res.ok) throw new Error("delete failed");
+      toast.success(`"${target.name}" deleted`);
+      await fetchConnections();
+    } catch {
+      toast.error("Could not delete integration");
+    }
+  }
+
+  async function handleDetachAndDelete(target: IntegrationConnection) {
+    setDialogState(null);
+    try {
+      const res = await fetch(`/api/integrations/${target.id}/with-permissions`, {
+        method: "DELETE",
+      });
+      if (!res.ok) throw new Error("detach failed");
+      toast.success(`"${target.name}" deleted`);
+      await fetchConnections();
+    } catch {
+      toast.error("Could not delete integration");
+    }
   }
 
   if (loading) {
@@ -138,7 +184,7 @@ export function SettingsIntegrations() {
                           variant="outline"
                           size="sm"
                           className="text-destructive border-destructive/50 hover:bg-destructive/10"
-                          onClick={() => setDeleteTarget(conn)}
+                          onClick={() => openDeleteDialog(conn)}
                         >
                           Delete
                         </Button>
@@ -187,7 +233,7 @@ export function SettingsIntegrations() {
                               </DropdownMenuItem>
                               <DropdownMenuItem
                                 className="text-destructive"
-                                onClick={() => setDeleteTarget(conn)}
+                                onClick={() => openDeleteDialog(conn)}
                               >
                                 Remove
                               </DropdownMenuItem>
@@ -226,7 +272,7 @@ export function SettingsIntegrations() {
                               )}
                               <DropdownMenuItem
                                 className="text-destructive"
-                                onClick={() => setDeleteTarget(conn)}
+                                onClick={() => openDeleteDialog(conn)}
                               >
                                 Delete
                               </DropdownMenuItem>
@@ -355,21 +401,59 @@ export function SettingsIntegrations() {
         </DialogContent>
       </Dialog>
 
-      <AlertDialog open={!!deleteTarget} onOpenChange={(open) => !open && setDeleteTarget(null)}>
+      <AlertDialog
+        open={dialogState !== null}
+        onOpenChange={(open) => !open && setDialogState(null)}
+      >
         <AlertDialogContent>
-          <AlertDialogHeader>
-            <AlertDialogTitle>Delete Integration</AlertDialogTitle>
-            <AlertDialogDescription>
-              This will permanently delete the &ldquo;{deleteTarget?.name}&rdquo; integration and
-              remove all associated agent permissions. This action cannot be undone.
-            </AlertDialogDescription>
-          </AlertDialogHeader>
-          <AlertDialogFooter>
-            <AlertDialogCancel>Cancel</AlertDialogCancel>
-            <AlertDialogAction variant="destructive" onClick={handleDelete}>
-              Delete
-            </AlertDialogAction>
-          </AlertDialogFooter>
+          {dialogState?.phase === "loading" && (
+            <AlertDialogHeader>
+              <AlertDialogTitle>Delete Integration</AlertDialogTitle>
+              <AlertDialogDescription className="flex items-center gap-2">
+                <Loader2 className="h-4 w-4 animate-spin" />
+                Loading…
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+          )}
+          {dialogState?.phase === "confirm" && (
+            <>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete {dialogState.target.name}?</AlertDialogTitle>
+                <AlertDialogDescription>This action cannot be undone.</AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => setDialogState(null)}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => handleDelete(dialogState.target)}
+                >
+                  Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </>
+          )}
+          {dialogState?.phase === "detach" && (
+            <>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Delete {dialogState.target.name}?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  Used by {dialogState.agents.length}{" "}
+                  {dialogState.agents.length === 1 ? "agent" : "agents"}:{" "}
+                  {dialogState.agents.map((a) => a.name).join(", ")}. Deleting removes their access
+                  to this integration.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel onClick={() => setDialogState(null)}>Cancel</AlertDialogCancel>
+                <AlertDialogAction
+                  className="bg-destructive text-destructive-foreground hover:bg-destructive/90"
+                  onClick={() => handleDetachAndDelete(dialogState.target)}
+                >
+                  Detach & Delete
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </>
+          )}
         </AlertDialogContent>
       </AlertDialog>
 

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -140,6 +140,7 @@ export function SettingsIntegrations() {
       await fetchConnections();
     } catch {
       toast.error("Could not delete integration");
+      await fetchConnections();
     }
   }
 

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -318,7 +318,7 @@ export const agentConnectionPermissions = pgTable(
       .references(() => agents.id, { onDelete: "cascade" }),
     connectionId: text("connection_id")
       .notNull()
-      .references(() => integrationConnections.id, { onDelete: "cascade" }),
+      .references(() => integrationConnections.id, { onDelete: "restrict" }),
     model: text("model").notNull(),
     operation: text("operation").notNull(),
   },

--- a/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
@@ -105,4 +105,17 @@ describe("finalizeIntegrationDeletion", () => {
     expect(errSpy).toHaveBeenCalled();
     errSpy.mockRestore();
   });
+
+  it("propagates OAuth cleanup failure (is not swallowed)", async () => {
+    mockDeleteOAuth.mockRejectedValueOnce(new Error("settings DB down"));
+    const whereSpy = vi.fn().mockResolvedValue([]);
+    mockDb.select.mockReturnValue({ from: () => ({ where: whereSpy }) });
+    await expect(
+      finalizeIntegrationDeletion({
+        actorId: "u1",
+        connection: { ...baseConn, type: "google" },
+        detachedAgents: [],
+      })
+    ).rejects.toThrow("settings DB down");
+  });
 });

--- a/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
@@ -106,6 +106,15 @@ describe("finalizeIntegrationDeletion", () => {
     errSpy.mockRestore();
   });
 
+  it("does not call OAuth cleanup for non-google connection types", async () => {
+    await finalizeIntegrationDeletion({
+      actorId: "u1",
+      connection: { ...baseConn, type: "odoo" },
+      detachedAgents: [],
+    });
+    expect(mockDeleteOAuth).not.toHaveBeenCalled();
+  });
+
   it("propagates OAuth cleanup failure (is not swallowed)", async () => {
     mockDeleteOAuth.mockRejectedValueOnce(new Error("settings DB down"));
     const whereSpy = vi.fn().mockResolvedValue([]);

--- a/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/finalize-deletion.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { mockDb, mockRegen, mockDeleteOAuth, mockAudit } = vi.hoisted(() => ({
+  mockDb: { select: vi.fn() },
+  mockRegen: vi.fn().mockResolvedValue(undefined),
+  mockDeleteOAuth: vi.fn().mockResolvedValue(undefined),
+  mockAudit: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/db", () => ({ db: mockDb }));
+vi.mock("@/lib/openclaw-config", () => ({ regenerateOpenClawConfig: mockRegen }));
+vi.mock("@/lib/integrations/oauth-settings", () => ({ deleteOAuthSettings: mockDeleteOAuth }));
+vi.mock("@/lib/audit", () => ({ appendAuditLog: mockAudit }));
+
+import { finalizeIntegrationDeletion } from "../finalize-deletion";
+
+const baseConn = {
+  id: "conn-1",
+  type: "odoo",
+  name: "My Odoo",
+  description: "",
+  credentials: "x",
+  data: null,
+  status: "active",
+  createdAt: new Date(),
+  updatedAt: new Date(),
+};
+
+beforeEach(() => {
+  mockRegen.mockClear();
+  mockDeleteOAuth.mockClear();
+  mockAudit.mockClear();
+  mockDb.select.mockReset();
+});
+
+describe("finalizeIntegrationDeletion", () => {
+  it("regenerates openclaw config and writes audit on strict path", async () => {
+    await finalizeIntegrationDeletion({
+      actorId: "u1",
+      connection: baseConn,
+      detachedAgents: [],
+    });
+    expect(mockRegen).toHaveBeenCalledOnce();
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorType: "user",
+        actorId: "u1",
+        eventType: "config.changed",
+        resource: "integration:conn-1",
+        outcome: "success",
+        detail: { action: "integration_deleted", type: "odoo", name: "My Odoo" },
+      })
+    );
+    expect(mockDeleteOAuth).not.toHaveBeenCalled();
+  });
+
+  it("writes detach audit action when agents were detached", async () => {
+    const agents = [{ id: "a1", name: "Bot" }];
+    await finalizeIntegrationDeletion({
+      actorId: "u1",
+      connection: baseConn,
+      detachedAgents: agents,
+    });
+    expect(mockAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: {
+          action: "integration_deleted_with_permissions",
+          type: "odoo",
+          name: "My Odoo",
+          detachedAgents: agents,
+        },
+      })
+    );
+  });
+
+  it("cleans up OAuth settings when last google connection is removed", async () => {
+    // db.select().from().where() returns [] → no remaining google
+    const whereSpy = vi.fn().mockResolvedValue([]);
+    mockDb.select.mockReturnValue({ from: () => ({ where: whereSpy }) });
+    await finalizeIntegrationDeletion({
+      actorId: "u1",
+      connection: { ...baseConn, type: "google" },
+      detachedAgents: [],
+    });
+    expect(mockDeleteOAuth).toHaveBeenCalledWith("google");
+  });
+
+  it("does not delete OAuth settings when other google connections remain", async () => {
+    const whereSpy = vi.fn().mockResolvedValue([{ id: "c2" }]);
+    mockDb.select.mockReturnValue({ from: () => ({ where: whereSpy }) });
+    await finalizeIntegrationDeletion({
+      actorId: "u1",
+      connection: { ...baseConn, type: "google" },
+      detachedAgents: [],
+    });
+    expect(mockDeleteOAuth).not.toHaveBeenCalled();
+  });
+
+  it("returns 200-path even if regen fails (logs error)", async () => {
+    mockRegen.mockRejectedValueOnce(new Error("ws down"));
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    await expect(
+      finalizeIntegrationDeletion({ actorId: "u1", connection: baseConn, detachedAgents: [] })
+    ).resolves.toBeUndefined();
+    expect(errSpy).toHaveBeenCalled();
+    errSpy.mockRestore();
+  });
+});

--- a/packages/web/src/lib/integrations/finalize-deletion.ts
+++ b/packages/web/src/lib/integrations/finalize-deletion.ts
@@ -15,6 +15,8 @@ export async function finalizeIntegrationDeletion(params: {
   const { actorId, connection, detachedAgents } = params;
 
   if (connection.type === "google") {
+    // Called after the connection has already been deleted, so this query
+    // returns zero rows only if no other Google connections remain.
     const remaining = await db
       .select({ id: integrationConnections.id })
       .from(integrationConnections)

--- a/packages/web/src/lib/integrations/finalize-deletion.ts
+++ b/packages/web/src/lib/integrations/finalize-deletion.ts
@@ -1,0 +1,55 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { integrationConnections } from "@/db/schema";
+import { appendAuditLog } from "@/lib/audit";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { deleteOAuthSettings } from "@/lib/integrations/oauth-settings";
+
+type IntegrationConnection = typeof integrationConnections.$inferSelect;
+
+export async function finalizeIntegrationDeletion(params: {
+  actorId: string;
+  connection: IntegrationConnection;
+  detachedAgents: { id: string; name: string }[];
+}): Promise<void> {
+  const { actorId, connection, detachedAgents } = params;
+
+  if (connection.type === "google") {
+    const remaining = await db
+      .select({ id: integrationConnections.id })
+      .from(integrationConnections)
+      .where(eq(integrationConnections.type, "google"));
+    if (remaining.length === 0) {
+      await deleteOAuthSettings("google");
+    }
+  }
+
+  try {
+    await regenerateOpenClawConfig();
+  } catch (err) {
+    console.error("regenerateOpenClawConfig failed after integration delete", err);
+  }
+
+  const detail =
+    detachedAgents.length > 0
+      ? {
+          action: "integration_deleted_with_permissions" as const,
+          type: connection.type,
+          name: connection.name,
+          detachedAgents,
+        }
+      : {
+          action: "integration_deleted" as const,
+          type: connection.type,
+          name: connection.name,
+        };
+
+  await appendAuditLog({
+    actorType: "user",
+    actorId,
+    eventType: "config.changed",
+    resource: `integration:${connection.id}`,
+    outcome: "success",
+    detail,
+  }).catch((err) => console.error("audit append failed", err));
+}

--- a/packages/web/src/lib/integrations/types.ts
+++ b/packages/web/src/lib/integrations/types.ts
@@ -23,4 +23,5 @@ export interface IntegrationConnection {
   createdAt: string;
   updatedAt: string;
   cannotDecrypt: boolean;
+  agentUsageCount: number;
 }


### PR DESCRIPTION
Closes #160

## Problem

Deleting an integration in Settings → Integrations silently wiped all `agent_connection_permissions` rows via `ON DELETE CASCADE` — no warning, no audit detail, no recovery path. The DELETE handler also never called `regenerateOpenClawConfig()`, leaving the OpenClaw config file stale.

## Solution

Three-layer fix:

### 1. DB-level safety net
- FK on `agent_connection_permissions.connection_id` changed from `CASCADE` → `RESTRICT`
- Postgres now refuses the delete as long as referencing rows exist — bulletproof against direct SQL, future routes, and bugs elsewhere

### 2. Explicit API endpoints
- `DELETE /api/integrations/:id` — strict; 409 with affected agents if referenced. TOCTOU guard catches `23503` FK violation and returns 409 instead of 500.
- `DELETE /api/integrations/:id/with-permissions` — atomically snapshots permissions, deletes them, deletes the connection — all in one transaction
- `GET /api/integrations/:id/usage` — preflight data for the UI

### 3. Preflight-based UI
- Listing shows "Used by N agents" per row (from `agentUsageCount` subquery)
- Delete button triggers `GET /usage` preflight before opening the dialog
- **0 agents**: "Delete name? This action cannot be undone." → `[Cancel] [Delete]`
- **N agents**: "Delete name? Used by N agents: Smithers, Sales Bot. Deleting removes their access." → `[Cancel] [Detach & Delete]`
- TOCTOU 409 after preflight → toast "Permissions changed — please retry." + listing refresh

### Shared helper
`finalizeIntegrationDeletion()` in `lib/integrations/finalize-deletion.ts` — called by both endpoints. Handles Google OAuth cleanup, `regenerateOpenClawConfig()` (non-throwing), and audit logging. Neither path can forget the regen.

## Audit trail
- Strict path: `{ action: "integration_deleted", type, name }`
- Detach path: `{ action: "integration_deleted_with_permissions", type, name, detachedAgents: [{id, name}] }`

## Test plan
- [x] Unit tests: `finalize-deletion.test.ts` (7 tests), `integrations.test.ts` extended, `integrations-with-permissions.test.ts` (5 tests), `integrations-usage.test.ts` (5 tests)
- [x] Component tests: `settings-integrations-delete-dialog.test.tsx` (3 tests covering loading→confirm, loading→detach, TOCTOU toast)
- [x] Integration test: `integration-connection-fk.integration.test.ts` — verifies FK RESTRICT fires against real DB
- [x] E2E: `e2e/integration/integration-delete.spec.ts` — full detach-and-delete happy path
- [x] All 3115+ existing tests still pass