### PR TITLE
fix(openclaw): inotify + chmod-tick to win the secrets reload race

### DIFF
--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -254,15 +254,26 @@ SECRETS_MTIME=$(get_secrets_mtime)
 # rename, closing the window before any reload can pick up the bad owner.
 # Watches the directory (not the file) because Pinchy's writeSecretsFile
 # uses tmp+rename, which replaces the inode each time.
-(inotifywait -m -q -e close_write,moved_to "$(dirname "$SECRETS_FILE")" 2>/dev/null | \
-    while read -r _dir _events filename; do
-        # Only react to the secrets file itself, ignoring sibling .tmp writes
-        # and any other unrelated activity in the directory.
-        if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
-            chown root:root "$SECRETS_FILE" 2>/dev/null || true
-            chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
-        fi
-    done) &
+#
+# Wrapped in a respawn loop: inotifywait can die if the kernel watch limit
+# (fs.inotify.max_user_watches) is exhausted or the binary OOMs. Without
+# this loop the secrets file would be defended only by the 0.2 s chmod
+# tick — still safer than nothing, but the tighter inotify response is the
+# primary guarantee. The 1 s sleep prevents a tight crash loop from
+# burning CPU if inotifywait fails to start at all.
+(while true; do
+    inotifywait -m -q -e close_write,moved_to "$(dirname "$SECRETS_FILE")" 2>/dev/null | \
+        while read -r _dir _events filename; do
+            # Only react to the secrets file itself, ignoring sibling .tmp writes
+            # and any other unrelated activity in the directory.
+            if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
+                chown root:root "$SECRETS_FILE" 2>/dev/null || true
+                chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+            fi
+        done
+    echo "[secrets-watcher] inotifywait exited; respawning in 1s"
+    sleep 1
+done) &
 
 # Start auto-approver in background — stops when Pinchy signals connection
 # (writes pinchy-device-approved). Safety timeout: 5 minutes.

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -165,6 +165,19 @@ fix_config_permissions() {
     # a+rX: r for all files, x only for directories (capital X) so uid 999
     # can both enter the credentials/ dir (exec bit) and read files inside it.
     chmod -R a+rX /root/.openclaw/credentials 2>/dev/null || true
+    # Re-take ownership of secrets.json. Pinchy writes it as uid 999 (the
+    # pinchy user inside its container); OpenClaw's secret-resolver requires
+    # owner == process uid (root) and refuses to reload otherwise. The 30 s
+    # mtime watch loop further down chowns it after a write, but the [reload]
+    # pipeline triggered by inotify on openclaw.json fires within ~100 ms of
+    # Pinchy's regenerateOpenClawConfig() — long before that loop wakes up.
+    # Without this fast tick, a freshly created agent surfaces as
+    # `unknown agent id` because the reload fails on secrets and the new
+    # agents.list never enters runtime. See issue #200.
+    if [ -f "$SECRETS_FILE" ]; then
+        chown root:root "$SECRETS_FILE" 2>/dev/null || true
+        chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+    fi
 }
 fix_config_permissions
 

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -246,6 +246,24 @@ SECRETS_MTIME=$(get_secrets_mtime)
 # fix(openclaw-config): guard targeted writes against EACCES read).
 (while true; do sleep 0.2; fix_config_permissions; done) &
 
+# Defense in depth for the secrets owner race (#200): the 0.2 s tick above
+# averages ~100 ms behind a Pinchy write, but OpenClaw's inotify-driven
+# reload pipeline also fires within ~50–100 ms — leaving a small window
+# where the reload sees uid 999 and bails with SECRETS_RELOADER_DEGRADED.
+# inotifywait reacts within a handful of milliseconds to Pinchy's atomic
+# rename, closing the window before any reload can pick up the bad owner.
+# Watches the directory (not the file) because Pinchy's writeSecretsFile
+# uses tmp+rename, which replaces the inode each time.
+(inotifywait -m -q -e close_write,moved_to "$(dirname "$SECRETS_FILE")" 2>/dev/null | \
+    while read -r _dir _events filename; do
+        # Only react to the secrets file itself, ignoring sibling .tmp writes
+        # and any other unrelated activity in the directory.
+        if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
+            chown root:root "$SECRETS_FILE" 2>/dev/null || true
+            chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+        fi
+    done) &
+
 # Start auto-approver in background — stops when Pinchy signals connection
 # (writes pinchy-device-approved). Safety timeout: 5 minutes.
 auto_approve_devices &

