### PR TITLE
fix(telegram): allow Pinchy to read OpenClaw's pairing file

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -828,9 +828,16 @@ jobs:
     name: Telegram E2E Tests
     runs-on: ubuntu-latest
 
-    # Dev-mode CI test: images are built by compose via docker-compose.dev.yml.
-    # Satisfy the compose fail-loud check on ${PINCHY_VERSION:?} — value is
-    # just the build tag, never pulled from a registry.
+    # Production-image CI test: images are built locally via
+    # docker-compose.e2e.yml using the production Dockerfile.pinchy
+    # (uid 999 demotion via entrypoint.sh), matching what end users
+    # actually run. Catches uid/permission mismatches between Pinchy
+    # (uid 999) and OpenClaw (root) — see e.g. PR #195's regression for
+    # the telegram-pairing.json mode 0600 case.
+    #
+    # ${PINCHY_VERSION:?} on docker-compose.yml's `image:` line is
+    # satisfied by any non-empty string; the build directive in
+    # docker-compose.e2e.yml takes precedence and tags with that name.
     env:
       PINCHY_VERSION: latest
 
@@ -855,7 +862,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Start test stack with mock Telegram
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml up --build -d
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -870,7 +877,7 @@ jobs:
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy not healthy after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs pinchy
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs pinchy
               exit 1
             fi
             sleep 2
@@ -883,20 +890,20 @@ jobs:
             fi
             if [ "$i" -eq 15 ]; then
               echo "::error::Mock Telegram not healthy after 30s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs telegram-mock
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs telegram-mock
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for OpenClaw connection..."
           for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
               echo "OpenClaw connected (attempt $i)"
               break
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs pinchy openclaw
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs pinchy openclaw
               exit 1
             fi
             sleep 2
@@ -911,15 +918,15 @@ jobs:
         if: failure()
         run: |
           echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs pinchy 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs pinchy 2>&1 | tail -50
           echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs openclaw 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs openclaw 2>&1 | tail -50
           echo "=== Mock Telegram logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml logs telegram-mock 2>&1 | tail -30
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs telegram-mock 2>&1 | tail -30
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.test.yml down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml down -v
 
   integration:
     name: Integration Tests (OpenClaw + Fake Ollama)

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,9 +728,10 @@ jobs:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest
 
-    # Dev-mode CI test: images are built by compose via docker-compose.dev.yml.
-    # Satisfy the compose fail-loud check on ${PINCHY_VERSION:?} — value is
-    # just the build tag, never pulled from a registry.
+    # Production-image CI test (matches telegram-e2e): images are built locally
+    # via docker-compose.e2e.yml using the production Dockerfile.pinchy
+    # (uid 999 demotion, baked plugins, real Next.js production build).
+    # See e2e overlay's header comment for rationale.
     env:
       PINCHY_VERSION: latest
 
@@ -755,7 +756,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Start test stack with mock Odoo
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml up --build -d
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -770,7 +771,7 @@ jobs:
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy not healthy after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy
               exit 1
             fi
             sleep 2
@@ -783,20 +784,20 @@ jobs:
             fi
             if [ "$i" -eq 15 ]; then
               echo "::error::Mock Odoo not healthy after 30s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for OpenClaw connection..."
           for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
               echo "OpenClaw connected (attempt $i)"
               break
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
               exit 1
             fi
             sleep 2
@@ -814,15 +815,15 @@ jobs:
         if: failure()
         run: |
           echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
           echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
           echo "=== Mock Odoo logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml down -v
 
   telegram-e2e:
     name: Telegram E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -728,10 +728,11 @@ jobs:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest
 
-    # Production-image CI test (matches telegram-e2e): images are built locally
-    # via docker-compose.e2e.yml using the production Dockerfile.pinchy
-    # (uid 999 demotion, baked plugins, real Next.js production build).
-    # See e2e overlay's header comment for rationale.
+    # Dev-mode CI test: images are built by compose via docker-compose.dev.yml.
+    # Should ideally match telegram-e2e and run against the production image,
+    # but the Odoo UI login flow hits a NODE_ENV=production-specific quirk
+    # that I couldn't immediately root-cause. Tracked in #196 with the rest
+    # of the dev/prod parity work.
     env:
       PINCHY_VERSION: latest
 
@@ -756,7 +757,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Start test stack with mock Odoo
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up --build -d
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -771,7 +772,7 @@ jobs:
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy not healthy after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy
+              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy
               exit 1
             fi
             sleep 2
@@ -784,20 +785,20 @@ jobs:
             fi
             if [ "$i" -eq 15 ]; then
               echo "::error::Mock Odoo not healthy after 30s"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock
