### PR TITLE
fix(openclaw-config): fire-and-forget RPC push, never block on gateway restart

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1130,10 +1130,32 @@ describe("regenerateOpenClawConfig", () => {
     // internal inotify watcher, which on production volumes had ~60 s of
     // pickup latency. Users sending messages right after creating an
     // agent saw `unknown agent id "<uuid>"` because the runtime didn't
-    // yet know the agent. The fix is to call `client.config.apply` over
-    // the WebSocket RPC — same content, but propagated immediately.
+    // yet know the agent. The fix is twofold:
+    //  1. Always write the file synchronously so the slow inotify path is
+    //     guaranteed to eventually pick it up.
+    //  2. Trigger a fire-and-forget `config.apply` RPC for faster runtime
+    //     propagation when the WS is connected. Fire-and-forget keeps POST
+    //     /api/agents (and any other regenerate caller) responsive even
+    //     when the apply itself blocks on a gateway restart (10–30 s).
 
-    it("calls client.config.apply when the OpenClaw client is connected, instead of writing the file", async () => {
+    it("writes the config file synchronously regardless of OpenClaw connection state", async () => {
+      // Default beforeEach has mockGetClient throwing — cold start path.
+      await regenerateOpenClawConfig();
+      expect(mockedWriteFileSync).toHaveBeenCalled();
+
+      vi.clearAllMocks();
+
+      // Now the connected path.
+      mockConfigGet.mockResolvedValue({ hash: "abc123" });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      await regenerateOpenClawConfig();
+      expect(mockedWriteFileSync).toHaveBeenCalled();
+    });
+
+    it("triggers the background RPC push when the OpenClaw client is connected", async () => {
       mockConfigGet.mockResolvedValue({ hash: "abc123" });
       mockConfigApply.mockResolvedValue(undefined);
       mockGetClient.mockReturnValue({
@@ -1142,66 +1164,41 @@ describe("regenerateOpenClawConfig", () => {
 
       await regenerateOpenClawConfig();
 
-      expect(mockConfigGet).toHaveBeenCalledOnce();
+      // The push is fire-and-forget — flush microtasks until the
+      // background coroutine has reached config.apply (or give up).
+      for (let i = 0; i < 50 && mockConfigApply.mock.calls.length === 0; i++) {
+        await new Promise((r) => setTimeout(r, 10));
+      }
+
       expect(mockConfigApply).toHaveBeenCalledOnce();
-
-      // Critical: the file write path must NOT be taken when the RPC succeeds.
-      // Otherwise both inotify (from the file write) AND the apply trigger
-      // separate reload cycles, causing back-to-back gateway restarts that
-      // leave chat.history unavailable for tens of seconds.
-      expect(mockedWriteFileSync).not.toHaveBeenCalled();
-
-      // The apply must include the regenerated config content and the hash
-      // returned by config.get for optimistic-locking.
       const applyArgs = mockConfigApply.mock.calls[0];
       expect(applyArgs[0]).toContain('"agents"'); // raw config JSON
       expect(applyArgs[1]).toBe("abc123"); // baseHash
     });
 
-    it("retries config.apply across transient WebSocket disconnects, then succeeds", async () => {
-      // openclaw-node throws this exact error string when the WS is
-      // mid-reconnect — extremely common during cold start.
-      const transient = new Error("Not connected to OpenClaw Gateway");
-      mockConfigGet
-        .mockRejectedValueOnce(transient)
-        .mockRejectedValueOnce(transient)
-        .mockResolvedValue({ hash: "xyz789" });
-      mockConfigApply.mockResolvedValue(undefined);
-      mockGetClient.mockReturnValue({
-        config: { get: mockConfigGet, apply: mockConfigApply },
-      });
-
-      await regenerateOpenClawConfig();
-
-      expect(mockConfigGet.mock.calls.length).toBeGreaterThanOrEqual(3);
-      expect(mockConfigApply).toHaveBeenCalledOnce();
-      expect(mockedWriteFileSync).not.toHaveBeenCalled();
-    });
-
-    it("falls back to writing the file when config.apply fails after all retries", async () => {
-      // Persistent disconnection — every retry fails. We must still write the
-      // file so OpenClaw eventually picks it up via inotify; otherwise the
-      // new agent would never reach the runtime at all.
+    it("does not throw when the client is connected but config.apply fails", async () => {
+      // Background apply errors must not bubble up. POST /api/agents must
+      // succeed even if the runtime push can't be delivered — inotify
+      // remains the safety net.
       mockConfigGet.mockRejectedValue(new Error("Not connected to OpenClaw Gateway"));
       mockGetClient.mockReturnValue({
         config: { get: mockConfigGet, apply: mockConfigApply },
       });
 
-      await regenerateOpenClawConfig();
-
-      expect(mockConfigApply).not.toHaveBeenCalled();
-      // Fallback wrote the file — OpenClaw's inotify will eventually catch up.
+      await expect(regenerateOpenClawConfig()).resolves.not.toThrow();
       expect(mockedWriteFileSync).toHaveBeenCalled();
-    }, 30000);
+    });
 
-    it("falls back to writing the file at cold start before the OpenClaw client is initialised", async () => {
-      // Default beforeEach sets mockGetClient to throw — covers the cold-start
-      // path. The file write must happen so OpenClaw gets a config to load.
+    it("does not call config.apply at cold start before the OpenClaw client is initialised", async () => {
+      // beforeEach sets mockGetClient to throw — exercises the no-client
+      // path. We must still write the file (verified above) but must NOT
+      // attempt the RPC.
       await regenerateOpenClawConfig();
+      // Background coroutine bails immediately when client unavailable.
+      await new Promise((r) => setTimeout(r, 50));
 
       expect(mockConfigGet).not.toHaveBeenCalled();
       expect(mockConfigApply).not.toHaveBeenCalled();
-      expect(mockedWriteFileSync).toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -799,17 +799,16 @@ async function pushOrWriteConfig(newContent: string): Promise<void> {
     return;
   }
 
-  // Retry the apply until OpenClaw's WebSocket is actually reachable. The
-  // openclaw-node client auto-reconnects, but during a gateway restart
-  // cascade (cold start, secrets.json mtime change, plugin enable, …) it
-  // can be disconnected for several seconds. Without retry, the very common
-  // case of POST /api/agents-during-cold-start falls back to file-write +
-  // inotify, which on production volumes is the 60 s slow path the apply
-  // RPC was meant to avoid.
+  // Brief retry to absorb transient disconnects (the openclaw-node WS
+  // reconnects within a couple of seconds in normal operation). Past that,
+  // fall back to file write — the cold-start cascade window can keep the
+  // WS down for tens of seconds, and we don't want interactive save flows
+  // (e.g. agent permissions save) hanging that long. inotify will still
+  // pick up the file write eventually, just slower.
   //
-  // Total budget ~15 s: covers one full gateway restart cycle. Past that,
-  // fall back to file write so agent creation never fails outright.
-  const backoffsMs = [100, 250, 500, 1000, 2000, 4000, 7000];
+  // Budget ~3.5 s sums to less than the typical UX timeout for save
+  // operations (~5 s spinners) while still riding through brief blips.
+  const backoffsMs = [100, 250, 500, 1000, 2000];
   let lastErr: unknown = null;
   for (const delayMs of backoffsMs) {
     try {

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -775,60 +775,55 @@ export async function regenerateOpenClawConfig() {
     // File doesn't exist yet — write it
   }
 
-  // Prefer pushing via the WebSocket RPC: config.apply writes the file on
-  // OpenClaw's side AND triggers a single reload. Writing the file ourselves
-  // first would cause inotify to fire, then config.apply to fire again —
-  // two restart cascades back-to-back, which leaves chat.history unavailable
-  // for tens of seconds and surfaces as `unknown agent id` to users sending
-  // messages mid-cycle.
-  //
-  // Fallback: if no client is connected yet (cold start before the first WS
-  // session) or the RPC errors, write the file ourselves and rely on
-  // OpenClaw's inotify to pick it up.
-  await pushOrWriteConfig(newContent);
+  // The file is the canonical source of truth. OpenClaw's inotify watcher
+  // will eventually pick it up — slowly on production volumes (~60 s),
+  // which is the latency `pushConfigInBackground` exists to hide.
+  writeConfigAtomic(newContent);
+
+  // Best-effort RPC push for faster runtime propagation. Fire-and-forget:
+  // the user-visible POST that triggered this regenerate must return as
+  // soon as the file is on disk, since `config.apply` can block 10–30 s
+  // when the change requires a gateway restart. Blocking that long broke
+  // interactive save flows (Odoo permissions Save & Restart, where the
+  // UI waits for "All changes saved").
+  pushConfigInBackground(newContent);
 }
 
-async function pushOrWriteConfig(newContent: string): Promise<void> {
-  let client;
-  try {
-    const { getOpenClawClient } = await import("@/server/openclaw-client");
-    client = getOpenClawClient();
-  } catch {
-    // Client not initialised yet — typical pre-WS-connect cold start.
-    writeConfigAtomic(newContent);
-    return;
-  }
-
-  // Brief retry to absorb transient disconnects (the openclaw-node WS
-  // reconnects within a couple of seconds in normal operation). Past that,
-  // fall back to file write — the cold-start cascade window can keep the
-  // WS down for tens of seconds, and we don't want interactive save flows
-  // (e.g. agent permissions save) hanging that long. inotify will still
-  // pick up the file write eventually, just slower.
-  //
-  // Budget ~3.5 s sums to less than the typical UX timeout for save
-  // operations (~5 s spinners) while still riding through brief blips.
-  const backoffsMs = [100, 250, 500, 1000, 2000];
-  let lastErr: unknown = null;
-  for (const delayMs of backoffsMs) {
+function pushConfigInBackground(newContent: string): void {
+  void (async () => {
+    let client;
     try {
-      const current = (await client.config.get()) as { hash: string };
-      await client.config.apply(newContent, current.hash, {
-        note: "pinchy: regenerateOpenClawConfig",
-      });
+      const { getOpenClawClient } = await import("@/server/openclaw-client");
+      client = getOpenClawClient();
+    } catch {
+      // No client — file write + inotify is the only path here.
       return;
-    } catch (err) {
-      lastErr = err;
-      await new Promise((resolve) => setTimeout(resolve, delayMs));
     }
-  }
 
-  const message = lastErr instanceof Error ? lastErr.message : String(lastErr);
-  console.warn(
-    "[openclaw-config] config.apply RPC failed after retries; falling back to file write:",
-    message
-  );
-  writeConfigAtomic(newContent);
+    // Brief retry across transient WS disconnects. Beyond ~3.5 s the WS is
+    // probably down due to the cold-start cascade, and inotify will catch
+    // up; no point keeping a background coroutine alive longer.
+    const backoffsMs = [100, 250, 500, 1000, 2000];
+    for (let i = 0; i < backoffsMs.length; i++) {
+      try {
+        const current = (await client.config.get()) as { hash: string };
+        await client.config.apply(newContent, current.hash, {
+          note: "pinchy: regenerateOpenClawConfig",
+        });
+        return;
+      } catch (err) {
+        if (i === backoffsMs.length - 1) {
+          const message = err instanceof Error ? err.message : String(err);
+          console.warn(
+            "[openclaw-config] background config.apply failed; relying on inotify:",
+            message
+          );
+          return;
+        }
+        await new Promise((resolve) => setTimeout(resolve, backoffsMs[i]));
+      }
+    }
+  })();
 }
 
 // ── Targeted config updates ───────────────────────────────────────────────


### PR DESCRIPTION
## Why

Even with a shorter retry budget, the previous fix blocked POST
\`/api/agents\` on the \`config.apply\` RPC. That RPC itself blocks
10–30 s when the change requires a gateway restart — far past the
30 s budget the Odoo \`save and reload preserves state\` test gives
\"All changes saved\" to appear.

## Fix

- Always write the file synchronously. OpenClaw's inotify will
  eventually pick it up — slow, but always works.
- Fire-and-forget the \`config.apply\` RPC. Faster runtime
  propagation when the WS is connected, but doesn't hold the
  user-visible POST.

\`\`\`ts
async function regenerateOpenClawConfig() {
  // ...
  writeConfigAtomic(newContent);            // synchronous, fast
  pushConfigInBackground(newContent);       // void, returns immediately
}
\`\`\`

## Trade-offs

- When a config change requires a gateway restart, both the file
  inotify AND the RPC apply can each trigger a reload. The user
  has already opted into the restart via \"Save & Restart\"; a
  double-cycle is acceptable in that path.
- For agent-create (#200), the RPC still propagates the new
  \`agents.list\` to the runtime in sub-second, beating the ~60 s
  inotify slow path on production volumes. The original
  \"unknown agent id\" bug stays fixed in steady state.

## Tests

Unit tests rewritten to match fire-and-forget semantics:
- File is always written, regardless of WS connection state.
- RPC apply is triggered (background) when the WS is connected.
- Background errors don't bubble up; POST stays responsive.
- Cold start (no client) skips the RPC entirely.

3312 unit tests pass locally.

## Test plan

- [x] Unit tests pass
- [ ] CI green (Odoo permissions test was the regression target)
- [ ] After merge: redeploy staging, verify agent-create still works