### PR TITLE
docs: comprehensive docs audit and refresh (fixes #153)

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,13 +1,12 @@
-name: Deploy Docs
+name: Deploy Docs (no screenshots)
 
 on:
-  # Called from release.yml after a release is published, so docs stay in
-  # lockstep with releases. Edits to main between releases stay unpublished
-  # until the next tag. We can't use the `release: published` trigger here
-  # because releases created by GITHUB_TOKEN don't fire workflow events.
-  # Manual runs stay available for one-off corrections (e.g. typo fix
-  # without a release).
-  workflow_call:
+  # Manual-only fallback for urgent text-only fixes between releases, when
+  # regenerating screenshots is unnecessary or infeasible. The normal release
+  # path is release.yml → screenshots.yml, which captures fresh screenshots
+  # against the just-released build and then deploys the docs. This workflow
+  # deploys docs with whatever screenshots are already in the artifact store —
+  # intended for typo fixes, not feature changes.
   workflow_dispatch:
 
 permissions:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -98,13 +98,16 @@ jobs:
             /tmp/cloud-init.yml
 
   docs:
-    name: Deploy Docs
+    name: Capture Screenshots & Deploy Docs
     needs: release
     # Releases created by GITHUB_TOKEN don't fire `release: published`
-    # events, so we call the docs workflow directly from here instead
-    # of relying on a trigger in docs.yml.
-    uses: ./.github/workflows/docs.yml
+    # events, so we call the screenshots workflow directly from here. It
+    # generates fresh screenshots against the newly released build and
+    # then deploys the docs site with those screenshots embedded — keeping
+    # screenshots in lockstep with the released UI.
+    uses: ./.github/workflows/screenshots.yml
+    secrets: inherit
     permissions:
-      contents: read
+      contents: write
       pages: write
       id-token: write

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -1,8 +1,7 @@
 name: Screenshots
 
 on:
-  release:
-    types: [published]
+  workflow_call:
   workflow_dispatch:
 
 permissions:
@@ -84,13 +83,15 @@ jobs:
           retention-days: 90
 
       - name: Upload to release assets
-        if: github.event_name == 'release'
+        # When invoked via workflow_call from release.yml (tag push), attach
+        # the screenshots tarball to the GitHub Release created in release.yml.
+        if: startsWith(github.ref, 'refs/tags/v')
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           cd screenshots/output
           tar czf /tmp/pinchy-screenshots.tar.gz *.png
-          gh release upload "${{ github.event.release.tag_name }}" \
+          gh release upload "${{ github.ref_name }}" \
             /tmp/pinchy-screenshots.tar.gz \
             --clobber
 

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,9 +24,10 @@ First off — thank you! Every contribution matters, whether it's code, docs, bu
    - `feat: add plugin permission layer`
    - `fix: resolve cross-channel routing issue`
    - `docs: update getting started guide`
-4. **Add tests** for new features when applicable.
-5. **Update docs** if your change affects user-facing behavior.
-6. Submit your PR and fill out the template.
+4. **Keep commits atomic.** Each commit should represent one logical change and pass CI on its own. PRs are merged via rebase — the commit history lands verbatim on `main`, so individual commits must make sense in isolation.
+5. **Add tests** for new features when applicable.
+6. **Update docs** if your change affects user-facing behavior.
+7. Submit your PR and fill out the template.
 
 ### Voice & Personality
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -61,7 +61,7 @@ When a message arrives, the `ClientRouter` passes the `agentId` from the browser
 
 ### Chat sessions
 
-Pinchy derives a deterministic session key for each `(agentId, userId)` pair using the format `agent:<agentId>:user-<userId>`. This gives each user their own conversation per agent — even for shared agents. Session keys are resolved in-memory via a `SessionCache` that periodically syncs with OpenClaw's session list — no database table is needed. The session key is opaque and never leaves the server — the browser only sends an `agentId`, and Pinchy resolves the session internally.
+Pinchy derives a deterministic session key for each `(agentId, userId)` pair using the format `agent:<agentId>:direct:<userId>`. This gives each user their own conversation per agent — even for shared agents. Session keys are resolved in-memory via a `SessionCache` that periodically syncs with OpenClaw's session list — no database table is needed. The session key is opaque and never leaves the server — the browser only sends an `agentId`, and Pinchy resolves the session internally.
 
 The browser can request conversation history by sending a `{ type: "history", agentId }` message. Pinchy fetches the history from OpenClaw via `openclaw-node` and strips internal metadata (timestamps, thinking blocks) before returning it.
 
@@ -71,9 +71,9 @@ Session keys follow the format `agent:<agentId>:<scope>`. OpenClaw validates tha
 
 **Current format:**
 
-| Scope             | Key format                      | Example                                |
-| ----------------- | ------------------------------- | -------------------------------------- |
-| Per-user sessions | `agent:<agentId>:user-<userId>` | `agent:83aa6035-...:user-8c0953d2-...` |
+| Scope             | Key format                        | Example                                  |
+| ----------------- | --------------------------------- | ---------------------------------------- |
+| Per-user sessions | `agent:<agentId>:direct:<userId>` | `agent:83aa6035-...:direct:8c0953d2-...` |
 
 This format is used for both personal and shared agents. Each user always gets their own session, which means converting a personal agent to a shared agent is seamless — the original user keeps their session, and other users get new ones.
 
@@ -195,7 +195,7 @@ Pinchy includes a cryptographic audit trail for compliance and security. Every s
 
 ### What gets logged
 
-Pinchy logs 12 event types covering authentication, agent management, user management, configuration changes, and tool execution. Chat message content is **not** logged — only tool calls and permission-relevant actions.
+Pinchy logs events across seven categories: authentication, agent management, user management, group management, channel management, configuration changes, and tool execution. Chat message content is **not** logged — only tool calls and permission-relevant actions. See [Audit Trail](/concepts/audit-trail/) for the complete list of event types.
 
 ### Integrity verification
 
@@ -213,30 +213,82 @@ OpenClaw runs as a separate Docker container. Pinchy communicates with it via `o
 
 ### Config generation
 
-Pinchy owns the OpenClaw configuration file (`openclaw.json`). Config generation happens in two scenarios:
+Pinchy owns the OpenClaw configuration file (`openclaw.json`). A single function, `regenerateOpenClawConfig()`, handles every write — from the first config during setup to every subsequent change when agents, permissions, or providers are modified. It rebuilds the config from current database state, preserving only the `gateway` block (auth token and OpenClaw-generated fields).
 
-1. **Initial setup** — during the onboarding wizard, `writeOpenClawConfig()` writes the first config with provider credentials and a randomly generated auth token
-2. **Regeneration** — whenever agents, permissions, or providers change, `regenerateOpenClawConfig()` rebuilds the config from DB state
+Because the database is the source of truth, regeneration is **idempotent** and self-healing: deleted providers and agents are cleaned up automatically, and calling it twice produces the same file. To avoid unnecessary restarts, Pinchy short-circuits the write when the new content is identical to what's already on disk.
 
-Regeneration is **idempotent**: it preserves only the `gateway` block (which contains the auth token and OpenClaw-generated fields) and rebuilds everything else — `env`, `agents`, and `plugins` — from the database. This ensures deleted providers and agents are cleaned up automatically.
-
-An inotify-based wrapper script inside the OpenClaw container detects the config change and restarts the gateway automatically.
+An inotify-based wrapper script inside the OpenClaw container detects config file changes and restarts the gateway automatically, with a 30-second grace period between restarts to prevent restart loops.
 
 ### Authentication
 
 Pinchy authenticates to OpenClaw Gateway using a bearer token. The token is auto-generated on first setup via `crypto.randomBytes(24)` and stored in the `gateway.auth` block of `openclaw.json`. It never appears in source control.
 
+## Channels
+
+Users don't have to reach their agents through the web UI. Pinchy supports external **channels** that connect agents to messaging platforms. Telegram is the first implemented channel; additional channels (email, Slack) are planned.
+
+### Per-agent bots
+
+Each agent can be connected to its own Telegram bot via **Agent Settings → Telegram**. The main Pinchy bot (the Smithers bot) is set up once globally via **Settings → Telegram** and acts as the entry point for user account linking. Additional agent bots require the main bot to be configured first — users link their Telegram account via the main bot and then gain access to any bot they have permission to use.
+
+### Identity linking
+
+Users link their Telegram account to their Pinchy account via a one-time pairing code: the user messages the bot, receives a code, and enters it in Pinchy. The link is stored in the `identityLinks` table. All inbound Telegram messages are resolved to the linked Pinchy user before being routed to the agent — so the agent always knows who it's talking to.
+
+### Session unification
+
+Messages from Telegram and the web UI flow through the same session cache using the same `agent:<agentId>:direct:<userId>` key format. This means switching channels doesn't fork conversation history — a user who chats with an agent on the web and then messages it on Telegram sees the combined conversation.
+
+### Config propagation
+
+Telegram bot tokens and channel settings live in the database as the source of truth. Changes trigger a `regenerateOpenClawConfig()` write, and OpenClaw picks up the new config via the file watcher. There's no WebSocket RPC for channel configuration — the config file is the contract.
+
+For the user-facing setup, see [Set Up Telegram](/guides/telegram-setup/).
+
+## Integrations
+
+Integrations let agents work with external business data — email accounts, ERPs, search engines — without giving them direct system access. Each integration is a connection stored in the database, referenced by agents via per-agent permissions.
+
+| Integration        | Connection method | Stored credentials                |
+| ------------------ | ----------------- | --------------------------------- |
+| **Gmail**          | OAuth 2.0         | Access token + refresh token      |
+| **Odoo**           | API key           | URL, database, login, API key     |
+| **Web Search**     | API key           | Brave Search API key              |
+
+All credentials are encrypted at rest with AES-256-GCM and isolated per-row: a single decryption failure no longer hides every integration (see upgrade notes for %%PINCHY_VERSION%%). Credentials never reach the OpenClaw config file — plugins fetch them on-demand via Pinchy's internal API, authenticated with the shared gateway token.
+
+Each integration enforces its own permission model on the agent side:
+
+- **Gmail** — checkbox-based permissions (Read / Create drafts / Send) map to specific tool IDs
+- **Odoo** — access levels (Read-only / Read & Write / Full / Custom) with optional per-model restrictions
+- **Web Search** — tool checkboxes plus per-agent filters (Domain allow/deny, Freshness, Language, Region)
+
+For the conceptual overview, see [Integrations](/concepts/integrations/). For per-integration setup, see the guides: [Connect Email](/guides/connect-email/), [Connect Odoo](/guides/connect-odoo/), [Set Up Web Search](/guides/web-search-setup/).
+
+## Domain lock and insecure mode
+
+Pinchy's security profile is controlled by a single runtime setting: the locked domain. When a domain is locked via **Settings → Security**, Pinchy:
+
+- Rejects requests whose `Host` header doesn't match the locked domain (`403 Access Denied`)
+- Issues cookies with `Secure` and `SameSite=Lax`
+- Advertises HSTS
+- Enforces origin checks on state-changing requests
+
+When unlocked, Pinchy shows an insecure-mode warning banner to admins in the UI. This flips security-relevant middleware off as a package — convenient for local development, unsafe for production. A `docker exec pinchy pnpm domain:reset` CLI recovers access if HTTPS goes down after a lock. See [HTTPS & Domain Lock](/guides/domain-lock/) for the full flow.
+
 ## Tech stack
 
-| Layer         | Technology                                       |
-| ------------- | ------------------------------------------------ |
-| Frontend      | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui |
-| Chat UI       | assistant-ui (React)                             |
-| Auth          | Better Auth (email/password, DB sessions)        |
-| Database      | PostgreSQL 17, Drizzle ORM                       |
-| Agent runtime | OpenClaw Gateway (WebSocket)                     |
-| Encryption    | AES-256-GCM (Node.js crypto)                     |
-| Testing       | Vitest, React Testing Library                    |
-| CI/CD         | GitHub Actions, ESLint, Prettier                 |
-| Deployment    | Docker Compose                                   |
-| License       | AGPL-3.0                                         |
+| Layer          | Technology                                       |
+| -------------- | ------------------------------------------------ |
+| Frontend       | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui |
+| Chat UI        | assistant-ui (React)                             |
+| Auth           | Better Auth (email/password, DB sessions)        |
+| Database       | PostgreSQL 17, Drizzle ORM                       |
+| Agent runtime  | OpenClaw Gateway (WebSocket)                     |
+| Encryption     | AES-256-GCM (Node.js crypto)                     |
+| Testing        | Vitest, React Testing Library, Playwright (E2E)  |
+| CI/CD          | GitHub Actions, ESLint, Prettier                 |
+| Deployment     | Docker Compose, pre-built images on GHCR         |
+| Reverse proxy  | Caddy (recommended) or nginx                     |
+| SBOM           | Syft via `anchore/sbom-action`                   |
+| License        | AGPL-3.0                                         |

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -255,7 +255,7 @@ Integrations let agents work with external business data — email accounts, ERP
 | **Odoo**       | API key           | URL, database, login, API key |
 | **Web Search** | API key           | Brave Search API key          |
 
-All credentials are encrypted at rest with AES-256-GCM and isolated per-row: a single decryption failure no longer hides every integration (see upgrade notes for %%PINCHY_VERSION%%). Credentials never reach the OpenClaw config file — plugins fetch them on-demand via Pinchy's internal API, authenticated with the shared gateway token.
+All credentials are encrypted at rest with AES-256-GCM and isolated per-row: a single decryption failure no longer hides every integration. Credentials never reach the OpenClaw config file — plugins fetch them on-demand via Pinchy's internal API, authenticated with the shared gateway token.
 
 Each integration enforces its own permission model on the agent side:
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -249,11 +249,11 @@ For the user-facing setup, see [Set Up Telegram](/guides/telegram-setup/).
 
 Integrations let agents work with external business data — email accounts, ERPs, search engines — without giving them direct system access. Each integration is a connection stored in the database, referenced by agents via per-agent permissions.
 
-| Integration        | Connection method | Stored credentials                |
-| ------------------ | ----------------- | --------------------------------- |
-| **Gmail**          | OAuth 2.0         | Access token + refresh token      |
-| **Odoo**           | API key           | URL, database, login, API key     |
-| **Web Search**     | API key           | Brave Search API key              |
+| Integration    | Connection method | Stored credentials            |
+| -------------- | ----------------- | ----------------------------- |
+| **Gmail**      | OAuth 2.0         | Access token + refresh token  |
+| **Odoo**       | API key           | URL, database, login, API key |
+| **Web Search** | API key           | Brave Search API key          |
 
 All credentials are encrypted at rest with AES-256-GCM and isolated per-row: a single decryption failure no longer hides every integration (see upgrade notes for %%PINCHY_VERSION%%). Credentials never reach the OpenClaw config file — plugins fetch them on-demand via Pinchy's internal API, authenticated with the shared gateway token.
 
@@ -278,17 +278,17 @@ When unlocked, Pinchy shows an insecure-mode warning banner to admins in the UI.
 
 ## Tech stack
 
-| Layer          | Technology                                       |
-| -------------- | ------------------------------------------------ |
-| Frontend       | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui |
-| Chat UI        | assistant-ui (React)                             |
-| Auth           | Better Auth (email/password, DB sessions)        |
-| Database       | PostgreSQL 17, Drizzle ORM                       |
-| Agent runtime  | OpenClaw Gateway (WebSocket)                     |
-| Encryption     | AES-256-GCM (Node.js crypto)                     |
-| Testing        | Vitest, React Testing Library, Playwright (E2E)  |
-| CI/CD          | GitHub Actions, ESLint, Prettier                 |
-| Deployment     | Docker Compose, pre-built images on GHCR         |
-| Reverse proxy  | Caddy (recommended) or nginx                     |
-| SBOM           | Syft via `anchore/sbom-action`                   |
-| License        | AGPL-3.0                                         |
+| Layer         | Technology                                       |
+| ------------- | ------------------------------------------------ |
+| Frontend      | Next.js 16, React 19, Tailwind CSS v4, shadcn/ui |
+| Chat UI       | assistant-ui (React)                             |
+| Auth          | Better Auth (email/password, DB sessions)        |
+| Database      | PostgreSQL 17, Drizzle ORM                       |
+| Agent runtime | OpenClaw Gateway (WebSocket)                     |
+| Encryption    | AES-256-GCM (Node.js crypto)                     |
+| Testing       | Vitest, React Testing Library, Playwright (E2E)  |
+| CI/CD         | GitHub Actions, ESLint, Prettier                 |
+| Deployment    | Docker Compose, pre-built images on GHCR         |
+| Reverse proxy | Caddy (recommended) or nginx                     |
+| SBOM          | Syft via `anchore/sbom-action`                   |
+| License       | AGPL-3.0                                         |

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -122,11 +122,11 @@ Each agent can also have per-agent filters (Domain restrictions with Include/Exc
 
 When you connect a Gmail account and grant an agent access to it, Pinchy enables email tools based on which operations you check. Each permission maps to a specific set of tools.
 
-| Permission        | Tools enabled                                  | What the agent can do                           |
-| ----------------- | ---------------------------------------------- | ----------------------------------------------- |
-| **Read messages** | `email_list`, `email_read`, `email_search`     | List, read, and search emails                   |
-| **Create drafts** | above + `email_draft`                          | Create draft emails, including reply drafts     |
-| **Send messages** | above + `email_send`                           | Send emails immediately — cannot be undone      |
+| Permission        | Tools enabled                              | What the agent can do                       |
+| ----------------- | ------------------------------------------ | ------------------------------------------- |
+| **Read messages** | `email_list`, `email_read`, `email_search` | List, read, and search emails               |
+| **Create drafts** | above + `email_draft`                      | Create draft emails, including reply drafts |
+| **Send messages** | above + `email_send`                       | Send emails immediately — cannot be undone  |
 
 Permissions are additive — granting Send automatically includes Read and Draft. Each permission is selected per-agent, so you can have one agent that only reads email and another that can send on your behalf.
 

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -59,17 +59,19 @@ An agent with powerful tools enabled has significantly broader capabilities. Use
 
 ## The Permissions tab
 
-Admins configure tool permissions in the **Permissions tab** of an agent's settings page. The settings page has four tabs — General, Personality, Instructions, and Permissions. To access the Permissions tab:
+Admins configure tool permissions in the **Permissions tab** of a shared agent's settings page. To access it:
 
-1. Open an agent's chat
+1. Open a shared agent's chat
 2. Click the settings icon (gear) to open Agent Settings
 3. Select the **Permissions** tab
 
 The Permissions tab shows all available tools grouped by category. Check or uncheck tools to control what the agent can do, then click **Save**.
 
 :::note
-The Permissions tab is only visible to admins and is not available for personal agents (the auto-created Smithers agent each user gets).
+The Permissions tab is only visible to admins and only for shared agents. Personal agents (the auto-created Smithers each user gets) don't have this tab — they run with default tools only.
 :::
+
+For the full list of tabs in Agent Settings and who sees which, see [Agent Settings](/concepts/agent-settings/).
 
 ### Configuring directory access
 
@@ -116,7 +118,23 @@ Web search tools are enabled individually per agent via checkboxes in the Permis
 
 Each agent can also have per-agent filters (Domain restrictions with Include/Exclude modes, Freshness, Language, Region) that control what the agent can access. See [Set Up Web Search](/guides/web-search-setup/) for configuration details.
 
-For details on setting up connections, see [Integrations](/concepts/integrations/).
+### Email tools
+
+When you connect a Gmail account and grant an agent access to it, Pinchy enables email tools based on which operations you check. Each permission maps to a specific set of tools.
+
+| Permission        | Tools enabled                                  | What the agent can do                           |
+| ----------------- | ---------------------------------------------- | ----------------------------------------------- |
+| **Read messages** | `email_list`, `email_read`, `email_search`     | List, read, and search emails                   |
+| **Create drafts** | above + `email_draft`                          | Create draft emails, including reply drafts     |
+| **Send messages** | above + `email_send`                           | Send emails immediately — cannot be undone      |
+
+Permissions are additive — granting Send automatically includes Read and Draft. Each permission is selected per-agent, so you can have one agent that only reads email and another that can send on your behalf.
+
+:::caution[Send is powerful]
+**Send messages** lets the agent send email from the connected account without human review. Prefer **Create drafts** when a human can review before sending — it's safer by default.
+:::
+
+For the full setup walkthrough, see [Connect Email](/guides/connect-email/). For details on setting up connections in general, see [Integrations](/concepts/integrations/).
 
 ## Agent templates and default permissions
 

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -7,14 +7,14 @@ import { Aside, Badge } from "@astrojs/starlight/components";
 
 Every agent in Pinchy is configured through a settings page. To open it, navigate to an agent's chat and click the **gear icon** in the top bar. Which tabs you see depends on your role and the agent type.
 
-| Tab              | What it controls                          | Who can see it                |
-| ---------------- | ----------------------------------------- | ----------------------------- |
-| **General**      | Name, tagline, model, agent type          | Everyone who can edit         |
-| **Personality**  | Avatar, personality preset, SOUL.md       | Everyone who can edit         |
-| **Instructions** | AGENTS.md operating instructions          | Everyone who can edit         |
-| **Permissions**  | Tool allow-list, directory access         | Admins only, shared agents    |
-| **Access** <Badge text="Enterprise" variant="note" />       | Visibility mode, group assignment         | Admins only, shared agents    |
-| **Telegram**     | Connect a Telegram bot to this agent      | Admins only                   |
+| Tab                                                   | What it controls                     | Who can see it             |
+| ----------------------------------------------------- | ------------------------------------ | -------------------------- |
+| **General**                                           | Name, tagline, model, agent type     | Everyone who can edit      |
+| **Personality**                                       | Avatar, personality preset, SOUL.md  | Everyone who can edit      |
+| **Instructions**                                      | AGENTS.md operating instructions     | Everyone who can edit      |
+| **Permissions**                                       | Tool allow-list, directory access    | Admins only, shared agents |
+| **Access** <Badge text="Enterprise" variant="note" /> | Visibility mode, group assignment    | Admins only, shared agents |
+| **Telegram**                                          | Connect a Telegram bot to this agent | Admins only                |
 
 The Permissions and Access tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show them because there's nothing to share. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
 

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -1,21 +1,26 @@
 ---
 title: Agent Settings
-description: Reference for all agent configuration options — general settings, personality presets, instructions, permissions, and access control.
+description: Reference for all agent configuration options — general settings, personality presets, instructions, permissions, access control, and Telegram channels.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Badge } from "@astrojs/starlight/components";
 
-Every agent in Pinchy is configured through a settings page with up to five tabs. To open it, navigate to an agent's chat and click the **gear icon** in the top bar.
+Every agent in Pinchy is configured through a settings page. To open it, navigate to an agent's chat and click the **gear icon** in the top bar. Which tabs you see depends on your role and the agent type.
 
-| Tab              | What it controls                    | Who can see it                          |
-| ---------------- | ----------------------------------- | --------------------------------------- |
-| **General**      | Name, tagline, model, agent type    | Admins and personal agent owners        |
-| **Personality**  | Avatar, personality preset, SOUL.md | Admins and personal agent owners        |
-| **Instructions** | AGENTS.md operating instructions    | Admins and personal agent owners        |
-| **Permissions**  | Tool allow-list, directory access   | Admins only (shared agents)             |
-| **Access**       | Visibility mode, group assignment   | Admins only (shared agents, enterprise) |
+| Tab              | What it controls                          | Who can see it                |
+| ---------------- | ----------------------------------------- | ----------------------------- |
+| **General**      | Name, tagline, model, agent type          | Everyone who can edit         |
+| **Personality**  | Avatar, personality preset, SOUL.md       | Everyone who can edit         |
+| **Instructions** | AGENTS.md operating instructions          | Everyone who can edit         |
+| **Permissions**  | Tool allow-list, directory access         | Admins only, shared agents    |
+| **Access** <Badge text="Enterprise" variant="note" />       | Visibility mode, group assignment         | Admins only, shared agents    |
+| **Telegram**     | Connect a Telegram bot to this agent      | Admins only                   |
 
-The Permissions and Access tabs are only visible for shared agents and only to admins. Personal agents (the auto-created agent each user gets) do not show these tabs.
+The Permissions and Access tabs exist only for shared agents. Personal agents (the auto-created Smithers each user gets) don't show them because there's nothing to share. Admins still see the Telegram tab on Smithers, but the main Smithers bot is managed centrally via **Settings → Telegram** rather than per-agent.
+
+:::note[Enterprise feature]
+The **Access** tab requires a Pinchy Enterprise license. Without a license, the tab shows an upgrade prompt. See [Enterprise Setup](/guides/enterprise-setup/) for details.
+:::
 
 ## General tab
 
@@ -109,15 +114,11 @@ When a safe tool is enabled, the **Allowed Directories** picker appears so you c
 
 For a deeper explanation of the permission model, defense in depth, and how permissions are translated to OpenClaw configuration, see [Agent Permissions](/concepts/agent-permissions/).
 
-## Access tab
+## Access tab <Badge text="Enterprise" variant="note" />
 
-<Aside type="tip">
-  Access control is an enterprise feature. It requires an active enterprise
-  license key. See [Groups](/concepts/groups/) for details on creating and
-  managing groups.
-</Aside>
+The Access tab controls which users can see and use an agent. Without an enterprise license, this tab shows an upgrade prompt. See [Groups](/concepts/groups/) for details on creating and managing groups.
 
-The Access tab controls which users can see and use an agent. Without an enterprise license, this tab shows an upgrade prompt.
+![Agent Settings — Access tab with visibility modes and group picker](/screenshots/agent-settings-access.png)
 
 ### Visibility modes
 
@@ -132,15 +133,28 @@ New agents are created with **Restricted** visibility by default. This lets admi
 
 When visibility is set to **Restricted**, a group picker appears listing all groups configured in **Settings**. Check one or more groups to grant their members access. If no groups are selected, only admins can see the agent.
 
+## Telegram tab
+
+![Agent Settings — Telegram tab with bot connection status](/screenshots/agent-settings-telegram.png)
+
+The Telegram tab lets admins connect a Telegram bot directly to this agent, so users can chat with the agent from their phone. Each agent can have its own bot with its own Telegram username.
+
+The main Pinchy bot must be set up first via **Settings → Telegram** — users link their Telegram accounts once via the main bot and can then message any bot they have permission to use. For Smithers, this tab shows the shared main bot status; to remove it, use "Remove Telegram for everyone" in **Settings → Telegram**. For other agents, the tab shows a token field and a Connect button.
+
+For the full flow including BotFather setup and account linking, see [Set Up Telegram](/guides/telegram-setup/).
+
 ## Creating agents
 
-Agents are created from the **Create New Agent** page. The flow is:
+Agents are created from the **Create New Agent** page. Pinchy ships with pre-configured templates for common use cases — Knowledge Base agents, vision-powered document analyzers, Odoo ERP assistants, email agents, and more. Each template auto-configures tools, personality, and system instructions; you choose a name and any template-specific options.
 
-1. **Choose a template** — select either **Knowledge Base** (pre-configured with safe file tools) or **Custom Agent** (starts with no tools).
-2. **Configure basics** — enter a name and optional tagline. Knowledge Base agents also require selecting at least one data directory.
-3. **Create** — the agent is created and the runtime restarts. You are redirected to the new agent's chat.
+The generic starting points are:
 
-After creation, all settings can be changed at any time through the settings page described above.
+- **Knowledge Base** — pre-configured with safe file tools for answering questions from directories you select
+- **Custom Agent** — starts with no tools, for when you want to configure everything manually
+
+Domain-specific templates (e.g., Sales Analyst, HR Analyst, Contract Analyzer) appear in the template picker when the corresponding integration is connected or their required capabilities are available. See [Connect Odoo](/guides/connect-odoo/#agent-templates) for the Odoo template list.
+
+After creation, all settings can be changed at any time through the settings page described above. The runtime restarts automatically after creation to activate the new agent's config.
 
 ## Save behavior
 

--- a/docs/src/content/docs/concepts/context.mdx
+++ b/docs/src/content/docs/concepts/context.mdx
@@ -76,7 +76,7 @@ For admin users, Smithers goes further — after saving user context, it asks ab
 
 Once onboarding is complete, the onboarding instructions are removed from Smithers automatically, and the saved context is used for all future conversations. Users can review and refine what Smithers wrote by going to **Settings > Context** at any time.
 
-For more on the onboarding flow, see the [Getting Started](/guides/getting-started/) guide.
+For more on the onboarding flow, see the [Smithers Onboarding](/guides/smithers-onboarding/) guide.
 
 ## The pinchy-context plugin
 

--- a/docs/src/content/docs/concepts/groups.mdx
+++ b/docs/src/content/docs/concepts/groups.mdx
@@ -60,12 +60,12 @@ Personal agents (the auto-created Smithers agent each user gets) are not affecte
 
 Every group management action is logged in the [audit trail](/concepts/audit-trail/) as a specific event type:
 
-| Action                    | Audit event              |
-| ------------------------- | ------------------------ |
-| Group created             | `group.created`          |
-| Group name or description | `group.updated`          |
-| Group deleted             | `group.deleted`          |
-| Member added or removed   | `group.members_updated`  |
-| User's group memberships  | `user.groups_updated`    |
+| Action                    | Audit event             |
+| ------------------------- | ----------------------- |
+| Group created             | `group.created`         |
+| Group name or description | `group.updated`         |
+| Group deleted             | `group.deleted`         |
+| Member added or removed   | `group.members_updated` |
+| User's group memberships  | `user.groups_updated`   |
 
 Each entry snapshots the group name and affected user names alongside their IDs, so the log stays meaningful even after groups or users are deleted.

--- a/docs/src/content/docs/concepts/groups.mdx
+++ b/docs/src/content/docs/concepts/groups.mdx
@@ -3,8 +3,8 @@ title: Groups
 description: How to use groups to control which users can access which agents.
 ---
 
-:::note[Enterprise Feature]
-Groups and agent access control are enterprise features. Activate them by entering a license key in **Settings → License** or via the `PINCHY_ENTERPRISE_KEY` environment variable. See [Enterprise Setup](/guides/enterprise-setup/) for details.
+:::note[Enterprise feature]
+Groups and agent access control require a Pinchy Enterprise license. Activate it by entering a license key in **Settings → License** or via the `PINCHY_ENTERPRISE_KEY` environment variable. See [Enterprise Setup](/guides/enterprise-setup/).
 :::
 
 ![Groups management with member counts](/screenshots/groups.png)
@@ -58,4 +58,14 @@ Personal agents (the auto-created Smithers agent each user gets) are not affecte
 
 ## Audit trail
 
-All group management actions are logged in the [audit trail](/concepts/audit-trail/): group creation, updates, deletion, and member changes.
+Every group management action is logged in the [audit trail](/concepts/audit-trail/) as a specific event type:
+
+| Action                    | Audit event              |
+| ------------------------- | ------------------------ |
+| Group created             | `group.created`          |
+| Group name or description | `group.updated`          |
+| Group deleted             | `group.deleted`          |
+| Member added or removed   | `group.members_updated`  |
+| User's group memberships  | `user.groups_updated`    |
+
+Each entry snapshots the group name and affected user names alongside their IDs, so the log stays meaningful even after groups or users are deleted.

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -28,6 +28,37 @@ These are two separate concepts:
 
 Creating a connection doesn't give any agent access. You must explicitly grant access in each agent's Permissions tab.
 
+## Gmail (Google)
+
+Gmail is the first email integration. An admin connects a Google account via OAuth 2.0, then grants specific permissions per agent.
+
+### Setup flow
+
+Gmail requires a Google Cloud OAuth app (one-time, per Pinchy installation). Once created, admins connect one or more Google accounts through the Add Integration wizard. Google requires HTTPS — the wizard shows a warning and blocks the OAuth flow when Pinchy is running without HTTPS.
+
+### Permissions model
+
+Each agent gets email permissions independently. Permissions are additive: granting **Send** automatically includes **Read** and **Draft**.
+
+| Permission        | Tools enabled                                  |
+| ----------------- | ---------------------------------------------- |
+| **Read messages** | `email_list`, `email_read`, `email_search`     |
+| **Create drafts** | above + `email_draft`                          |
+| **Send messages** | above + `email_send`                           |
+
+### Token handling
+
+OAuth access tokens expire after about one hour. Pinchy refreshes them in the background using the stored refresh token. If a refresh fails (the user revoked access, or the refresh token expired in Google's Testing mode), the integration surfaces the error and prompts the admin to reconnect.
+
+### Security
+
+- Client ID and Client Secret are encrypted with AES-256-GCM before storage
+- Access and refresh tokens are encrypted per-connection
+- Tokens are decrypted on-demand when the agent makes an API call — they never end up in the OpenClaw config file
+- The `pinchy-email` plugin fetches tokens via Pinchy's internal API, authenticated by the shared gateway token
+
+For the full setup walkthrough, see [Connect Email](/guides/connect-email/).
+
 ## Web Search (Brave)
 
 Web Search is the simplest integration — a single API key connects Pinchy to the Brave Search API, giving agents the ability to search the web and fetch pages.

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -40,11 +40,11 @@ Gmail requires a Google Cloud OAuth app (one-time, per Pinchy installation). Onc
 
 Each agent gets email permissions independently. Permissions are additive: granting **Send** automatically includes **Read** and **Draft**.
 
-| Permission        | Tools enabled                                  |
-| ----------------- | ---------------------------------------------- |
-| **Read messages** | `email_list`, `email_read`, `email_search`     |
-| **Create drafts** | above + `email_draft`                          |
-| **Send messages** | above + `email_send`                           |
+| Permission        | Tools enabled                              |
+| ----------------- | ------------------------------------------ |
+| **Read messages** | `email_list`, `email_read`, `email_search` |
+| **Create drafts** | above + `email_draft`                      |
+| **Send messages** | above + `email_send`                       |
 
 ### Token handling
 

--- a/docs/src/content/docs/concepts/philosophy.mdx
+++ b/docs/src/content/docs/concepts/philosophy.mdx
@@ -40,4 +40,4 @@ We don't just claim to care about data sovereignty. The architecture enforces it
 
 Pinchy is [AGPL-3.0 licensed](https://github.com/heypinchy/pinchy) and built in public. You can read every line of code, audit the security model, and contribute improvements.
 
-We write about what we build, why we build it, and what we learn along the way — on our [blog](https://heypinchy.com/blog) and in our [changelog](/reference/changelog).
+We write about what we build, why we build it, and what we learn along the way — on our [blog](https://heypinchy.com/blog) and in our [release notes](https://github.com/heypinchy/pinchy/releases).

--- a/docs/src/content/docs/concepts/user-roles.mdx
+++ b/docs/src/content/docs/concepts/user-roles.mdx
@@ -3,7 +3,7 @@ title: User Roles and Permissions
 description: How Pinchy's two-role system controls what users can see and do across the platform.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Badge } from "@astrojs/starlight/components";
 
 Pinchy uses two roles — **Admin** and **Member** — to control access to platform features. Every user has exactly one role.
 
@@ -55,7 +55,7 @@ Roles interact with agent visibility to determine which agents a user can see in
 - **Members** see:
   - Their own personal Smithers agent
   - Shared agents with visibility set to **All users**
-  - Shared agents with **Restricted** visibility, if they belong to an assigned group (enterprise feature)
+  - Shared agents with **Restricted** visibility, if they belong to an assigned group <Badge text="Enterprise" variant="note" />
 
 Members cannot see other users' personal agents or restricted agents they are not grouped into.
 
@@ -76,9 +76,10 @@ The Settings page shows different tabs depending on the user's role:
 
 Members see only the Context and Profile tabs. Admin-only tabs are completely hidden — not just disabled.
 
-<Aside type="tip" title="Groups for granular access">
-  Roles provide platform-wide access control. For more granular, per-agent
-  access control, use [Groups](/concepts/groups/) to scope agent visibility to
-  specific teams. Groups are an enterprise feature — activate them with a
-  license key.
-</Aside>
+## Emergency admin recovery
+
+If no admin is available to reset a locked-out user's password, an admin with shell access to the server can run `docker compose exec pinchy pnpm reset-admin` to generate a new admin password from the CLI. See [User Management — Emergency admin password reset](/guides/user-management/#emergency-admin-password-reset-cli) for the full flow.
+
+:::note[Enterprise feature]
+Roles provide platform-wide access control. For granular, per-agent access scoped to specific teams, use [Groups](/concepts/groups/) with a Pinchy Enterprise license. See [Enterprise Setup](/guides/enterprise-setup/).
+:::

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -3,6 +3,8 @@ title: Quick Start
 description: Get Pinchy running in 5 minutes with Docker Compose.
 ---
 
+import { Badge } from "@astrojs/starlight/components";
+
 This guide walks you through getting Pinchy up and running — from downloading Pinchy to chatting with your first AI agent.
 
 ## Prerequisites
@@ -55,11 +57,11 @@ Your API key is encrypted at rest using AES-256-GCM before being stored in the d
 
 ## 5. Chat with Smithers
 
-Once your provider is configured, Pinchy redirects you to the chat interface. Your default agent — **Smithers** — greets you automatically.
+Once your provider is configured, Pinchy redirects you to the chat interface. Your default agent — **Smithers** — greets you automatically and starts a short onboarding interview to learn about you (and your organization, if you're an admin). This builds context that every agent on the platform can use.
 
 ![Smithers chat interface with agent sidebar](/screenshots/chat-interface.png)
 
-Type a message and hit Enter. Smithers responds in real time via WebSocket.
+Type a message and hit Enter. Smithers responds in real time via WebSocket. See [Smithers Onboarding](/guides/smithers-onboarding/) for what Smithers asks and how the context is saved.
 
 ## 6. Invite your team
 
@@ -71,21 +73,37 @@ Each invited user gets their own personal **Smithers** agent, created automatica
 
 You can create agents from templates. Creating an agent is simple: pick a template, give it a name, add an optional tagline, and click Create. Each agent gets a unique auto-generated avatar.
 
-For example, a **Knowledge Base** agent can read text files, Markdown, and **PDF documents** (including scanned PDFs with vision-capable models) from directories you select — but has no access to anything else by default. After creating the agent, you can customize it through the agent settings tabs:
+For example, a **Knowledge Base** agent can read text files, Markdown, and **PDF documents** (including scanned PDFs with vision-capable models) from directories you select — but has no access to anything else by default.
+
+After creating the agent, you can customize it through the agent settings tabs. Which tabs you see depends on your role and the agent type:
+
+**Always visible:**
 
 - **General** — Change the agent's name, tagline, avatar, and model
 - **Personality** — Choose a personality preset or write custom personality instructions (SOUL.md)
 - **Instructions** — Define what the agent should do and how it should handle tasks (AGENTS.md)
+
+**Admin-only, shared agents only:**
+
 - **Permissions** — Configure which tools and directories the agent can access
+- **Access** <Badge text="Enterprise" variant="note" /> — Set visibility to all users or restrict to specific groups
+
+**Admin-only, any agent:**
+
+- **Telegram** — Connect a Telegram bot to this agent
+
+Smithers is a personal agent per user, so Permissions and Access don't apply — they only exist for shared agents. See [Agent Settings](/concepts/agent-settings/) for the full reference.
 
 User and organization context (personal preferences, team structure, company conventions) is managed in **Settings → Context**, not in per-agent settings.
 
 To try it out, mount a directory with documents into the Pinchy container and create an agent from the Knowledge Base template. See the [Create a Knowledge Base Agent](/guides/create-knowledge-base-agent/) guide for the full walkthrough.
 
-## New in %%PINCHY_VERSION%%
+## Recently added
 
+- **[Web Search](/guides/web-search-setup/)** — Give agents live web access via the Brave Search API, with per-agent domain allow/deny lists
+- **[Gmail Integration](/guides/connect-email/)** — Let agents read, search, draft, and send emails through a guided OAuth wizard
 - **[Telegram Channels](/guides/telegram-setup/)** — Chat with your agents from Telegram, with user accounts linked via pairing code
-- **[Odoo Integration](/guides/connect-odoo/)** — Give agents scoped, permission-aware access to your Odoo ERP
+- **[Odoo Integration](/guides/connect-odoo/)** — Give agents scoped, permission-aware access to your Odoo ERP with 16 pre-built templates
 - **[Ollama (Local & Cloud)](/guides/ollama-setup/)** — Run agents fully air-gapped on your own hardware, or use Ollama Cloud models
 - **[Usage & Costs Dashboard](/guides/usage-dashboard/)** — Track token usage, estimated costs, and cache savings per agent and user
 

--- a/docs/src/content/docs/guides/connect-email.mdx
+++ b/docs/src/content/docs/guides/connect-email.mdx
@@ -124,6 +124,8 @@ A dialog appears with your **Client ID** and **Client Secret**. **Copy both valu
 
     In Pinchy, go to **Settings → Integrations** and click **Add Integration**, then select **Google**.
 
+    ![Add Integration → Google wizard with Client ID and Client Secret fields](/screenshots/integrations-google-wizard.png)
+
 2.  **Enter your OAuth credentials**
 
     Paste the **Client ID** and **Client Secret** from Part 1 and click **Save & Continue**.

--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -37,6 +37,8 @@ The API key inherits the Odoo permissions of the user who created it. If you wan
    - **API Key** — the key you copied in step 1
 4. Click **Test & Connect**
 
+![Add Integration → Odoo wizard with URL, database, email, and API key fields](/screenshots/integrations-odoo-wizard.png)
+
 Pinchy verifies the credentials and probes the available data models. If the connection fails, double-check the URL and API key.
 
 ## 3. Review the sync

--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -79,12 +79,18 @@ Renew your key and permissions are restored instantly.
 
 ## Enterprise features
 
-| Feature                     | Description                                                      |
-| --------------------------- | ---------------------------------------------------------------- |
-| [Groups](/concepts/groups/) | Organize users into teams, scope agent access per group          |
-| Agent Access Control        | Set agents to "Restricted" visibility, assign to specific groups |
-| Role-Based Access Control   | Granular permissions per user, per agent, per action             |
-| Priority Support            | Direct access to the Pinchy team with priority response times    |
+This is the canonical list of features that require an active Pinchy Enterprise license. Any feature documented elsewhere with an `Enterprise` badge or a "Enterprise feature" callout maps to one of the rows below.
+
+| Feature                   | Where it appears                                                                | Documentation                                             |
+| ------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------- |
+| Groups                    | Settings → Groups                                                               | [Groups](/concepts/groups/)                               |
+| Agent Access Control      | Agent Settings → **Access** tab (visibility modes, group assignment)            | [Agent Settings](/concepts/agent-settings/#access-tab)    |
+| Group-scoped invites      | Settings → Users → **Invite User** (Groups field when inviting)                 | [User Management](/guides/user-management/#inviting-users)|
+| Per-user usage breakdown  | Usage Dashboard → **Per-User Breakdown** card                                   | [Usage Dashboard](/guides/usage-dashboard/)               |
+| Usage CSV export          | Usage Dashboard → **Export CSV** button                                         | [Usage Dashboard](/guides/usage-dashboard/#export)        |
+| Priority Support          | Direct contact with the Pinchy team with priority response times                | —                                                         |
+
+When a license is not active, Enterprise-gated UI shows clear upgrade prompts rather than hiding completely — so you always know what's available.
 
 ## Offline validation
 

--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -81,14 +81,14 @@ Renew your key and permissions are restored instantly.
 
 This is the canonical list of features that require an active Pinchy Enterprise license. Any feature documented elsewhere with an `Enterprise` badge or a "Enterprise feature" callout maps to one of the rows below.
 
-| Feature                   | Where it appears                                                                | Documentation                                             |
-| ------------------------- | ------------------------------------------------------------------------------- | --------------------------------------------------------- |
-| Groups                    | Settings → Groups                                                               | [Groups](/concepts/groups/)                               |
-| Agent Access Control      | Agent Settings → **Access** tab (visibility modes, group assignment)            | [Agent Settings](/concepts/agent-settings/#access-tab)    |
-| Group-scoped invites      | Settings → Users → **Invite User** (Groups field when inviting)                 | [User Management](/guides/user-management/#inviting-users)|
-| Per-user usage breakdown  | Usage Dashboard → **Per-User Breakdown** card                                   | [Usage Dashboard](/guides/usage-dashboard/)               |
-| Usage CSV export          | Usage Dashboard → **Export CSV** button                                         | [Usage Dashboard](/guides/usage-dashboard/#export)        |
-| Priority Support          | Direct contact with the Pinchy team with priority response times                | —                                                         |
+| Feature                  | Where it appears                                                     | Documentation                                              |
+| ------------------------ | -------------------------------------------------------------------- | ---------------------------------------------------------- |
+| Groups                   | Settings → Groups                                                    | [Groups](/concepts/groups/)                                |
+| Agent Access Control     | Agent Settings → **Access** tab (visibility modes, group assignment) | [Agent Settings](/concepts/agent-settings/#access-tab)     |
+| Group-scoped invites     | Settings → Users → **Invite User** (Groups field when inviting)      | [User Management](/guides/user-management/#inviting-users) |
+| Per-user usage breakdown | Usage Dashboard → **Per-User Breakdown** card                        | [Usage Dashboard](/guides/usage-dashboard/)                |
+| Usage CSV export         | Usage Dashboard → **Export CSV** button                              | [Usage Dashboard](/guides/usage-dashboard/#export)         |
+| Priority Support         | Direct contact with the Pinchy team with priority response times     | —                                                          |
 
 When a license is not active, Enterprise-gated UI shows clear upgrade prompts rather than hiding completely — so you always know what's available.
 

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -88,3 +88,7 @@ docker compose exec openclaw ls /data/
 ```
 
 You should see your mounted directories listed.
+
+## Supported file types
+
+Knowledge Base agents can read text files, Markdown, and **PDF documents** — including scanned PDFs, which are analyzed using the configured model's vision capabilities. See [Create a Knowledge Base Agent — PDF support](/guides/create-knowledge-base-agent/#pdf-support) for details.

--- a/docs/src/content/docs/guides/smithers-onboarding.mdx
+++ b/docs/src/content/docs/guides/smithers-onboarding.mdx
@@ -42,16 +42,16 @@ The organization questions cover:
 This organization context is applied to all shared agents on the platform, so every team member benefits from it.
 
 <Aside type="tip">
-  Regular users only have `save_user_context` available. Admins also get
-  `save_org_context`, which is why only admins are asked about the organization.
+  Regular users only have `pinchy_save_user_context` available. Admins also get
+  `pinchy_save_org_context`, which is why only admins are asked about the organization.
 </Aside>
 
 ## How context is saved
 
 Smithers uses the **pinchy-context** plugin to save context through two tools:
 
-- **`save_user_context`** — Saves a Markdown-formatted summary of the user's personal context (role, preferences, work style). Available to all users during onboarding.
-- **`save_org_context`** — Saves a Markdown-formatted summary of the organization context (company info, team structure, conventions). Available to admins only.
+- **`pinchy_save_user_context`** — Saves a Markdown-formatted summary of the user's personal context (role, preferences, work style). Available to all users during onboarding.
+- **`pinchy_save_org_context`** — Saves a Markdown-formatted summary of the organization context (company info, team structure, conventions). Available to admins only.
 
 When Smithers calls these tools, the context is stored in the database and written to the agent workspace. Once both the personal context (and organization context for admins) are saved, the onboarding instructions are removed from Smithers' prompt automatically, and future conversations proceed without the onboarding flow.
 
@@ -74,10 +74,10 @@ Changes to context are picked up by agents on the next conversation.
 
 ## Summary
 
-| Step                 | Who         | What happens                                                                                            |
-| -------------------- | ----------- | ------------------------------------------------------------------------------------------------------- |
-| First login          | All users   | Smithers greets you and starts the onboarding interview                                                 |
-| Personal context     | All users   | Smithers asks about your role, language, and communication style, then saves it via `save_user_context` |
-| Organization context | Admins only | Smithers asks about the company and saves it via `save_org_context`                                     |
-| Onboarding complete  | All users   | Onboarding instructions are removed; Smithers behaves as a regular assistant going forward              |
-| Edit later           | All users   | Go to **Settings → Context** to update your context at any time                                         |
+| Step                 | Who         | What happens                                                                                                   |
+| -------------------- | ----------- | -------------------------------------------------------------------------------------------------------------- |
+| First login          | All users   | Smithers greets you and starts the onboarding interview                                                        |
+| Personal context     | All users   | Smithers asks about your role, language, and communication style, then saves it via `pinchy_save_user_context` |
+| Organization context | Admins only | Smithers asks about the company and saves it via `pinchy_save_org_context`                                     |
+| Onboarding complete  | All users   | Onboarding instructions are removed; Smithers behaves as a regular assistant going forward                     |
+| Edit later           | All users   | Go to **Settings → Context** to update your context at any time                                                |

--- a/docs/src/content/docs/guides/smithers-onboarding.mdx
+++ b/docs/src/content/docs/guides/smithers-onboarding.mdx
@@ -43,7 +43,8 @@ This organization context is applied to all shared agents on the platform, so ev
 
 <Aside type="tip">
   Regular users only have `pinchy_save_user_context` available. Admins also get
-  `pinchy_save_org_context`, which is why only admins are asked about the organization.
+  `pinchy_save_org_context`, which is why only admins are asked about the
+  organization.
 </Aside>
 
 ## How context is saved

--- a/docs/src/content/docs/guides/telegram-setup.mdx
+++ b/docs/src/content/docs/guides/telegram-setup.mdx
@@ -30,6 +30,8 @@ Use [Telegram Web](https://web.telegram.org) or the desktop app to easily copy t
 3. Paste the bot token
 4. Click **Connect**
 
+![Settings → Telegram with bot setup and user pairing](/screenshots/settings-telegram.png)
+
 Your bot token is encrypted at rest and never leaves your server.
 
 ## Step 3: Link Your Telegram Account
@@ -55,6 +57,8 @@ Pinchy's main Telegram bot must already be set up in **Settings → Telegram** (
 1. Create a new bot via BotFather (repeat Step 1)
 2. Go to **Agent Settings → Telegram** for the agent you want to connect
 3. Paste the new bot token and click **Connect**
+
+![Agent Settings → Telegram tab with bot connection](/screenshots/agent-settings-telegram.png)
 
 :::note
 Each bot token can only be used by one agent. If you try to use the same token for two agents, Pinchy will reject it.

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -125,6 +125,12 @@ curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%
 docker compose pull && docker compose up -d
 ```
 
+### What's new in %%PINCHY_VERSION%%
+
+- **Web Search integration** — connect Pinchy to the Brave Search API and grant agents per-tool access to search and page fetch. Per-agent filters for domain allow/deny, freshness, language, and region let you scope what each agent can reach. See [Set Up Web Search](/guides/web-search-setup/).
+- **Gmail integration** — connect Google accounts via OAuth and give agents scoped email access: read, create drafts, or send. A guided wizard walks admins through the Google Cloud Console setup. See [Connect Email](/guides/connect-email/).
+- **Per-template model recommendations** — agent templates now declare preferred model tiers (fast, balanced, reasoning) and required capabilities (vision, long-context, tools). When creating an agent from a template, Pinchy picks the best match from your installed models automatically.
+
 ### What's fixed in %%PINCHY_VERSION%%
 
 - **Integrations list no longer blanks out when one row can't be decrypted** — if the `ENCRYPTION_KEY` ever changed (e.g. accidentally overridden via `.env`), one un-decryptable row in `integration_connections` silently caused `GET /api/integrations` to return 500, and the UI fell back to "No integrations configured yet" for every integration — including freshly-added ones that would decrypt fine. Each row is now decrypted in isolation; unreadable rows surface in Settings → Integrations as a warning card with a Delete action so admins can recover without DB access. `regenerateOpenClawConfig()` got the same per-row isolation, so one broken connection no longer takes down every agent's config.

--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -17,6 +17,8 @@ Admins only. Non-admin users get redirected to the home page if they try to open
 
 ## What you see
 
+![Usage & Costs dashboard with token totals, cost estimate, and per-agent breakdown](/screenshots/usage-dashboard.png)
+
 Open **Usage** from the sidebar (or visit `/usage`).
 
 - **Total Tokens** — sum of input and output tokens for the selected period and agent filter

--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -3,9 +3,13 @@ title: Usage & Costs Dashboard
 description: Track token consumption and estimated costs for every agent on your Pinchy instance.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Badge } from "@astrojs/starlight/components";
 
 Pinchy keeps a running tally of how many tokens each agent burns through and what they roughly cost. The Usage Dashboard at `/usage` is where admins go to answer "where is the money going" without leaving the platform or stitching together provider invoices.
+
+:::note[Enterprise features on this page]
+The **Per-User Breakdown** and **CSV Export** are Pinchy Enterprise features. Everything else works without a license. See [Enterprise Setup](/guides/enterprise-setup/).
+:::
 
 ## Who can see it
 
@@ -21,7 +25,7 @@ Open **Usage** from the sidebar (or visit `/usage`).
 - **Source Breakdown** — how those tokens split across Chat, System, and Plugin use (see below)
 - **Daily Token Usage** chart — input vs output tokens over time. Days with no usage show as zero instead of being skipped, so you see actual gaps rather than misleading interpolation. The chart groups days by your browser's timezone, not UTC
 - **Per-Agent Breakdown** — which agents consume what, sorted by cost. Deleted agents are marked with "(deleted)" so you can still see their historical usage
-- **Per-User Breakdown** — Enterprise only — same numbers split by who chatted with the agent
+- **Per-User Breakdown** <Badge text="Enterprise" variant="note" /> — same numbers split by who chatted with the agent
 
 ### Token sources
 
@@ -53,9 +57,7 @@ A few honest caveats:
 - **Local Ollama shows "—" for cost.** Local models record token counts but have no pricing config. The dashboard shows a dash instead of $0.00 to make this clear.
 - **Tool execution time isn't tracked here.** Only the LLM tokens count. The Audit Trail at `/audit` is where you go for tool-use details.
 
-## Export
-
-<Aside type="note">CSV export is an Enterprise feature.</Aside>
+## Export <Badge text="Enterprise" variant="note" />
 
 With an active Enterprise license, the **Export CSV** button (top-right) downloads the current view — period and agent filter applied — as a CSV file. The export includes cache read and write tokens alongside the regular token columns. Useful for finance hand-offs or feeding the data into your own dashboards.
 

--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -199,12 +199,12 @@ docker compose exec pinchy pnpm reset-admin --email admin@example.com
 
 All user management actions performed by admins are logged in the audit trail:
 
-| Action                     | Audit event           |
-| -------------------------- | --------------------- |
-| User invited               | `user.invited`        |
-| Role changed               | `user.role_updated`   |
-| Group memberships changed  | `user.groups_updated` |
-| Profile or password change | `user.updated`        |
-| User deactivated           | `user.deleted`        |
+| Action                    | Audit event           |
+| ------------------------- | --------------------- |
+| User invited              | `user.invited`        |
+| Role changed              | `user.role_updated`   |
+| Group memberships changed | `user.groups_updated` |
+| User reactivated          | `user.updated`        |
+| User deactivated          | `user.deleted`        |
 
 Each entry records which admin took the action, the affected user's name and email, and before/after values for role or group changes. See [Audit Trail](/concepts/audit-trail/) for more information on viewing and exporting audit logs.

--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -3,7 +3,7 @@ title: User Management
 description: How to invite users, manage roles, reset passwords, and configure profile settings in Pinchy.
 ---
 
-import { Aside } from "@astrojs/starlight/components";
+import { Aside, Badge } from "@astrojs/starlight/components";
 
 Pinchy uses an invite-only system for user onboarding. Admins create invite links, new users claim them by setting up their account, and then they are guided through an onboarding conversation with Smithers. This guide covers the full lifecycle: inviting, onboarding, managing, and deactivating users.
 
@@ -23,7 +23,7 @@ Only admins can invite new users. Here is how:
 3. Fill out the invite form:
    - **Email** (optional) — Pre-fills the email for the new user's account. If left empty, the invite link can be used by anyone.
    - **Role** — Choose **Member** or **Admin**.
-   - **Groups** (enterprise only) — If you have an active enterprise license and have created groups, you can assign the new user to one or more groups during invitation. See [Groups](/concepts/groups/) for details.
+   - **Groups** <Badge text="Enterprise" variant="note" /> — If you have an active enterprise license and have created groups, you can assign the new user to one or more groups during invitation. See [Groups](/concepts/groups/) for details.
 4. Click **Create Invite**.
 5. Copy the generated invite link and share it with the user.
 
@@ -65,7 +65,7 @@ The **Settings → Users** page shows all users and pending invites in a single 
 - **Name** — The user's display name (or a dash for pending invites).
 - **Email** — The user's email address.
 - **Role** — Admin or Member.
-- **Groups** — Group memberships (visible only with an active enterprise license).
+- **Groups** <Badge text="Enterprise" variant="note" /> — Group memberships. Only visible with an active enterprise license.
 - **Status** — Active, Pending (invite not yet claimed), Expired (invite token expired), or Deactivated.
 
 ### Viewing user details
@@ -73,11 +73,17 @@ The **Settings → Users** page shows all users and pending invites in a single 
 Click on any active user row to open the user detail panel. From here you can:
 
 - **Change their role** — Switch between Admin and Member using the Role dropdown. You cannot change your own role, and you cannot demote the last remaining admin.
-- **Manage group memberships** (enterprise only) — Check or uncheck groups to add or remove the user from groups.
+- **Manage group memberships** <Badge text="Enterprise" variant="note" /> — Check or uncheck groups to add or remove the user from groups.
 - **Reset their password** — Generate a password reset link (see below).
 - **Deactivate the user** — Prevent the user from logging in (see below).
 
 Click **Save** to apply any role or group changes.
+
+### How groups affect agent access
+
+Group membership determines which restricted agents a user can see. Agents configured with **Restricted** visibility in **Agent Settings → Access** list one or more groups; only members of those groups (and admins) can see the agent in the sidebar or message it via Telegram. Agents set to **All users** ignore group membership entirely.
+
+Changes propagate immediately: removing a user from a group revokes their access to restricted agents on the next sidebar refresh, and adding them grants access without a restart. For the full group model, see [Groups](/concepts/groups/).
 
 ### Changing a user's role
 
@@ -191,12 +197,14 @@ docker compose exec pinchy pnpm reset-admin --email admin@example.com
 
 ## Audit trail
 
-All user management actions performed by admins are logged in the audit trail, including:
+All user management actions performed by admins are logged in the audit trail:
 
-- User invited
-- Role changed
-- User deactivated
-- User reactivated
-- Password reset initiated
+| Action                     | Audit event           |
+| -------------------------- | --------------------- |
+| User invited               | `user.invited`        |
+| Role changed               | `user.role_updated`   |
+| Group memberships changed  | `user.groups_updated` |
+| Profile or password change | `user.updated`        |
+| User deactivated           | `user.deleted`        |
 
-See [Audit Trail](/concepts/audit-trail/) for more information on viewing and exporting audit logs.
+Each entry records which admin took the action, the affected user's name and email, and before/after values for role or group changes. See [Audit Trail](/concepts/audit-trail/) for more information on viewing and exporting audit logs.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -28,7 +28,7 @@ We believe AI agents should run on **your** servers, with **your** data, under *
 
 ## Current Status
 
-Pinchy is in early development. The core is working — setup, authentication, provider configuration, agent chat via OpenClaw, agent permissions, knowledge base agents, user management, per-user/org context, Smithers onboarding interview, and cryptographic audit trail. We're building the remaining enterprise features (granular RBAC with custom roles and per-resource permissions, plugin marketplace) next.
+Pinchy is in early development, but the core is working end-to-end. Shipped features include setup, authentication, provider configuration (Anthropic, OpenAI, Google, Ollama local & cloud), agent chat via OpenClaw, agent permissions with defense in depth, knowledge base agents with PDF support, user management with invite-based onboarding, per-user and per-org context, the Smithers onboarding interview, a cryptographic audit trail, Telegram channels with account linking, a usage & costs dashboard, Web Search integration via Brave, Gmail integration via OAuth, Odoo ERP integration with 16 pre-built agent templates, and a domain-lock security profile. We're building the remaining enterprise features (granular RBAC with custom roles and per-resource permissions, plugin marketplace, additional channel integrations) next.
 
 <CardGrid>
   <Card title="Quick Start" icon="rocket">

--- a/screenshots/capture.ts
+++ b/screenshots/capture.ts
@@ -213,4 +213,77 @@ test.describe("Feature screenshots", () => {
     }
     await screenshot(page, "provider-settings.png");
   });
+
+  test("agent settings - telegram", async ({ page }) => {
+    const agentId = await getAgentId(page, "Frink");
+    if (agentId) {
+      await page.goto(`${BASE_URL}/chat/${agentId}/settings`);
+      await page.waitForTimeout(1500);
+      const tab = page.getByRole("tab", { name: /telegram/i });
+      if (await tab.isVisible({ timeout: 3000 }).catch(() => false)) {
+        await tab.click();
+        await page.waitForTimeout(1500);
+      }
+    }
+    await screenshot(page, "agent-settings-telegram.png");
+  });
+
+  test("settings telegram", async ({ page }) => {
+    await page.goto(`${BASE_URL}/settings`);
+    await page.waitForTimeout(1500);
+    const telegramTab = page.getByRole("tab", { name: /telegram/i });
+    if (await telegramTab.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await telegramTab.click();
+    } else {
+      await page.locator("text=Telegram").first().click().catch(() => {});
+    }
+    await page.waitForTimeout(1500);
+    await screenshot(page, "settings-telegram.png");
+  });
+
+  test("integrations odoo wizard", async ({ page }) => {
+    await page.goto(`${BASE_URL}/settings`);
+    await page.waitForTimeout(1500);
+    const integrationsTab = page.getByRole("tab", { name: /integrations/i });
+    if (await integrationsTab.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await integrationsTab.click();
+    } else {
+      await page.locator("text=Integrations").first().click().catch(() => {});
+    }
+    await page.waitForTimeout(1500);
+    const addButton = page.getByRole("button", { name: /add integration/i });
+    if (await addButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await addButton.click();
+      await page.waitForTimeout(800);
+      const odooOption = page.getByRole("button", { name: /odoo/i }).first();
+      if (await odooOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await odooOption.click();
+        await page.waitForTimeout(1000);
+      }
+    }
+    await screenshot(page, "integrations-odoo-wizard.png");
+  });
+
+  test("integrations google wizard", async ({ page }) => {
+    await page.goto(`${BASE_URL}/settings`);
+    await page.waitForTimeout(1500);
+    const integrationsTab = page.getByRole("tab", { name: /integrations/i });
+    if (await integrationsTab.isVisible({ timeout: 3000 }).catch(() => false)) {
+      await integrationsTab.click();
+    } else {
+      await page.locator("text=Integrations").first().click().catch(() => {});
+    }
+    await page.waitForTimeout(1500);
+    const addButton = page.getByRole("button", { name: /add integration/i });
+    if (await addButton.isVisible({ timeout: 2000 }).catch(() => false)) {
+      await addButton.click();
+      await page.waitForTimeout(800);
+      const googleOption = page.getByRole("button", { name: /google/i }).first();
+      if (await googleOption.isVisible({ timeout: 2000 }).catch(() => false)) {
+        await googleOption.click();
+        await page.waitForTimeout(1000);
+      }
+    }
+    await screenshot(page, "integrations-google-wizard.png");
+  });
 });


### PR DESCRIPTION
## Summary

- Fixes #153 — agent settings tab documentation was wrong on three pages; now documents the three actual variants (3/4/6 tabs depending on role and agent type)
- Corrects architecture page factual errors (session key format, deleted `writeOpenClawConfig()`, event count) and adds missing sections for Channels, Integrations, and Domain Lock
- Standardizes Enterprise gating with a consistent `<Badge>` + callout convention across every gated page, with `enterprise-setup.mdx` as the canonical feature list
- Fills content gaps (Gmail integration section, Email tools in Agent Permissions, audit event tables)
- Extends `capture.ts` with four new screenshot scenarios (per-agent Telegram, Settings → Telegram, Odoo wizard, Gmail wizard)
- Fixes the release workflow so docs deploy with fresh screenshots — previously `release.yml → docs.yml` built docs without screenshots, and `screenshots.yml`'s `release: published` trigger never fired for `GITHUB_TOKEN`-created releases

## What's in each commit

- `docs: correct agent settings tab documentation (#153)` — tab matrix fix in 3 files
- `docs: correct architecture page and add missing sections` — factual fixes + Channels, Integrations, Domain Lock
- `docs: standardize Enterprise gating with Badge + callout convention` — groups, user-roles, user-management
- `docs: apply Enterprise Badge convention to Usage Dashboard` — usage-dashboard Badge conversions
- `docs: expand enterprise-setup as canonical Enterprise feature list` — central feature table
- `docs: document Gmail integration alongside Odoo and Web Search` — integrations concept page
- `docs: fix broken internal links and align plugin tool names` — /reference/changelog, getting-started path, `pinchy_` tool prefix
- `docs: refresh status line, release notes, and add PDF note` — index, upgrading, mount-data-directories
- `docs: extend screenshot capture with four new scenarios` — capture.ts + 4 doc references
- `ci: deploy docs with fresh screenshots after every release` — workflow fix

## Test plan

- [ ] `cd docs && pnpm build` succeeds on Node 22+ (couldn't verify locally — env has Node 20)
- [ ] Tag a test release or trigger `screenshots.yml` via `workflow_dispatch` to confirm the new screenshots render and the docs deploy with them
- [ ] Walk the deployed docs and verify: tab matrix reads correctly, Enterprise badges render, all internal links resolve, new screenshots appear on the referenced pages
- [ ] Confirm the Badge + callout convention reads well on both light and dark themes