### PR TITLE
fix: surface LLM provider errors in chat (fixes #152)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# Worktrees
+.worktrees/
+
 # Dependencies
 node_modules/
 .pnpm-store/

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -41,7 +41,7 @@
     "next": "16.2.3",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
-    "openclaw-node": "0.4.0",
+    "openclaw-node": "0.6.0",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",
     "qrcode.react": "^4.2.0",

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -175,35 +175,6 @@ export class ClientRouter {
       let heartbeatInterval: ReturnType<typeof setInterval> | null = null;
 
       try {
-        // Debug shortcut: "__debug_error:<type>" messages bypass OpenClaw and
-        // inject a fake error chunk directly. Remove before going to production.
-        const DEBUG_ERRORS: Record<string, string> = {
-          billing:
-            "Your credit balance is too low to access the Anthropic API. Please go to Plans & Billing to upgrade or purchase credits.",
-          invalid_key: "Invalid API key provided. You must provide a valid API key.",
-          unauthorized: "Unauthorized: invalid x-api-key",
-          quota: "You exceeded your current quota, please check your plan and billing details.",
-          rate_limit: "Rate limit exceeded: Too many requests. Please retry after 60 seconds.",
-          timeout: "Request timeout: The server did not respond in time.",
-          overloaded: "The server is overloaded. Please try again later. (529)",
-          unknown: "Unexpected internal error: SIGPIPE broken pipe during inference.",
-        };
-        if (text.startsWith("__debug_error:")) {
-          const key = text.replace("__debug_error:", "").trim();
-          const fakeError =
-            DEBUG_ERRORS[key] ??
-            `Unknown debug error type: "${key}". Available: ${Object.keys(DEBUG_ERRORS).join(", ")}`;
-          await new Promise((r) => setTimeout(r, 600)); // brief fake thinking delay
-          this.sendToClient(clientWs, {
-            type: "error",
-            agentName: agent.name,
-            providerError: fakeError,
-            hint: getErrorHint(fakeError, this.userRole),
-            messageId,
-          });
-          return;
-        }
-
         for await (const chunk of stream) {
           // Stop consuming the stream if the browser disconnected — frees
           // server resources while letting OpenClaw finish on its side.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -88,8 +88,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       openclaw-node:
-        specifier: 0.4.0
-        version: 0.4.0
+        specifier: 0.6.0
+        version: 0.6.0
       postgres:
         specifier: ^3.4.9
         version: 3.4.9
@@ -4092,8 +4092,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openclaw-node@0.4.0:
-    resolution: {integrity: sha512-Yd0OMGoYPFaHp/SP4AvNw7el4EGNrb77wuz2eKjA9kYn8MsRGW4muj9yUJix4ufHsYmsXo5GwAndJrdmI0fA1w==}
+  openclaw-node@0.6.0:
+    resolution: {integrity: sha512-CcFoKA3KOuxcdh3uvMw9NlJVgrHkmcC/BEgFKsWyWxMtPZtctOFMkbMvJ0j3JJckaWwgPCCLtTLclnhnR5yxoQ==}
     engines: {node: '>=20.0.0'}
 
   optionator@0.9.4:
@@ -8895,7 +8895,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openclaw-node@0.4.0:
+  openclaw-node@0.6.0:
     optionalDependencies:
       ws: 8.20.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Bumps `openclaw-node` to 0.6.0, which routes OpenClaw lifecycle-error events (provider auth/quota/rate-limit failures) as `{type: "error"}` chunks. Pinchy's existing error-card infrastructure surfaces them automatically.
- Removes the dev-only `__debug_error:` shortcut from `client-router.ts` (marked "Remove before going to production" and never removed).

Fixes #152 (regression of #94 — 401 errors from Anthropic silently stopped the chat spinner).

## Upstream change

openclaw-node PR: https://github.com/heypinchy/openclaw-node/pull/16 (merged, v0.6.0 on NPM)

## Test plan

- [x] `pnpm lint` — 0 errors (238 pre-existing warnings)
- [x] `pnpm format:check` — clean
- [x] `pnpm test` — 3089 passing
- [x] Docker smoke-test with invalid Anthropic key: error card renders in chat with provider text + admin hint:
  > **Smithers couldn't respond**
  > HTTP 401 authentication_error: invalid x-api-key
  > Go to Settings > Providers to check your API configuration.