### PR TITLE
fix(pinchy-odoo): write apiKey as plaintext, not SecretRef

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -764,14 +764,35 @@ const controlServer = http.createServer(async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
-// Start servers
+// Public API for in-process consumers (vitest integration tests).
+//
+// Auto-starts on the published Docker ports when run as a CLI (e.g. inside
+// the docker-compose service). Tests can instead import the module and
+// call `start()` to spin both servers up on ephemeral ports without
+// touching the docker-compose stack.
 // ---------------------------------------------------------------------------
 resetNextIds();
 
-jsonRpcServer.listen(8069, () => {
-  console.log("Mock Odoo JSON-RPC server listening on port 8069");
-});
+async function start({ jsonRpcPort = 8069, controlPort = 9002 } = {}) {
+  await new Promise((resolve) => jsonRpcServer.listen(jsonRpcPort, resolve));
+  await new Promise((resolve) => controlServer.listen(controlPort, resolve));
+  return {
+    jsonRpcPort: jsonRpcServer.address().port,
+    controlPort: controlServer.address().port,
+    async stop() {
+      await Promise.all([
+        new Promise((r) => jsonRpcServer.close(r)),
+        new Promise((r) => controlServer.close(r)),
+      ]);
+    },
+  };
+}
 
-controlServer.listen(9002, () => {
-  console.log("Mock Odoo Control API listening on port 9002");
-});
+if (require.main === module) {
+  start().then(({ jsonRpcPort, controlPort }) => {
+    console.log(`Mock Odoo JSON-RPC server listening on port ${jsonRpcPort}`);
+    console.log(`Mock Odoo Control API listening on port ${controlPort}`);
+  });
+}
+
+module.exports = { start };

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Integration tests for pinchy-odoo against the real mock-odoo HTTP server.
+ *
+ * Layer 2 of the #209 guardrails: catches anything that breaks the actual
+ * plugin → odoo-node → Odoo JSON-RPC chain end-to-end. Layer 1 (unit tests
+ * in `tools.test.ts`) mock `odoo-node` away, so a regression in the way
+ * Pinchy's `apiKey` reaches Odoo (e.g. shape, encoding, header placement)
+ * would slip past them. This file uses the real `odoo-node` library
+ * against an in-process instance of `config/odoo-mock/server.js`.
+ *
+ * The original bug: Pinchy wrote the apiKey as a SecretRef object,
+ * `odoo-node` forwarded that dict to Odoo, and Odoo crashed with
+ * `unhashable type: 'dict'`. With this test in place, that exact
+ * regression — or any future variant where the wrong shape reaches
+ * Odoo over the wire — fails CI on a real RPC round-trip.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "module";
+import plugin from "../index";
+
+const require = createRequire(import.meta.url);
+
+interface MockOdooHandle {
+  jsonRpcPort: number;
+  controlPort: number;
+  stop: () => Promise<void>;
+}
+
+interface AgentTool {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+let mockOdoo: MockOdooHandle;
+
+beforeAll(async () => {
+  // Use port 0 so the OS picks an unused port — avoids collisions with
+  // any other mock-odoo running on the same host (docker-compose, etc.).
+  const mockServer = require("../../../../config/odoo-mock/server.js") as {
+    start: (opts: { jsonRpcPort: number; controlPort: number }) => Promise<MockOdooHandle>;
+  };
+  mockOdoo = await mockServer.start({ jsonRpcPort: 0, controlPort: 0 });
+});
+
+afterAll(async () => {
+  await mockOdoo?.stop();
+});
+
+function createApi(agentConfigs: Record<string, unknown> = {}) {
+  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> =
+    [];
+  const api = {
+    pluginConfig: { agents: agentConfigs },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string }
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (plugin as any).register(api);
+  return tools;
+}
+
+function findTool(tools: ReturnType<typeof createApi>, name: string, agentId: string): AgentTool {
+  const entry = tools.find((t) => t.name === name);
+  if (!entry) throw new Error(`Tool ${name} not registered`);
+  const tool = entry.factory({ agentId });
+  if (!tool) throw new Error(`Tool ${name} factory returned null for agent ${agentId}`);
+  return tool;
+}
+
+const agentId = "agent-integration";
+
+function buildAgentConfig(overrides: Partial<{ apiKey: unknown; uid: unknown }> = {}) {
+  return {
+    connection: {
+      name: "Mock Odoo",
+      description: "In-process mock for integration tests",
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: overrides.uid ?? 2,
+      // The default apiKey here is a plain string — exactly what Pinchy
+      // should be writing into the plugin config (the bug-fixing shape).
+      apiKey: overrides.apiKey ?? "test-api-key",
+    },
+    permissions: {
+      "sale.order": ["read"],
+      "res.partner": ["read"],
+    },
+    modelNames: { "sale.order": "Sales Order", "res.partner": "Contact" },
+  };
+}
+
+describe("pinchy-odoo against real mock-odoo (#209 layer 2)", () => {
+  it("odoo_schema returns the model's fields when apiKey is a plain string", async () => {
+    const tools = createApi({ [agentId]: buildAgentConfig() });
+    const tool = findTool(tools, "odoo_schema", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order" });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.name).toBe("Sales Order");
+    expect(data.fields.length).toBeGreaterThan(0);
+    expect(data.fields.some((f: { name: string }) => f.name === "name")).toBe(true);
+  });
+
+  it("odoo_count returns { count: number } for an empty filter", async () => {
+    const tools = createApi({ [agentId]: buildAgentConfig() });
+    const tool = findTool(tools, "odoo_count", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(typeof data.count).toBe("number");
+  });
+
+  it("odoo_read returns records and total for an empty filter", async () => {
+    const tools = createApi({ [agentId]: buildAgentConfig() });
+    const tool = findTool(tools, "odoo_read", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(Array.isArray(data.records)).toBe(true);
+    expect(typeof data.total).toBe("number");
+  });
+
+  it("REGRESSION: odoo_schema fails fast with a clear error when apiKey is the SecretRef dict (#209)", async () => {
+    // This is exactly the bug shape from staging: Pinchy used to write
+    // apiKey as an unresolved SecretRef object, OpenClaw didn't resolve
+    // it, the plugin forwarded the dict to Odoo, and Odoo crashed with
+    // `unhashable type: 'dict'`. With the layer-3 runtime check in
+    // `createClient`, the plugin now refuses to start a request whose
+    // apiKey isn't a string — the user gets a clear plugin-side error
+    // instead of a confusing Python crash.
+    const brokenConfig = buildAgentConfig({
+      apiKey: { source: "file", provider: "pinchy", id: "/integrations/x/odooApiKey" },
+    });
+    const tools = createApi({ [agentId]: brokenConfig });
+    const tool = findTool(tools, "odoo_schema", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order" });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("apiKey must be a string");
+    expect(text).toContain("#209");
+    // Crucially, the error should NOT be the Python crash message —
+    // i.e. the request should never reach Odoo if the shape is wrong.
+    expect(text).not.toContain("unhashable type");
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -511,3 +511,64 @@ describe("client caching", () => {
     expect(OdooClient).toHaveBeenCalledTimes(2);
   });
 });
+
+/**
+ * Defense-in-depth runtime checks at the plugin's edge. The TypeScript
+ * type says `apiKey: string`, but Pinchy historically wrote it as a
+ * `SecretRef` object — OpenClaw didn't resolve it, the plugin forwarded
+ * the dict to Odoo, and Odoo crashed with `unhashable type: 'dict'`
+ * (#209). These tests assert the plugin fails fast with a clear error
+ * if a future regression sends the wrong shape, instead of producing a
+ * Python-server crash deep inside `odoo-node`.
+ */
+describe("connection shape validation (#209 guardrail)", () => {
+  it("rejects an unresolved SecretRef-shaped apiKey with a clear plugin-side error", async () => {
+    const brokenConfig = {
+      connection: {
+        ...testConnection,
+        // Exactly the shape Pinchy was writing pre-#209: an unresolved
+        // SecretRef object instead of a plaintext string.
+        apiKey: { source: "file", provider: "pinchy", id: "/integrations/x/odooApiKey" },
+      },
+      permissions: testPermissions,
+      modelNames: {},
+    };
+
+    const tools = createApi({ [agentId]: brokenConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("apiKey must be a string");
+    expect(text).toContain("SecretRef");
+    expect(text).toContain("#209");
+  });
+
+  it("rejects a non-numeric uid with a clear error", async () => {
+    const brokenConfig = {
+      connection: {
+        ...testConnection,
+        uid: "2" as unknown as number, // came from JSON without coercion
+      },
+      permissions: testPermissions,
+      modelNames: {},
+    };
+
+    const tools = createApi({ [agentId]: brokenConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("uid must be a number");
+  });
+
+  it("does not reject a well-formed connection", async () => {
+    mockSearchCount.mockResolvedValue(0);
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    expect(result.isError).toBeFalsy();
+  });
+});

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -52,7 +52,37 @@ function getAgentConfig(
   return agentConfigs[agentId] ?? null;
 }
 
+/**
+ * Defense-in-depth runtime validation. The TypeScript signature claims
+ * `apiKey: string`, but Pinchy historically wrote it as a `SecretRef`
+ * object (`{ source, provider, id }`) intending OpenClaw to resolve it.
+ * OpenClaw 2026.4.x does not resolve SecretRefs in arbitrary plugin
+ * config paths, so the unresolved object reached this plugin and was
+ * forwarded to `odoo-node` as the password — causing Odoo to crash with
+ * `unhashable type: 'dict'` (#209). If a future regression sends the
+ * wrong shape again, fail fast here with a clear, plugin-side error
+ * instead of producing a confusing Python-server crash.
+ */
+function assertConnectionShape(connection: AgentOdooConfig["connection"]): void {
+  const fields: Array<[keyof AgentOdooConfig["connection"], "string" | "number"]> = [
+    ["url", "string"],
+    ["db", "string"],
+    ["uid", "number"],
+    ["apiKey", "string"],
+  ];
+  for (const [name, expected] of fields) {
+    const actual = typeof connection[name];
+    if (actual !== expected) {
+      throw new Error(
+        `pinchy-odoo: connection.${name} must be a ${expected}, got ${actual}` +
+          `${actual === "object" ? " (looks like an unresolved SecretRef — see issue #209)" : ""}`
+      );
+    }
+  }
+}
+
 function createClient(config: AgentOdooConfig): OdooClient {
+  assertConnectionShape(config.connection);
   return new OdooClient({
     url: config.connection.url,
     db: config.connection.db,

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1845,7 +1845,22 @@ describe("pinchy-odoo config size", () => {
   });
 });
 
-describe("pinchy-odoo connection.apiKey as SecretRef", () => {
+describe("pinchy-odoo connection.apiKey", () => {
+  // Background: we originally wrote `apiKey` as a SecretRef pointer
+  // (`{ source: "file", provider: "pinchy", id: "/integrations/.../odooApiKey" }`)
+  // intending OpenClaw to resolve it at runtime. OpenClaw 2026.4.x does NOT
+  // resolve SecretRef objects in arbitrary plugin config paths — only in a
+  // hand-coded list of known fields (e.g. `models.providers.X.apiKey`,
+  // `gateway.auth.token`). The unresolved object reached the `pinchy-odoo`
+  // plugin, was forwarded to `odoo-node` as the password, and Odoo's
+  // Python server failed with `unhashable type: 'dict'` when it tried to
+  // use the dict as a hash key (#209). Pinchy now writes `apiKey` as a
+  // plaintext string, matching the existing pattern used for
+  // `pinchy-context.config.gatewayToken`. Odoo API keys don't match any
+  // pattern in `openclaw-plaintext-scanner.ts` so the
+  // defense-in-depth check still passes; the `tools.openclaw-secrets`
+  // tmpfs is irrelevant for this field.
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockedExistsSync.mockReturnValue(true);
@@ -1855,7 +1870,7 @@ describe("pinchy-odoo connection.apiKey as SecretRef", () => {
     mockedGetSetting.mockResolvedValue(null);
   });
 
-  it("writes odoo connection.apiKey as SecretRef keyed by connection id", async () => {
+  it("writes odoo connection.apiKey as a plaintext string the plugin can use directly", async () => {
     const agentsData = [
       {
         id: "odoo-agent",
@@ -1903,7 +1918,6 @@ describe("pinchy-odoo connection.apiKey as SecretRef", () => {
 
     await regenerateOpenClawConfig();
 
-    // openclaw.json must contain a SecretRef for apiKey, not the plaintext key
     const written = mockedWriteFileSync.mock.calls.find(
       (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
     );
@@ -1912,20 +1926,18 @@ describe("pinchy-odoo connection.apiKey as SecretRef", () => {
 
     const odooConfig = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents?.["odoo-agent"];
     expect(odooConfig).toBeDefined();
-    expect(odooConfig.connection.apiKey).toEqual({
-      source: "file",
-      provider: "pinchy",
-      id: "/integrations/conn-odoo-1/odooApiKey",
-    });
-    // Other connection fields must still be present in plaintext
+
+    // Critical: apiKey must be a string. If it leaks through as the
+    // SecretRef object `{ source, provider, id }`, the plugin forwards
+    // that dict to Odoo and Python crashes with
+    // `unhashable type: 'dict'`.
+    expect(typeof odooConfig.connection.apiKey).toBe("string");
+    expect(odooConfig.connection.apiKey).toBe("secret-odoo-key");
+
+    // Other connection fields are unchanged.
     expect(odooConfig.connection.url).toBe("https://odoo.example.com");
     expect(odooConfig.connection.db).toBe("mydb");
     expect(odooConfig.connection.uid).toBe(2);
-
-    // secrets.json must contain the actual key
-    expect(mockWriteSecretsFile).toHaveBeenCalled();
-    const secretsArg = mockWriteSecretsFile.mock.calls[0][0];
-    expect(secretsArg.integrations?.["conn-odoo-1"]?.odooApiKey).toBe("secret-odoo-key");
   });
 });
 

--- a/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it, vi } from "vitest";
 import { resolveModelForTemplate } from "..";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
 import type { ProviderName } from "@/lib/providers";
 
 vi.mock("@/lib/provider-models", () => ({
@@ -69,4 +70,32 @@ describe("template + provider resolves to expected model", () => {
       expect(result.model).toBe(expected);
     }
   );
+});
+
+/**
+ * Regression guard for the v0.5.0 staging bug where the CRM template's
+ * `tier=balanced + general` hint resolved to `ollama-cloud/llama3.3:70b`,
+ * a model that no longer exists on Ollama Cloud — surfacing as
+ * `HTTP 404: model "llama3.3:70b" not found` to the user.
+ *
+ * Walks every template that has a `modelHint`, resolves it under the
+ * Ollama Cloud provider, and asserts the resulting model ID is in the
+ * curated `TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS` list — the only IDs we
+ * know Ollama Cloud actually serves.
+ *
+ * The static type-level guard (OllamaCloudModelId in the resolver) catches
+ * this at compile time for a single resolver. This test catches it at
+ * runtime across every template-resolver pairing — a second line of
+ * defence that survives any future code path that bypasses the type.
+ */
+describe("every template resolves to an actually-existing Ollama Cloud model", () => {
+  const templatesWithHint = Object.entries(AGENT_TEMPLATES)
+    .filter(([, t]) => t.modelHint !== undefined)
+    .map(([id, t]) => ({ id, hint: t.modelHint! }));
+
+  it.each(templatesWithHint)("$id resolves to a curated Ollama Cloud model", async ({ hint }) => {
+    const result = await resolveModelForTemplate({ hint, provider: "ollama-cloud" });
+    const idWithoutPrefix = result.model.replace(/^ollama-cloud\//, "");
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).toContain(idWithoutPrefix);
+  });
 });

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -1,21 +1,29 @@
 import type { ModelHint, ModelTaskType, ModelTier, ResolverResult } from "../types";
+import type { OllamaCloudModelId } from "@/lib/ollama-cloud-models";
+
+// `OllamaCloudModelId` is a literal-string union derived from the curated
+// list in `ollama-cloud-models.ts`. By typing each entry as
+// `ollama-cloud/${OllamaCloudModelId}`, any stale or removed model ID
+// becomes a TypeScript compile error — the v0.5.0 staging bug
+// (`llama3.3:70b → HTTP 404`) would have failed `tsc` here.
+type OllamaCloudModelRef = `ollama-cloud/${OllamaCloudModelId}`;
 
 const BY_TIER_FAMILY: Record<
   ModelTier,
-  Partial<Record<ModelTaskType, string>> & { general: string }
+  Partial<Record<ModelTaskType, OllamaCloudModelRef>> & { general: OllamaCloudModelRef }
 > = {
   fast: {
-    general: "ollama-cloud/gemini-2.0-flash",
-    coder: "ollama-cloud/qwen3-coder:30b",
+    general: "ollama-cloud/deepseek-v4-flash",
+    coder: "ollama-cloud/qwen3-coder-next",
   },
   balanced: {
-    general: "ollama-cloud/llama3.3:70b",
-    coder: "ollama-cloud/qwen3-coder:30b",
-    vision: "ollama-cloud/qwen3-vl:32b",
+    general: "ollama-cloud/glm-4.7",
+    coder: "ollama-cloud/qwen3-coder:480b",
+    vision: "ollama-cloud/qwen3-vl:235b",
   },
   reasoning: {
-    general: "ollama-cloud/deepseek-v3",
-    reasoning: "ollama-cloud/deepseek-r1:32b",
+    general: "ollama-cloud/deepseek-v4-pro",
+    reasoning: "ollama-cloud/kimi-k2-thinking",
   },
 };
 

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -40,7 +40,10 @@ export interface OllamaCloudModel {
 
 const ZERO_COST = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 } as const;
 
-export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: readonly OllamaCloudModel[] = [
+// `as const satisfies` keeps the literal types of every `id` (so we can
+// derive a strict union below) while still validating each entry against
+// the `OllamaCloudModel` shape.
+export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   {
     id: "deepseek-v3.1:671b",
     contextWindow: 163840,
@@ -153,15 +156,31 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS: readonly OllamaCloudModel[] = [
   },
   { id: "qwen3.5:397b", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
   { id: "rnj-1:8b", contextWindow: 32768, maxTokens: 8192, reasoning: false, vision: false },
-];
+] as const satisfies readonly OllamaCloudModel[];
+
+/**
+ * Literal-string union of every model ID in the curated list. Use this in
+ * resolvers, agent templates, and anywhere else that hard-codes an Ollama
+ * Cloud model — TypeScript will then refuse to compile if you reference a
+ * model that's been removed (the `llama3.3:70b → HTTP 404` bug from
+ * v0.5.0 staging would have failed at the type level).
+ */
+export type OllamaCloudModelId = (typeof TOOL_CAPABLE_OLLAMA_CLOUD_MODELS)[number]["id"];
 
 /** Just the IDs — used by the `/v1/models` transform and fallback list. */
-export const TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map(
-  (m) => m.id
-);
+export const TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS: readonly OllamaCloudModelId[] =
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => m.id);
 
-/** Subset of IDs that accept image input. Used by the vision-capability check. */
-export const VISION_OLLAMA_CLOUD_MODEL_IDS = new Set(
+/**
+ * Subset of IDs that accept image input. Used by the vision-capability check.
+ *
+ * Typed as `Set<string>` (not `Set<OllamaCloudModelId>`) because callers
+ * pass model strings of unknown provenance (e.g. names returned from
+ * OpenClaw's runtime, user input). `Set.has` is strict on its element type
+ * in modern TS; widening here keeps the call sites simple without
+ * sacrificing correctness — the set still only ever contains curated IDs.
+ */
+export const VISION_OLLAMA_CLOUD_MODEL_IDS: ReadonlySet<string> = new Set(
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.filter((m) => m.vision).map((m) => m.id)
 );
 

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -460,11 +460,6 @@ export async function regenerateOpenClawConfig() {
       }
     }
 
-    integrationSecrets[conn.id] = {
-      ...(integrationSecrets[conn.id] || {}),
-      odooApiKey: decryptedCreds.apiKey,
-    };
-
     odooAgentConfigs[agentId] = {
       connection: {
         name: conn.name,
@@ -472,7 +467,17 @@ export async function regenerateOpenClawConfig() {
         url: decryptedCreds.url,
         db: decryptedCreds.db,
         uid: decryptedCreds.uid,
-        apiKey: secretRef(`/integrations/${conn.id}/odooApiKey`),
+        // Plaintext, not SecretRef. OpenClaw 2026.4.x does not resolve
+        // SecretRef objects in plugin config paths — only in a hand-coded
+        // set of known fields (e.g. models.providers.*.apiKey). When this
+        // was a SecretRef, the unresolved `{ source, provider, id }` dict
+        // reached `pinchy-odoo`, was forwarded as the password to Odoo,
+        // and Python failed with `unhashable type: 'dict'` (#209). Same
+        // pragma as `pinchy-context.config.gatewayToken` and Telegram bot
+        // tokens — all plaintext for the same reason. Odoo API keys don't
+        // match any provider-key pattern in `openclaw-plaintext-scanner`,
+        // so its defense-in-depth check still passes.
+        apiKey: decryptedCreds.apiKey,
       },
       permissions,
       modelNames,


### PR DESCRIPTION
## Closes #209

User on staging: every \`pinchy-odoo\` tool call returned
\`Error: unhashable type: 'dict'\`. The Odoo template (Piper) was unusable; same for any other Odoo-backed agent.

## Root cause

\`openclaw-config.ts\` wrote \`pinchy-odoo.config.agents.<id>.connection.apiKey\` as a SecretRef object intending OpenClaw to resolve it at runtime. OpenClaw 2026.4.x only resolves SecretRefs in a hand-coded set of known config paths; it does not walk arbitrary plugin config trees. The unresolved dict reached \`pinchy-odoo\`, was forwarded to \`odoo-node\` as the password, and Odoo's Python server crashed when trying to use the dict as a hash key in its API-key lookup.

## Fix + four layers of guardrails

The runtime fix is in \`packages/web/src/lib/openclaw-config.ts\` — write \`apiKey\` as a plaintext string, same pragma already applied to \`pinchy-context.config.gatewayToken\` and Telegram bot tokens. Odoo API keys don't match any provider-key pattern in \`openclaw-plaintext-scanner.ts\` so the defense-in-depth check still passes.

**Layer 1 — Pinchy unit test (\`openclaw-config.test.ts\`).**
Asserts that \`apiKey\` lands in openclaw.json as a string. Regressing to the SecretRef shape fails this test before code is shipped.

**Layer 2 — Plugin runtime validation (\`pinchy-odoo/index.ts\`).**
\`createClient\` asserts \`connection.apiKey\` is a string and \`connection.uid\` is a number before instantiating \`OdooClient\`. If a future code path bypasses the type system (JSON without coercion, an unresolved SecretRef leaking through, etc.), users get a clear plugin-side error — \`apiKey must be a string, got object\` with a hint about #209 — instead of a confusing \`unhashable type: 'dict'\` from deep inside Odoo's Python.

**Layer 3 — Plugin unit tests for the validation (\`pinchy-odoo/__tests__/tools.test.ts\`).**
New \`connection shape validation (#209 guardrail)\` describe block: rejects SecretRef-shaped apiKey, rejects non-numeric uid, accepts well-formed config.

**Layer 4 — Plugin integration test against real mock-odoo (\`pinchy-odoo/__tests__/integration.test.ts\`).**
This file does NOT mock \`odoo-node\`. It boots an in-process instance of \`config/odoo-mock/server.js\` on an OS-picked port and exercises \`odoo_schema\`, \`odoo_count\`, \`odoo_read\`, plus a regression test that pushes the SecretRef-shaped dict through the full chain. The bug-shape test asserts the plugin fails fast and never produces the Python-server crash. Catches \`odoo-node\` serialisation issues that would slip past mocked unit tests.

\`config/odoo-mock/server.js\` exposes a \`start({ jsonRpcPort, controlPort })\` function so vitest can spin up isolated instances on ephemeral ports. CLI behaviour preserved via \`require.main\` check — the docker-compose service still auto-starts on 8069/9002.

## Tests

3344 tests pass locally (7 new). \`tsc --noEmit\` clean.

## Test plan

- [x] All tests pass locally + tsc clean
- [ ] CI green
- [ ] After merge + redeploy staging: Piper / Sales Analyst tool calls succeed (no more \`unhashable type: 'dict'\`)

## Related

- #208 — separate stale model ID fix (Piper got HTTP 404 *before* hitting this bug)
- #209 — root cause issue this PR closes