+              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for OpenClaw connection..."
           for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+            if docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
               echo "OpenClaw connected (attempt $i)"
               break
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
+              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
               exit 1
             fi
             sleep 2
@@ -815,15 +816,15 @@ jobs:
         if: failure()
         run: |
           echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
           echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
           echo "=== Mock Odoo logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
+          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml down -v
 
   telegram-e2e:
     name: Telegram E2E Tests

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -151,8 +151,18 @@ node -e "
 # Make OpenClaw config writable by Pinchy (non-root).
 # OpenClaw creates openclaw.json with 600 (root-only). Pinchy needs write access
 # to update provider keys and agent configuration via regenerateOpenClawConfig().
+#
+# Also fix the telegram-pairing.json file: OpenClaw 2026.4.12 writes it as
+# root:0600, but Pinchy (uid 999) needs to read it to look up Telegram user
+# IDs from pairing codes. Without this chmod, every linkTelegram POST returns
+# "Invalid or expired pairing code" because readFileSync throws EACCES inside
+# resolvePairingCode and the bare catch returns { found: false } silently.
 fix_config_permissions() {
     chmod 666 /root/.openclaw/openclaw.json 2>/dev/null || true
+    # Use a glob so we also catch any sibling credential files OpenClaw
+    # writes alongside the pairing file (allowFrom stores etc.) — they too
+    # are written by root and consumed by Pinchy.
+    chmod -R a+r /root/.openclaw/credentials 2>/dev/null || true
 }
 fix_config_permissions
 

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -162,7 +162,9 @@ fix_config_permissions() {
     # Use a glob so we also catch any sibling credential files OpenClaw
     # writes alongside the pairing file (allowFrom stores etc.) — they too
     # are written by root and consumed by Pinchy.
-    chmod -R a+r /root/.openclaw/credentials 2>/dev/null || true
+    # a+rX: r for all files, x only for directories (capital X) so uid 999
+    # can both enter the credentials/ dir (exec bit) and read files inside it.
+    chmod -R a+rX /root/.openclaw/credentials 2>/dev/null || true
 }
 fix_config_permissions
 

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -223,8 +223,13 @@ load_provider_env_vars
 SECRETS_MTIME=$(get_secrets_mtime)
 
 # OpenClaw rewrites openclaw.json with root-only permissions on every startup
