### PR TITLE
Scope 1: Release-process hardening

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -539,6 +539,8 @@ jobs:
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
+          # gh release list returns newest-first (gh CLI v2 default).
+          # .[0] is the latest release; .[1] is the previous one to upgrade from.
           TAG=$(gh release list --repo heypinchy/pinchy --limit 2 --json tagName -q '.[1].tagName // empty')
           if [ -z "$TAG" ]; then
             echo "::notice::No previous release found — skipping upgrade test."
@@ -611,7 +613,7 @@ jobs:
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
       - name: Tear down
-        if: always()
+        if: always() && steps.prev.outputs.skip == 'false'
         working-directory: ${{ steps.install-dir.outputs.path }}
         run: docker compose down -v
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,102 @@ jobs:
         working-directory: ${{ steps.install-dir.outputs.path }}
         run: docker compose down -v
 
+  end-user-upgrade:
+    name: End-user upgrade simulation
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/docker-mirror
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Determine previous release tag
+        id: prev
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          TAG=$(gh release list --repo heypinchy/pinchy --limit 2 --json tagName -q '.[1].tagName // empty')
+          if [ -z "$TAG" ]; then
+            echo "::notice::No previous release found — skipping upgrade test."
+            echo "skip=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "Previous tag: $TAG"
+            echo "tag=$TAG" >> "$GITHUB_OUTPUT"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Build this PR's images locally
+        if: steps.prev.outputs.skip == 'false'
+        run: |
+          docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .
+          docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
+
+      - name: Prepare clean install directory
+        if: steps.prev.outputs.skip == 'false'
+        id: install-dir
+        run: |
+          INSTALL_DIR=$(mktemp -d)
+          cp docker-compose.yml "$INSTALL_DIR/"
+          echo "path=$INSTALL_DIR" >> "$GITHUB_OUTPUT"
+
+      - name: Start previous version and wait healthy
+        if: steps.prev.outputs.skip == 'false'
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          sed -i "s|:latest|:${{ steps.prev.outputs.tag }}|g" docker-compose.yml
+          docker compose pull
+          docker compose up -d
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:7777/api/health; then
+              echo "Previous version healthy"
+              break
+            fi
+            echo "Attempt $i: not ready yet"
+            sleep 2
+            if [ "$i" -eq 30 ]; then
+              echo "::error::Previous version (${{ steps.prev.outputs.tag }}) did not come up"
+              docker compose logs
+              exit 1
+            fi
+          done
+        env:
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Swap to this PR's images and wait healthy (upgrade path)
+        if: steps.prev.outputs.skip == 'false'
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          docker compose stop
+          sed -i "s|:${{ steps.prev.outputs.tag }}|:latest|g" docker-compose.yml
+          docker compose up -d
+          for i in $(seq 1 60); do
+            # 60s because migrations may run on startup
+            if curl -sf http://localhost:7777/api/health; then
+              echo "Upgraded version healthy — migrations succeeded"
+              exit 0
+            fi
+            echo "Attempt $i: not ready yet"
+            sleep 2
+          done
+          echo "::error::Upgrade from ${{ steps.prev.outputs.tag }} did not come up healthy"
+          docker compose logs
+          exit 1
+        env:
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Tear down
+        if: always()
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: docker compose down -v
+
   odoo-e2e:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,21 @@ jobs:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