--- a/packages/web/e2e/telegram/agent-hot-reload.spec.ts
+++ b/packages/web/e2e/telegram/agent-hot-reload.spec.ts
@@ -9,17 +9,19 @@
  *   by the current user (uid=0)` → new agents.list silently dropped
  *   → user sees `unknown agent id "<uuid>"` when chatting.
  *
- * Fix: chown the secrets file in the same 0.2 s tick that already
- * chmods openclaw.json + credentials/, so the window between Pinchy's
- * write (uid 999) and OpenClaw's reload pickup never exposes the bad
- * owner. See `config/start-openclaw.sh:fix_config_permissions`.
+ * Fix (two layers): inotifywait on /openclaw-secrets/ chowns the file
+ * on every close_write/moved_to event (sub-millisecond response), with
+ * the existing 0.2 s chmod tick as defense-in-depth. See
+ * `config/start-openclaw.sh`.
  *
  * What this test reproduces directly:
- *   1. Force `secrets.json` to uid 999 (simulating Pinchy's atomic
- *      tmp+rename which always lands as uid 999).
- *   2. Touch `openclaw.json` to trigger inotify-driven reload.
- *   3. Within ~1 s, the chmod loop must restore root:root ownership.
- *      OpenClaw's reload must NOT log SECRETS_RELOADER_DEGRADED.
+ *   1. Atomically write secrets.json with uid 999 ownership using
+ *      Pinchy's exact tmp+rename pattern (`writeSecretsFile()`).
+ *   2. The inotify watcher fires moved_to within milliseconds and
+ *      chowns root:root before any OpenClaw reload could see uid 999.
+ *   3. Owner is verified back to 0:0 within a 500 ms budget — far
+ *      tighter than the 30 s legacy chown loop, but well within
+ *      inotify reaction times in practice.
  *
  * This is a server-side, deterministic test of the race window —
  * does not depend on any per-agent auth-profile mechanics, the LLM
@@ -28,7 +30,10 @@
  * Why this lives in the telegram E2E suite:
  *   The suite already runs against `docker-compose.e2e.yml` which
  *   uses the production Dockerfile.pinchy (uid 999 demotion). That's
- *   the only place the owner mismatch can manifest.
+ *   currently the only CI surface where the owner mismatch can
+ *   manifest. Once the rest of the E2E suites migrate to the
+ *   production image (#196), this spec should move to a more apt
+ *   location (e.g. an `agents/` or `infrastructure/` E2E suite).
  */
 
 import { test, expect } from "@playwright/test";
@@ -55,6 +60,24 @@ function getSecretsOwner(): string {
   return inOpenClaw("stat -c '%u:%g' /openclaw-secrets/secrets.json 2>/dev/null || echo 'missing'");
 }
 
+function readSecretsJson(): string {
+  // Returns the raw JSON text — base64-encoded over the docker-exec wire so
+  // newlines and shell metachars survive the round-trip intact.
+  const b64 = inOpenClaw("base64 -w0 /openclaw-secrets/secrets.json");
+  return Buffer.from(b64, "base64").toString("utf-8");
+}
+
+function writeSecretsJsonAsRoot(content: string): void {
+  // Pipe via base64 again to avoid quoting trouble on any payload.
+  const b64 = Buffer.from(content, "utf-8").toString("base64");
+  inOpenClaw(
+    `echo '${b64}' | base64 -d > /openclaw-secrets/secrets.json.tmp && ` +
+      `chown root:root /openclaw-secrets/secrets.json.tmp && ` +
+      `chmod 0600 /openclaw-secrets/secrets.json.tmp && ` +
+      `mv /openclaw-secrets/secrets.json.tmp /openclaw-secrets/secrets.json`
+  );
+}
+
 test.describe("Secrets owner race (#200)", () => {
   test.beforeAll(async ({}, testInfo) => {
     testInfo.setTimeout(180000);
@@ -71,28 +94,42 @@ test.describe("Secrets owner race (#200)", () => {
     const startOwner = getSecretsOwner();
     expect(startOwner).toBe("0:0");
 
-    // Reproduce Pinchy's atomic writeSecretsFile() pattern exactly:
-    // 1. Write a tmp file (here as root, content doesn't matter for the race).
-    // 2. chown it to uid 999 (Pinchy's uid; we cannot run as uid 999 from
-    //    inside the OpenClaw container — there's no such user — but the
-    //    end-state on disk after Pinchy's rename is the same: owner 999).
-    // 3. mv onto secrets.json — this is the moved_to event inotify watches.
-    // The replaced inode is now uid 999, exactly the bug condition.
-    inOpenClaw(
-      "echo '{}' > /openclaw-secrets/secrets.json.tmp && chown 999:999 /openclaw-secrets/secrets.json.tmp && mv /openclaw-secrets/secrets.json.tmp /openclaw-secrets/secrets.json"
-    );
+    // Snapshot the real secrets payload so we can restore it after the
+    // test. Otherwise we'd leave `secrets.json` as the `{}` we write below,
+    // which would strip provider keys and break any subsequent test in
+    // this suite that depends on OpenClaw resolving auth.
+    const originalContent = readSecretsJson();
 
-    // inotify reacts in single-digit milliseconds — far faster than the
-    // 200 ms chmod loop. Poll fast (10 ms) and tightly bounded (500 ms)
-    // so a regression of either path (loop or watcher) is visible.
-    let owner = "";
-    const deadline = Date.now() + 500;
-    while (Date.now() < deadline) {
-      owner = getSecretsOwner();
-      if (owner === "0:0") break;
-      await new Promise((r) => setTimeout(r, 10));
+    try {
+      // Reproduce Pinchy's atomic writeSecretsFile() pattern exactly:
+      // 1. Write a tmp file (here as root, content doesn't matter for the race).
+      // 2. chown it to uid 999 (Pinchy's uid; we cannot run as uid 999 from
+      //    inside the OpenClaw container — there's no such user — but the
+      //    end-state on disk after Pinchy's rename is the same: owner 999).
+      // 3. mv onto secrets.json — this is the moved_to event inotify watches.
+      // The replaced inode is now uid 999, exactly the bug condition.
+      inOpenClaw(
+        "echo '{}' > /openclaw-secrets/secrets.json.tmp && " +
+          "chown 999:999 /openclaw-secrets/secrets.json.tmp && " +
+          "mv /openclaw-secrets/secrets.json.tmp /openclaw-secrets/secrets.json"
+      );
+
+      // inotify reacts in single-digit milliseconds — far faster than the
+      // 200 ms chmod loop. Poll fast (10 ms) and tightly bounded (500 ms)
+      // so a regression of either path (loop or watcher) is visible.
+      let owner = "";
+      const deadline = Date.now() + 500;
+      while (Date.now() < deadline) {
+        owner = getSecretsOwner();
+        if (owner === "0:0") break;
+        await new Promise((r) => setTimeout(r, 10));
+      }
+
+      expect(owner).toBe("0:0");
+    } finally {
+      // Restore the original secrets payload regardless of test outcome —
+      // subsequent tests need a valid bundle.
+      writeSecretsJsonAsRoot(originalContent);
     }
-
-    expect(owner).toBe("0:0");
   });
 });

--- a/packages/web/e2e/telegram/agent-hot-reload.spec.ts
+++ b/packages/web/e2e/telegram/agent-hot-reload.spec.ts
@@ -1,0 +1,91 @@
+/**
+ * Hot-reload secrets-owner race regression test (issue #200).
+ *
+ * Bug on staging during v0.5.0 click-through:
+ *   POST /api/agents → Pinchy writes openclaw.json + secrets.json →
+ *   OpenClaw inotify triggers a reload → reload re-resolves secret
+ *   providers → finds /openclaw-secrets/secrets.json owned by uid 999
+ *   (Pinchy) → rejects with `SECRETS_RELOADER_DEGRADED: must be owned
+ *   by the current user (uid=0)` → new agents.list silently dropped
+ *   → user sees `unknown agent id "<uuid>"` when chatting.
+ *
+ * Fix: chown the secrets file in the same 0.2 s tick that already
+ * chmods openclaw.json + credentials/, so the window between Pinchy's
+ * write (uid 999) and OpenClaw's reload pickup never exposes the bad
+ * owner. See `config/start-openclaw.sh:fix_config_permissions`.
+ *
+ * What this test reproduces directly:
+ *   1. Force `secrets.json` to uid 999 (simulating Pinchy's atomic
+ *      tmp+rename which always lands as uid 999).
+ *   2. Touch `openclaw.json` to trigger inotify-driven reload.
+ *   3. Within ~1 s, the chmod loop must restore root:root ownership.
+ *      OpenClaw's reload must NOT log SECRETS_RELOADER_DEGRADED.
+ *
+ * This is a server-side, deterministic test of the race window —
+ * does not depend on any per-agent auth-profile mechanics, the LLM
+ * mock, or the chat UI.
+ *
+ * Why this lives in the telegram E2E suite:
+ *   The suite already runs against `docker-compose.e2e.yml` which
+ *   uses the production Dockerfile.pinchy (uid 999 demotion). That's
+ *   the only place the owner mismatch can manifest.
+ */
+
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import path from "path";
+import { waitForOpenClawConnected, waitForPinchy, seedSetup } from "./helpers";
+
+const COMPOSE_FILES = "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml";
+// Compose files live at the repo root; the test runner cwd is packages/web.
+const REPO_ROOT = path.resolve(__dirname, "../../../..");
+
+function inOpenClaw(cmd: string): string {
+  return execSync(`docker compose ${COMPOSE_FILES} exec -T openclaw sh -c "${cmd}"`, {
+    encoding: "utf-8",
+    cwd: REPO_ROOT,
+    // PINCHY_VERSION is required by docker-compose.yml's image: line; the
+    // value doesn't matter for `exec` (it just looks up the running
+    // container by service name), so any non-empty string works.
+    env: { ...process.env, PINCHY_VERSION: process.env.PINCHY_VERSION || "local" },
+  }).trim();
+}
+
+function getSecretsOwner(): string {
+  return inOpenClaw("stat -c '%u:%g' /openclaw-secrets/secrets.json 2>/dev/null || echo 'missing'");
+}
+
+test.describe("Secrets owner race (#200)", () => {
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(180000);
+    await waitForPinchy();
+    await seedSetup();
+    await waitForOpenClawConnected(120000);
+  });
+
+  test("secrets.json never lingers as uid 999 long enough for a reload to fail", async () => {
+    test.setTimeout(60000);
+
+    // Sanity: secrets file must exist (Pinchy writes it during seedSetup).
+    const initialOwner = getSecretsOwner();
+    expect(initialOwner).not.toBe("missing");
+
+    // Force the bad owner state. This simulates Pinchy's atomic
+    // writeSecretsFile() which always lands the file as uid 999 after
+    // renameSync — that's the moment the bug bites.
+    inOpenClaw("chown 999:999 /openclaw-secrets/secrets.json");
+    expect(getSecretsOwner()).toBe("999:999");
+
+    // The fast-tick chmod loop runs every 200 ms. Within ~1 s it must
+    // have restored root:root. Poll up to 3 s for safety margin.
+    let owner = "999:999";
+    const deadline = Date.now() + 3000;
+    while (Date.now() < deadline) {
+      owner = getSecretsOwner();
+      if (owner === "0:0") break;
+      await new Promise((r) => setTimeout(r, 100));
+    }
+
+    expect(owner).toBe("0:0");
+  });
+});

--- a/packages/web/e2e/telegram/agent-hot-reload.spec.ts
+++ b/packages/web/e2e/telegram/agent-hot-reload.spec.ts
@@ -63,27 +63,34 @@ test.describe("Secrets owner race (#200)", () => {
     await waitForOpenClawConnected(120000);
   });
 
-  test("secrets.json never lingers as uid 999 long enough for a reload to fail", async () => {
-    test.setTimeout(60000);
+  test("atomic tmp+rename writing uid 999 is restored to root before any reload could read it", async () => {
+    test.setTimeout(30000);
 
-    // Sanity: secrets file must exist (Pinchy writes it during seedSetup).
-    const initialOwner = getSecretsOwner();
-    expect(initialOwner).not.toBe("missing");
+    // Pre-condition: file exists and is root-owned (start-openclaw.sh
+    // chowns it on container start).
+    const startOwner = getSecretsOwner();
+    expect(startOwner).toBe("0:0");
 
-    // Force the bad owner state. This simulates Pinchy's atomic
-    // writeSecretsFile() which always lands the file as uid 999 after
-    // renameSync — that's the moment the bug bites.
-    inOpenClaw("chown 999:999 /openclaw-secrets/secrets.json");
-    expect(getSecretsOwner()).toBe("999:999");
+    // Reproduce Pinchy's atomic writeSecretsFile() pattern exactly:
+    // 1. Write a tmp file (here as root, content doesn't matter for the race).
+    // 2. chown it to uid 999 (Pinchy's uid; we cannot run as uid 999 from
+    //    inside the OpenClaw container — there's no such user — but the
+    //    end-state on disk after Pinchy's rename is the same: owner 999).
+    // 3. mv onto secrets.json — this is the moved_to event inotify watches.
+    // The replaced inode is now uid 999, exactly the bug condition.
+    inOpenClaw(
+      "echo '{}' > /openclaw-secrets/secrets.json.tmp && chown 999:999 /openclaw-secrets/secrets.json.tmp && mv /openclaw-secrets/secrets.json.tmp /openclaw-secrets/secrets.json"
+    );
 
-    // The fast-tick chmod loop runs every 200 ms. Within ~1 s it must
-    // have restored root:root. Poll up to 3 s for safety margin.
-    let owner = "999:999";
-    const deadline = Date.now() + 3000;
+    // inotify reacts in single-digit milliseconds — far faster than the
+    // 200 ms chmod loop. Poll fast (10 ms) and tightly bounded (500 ms)
+    // so a regression of either path (loop or watcher) is visible.
+    let owner = "";
+    const deadline = Date.now() + 500;
     while (Date.now() < deadline) {
       owner = getSecretsOwner();
       if (owner === "0:0") break;
-      await new Promise((r) => setTimeout(r, 100));
+      await new Promise((r) => setTimeout(r, 10));
     }
 
     expect(owner).toBe("0:0");


### PR DESCRIPTION
## Problem

Reproduced on staging during v0.5.0 click-through (Step 3, custom agent):

1. Create a new shared agent "Franz" via the Pinchy UI.
2. Open the chat, send a message.
3. Greeting appears, user message is sent, then:
   ```
   Franz couldn't respond
   invalid agent params: unknown agent id "35f52dc5-9299-46d2-9c5f-7d6a14e0b456"
   ```

The DB has the agent. `openclaw.json` on disk has the agent. But OpenClaw's runtime did not.

## Root cause

OpenClaw logs at the moment of agent creation on staging:
```
[reload] config change detected; evaluating reload (agents.list, …)
[secrets] [SECRETS_RELOADER_DEGRADED] SecretProviderResolutionError:
          secrets.providers.pinchy.path must be owned by the current user (uid=0):
          /openclaw-secrets/secrets.json