-# and internal restart. Run a background loop that keeps fixing permissions.
-(while true; do sleep 3; fix_config_permissions; done) &
+# and internal restart. Run a tight background loop that fixes permissions
+# faster than Pinchy can hit the EACCES window. 0.2s tick keeps the worst
+# case under 250ms — comfortably inside Pinchy's readExistingConfig retry
+# budget (5 × 100ms). Was 3s previously, which let Pinchy give up before
+# the chmod caught up and silently wrote a stripped config (see
+# fix(openclaw-config): guard targeted writes against EACCES read).
+(while true; do sleep 0.2; fix_config_permissions; done) &
 
 # Start auto-approver in background — stops when Pinchy signals connection
 # (writes pinchy-device-approved). Safety timeout: 5 minutes.

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -1,0 +1,25 @@
+# E2E test overlay: builds Pinchy and OpenClaw from the PRODUCTION
+# Dockerfiles (matching what end users actually run, including the
+# uid 999 demotion via entrypoint.sh's `su -s /bin/sh pinchy`).
+#
+# Usage: docker compose -f docker-compose.yml \
+#                       -f docker-compose.e2e.yml \
+#                       -f docker-compose.test.yml up --build -d
+#
+# Why this exists separately from docker-compose.dev.yml:
+#   docker-compose.dev.yml runs Pinchy via `Dockerfile.pinchy.dev` which
+#   skips the user demotion. CI E2E ran under that image and missed the
+#   class of bugs where Pinchy (uid 999) can't read files OpenClaw writes
+#   as root (e.g. telegram-pairing.json mode 0600). Running E2E against
+#   the production image catches them. See docs/contributing or PR for
+#   detail.
+
+services:
+  pinchy:
+    build:
+      context: .
+      dockerfile: Dockerfile.pinchy
+  openclaw:
+    build:
+      context: .
+      dockerfile: Dockerfile.openclaw

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -23,3 +23,9 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.openclaw
+  db:
+    # Expose Postgres to the host for direct seeding from Playwright helpers
+    # (seedSetup, createAgent). Production compose deliberately keeps the DB
+    # network-internal; tests need a back door.
+    ports:
+      - "5434:5432"

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -34,7 +34,6 @@ vi.mock("@/lib/openclaw-config", () => ({
 const mockClearAllowStoreForAccount = vi.fn();
 const mockRecalculateTelegramAllowStores = vi.fn().mockResolvedValue(undefined);
 vi.mock("@/lib/telegram-allow-store", () => ({
-  clearAllowStore: vi.fn(),
   clearAllowStoreForAccount: (...args: unknown[]) => mockClearAllowStoreForAccount(...args),
   recalculateTelegramAllowStores: (...args: unknown[]) =>
     mockRecalculateTelegramAllowStores(...args),

--- a/packages/web/src/__tests__/api/data-directories.test.ts
+++ b/packages/web/src/__tests__/api/data-directories.test.ts
@@ -62,6 +62,28 @@ describe("GET /api/data-directories", () => {
     expect(body.directories).toEqual([]);
   });
 
+  it("should log a warning and return empty array when file is not readable due to EACCES", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const err = new Error(
+      "EACCES: permission denied, open '/openclaw-config/data-directories.json'"
+    );
+    (err as NodeJS.ErrnoException).code = "EACCES";
+    vi.mocked(readFileSync).mockImplementation(() => {
+      throw err;
+    });
+
+    const response = await GET();
+    const body = await response.json();
+
+    expect(body.directories).toEqual([]);
+    expect(warn).toHaveBeenCalledWith(
+      expect.stringContaining("[data-directories]"),
+      expect.any(String),
+      expect.stringContaining("EACCES")
+    );
+    warn.mockRestore();
+  });
+
   it("should return 401 without auth", async () => {
     const { auth } = await import("@/lib/auth");
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2675,7 +2675,7 @@ describe("updateIdentityLinks", () => {
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
   });
 
-  it("regression: refuses to write if existing config has no gateway.mode (avoids clobber from EACCES)", async () => {
+  it("regression: throws if existing config has no gateway.mode (avoids clobber from EACCES)", async () => {
     // This reproduces the production-image telegram-e2e cascade: while
     // OpenClaw is mid-SIGUSR1-restart, openclaw.json is briefly root:0600.
     // readExistingConfig hits EACCES, returns {} after retries. Without
@@ -2692,14 +2692,12 @@ describe("updateIdentityLinks", () => {
     });
 
     const { updateIdentityLinks } = await import("@/lib/openclaw-config");
-    updateIdentityLinks({ "user-1": ["telegram:123"] });
 
+    // Throwing (rather than silently returning) lets the API route surface
+    // the failure as a 5xx so the user can retry, instead of dropping the
+    // identity-link update on the floor.
+    expect(() => updateIdentityLinks({ "user-1": ["telegram:123"] })).toThrow(/gateway\.mode/);
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
-    // Two warns expected: one from readExistingConfig's persistent-EACCES
-    // path, one from updateIdentityLinks' missing-gateway.mode guard. We
-    // only assert the latter — its presence proves the safety check fired.
-    const allWarnCalls = warnSpy.mock.calls.map((call) => call.join(" "));
-    expect(allWarnCalls.some((msg) => msg.includes("refusing to write"))).toBe(true);
     warnSpy.mockRestore();
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2674,6 +2674,34 @@ describe("updateIdentityLinks", () => {
 
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
   });
+
+  it("regression: refuses to write if existing config has no gateway.mode (avoids clobber from EACCES)", async () => {
+    // This reproduces the production-image telegram-e2e cascade: while
+    // OpenClaw is mid-SIGUSR1-restart, openclaw.json is briefly root:0600.
+    // readExistingConfig hits EACCES, returns {} after retries. Without
+    // the safety check below, updateIdentityLinks would write a config
+    // with ONLY a session block — no gateway, no agents, nothing — and
+    // OpenClaw's next start refuses with "missing gateway.mode" then
+    // crash-loops.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation(() => {
+      const err = new Error("EACCES: permission denied") as Error & { code: string };
+      err.code = "EACCES";
+      throw err;
+    });
+
+    const { updateIdentityLinks } = await import("@/lib/openclaw-config");
+    updateIdentityLinks({ "user-1": ["telegram:123"] });
+
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    // Two warns expected: one from readExistingConfig's persistent-EACCES
+    // path, one from updateIdentityLinks' missing-gateway.mode guard. We
+    // only assert the latter — its presence proves the safety check fired.
+    const allWarnCalls = warnSpy.mock.calls.map((call) => call.join(" "));
+    expect(allWarnCalls.some((msg) => msg.includes("refusing to write"))).toBe(true);
+    warnSpy.mockRestore();
+  });
 });
 
 describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support SecretRef in channel configs)", () => {

--- a/packages/web/src/__tests__/lib/telegram-allow-store.test.ts
+++ b/packages/web/src/__tests__/lib/telegram-allow-store.test.ts
@@ -80,9 +80,6 @@ vi.mock("@/lib/settings", () => ({
 }));
 
 import {
-  addToAllowStore,
-  removeFromAllowStore,
-  clearAllowStore,
   removePairingRequest,
   recalculateTelegramAllowStores,
   getStorePathForAccount,
@@ -90,112 +87,16 @@ import {
   clearAllAllowStores,
 } from "@/lib/telegram-allow-store";
 
+function makeEaccesError() {
+  const err = new Error("EACCES: permission denied, open '/openclaw-config/credentials/file.json'");
+  (err as NodeJS.ErrnoException).code = "EACCES";
+  return err;
+}
+
 describe("telegram-allow-store", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockExistsSync.mockReturnValue(true);
-  });
-
-  // ── Legacy single-store functions (backward compat) ───────────────
-
-  describe("addToAllowStore", () => {
-    it("creates store with user when file does not exist", () => {
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
-
-      addToAllowStore("8754697762");
-
-      expect(mockWriteFileSync).toHaveBeenCalledOnce();
-      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-      expect(written).toEqual({ version: 1, allowFrom: ["8754697762"] });
-      // Atomic: writes tmp then renames
-      expect(mockRenameSync).toHaveBeenCalledOnce();
-    });
-
-    it("adds user to existing store", () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: 1, allowFrom: ["111222333"] }));
-
-      addToAllowStore("8754697762");
-
-      expect(mockWriteFileSync).toHaveBeenCalledOnce();
-      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-      expect(written.allowFrom).toEqual(["111222333", "8754697762"]);
-    });
-
-    it("does not duplicate existing user", () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: 1, allowFrom: ["8754697762"] }));
-
-      addToAllowStore("8754697762");
-
-      // Should not write if no change
-      expect(mockWriteFileSync).not.toHaveBeenCalled();
-    });
-
-    it("creates credentials directory if it does not exist", () => {
-      mockExistsSync.mockReturnValue(false);
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
-
-      addToAllowStore("8754697762");
-
-      expect(mockMkdirSync).toHaveBeenCalledWith(expect.any(String), { recursive: true });
-    });
-  });
-
-  describe("removeFromAllowStore", () => {
-    it("removes user from store", () => {
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({ version: 1, allowFrom: ["8754697762", "111222333"] })
-      );
-
-      removeFromAllowStore("8754697762");
-
-      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-      expect(written.allowFrom).toEqual(["111222333"]);
-    });
-
-    it("does nothing if user not in store", () => {
-      mockReadFileSync.mockReturnValue(JSON.stringify({ version: 1, allowFrom: ["111222333"] }));
-
-      removeFromAllowStore("8754697762");
-
-      expect(mockWriteFileSync).not.toHaveBeenCalled();
-    });
-
-    it("does nothing if store does not exist", () => {
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
-
-      removeFromAllowStore("8754697762");
-
-      expect(mockWriteFileSync).not.toHaveBeenCalled();
-    });
-  });
-
-  describe("clearAllowStore", () => {
-    it("writes empty allowFrom array", () => {
-      mockReadFileSync.mockReturnValue(
-        JSON.stringify({ version: 1, allowFrom: ["8754697762", "111222333"] })
-      );
-
-      clearAllowStore();
-
-      const written = JSON.parse(mockWriteFileSync.mock.calls[0][1] as string);
-      expect(written).toEqual({ version: 1, allowFrom: [] });
-    });
-
-    it("does nothing if store does not exist", () => {
-      mockReadFileSync.mockImplementation(() => {
-        throw new Error("ENOENT");
-      });
-
-      clearAllowStore();
-
-      expect(mockWriteFileSync).not.toHaveBeenCalled();
-    });
   });
 
   describe("removePairingRequest", () => {
@@ -236,6 +137,23 @@ describe("telegram-allow-store", () => {
 
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
+
+    it("logs a warning and does nothing when pairing file is not readable due to EACCES", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFileSync.mockImplementation(() => {
+        throw makeEaccesError();
+      });
+
+      removePairingRequest("8754697762");
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[telegram-allow-store]"),
+        expect.any(String),
+        expect.stringContaining("EACCES")
+      );
+      warn.mockRestore();
+    });
   });
 
   // ── Per-account store functions ───────────────────────────────────
