### PR TITLE
fix(secrets): readGatewayToken falls back to openclaw.json (cold-start race)

### DIFF
--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -16,7 +16,7 @@ import { logCapture } from "./src/lib/log-capture";
 import { startUsagePoller, stopUsagePoller } from "./src/lib/usage-poller";
 import { registerShutdownHandlers } from "./src/lib/shutdown";
 import { seedSessionCache } from "./src/server/session-cache-seeder";
-import { readSecretsFile } from "./src/lib/openclaw-secrets";
+import { readGatewayToken } from "./src/lib/gateway-token-reader";
 
 logCapture.install();
 
@@ -32,14 +32,6 @@ const app = next({ dev });
 const handle = app.getRequestHandler();
 
 const OPENCLAW_WS_URL = process.env.OPENCLAW_WS_URL;
-
-function readGatewayToken(): string {
-  try {
-    return readSecretsFile().gateway?.token ?? "";
-  } catch {
-    return "";
-  }
-}
 
 async function waitForGatewayToken(maxWaitMs = 30000): Promise<string> {
   const start = Date.now();

--- a/packages/web/src/__tests__/lib/gateway-token-reader.test.ts
+++ b/packages/web/src/__tests__/lib/gateway-token-reader.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, mkdirSync, chmodSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+
+// readSecretsFile reads from /openclaw-secrets/secrets.json by default;
+// override per-test via OPENCLAW_SECRETS_PATH so we don't touch real fs.
+
+let tmpDir: string;
+let configPath: string;
+let secretsPath: string;
+const origConfigPath = process.env.OPENCLAW_CONFIG_PATH;
+const origSecretsPath = process.env.OPENCLAW_SECRETS_PATH;
+
+beforeEach(() => {
+  tmpDir = mkdtempSync(join(tmpdir(), "pinchy-gtoken-"));
+  configPath = join(tmpDir, "openclaw.json");
+  secretsPath = join(tmpDir, "secrets.json");
+  process.env.OPENCLAW_CONFIG_PATH = configPath;
+  process.env.OPENCLAW_SECRETS_PATH = secretsPath;
+  vi.resetModules();
+});
+
+afterEach(() => {
+  rmSync(tmpDir, { recursive: true, force: true });
+  if (origConfigPath !== undefined) process.env.OPENCLAW_CONFIG_PATH = origConfigPath;
+  else delete process.env.OPENCLAW_CONFIG_PATH;
+  if (origSecretsPath !== undefined) process.env.OPENCLAW_SECRETS_PATH = origSecretsPath;
+  else delete process.env.OPENCLAW_SECRETS_PATH;
+});
+
+describe("readGatewayToken", () => {
+  it("returns token from openclaw.json when set", async () => {
+    writeFileSync(
+      configPath,
+      JSON.stringify({ gateway: { auth: { token: "abc-from-openclaw-json" } } })
+    );
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("abc-from-openclaw-json");
+  });
+
+  it("falls back to secrets.json when openclaw.json missing", async () => {
+    // Cold-start-after-restart edge: openclaw.json briefly unavailable,
+    // but Pinchy's last writeSecretsFile() left the token in secrets.json.
+    writeFileSync(secretsPath, JSON.stringify({ gateway: { token: "abc-from-secrets-json" } }));
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("abc-from-secrets-json");
+  });
+
+  it("falls back to secrets.json when openclaw.json has empty token", async () => {
+    writeFileSync(configPath, JSON.stringify({ gateway: { auth: { token: "" } } }));
+    writeFileSync(secretsPath, JSON.stringify({ gateway: { token: "abc-fallback" } }));
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("abc-fallback");
+  });
+
+  it("falls back to secrets.json when openclaw.json has malformed json", async () => {
+    writeFileSync(configPath, "{ this is not valid json }");
+    writeFileSync(secretsPath, JSON.stringify({ gateway: { token: "abc-fallback" } }));
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("abc-fallback");
+  });
+
+  it("returns empty string when neither file has a token", async () => {
+    // No config, no secrets — never throw, just return "".
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("");
+  });
+
+  it("returns empty string when openclaw.json exists but has no gateway block", async () => {
+    writeFileSync(configPath, JSON.stringify({ env: {} }));
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("");
+  });
+
+  it("regression: even when secrets.json is unreadable (mode 0600 root-owned), token from openclaw.json wins", async () => {
+    // Reproduces the v0.5.0 staging cold-start race: ensure-gateway-token.js
+    // writes openclaw.json with the token. start-openclaw.sh's chmod 0600
+    // (added to satisfy OpenClaw's strict secrets-mode check) prevents Pinchy
+    // (uid 999) from reading secrets.json. Without this fallback path,
+    // readGatewayToken would return "" and Pinchy would connect to OpenClaw
+    // unauthenticated, then never recover.
+    writeFileSync(configPath, JSON.stringify({ gateway: { auth: { token: "the-real-token" } } }));
+    // Make secrets.json effectively unreadable. We can't chmod 0600 to root in
+    // tests (we're not root), so we simulate by deleting the file — same end
+    // state from readSecretsFile()'s perspective: existsSync returns false →
+    // returns {} → no token.
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("the-real-token");
+    void mkdirSync; // silence unused import
+    void chmodSync;
+  });
+});

--- a/packages/web/src/lib/gateway-token-reader.ts
+++ b/packages/web/src/lib/gateway-token-reader.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from "fs";
+import { readSecretsFile } from "@/lib/openclaw-secrets";
+
+/**
+ * Reads the OpenClaw gateway token Pinchy needs to authenticate its
+ * WebSocket connection.
+ *
+ * Source priority:
+ *
+ *   1. **openclaw.json `gateway.auth.token`** — written by
+ *      `ensure-gateway-token.js` at every OpenClaw container start, plain
+ *      string, mode 0644 on a shared volume Pinchy can read. Available
+ *      from the moment OpenClaw boots, regardless of whether Pinchy's
+ *      `regenerateOpenClawConfig()` has run yet.
+ *
+ *   2. **secrets.json `gateway.token`** — written by Pinchy's
+ *      `writeSecretsFile()` after `regenerateOpenClawConfig()` runs (i.e.,
+ *      only after setup completes or settings change). Mode 0600 in the
+ *      production architecture (root-owned after our chown defense), so
+ *      Pinchy (uid 999 in production) cannot read it directly anymore.
+ *
+ * Why the fallback matters: relying only on secrets.json was the bug.
+ * On cold start (pre-setup-wizard or right after a fresh install),
+ * secrets.json doesn't have a gateway.token yet. The old `readSecretsFile()`-only
+ * implementation would time out, log "Gateway token not available after waiting",
+ * and connect without a token. openclaw-node caches the unauthenticated
+ * connection; subsequent reconnects keep failing with `reason=token_missing`
+ * even after the token becomes available — Smithers can never reach OpenClaw.
+ */
+export function readGatewayToken(): string {
+  try {
+    const configPath = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
+    const config = JSON.parse(readFileSync(configPath, "utf-8")) as {
+      gateway?: { auth?: { token?: unknown } };
+    };
+    const tokenFromConfig = config.gateway?.auth?.token;
+    if (typeof tokenFromConfig === "string" && tokenFromConfig.length > 0) {
+      return tokenFromConfig;
+    }
+  } catch {
+    // openclaw.json unreadable / malformed / missing — fall through.
+  }
+  try {
+    return readSecretsFile().gateway?.token ?? "";
+  } catch {
+    return "";
+  }
+}


### PR DESCRIPTION
## Summary

**Release-blocker for v0.5.0.** Discovered on the second staging redeploy after #186 was merged.

Smithers couldn't connect to OpenClaw on cold start. The chain:

1. \`ensure-gateway-token.js\` writes the token to **both** \`openclaw.json\` (\`gateway.auth.token\`, plain string mode 0644) and \`secrets.json\` (\`gateway.token\`, mode 0644 — comment in script: "cross-container handoff: OpenClaw root writes here, Pinchy uid 999 needs to read")
2. \`start-openclaw.sh\`'s \`ensure_secrets_root_owned\` (added in #186 to satisfy OpenClaw's strict mode check during SecretRef resolution) chmods \`secrets.json\` to **0600**
3. Pinchy (uid 999) can no longer read \`secrets.json\`, and the chmod is **necessary** — OpenClaw rejects mode 0644 as "permissions are too open" the moment it resolves a SecretRef from this file (every reload after a settings change)
4. Pinchy's \`readGatewayToken\` only read from \`secrets.json\` → returns "" → \`waitForGatewayToken\` times out at 30s → connects to OpenClaw without a token → openclaw-node caches the unauthenticated connection → every subsequent reconnect fails with \`reason=token_missing\` → Smithers never reaches gateway

The two requirements (Pinchy reads + OpenClaw mode-locks) genuinely conflict on the same file. **Fix**: Pinchy reads from \`openclaw.json\` (the main config, plain string, mode 0644 by design — not subject to the strict secrets-provider mode check). \`secrets.json\` stays 0600 root-owned for OpenClaw's SecretRef resolution. The two files were already kept in sync by \`ensure-gateway-token.js\`; we just stop reading from the one we can't access.

## TDD discipline

- **New module**: \`packages/web/src/lib/gateway-token-reader.ts\` — extracted readGatewayToken so it's unit-testable
- **New tests**: \`packages/web/src/__tests__/lib/gateway-token-reader.test.ts\` — 7 tests on real fs (tmpdir):
  1. Returns token from openclaw.json when set
  2. Falls back to secrets.json when openclaw.json missing
  3. Falls back to secrets.json when openclaw.json has empty token
  4. Falls back to secrets.json when openclaw.json has malformed JSON
  5. Returns "" when neither has a token (no throw)
  6. Returns "" when openclaw.json exists but has no gateway block
  7. **Regression test**: even when secrets.json is unreadable (the v0.5.0 chmod-0600 case), the token from openclaw.json wins
- **Verified RED-then-GREEN**: with the old impl (only readSecretsFile), tests #1 and #7 fail. Restored new impl, all 7 pass. Confirmed with vitest output before commit.

## How this composes with other v0.5.0 fixes

| File | Mode | Owner | Reader |
|------|------|-------|--------|
| \`openclaw.json\` | 0644 | root (fix_config_permissions keeps it readable to Pinchy via shared volume) | Pinchy reads gateway token, OpenClaw reads main config |
| \`secrets.json\` | 0600 | root (chown in ensure_secrets_root_owned, #186) | Only OpenClaw — for SecretRef resolution |

End-to-end gateway-auth path now consistent with both Pinchy and OpenClaw constraints.

## Test plan

- [x] \`pnpm test\` — 3304 passed, 0 failed
- [x] Tests RED with old impl, GREEN with new (verified locally)
- [ ] CI green
- [ ] Manual: redeploy staging from \`staging/cloud-init.yml\` after merge → Smithers connects on cold start without timeout

## Sequence with other open PRs

1. PR #187 (Caddyfile prod-parity, currently green) — orthogonal, can merge any time
2. **This PR** — release-blocker, must be in v0.5.0
3. After both merge: redeploy staging once with both fixes pulled in via \`:next\`