### PR TITLE
feat(release): Scope 3 — Migration policy (Squawk lint + release-notes template)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,15 +32,13 @@ jobs:
       - name: Format check (docs & workflows)
         run: pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"
 
-      - name: Test
-        run: pnpm test
-
       - name: Squawk migration lint (changed files only)
         if: github.event_name == 'pull_request'
         run: |
           # Default checkout is shallow (depth 1); fetch base ref so git diff
           # has a comparison target. Filtering to changed migration files only
           # keeps historical destructive DDL (pre-Scope-3) untouched.
+          # Pinned version: when bumping, re-verify rule names in .squawk.toml.
           git fetch --no-tags --depth=50 origin "${{ github.base_ref }}"
           BASE="origin/${{ github.base_ref }}"
           CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'packages/web/drizzle/*.sql' | tr '\n' ' ')
@@ -50,7 +48,10 @@ jobs:
           fi
           echo "Linting changed migrations: $CHANGED"
           # shellcheck disable=SC2086 -- word-split intentional: passes each migration path as a separate squawk arg
-          npx --yes squawk-cli@^2 $CHANGED
+          npx --yes squawk-cli@2.48.0 $CHANGED
+
+      - name: Test
+        run: pnpm test
 
       - name: Build
         run: pnpm build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,6 +35,23 @@ jobs:
       - name: Test
         run: pnpm test
 
+      - name: Squawk migration lint (changed files only)
+        if: github.event_name == 'pull_request'
+        run: |
+          # Default checkout is shallow (depth 1); fetch base ref so git diff
+          # has a comparison target. Filtering to changed migration files only
+          # keeps historical destructive DDL (pre-Scope-3) untouched.
+          git fetch --no-tags --depth=50 origin "${{ github.base_ref }}"
+          BASE="origin/${{ github.base_ref }}"
+          CHANGED=$(git diff --name-only "$BASE"...HEAD -- 'packages/web/drizzle/*.sql' | tr '\n' ' ')
+          if [ -z "$CHANGED" ]; then
+            echo "No migration changes — skipping Squawk lint"
+            exit 0
+          fi
+          echo "Linting changed migrations: $CHANGED"
+          # shellcheck disable=SC2086 -- word-split intentional: passes each migration path as a separate squawk arg
+          npx --yes squawk-cli@^2 $CHANGED
+
       - name: Build
         run: pnpm build
 

--- a/.squawk.toml
+++ b/.squawk.toml
@@ -1,0 +1,53 @@
+# Squawk configuration — Postgres migration linter.
+# https://squawkhq.com/docs/
+#
+# Pinchy enables only these three rules at this time:
+#   - ban-drop-column
+#   - ban-drop-table
+#   - changing-column-type  (i.e. ALTER COLUMN ... TYPE)
+#
+# Rationale: see CONTRIBUTING.md § Schema migration policy.
+# To override a single statement, add `-- squawk-ignore <rule>` directly above it.
+# Every override MUST be paired with a `### Breaking changes` entry in
+# docs/src/content/docs/guides/upgrading.mdx for the target release; the
+# release script enforces presence of that subsection.
+
+# Postgres version Squawk should reason about. Pinchy ships postgres:17.
+pg_version = "17.0"
+
+# All Drizzle-generated migrations run inside an implicit transaction.
+assume_in_transaction = true
+
+# All other Squawk rules are out of scope for now (lock-safety, performance,
+# style preferences). Enable them in a future scope if a real incident
+# demonstrates the need.
+excluded_rules = [
+  "adding-field-with-default",
+  "adding-foreign-key-constraint",
+  "adding-not-nullable-field",
+  "adding-required-field",
+  "adding-serial-primary-key-field",
+  "ban-alter-domain-with-add-constraint",
+  "ban-char-field",
+  "ban-concurrent-index-creation-in-transaction",
+  "ban-create-domain-with-constraint",
+  "ban-drop-database",
+  "ban-drop-not-null",
+  "ban-truncate-cascade",
+  "ban-uncommitted-transaction",
+  "constraint-missing-not-valid",
+  "disallowed-unique-constraint",
+  "prefer-bigint-over-int",
+  "prefer-bigint-over-smallint",
+  "prefer-identity",
+  "prefer-robust-stmts",
+  "prefer-text-field",
+  "prefer-timestamp-tz",
+  "renaming-column",
+  "renaming-table",
+  "require-concurrent-index-creation",
+  "require-concurrent-index-deletion",
+  "require-enum-value-ordering",
+  "require-timeout-settings",
+  "transaction-nesting",
+]

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -111,7 +111,7 @@ These don't break running app instances during a rolling deployment, and they do
 
 ### Destructive DDL: Expand/Contract over two releases
 
