### PR TITLE
feat(license): support JWT schema v1 (ver, maxUsers) with seat cap enforcement

### DIFF
--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -61,6 +61,38 @@ After entering a key, go to **Settings → License**. You should see:
 
 The enterprise features (Groups tab, agent access control) should now be available.
 
+## Seat cap enforcement
+
+Enterprise license tokens include a `maxUsers` field that limits how many seats your organisation can use. A seat counts as either an **active user** or a **valid pending invitation** — both consume a seat.
+
+### What "at cap" means
+
+When `seatsUsed >= maxUsers`:
+
+- The **Invite User** button in **Settings → Users** is disabled and a banner explains why.
+- The **Settings → License** page shows the current seat count next to the cap (`7 / 10 seats used`).
+- Attempting to create an invite via the API returns `403 Forbidden` with `{ "error": "Seat limit reached" }`.
+- **No existing users are locked out.** Pinchy never deactivates an account to enforce a cap. Only new invitations are blocked.
+
+### Freeing up a seat
+
+To invite someone new when you are at cap, you can:
+
+1. **Revoke a pending invitation** — if an invite was sent but not yet claimed, revoking it frees the seat immediately.
+2. **Deactivate an existing user** — deactivated users no longer count toward the seat total.
+
+Both actions take effect immediately — the invite button re-enables without a page reload.
+
+### Trials and unlimited licenses
+
+A `maxUsers` value of **0** means unlimited seats. Trial keys issued by Pinchy carry `maxUsers: 0`, so seat enforcement does not apply during a trial. Paid keys include the seat count negotiated with your order.
+
+<Aside type="note">
+  The seat count shown in **Settings → License** includes both active users and
+  pending invitations. If the count looks higher than expected, check for
+  unclaimed invites in **Settings → Users**.
+</Aside>
+
 ## What happens when a key expires
 
 Pinchy degrades gracefully. Nothing breaks:

--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -36,11 +36,11 @@ On devices that support it, a **Share** button appears instead of Copy, letting 
 </Aside>
 
 <Aside type="note">