+      - name: Assert pinchy still binds to 127.0.0.1 after upgrade (not 0.0.0.0)
+        if: steps.prev.outputs.skip == 'false'
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          # Docker bypasses UFW — only 127.0.0.1 binding prevents external access.
+          # Assert the upgrade path doesn't re-expose port 7777 globally (regression guard).
+          BINDING=$(docker inspect \
+            --format '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{.HostIp}}{{end}}{{end}}' \
+            "$(docker compose ps -q pinchy)")
+          echo "Pinchy port binding host IP after upgrade: $BINDING"
+          if [ "$BINDING" != "127.0.0.1" ]; then
+            echo "::error::Pinchy must bind to 127.0.0.1 after upgrade (got '$BINDING'). Docker bypasses UFW, so 0.0.0.0 exposes the port to the internet regardless of firewall rules."
+            exit 1
+          fi
+
       - name: Tear down
         if: always() && steps.prev.outputs.skip == 'false'
         working-directory: ${{ steps.install-dir.outputs.path }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -540,8 +540,8 @@ jobs:
           GH_TOKEN: ${{ github.token }}
         run: |
           # gh release list returns newest-first (gh CLI v2 default).
-          # .[0] is the latest release; .[1] is the previous one to upgrade from.
-          TAG=$(gh release list --repo heypinchy/pinchy --limit 2 --json tagName -q '.[1].tagName // empty')
+          # .[0] is the most recent release — the version real users are upgrading from.
+          TAG=$(gh release list --repo heypinchy/pinchy --limit 1 --json tagName -q '.[0].tagName // empty')
           if [ -z "$TAG" ]; then
             echo "::notice::No previous release found — skipping upgrade test."
             echo "skip=true" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -22,7 +22,7 @@ jobs:
 
       - name: Short SHA
         id: sha
-        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+        run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
@@ -79,6 +79,7 @@ jobs:
           package-type: container
           min-versions-to-keep: 10
           # Safety: only tags matching this pattern will be considered
-          # for deletion. :latest, :next, and :v* tags are NEVER matched.
+          # for deletion. :latest, :next, and semver v* tags (including
+          # pre-release suffixes like v0.5.0-rc.1) are NEVER matched.
           delete-only-pre-release-versions: false
-          ignore-versions: '^(latest|next|v\d+\.\d+\.\d+)$'
+          ignore-versions: '^(latest|next|v\d+\.\d+\.\d+(-[a-zA-Z0-9.]+)?)$'

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -1,0 +1,84 @@
+name: Pre-release
+
+on:
+  push:
+    branches: [main]
+  schedule:
+    # Biweekly: prune old :sha-* tags from GHCR. Runs at 03:00 UTC on the 1st and 15th.
+    - cron: "0 3 1,15 * *"
+  workflow_dispatch: {}
+
+permissions:
+  contents: read
+  packages: write
+
+jobs:
+  build:
+    name: Build & push :next and :sha-<short>
+    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Short SHA
+        id: sha
+        run: echo "short=$(git rev-parse --short=7 HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+        with:
+          config-inline: |
+            [registry."docker.io"]
+              mirrors = ["mirror.gcr.io"]
+
+      - name: Log in to GHCR
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build and push Pinchy image (:next, :sha-<short>)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.pinchy
+          push: true
+          tags: |
+            ghcr.io/heypinchy/pinchy:next
+            ghcr.io/heypinchy/pinchy:sha-${{ steps.sha.outputs.short }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+      - name: Build and push OpenClaw image (:next, :sha-<short>)
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.openclaw
+          push: true
+          tags: |
+            ghcr.io/heypinchy/pinchy-openclaw:next
+            ghcr.io/heypinchy/pinchy-openclaw:sha-${{ steps.sha.outputs.short }}
+          platforms: linux/amd64
+          cache-from: type=gha
+          cache-to: type=gha,mode=max
+
+  prune-sha-tags:
+    name: Prune :sha-* tags older than 30 days
+    if: github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        package: [pinchy, pinchy-openclaw]
+    steps:
+      - name: Delete old :sha-* tags for ${{ matrix.package }}
+        uses: actions/delete-package-versions@v5
+        with:
+          package-name: ${{ matrix.package }}
+          package-type: container
+          min-versions-to-keep: 10
+          # Safety: only tags matching this pattern will be considered
+          # for deletion. :latest, :next, and :v* tags are NEVER matched.
+          delete-only-pre-release-versions: false
+          ignore-versions: '^(latest|next|v\d+\.\d+\.\d+)$'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -78,10 +78,80 @@ jobs:
           cache-from: type=gha
           cache-to: type=gha,mode=max
 
+  end-user-install-published:
+    name: End-user install (published images)
+    runs-on: ubuntu-latest
+    needs: docker
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Ensure no GHCR credentials
+        run: docker logout ghcr.io || true
+
+      - name: Prepare clean install directory
+        id: install-dir
+        run: |
+          INSTALL_DIR=$(mktemp -d)
+          cp docker-compose.yml "$INSTALL_DIR/"
+          echo "path=$INSTALL_DIR" >> "$GITHUB_OUTPUT"
+          echo "Clean install dir: $INSTALL_DIR"
+          ls -la "$INSTALL_DIR"
+
+      - name: Pin image tags to this release
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          # Scope 2 will migrate this to .env-based versioning.
+          # For now: sed :latest → :<tag> in docker-compose.yml.
+          sed -i "s|:latest|:${GITHUB_REF_NAME}|g" docker-compose.yml
+          cat docker-compose.yml
+
+      - name: Pull images anonymously (fails loudly if GHCR is private)
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: docker compose pull
+
+      - name: Start stack from clean install dir
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: docker compose up -d
+        env:
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Wait for health
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:7777/api/health; then
+              echo "Stack healthy"
+              exit 0
+            fi
+            echo "Attempt $i: not ready yet"
+            if [ "$i" -eq 1 ] || [ $((i % 5)) -eq 0 ]; then
+              docker compose ps
+              docker compose logs --tail=20 pinchy
+            fi
+            sleep 2
+          done
+          echo "::error::Published-image install health check failed"
+          docker compose ps
+          docker compose logs
+          exit 1
+
+      - name: Assert all services running
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          RUNNING=$(docker compose ps --format json | jq -rs '[.[] | select(.State == "running")] | length')
+          echo "Running services: $RUNNING"
+          if [ "$RUNNING" -ne 3 ]; then
+            echo "::error::Expected 3 running services, got $RUNNING"
+            docker compose ps
+            exit 1
+          fi
+
   release:
     name: Create GitHub Release
     runs-on: ubuntu-latest
-    needs: docker
+    needs: [docker, end-user-install-published]
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -143,10 +143,29 @@ jobs:
           RUNNING=$(docker compose ps --format json | jq -rs '[.[] | select(.State == "running")] | length')
           echo "Running services: $RUNNING"
           if [ "$RUNNING" -ne 3 ]; then
-            echo "::error::Expected 3 running services, got $RUNNING"
+            echo "::error::Expected 3 running services (pinchy, openclaw, db), got $RUNNING"
             docker compose ps
             exit 1
           fi
+
+      - name: Assert pinchy binds to 127.0.0.1 by default (not 0.0.0.0)
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          # Docker bypasses UFW — only 127.0.0.1 binding prevents external access.
+          # This assertion catches any regression that re-exposes port 7777 globally.
+          BINDING=$(docker inspect \
+            --format '{{range $p, $c := .NetworkSettings.Ports}}{{range $c}}{{.HostIp}}{{end}}{{end}}' \
+            "$(docker compose ps -q pinchy)")
+          echo "Pinchy port binding host IP: $BINDING"
+          if [ "$BINDING" != "127.0.0.1" ]; then
+            echo "::error::Pinchy must bind to 127.0.0.1 by default (got '$BINDING'). Docker bypasses UFW, so 0.0.0.0 exposes the port to the internet regardless of firewall rules."
+            exit 1
+          fi
+
+      - name: Tear down
+        if: always()
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: docker compose down -v
 
   release:
     name: Create GitHub Release

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -178,10 +178,37 @@ jobs:
       - name: Generate versioned cloud-init.yml
         run: sed "s/%%PINCHY_VERSION%%/${GITHUB_REF_NAME}/g" docs/src/snippets/cloud-init.yml > /tmp/cloud-init.yml
 
+      - name: Extract upgrade notes for release body
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          # The new tag (this release) has been pushed but the GitHub Release
+          # for it hasn't been created yet, so `gh release list --limit 1`
+          # returns the *previous* release — the version users are upgrading from.
+          TARGET="${GITHUB_REF_NAME#v}"
+          PREV=$(gh release list --repo "${{ github.repository }}" --limit 1 --json tagName -q '.[0].tagName // empty' | sed 's/^v//')
+          if [ -z "$PREV" ]; then
+            echo "No previous release found — skipping upgrade-notes extraction (first release)."
+            : > /tmp/upgrade-notes.md
+          else
+            echo "Extracting upgrade notes for v${PREV} → v${TARGET}..."
+            {
+              echo "## Upgrade notes"
+              echo ""
+              node scripts/extract-upgrade-notes.mjs "$PREV" "$TARGET"
+              echo ""
+            } > /tmp/upgrade-notes.md
+            echo "=== /tmp/upgrade-notes.md ==="
+            cat /tmp/upgrade-notes.md
+            echo "============================="
+          fi
+
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           generate_release_notes: true
+          # body_path content is pre-pended to the auto-generated notes.
+          body_path: /tmp/upgrade-notes.md
           files: |
             docs/public/installing.html
             /tmp/cloud-init.yml

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -202,7 +202,7 @@ The release script and CI enforce image builds, GHCR visibility, end-user instal
 ### Release steps
 
 1. Complete the checklist above on `main`.
-2. Run `pnpm release 0.5.0`. The script verifies: clean working tree, on `main`, CI green, tag not taken, `upgrading.mdx` has the target-version section, `pnpm audit --audit-level=high --prod` passes, then bumps versions, commits, tags, and pushes.
+2. Run `pnpm release <new-version>` (e.g. `pnpm release 0.5.0`). The script verifies: clean working tree, on `main`, CI green, tag not taken, `upgrading.mdx` has the target-version section, `pnpm audit --audit-level=high --prod` passes, then bumps versions, commits, tags, and pushes.
 3. GitHub Actions runs the release workflow: build + push images, verify GHCR visibility (anonymous pull test), run the end-user install smoke against published images, create the GitHub Release, deploy docs. Any failure means **the release is not installable for end-users — do not announce until fixed.**
 4. Edit the auto-generated GitHub Release notes and insert your drafted `upgrading.mdx` content under an "Upgrade notes" heading.
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -135,7 +135,7 @@ Pinchy uses [Semantic Versioning](https://semver.org/) and tags on `main`.
 Before cutting a tag, the maintainer runs the pre-release build on a dedicated staging instance. Pushes to `main` automatically publish two tags:
 
 - `ghcr.io/heypinchy/pinchy:next` — mutable, always HEAD of `main`
-- `ghcr.io/heypinchy/pinchy:sha-<7-chars>` — immutable per commit
+- `ghcr.io/heypinchy/pinchy:sha-<12-chars>` — immutable per commit
 
 Same for `pinchy-openclaw`.
 
@@ -193,7 +193,7 @@ The release script and CI enforce image builds, GHCR visibility, end-user instal
 - [ ] New Ollama family or new LLM provider added → resolver file + tests exist
 
 **Documentation**
-- [ ] `docs/src/content/docs/guides/upgrading.mdx` — new section drafted for this version (heading format: `## Upgrading from v<prev> to %%PINCHY_VERSION%%`). This content will be inserted into the auto-generated release notes after tag-push.
+- [ ] `docs/src/content/docs/guides/upgrading.mdx` — new section drafted for this version (heading format: `## Upgrading from v<prev> to %%PINCHY_VERSION%%`). The release workflow extracts this section automatically and prepends it to the GitHub Release body under an "Upgrade notes" heading.
 - [ ] `packages/web/src/lib/smithers-soul.ts` — updated if user-facing features changed
 
 **Staging**
@@ -203,8 +203,8 @@ The release script and CI enforce image builds, GHCR visibility, end-user instal
 
 1. Complete the checklist above on `main`.
 2. Run `pnpm release <new-version>` (e.g. `pnpm release 0.5.0`). The script verifies: clean working tree, on `main`, CI green, tag not taken, `upgrading.mdx` has the target-version section, `pnpm audit --audit-level=high --prod` passes, then bumps versions, commits, tags, and pushes.
-3. GitHub Actions runs the release workflow: build + push images, verify GHCR visibility (anonymous pull test), run the end-user install smoke against published images, create the GitHub Release, deploy docs. Any failure means **the release is not installable for end-users — do not announce until fixed.**
-4. Edit the auto-generated GitHub Release notes and insert your drafted `upgrading.mdx` content under an "Upgrade notes" heading.
+3. GitHub Actions runs the release workflow: build + push images, verify GHCR visibility (anonymous pull test), run the end-user install smoke against published images, extract the upgrade notes from `upgrading.mdx`, create the GitHub Release (auto-generated notes with the upgrade-notes section prepended), deploy docs. Any failure means **the release is not installable for end-users — do not announce until fixed.**
+4. Review the auto-generated GitHub Release notes. The "Upgrade notes" section at the top comes from `upgrading.mdx` — if it looks wrong, edit the release on GitHub directly.
 
 ### If the release workflow fails
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -130,47 +130,106 @@ By participating in this project, you agree to our [Code of Conduct](CODE_OF_CON
 
 Pinchy uses [Semantic Versioning](https://semver.org/) and tags on `main`.
 
+### Testing a release candidate
+
+Before cutting a tag, the maintainer runs the pre-release build on a dedicated staging instance. Pushes to `main` automatically publish two tags:
+
+- `ghcr.io/heypinchy/pinchy:next` — mutable, always HEAD of `main`
+- `ghcr.io/heypinchy/pinchy:sha-<7-chars>` — immutable per commit
+
+Same for `pinchy-openclaw`.
+
+**One-time staging setup** on your staging host:
+
+1. Deploy Pinchy normally, but pin `:next` in your `.env`:
+   ```env
+   PINCHY_VERSION=next
+   OPENCLAW_VERSION=next
+   ```
+   (After Scope 2 lands. For now, edit `docker-compose.yml` directly.)
+
+2. Install `/usr/local/bin/update-pinchy`:
+   ```bash
+   #!/usr/bin/env bash
+   set -euo pipefail
+   cd /srv/pinchy
+   LOG=/var/log/pinchy-update.log
+   echo "[$(date -Iseconds)] pulling" | tee -a "$LOG"
+   docker compose pull 2>&1 | tee -a "$LOG"
+   echo "[$(date -Iseconds)] restarting" | tee -a "$LOG"
+   docker compose up -d 2>&1 | tee -a "$LOG"
+   echo "[$(date -Iseconds)] waiting for health" | tee -a "$LOG"
+   for i in $(seq 1 30); do
+     curl -sf http://localhost:7777/api/health \
+       && { echo "healthy" | tee -a "$LOG"; exit 0; }
+     sleep 2
+   done
+   echo "health check failed" | tee -a "$LOG"
+   docker compose ps | tee -a "$LOG"
+   exit 1
+   ```
+   Make it executable: `chmod +x /usr/local/bin/update-pinchy`.
+
+3. Schedule nightly updates via cron or systemd timer:
+   ```cron
+   0 4 * * *  root  /usr/local/bin/update-pinchy
+   ```
+
+**Before each release**, run `sudo update-pinchy` manually during business hours to pull the latest `:next` build, then click through the key flows on staging: Smithers chat, one live integration, one custom agent with chat history.
+
+**Use synthetic data in staging.** Do not restore prod dumps — unnecessary privacy surface.
+
 ### Pre-release checklist
 
-Before running the release script, complete these manual steps:
+The release script and CI enforce image builds, GHCR visibility, end-user install, upgrade path, `pnpm audit`, and the presence of an upgrade-notes section. The items below are the remaining human judgment calls.
 
-**Code & dependencies**
+**Scope**
 - [ ] All feature/fix PRs for this release are merged to `main`
-- [ ] CI is green on `main` (the release script verifies this automatically)
-- [ ] Dependencies up to date (`pnpm outdated` — no critical/security updates pending)
-- [ ] If upgrading OpenClaw: version updated in `Dockerfile.openclaw`
+- [ ] Dependencies reviewed (`pnpm outdated`) — no critical/security updates pending
+- [ ] If upgrading OpenClaw: version bumped in `Dockerfile.openclaw`
 
-**Model resolver**
-- [ ] Every non-`custom` template in `AGENT_TEMPLATES` has a `modelHint` with a valid `tier` — run `pnpm test src/lib/__tests__/agent-templates.test.ts` and confirm green
-- [ ] Model IDs in `src/lib/model-resolver/providers/` still match live provider offerings — spot-check Anthropic/OpenAI/Google changelogs for deprecated model IDs
-- [ ] If new Ollama families gained popularity since last release, update `src/lib/model-resolver/families.ts` and `ollama-cloud.ts`
-- [ ] If a new LLM provider was added, a resolver file exists under `src/lib/model-resolver/providers/<provider>.ts` with tests
+**Model resolver** (only if models or templates changed)
+- [ ] Spot-check Anthropic/OpenAI/Google changelogs for deprecated model IDs referenced in `src/lib/model-resolver/providers/`
+- [ ] New Ollama family or new LLM provider added → resolver file + tests exist
 
 **Documentation**
-- [ ] `docs/src/content/docs/guides/upgrading.mdx` — add a section for the new version (breaking changes, new env vars, migration notes)
-- [ ] `packages/web/src/lib/smithers-soul.ts` — update if user-facing features changed
+- [ ] `docs/src/content/docs/guides/upgrading.mdx` — new section drafted for this version (heading format: `## Upgrading from v<prev> to %%PINCHY_VERSION%%`). This content will be inserted into the auto-generated release notes after tag-push.
+- [ ] `packages/web/src/lib/smithers-soul.ts` — updated if user-facing features changed
 
-Everything else (version bumps in `package.json`, commit, tag, push) is handled automatically by the release script.
+**Staging**
+- [ ] Staging instance on `:next` was clicked through today: Smithers chat, one live integration, one custom agent
 
 ### Release steps
 
-1. Complete the manual checklist above on `main`.
-2. Run the release script:
-   ```bash
-   pnpm release 0.3.0
-   ```
-   The script checks: clean working tree, on `main`, CI green, tag not already taken — then bumps versions, commits, tags, and pushes.
-3. GitHub Actions creates the GitHub Release with auto-generated notes and deploys the docs automatically.
-4. Review the auto-generated release notes on GitHub — edit if needed to highlight breaking changes or upgrade steps.
+1. Complete the checklist above on `main`.
+2. Run `pnpm release 0.5.0`. The script verifies: clean working tree, on `main`, CI green, tag not taken, `upgrading.mdx` has the target-version section, `pnpm audit --audit-level=high --prod` passes, then bumps versions, commits, tags, and pushes.
+3. GitHub Actions runs the release workflow: build + push images, verify GHCR visibility (anonymous pull test), run the end-user install smoke against published images, create the GitHub Release, deploy docs. Any failure means **the release is not installable for end-users — do not announce until fixed.**
+4. Edit the auto-generated GitHub Release notes and insert your drafted `upgrading.mdx` content under an "Upgrade notes" heading.
 
-### First-time-only: publish container images
+### If the release workflow fails
 
-GHCR creates packages as **private** on first push. If you ever add a new image name to `release.yml` (today we publish `pinchy` and `pinchy-openclaw`), do this **once** right after the first release that pushes it, otherwise `docker compose pull` on users' servers will fail with `unauthorized`:
+**GHCR visibility gate (`end-user-install-published` job)**
+A newly-added `ghcr.io/heypinchy/*` package defaulted to private. Fix:
+1. Visit `https://github.com/heypinchy/pinchy/pkgs/container/<image-name>` → **Package settings** → **Change visibility** → **Public**.
+2. Re-run the failed workflow job. Subsequent releases inherit the visibility automatically.
 
-1. If the org's package-visibility policy disallows public packages, open [Org Settings → Packages](https://github.com/organizations/heypinchy/settings/packages) and allow "Public" under "Container image visibility."
-2. Visit the new package page at `https://github.com/heypinchy/pinchy/pkgs/container/<image-name>`, click **Package settings**, and under "Danger Zone" → **Change visibility** set it to **Public**.
+**End-user install published-image fail**
+The published images + `docker-compose.yml` didn't start cleanly. Reproduce locally:
+```bash
+mkdir /tmp/pinchy-verify && cd /tmp/pinchy-verify
+curl -o docker-compose.yml \
+  https://raw.githubusercontent.com/heypinchy/pinchy/<tag>/docker-compose.yml
+docker logout ghcr.io
+docker compose pull
+docker compose up -d
+```
+Fix the root cause and cut a patch release. Tags are immutable — never force-update.
 
-Once public, subsequent tag pushes (every release) inherit the visibility — no recurring step.
+**End-user upgrade fail (CI, before release)**
+A Drizzle migration or config change breaks the upgrade from the previous tag. Reproduce with the CI job's steps locally. Fix before merging; this gate is meant to prevent broken upgrade paths from ever landing on `main`.
+
+**`pnpm audit` fail (release script)**
+A high or critical CVE was flagged in a production dependency. Fix the vulnerability (update the dep or switch to a patched version), or — if the finding is a false positive or acceptable risk — re-run with `--skip-audit` and document the acceptance in the release notes under a "Known issues" subsection.
 
 ## Questions?
 

--- a/scripts/extract-upgrade-notes.mjs
+++ b/scripts/extract-upgrade-notes.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Extracts the upgrade-notes section for a release from upgrading.mdx
+ * and writes it to stdout. Used by the release workflow to prepend the
+ * section to the auto-generated GitHub Release body.
+ *
+ * Usage: node scripts/extract-upgrade-notes.mjs <prev-version> <target-version>
+ *   e.g. node scripts/extract-upgrade-notes.mjs 0.4.4 0.5.0
+ *
+ * Writes the trimmed section body (with %%PINCHY_VERSION%% resolved to
+ * v<target>) to stdout. If no matching section is found, writes nothing
+ * and exits 0 — missing notes is not a release-blocking error at this
+ * stage; the release script's assertUpgradingSectionExists gate runs
+ * earlier and would have rejected a missing section.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { extractUpgradeNotes } from "./lib/release-logic.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const [, , prev, target] = process.argv;
+if (!prev || !target) {
+  process.stderr.write(
+    "Usage: extract-upgrade-notes.mjs <prev-version> <target-version>\n",
+  );
+  process.exit(1);
+}
+
+const mdxPath = resolve(ROOT, "docs/src/content/docs/guides/upgrading.mdx");
+const mdx = readFileSync(mdxPath, "utf8");
+process.stdout.write(extractUpgradeNotes(mdx, prev, target));

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -51,3 +51,43 @@ export function buildTagName(version) {
 export function buildCommitMessage(version) {
   return `chore: release v${version}`;
 }
+
+/**
+ * Escapes a string for safe inclusion in a RegExp pattern.
+ * @param {string} s
+ * @returns {string}
+ */
+function escapeRegex(s) {
+  return s.replace(/[.*+?^${}()|[\]\\]/g, "\\$&");
+}
+
+/**
+ * Asserts that upgrading.mdx contains a section for the target release.
+ *
+ * The heading must explicitly reference both the previous version (as
+ * "from v<prev>") and the target version (either as "to v<target>" or
+ * as "to %%PINCHY_VERSION%%", which is Pinchy's docs convention — the
+ * placeholder is replaced at docs-build time by inject-version.sh).
+ *
+ * Requiring "from v<prev>" prevents a stale heading from a prior release
+ * (e.g. "from v0.4.3 to %%PINCHY_VERSION%%") from silently satisfying
+ * the gate for the next release.
+ *
+ * @param {string} mdx - contents of docs/src/content/docs/guides/upgrading.mdx
+ * @param {string} prevVersion - previous release, no leading 'v' (e.g. "0.4.4")
+ * @param {string} targetVersion - new release, no leading 'v' (e.g. "0.5.0")
+ * @throws {Error} if no matching heading is found
+ */
+export function assertUpgradingSectionExists(mdx, prevVersion, targetVersion) {
+  const pattern = new RegExp(
+    `^##\\s+Upgrading\\s+from\\s+v${escapeRegex(prevVersion)}\\s+to\\s+(v${escapeRegex(targetVersion)}|%%PINCHY_VERSION%%)\\s*$`,
+    "m",
+  );
+  if (!pattern.test(mdx)) {
+    throw new Error(
+      `No upgrade-notes section for v${targetVersion} in upgrading.mdx.\n` +
+        `Add a heading:\n\n  ## Upgrading from v${prevVersion} to %%PINCHY_VERSION%%\n\n` +
+        `then draft the upgrade notes under it before releasing.`,
+    );
+  }
+}

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -91,3 +91,32 @@ export function assertUpgradingSectionExists(mdx, prevVersion, targetVersion) {
     );
   }
 }
+
+/**
+ * Extracts the body of the upgrade-notes section for a release.
+ *
+ * Finds the `## Upgrading from v<prev> to (v<target>|%%PINCHY_VERSION%%)`
+ * heading, returns all content up to the next `## ` heading (nested `###`
+ * subheadings are preserved), with `%%PINCHY_VERSION%%` replaced by the
+ * resolved `v<target>` string so the output is ready to be used as
+ * GitHub Release body content.
+ *
+ * @param {string} mdx - contents of docs/src/content/docs/guides/upgrading.mdx
+ * @param {string} prevVersion - previous release, no leading 'v' (e.g. "0.4.4")
+ * @param {string} targetVersion - new release, no leading 'v' (e.g. "0.5.0")
+ * @returns {string} section body (trimmed), or empty string if the section is missing
+ */
+export function extractUpgradeNotes(mdx, prevVersion, targetVersion) {
+  const heading = new RegExp(
+    `^##\\s+Upgrading\\s+from\\s+v${escapeRegex(prevVersion)}\\s+to\\s+(v${escapeRegex(targetVersion)}|%%PINCHY_VERSION%%)\\s*$`,
+    "m",
+  );
+  const match = heading.exec(mdx);
+  if (!match) return "";
+
+  const remainder = mdx.slice(match.index + match[0].length);
+  const nextHeading = /^## /m.exec(remainder);
+  const body = remainder.slice(0, nextHeading ? nextHeading.index : remainder.length);
+
+  return body.trim().replace(/%%PINCHY_VERSION%%/g, `v${targetVersion}`);
+}

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -5,6 +5,7 @@ import {
   bumpPackageJson,
   buildTagName,
   buildCommitMessage,
+  assertUpgradingSectionExists,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -65,4 +66,59 @@ test("buildTagName prefixes version with v", () => {
 
 test("buildCommitMessage follows conventional commit format", () => {
   assert.equal(buildCommitMessage("0.3.0"), "chore: release v0.3.0");
+});
+
+// assertUpgradingSectionExists
+
+test("assertUpgradingSectionExists accepts %%PINCHY_VERSION%% placeholder", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to %%PINCHY_VERSION%%",
+    "",
+    "Notes go here.",
+  ].join("\n");
+  assert.doesNotThrow(() =>
+    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+  );
+});
+
+test("assertUpgradingSectionExists accepts concrete target version", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to v0.5.0",
+    "",
+    "Notes.",
+  ].join("\n");
+  assert.doesNotThrow(() =>
+    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+  );
+});
+
+test("assertUpgradingSectionExists rejects missing section", () => {
+  const mdx = "## Upgrading from v0.4.3 to v0.4.4\n\nOld notes.\n";
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /no upgrade-notes section for v0\.5\.0/i,
+  );
+});
+
+test("assertUpgradingSectionExists rejects stale section (wrong 'from' version)", () => {
+  const mdx = "## Upgrading from v0.4.3 to %%PINCHY_VERSION%%\n\nStale.\n";
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /no upgrade-notes section for v0\.5\.0/i,
+  );
+});
+
+test("assertUpgradingSectionExists is whitespace-tolerant in the heading", () => {
+  const mdx = "##   Upgrading  from  v0.4.4  to  %%PINCHY_VERSION%%  \n";
+  assert.doesNotThrow(() =>
+    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+  );
+});
+
+test("assertUpgradingSectionExists error message suggests the heading to add", () => {
+  const mdx = "(empty)";
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /## Upgrading from v0\.4\.4 to %%PINCHY_VERSION%%/,
+  );
 });

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -6,6 +6,7 @@ import {
   buildTagName,
   buildCommitMessage,
   assertUpgradingSectionExists,
+  extractUpgradeNotes,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -121,4 +122,85 @@ test("assertUpgradingSectionExists error message suggests the heading to add", (
     () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
     /## Upgrading from v0\.4\.4 to %%PINCHY_VERSION%%/,
   );
+});
+
+// extractUpgradeNotes
+
+test("extractUpgradeNotes returns the body under the matching section", () => {
+  const mdx = [
+    "# Upgrading Pinchy",
+    "",
+    "## Upgrading from v0.4.4 to %%PINCHY_VERSION%%",
+    "",
+    "First note.",
+    "Second note.",
+    "",
+    "## Upgrading from v0.4.3 to v0.4.4",
+    "",
+    "Older note.",
+  ].join("\n");
+  const result = extractUpgradeNotes(mdx, "0.4.4", "0.5.0");
+  assert.match(result, /First note\./);
+  assert.match(result, /Second note\./);
+  assert.doesNotMatch(result, /Older note\./);
+});
+
+test("extractUpgradeNotes replaces %%PINCHY_VERSION%% with v<target>", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to %%PINCHY_VERSION%%",
+    "",
+    "See the %%PINCHY_VERSION%% changelog for details.",
+  ].join("\n");
+  const result = extractUpgradeNotes(mdx, "0.4.4", "0.5.0");
+  assert.match(result, /v0\.5\.0 changelog/);
+  assert.doesNotMatch(result, /%%PINCHY_VERSION%%/);
+});
+
+test("extractUpgradeNotes returns empty string when section is missing", () => {
+  const mdx = "# Upgrading Pinchy\n\n## Upgrading from v0.4.2 to v0.4.3\n\nOld.\n";
+  assert.equal(extractUpgradeNotes(mdx, "0.4.4", "0.5.0"), "");
+});
+
+test("extractUpgradeNotes handles section at end of file (no trailing heading)", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to v0.5.0",
+    "",
+    "Only section — no trailing heading.",
+  ].join("\n");
+  const result = extractUpgradeNotes(mdx, "0.4.4", "0.5.0");
+  assert.match(result, /Only section/);
+});
+
+test("extractUpgradeNotes preserves nested ### subheadings but stops at next ## heading", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to %%PINCHY_VERSION%%",
+    "",
+    "### Breaking changes",
+    "Changed.",
+    "",
+    "### Migrations",
+    "Migrated.",
+    "",
+    "## Upgrading from v0.4.3 to v0.4.4",
+    "",
+    "Older.",
+  ].join("\n");
+  const result = extractUpgradeNotes(mdx, "0.4.4", "0.5.0");
+  assert.match(result, /### Breaking changes/);
+  assert.match(result, /### Migrations/);
+  assert.doesNotMatch(result, /Older\./);
+});
+
+test("extractUpgradeNotes trims leading and trailing whitespace", () => {
+  const mdx = [
+    "## Upgrading from v0.4.4 to v0.5.0",
+    "",
+    "",
+    "Content.",
+    "",
+    "",
+    "## Upgrading from v0.4.3 to v0.4.4",
+  ].join("\n");
+  const result = extractUpgradeNotes(mdx, "0.4.4", "0.5.0");
+  assert.equal(result, "Content.");
 });

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -2,17 +2,21 @@
 /**
  * Pinchy release script
  *
- * Usage: pnpm release <version>
- *   e.g. pnpm release 0.3.0
+ * Usage: pnpm release <version> [--skip-audit]
+ *   e.g. pnpm release 0.5.0
+ *        pnpm release 0.5.0 --skip-audit   # only after documenting the CVE acceptance
  *
  * What it does:
  *   1. Validates the version (semver)
- *   2. Checks: clean working tree, on main branch, CI green
+ *   2. Gates:
+ *      - upgrading.mdx has a section for the target version
+ *      - clean working tree, on main branch, CI green, tag not taken
+ *      - pnpm audit --audit-level=high --prod passes (or --skip-audit)
  *   3. Bumps version in root package.json and packages/web/package.json
  *   4. Commits, tags, and pushes
  *
  * What to do manually first (see CONTRIBUTING.md):
- *   - Update docs/src/content/docs/guides/upgrading.mdx
+ *   - Update docs/src/content/docs/guides/upgrading.mdx (enforced)
  *   - Update packages/web/src/lib/smithers-soul.ts if user-facing features changed
  */
 