-Removing or transforming columns/tables requires the **Expand/Contract** pattern across **two minor releases**:
+Removing or transforming columns/tables requires the **Expand/Contract** pattern across **two consecutive releases** (minor or patch):
 
 **Release N (Expand):**
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -92,6 +92,64 @@ All new features require tests. We practice TDD — write the failing test first
 - Run `pnpm lint` and `pnpm format` before submitting
 - Pre-commit hook runs linting automatically via Husky
 
+## Schema migration policy
+
+Pinchy's schema migrations are **forward-only**. Drizzle has no native rollback support and we don't fake it. Once a migration lands on `main`, the only way to undo it on a deployed instance is `pg_dump` restore + image rollback.
+
+This shapes how we author destructive changes.
+
+### Additive-only by default
+
+In a normal release, schema changes are **additive**:
+
+- New tables ✓
+- New columns (NULL or with DEFAULT) ✓
+- New indexes ✓ (note: Drizzle wraps migrations in transactions; `CREATE INDEX CONCURRENTLY` raises an error inside a transaction block — for large live tables, use a separate migration step outside a transaction block)
+- New constraints `NOT VALID` (validate later) ✓
+
+These don't break running app instances during a rolling deployment, and they don't hold ACCESS EXCLUSIVE locks for noticeable durations.
+
+### Destructive DDL: Expand/Contract over two releases
+
+Removing or transforming columns/tables requires the **Expand/Contract** pattern across **two minor releases**:
+
+**Release N (Expand):**
+
+- Add the new column/table
+- Backfill data
+- Update code to write to BOTH old and new
+- Update code to read from new (with old as fallback)
+
+**Release N+1 (Contract):**
+
+- Remove old code paths
+- Drop the old column/table
+
+This means the app version running on a given DB always works with the schema at that point in time.
+
+Column and table **renames are equally destructive** — any app version reading the old name breaks immediately. They are not currently blocked by Squawk. Treat renames the same way: add the new name, migrate all reads/writes, then drop the old name in a later release.
+
+### CI enforcement
+
+`.github/workflows/ci.yml` runs [Squawk](https://squawkhq.com/) on changed migration files in every PR. The following rules block merge:
+
+- `ban-drop-column`
+- `ban-drop-table`
+- `changing-column-type` (`ALTER COLUMN ... TYPE`)
+
+To override (only in a planned Contract release), add a Squawk-ignore comment directly above the offending statement:
+
+```sql
+-- squawk-ignore ban-drop-column
+ALTER TABLE "agents" DROP COLUMN "old_field";
+```
+
+Adding the `squawk-ignore` comment is a deliberate act — Reviewers are expected to challenge it. Every override **must** be paired with a corresponding entry in `docs/src/content/docs/guides/upgrading.mdx` under `### Breaking changes` for that release. The `pnpm release` script enforces presence of that subsection — the release aborts if it's missing.
+
+### Why no rollback automation?
+
+[Drizzle does not support down-migrations](https://github.com/drizzle-team/drizzle-orm/discussions/1339), and writing reliable down-SQL by hand for every migration costs more than it saves. Our explicit stance: **rollback = restore from `pg_dump` + re-pin previous image tag.** This is also documented in the upgrading guide so admins aren't surprised.
+
 ## UI Conventions
 
 ### Error Messages & Notifications
@@ -99,6 +157,7 @@ All new features require tests. We practice TDD — write the failing test first
 We use two patterns for user feedback — **inline errors** and **toast notifications**. Using the right one matters for consistency.
 
 **Inline errors** (rendered below the input field):
+
 - Form validation failures — wrong password, invalid token, expired code
 - The user needs to correct something and retry
 - The form stays open
@@ -108,10 +167,13 @@ const [error, setError] = useState("");
 // In the handler:
 setError("Invalid or expired pairing code");
 // In JSX:
-{error && <p className="text-sm text-destructive">{error}</p>}
+{
+  error && <p className="text-sm text-destructive">{error}</p>;
+}
 ```
 
 **Toast notifications** (via [sonner](https://sonner.emilkowal.dev/)):
+
 - Success confirmations — "Settings saved", "Bot connected"
 - System errors not tied to a form field
 - Actions where the UI navigates away afterward
@@ -143,11 +205,13 @@ Same for `pinchy-openclaw`.
 **One-time staging setup** on your staging host:
 
 1. Deploy Pinchy normally, but pin `:next` in your `.env`:
+
    ```env
    PINCHY_VERSION=next
    ```
 
 2. Install `/usr/local/bin/update-pinchy`:
+
    ```bash
    #!/usr/bin/env bash
    set -euo pipefail
@@ -167,6 +231,7 @@ Same for `pinchy-openclaw`.
    docker compose ps | tee -a "$LOG"
    exit 1
    ```
+
    Make it executable: `chmod +x /usr/local/bin/update-pinchy`.
 
 3. Schedule nightly updates via cron or systemd timer:
@@ -180,22 +245,26 @@ Same for `pinchy-openclaw`.
 
 ### Pre-release checklist
 
-The release script and CI enforce image builds, GHCR visibility, end-user install, upgrade path, `pnpm audit`, and the presence of an upgrade-notes section. The items below are the remaining human judgment calls.
+The release script and CI enforce image builds, GHCR visibility, end-user install, upgrade path, `pnpm audit`, and the presence of a correctly-structured upgrade-notes section. The items below are the remaining human judgment calls.
 
 **Scope**
+
 - [ ] All feature/fix PRs for this release are merged to `main`
 - [ ] Dependencies reviewed (`pnpm outdated`) — no critical/security updates pending
 - [ ] If upgrading OpenClaw: version bumped in `Dockerfile.openclaw`
 
 **Model resolver** (only if models or templates changed)
+
 - [ ] Spot-check Anthropic/OpenAI/Google changelogs for deprecated model IDs referenced in `src/lib/model-resolver/providers/`
 - [ ] New Ollama family or new LLM provider added → resolver file + tests exist
 
 **Documentation**
-- [ ] `docs/src/content/docs/guides/upgrading.mdx` — new section drafted for this version (heading format: `## Upgrading from v<prev> to %%PINCHY_VERSION%%`). The release workflow extracts this section automatically and prepends it to the GitHub Release body under an "Upgrade notes" heading.
+
+- [ ] `docs/src/content/docs/guides/upgrading.mdx` — new section drafted for this version (heading format: `## Upgrading from v<prev> to %%PINCHY_VERSION%%`) containing `### Breaking changes` (write "None." if there are none) and `### Upgrade notes` subsections. The release script enforces both subsections. The release workflow extracts this section automatically and prepends it to the GitHub Release body.
 - [ ] `packages/web/src/lib/smithers-soul.ts` — updated if user-facing features changed
 
 **Staging**
+
 - [ ] Staging instance on `:next` was clicked through today: Smithers chat, one live integration, one custom agent
 
 ### Release steps
@@ -209,11 +278,13 @@ The release script and CI enforce image builds, GHCR visibility, end-user instal
 
 **GHCR visibility gate (`end-user-install-published` job)**
 A newly-added `ghcr.io/heypinchy/*` package defaulted to private. Fix:
+
 1. Visit `https://github.com/heypinchy/pinchy/pkgs/container/<image-name>` → **Package settings** → **Change visibility** → **Public**.
 2. Re-run the failed workflow job. Subsequent releases inherit the visibility automatically.
 
 **End-user install published-image fail**
 The published images + `docker-compose.yml` didn't start cleanly. Reproduce locally:
+
 ```bash
 mkdir /tmp/pinchy-verify && cd /tmp/pinchy-verify
 curl -o docker-compose.yml \
@@ -222,6 +293,7 @@ docker logout ghcr.io
 docker compose pull
 docker compose up -d
 ```
+
 Fix the root cause and cut a patch release. Tags are immutable — never force-update.
 
 **End-user upgrade fail (CI, before release)**

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -102,9 +102,13 @@ If you need to roll back after an upgrade:
 
 ## Upgrading from v0.4.4 to %%PINCHY_VERSION%%
 
-%%PINCHY_VERSION%% moves image version pinning from `docker-compose.yml` into `.env`. This is a one-time migration — after this, upgrading only means editing `PINCHY_VERSION` in `.env` and running `docker compose pull && docker compose up -d`.
+### Breaking changes
 
-### Upgrade steps
+None. This release moves image version pinning into `.env` (a one-time `.env` edit), but no schema, API, or behaviour changes break running deployments.
+
+### Upgrade notes
+
+%%PINCHY_VERSION%% moves image version pinning from `docker-compose.yml` into `.env`. This is a one-time migration — after this, upgrading only means editing `PINCHY_VERSION` in `.env` and running `docker compose pull && docker compose up -d`.
 
 <Steps>
 
@@ -137,7 +141,7 @@ If you need to roll back after an upgrade:
 
 If you skip step 3, `docker compose up` fails loudly with a clear message telling you exactly what to add — this is by design, so a forgotten pin can't silently pull the wrong version.
 
-### Future upgrades
+#### Future upgrades
 
 From %%PINCHY_VERSION%% onwards, upgrading is just:
 

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -97,19 +97,39 @@ function escapeRegex(s) {
  * @param {string} mdx - contents of docs/src/content/docs/guides/upgrading.mdx
  * @param {string} prevVersion - previous release, no leading 'v' (e.g. "0.4.4")
  * @param {string} targetVersion - new release, no leading 'v' (e.g. "0.5.0")
- * @throws {Error} if no matching heading is found
+ * @throws {Error} if no matching heading is found, or if the section is
+ *               missing a '### Breaking changes' or '### Upgrade notes' subsection
  */
 export function assertUpgradingSectionExists(mdx, prevVersion, targetVersion) {
-  const pattern = new RegExp(
+  const headingPattern = new RegExp(
     `^##\\s+Upgrading\\s+from\\s+v${escapeRegex(prevVersion)}\\s+to\\s+(v${escapeRegex(targetVersion)}|%%PINCHY_VERSION%%)\\s*$`,
     "m",
   );
-  if (!pattern.test(mdx)) {
+  const headingMatch = headingPattern.exec(mdx);
+  if (!headingMatch) {
     throw new Error(
       `No upgrade-notes section for v${targetVersion} in upgrading.mdx.\n` +
         `Add a heading:\n\n  ## Upgrading from v${prevVersion} to %%PINCHY_VERSION%%\n\n` +
         `then draft the upgrade notes under it before releasing.`,
     );
+  }
+
+  // Slice from the matched heading to the next `## ` heading (or EOF) so
+  // subsection checks scan only THIS version entry, not later ones.
+  const sectionStart = headingMatch.index + headingMatch[0].length;
+  const remainder = mdx.slice(sectionStart);
+  const nextHeading = /^## /m.exec(remainder);
+  const sectionBody = remainder.slice(0, nextHeading ? nextHeading.index : remainder.length);
+
+  for (const required of ["Breaking changes", "Upgrade notes"]) {
+    const subPattern = new RegExp(`^###\\s+${escapeRegex(required)}\\s*$`, "m");
+    if (!subPattern.test(sectionBody)) {
+      throw new Error(
+        `Missing '${required}' subsection in v${targetVersion} entry of upgrading.mdx.\n` +
+          `Each upgrade-notes section must contain '### Breaking changes' and '### Upgrade notes'.\n` +
+          `Content "None." is fine; absent is not.`,
+      );
+    }
   }
 }
 

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -98,7 +98,7 @@ function escapeRegex(s) {
  * @param {string} prevVersion - previous release, no leading 'v' (e.g. "0.4.4")
  * @param {string} targetVersion - new release, no leading 'v' (e.g. "0.5.0")
  * @throws {Error} if no matching heading is found, or if the section is
- *               missing a '### Breaking changes' or '### Upgrade notes' subsection
+ *   missing a '### Breaking changes' or '### Upgrade notes' subsection
  */
 export function assertUpgradingSectionExists(mdx, prevVersion, targetVersion) {
   const headingPattern = new RegExp(

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -76,6 +76,12 @@ test("assertUpgradingSectionExists accepts %%PINCHY_VERSION%% placeholder", () =
   const mdx = [
     "## Upgrading from v0.4.4 to %%PINCHY_VERSION%%",
     "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
     "Notes go here.",
   ].join("\n");
   assert.doesNotThrow(() =>
@@ -86,6 +92,12 @@ test("assertUpgradingSectionExists accepts %%PINCHY_VERSION%% placeholder", () =
 test("assertUpgradingSectionExists accepts concrete target version", () => {
   const mdx = [
     "## Upgrading from v0.4.4 to v0.5.0",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
     "",
     "Notes.",
   ].join("\n");
@@ -111,7 +123,8 @@ test("assertUpgradingSectionExists rejects stale section (wrong 'from' version)"
 });
 
 test("assertUpgradingSectionExists is whitespace-tolerant in the heading", () => {
-  const mdx = "##   Upgrading  from  v0.4.4  to  %%PINCHY_VERSION%%  \n";
+  const mdx =
+    "##   Upgrading  from  v0.4.4  to  %%PINCHY_VERSION%%  \n\n### Breaking changes\n\nNone.\n\n### Upgrade notes\n\nNotes.\n";
   assert.doesNotThrow(() =>
     assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
   );
@@ -122,6 +135,46 @@ test("assertUpgradingSectionExists error message suggests the heading to add", (
   assert.throws(
     () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
     /## Upgrading from v0\.4\.4 to %%PINCHY_VERSION%%/,
+  );
+});
+
+test("assertUpgradingSectionExists accepts a section with both required subsections", () => {
+  const mdx = `## Upgrading from v0.4.4 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+None.
+
+### Upgrade notes
+
+Standard upgrade.
+`;
+  assert.doesNotThrow(() => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"));
+});
+
+test("assertUpgradingSectionExists rejects a section missing the Breaking changes subsection", () => {
+  const mdx = `## Upgrading from v0.4.4 to %%PINCHY_VERSION%%
+
+### Upgrade notes
+
+Standard upgrade — no required action.
+`;
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /Missing.*Breaking changes.*subsection/i,
+  );
+});
+
+test("assertUpgradingSectionExists rejects a section missing the Upgrade notes subsection", () => {
+  const mdx = `## Upgrading from v0.4.4 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+None.
+`;
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /Missing.*Upgrade notes.*subsection/i,
   );
 });
 

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -178,6 +178,31 @@ None.
   );
 });
 
+test("assertUpgradingSectionExists doesn't satisfy current section with later section's subsections", () => {
+  // The current v0.5.0 section has no subsections; a LATER (older) version
+  // section happens to contain both required subsections. The slice logic
+  // must stop at the next `## ` heading so the older section's subsections
+  // never satisfy the current check.
+  const mdx = `## Upgrading from v0.4.4 to %%PINCHY_VERSION%%
+
+No subsections here.
+
+## Upgrading from v0.4.3 to v0.4.4
+
+### Breaking changes
+
+None.
+
+### Upgrade notes
+
+Older notes.
+`;
+  assert.throws(
+    () => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
+    /Missing.*Breaking changes.*subsection/i,
+  );
+});
+
 // extractUpgradeNotes
 
 test("extractUpgradeNotes returns the body under the matching section", () => {


### PR DESCRIPTION
## Summary

- Adds `.squawk.toml` configuring Squawk for Postgres 17 with three destructive-DDL rules active (`ban-drop-column`, `ban-drop-table`, `changing-column-type`); all other rules explicitly excluded
- Adds a Squawk lint step to the `quality` CI job — runs only on PRs, diff-scoped to changed `packages/web/drizzle/*.sql` files so historical migrations are never re-scanned
- Extends `assertUpgradingSectionExists` (release Gate A) to require `### Breaking changes` and `### Upgrade notes` subsections in each upgrading.mdx version entry; 3 new TDD tests
- Refactors the v0.4.4 → v0.5.0 section in `upgrading.mdx` to include both required subsections (`### Breaking changes: None.`)
- Adds a `## Schema migration policy` section to `CONTRIBUTING.md` documenting the forward-only / Expand-Contract stance, the three banned Squawk patterns + override syntax, and the no-rollback-automation stance

Closes #147 Scope 3. Part of v0.5.0.

## Test plan

- [ ] CI `quality` job passes — Squawk step logs "No migration changes — skipping Squawk lint" (no `.sql` files in this PR's diff)
- [ ] `pnpm test:release` passes locally — all 28 tests green
- [ ] Release gate smoke: `node --input-type=module -e "import { assertUpgradingSectionExists } from './scripts/lib/release-logic.mjs'; import { readFileSync } from 'node:fs'; assertUpgradingSectionExists(readFileSync('docs/src/content/docs/guides/upgrading.mdx','utf8'),'0.4.4','0.5.0'); console.log('OK')"` prints OK
- [ ] Optional: open a throwaway PR with a dummy `DROP TABLE foo;` migration and verify Squawk reds the `quality` job, then close without merging