### PR TITLE
fix(chat): keep composer input enabled during reconnects

### DIFF
--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -433,9 +433,12 @@ describe("Composer input vs send disabled state", () => {
     expect(screen.getByRole("button", { name: /send message/i })).toBeDisabled();
   });
 
-  it("disables both input and send when 'unavailable'", async () => {
+  it("keeps input enabled but disables send when 'unavailable'", async () => {
+    // Typing must never be blocked: a user mid-sentence shouldn't lose
+    // their thought just because the WebSocket reconnects. Only Send is
+    // gated on connection state.
     await renderComposerWith({ kind: "unavailable", reason: "disconnected" });
-    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
     expect(screen.getByRole("button", { name: /send message/i })).toBeDisabled();
   });
 
@@ -445,9 +448,17 @@ describe("Composer input vs send disabled state", () => {
     expect(screen.getByRole("button", { name: /send message/i })).not.toBeDisabled();
   });
 
-  it("disables both input and send when 'starting'", async () => {
+  it("keeps input enabled but disables send when 'starting'", async () => {
+    // Same intent as the 'unavailable' case: let users start typing while
+    // history loads; submission stays gated until the runtime is ready.
     await renderComposerWith({ kind: "starting" });
-    expect(screen.getByRole("textbox")).toBeDisabled();
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
+    expect(screen.getByRole("button", { name: /send message/i })).toBeDisabled();
+  });
+
+  it("keeps input enabled but disables send when 'unavailable/configuring'", async () => {
+    await renderComposerWith({ kind: "unavailable", reason: "configuring" });
+    expect(screen.getByRole("textbox")).not.toBeDisabled();
     expect(screen.getByRole("button", { name: /send message/i })).toBeDisabled();
   });
 });

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -241,9 +241,9 @@ const DraftPersistence: FC = () => {
 };
 
 export const Composer: FC = () => {
-  const chatStatus = useContext(ChatStatusContext);
-  const inputAllowed = chatStatus.kind !== "unavailable" && chatStatus.kind !== "starting";
-
+  // Typing is always allowed — only the send button reflects connection
+  // state. A reconnect mid-sentence must not block the user from finishing
+  // their thought; submission is what's gated.
   return (
     <ComposerPrimitive.Root className="aui-composer-root relative flex w-full flex-col">
       <DraftPersistence />
@@ -255,7 +255,6 @@ export const Composer: FC = () => {
           rows={1}
           autoFocus
           aria-label="Message input"
-          disabled={!inputAllowed}
         />
         <ComposerAction />
       </ComposerPrimitive.AttachmentDropzone>


### PR DESCRIPTION
## Problem

Reported on staging:

> Smithers meldet sich ok schnell (< 10 Sekunden), aber danach reißt die Verbindung nochmal ab. Ich war gerade dabei eine Nachricht zu schreiben, aber dann hat sich das Textfeld beim Disconnect gesperrt, was super nervig ist.

When the WebSocket disconnects (during the gateway-restart cascade triggered by settings saves, or any reconnect cycle), the composer's textarea was disabled — interrupting users mid-sentence.

## Fix

The send button stays gated on `chatStatus.kind === "ready"` (correct — can't send to a dead connection). The input itself shouldn't be — typing is local and preserves the user's flow. After reconnect, they hit Send and the message goes.

Removed the `disabled={!inputAllowed}` from `ComposerPrimitive.Input` and the now-unused `inputAllowed` derivation.

## Test changes

Three existing tests in `thread.test.tsx > Composer input vs send disabled state` previously asserted that the textarea was disabled in `unavailable` and `starting` states — locking in the wrong behavior. Updated them to assert the textarea remains **enabled** in those states (only Send is disabled). Added a fourth case for `unavailable/configuring` which was previously uncovered.

Verified RED → GREEN with TDD: tests fail with current code, pass after the one-line removal.

```
Test Files  4 passed (4)
     Tests  67 passed (67)
```

## Test plan

- [x] Unit tests cover `unavailable/disconnected`, `unavailable/configuring`, `starting`, and `ready` for both input and send
- [ ] Manual verification on staging after deploy: type a message, kill the gateway, confirm typing continues, reconnect, confirm send works

## Related

Disconnect frequency itself is a separate concern (see #189 / #190 — gateway restart cascade triggered by settings saves). This PR makes the UX survivable while those root causes are still in flight.