-  If your enterprise license has a seat cap and all seats are in use, the **Invite
-  User** button is disabled and a banner explains how many seats are in use. To
-  free up a seat, revoke a pending invitation or deactivate an existing user. See
-  [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement)
-  for details.
+  If your enterprise license has a seat cap and all seats are in use, the
+  **Invite User** button is disabled and a banner explains how many seats are in
+  use. To free up a seat, revoke a pending invitation or deactivate an existing
+  user. See [Enterprise Setup — Seat cap
+  enforcement](/guides/enterprise-setup/#seat-cap-enforcement) for details.
 </Aside>
 
 ### Invite token details
@@ -207,13 +207,13 @@ docker compose exec pinchy pnpm reset-admin --email admin@example.com
 
 All user management actions performed by admins are logged in the audit trail:
 
-| Action                    | Audit event             |
-| ------------------------- | ----------------------- |
-| User invited              | `user.invited`          |
-| Invite blocked (seat cap) | `user.invite_blocked`   |
-| Role changed              | `user.role_updated`     |
-| Group memberships changed | `user.groups_updated`   |
-| User reactivated          | `user.updated`          |
-| User deactivated          | `user.deleted`          |
+| Action                    | Audit event           |
+| ------------------------- | --------------------- |
+| User invited              | `user.invited`        |
+| Invite blocked (seat cap) | `user.invite_blocked` |
+| Role changed              | `user.role_updated`   |
+| Group memberships changed | `user.groups_updated` |
+| User reactivated          | `user.updated`        |
+| User deactivated          | `user.deleted`        |
 
 Each entry records which admin took the action, the affected user's name and email, and before/after values for role or group changes. See [Audit Trail](/concepts/audit-trail/) for more information on viewing and exporting audit logs.

--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -35,6 +35,14 @@ On devices that support it, a **Share** button appears instead of Copy, letting 
   address.
 </Aside>
 
+<Aside type="note">
+  If your enterprise license has a seat cap and all seats are in use, the **Invite
+  User** button is disabled and a banner explains how many seats are in use. To
+  free up a seat, revoke a pending invitation or deactivate an existing user. See
+  [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement)
+  for details.
+</Aside>
+
 ### Invite token details
 
 - Each invite token is **valid for 7 days** from creation.
@@ -199,12 +207,13 @@ docker compose exec pinchy pnpm reset-admin --email admin@example.com
 
 All user management actions performed by admins are logged in the audit trail:
 
-| Action                    | Audit event           |
-| ------------------------- | --------------------- |
-| User invited              | `user.invited`        |
-| Role changed              | `user.role_updated`   |
-| Group memberships changed | `user.groups_updated` |
-| User reactivated          | `user.updated`        |
-| User deactivated          | `user.deleted`        |
+| Action                    | Audit event             |
+| ------------------------- | ----------------------- |
+| User invited              | `user.invited`          |
+| Invite blocked (seat cap) | `user.invite_blocked`   |
+| Role changed              | `user.role_updated`     |
+| Group memberships changed | `user.groups_updated`   |
+| User reactivated          | `user.updated`          |
+| User deactivated          | `user.deleted`          |
 
 Each entry records which admin took the action, the affected user's name and email, and before/after values for role or group changes. See [Audit Trail](/concepts/audit-trail/) for more information on viewing and exporting audit logs.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -828,16 +828,16 @@ Get the current enterprise license status and seat usage. Any authenticated user
 }
 ```
 
-| Field           | Type            | Description                                                                                                    |
-| --------------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
-| `enterprise`    | boolean         | Whether an active enterprise license is present                                                                |
-| `type`          | string \| null  | `"trial"` or `"paid"`. `null` when no license is active.                                                       |
-| `org`           | string \| null  | Organisation name encoded in the license token. `null` when no license is active.                              |
-| `expiresAt`     | string \| null  | ISO 8601 expiry timestamp. `null` for non-expiring tokens or when no license is active.                        |
-| `daysRemaining` | number \| null  | Days until the key expires. `null` when the key has no expiry or no license is active.                         |
-| `managedByEnv`  | boolean         | `true` when the key comes from the `PINCHY_ENTERPRISE_KEY` environment variable (read-only in the Settings UI) |
-| `seatsUsed`     | number          | Number of seats currently in use: active users + valid pending invitations                                     |
-| `maxUsers`      | number          | Maximum seats allowed by the license. `0` means unlimited.                                                     |
+| Field           | Type           | Description                                                                                                    |
+| --------------- | -------------- | -------------------------------------------------------------------------------------------------------------- |
+| `enterprise`    | boolean        | Whether an active enterprise license is present                                                                |
+| `type`          | string \| null | `"trial"` or `"paid"`. `null` when no license is active.                                                       |
+| `org`           | string \| null | Organisation name encoded in the license token. `null` when no license is active.                              |
+| `expiresAt`     | string \| null | ISO 8601 expiry timestamp. `null` for non-expiring tokens or when no license is active.                        |
+| `daysRemaining` | number \| null | Days until the key expires. `null` when the key has no expiry or no license is active.                         |
+| `managedByEnv`  | boolean        | `true` when the key comes from the `PINCHY_ENTERPRISE_KEY` environment variable (read-only in the Settings UI) |
+| `seatsUsed`     | number         | Number of seats currently in use: active users + valid pending invitations                                     |
+| `maxUsers`      | number         | Maximum seats allowed by the license. `0` means unlimited.                                                     |
 
 **Seat cap behaviour:** when `seatsUsed >= maxUsers` and `maxUsers > 0`, the **Invite User** button is disabled and the API rejects new invitations with `403`. Existing users are never affected. See [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement) for the full explanation.
 
@@ -851,8 +851,8 @@ Save or update the enterprise license key. **Admin only.** Not available when th
 
 **Request body:**
 
-| Field | Type   | Required | Description          |
-| ----- | ------ | -------- | -------------------- |
+| Field | Type   | Required | Description           |
+| ----- | ------ | -------- | --------------------- |
 | `key` | string | Yes      | The JWT license token |
 
 **Response:** `{ "success": true }` — the new license status takes effect immediately without a restart.

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -517,7 +517,7 @@ The admin constructs the invite URL from the returned token: `{origin}/invite/{t
 
 - `400` — missing or invalid role
 - `401` — not authenticated
-- `403` — not an admin
+- `403` — not an admin, or seat cap reached (enterprise license `maxUsers` limit exceeded — see `GET /api/enterprise/status`)
 
 ### `GET /api/users/invites`
 
@@ -806,6 +806,62 @@ Usage over time — used to render the dashboard charts. Query parameters: `days
 ### `GET /api/usage/export`
 
 Export usage records as CSV. **Enterprise license required.**
+
+## Enterprise License
+
+### `GET /api/enterprise/status`
+
+Get the current enterprise license status and seat usage. Any authenticated user can call this endpoint (non-admins see it too, so the UI can show licence-gated features correctly).
+
+**Response:**
+
+```json
+{
+  "enterprise": true,
+  "type": "paid",
+  "org": "Acme Corp",
+  "expiresAt": "2027-01-15T00:00:00.000Z",
+  "daysRemaining": 263,
+  "managedByEnv": false,
+  "seatsUsed": 7,
+  "maxUsers": 10
+}
+```
+
+| Field           | Type            | Description                                                                                                    |
+| --------------- | --------------- | -------------------------------------------------------------------------------------------------------------- |
+| `enterprise`    | boolean         | Whether an active enterprise license is present                                                                |
+| `type`          | string \| null  | `"trial"` or `"paid"`. `null` when no license is active.                                                       |
+| `org`           | string \| null  | Organisation name encoded in the license token. `null` when no license is active.                              |
+| `expiresAt`     | string \| null  | ISO 8601 expiry timestamp. `null` for non-expiring tokens or when no license is active.                        |
+| `daysRemaining` | number \| null  | Days until the key expires. `null` when the key has no expiry or no license is active.                         |
+| `managedByEnv`  | boolean         | `true` when the key comes from the `PINCHY_ENTERPRISE_KEY` environment variable (read-only in the Settings UI) |
+| `seatsUsed`     | number          | Number of seats currently in use: active users + valid pending invitations                                     |
+| `maxUsers`      | number          | Maximum seats allowed by the license. `0` means unlimited.                                                     |
+
+**Seat cap behaviour:** when `seatsUsed >= maxUsers` and `maxUsers > 0`, the **Invite User** button is disabled and the API rejects new invitations with `403`. Existing users are never affected. See [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement) for the full explanation.
+
+**Errors:**
+
+- `401` — not authenticated
+
+### `POST /api/enterprise/key`
+
+Save or update the enterprise license key. **Admin only.** Not available when the key is managed via the `PINCHY_ENTERPRISE_KEY` environment variable (`managedByEnv: true`).
+
+**Request body:**
+
+| Field | Type   | Required | Description          |
+| ----- | ------ | -------- | -------------------- |
+| `key` | string | Yes      | The JWT license token |
+
+**Response:** `{ "success": true }` — the new license status takes effect immediately without a restart.
+
+**Errors:**
+
+- `400` — key is missing or the JWT signature is invalid
+- `401` — not authenticated
+- `403` — not an admin, or key is managed by env var
 
 ## Groups (admin only, enterprise)
 

--- a/packages/web/src/__tests__/api/enterprise-status.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-status.test.ts
@@ -72,4 +72,20 @@ describe("GET /api/enterprise/status", () => {
     expect(body.seatsUsed).toBe(12);
     expect(body.maxUsers).toBe(0);
   });
+
+  it("skips getSeatUsage and returns seatsUsed=0 when license is inactive", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: false,
+      ver: 1,
+      maxUsers: 0,
+      features: [],
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.enterprise).toBe(false);
+    expect(body.seatsUsed).toBe(0);
+    expect(body.maxUsers).toBe(0);
+    expect(getSeatUsage).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/__tests__/api/enterprise-status.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-status.test.ts
@@ -1,0 +1,75 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/auth", () => ({
+  getSession: vi.fn(),
+}));
+vi.mock("next/headers", () => ({
+  headers: async () => new Headers(),
+}));
+vi.mock("@/lib/enterprise", () => ({
+  getLicenseStatus: vi.fn(),
+  isKeyFromEnv: vi.fn(),
+}));
+vi.mock("@/lib/seat-usage", () => ({
+  getSeatUsage: vi.fn(),
+}));
+
+const { getSession } = await import("@/lib/auth");
+const { getLicenseStatus, isKeyFromEnv } = await import("@/lib/enterprise");
+const { getSeatUsage } = await import("@/lib/seat-usage");
+
+describe("GET /api/enterprise/status", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "u1" },
+    });
+    (isKeyFromEnv as ReturnType<typeof vi.fn>).mockReturnValue(false);
+  });
+
+  it("includes seatsUsed and maxUsers in the response", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+      type: "paid",
+      org: "TestCo",
+    });
+    (getSeatUsage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      used: 7,
+      max: 10,
+      available: 3,
+      unlimited: false,
+      activeUsers: 5,
+      pendingInvites: 2,
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.seatsUsed).toBe(7);
+    expect(body.maxUsers).toBe(10);
+  });
+
+  it("computes seatsUsed even when license is unlimited", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 0,
+      features: ["enterprise"],
+    });
+    (getSeatUsage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      used: 12,
+      max: 0,
+      available: null,
+      unlimited: true,
+      activeUsers: 12,
+      pendingInvites: 0,
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.seatsUsed).toBe(12);
+    expect(body.maxUsers).toBe(0);
+  });
+});

--- a/packages/web/src/__tests__/api/invites.test.ts
+++ b/packages/web/src/__tests__/api/invites.test.ts
@@ -27,6 +27,20 @@ vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Default to inactive license so existing tests are unaffected by seat-cap logic
+vi.mock("@/lib/enterprise", () => ({
+  getLicenseStatus: vi.fn().mockResolvedValue({
+    active: false,
+    ver: 1,
+    maxUsers: 0,
+    features: [],
+  }),
+}));
+
+vi.mock("@/lib/seat-usage", () => ({
+  getSeatUsage: vi.fn(),
+}));
+
 vi.mock("@/db", () => {
   const mockFrom = vi.fn().mockImplementation(() => {
     const result = Promise.resolve([]);

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -130,7 +130,7 @@ describe("POST /api/users/invite — seat cap", () => {
           seatsUsed: 5,
           maxUsers: 5,
         }),
-      }),
+      })
     );
   });
 

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -118,6 +118,8 @@ describe("POST /api/users/invite — seat cap", () => {
     // after() runs synchronously in tests (see test-setup.ts)
     expect(appendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
+        actorType: "user",
+        actorId: "admin-1",
         eventType: "user.invite_blocked",
         outcome: "failure",
         error: { message: "Seat cap reached" },

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/invites", () => ({
+  createInvite: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  getLicenseStatus: vi.fn(),
+}));
+
+vi.mock("@/lib/seat-usage", () => ({
+  getSeatUsage: vi.fn(),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    }),
+  },
+}));
+
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal();
+  return {
+    ...(actual as object),
+    inArray: vi.fn(),
+  };
+});
+
+import { requireAdmin } from "@/lib/api-auth";
+import { createInvite } from "@/lib/invites";
+import { appendAuditLog } from "@/lib/audit";
+import { getLicenseStatus } from "@/lib/enterprise";
+import { getSeatUsage } from "@/lib/seat-usage";
+
+function makeRequest(body: object) {
+  return new NextRequest("http://localhost/api/users/invite", {
+    method: "POST",
+    body: JSON.stringify(body),
+  });
+}
+
+describe("POST /api/users/invite — seat cap", () => {
+  let POST: typeof import("@/app/api/users/invite/route").POST;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(createInvite).mockResolvedValue({
+      id: "inv-1",
+      tokenHash: "h",
+    } as never);
+    const mod = await import("@/app/api/users/invite/route");
+    POST = mod.POST;
+  });
+
+  it("returns 403 when seat cap is reached", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+    });
+    vi.mocked(getSeatUsage).mockResolvedValue({
+      used: 10,
+      max: 10,
+      available: 0,
+      unlimited: false,
+      activeUsers: 8,
+      pendingInvites: 2,
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(403);
+    const body = await res.json();
+    expect(body.error).toBe("Seat limit reached");
+    expect(body.seatsUsed).toBe(10);
+    expect(body.maxUsers).toBe(10);
+    expect(createInvite).not.toHaveBeenCalled();
+  });
+
+  it("logs an audit event with outcome=failure when blocked", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 5,
+      features: ["enterprise"],
+    });
+    vi.mocked(getSeatUsage).mockResolvedValue({
+      used: 5,
+      max: 5,
+      available: 0,
+      unlimited: false,
+      activeUsers: 5,
+      pendingInvites: 0,
+    });
+    await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    // after() runs synchronously in tests (see test-setup.ts)
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "user.invite_blocked",
+        outcome: "failure",
+        error: { message: "Seat cap reached" },
+        detail: expect.objectContaining({
+          email: "new@test.com",
+          role: "member",
+          reason: "seat_cap",
+          seatsUsed: 5,
+          maxUsers: 5,
+        }),
+      }),
+    );
+  });
+
+  it("creates the invite when below the cap", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+    });
+    vi.mocked(getSeatUsage).mockResolvedValue({
+      used: 3,
+      max: 10,
+      available: 7,
+      unlimited: false,
+      activeUsers: 3,
+      pendingInvites: 0,
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(201);
+    expect(createInvite).toHaveBeenCalled();
+  });
+
+  it("does not check seat usage when license is unlimited", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 0,
+      features: ["enterprise"],
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(201);
+    expect(getSeatUsage).not.toHaveBeenCalled();
+  });
+
+  it("does not check seat usage when no enterprise license", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: false,
+      ver: 1,
+      maxUsers: 0,
+      features: [],
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(201);
+    expect(getSeatUsage).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -1,11 +1,25 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 
 const mockFetch = vi.fn();
 global.fetch = mockFetch;
 
 import { EnterpriseBanner } from "@/components/enterprise-banner";
+
+function statusJson(overrides: Record<string, unknown> = {}) {
+  return {
+    enterprise: true,
+    type: "paid",
+    daysRemaining: 200,
+    expiresAt: new Date(Date.now() + 200 * 86400000).toISOString(),
+    ...overrides,
+  };
+}
+
+function mockStatusResponse(data: object) {
+  return { ok: true, json: async () => data } as Response;
+}
 
 describe("EnterpriseBanner", () => {
   beforeEach(() => {
@@ -144,5 +158,90 @@ describe("EnterpriseBanner", () => {
     });
     expect(screen.getByText(/license has expired/i)).toBeInTheDocument();
     expect(screen.getByText(/enter new key/i)).toBeInTheDocument();
+  });
+
+  describe("re-fetch triggers", () => {
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-fetches when the tab becomes visible", async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(statusJson()));
+      render(<EnterpriseBanner isAdmin={true} />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "visible",
+      });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    });
+
+    it("does not re-fetch when the tab becomes hidden", async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(statusJson()));
+      render(<EnterpriseBanner isAdmin={true} />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => "hidden",
+      });
+      await act(async () => {
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+
+      // Give any stray promises a chance to land
+      await new Promise((resolve) => setTimeout(resolve, 10));
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("re-fetches periodically (every 15 minutes)", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockFetch.mockResolvedValue(mockStatusResponse(statusJson()));
+      render(<EnterpriseBanner isAdmin={true} />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+      });
+      expect(mockFetch).toHaveBeenCalledTimes(3);
+    });
+
+    it("re-fetches when a 'license-updated' event is dispatched", async () => {
+      mockFetch.mockResolvedValue(mockStatusResponse(statusJson()));
+      render(<EnterpriseBanner isAdmin={true} />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      await act(async () => {
+        window.dispatchEvent(new Event("license-updated"));
+      });
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(2));
+    });
+
+    it("removes listeners and timers on unmount", async () => {
+      vi.useFakeTimers({ shouldAdvanceTime: true });
+      mockFetch.mockResolvedValue(mockStatusResponse(statusJson()));
+      const { unmount } = render(<EnterpriseBanner isAdmin={true} />);
+      await waitFor(() => expect(mockFetch).toHaveBeenCalledTimes(1));
+
+      unmount();
+      mockFetch.mockClear();
+
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(15 * 60 * 1000);
+        window.dispatchEvent(new Event("license-updated"));
+        document.dispatchEvent(new Event("visibilitychange"));
+      });
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -256,4 +256,45 @@ describe("SettingsLicense", () => {
     render(<SettingsLicense initialLicense={license} />);
     expect(fetchSpy).not.toHaveBeenCalledWith("/api/enterprise/status");
   });
+
+  it("dispatches a 'license-updated' event after a successful save", async () => {
+    fetchSpy.mockResolvedValueOnce(
+      statusOkResponse({
+        enterprise: true,
+        type: "paid",
+        org: "Acme",
+        expiresAt: null,
+        daysRemaining: null,
+        managedByEnv: false,
+        maxUsers: 0,
+        seatsUsed: 0,
+      })
+    );
+    const onLicenseUpdated = vi.fn();
+    window.addEventListener("license-updated", onLicenseUpdated);
+
+    render(<SettingsLicense initialLicense={noLicenseStatus} />);
+    await userEvent.type(screen.getByLabelText(/license key/i), "eyJvalid");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(onLicenseUpdated).toHaveBeenCalled());
+    window.removeEventListener("license-updated", onLicenseUpdated);
+  });
+
+  it("does not dispatch 'license-updated' when save fails", async () => {
+    fetchSpy.mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Invalid license key" }),
+    } as Response);
+    const onLicenseUpdated = vi.fn();
+    window.addEventListener("license-updated", onLicenseUpdated);
+
+    render(<SettingsLicense initialLicense={noLicenseStatus} />);
+    await userEvent.type(screen.getByLabelText(/license key/i), "eyJbad");
+    await userEvent.click(screen.getByRole("button", { name: /save/i }));
+
+    await waitFor(() => expect(screen.getByText(/invalid license key/i)).toBeInTheDocument());
+    expect(onLicenseUpdated).not.toHaveBeenCalled();
+    window.removeEventListener("license-updated", onLicenseUpdated);
+  });
 });

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -44,6 +44,8 @@ describe("SettingsLicense", () => {
         expiresAt: null,
         daysRemaining: null,
         managedByEnv: false,
+        maxUsers: 0,
+        seatsUsed: 0,
       }),
     } as Response);
     render(<SettingsLicense />);
@@ -241,7 +243,6 @@ describe("SettingsLicense", () => {
   });
 
   it("does not refetch status when initialLicense is provided", () => {
-    const fetchSpy = vi.spyOn(global, "fetch");
     const license = {
       enterprise: true,
       type: "paid",

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -11,6 +11,8 @@ const noLicenseStatus = {
   expiresAt: null,
   daysRemaining: null,
   managedByEnv: false,
+  maxUsers: 0,
+  seatsUsed: 0,
 };
 
 const statusOkResponse = (data: object) =>
@@ -24,8 +26,7 @@ describe("SettingsLicense", () => {
 
   beforeEach(() => {
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
-    // Default: status fetch returns no-license (used by tests with initialLicense
-    // that still trigger fetchStatus() on mount)
+    // Default: status fetch returns no-license (used by tests without initialLicense)
     fetchSpy.mockResolvedValue(statusOkResponse(noLicenseStatus));
   });
 
@@ -59,6 +60,8 @@ describe("SettingsLicense", () => {
           expiresAt: null,
           daysRemaining: null,
           managedByEnv: false,
+          maxUsers: 0,
+          seatsUsed: 0,
         }}
       />
     );
@@ -76,6 +79,8 @@ describe("SettingsLicense", () => {
           expiresAt: "2027-01-01T00:00:00Z",
           daysRemaining: 365,
           managedByEnv: false,
+          maxUsers: 0,
+          seatsUsed: 0,
         }}
       />
     );
@@ -94,6 +99,8 @@ describe("SettingsLicense", () => {
           expiresAt: null,
           daysRemaining: null,
           managedByEnv: false,
+          maxUsers: 0,
+          seatsUsed: 0,
         }}
       />
     );
@@ -110,6 +117,8 @@ describe("SettingsLicense", () => {
           expiresAt: null,
           daysRemaining: null,
           managedByEnv: true,
+          maxUsers: 0,
+          seatsUsed: 0,
         }}
       />
     );
@@ -127,6 +136,8 @@ describe("SettingsLicense", () => {
           expiresAt: null,
           daysRemaining: null,
           managedByEnv: false,
+          maxUsers: 0,
+          seatsUsed: 0,
         }}
       />
     );
@@ -134,8 +145,7 @@ describe("SettingsLicense", () => {
   });
 
   it("calls PUT /api/enterprise/key when save is clicked", async () => {
-    // First call: status fetch on mount; second call: PUT /api/enterprise/key
-    fetchSpy.mockResolvedValueOnce(statusOkResponse(noLicenseStatus)).mockResolvedValueOnce(
+    fetchSpy.mockResolvedValueOnce(
       statusOkResponse({
         enterprise: true,
         type: "paid",
@@ -143,6 +153,8 @@ describe("SettingsLicense", () => {
         expiresAt: null,
         daysRemaining: null,
         managedByEnv: false,
+        maxUsers: 0,
+        seatsUsed: 0,
       })
     );
 
@@ -160,8 +172,7 @@ describe("SettingsLicense", () => {
   });
 
   it("shows error message when save fails", async () => {
-    // First call: status fetch on mount; second call: PUT /api/enterprise/key (fails)
-    fetchSpy.mockResolvedValueOnce(statusOkResponse(noLicenseStatus)).mockResolvedValueOnce({
+    fetchSpy.mockResolvedValueOnce({
       ok: false,
       json: async () => ({ error: "Invalid license key" }),
     } as Response);
@@ -176,8 +187,7 @@ describe("SettingsLicense", () => {
 
   it("calls onEnterpriseActivated callback after successful activation", async () => {
     const onActivated = vi.fn();
-    // First call: status fetch on mount; second call: PUT /api/enterprise/key
-    fetchSpy.mockResolvedValueOnce(statusOkResponse(noLicenseStatus)).mockResolvedValueOnce(
+    fetchSpy.mockResolvedValueOnce(
       statusOkResponse({
         enterprise: true,
         type: "paid",
@@ -185,6 +195,8 @@ describe("SettingsLicense", () => {
         expiresAt: null,
         daysRemaining: null,
         managedByEnv: false,
+        maxUsers: 0,
+        seatsUsed: 0,
       })
     );
 
@@ -196,5 +208,51 @@ describe("SettingsLicense", () => {
     await userEvent.click(screen.getByRole("button", { name: /save/i }));
 
     await waitFor(() => expect(onActivated).toHaveBeenCalled());
+  });
+
+  it("shows seats line when maxUsers > 0", () => {
+    const license = {
+      enterprise: true,
+      type: "paid",
+      org: "TestCo",
+      expiresAt: "2027-01-01T00:00:00Z",
+      daysRemaining: 250,
+      managedByEnv: false,
+      maxUsers: 10,
+      seatsUsed: 7,
+    };
+    render(<SettingsLicense initialLicense={license} />);
+    expect(screen.getByText(/Seats: 7 \/ 10 used/)).toBeInTheDocument();
+  });
+
+  it("hides seats line when license is unlimited (maxUsers=0)", () => {
+    const license = {
+      enterprise: true,
+      type: "trial",
+      org: "TestCo",
+      expiresAt: "2027-01-01T00:00:00Z",
+      daysRemaining: 14,
+      managedByEnv: false,
+      maxUsers: 0,
+      seatsUsed: 5,
+    };
+    render(<SettingsLicense initialLicense={license} />);
+    expect(screen.queryByText(/Seats:/)).not.toBeInTheDocument();
+  });
+
+  it("does not refetch status when initialLicense is provided", () => {
+    const fetchSpy = vi.spyOn(global, "fetch");
+    const license = {
+      enterprise: true,
+      type: "paid",
+      org: "TestCo",
+      expiresAt: null,
+      daysRemaining: null,
+      managedByEnv: false,
+      maxUsers: 0,
+      seatsUsed: 0,
+    };
+    render(<SettingsLicense initialLicense={license} />);
+    expect(fetchSpy).not.toHaveBeenCalledWith("/api/enterprise/status");
   });
 });

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -734,4 +734,78 @@ describe("SettingsUsers", () => {
       expect(tableView.getByText("deactivated")).toBeInTheDocument();
     });
   });
+
+  it("shows seat usage banner when maxUsers > 0", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      if (String(url) === "/api/users") {
+        return { ok: true, json: async () => ({ users: [] }) } as Response;
+      }
+      if (String(url) === "/api/users/invites") {
+        return { ok: true, json: async () => ({ invites: [] }) } as Response;
+      }
+      if (String(url) === "/api/groups") {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (String(url) === "/api/enterprise/status") {
+        return {
+          ok: true,
+          json: async () => ({ enterprise: true, type: "paid", maxUsers: 10, seatsUsed: 7 }),
+        } as Response;
+      }
+      return { ok: false } as Response;
+    });
+    render(<SettingsUsers currentUserId="u1" />);
+    expect(await screen.findByText(/7 of 10 seats used/i)).toBeInTheDocument();
+  });
+
+  it("disables the invite button when at the cap", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      if (String(url) === "/api/users") {
+        return { ok: true, json: async () => ({ users: [] }) } as Response;
+      }
+      if (String(url) === "/api/users/invites") {
+        return { ok: true, json: async () => ({ invites: [] }) } as Response;
+      }
+      if (String(url) === "/api/groups") {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (String(url) === "/api/enterprise/status") {
+        return {
+          ok: true,
+          json: async () => ({ enterprise: true, maxUsers: 10, seatsUsed: 10 }),
+        } as Response;
+      }
+      return { ok: false } as Response;
+    });
+    render(<SettingsUsers currentUserId="u1" />);
+    const inviteBtn = await screen.findByRole("button", { name: /invite user/i });
+    expect(inviteBtn).toBeDisabled();
+  });
+
+  it("hides banner when license is unlimited", async () => {
+    vi.mocked(global.fetch).mockImplementation(async (url) => {
+      if (String(url) === "/api/users") {
+        return { ok: true, json: async () => ({ users: [] }) } as Response;
+      }
+      if (String(url) === "/api/users/invites") {
+        return { ok: true, json: async () => ({ invites: [] }) } as Response;
+      }
+      if (String(url) === "/api/groups") {
+        return { ok: true, json: async () => [] } as Response;
+      }
+      if (String(url) === "/api/enterprise/status") {
+        return {
+          ok: true,
+          json: async () => ({ enterprise: true, maxUsers: 0, seatsUsed: 12 }),
+        } as Response;
+      }
+      return { ok: false } as Response;
+    });
+    render(<SettingsUsers currentUserId="u1" />);
+    // Wait for loading to finish so the component has processed the enterprise status response
+    await waitFor(() => {
+      expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
+    });
+    expect(screen.queryByText(/seats used/i)).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -71,7 +71,11 @@ describe("SettingsUsers", () => {
   function mockFetchForUsers(
     users: unknown[],
     invites: unknown[] = mockInvites,
-    { enterprise = false }: { enterprise?: boolean } = {}
+    {
+      enterprise = false,
+      maxUsers = 0,
+      seatsUsed = 0,
+    }: { enterprise?: boolean; maxUsers?: number; seatsUsed?: number } = {}
   ) {
     vi.mocked(global.fetch).mockImplementation(async (url) => {
       if (String(url) === "/api/users") {
@@ -84,7 +88,7 @@ describe("SettingsUsers", () => {
         return { ok: true, json: async () => [] } as Response;
       }
       if (String(url) === "/api/enterprise/status") {
-        return { ok: true, json: async () => ({ enterprise }) } as Response;
+        return { ok: true, json: async () => ({ enterprise, maxUsers, seatsUsed }) } as Response;
       }
       return { ok: false } as Response;
     });
@@ -736,73 +740,21 @@ describe("SettingsUsers", () => {
   });
 
   it("shows seat usage banner when maxUsers > 0", async () => {
-    vi.mocked(global.fetch).mockImplementation(async (url) => {
-      if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users: [] }) } as Response;
-      }
-      if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites: [] }) } as Response;
-      }
-      if (String(url) === "/api/groups") {
-        return { ok: true, json: async () => [] } as Response;
-      }
-      if (String(url) === "/api/enterprise/status") {
-        return {
-          ok: true,
-          json: async () => ({ enterprise: true, type: "paid", maxUsers: 10, seatsUsed: 7 }),
-        } as Response;
-      }
-      return { ok: false } as Response;
-    });
+    mockFetchForUsers([], [], { enterprise: true, maxUsers: 10, seatsUsed: 7 });
     render(<SettingsUsers currentUserId="u1" />);
     expect(await screen.findByText(/7 of 10 seats used/i)).toBeInTheDocument();
   });
 
   it("disables the invite button when at the cap", async () => {
-    vi.mocked(global.fetch).mockImplementation(async (url) => {
-      if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users: [] }) } as Response;
-      }
-      if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites: [] }) } as Response;
-      }
-      if (String(url) === "/api/groups") {
-        return { ok: true, json: async () => [] } as Response;
-      }
-      if (String(url) === "/api/enterprise/status") {
-        return {
-          ok: true,
-          json: async () => ({ enterprise: true, maxUsers: 10, seatsUsed: 10 }),
-        } as Response;
-      }
-      return { ok: false } as Response;
-    });
+    mockFetchForUsers([], [], { enterprise: true, maxUsers: 10, seatsUsed: 10 });
     render(<SettingsUsers currentUserId="u1" />);
     const inviteBtn = await screen.findByRole("button", { name: /invite user/i });
     expect(inviteBtn).toBeDisabled();
   });
 
   it("hides banner when license is unlimited", async () => {
-    vi.mocked(global.fetch).mockImplementation(async (url) => {
-      if (String(url) === "/api/users") {
-        return { ok: true, json: async () => ({ users: [] }) } as Response;
-      }
-      if (String(url) === "/api/users/invites") {
-        return { ok: true, json: async () => ({ invites: [] }) } as Response;
-      }
-      if (String(url) === "/api/groups") {
-        return { ok: true, json: async () => [] } as Response;
-      }
-      if (String(url) === "/api/enterprise/status") {
-        return {
-          ok: true,
-          json: async () => ({ enterprise: true, maxUsers: 0, seatsUsed: 12 }),
-        } as Response;
-      }
-      return { ok: false } as Response;
-    });
+    mockFetchForUsers([], [], { enterprise: true, maxUsers: 0, seatsUsed: 12 });
     render(<SettingsUsers currentUserId="u1" />);
-    // Wait for loading to finish so the component has processed the enterprise status response
     await waitFor(() => {
       expect(screen.queryByText("Loading...")).not.toBeInTheDocument();
     });

--- a/packages/web/src/__tests__/helpers/license-fixtures.ts
+++ b/packages/web/src/__tests__/helpers/license-fixtures.ts
@@ -1,0 +1,16 @@
+// packages/web/src/__tests__/helpers/license-fixtures.ts
+import type { LicenseStatus } from "@/lib/license";
+
+export function makeLicense(overrides: Partial<LicenseStatus> = {}): LicenseStatus {
+  return {
+    active: true,
+    type: "paid",
+    org: "Test Org",
+    features: ["enterprise"],
+    expiresAt: new Date(Date.now() + 365 * 86400000),
+    daysRemaining: 365,
+    ver: 1,
+    maxUsers: 0,
+    ...overrides,
+  };
+}

--- a/packages/web/src/__tests__/helpers/license-fixtures.ts
+++ b/packages/web/src/__tests__/helpers/license-fixtures.ts
@@ -7,7 +7,7 @@ export function makeLicense(overrides: Partial<LicenseStatus> = {}): LicenseStat
     type: "paid",
     org: "Test Org",
     features: ["enterprise"],
-    expiresAt: new Date(Date.now() + 365 * 86400000),
+    expiresAt: new Date("2027-04-27T00:00:00.000Z"),
     daysRemaining: 365,
     ver: 1,
     maxUsers: 0,

--- a/packages/web/src/__tests__/helpers/license-fixtures.ts
+++ b/packages/web/src/__tests__/helpers/license-fixtures.ts
@@ -1,4 +1,3 @@
-// packages/web/src/__tests__/helpers/license-fixtures.ts
 import type { LicenseStatus } from "@/lib/license";
 
 export function makeLicense(overrides: Partial<LicenseStatus> = {}): LicenseStatus {

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -141,9 +141,7 @@ describe("validateLicense", () => {
     const { validateLicense } = await import("@/lib/license");
     const token = await createTestToken({ ver: 2 });
     await validateLicense(token, testPublicKeyPem);
-    expect(warnSpy).toHaveBeenCalledWith(
-      expect.stringContaining("ver=2"),
-    );
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining("ver=2"));
     warnSpy.mockRestore();
   });
 

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -1,5 +1,5 @@
 // @vitest-environment node
-import { describe, it, expect, beforeAll } from "vitest";
+import { describe, it, expect, beforeAll, vi } from "vitest";
 import * as jose from "jose";
 
 let testPublicKeyPem: string;
@@ -103,5 +103,55 @@ describe("validateLicense", () => {
     const token = await createTestToken({ features: ["something-else"] });
     const status = await validateLicense(token, testPublicKeyPem);
     expect(status.active).toBe(false);
+  });
+
+  it("extracts ver and maxUsers from token claims", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({ ver: 1, maxUsers: 10 });
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.ver).toBe(1);
+    expect(status.maxUsers).toBe(10);
+  });
+
+  it("defaults ver to 1 when missing from token", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({});
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.ver).toBe(1);
+  });
+
+  it("defaults maxUsers to 0 (unlimited) when missing from token", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({});
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.maxUsers).toBe(0);
+  });
+
+  it("validates tokens with higher ver (forward compat)", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({ ver: 2, maxUsers: 5 });
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.active).toBe(true);
+    expect(status.ver).toBe(2);
+    expect(status.maxUsers).toBe(5);
+  });
+
+  it("logs a warning for tokens with unknown higher ver", async () => {
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({ ver: 2 });
+    await validateLicense(token, testPublicKeyPem);
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("ver=2"),
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("INACTIVE result has ver=1 and maxUsers=0 defaults", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const status = await validateLicense("", testPublicKeyPem);
+    expect(status.active).toBe(false);
+    expect(status.ver).toBe(1);
+    expect(status.maxUsers).toBe(0);
   });
 });

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -130,4 +130,3 @@ describeIf("getSeatUsage", () => {
     expect(usage.available).toBe(0);
   });
 });
-

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -76,6 +76,22 @@ describe("getSeatUsage", () => {
     expect(usage.activeUsers).toBe(1);
   });
 
+  it("counts users with null banned as active", async () => {
+    await db.insert(users).values({
+      id: "u-null-banned",
+      email: "null-banned@test.local",
+      name: "null-banned",
+      role: "member",
+      banned: null,
+      emailVerified: true,
+      createdAt: new Date(),
+      updatedAt: new Date(),
+    });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 5 }));
+    expect(usage.activeUsers).toBe(1);
+  });
+
   it("excludes expired invites", async () => {
     await seedUser({ id: "u1" });
     await seedInvite({

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -4,6 +4,9 @@ import { db } from "@/db";
 import { users, invites } from "@/db/schema";
 import { makeLicense } from "../helpers/license-fixtures";
 
+const url = process.env.DATABASE_URL;
+const describeIf = url ? describe : describe.skip;
+
 async function clearTables() {
   await db.delete(invites);
   await db.delete(users);
@@ -39,7 +42,7 @@ async function seedInvite(opts: {
   });
 }
 
-describe("getSeatUsage", () => {
+describeIf("getSeatUsage", () => {
   beforeEach(clearTables);
 
   it("returns unlimited when license has maxUsers=0", async () => {
@@ -128,7 +131,7 @@ describe("getSeatUsage", () => {
   });
 });
 
-describe("isSeatAvailable", () => {
+describeIf("isSeatAvailable", () => {
   beforeEach(clearTables);
 
   it("is always true when license is unlimited", async () => {

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -1,0 +1,136 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach } from "vitest";
+import { db } from "@/db";
+import { users, invites } from "@/db/schema";
+import { makeLicense } from "../helpers/license-fixtures";
+
+async function clearTables() {
+  await db.delete(invites);
+  await db.delete(users);
+}
+
+async function seedUser(opts: { id: string; banned?: boolean }) {
+  await db.insert(users).values({
+    id: opts.id,
+    email: `${opts.id}@test.local`,
+    name: opts.id,
+    role: "member",
+    banned: opts.banned ?? false,
+    emailVerified: true,
+    createdAt: new Date(),
+    updatedAt: new Date(),
+  });
+}
+
+async function seedInvite(opts: {
+  id: string;
+  claimedAt?: Date | null;
+  expiresAt: Date;
+  createdBy: string;
+}) {
+  await db.insert(invites).values({
+    id: opts.id,
+    tokenHash: `hash-${opts.id}`,
+    role: "member",
+    type: "invite",
+    createdBy: opts.createdBy,
+    expiresAt: opts.expiresAt,
+    claimedAt: opts.claimedAt ?? null,
+  });
+}
+
+describe("getSeatUsage", () => {
+  beforeEach(clearTables);
+
+  it("returns unlimited when license has maxUsers=0", async () => {
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 0 }));
+    expect(usage.unlimited).toBe(true);
+    expect(usage.available).toBeNull();
+    expect(usage.max).toBe(0);
+  });
+
+  it("counts active users plus valid pending invites", async () => {
+    await seedUser({ id: "u1" });
+    await seedUser({ id: "u2" });
+    await seedUser({ id: "u3" });
+    await seedInvite({
+      id: "i1",
+      expiresAt: new Date(Date.now() + 86400000),
+      createdBy: "u1",
+    });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 5 }));
+    expect(usage.activeUsers).toBe(3);
+    expect(usage.pendingInvites).toBe(1);
+    expect(usage.used).toBe(4);
+    expect(usage.available).toBe(1);
+    expect(usage.unlimited).toBe(false);
+  });
+
+  it("excludes banned users from active count", async () => {
+    await seedUser({ id: "u1" });
+    await seedUser({ id: "u2", banned: true });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 5 }));
+    expect(usage.activeUsers).toBe(1);
+  });
+
+  it("excludes expired invites", async () => {
+    await seedUser({ id: "u1" });
+    await seedInvite({
+      id: "i1",
+      expiresAt: new Date(Date.now() - 86400000),
+      createdBy: "u1",
+    });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 5 }));
+    expect(usage.pendingInvites).toBe(0);
+  });
+
+  it("excludes claimed invites", async () => {
+    await seedUser({ id: "u1" });
+    await seedInvite({
+      id: "i1",
+      expiresAt: new Date(Date.now() + 86400000),
+      claimedAt: new Date(),
+      createdBy: "u1",
+    });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 5 }));
+    expect(usage.pendingInvites).toBe(0);
+  });
+
+  it("clamps available to 0 when over cap", async () => {
+    await seedUser({ id: "u1" });
+    await seedUser({ id: "u2" });
+    await seedUser({ id: "u3" });
+    const { getSeatUsage } = await import("@/lib/seat-usage");
+    const usage = await getSeatUsage(makeLicense({ maxUsers: 2 }));
+    expect(usage.used).toBe(3);
+    expect(usage.available).toBe(0);
+  });
+});
+
+describe("isSeatAvailable", () => {
+  beforeEach(clearTables);
+
+  it("is always true when license is unlimited", async () => {
+    await seedUser({ id: "u1" });
+    const { isSeatAvailable } = await import("@/lib/seat-usage");
+    expect(await isSeatAvailable(makeLicense({ maxUsers: 0 }))).toBe(true);
+  });
+
+  it("is false when at the cap", async () => {
+    await seedUser({ id: "u1" });
+    await seedUser({ id: "u2" });
+    const { isSeatAvailable } = await import("@/lib/seat-usage");
+    expect(await isSeatAvailable(makeLicense({ maxUsers: 2 }))).toBe(false);
+  });
+
+  it("is true when below the cap", async () => {
+    await seedUser({ id: "u1" });
+    const { isSeatAvailable } = await import("@/lib/seat-usage");
+    expect(await isSeatAvailable(makeLicense({ maxUsers: 5 }))).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/seat-usage.test.ts
+++ b/packages/web/src/__tests__/lib/seat-usage.test.ts
@@ -131,25 +131,3 @@ describeIf("getSeatUsage", () => {
   });
 });
 
-describeIf("isSeatAvailable", () => {
-  beforeEach(clearTables);
-
-  it("is always true when license is unlimited", async () => {
-    await seedUser({ id: "u1" });
-    const { isSeatAvailable } = await import("@/lib/seat-usage");
-    expect(await isSeatAvailable(makeLicense({ maxUsers: 0 }))).toBe(true);
-  });
-
-  it("is false when at the cap", async () => {
-    await seedUser({ id: "u1" });
-    await seedUser({ id: "u2" });
-    const { isSeatAvailable } = await import("@/lib/seat-usage");
-    expect(await isSeatAvailable(makeLicense({ maxUsers: 2 }))).toBe(false);
-  });
-
-  it("is true when below the cap", async () => {
-    await seedUser({ id: "u1" });
-    const { isSeatAvailable } = await import("@/lib/seat-usage");
-    expect(await isSeatAvailable(makeLicense({ maxUsers: 5 }))).toBe(true);
-  });
-});

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { getSession } from "@/lib/auth";
 import { getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
+import { getSeatUsage } from "@/lib/seat-usage";
 import { SettingsPageContent } from "@/components/settings-page-content";
 
 export const metadata: Metadata = {
@@ -20,6 +21,7 @@ export default async function SettingsPage({
     getLicenseStatus(),
   ]);
   const isAdmin = session?.user?.role === "admin";
+  const usage = isAdmin ? await getSeatUsage(licenseStatus) : null;
   return (
     <SettingsPageContent
       initialTab={tab}
@@ -33,6 +35,8 @@ export default async function SettingsPage({
               expiresAt: licenseStatus.expiresAt?.toISOString() ?? null,
               daysRemaining: licenseStatus.daysRemaining ?? null,
               managedByEnv: isKeyFromEnv(),
+              maxUsers: licenseStatus.maxUsers,
+              seatsUsed: usage?.used ?? 0,
             }
           : undefined
       }

--- a/packages/web/src/app/api/enterprise/status/route.ts
+++ b/packages/web/src/app/api/enterprise/status/route.ts
@@ -2,6 +2,7 @@ import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { getSession } from "@/lib/auth";
 import { getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
+import { getSeatUsage } from "@/lib/seat-usage";
 
 export async function GET() {
   const session = await getSession({ headers: await headers() });
@@ -10,6 +11,7 @@ export async function GET() {
   }
 
   const status = await getLicenseStatus();
+  const usage = await getSeatUsage(status);
   return NextResponse.json({
     enterprise: status.active,
     type: status.type ?? null,
@@ -17,5 +19,7 @@ export async function GET() {
     expiresAt: status.expiresAt?.toISOString() ?? null,
     daysRemaining: status.daysRemaining ?? null,
     managedByEnv: isKeyFromEnv(),
+    seatsUsed: usage.used,
+    maxUsers: status.maxUsers,
   });
 }

--- a/packages/web/src/app/api/enterprise/status/route.ts
+++ b/packages/web/src/app/api/enterprise/status/route.ts
@@ -11,7 +11,7 @@ export async function GET() {
   }
 
   const status = await getLicenseStatus();
-  const usage = await getSeatUsage(status);
+  const usage = status.active ? await getSeatUsage(status) : null;
   return NextResponse.json({
     enterprise: status.active,
     type: status.type ?? null,
@@ -19,7 +19,7 @@ export async function GET() {
     expiresAt: status.expiresAt?.toISOString() ?? null,
     daysRemaining: status.daysRemaining ?? null,
     managedByEnv: isKeyFromEnv(),
-    seatsUsed: usage.used,
+    seatsUsed: usage?.used ?? 0,
     maxUsers: status.maxUsers,
   });
 }

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -37,7 +37,7 @@ export async function POST(request: NextRequest) {
           },
           outcome: "failure",
           error: { message: "Seat cap reached" },
-        }),
+        })
       );
       return NextResponse.json(
         {
@@ -46,7 +46,7 @@ export async function POST(request: NextRequest) {
           seatsUsed: usage.used,
           maxUsers: license.maxUsers,
         },
-        { status: 403 },
+        { status: 403 }
       );
     }
   }
@@ -74,7 +74,7 @@ export async function POST(request: NextRequest) {
         ...(auditGroups.length > 0 ? { groups: auditGroups } : {}),
       },
       outcome: "success",
-    }),
+    })
   );
 
   return NextResponse.json(invite, { status: 201 });

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -2,6 +2,8 @@ import { NextRequest, NextResponse, after } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { createInvite } from "@/lib/invites";
 import { appendAuditLog } from "@/lib/audit";
+import { getLicenseStatus } from "@/lib/enterprise";
+import { getSeatUsage } from "@/lib/seat-usage";
 import { db } from "@/db";
 import { groups } from "@/db/schema";
 import { inArray } from "drizzle-orm";
@@ -15,6 +17,38 @@ export async function POST(request: NextRequest) {
 
   if (!role || !["admin", "member"].includes(role)) {
     return NextResponse.json({ error: "Role must be 'admin' or 'member'" }, { status: 400 });
+  }
+
+  const license = await getLicenseStatus();
+  if (license.active && license.maxUsers > 0) {
+    const usage = await getSeatUsage(license);
+    if (usage.used >= license.maxUsers) {
+      after(() =>
+        appendAuditLog({
+          actorType: "user",
+          actorId: session.user.id!,
+          eventType: "user.invite_blocked",
+          detail: {
+            email,
+            role,
+            reason: "seat_cap",
+            seatsUsed: usage.used,
+            maxUsers: license.maxUsers,
+          },
+          outcome: "failure",
+          error: { message: "Seat cap reached" },
+        }),
+      );
+      return NextResponse.json(
+        {
+          error: "Seat limit reached",
+          message: `Your license allows ${license.maxUsers} seats, all are in use. Remove an existing user or pending invitation, or upgrade your subscription.`,
+          seatsUsed: usage.used,
+          maxUsers: license.maxUsers,
+        },
+        { status: 403 },
+      );
+    }
   }
 
   const invite = await createInvite({ email, role, createdBy: session.user.id, groupIds });
@@ -40,7 +74,7 @@ export async function POST(request: NextRequest) {
         ...(auditGroups.length > 0 ? { groups: auditGroups } : {}),
       },
       outcome: "success",
-    })
+    }),
   );
 
   return NextResponse.json(invite, { status: 201 });

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -1,7 +1,9 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useCallback } from "react";
 import Link from "next/link";
+
+const REFETCH_INTERVAL_MS = 15 * 60 * 1000;
 
 interface LicenseInfo {
   enterprise: boolean;
@@ -87,9 +89,7 @@ function shouldShowBanner(license: LicenseInfo): {
 export function EnterpriseBanner({ isAdmin }: { isAdmin: boolean }) {
   const [banner, setBanner] = useState<ReturnType<typeof shouldShowBanner> | null>(null);
 
-  useEffect(() => {
-    if (!isAdmin) return;
-
+  const fetchStatus = useCallback(() => {
     fetch("/api/enterprise/status")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
@@ -98,7 +98,27 @@ export function EnterpriseBanner({ isAdmin }: { isAdmin: boolean }) {
         }
       })
       .catch(() => {});
-  }, [isAdmin]);
+  }, []);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    fetchStatus();
+
+    const onVisibility = () => {
+      if (document.visibilityState === "visible") fetchStatus();
+    };
+    const onLicenseUpdated = () => fetchStatus();
+    const interval = setInterval(fetchStatus, REFETCH_INTERVAL_MS);
+
+    document.addEventListener("visibilitychange", onVisibility);
+    window.addEventListener("license-updated", onLicenseUpdated);
+
+    return () => {
+      clearInterval(interval);
+      document.removeEventListener("visibilitychange", onVisibility);
+      window.removeEventListener("license-updated", onLicenseUpdated);
+    };
+  }, [isAdmin, fetchStatus]);
 
   if (!isAdmin || !banner?.show) return null;
 

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -14,6 +14,8 @@ interface LicenseInfo {
   expiresAt: string | null;
   daysRemaining: number | null;
   managedByEnv: boolean;
+  maxUsers: number;
+  seatsUsed: number;
 }
 
 interface SettingsLicenseProps {
@@ -42,8 +44,9 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
   }, []);
 
   useEffect(() => {
+    if (initialLicense) return;
     fetchStatus();
-  }, [fetchStatus]);
+  }, [fetchStatus, initialLicense]);
 
   const handleSave = async () => {
     setSaving(true);
@@ -110,6 +113,11 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
                   day: "numeric",
                 })}{" "}
                 ({license.daysRemaining} days remaining)
+              </p>
+            )}
+            {license.maxUsers > 0 && (
+              <p className="text-sm">
+                Seats: {license.seatsUsed} / {license.maxUsers} used
               </p>
             )}
             {license.managedByEnv && (

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -52,6 +52,7 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
         await fetchStatus();
         setKeyInput("");
         setShowInput(false);
+        window.dispatchEvent(new Event("license-updated"));
         if (data.enterprise) {
           onEnterpriseActivated?.();
         }

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -6,17 +6,7 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
-
-interface LicenseInfo {
-  enterprise: boolean;
-  type: string | null;
-  org: string | null;
-  expiresAt: string | null;
-  daysRemaining: number | null;
-  managedByEnv: boolean;
-  maxUsers: number;
-  seatsUsed: number;
-}
+import type { LicenseInfo } from "@/lib/enterprise";
 
 interface SettingsLicenseProps {
   onEnterpriseActivated?: () => void;

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -59,7 +59,7 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
       });
       if (res.ok) {
         const data = await res.json();
-        setLicense(data);
+        await fetchStatus();
         setKeyInput("");
         setShowInput(false);
         if (data.enterprise) {

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -37,6 +37,8 @@ interface LicenseInfo {
   expiresAt: string | null;
   daysRemaining: number | null;
   managedByEnv: boolean;
+  maxUsers: number;
+  seatsUsed: number;
 }
 
 export function SettingsPageContent({

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -15,6 +15,7 @@ import { SettingsIntegrations } from "@/components/settings-integrations";
 import { SettingsLicense } from "@/components/settings-license";
 import { TelegramLinkSettings } from "@/components/telegram-link-settings";
 import { SettingsSecurity } from "@/components/settings-security";
+import type { LicenseInfo } from "@/lib/enterprise";
 
 interface ProviderStatus {
   defaultProvider: string | null;
@@ -28,17 +29,6 @@ function DirtyDot() {
       aria-label="unsaved changes"
     />
   );
-}
-
-interface LicenseInfo {
-  enterprise: boolean;
-  type: string | null;
-  org: string | null;
-  expiresAt: string | null;
-  daysRemaining: number | null;
-  managedByEnv: boolean;
-  maxUsers: number;
-  seatsUsed: number;
 }
 
 export function SettingsPageContent({

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -79,6 +79,10 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
   const [selectedUser, setSelectedUser] = useState<(UserListItem & { kind: "user" }) | null>(null);
   const [allGroups, setAllGroups] = useState<{ id: string; name: string }[]>([]);
   const [isEnterprise, setIsEnterprise] = useState(false);
+  const [seatInfo, setSeatInfo] = useState<{ maxUsers: number; seatsUsed: number } | null>(null);
+
+  const atCap = seatInfo !== null && seatInfo.maxUsers > 0 && seatInfo.seatsUsed >= seatInfo.maxUsers;
+  const showBanner = seatInfo !== null && seatInfo.maxUsers > 0;
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -99,6 +103,12 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
       }
       setAllGroups(Array.isArray(groupsData) ? groupsData : []);
       setIsEnterprise(enterpriseData?.enterprise ?? false);
+      if (
+        typeof enterpriseData?.maxUsers === "number" &&
+        typeof enterpriseData?.seatsUsed === "number"
+      ) {
+        setSeatInfo({ maxUsers: enterpriseData.maxUsers, seatsUsed: enterpriseData.seatsUsed });
+      }
     } finally {
       setLoading(false);
     }
@@ -151,7 +161,17 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Users</CardTitle>
-          <Button onClick={() => setInviteOpen(true)}>Invite User</Button>
+          <Button
+            onClick={() => setInviteOpen(true)}
+            disabled={atCap}
+            title={
+              atCap
+                ? "Seat limit reached — remove an existing user or pending invitation first."
+                : undefined
+            }
+          >
+            Invite User
+          </Button>
         </CardHeader>
         <CardContent>
           {resetLink && (
@@ -166,6 +186,20 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
               >
                 {isResetLinkCopied ? "Copied!" : "Copy"}
               </Button>
+            </div>
+          )}
+
+          {showBanner && (
+            <div
+              className={`mb-4 rounded-md border p-3 text-sm ${
+                atCap
+                  ? "border-destructive/50 bg-destructive/5 text-destructive-foreground"
+                  : "bg-muted text-muted-foreground"
+              }`}
+            >
+              {atCap
+                ? `${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used. Remove a user or pending invitation to invite someone new, or upgrade your subscription.`
+                : `${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used.`}
             </div>
           )}
 

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -81,7 +81,8 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
   const [isEnterprise, setIsEnterprise] = useState(false);
   const [seatInfo, setSeatInfo] = useState<{ maxUsers: number; seatsUsed: number } | null>(null);
 
-  const atCap = seatInfo !== null && seatInfo.maxUsers > 0 && seatInfo.seatsUsed >= seatInfo.maxUsers;
+  const atCap =
+    seatInfo !== null && seatInfo.maxUsers > 0 && seatInfo.seatsUsed >= seatInfo.maxUsers;
   const showBanner = seatInfo !== null && seatInfo.maxUsers > 0;
 
   const fetchUsers = useCallback(async () => {

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -19,6 +19,7 @@ import { StatusBadge } from "@/components/status-badge";
 import { toast } from "sonner";
 import { mergeUserList, type UserListItem, type UserGroup } from "@/lib/user-list";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
+import { cn } from "@/lib/utils";
 
 interface SettingsUsersProps {
   currentUserId: string;
@@ -192,11 +193,12 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
 
           {showBanner && (
             <div
-              className={`mb-4 rounded-md border p-3 text-sm ${
+              className={cn(
+                "mb-4 rounded-md border p-3 text-sm",
                 atCap
                   ? "border-destructive/50 bg-destructive/5 text-destructive-foreground"
                   : "bg-muted text-muted-foreground"
-              }`}
+              )}
             >
               {atCap
                 ? `${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used. Remove a user or pending invitation to invite someone new, or upgrade your subscription.`

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -149,7 +149,7 @@ export type AuditLogEntry =
       detail: DeleteDetail;
     })
   | (AuditLogBase & {
-      eventType: `${AuditResource}.created` | "user.invited" | "config.changed";
+      eventType: `${AuditResource}.created` | "user.invited" | "user.invite_blocked" | "config.changed";
       detail: Record<string, unknown>;
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -150,7 +150,11 @@ export type AuditLogEntry =
       detail: DeleteDetail;
     })
   | (AuditLogBase & {
-      eventType: `${AuditResource}.created` | "user.invited" | "user.invite_blocked" | "config.changed";
+      eventType:
+        | `${AuditResource}.created`
+        | "user.invited"
+        | "user.invite_blocked"
+        | "config.changed";
       detail: Record<string, unknown>;
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -34,6 +34,7 @@ export type AuditEventType =
   | "agent.updated"
   | "agent.deleted"
   | "user.invited"
+  | "user.invite_blocked"
   | "user.updated"
   | "user.deleted"
   | "config.changed"

--- a/packages/web/src/lib/enterprise.ts
+++ b/packages/web/src/lib/enterprise.ts
@@ -3,6 +3,17 @@ import { validateLicense, type LicenseStatus } from "@/lib/license";
 
 export type { LicenseStatus, LicenseType } from "@/lib/license";
 
+export interface LicenseInfo {
+  enterprise: boolean;
+  type: string | null;
+  org: string | null;
+  expiresAt: string | null;
+  daysRemaining: number | null;
+  managedByEnv: boolean;
+  maxUsers: number;
+  seatsUsed: number;
+}
+
 // Production public key (ES256 / P-256)
 // Generated with: npx tsx scripts/generate-license.ts --generate-keypair
 const PRODUCTION_PUBLIC_KEY = `-----BEGIN PUBLIC KEY-----

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -36,7 +36,7 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
 
     if (ver > 1) {
       console.warn(
-        `License token has ver=${ver}, this app understands up to ver=1. Unknown fields ignored.`,
+        `License token has ver=${ver}, this app understands up to ver=1. Unknown fields ignored.`
       );
     }
 

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -9,9 +9,11 @@ export interface LicenseStatus {
   features: string[];
   expiresAt?: Date;
   daysRemaining?: number;
+  ver: number;
+  maxUsers: number;
 }
 
-const INACTIVE: LicenseStatus = { active: false, features: [] };
+const INACTIVE: LicenseStatus = { active: false, features: [], ver: 1, maxUsers: 0 };
 
 /**
  * Validate a JWT license token against a public key.
@@ -29,6 +31,15 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
     const features = (payload.features as string[]) ?? [];
     if (!features.includes("enterprise")) return INACTIVE;
 
+    const ver = typeof payload.ver === "number" ? payload.ver : 1;
+    const maxUsers = typeof payload.maxUsers === "number" ? payload.maxUsers : 0;
+
+    if (ver > 1) {
+      console.warn(
+        `License token has ver=${ver}, this app understands up to ver=1. Unknown fields ignored.`,
+      );
+    }
+
     const expiresAt = payload.exp ? new Date(payload.exp * 1000) : undefined;
     const now = new Date();
     const daysRemaining = expiresAt
@@ -42,6 +53,8 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
       features,
       expiresAt,
       daysRemaining,
+      ver,
+      maxUsers,
     };
   } catch {
     return INACTIVE;

--- a/packages/web/src/lib/seat-usage.ts
+++ b/packages/web/src/lib/seat-usage.ts
@@ -36,4 +36,3 @@ export async function getSeatUsage(license: LicenseStatus): Promise<SeatUsage> {
     pendingInvites,
   };
 }
-

--- a/packages/web/src/lib/seat-usage.ts
+++ b/packages/web/src/lib/seat-usage.ts
@@ -1,0 +1,44 @@
+import { and, count, eq, gt, isNull, or } from "drizzle-orm";
+import { db } from "@/db";
+import { users, invites } from "@/db/schema";
+import type { LicenseStatus } from "@/lib/license";
+
+export interface SeatUsage {
+  used: number;
+  max: number;
+  available: number | null;
+  unlimited: boolean;
+  activeUsers: number;
+  pendingInvites: number;
+}
+
+export async function getSeatUsage(license: LicenseStatus): Promise<SeatUsage> {
+  const [activeRows, pendingRows] = await Promise.all([
+    db
+      .select({ count: count() })
+      .from(users)
+      .where(or(eq(users.banned, false), isNull(users.banned))),
+    db
+      .select({ count: count() })
+      .from(invites)
+      .where(and(isNull(invites.claimedAt), gt(invites.expiresAt, new Date()))),
+  ]);
+  const activeUsers = activeRows[0].count;
+  const pendingInvites = pendingRows[0].count;
+  const used = activeUsers + pendingInvites;
+  const max = license.maxUsers;
+  return {
+    used,
+    max,
+    available: max === 0 ? null : Math.max(0, max - used),
+    unlimited: max === 0,
+    activeUsers,
+    pendingInvites,
+  };
+}
+
+export async function isSeatAvailable(license: LicenseStatus): Promise<boolean> {
+  if (license.maxUsers === 0) return true;
+  const usage = await getSeatUsage(license);
+  return usage.used < license.maxUsers;
+}

--- a/packages/web/src/lib/seat-usage.ts
+++ b/packages/web/src/lib/seat-usage.ts
@@ -37,8 +37,3 @@ export async function getSeatUsage(license: LicenseStatus): Promise<SeatUsage> {
   };
 }
 
-export async function isSeatAvailable(license: LicenseStatus): Promise<boolean> {
-  if (license.maxUsers === 0) return true;
-  const usage = await getSeatUsage(license);
-  return usage.used < license.maxUsers;
-}


### PR DESCRIPTION
## Summary
- Parse `ver` and `maxUsers` fields from the new JWT schema (Odoo `pinchy_sale_license` commit 557a359), with safe defaults for backwards compatibility.
- Enforce `maxUsers` as a soft seat cap on the invite endpoint: existing users are never deactivated; new invites blocked once `activeUsers + pendingInvites >= maxUsers`.
- Forward-compatible: tokens with `ver > 1` validate with a console warning instead of failing.
- Settings UI shows seat usage banner with breakdown; invite button disabled when at cap.
- Settings → License shows "Seats: X / Y used" line; refreshes after key save.
- Audit log records `user.invite_blocked` events with `outcome: failure`.
- Enterprise expiry banner now refreshes automatically without page reload, so an admin who keeps Pinchy open in a tab does not miss an expiring key.

## Test plan
- [x] Unit: `license.test.ts` covers ver/maxUsers parsing, defaults, forward compat
- [x] Integration: `seat-usage.test.ts` covers active users, pending invites, banned/null-banned exclusion, expired/claimed exclusion
- [x] API: `users-invite.test.ts` covers cap-blocked + audit + success paths
- [x] API: `enterprise-status.test.ts` covers seatsUsed/maxUsers in response
- [x] Component: `settings-license.test.tsx` covers seats line, no-refetch optimization, and `license-updated` dispatch
- [x] Component: `settings-users.test.tsx` covers banner + disabled invite button
- [x] Component: `enterprise-banner.test.tsx` covers re-fetch on visibilitychange / interval / `license-updated` event and cleanup on unmount
- [x] Manual: Smoke-tested end-to-end with an Odoo-issued `maxUsers=2` token — seat banner, disabled invite button, 403 from API, and audit row all verified
- [ ] Manual: Verify banner refreshes on tab visibility change and after key save in browser

## Backwards compatibility
- `LIC-000002` (Trial without ver/maxUsers) still validates as `ver=1, maxUsers=0` (unlimited).
- All freshly-issued tokens carry `ver=1, maxUsers=N` explicitly.

## Design decisions
- Option E (block invites only): existing users are never locked out, even if over cap.
- Seat count = active (non-banned) users + valid pending invitations.
- No seat cache — two indexed `count(*)` queries, sub-millisecond, called rarely.
- `ver > 1` warns but does not reject — forward compatibility.
- Three banner re-fetch triggers (hybrid SWR-style): `visibilitychange` covers tab switches, a 15-minute interval is the safety net for never-hidden tabs, and a `license-updated` window event covers the "just saved a new key" case. All three call the same `fetchStatus` for DRY.

## Code review follow-ups (commit `d522cedef`)
- Removed dead `isSeatAvailable` export (YAGNI).
- Guarded `getSeatUsage` in `enterprise/status` route — skip DB queries when license is inactive.
- Extracted `LicenseInfo` into `@/lib/enterprise` to eliminate the duplicate interface in `settings-license` and `settings-page-content`.
- Use `cn()` for banner className in `settings-users` (consistent with the rest of the codebase).