@@ -269,6 +187,23 @@ describe("telegram-allow-store", () => {
 
       expect(mockWriteFileSync).not.toHaveBeenCalled();
     });
+
+    it("logs a warning and does nothing when store is not readable due to EACCES", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReadFileSync.mockImplementation(() => {
+        throw makeEaccesError();
+      });
+
+      clearAllowStoreForAccount("agent-1");
+
+      expect(mockWriteFileSync).not.toHaveBeenCalled();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[telegram-allow-store]"),
+        expect.any(String),
+        expect.stringContaining("EACCES")
+      );
+      warn.mockRestore();
+    });
   });
 
   describe("clearAllAllowStores", () => {
@@ -299,6 +234,21 @@ describe("telegram-allow-store", () => {
 
       // Legacy + per-account = 2 writes
       expect(mockWriteFileSync).toHaveBeenCalledTimes(2);
+    });
+
+    it("logs a warning and does not throw when credentials dir is not readable due to EACCES", () => {
+      const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+      mockReaddirSync.mockImplementation(() => {
+        throw makeEaccesError();
+      });
+
+      expect(() => clearAllAllowStores()).not.toThrow();
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining("[telegram-allow-store]"),
+        expect.any(String),
+        expect.stringContaining("EACCES")
+      );
+      warn.mockRestore();
     });
   });
 

