### PR TITLE
chore(ci): remove workflow_dispatch from pre-release.yml

### DIFF
--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -6,7 +6,6 @@ on:
   schedule:
     # Biweekly: prune old :sha-* tags from GHCR. Runs at 03:00 UTC on the 1st and 15th.
     - cron: "0 3 1,15 * *"
-  workflow_dispatch: {}
 
 permissions:
   contents: read
@@ -15,7 +14,7 @@ permissions:
 jobs:
   build:
     name: Build & push :next and :sha-<short>
-    if: github.event_name == 'push' || github.event_name == 'workflow_dispatch'
+    if: github.event_name == 'push'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Summary

- Removes the temporary `workflow_dispatch: {}` trigger (and the now-redundant `|| workflow_dispatch` arm of the job's `if:` condition) from `pre-release.yml`.
- The trigger was a plan-sanctioned post-merge smoke-test hook. It did its job: run [24832533812](https://github.com/heypinchy/pinchy/actions/runs/24832533812) pushed `:next` + `:sha-921a4e8ac4f2` for both `pinchy` and `pinchy-openclaw` (verified via the GHCR registry API).
- Going forward, only push-on-`main` builds images and the biweekly schedule prunes.

## Test plan

- [x] `pre-release.yml` only triggers on `push: main` and `schedule`
- [x] `:next` + `:sha-<12>` tags already confirmed in GHCR from the dispatched run
- [ ] After merge: next push to `main` auto-builds `:next` and a new `:sha-<12>` — verifies the push path still works