### PR TITLE
fix(model-resolver): type-constrain Ollama Cloud IDs against curated list

### DIFF
--- a/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { resolveModelForTemplate } from "..";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
 import type { ProviderName } from "@/lib/providers";
 
 vi.mock("@/lib/provider-models", () => ({
@@ -69,4 +70,32 @@ describe("template + provider resolves to expected model", () => {
       expect(result.model).toBe(expected);
     }
   );
+});
+
+/**
+ * Regression guard for the v0.5.0 staging bug where the CRM template's
+ * `tier=balanced + general` hint resolved to `ollama-cloud/llama3.3:70b`,
+ * a model that no longer exists on Ollama Cloud — surfacing as
+ * `HTTP 404: model "llama3.3:70b" not found` to the user.
+ *
+ * Walks every template that has a `modelHint`, resolves it under the
+ * Ollama Cloud provider, and asserts the resulting model ID is in the
+ * curated `TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS` list — the only IDs we
+ * know Ollama Cloud actually serves.
+ *
+ * The static type-level guard (OllamaCloudModelId in the resolver) catches
+ * this at compile time for a single resolver. This test catches it at
+ * runtime across every template-resolver pairing — a second line of
+ * defence that survives any future code path that bypasses the type.
+ */
+describe("every template resolves to an actually-existing Ollama Cloud model", () => {
+  const templatesWithHint = Object.entries(AGENT_TEMPLATES)
+    .filter(([, t]) => t.modelHint !== undefined)
+    .map(([id, t]) => ({ id, hint: t.modelHint! }));
+
+  it.each(templatesWithHint)("$id resolves to a curated Ollama Cloud model", async ({ hint }) => {
+    const result = await resolveModelForTemplate({ hint, provider: "ollama-cloud" });
+    const idWithoutPrefix = result.model.replace(/^ollama-cloud\//, "");
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).toContain(idWithoutPrefix);
+  });
 });

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -1,21 +1,29 @@
 import type { ModelHint, ModelTaskType, ModelTier, ResolverResult } from "../types";
+import type { OllamaCloudModelId } from "@/lib/ollama-cloud-models";
+
+// `OllamaCloudModelId` is a literal-string union derived from the curated
+// list in `ollama-cloud-models.ts`. By typing each entry as
+// `ollama-cloud/${OllamaCloudModelId}`, any stale or removed model ID
+// becomes a TypeScript compile error — the v0.5.0 staging bug
+// (`llama3.3:70b → HTTP 404`) would have failed `tsc` here.
+type OllamaCloudModelRef = `ollama-cloud/${OllamaCloudModelId}`;
 
 const BY_TIER_FAMILY: Record<
   ModelTier,
-  Partial<Record<ModelTaskType, string>> & { general: string }
+  Partial<Record<ModelTaskType, OllamaCloudModelRef>> & { general: OllamaCloudModelRef }
 > = {
   fast: {
-    general: "ollama-cloud/gemini-2.0-flash",
-    coder: "ollama-cloud/qwen3-coder:30b",
+    general: "ollama-cloud/deepseek-v4-flash",
+    coder: "ollama-cloud/qwen3-coder-next",
   },
   balanced: {
-    general: "ollama-cloud/llama3.3:70b",
-    coder: "ollama-cloud/qwen3-coder:30b",
-    vision: "ollama-cloud/qwen3-vl:32b",
+    general: "ollama-cloud/glm-4.7",
+    coder: "ollama-cloud/qwen3-coder:480b",
+    vision: "ollama-cloud/qwen3-vl:235b",
   },
   reasoning: {
-    general: "ollama-cloud/deepseek-v3",
-    reasoning: "ollama-cloud/deepseek-r1:32b",
+    general: "ollama-cloud/deepseek-v4-pro",
+    reasoning: "ollama-cloud/kimi-k2-thinking",
   },
 };
 

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -40,7 +40,10 @@ export interface OllamaCloudModel {
 
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 
-export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: readonly OllamaCloudModel[] = [
+// `as const satisfies` keeps the literal types of every `id` (so we can
+// derive a strict union below) while still validating each entry against
+// the `OllamaCloudModel` shape.
+export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   {
     id: "deepseek-v3.1:671b",
     contextWindow: 163840,
@@ -153,15 +156,31 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: readonly OllamaCloudModel[] = [
   },
   { id: "qwen3.5:397b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
   { id: "rnj-1:8b", contextWindow: 32768, maxTokens: 8192, reasoning: false, vision: false },
-];
+] as const satisfies readonly OllamaCloudModel[];
+
+/**
+ * Literal-string union of every model ID in the curated list. Use this in
+ * resolvers, agent templates, and anywhere else that hard-codes an Ollama
+ * Cloud model — TypeScript will then refuse to compile if you reference a
+ * model that's been removed (the `llama3.3:70b → HTTP 404` bug from
+ * v0.5.0 staging would have failed at the type level).
+ */
+export type OllamaCloudModelId = (typeof TOOL_CAPABLE_OLLAMA_CLOUD_MODELS)[number]["id"];
 
 /** Just the IDs — used by the `/v1/models` transform and fallback list. */
-export const TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map(
-  (m) => m.id
-);
+export const TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS: readonly OllamaCloudModelId[] =
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => m.id);
 
-/** Subset of IDs that accept image input. Used by the vision-capability check. */
-export const VISION_OLLAMA_CLOUD_MODEL_IDS = new Set(
+/**
+ * Subset of IDs that accept image input. Used by the vision-capability check.
+ *
+ * Typed as `Set<string>` (not `Set<OllamaCloudModelId>`) because callers
+ * pass model strings of unknown provenance (e.g. names returned from
+ * OpenClaw's runtime, user input). `Set.has` is strict on its element type
+ * in modern TS; widening here keeps the call sites simple without
+ * sacrificing correctness — the set still only ever contains curated IDs.
+ */
+export const VISION_OLLAMA_CLOUD_MODEL_IDS: ReadonlySet<string> = new Set(
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.filter((m) => m.vision).map((m) => m.id)
 );
 


### PR DESCRIPTION
## Problem

User-reported on staging during v0.5.0 click-through: chatting with the CRM template (Piper) returned

\`HTTP 404: model \"llama3.3:70b\" not found\`

The resolver's \`tier=balanced + general\` mapping pointed at \`ollama-cloud/llama3.3:70b\`, which no longer exists in the curated list. Five other tier/taskType pairings had the same staleness, all silently — they only fail when a user picks a template that hits that path.

## Stale → fixed mapping

| Tier / TaskType | Old ID (404) | New ID (in curated list) |
|--|--|--|
| fast / general | \`gemini-2.0-flash\` | \`deepseek-v4-flash\` |
| fast / coder | \`qwen3-coder:30b\` | \`qwen3-coder-next\` |
| balanced / general | \`llama3.3:70b\` | \`glm-4.7\` |
| balanced / coder | \`qwen3-coder:30b\` | \`qwen3-coder:480b\` |
| balanced / vision | \`qwen3-vl:32b\` | \`qwen3-vl:235b\` |
| reasoning / general | \`deepseek-v3\` | \`deepseek-v4-pro\` |
| reasoning / reasoning | \`deepseek-r1:32b\` | \`kimi-k2-thinking\` |

## Two-layer guard

**Type-level.** \`TOOL_CAPABLE_OLLAMA_CLOUD_MODELS\` is now
\`as const satisfies readonly OllamaCloudModel[]\` so each \`id\` keeps its literal type. Derived \`OllamaCloudModelId\` is a union over those literals. The resolver's tier→model map is typed
\`Record<…, \`ollama-cloud/${OllamaCloudModelId}\`>\` — referencing a stale ID becomes a TypeScript compile error. If \`llama3.3:70b\` is ever re-introduced, \`tsc\` fails CI's Lint, Test & Build job before any user can hit it.

**Runtime guard.** New parametric test in \`template-integration.test.ts\` walks every template that has a \`modelHint\`, resolves it under the Ollama Cloud provider, and asserts the result ID is in \`TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS\`. Catches anything that bypasses the type system (e.g. a future code path that builds the ID at runtime). Failed RED before the fix (25 templates ✗ × \"includes 'gemini-2.0-flash'\"), GREEN after.

## Test plan

- [x] All 3337 unit tests pass
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] After merge + redeploy staging: CRM template (Piper) responds successfully

## Related

- \`packages/web/src/lib/ollama-cloud-models.ts\` — the curated list, source of truth
- \`packages/web/src/lib/model-resolver/providers/ollama-cloud.ts\` — the resolver, now type-constrained
- \`packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts\` — new regression test