--- a/packages/web/src/__tests__/lib/telegram-pairing.test.ts
+++ b/packages/web/src/__tests__/lib/telegram-pairing.test.ts
@@ -76,4 +76,77 @@ describe("resolvePairingCode", () => {
     const result = resolvePairingCode("ABC123");
     expect(result).toEqual({ found: false });
   });
+
+  it("regression: logs a warning when the pairing file is unreadable (EACCES)", () => {
+    // On v0.5.0 staging, OpenClaw writes telegram-pairing.json as root:0600.
+    // Pinchy (uid 999) gets EACCES when reading it, but the resolver's bare
+    // catch{} swallowed the error and returned { found: false }, surfacing
+    // to the user as a misleading "Invalid or expired pairing code".
+    // The fix is operational (start-openclaw.sh chmods the file), but the
+    // resolver MUST log non-ENOENT errors so future regressions of this
+    // class are immediately visible in container logs instead of debugging
+    // for an hour.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation(() => {
+      const err = new Error(
+        "EACCES: permission denied, open '/openclaw-config/credentials/telegram-pairing.json'"
+      ) as Error & { code: string };
+      err.code = "EACCES";
+      throw err;
+    });
+
+    const result = resolvePairingCode("VVN2THRM");
+    expect(result).toEqual({ found: false });
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining("[telegram-pairing]"),
+      expect.stringContaining("EACCES")
+    );
+    warnSpy.mockRestore();
+  });
+
+  it("does NOT log when the pairing file simply does not exist (ENOENT is normal)", () => {
+    // existsSync handles the ENOENT-by-stat case; this guards against a
+    // future change that drops the existsSync check and starts logging on
+    // every cold start (where the file legitimately doesn't exist yet).
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockedExistsSync.mockReturnValue(false);
+
+    const result = resolvePairingCode("VVN2THRM");
+    expect(result).toEqual({ found: false });
+    expect(warnSpy).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
+
+  it("regression: matches the exact staging pairing-file shape (with lastSeenAt + meta)", () => {
+    // Reproduces the staging payload Pinchy's own /api/settings/telegram POST
+    // received on 2026-04-29 — verbatim file content from
+    // /openclaw-config/credentials/telegram-pairing.json. The user submitted
+    // the matching code via the UI and got "Invalid or expired pairing code".
+    // If this test passes locally, the bug is environmental (path, race,
+    // mtime), not in the resolver's matching logic.
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        version: 1,
+        requests: [
+          {
+            id: "8754697762",
+            code: "VVN2THRM",
+            createdAt: "2026-04-29T16:52:07.768Z",
+            lastSeenAt: "2026-04-29T16:56:04.803Z",
+            meta: {
+              username: "clemenshelm",
+              firstName: "Clemens",
+              lastName: "Helm",
+              accountId: "ffa4180a-b920-42f0-9ee1-c61250e952ed",
+            },
+          },
+        ],
+      })
+    );
+
+    const result = resolvePairingCode("VVN2THRM");
+    expect(result).toEqual({ found: true, telegramUserId: "8754697762" });
+  });
 });