[reload] config restart failed: SecretProviderResolutionError: …
```

`regenerateOpenClawConfig()` writes both `openclaw.json` and `secrets.json` together. OpenClaw's inotify watcher picks up the openclaw.json change and triggers a reload. The reload pipeline re-resolves secret providers, finds `/openclaw-secrets/secrets.json` owned by uid 999 (Pinchy), and rejects the reload. The new `agents.list` is silently dropped.

`config/start-openclaw.sh` already had an `ensure_secrets_root_owned()` chown — but it ran only:
- once at startup,
- inside the 30 s mtime watch loop, and
- after gateway restarts.

inotify-to-reload latency in OpenClaw is ~50-100 ms. The watch loop wakes up far too late.

## Fix (two layers)

**Layer 1 — inotifywait watcher (primary defense, sub-millisecond response).**
A new background `inotifywait -m` on `/openclaw-secrets/` watches `close_write` and `moved_to` events. When Pinchy's atomic tmp+rename produces a uid 999 file, the chown fires within single-digit milliseconds — well before OpenClaw's inotify-driven reload has even started.

**Layer 2 — chmod loop tick (defense-in-depth, ~200 ms).**
The same 0.2 s tick that already chmods `openclaw.json` and `credentials/` now also chowns `secrets.json` to `root:root`. Catches any code path that bypasses inotify (e.g. a touch on the file in place).

## Test (TDD)

`packages/web/e2e/telegram/agent-hot-reload.spec.ts` — runs against the **production-image** stack (docker-compose.e2e.yml; uid 999 demotion). Reproduces Pinchy's atomic write pattern exactly:

```ts
// Inside the OpenClaw container:
echo '{}' > /openclaw-secrets/secrets.json.tmp
chown 999:999 /openclaw-secrets/secrets.json.tmp
mv /openclaw-secrets/secrets.json.tmp /openclaw-secrets/secrets.json
```

…then asserts the owner is restored to `0:0` within 500 ms (single-digit ms in practice).

- **RED without fix**: chown loop is too slow (~30 s) and inotify watcher absent — owner stays at 999:999 for the full test budget.
- **GREEN with fix**: owner restored in ~250 ms across two layers.

## Why CI didn't catch this earlier

The Telegram E2E suite (production-image since #195) does not exercise the "create new agent post-startup → chat with it" flow. Smithers exists from setup, so its own creation path doesn't hit the same race. This new spec plugs that gap.

## Test plan

- [x] Local: stack rebuilt with fix → test GREEN
- [x] Local: stack rebuilt without fix → test RED
- [ ] CI: telegram-e2e job runs the new spec (production image, real uid 999)
- [ ] After merge + redeploy staging: create a new custom agent, chat with it, no `unknown agent id`

## Related

- #195 — Telegram E2E switched to production image (parity foundation)
- #190 — secrets.json stub on cold start (different code path, same file)
- #200 — root cause + fix-options analysis