@@ -47,6 +51,7 @@ function fail(msg) {
 // ─── Argument ────────────────────────────────────────────────────────────────
 
 const input = process.argv[2];
+const skipAudit = process.argv.includes("--skip-audit");
 if (!input) {
   fail("Usage: pnpm release <version>  (e.g. pnpm release 0.3.0)");
 }
@@ -114,6 +119,31 @@ if (existingTags.split("\n").includes(tag)) {
   fail(`Tag ${tag} already exists.`);
 }
 log(`  ✔ Tag ${tag} is free`);
+
+// ─── Dependency audit gate ────────────────────────────────────────────────────
+
+log("Running pnpm audit (production dependencies, high/critical only)...");
+try {
+  execSync("pnpm audit --audit-level=high --prod", {
+    cwd: ROOT,
+    stdio: "inherit",
+  });
+  log("  ✔ No high or critical vulnerabilities in production deps");
+} catch {
+  if (skipAudit) {
+    log(
+      "  ⚠ pnpm audit reported findings — continuing because --skip-audit was passed.",
+    );
+    log(
+      "    Document the acceptance in the release notes (CONTRIBUTING.md).",
+    );
+  } else {
+    fail(
+      "pnpm audit reported high or critical vulnerabilities.\n" +
+        "Fix them, or re-run with --skip-audit and document the acceptance in the release notes.",
+    );
+  }
+}
 
 // ─── Version bumps ────────────────────────────────────────────────────────────
 

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -69,8 +69,15 @@ log(`\nReleasing Pinchy ${tag}\n`);
 // ─── Upgrade notes gate ───────────────────────────────────────────────────────
 
 log("Checking upgrading.mdx has section for target version...");
-const prevTagRaw = exec("git describe --tags --abbrev=0");
-const prevVersion = prevTagRaw.replace(/^v/, "");
+let prevVersion;
+try {
+  prevVersion = exec("git describe --tags --abbrev=0").replace(/^v/, "");
+} catch {
+  fail(
+    "No previous git tag found — cannot determine the 'from' version for upgrade notes.\n" +
+      "If this is the first release, create the initial tag manually before running this script.",
+  );
+}
 const upgradingMdxPath = resolve(
   ROOT,
   "docs/src/content/docs/guides/upgrading.mdx",

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -139,7 +139,7 @@ try {
     );
   } else {
     fail(
-      "pnpm audit reported high or critical vulnerabilities.\n" +
+      "pnpm audit reported high or critical vulnerabilities (or failed to connect to the registry — check output above).\n" +
         "Fix them, or re-run with --skip-audit and document the acceptance in the release notes.",
     );
   }

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -25,6 +25,7 @@ import {
   bumpPackageJson,
   buildTagName,
   buildCommitMessage,
+  assertUpgradingSectionExists,
 } from "./lib/release-logic.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -59,6 +60,23 @@ try {
 
 const tag = buildTagName(version);
 log(`\nReleasing Pinchy ${tag}\n`);
+
+// ─── Upgrade notes gate ───────────────────────────────────────────────────────
+
+log("Checking upgrading.mdx has section for target version...");
+const prevTagRaw = exec("git describe --tags --abbrev=0");
+const prevVersion = prevTagRaw.replace(/^v/, "");
+const upgradingMdxPath = resolve(
+  ROOT,
+  "docs/src/content/docs/guides/upgrading.mdx",
+);
+const upgradingMdx = readFileSync(upgradingMdxPath, "utf8");
+try {
+  assertUpgradingSectionExists(upgradingMdx, prevVersion, version);
+} catch (e) {
+  fail(e.message);
+}
+log(`  ✔ Section for v${version} present (from v${prevVersion})`);
 
 // ─── Pre-flight checks ────────────────────────────────────────────────────────
 


### PR DESCRIPTION
Closes #147 Scope 1.

## What's in this PR

- Release-script gates: `assertUpgradingSectionExists` + `pnpm audit`
- CI: new `end-user-upgrade` job (previous tag → this PR's code upgrade path)
- Release workflow: new `end-user-install-published` job (anonymous ghcr.io pull; implicit visibility gate)
- New `pre-release.yml` workflow: `:next` + `:sha-<short>` tag scheme, biweekly prune
- CONTRIBUTING.md: refactored release section (shrunk checklist, new staging workflow doc, new fail-mode docs)

## Test plan

- [x] `pnpm test:release` — all new `assertUpgradingSectionExists` cases green
- [x] `pnpm release 99.99.99` (dry run) fails with clear upgrading.mdx error as first gate
- [x] CI read-through: job structure verified
- [ ] After merge: manually trigger `pre-release.yml` via workflow_dispatch to verify `:next` publishes
- [ ] Next real release exercises `end-user-install-published` gate for the first time