### PR TITLE
fix(staging): land prod-parity Caddyfile + installing.html (orphaned from PR #185)

### DIFF
--- a/packages/web/src/__tests__/config/cloud-init-next.test.ts
+++ b/packages/web/src/__tests__/config/cloud-init-next.test.ts
@@ -39,26 +39,36 @@ describe("cloud-init-next.yml (staging)", () => {
     expect(cloudInit).not.toMatch(/loading-server\.pid/);
   });
 
-  it("writes a Caddyfile that reverse_proxies to Pinchy without a separate loading-page upstream", () => {
-    // Staging skips the bundled installer page (no version-tag coupling).
-    // Caddy's `handle_errors` block returns a short "starting" message
-    // during the ~30s initial pull instead.
-    expect(cloudInit).toMatch(/reverse_proxy[^\n]*127\.0\.0\.1:7777/);
-    expect(cloudInit).toMatch(/handle_errors/);
-    expect(cloudInit).not.toMatch(/127\.0\.0\.1:9999/);
-    expect(cloudInit).not.toMatch(/\/var\/www\/pinchy-loading/);
+  it("writes a Caddyfile that reverse_proxies to Pinchy with a loading-page fallback (matches prod)", () => {
+    // Staging mirrors prod's Caddy design so the same plumbing is exercised
+    // end-to-end before each release. The loading page covers the cold-start
+    // window where Pinchy is unreachable (initial pull, JIT compile, restart);
+    // lb_policy first → primary preferred, fall back only when unreachable.
+    expect(cloudInit).toMatch(/reverse_proxy\s+127\.0\.0\.1:7777\s+127\.0\.0\.1:9999/);
+    expect(cloudInit).toMatch(/lb_policy\s+first/);
+    expect(cloudInit).toMatch(/lb_try_duration\s+1s/);
+    expect(cloudInit).toMatch(/fail_duration\s+\d+s/);
   });
 
-  it("does not set lb_try_duration on the staging reverse_proxy", () => {
-    // Regression guard: a 1s lb_try_duration was set initially (carried over
-    // from the prod Caddyfile, where it makes sense alongside the loading-page
-    // fallback upstream). On staging there's no fallback — Caddy aborting
-    // after 1s during Next.js's JIT route compile (3-5s on first request)
-    // sent every cold-start request straight to handle_errors → 503 →
-    // browser sees "Pinchy is starting" even after Pinchy was actually up.
-    // For a single-upstream proxy with no fallback, just let Caddy wait.
-    expect(cloudInit).not.toMatch(/lb_try_duration/);
-    expect(cloudInit).not.toMatch(/fail_duration/);
+  it("binds the fallback loading-page server to localhost only", () => {
+    // The :9999 upstream is a Caddy-internal fallback — exposing it publicly
+    // would leak the raw loading page on its own port.
+    expect(cloudInit).toMatch(/bind\s+127\.0\.0\.1/);
+  });
+
+  it("serves the loading page from a Caddy-accessible web root", () => {
+    expect(cloudInit).toMatch(/\/var\/www\/pinchy-loading\/index\.html/);
+    expect(cloudInit).toMatch(/file_server/);
+  });
+
+  it("fetches installing.html from the latest release (no version-tag pinning needed)", () => {
+    // GitHub redirects /releases/latest/download/<asset> to whatever the
+    // most recent release ships. Using `latest` instead of a hard-coded
+    // version means we don't have to bump this file every time we release.
+    expect(cloudInit).toMatch(
+      /github\.com\/heypinchy\/pinchy\/releases\/latest\/download\/installing\.html/
+    );
+    expect(cloudInit).not.toMatch(/releases\/download\/v\d/);
   });
 
   it("does not override PINCHY_PORT so Pinchy keeps the secure 127.0.0.1:7777 default", () => {

--- a/packages/web/src/__tests__/config/cloud-init-next.test.ts
+++ b/packages/web/src/__tests__/config/cloud-init-next.test.ts
@@ -49,6 +49,18 @@ describe("cloud-init-next.yml (staging)", () => {
     expect(cloudInit).not.toMatch(/\/var\/www\/pinchy-loading/);
   });
 
+  it("does not set lb_try_duration on the staging reverse_proxy", () => {
+    // Regression guard: a 1s lb_try_duration was set initially (carried over
+    // from the prod Caddyfile, where it makes sense alongside the loading-page
+    // fallback upstream). On staging there's no fallback — Caddy aborting
+    // after 1s during Next.js's JIT route compile (3-5s on first request)
+    // sent every cold-start request straight to handle_errors → 503 →
+    // browser sees "Pinchy is starting" even after Pinchy was actually up.
+    // For a single-upstream proxy with no fallback, just let Caddy wait.
+    expect(cloudInit).not.toMatch(/lb_try_duration/);
+    expect(cloudInit).not.toMatch(/fail_duration/);
+  });
+
   it("does not override PINCHY_PORT so Pinchy keeps the secure 127.0.0.1:7777 default", () => {
     expect(cloudInit).not.toMatch(/PINCHY_PORT=/);
     expect(compose).toMatch(/\$\{PINCHY_PORT:-127\.0\.0\.1:7777\}:7777/);

--- a/staging/cloud-init.yml
+++ b/staging/cloud-init.yml
@@ -1,23 +1,25 @@
 #cloud-config
 # Pinchy STAGING — automated VPS setup
-# https://docs.heypinchy.com/guides/deploy-hetzner/#staging-instance
+# https://github.com/heypinchy/pinchy/blob/main/CONTRIBUTING.md#staging-instance-setup
 #
-# This is the staging variant of cloud-init.yml. It tracks the `:next`
-# Docker images (rebuilt on every push to main) and uses the
-# docker-compose.yml from the main branch — so the instance always
-# reflects what will ship in the next release.
+# Tracks the `:next` Docker images (rebuilt on every push to main) and
+# uses the docker-compose.yml from the main branch — so the instance
+# always reflects what will ship in the next release.
 #
-# Differences vs the production cloud-init:
+# Differences vs the production cloud-init (kept minimal so staging
+# exercises the same Caddy + Docker + cloud-init plumbing as prod):
 #   - PINCHY_VERSION=next  (instead of a pinned vX.Y.Z tag)
 #   - docker-compose.yml is fetched from `main` (instead of a release tag)
-#   - No bundled loading page — Caddy serves a minimal "booting" message
-#     during the ~30-second initial pull. Staging is for the team, not
-#     the public, so the fancy installer page isn't worth the version-tag
-#     coupling.
+#   - installing.html is fetched from the `latest` release (GitHub
+#     redirects /releases/latest/download/X to whatever the most recent
+#     release ships) so we don't have to bump a version tag every time
+#     we cut a release
 #
-# After boot, visit http://<your-server-ip>. To enable HTTPS, replace `:80`
-# in /etc/caddy/Caddyfile with your staging domain (e.g. staging.heypinchy.com)
-# and run `systemctl reload caddy` — Let's Encrypt is automatic.
+# After boot, visit http://<your-server-ip>. Caddy shows the loading
+# page while images are pulling, then seamlessly hands off to Pinchy —
+# no refresh needed. To enable HTTPS, replace `:80` in
+# /etc/caddy/Caddyfile with your staging domain and run
+# `systemctl reload caddy` — Let's Encrypt is automatic.
 #
 # DO NOT enter production API keys into this instance. Use test keys only.
 
@@ -29,25 +31,44 @@ runcmd:
   - curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' | tee /etc/apt/sources.list.d/caddy-stable.list
   - apt-get update -qq
 
-  # Write Caddyfile BEFORE installing caddy, so Caddy's first start uses our config.
-  # Staging has no separate loading page upstream — during boot, Caddy responds with
-  # a short "Pinchy is starting…" body until Pinchy is reachable on 7777.
+  # Stage loading page for Caddy's fallback upstream
+  - mkdir -p /var/www/pinchy-loading
+  - curl -fsSL https://github.com/heypinchy/pinchy/releases/latest/download/installing.html -o /var/www/pinchy-loading/index.html
+  - sed -i "s/INSTALL_START_TIME/$(date +%s)000/" /var/www/pinchy-loading/index.html
+
+  # Write Caddyfile BEFORE installing caddy, so Caddy's first start uses our config
   - mkdir -p /etc/caddy
   - |
     cat > /etc/caddy/Caddyfile <<'EOF'
     # Pinchy STAGING reverse proxy
     # Primary upstream: Pinchy on 127.0.0.1:7777
-    # During the first ~30s after boot, Pinchy isn't up yet — Caddy serves
-    # a short "starting" message instead of bubbling up an upstream error.
+    # Fallback upstream: local loading page on 127.0.0.1:9999
+    #
+    # lb_policy first → prefer primary; fall back only when primary is unreachable.
+    # lb_try_duration 1s → fail fast so users never wait for a dead backend.
+    # fail_duration 5s → mark unreachable backend as dead for 5s before retry.
     #
     # To enable HTTPS: replace `:80` with your staging domain (e.g.
     # staging.heypinchy.com) and run `systemctl reload caddy`. Caddy
     # provisions Let's Encrypt automatically.
 
     :80 {
-        reverse_proxy 127.0.0.1:7777
-        handle_errors {
-            respond "Pinchy is starting — refresh in a few seconds." 503
+        reverse_proxy 127.0.0.1:7777 127.0.0.1:9999 {
+            lb_policy first
+            lb_try_duration 1s
+            fail_duration 5s
+        }
+    }
+
+    :9999 {
+        bind 127.0.0.1
+        handle /api/* {
+            respond 503
+        }
+        handle {
+            root * /var/www/pinchy-loading
+            try_files /index.html
+            file_server
         }
     }
     EOF
@@ -91,7 +112,7 @@ runcmd:
   - curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/main/docker-compose.yml -o /opt/pinchy/docker-compose.yml
   - cd /opt/pinchy && docker compose pull
 
-  # Start Pinchy
+  # Start Pinchy — Caddy automatically swaps to the primary upstream within 5s
   - cd /opt/pinchy && docker compose up -d
 
   # Wait for Pinchy to be healthy (polled directly, not through Caddy)

--- a/staging/cloud-init.yml
+++ b/staging/cloud-init.yml
@@ -45,13 +45,7 @@ runcmd:
     # provisions Let's Encrypt automatically.
 
     :80 {
-        @up {
-            path *
-        }
-        reverse_proxy @up 127.0.0.1:7777 {
-            lb_try_duration 1s
-            fail_duration 5s
-        }
+        reverse_proxy 127.0.0.1:7777
         handle_errors {
             respond "Pinchy is starting — refresh in a few seconds." 503
         }


### PR DESCRIPTION
## Summary

Two commits I pushed to the \`docs/staging-setup\` branch **after** PR #185 had already been merged. They never made it into a PR, so main's \`staging/cloud-init.yml\` is missing them. This PR brings them onto main as cherry-picks.

Symptom: redeploying staging from main's current \`staging/cloud-init.yml\` produces a Caddyfile with the buggy \`@up { path * }\` matcher and a 1-second \`lb_try_duration\` without a fallback upstream. Every cold-start request that hits Pinchy during the Next.js JIT-compile window (3-5s) trips Caddy's \`handle_errors\` and shows a bare-text "Pinchy is starting" 503 instead of the proper loading page.

## What's in here

**Commit 1** — \`fix(staging): drop lb_try_duration from staging Caddyfile\`:
The \`lb_try_duration 1s\` was carried over from the prod Caddyfile, where it makes sense **alongside** the loading-page fallback upstream. On staging it was paired with no fallback — so cold-start requests just got bare 503s. Also drops the bogus \`@up { path * }\` named matcher (Caddy warned but didn't error).

**Commit 2** — \`fix(staging): restore prod-parity Caddyfile + installing.html loading page\`:
Brings staging fully in line with prod's Caddy design: dual-upstream proxy (Pinchy primary, loading page fallback), \`:9999\` block serving \`/var/www/pinchy-loading\`, \`installing.html\` downloaded from \`releases/latest/download/\` (no version-tag pinning needed since GitHub redirects \`latest/download/X\` to whichever release shipped X most recently). Bonus: staging now exercises the exact same Caddy plumbing as prod, so issues in the prod Caddyfile show up on staging before release.

Tests in \`cloud-init-next.test.ts\` updated to assert the prod-parity shape (positive assertions for dual-upstream + loading-page file_server).

## Test plan

- [x] \`pnpm exec vitest run src/__tests__/config/cloud-init-next.test.ts\` — 11/11 pass
- [ ] CI green
- [ ] Manual: after merge, redeploy staging from \`staging/cloud-init.yml\`, verify the loading page shows during the ~30s initial pull instead of the bare-text fallback