--- a/packages/web/src/app/api/data-directories/route.ts
+++ b/packages/web/src/app/api/data-directories/route.ts
@@ -15,7 +15,12 @@ export async function GET() {
     const json = readFileSync(DATA_DIRECTORIES_JSON, "utf-8");
     const data = JSON.parse(json);
     return NextResponse.json({ directories: data.directories });
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[data-directories]", `failed to read ${DATA_DIRECTORIES_JSON}:`, message);
+    }
     return NextResponse.json({ directories: [] });
   }
 }

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -69,11 +69,40 @@ function writeConfigAtomic(content: string) {
 }
 
 function readExistingConfig(): Record<string, unknown> {
-  try {
-    return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
-  } catch {
-    return {};
+  // Retry briefly on EACCES. OpenClaw rewrites openclaw.json as root:0600 on
+  // every internal SIGUSR1 restart; start-openclaw.sh's 3s chmod loop opens
+  // it back up to 0666, but Pinchy (uid 999) can hit a small window where
+  // the file is unreadable. Without retry, readFileSync throws → catch
+  // returns {} → targeted writes (updateTelegramChannelConfig etc.) would
+  // produce a config WITHOUT the gateway block, and OpenClaw's next start
+  // refuses with "Gateway start blocked: existing config is missing
+  // gateway.mode". 5 × 100ms covers two chmod-loop ticks worst case.
+  for (let attempt = 0; attempt < 5; attempt++) {
+    try {
+      return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "EACCES") {
+        // ENOENT (file not yet written) is a normal cold-start case; other
+        // errors (parse failures, etc.) are bugs we can't paper over here.
+        return {};
+      }
+      if (attempt === 4) {
+        console.warn(
+          "[openclaw-config] readExistingConfig: persistent EACCES on",
+          CONFIG_PATH,
+          "— returning empty (callers must guard against partial writes)"
+        );
+        return {};
+      }
+      // Synchronous busy-wait. Async would change all caller signatures.
+      const start = Date.now();
+      while (Date.now() - start < 100) {
+        // spin
+      }
+    }
   }
+  return {};
 }
 
 function deepMerge(
@@ -766,6 +795,15 @@ export async function regenerateOpenClawConfig() {
 export function updateIdentityLinks(identityLinks: Record<string, string[]>): void {
   const existing = readExistingConfig();
 
+  // Same safety as updateTelegramChannelConfig — see comment there.
+  const existingGateway = existing.gateway as Record<string, unknown> | undefined;
+  if (!existingGateway?.mode) {
+    console.warn(
+      "[openclaw-config] updateIdentityLinks: refusing to write — existing config has no gateway.mode"
+    );
+    return;
+  }
+
   const session = (existing.session as Record<string, unknown>) || {};
   const updatedSession = {
     ...session,
@@ -805,6 +843,22 @@ export function updateTelegramChannelConfig(
   identityLinks: Record<string, string[]> | null
 ): void {
   const existing = readExistingConfig();
+
+  // Safety: refuse to write a config that would clobber the gateway block.
+  // If readExistingConfig returned an empty/partial object (EACCES race or
+  // corrupted file), modifying channels/bindings on top of it and writing
+  // back would produce a config without gateway.mode — OpenClaw refuses
+  // to start with "Gateway start blocked: existing config is missing
+  // gateway.mode" and falls into a restart loop. Better to log loudly and
+  // fail this single update than corrupt the running gateway.
+  const existingGateway = existing.gateway as Record<string, unknown> | undefined;
+  if (!existingGateway?.mode) {
+    console.warn(
+      "[openclaw-config] updateTelegramChannelConfig: refusing to write — existing config has no gateway.mode",
+      "(likely EACCES on initial read). The full regenerateOpenClawConfig path will repair it."
+    );
+    return;
+  }
 
   if (accountId && account) {
     const existingTelegram =

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -798,10 +798,10 @@ export function updateIdentityLinks(identityLinks: Record<string, string[]>): vo
   // Same safety as updateTelegramChannelConfig — see comment there.
   const existingGateway = existing.gateway as Record<string, unknown> | undefined;
   if (!existingGateway?.mode) {
-    console.warn(
-      "[openclaw-config] updateIdentityLinks: refusing to write — existing config has no gateway.mode"
+    throw new Error(
+      "[openclaw-config] updateIdentityLinks: existing config has no gateway.mode " +
+        "(likely EACCES race on /openclaw-config/openclaw.json). Retry the request."
     );
-    return;
   }
 
   const session = (existing.session as Record<string, unknown>) || {};
@@ -849,15 +849,15 @@ export function updateTelegramChannelConfig(
   // corrupted file), modifying channels/bindings on top of it and writing
   // back would produce a config without gateway.mode — OpenClaw refuses
   // to start with "Gateway start blocked: existing config is missing
-  // gateway.mode" and falls into a restart loop. Better to log loudly and
-  // fail this single update than corrupt the running gateway.
+  // gateway.mode" and falls into a restart loop. Throwing here lets the
+  // calling API route return 503 to the user instead of silently dropping
+  // the channel update.
   const existingGateway = existing.gateway as Record<string, unknown> | undefined;
   if (!existingGateway?.mode) {
-    console.warn(
-      "[openclaw-config] updateTelegramChannelConfig: refusing to write — existing config has no gateway.mode",
-      "(likely EACCES on initial read). The full regenerateOpenClawConfig path will repair it."
+    throw new Error(
+      "[openclaw-config] updateTelegramChannelConfig: existing config has no gateway.mode " +
+        "(likely EACCES race on /openclaw-config/openclaw.json). Retry the request."
     );
-    return;
   }
 
   if (accountId && account) {

--- a/packages/web/src/lib/telegram-allow-store.ts
+++ b/packages/web/src/lib/telegram-allow-store.ts
@@ -31,9 +31,6 @@ import { getSetting } from "@/lib/settings";
 const CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
 const CREDENTIALS_DIR = join(dirname(CONFIG_PATH), "credentials");
 
-// Legacy single-store path (pre-multi-account)
-const LEGACY_STORE_PATH = join(CREDENTIALS_DIR, "telegram-allowFrom.json");
-
 interface AllowFromStore {
   version: 1;
   allowFrom: string[];
@@ -50,7 +47,12 @@ export function getStorePathForAccount(accountId: string): string {
 function readStoreAt(path: string): AllowFromStore | null {
   try {
     return JSON.parse(readFileSync(path, "utf-8"));
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[telegram-allow-store]", `failed to read store at ${path}:`, message);
+    }
     return null;
   }
 }
@@ -66,29 +68,6 @@ function writeStoreAt(path: string, store: AllowFromStore) {
   renameSync(tmpPath, path);
 }
 
-// ── Legacy single-store functions (used by existing routes) ─────────
-
-export function addToAllowStore(telegramUserId: string) {
-  const store = readStoreAt(LEGACY_STORE_PATH) || { version: 1 as const, allowFrom: [] };
-  if (store.allowFrom.includes(telegramUserId)) return;
-  store.allowFrom.push(telegramUserId);
-  writeStoreAt(LEGACY_STORE_PATH, store);
-}
-
-export function removeFromAllowStore(telegramUserId: string) {
-  const store = readStoreAt(LEGACY_STORE_PATH);
-  if (!store) return;
-  const filtered = store.allowFrom.filter((id) => id !== telegramUserId);
-  if (filtered.length === store.allowFrom.length) return; // not found
-  writeStoreAt(LEGACY_STORE_PATH, { ...store, allowFrom: filtered });
-}
-
-export function clearAllowStore() {
-  const store = readStoreAt(LEGACY_STORE_PATH);
-  if (!store) return;
-  writeStoreAt(LEGACY_STORE_PATH, { ...store, allowFrom: [] });
-}
-
 // ── Per-account store functions ─────────────────────────────────────
 
 export function clearAllowStoreForAccount(accountId: string) {
@@ -100,7 +79,14 @@ export function clearAllowStoreForAccount(accountId: string) {
 
 export function clearAllAllowStores() {
   if (!existsSync(CREDENTIALS_DIR)) return;
-  const files = readdirSync(CREDENTIALS_DIR);
+  let files: string[];
+  try {
+    files = readdirSync(CREDENTIALS_DIR);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn("[telegram-allow-store]", "failed to read credentials dir:", message);
+    return;
+  }
   for (const file of files) {
     if (file.match(/^telegram-.*allowFrom\.json$/)) {
       const path = join(CREDENTIALS_DIR, file);
@@ -243,7 +229,14 @@ function cleanupOrphanedStoreFiles(activeAccountIds: string[]) {
   if (!existsSync(CREDENTIALS_DIR)) return;
 
   const activeFiles = new Set(activeAccountIds.map((id) => `telegram-${id}-allowFrom.json`));
-  const files = readdirSync(CREDENTIALS_DIR);
+  let files: string[];
+  try {
+    files = readdirSync(CREDENTIALS_DIR);
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn("[telegram-allow-store]", "failed to read credentials dir:", message);
+    return;
+  }
 
   for (const file of files) {
     // Match per-account files and legacy file
@@ -276,7 +269,16 @@ interface PairingStore {
 function readPairingStore(): PairingStore | null {
   try {
     return JSON.parse(readFileSync(PAIRING_PATH, "utf-8"));
-  } catch {
+  } catch (err) {
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn(
+        "[telegram-allow-store]",
+        `failed to read pairing store at ${PAIRING_PATH}:`,
+        message
+      );
+    }
     return null;
   }
 }

--- a/packages/web/src/lib/telegram-pairing.ts
+++ b/packages/web/src/lib/telegram-pairing.ts
@@ -34,7 +34,17 @@ export function resolvePairingCode(code: string): PairingResult {
     if (!match) return { found: false };
 
     return { found: true, telegramUserId: match.id };
-  } catch {
+  } catch (err) {
+    // Log non-ENOENT errors loudly. The default bare-catch swallowed EACCES
+    // on v0.5.0 staging (file written root:0600 by OpenClaw, Pinchy uid 999
+    // can't read it) which surfaced as a misleading "Invalid pairing code"
+    // to the user — the file existed but was unreadable, not missing. ENOENT
+    // is filtered out because cold start (file not yet written) is normal.
+    const code = (err as NodeJS.ErrnoException)?.code;
+    if (code !== "ENOENT") {
+      const message = err instanceof Error ? err.message : String(err);
+      console.warn("[telegram-pairing] failed to read pairing file:", message);
+    }
     return { found: false };
   }
 }


### PR DESCRIPTION
## Problem

Reported on staging during v0.5.0 click-through verification: every Telegram pairing attempt returns "Invalid or expired pairing code" even though the bot just issued the matching code. Subsequent investigation found the same silent-swallow pattern in several other file-operations on the shared volume.

## Root cause

OpenClaw writes files in the shared `openclaw-config` volume as `root:0600`. Pinchy in production runs as **uid 999** (entrypoint.sh demotes via `su -s /bin/sh pinchy`), so `readFileSync` throws `EACCES`. Bare `catch {}` blocks in multiple places swallowed the error silently, causing misleading downstream failures.

**The affected paths:**
- `telegram-pairing.json` → "Invalid pairing code" (even with correct code)
- `telegram-*-allowFrom.json` → allow-store reads assumed empty on EACCES
- `credentials/` directory readdir → unhandled crash if dir is 0700
- `data-directories.json` → empty Knowledge Base directory list, no error visible

## Why CI E2E silently passed for months

The `telegram-e2e` job ran via `docker-compose.dev.yml` → `Dockerfile.pinchy.dev`, which has **no `USER` directive and no entrypoint demotion**. Pinchy ran as root in CI and could read root-owned 0600 files. Production runs as uid 999.

This is a fundamental "build once, deploy many" / 12-Factor dev/prod parity gap. The whole point of containerized E2E is to test the actual deployment artifact — running a different image in CI than in production defeats it.

## Fixes

**1. chmod loop — `config/start-openclaw.sh`**
- `chmod -R a+r` → `chmod -R a+rX` (capital X adds execute bit on directories only, ensuring uid 999 can enter `credentials/` even if OpenClaw creates it with mode 0700)
- 3s tick tightened to 0.2s in a previous commit

**2. `telegram-pairing.ts`**
Non-ENOENT errors logged via `console.warn`. ENOENT filtered (cold start is normal).

**3. `telegram-allow-store.ts`**
- `readStoreAt()`: non-ENOENT errors logged — previously EACCES caused callers to treat a readable file as absent
- `readPairingStore()`: same — EACCES silently left stale pairing entries, blocking re-pairing without an OpenClaw restart
- `clearAllAllowStores()` + `cleanupOrphanedStoreFiles()`: `readdirSync` wrapped in try/catch — an unprotected EACCES would throw unhandled and 500 the caller
- Removed dead code: `addToAllowStore` / `removeFromAllowStore` / `clearAllowStore` — unused since multi-account migration (callers now use `recalculate*`)

**4. `data-directories` route**
EACCES logs warn instead of silently returning `[]` — Knowledge Base setup failures now visible in logs.

**5. EACCES guard in `openclaw-config.ts`**
`readExistingConfig()` retries on EACCES (5×100ms). Targeted writes throw if existing config has no `gateway.mode` (guards against writing a stripped config during a race).

**6. CI parity — `docker-compose.e2e.yml` + `.github/workflows/ci.yml`**
New compose overlay that builds the **production** Dockerfiles. Telegram E2E now runs against the same artifact end users deploy (uid 999, real entrypoint, baked plugins). The exact bug from this PR would have failed CI without the chmod fix, instead of going green.

Other E2E jobs (Odoo, integration) keep the dev image for now, tracked in #196.

## Tests

All new tests follow TDD (RED → GREEN):
- `telegram-pairing.test.ts`: EACCES regression + ENOENT-not-logged guard
- `openclaw-config.test.ts`: EACCES retry + gateway.mode safety throw
- `telegram-allow-store.test.ts`: EACCES warn on `readStoreAt`, `readPairingStore`, and `readdirSync`; removed legacy function tests alongside removed code
- `data-directories.test.ts`: EACCES warn + empty-array fallback

```
Test Files  257 passed | 3 skipped (260)
     Tests  3308 passed | 12 skipped | 3 todo (3323)
```

## Test plan

- [x] All unit tests pass (TDD, RED before fix → GREEN after)
- [x] `telegram-e2e` CI runs against production image
- [ ] Deploy to staging and verify Telegram pairing succeeds end-to-end
- [ ] Confirm `[telegram-*]` warn lines do NOT appear in steady-state logs

## Related

- #196 — CI image parity for remaining E2E suites (Odoo, integration)