### PR TITLE
fix(audit): allow validateGatewayToken to read token from openclaw.json

### DIFF
--- a/packages/web/src/__tests__/lib/gateway-auth.test.ts
+++ b/packages/web/src/__tests__/lib/gateway-auth.test.ts
@@ -1,15 +1,18 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { writeFileSync, unlinkSync, mkdirSync, existsSync } from "fs";
+import { writeFileSync, unlinkSync, mkdirSync, existsSync, rmSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 
 const TEST_SECRETS_DIR = join(tmpdir(), "pinchy-gateway-auth-test");
 const TEST_SECRETS_PATH = join(TEST_SECRETS_DIR, "secrets.json");
+const TEST_CONFIG_PATH = join(TEST_SECRETS_DIR, "openclaw.json");
+const origConfigPath = process.env.OPENCLAW_CONFIG_PATH;
 
 describe("validateGatewayToken", () => {
   beforeEach(() => {
     vi.resetModules();
     process.env.OPENCLAW_SECRETS_PATH = TEST_SECRETS_PATH;
+    process.env.OPENCLAW_CONFIG_PATH = TEST_CONFIG_PATH;
     if (!existsSync(TEST_SECRETS_DIR)) {
       mkdirSync(TEST_SECRETS_DIR, { recursive: true });
     }
@@ -17,8 +20,10 @@ describe("validateGatewayToken", () => {
 
   afterEach(() => {
     delete process.env.OPENCLAW_SECRETS_PATH;
+    if (origConfigPath !== undefined) process.env.OPENCLAW_CONFIG_PATH = origConfigPath;
+    else delete process.env.OPENCLAW_CONFIG_PATH;
     try {
-      unlinkSync(TEST_SECRETS_PATH);
+      rmSync(TEST_SECRETS_DIR, { recursive: true, force: true });
     } catch {
       // ignore
     }
@@ -78,5 +83,26 @@ describe("validateGatewayToken", () => {
 
     const headers = new Headers({ Authorization: "Bearer some-token" });
     expect(validateGatewayToken(headers)).toBe(false);
+  });
+
+  it("regression: validates against openclaw.json when secrets.json is unreadable (root-owned 0600)", async () => {
+    // Reproduces the v0.5.0 staging cold-start bug: start-openclaw.sh chmods
+    // secrets.json to root:root 0600 to satisfy OpenClaw's strict secrets-mode
+    // check. Pinchy (uid 999) can't read it. Without this fallback, every
+    // pinchy-audit before_tool_call hook returns 401 and Smithers can't use
+    // any tool — including pinchy-docs, so it can't read the docs.
+    //
+    // Both files normally carry the same token (regenerateOpenClawConfig writes
+    // both). Validation must succeed if EITHER source has a matching token.
+    writeFileSync(
+      TEST_CONFIG_PATH,
+      JSON.stringify({ gateway: { auth: { token: "the-real-token" } } })
+    );
+    // No secrets.json — simulates the file being unreadable.
+
+    const { validateGatewayToken } = await import("@/lib/gateway-auth");
+
+    const headers = new Headers({ Authorization: "Bearer the-real-token" });
+    expect(validateGatewayToken(headers)).toBe(true);
   });
 });

--- a/packages/web/src/lib/gateway-auth.ts
+++ b/packages/web/src/lib/gateway-auth.ts
@@ -1,14 +1,5 @@
 import { timingSafeEqual } from "crypto";
-import { readSecretsFile } from "@/lib/openclaw-secrets";
-
-function readGatewayToken(): string | null {
-  try {
-    const secrets = readSecretsFile();
-    return secrets.gateway?.token ?? null;
-  } catch {
-    return null;
-  }
-}
+import { readGatewayToken } from "@/lib/gateway-token-reader";
 
 export function constantTimeEqual(a: string, b: string): boolean {
   const aBuf = Buffer.from(a);


### PR DESCRIPTION
## Problem

When users sent messages that should trigger doc-reading tools (e.g. asking Smithers a Pinchy-specific question), Smithers replied:

> Die Doks konnte ich leider nicht erreichen…

The OpenClaw logs showed:

```
[pinchy-audit] audit failed (attempt 1/3): audit endpoint returned 401 for start docs_list
[pinchy-audit] audit failed (attempt 2/3): audit endpoint returned 401 for start docs_list
[agents/tools] before_tool_call hook failed: tool=docs_list error=Error: 401
[tools] docs_list failed: Tool call blocked because before_tool_call hook failed
```

The audit trail also showed no `tool.*` entries for any of these calls — they failed before the audit row could be written.

## Root cause

`validateGatewayToken` in `gateway-auth.ts` read the token **only** from `secrets.json`:

```ts
function readGatewayToken(): string | null {
  try {
    const secrets = readSecretsFile();
    return secrets.gateway?.token ?? null;
  } catch {
    return null;
  }
}
```

But on staging, `start-openclaw.sh` chmods `secrets.json` to `root:root 0600` to satisfy OpenClaw 2026.4.12's strict secrets-mode check. Pinchy runs as uid 999 → can't read the file → `readSecretsFile()` throws → `gatewayToken === null` → every plugin auth attempt returns 401.

Same root pattern as #188 (Pinchy's WebSocket connect), but a second consumer was missed: the `validateGatewayToken` used by every `/api/internal/*` endpoint that plugins talk to.

## Fix

Reuse the `readGatewayToken()` helper introduced in #188. It tries `openclaw.json` first (mode 0644, plain-string token) and only falls back to `secrets.json`. Validation now succeeds whenever either source has a matching token — and they always carry the same value because `regenerateOpenClawConfig()` writes both from one source.

## Test

Added a regression test that writes only `openclaw.json` (no `secrets.json`) and asserts validation succeeds. Verified RED before fix, GREEN after.

```
Test Files  2 passed (2)
     Tests  13 passed (13)
```

## Test plan

- [x] Unit test reproduces the staging failure mode (RED → GREEN)
- [x] All `src/__tests__/lib/` tests pass (962 passing)
- [ ] Verify on staging after deploy: Smithers can read docs, `tool.docs_list` events land in audit trail