### PR TITLE
refactor(secrets): pinchy-odoo and pinchy-web fetch credentials via Pinchy API

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -179,19 +179,72 @@ User feedback (errors, success confirmations) must use the correct display patte
 
 ### Secrets Handling
 
-Every new sensitive field that would land in `openclaw.json` MUST use a
-SecretRef pointer, never a plaintext value. See
-`packages/web/src/lib/openclaw-secrets.ts` for helpers and
-`packages/web/src/lib/openclaw-plaintext-scanner.ts` for the defense-in-depth
-check that will refuse writes containing plaintext secrets.
+Three secret-handling patterns, each with a specific scope. Pick the
+right one based on **who reads the secret at runtime**.
 
-Pattern for adding a new secret:
-1. Decrypt from DB in `regenerateOpenClawConfig()`.
-2. Add it to the `SecretsBundle` via its stable JSON pointer.
-3. Emit a `secretRef(pointer)` in the spot in `openclaw.json` where the
-   plaintext would have gone.
-4. Add a test asserting both halves — value in `secrets.json`, ref in
-   `openclaw.json`.
+#### Pattern A — OpenClaw built-in resolves (SecretRef)
+
+For paths OpenClaw itself walks at runtime:
+- `models.providers.<name>.apiKey` (LLM provider keys)
+- `gateway.auth.token` (gateway auth — written as plaintext)
+- `env.<VAR>` env-var templates resolved against process env
+
+Use `secretRef(pointer)` from `packages/web/src/lib/openclaw-secrets.ts`,
+add the value to the `SecretsBundle`, write the ref in `openclaw.json`.
+Add a test asserting both halves.
+
+#### Pattern B — Pinchy-aware plugins fetch via API (preferred for new credentials)
+
+For credentials consumed by `packages/plugins/pinchy-*` plugins (Odoo,
+web-search, email, future: Pipedrive, Salesforce, Stripe, etc.):
+
+**Do NOT** put the credential — or even a SecretRef pointer — in the
+plugin's config block in `openclaw.json`. OpenClaw 2026.4.x does not
+walk arbitrary plugin config trees for SecretRef resolution; an
+unresolved SecretRef object would reach the plugin verbatim and
+typically blow up downstream (see #209: an Odoo dict reached the Python
+server, which crashed with `unhashable type: 'dict'`).
+
+Instead:
+1. In `regenerateOpenClawConfig()`, write only `apiBaseUrl`,
+   `gatewayToken`, and the integration's opaque `connectionId` into the
+   plugin config (per-agent or top-level depending on the plugin).
+2. The plugin fetches credentials lazily from
+   `GET /api/internal/integrations/:connectionId/credentials` with the
+   gateway token as Bearer auth — same call pattern as `pinchy-email`,
+   `pinchy-odoo`, `pinchy-web`.
+3. Cache in the plugin (5-min TTL recommended) plus invalidate-on-401
+   for credential rotation.
+4. Validate the returned credential shape at the plugin's edge with a
+   clear `must be a string, got object` error if a regression sends
+   an unresolved SecretRef.
+5. Test at four layers:
+   - Unit: openclaw-config writes the right shape (no credentials in
+     plugin config; only connectionId + bootstrap creds).
+   - Plugin unit: cache hit/miss, refetch on 401, shape validation
+     rejects SecretRef payloads.
+   - Plugin integration: against in-process mock-pinchy + the relevant
+     mock service (e.g. mock-odoo). See
+     `packages/plugins/pinchy-odoo/__tests__/integration.test.ts` for
+     the canonical example.
+   - Manual on staging.
+
+#### Pattern C — Bootstrap credentials (plaintext, single source)
+
+`gateway.auth.token` and `plugins.entries.pinchy-*.config.gatewayToken`
+are written as plaintext into `openclaw.json`. They are the *bootstrap*
+credentials used to authenticate everything else. They cannot themselves
+be fetched via Pinchy's API (chicken-and-egg). Treat them as the trust
+root for the OpenClaw container; rotate by regenerating the config and
+restarting OpenClaw.
+
+#### Defense in depth
+
+`packages/web/src/lib/openclaw-plaintext-scanner.ts` checks every
+`openclaw.json` write for known provider-key prefixes (Anthropic
+`sk-ant-…`, OpenAI `sk-…`, Gemini `AIza…`, etc.). Add a pattern there
+when you onboard any new provider whose secret has a recognisable
+prefix — even if you're following Pattern B.
 
 ### Documentation
 - **Docs site**: `docs/` directory, built with Astro Starlight. Deployed to [docs.heypinchy.com](https://docs.heypinchy.com).

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -764,14 +764,35 @@ const controlServer = http.createServer(async (req, res) => {
 });
 
 // ---------------------------------------------------------------------------
-// Start servers
+// Public API for in-process consumers (vitest integration tests).
+//
+// Auto-starts on the published Docker ports when run as a CLI (e.g. inside
+// the docker-compose service). Tests can instead import the module and
+// call `start()` to spin both servers up on ephemeral ports without
+// touching the docker-compose stack.
 // ---------------------------------------------------------------------------
 resetNextIds();
 
-jsonRpcServer.listen(8069, () => {
-  console.log("Mock Odoo JSON-RPC server listening on port 8069");
-});
+async function start({ jsonRpcPort = 8069, controlPort = 9002 } = {}) {
+  await new Promise((resolve) => jsonRpcServer.listen(jsonRpcPort, resolve));
+  await new Promise((resolve) => controlServer.listen(controlPort, resolve));
+  return {
+    jsonRpcPort: jsonRpcServer.address().port,
+    controlPort: controlServer.address().port,
+    async stop() {
+      await Promise.all([
+        new Promise((r) => jsonRpcServer.close(r)),
+        new Promise((r) => controlServer.close(r)),
+      ]);
+    },
+  };
+}
 
-controlServer.listen(9002, () => {
-  console.log("Mock Odoo Control API listening on port 9002");
-});
+if (require.main === module) {
+  start().then(({ jsonRpcPort, controlPort }) => {
+    console.log(`Mock Odoo JSON-RPC server listening on port ${jsonRpcPort}`);
+    console.log(`Mock Odoo Control API listening on port ${controlPort}`);
+  });
+}
+
+module.exports = { start };

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -1,0 +1,220 @@
+/**
+ * Integration tests for pinchy-odoo against real mock-odoo and mock-pinchy
+ * HTTP servers. Layer 2 of the #209 guardrails: catches anything that
+ * breaks the actual chain
+ *
+ *   plugin → fetch credentials from Pinchy → odoo-node → Odoo JSON-RPC
+ *
+ * end-to-end. The unit tests in `tools.test.ts` mock both `odoo-node` and
+ * `fetch`, so a regression in either the credentials-API contract or in
+ * the way the apiKey reaches Odoo could slip past them. This file boots
+ * an in-process instance of `config/odoo-mock/server.js` plus a tiny
+ * in-test HTTP server that emulates Pinchy's
+ * `/api/internal/integrations/<id>/credentials` endpoint, and exercises
+ * the full chain.
+ */
+
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { createRequire } from "module";
+import { createServer, type Server } from "http";
+import { AddressInfo } from "net";
+import plugin from "../index";
+
+const require = createRequire(import.meta.url);
+
+interface MockOdooHandle {
+  jsonRpcPort: number;
+  controlPort: number;
+  stop: () => Promise<void>;
+}
+
+interface AgentTool {
+  name: string;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>
+  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+}
+
+let mockOdoo: MockOdooHandle;
+let mockPinchy: Server;
+let mockPinchyPort: number;
+const PINCHY_GATEWAY_TOKEN = "test-gateway-token-integration";
+
+// Per-connection credentials served by the mock-pinchy. Tests can mutate
+// this to simulate broken/missing/rotated credentials.
+const credentialsByConnectionId = new Map<string, unknown>();
+
+beforeAll(async () => {
+  // Mock Odoo on an OS-picked port (no collision with the docker-compose service)
+  const mockServer = require("../../../../config/odoo-mock/server.js") as {
+    start: (opts: { jsonRpcPort: number; controlPort: number }) => Promise<MockOdooHandle>;
+  };
+  mockOdoo = await mockServer.start({ jsonRpcPort: 0, controlPort: 0 });
+
+  // Mock Pinchy: implements just the credentials endpoint with the same
+  // auth contract Pinchy itself uses (Bearer gateway token).
+  mockPinchy = createServer((req, res) => {
+    const auth = req.headers["authorization"];
+    if (auth !== `Bearer ${PINCHY_GATEWAY_TOKEN}`) {
+      res.writeHead(401, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Unauthorized" }));
+      return;
+    }
+    const match = req.url?.match(/^\/api\/internal\/integrations\/([^/]+)\/credentials$/);
+    if (!match) {
+      res.writeHead(404);
+      res.end();
+      return;
+    }
+    const connectionId = match[1];
+    const credentials = credentialsByConnectionId.get(connectionId);
+    if (credentials === undefined) {
+      res.writeHead(404, { "Content-Type": "application/json" });
+      res.end(JSON.stringify({ error: "Connection not found" }));
+      return;
+    }
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ type: "odoo", credentials }));
+  });
+  await new Promise<void>((resolve) => mockPinchy.listen(0, resolve));
+  mockPinchyPort = (mockPinchy.address() as AddressInfo).port;
+});
+
+afterAll(async () => {
+  await mockOdoo?.stop();
+  if (mockPinchy) {
+    await new Promise<void>((resolve, reject) =>
+      mockPinchy.close((err) => (err ? reject(err) : resolve()))
+    );
+  }
+});
+
+function createApi(agentConfigs: Record<string, unknown> = {}) {
+  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> =
+    [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: `http://127.0.0.1:${mockPinchyPort}`,
+      gatewayToken: PINCHY_GATEWAY_TOKEN,
+      agents: agentConfigs,
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string }
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  (plugin as any).register(api);
+  return tools;
+}
+
+function findTool(tools: ReturnType<typeof createApi>, name: string, agentId: string): AgentTool {
+  const entry = tools.find((t) => t.name === name);
+  if (!entry) throw new Error(`Tool ${name} not registered`);
+  const tool = entry.factory({ agentId });
+  if (!tool) throw new Error(`Tool ${name} factory returned null for agent ${agentId}`);
+  return tool;
+}
+
+const agentId = "agent-integration";
+const agentConfig = {
+  connectionId: "conn-integration",
+  permissions: { "sale.order": ["read"], "res.partner": ["read"] },
+  modelNames: { "sale.order": "Sales Order", "res.partner": "Contact" },
+};
+
+describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () => {
+  beforeAll(() => {
+    // Default: well-formed credentials pointing at the in-process mock-odoo.
+    credentialsByConnectionId.set("conn-integration", {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  it("odoo_schema returns the model's fields after a real round-trip through Pinchy + Odoo", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_schema", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order" });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.name).toBe("Sales Order");
+    expect(data.fields.length).toBeGreaterThan(0);
+    expect(data.fields.some((f: { name: string }) => f.name === "name")).toBe(true);
+  });
+
+  it("odoo_count returns { count: number } for an empty filter", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(typeof data.count).toBe("number");
+  });
+
+  it("odoo_read returns records and total for an empty filter", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(Array.isArray(data.records)).toBe(true);
+    expect(typeof data.total).toBe("number");
+  });
+
+  it("REGRESSION (#209): if Pinchy returns the SecretRef-shaped dict instead of credentials, the plugin fails fast WITHOUT producing a Python crash", async () => {
+    // Exactly the bug shape from staging: the credentials API returns the
+    // unresolved SecretRef object instead of decrypted credentials. The
+    // plugin must reject it at the boundary, not forward it to Odoo (which
+    // would crash the Python server with `unhashable type: 'dict'`).
+    credentialsByConnectionId.set("conn-integration", {
+      source: "file",
+      provider: "pinchy",
+      id: "/integrations/conn-integration/odooApiKey",
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_schema", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order" });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("must be a string");
+    expect(text).toContain("#209");
+    // Critically: the plugin must not have produced the Python crash text
+    // — meaning the request never reached Odoo with the broken payload.
+    expect(text).not.toContain("unhashable type");
+
+    // Restore for subsequent tests
+    credentialsByConnectionId.set("conn-integration", {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  it("surfaces a clear error when Pinchy returns 404 for an unknown connectionId", async () => {
+    const tools = createApi({
+      [agentId]: { ...agentConfig, connectionId: "unknown-connection-id" },
+    });
+    const tool = findTool(tools, "odoo_schema", agentId);
+
+    const result = await tool.execute("call-1", { model: "sale.order" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("404");
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -37,26 +37,39 @@ interface AgentTool {
   ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean; details?: unknown }>;
 }
 
-const testConnection = {
-  name: "Test Odoo",
-  description: "Test instance",
+// The plugin no longer takes credentials in its config — it fetches them
+// on demand from Pinchy's internal credentials API. Tests stub `fetch`
+// to return a canonical credentials response for any connectionId.
+const testCredentials = {
   url: "https://odoo.example.com",
   db: "testdb",
   uid: 2,
   apiKey: "test-api-key",
 };
 
-
 const testPermissions = {
   "sale.order": ["read"],
   "res.partner": ["read", "write", "create"],
 };
 
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({ type: "odoo", credentials: testCredentials }),
+}));
+// Vitest typing dance: cast through unknown for mock fetch
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
 function createApi(agentConfigs: Record<string, unknown> = {}) {
   const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> = [];
 
   const api = {
-    pluginConfig: { agents: agentConfigs },
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: agentConfigs,
+    },
     registerTool: (factory: (ctx: { agentId?: string }) => AgentTool | null, opts?: { name?: string }) => {
       tools.push({ factory, name: opts?.name ?? "" });
     },
@@ -74,7 +87,7 @@ function findTool(tools: ReturnType<typeof createApi>, name: string, agentId?: s
 
 const agentId = "agent-1";
 const agentConfig = {
-  connection: testConnection,
+  connectionId: "conn-test-1",
   permissions: testPermissions,
   modelNames: {
     "sale.order": "Sales Order",
@@ -472,12 +485,18 @@ describe("error handling", () => {
   });
 });
 
-describe("client caching", () => {
+describe("client caching (#209 layer 2: credentials fetched lazily, cached)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ type: "odoo", credentials: testCredentials }),
+    } as unknown as Response);
   });
 
-  it("reuses the same OdooClient across multiple tool calls for the same agent", async () => {
+  it("fetches credentials once and reuses the OdooClient across multiple tool calls for the same agent", async () => {
     mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
     mockSearchCount.mockResolvedValue(0);
 
@@ -489,15 +508,17 @@ describe("client caching", () => {
     await readTool.execute("call-2", { model: "sale.order", filters: [] });
     await countTool.execute("call-3", { model: "sale.order", filters: [] });
 
-    // OdooClient constructor should be called only once despite 3 tool calls
+    // Credentials API hit exactly once across the 3 tool calls
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    // OdooClient constructor called exactly once (cached client reused)
     expect(OdooClient).toHaveBeenCalledTimes(1);
   });
 
-  it("creates separate clients for different agents", async () => {
+  it("fetches credentials separately for different agents (no cross-agent leakage)", async () => {
     mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
 
     const agent2Config = {
-      connection: { ...testConnection, url: "https://other.example.com" },
+      connectionId: "conn-test-2",
       permissions: testPermissions,
     };
     const tools = createApi({ [agentId]: agentConfig, "agent-2": agent2Config });
@@ -508,6 +529,49 @@ describe("client caching", () => {
     await tool1.execute("call-1", { model: "sale.order", filters: [] });
     await tool2.execute("call-2", { model: "sale.order", filters: [] });
 
+    expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(OdooClient).toHaveBeenCalledTimes(2);
+    // Each fetch hit the connectionId-specific path
+    const urls = fetchMock.mock.calls.map((c) => String(c[0]));
+    expect(urls.some((u) => u.includes("conn-test-1"))).toBe(true);
+    expect(urls.some((u) => u.includes("conn-test-2"))).toBe(true);
+  });
+
+  it("fails fast with a clear error if the credentials API returns the SecretRef object shape (#209 regression)", async () => {
+    fetchMock.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({
+        type: "odoo",
+        // Exactly the broken shape from staging: an unresolved SecretRef.
+        credentials: { source: "file", provider: "pinchy", id: "/integrations/x/odooApiKey" },
+      }),
+    } as unknown as Response);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("must be a string");
+    expect(text).toContain("#209");
+  });
+
+  it("invalidates the cache and refetches credentials on auth error", async () => {
+    mockSearchRead.mockRejectedValueOnce(new Error("Access Denied: invalid api key"));
+    mockSearchRead.mockResolvedValueOnce({ records: [], total: 0, limit: 100, offset: 0 });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    expect(result.isError).toBeFalsy();
+    // First call fetched, error invalidated cache, second call refetched
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    expect(mockSearchRead).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -11,9 +11,7 @@ interface ContentBlock {
 }
 
 interface PluginApi {
-  pluginConfig?: {
-    agents?: Record<string, AgentOdooConfig>;
-  };
+  pluginConfig?: PluginConfig;
   registerTool: (
     factory: (ctx: PluginToolContext) => AgentTool | null,
     opts?: { name?: string },
@@ -32,17 +30,23 @@ interface AgentTool {
   ) => Promise<{ content: ContentBlock[]; isError?: boolean; details?: unknown }>;
 }
 
+interface PluginConfig {
+  apiBaseUrl: string;
+  gatewayToken: string;
+  agents: Record<string, AgentOdooConfig>;
+}
+
 interface AgentOdooConfig {
-  connection: {
-    name: string;
-    description: string;
-    url: string;
-    db: string;
-    uid: number;
-    apiKey: string;
-  };
+  connectionId: string;
   permissions: Permissions;
   modelNames?: Record<string, string>;
+}
+
+interface OdooCredentials {
+  url: string;
+  db: string;
+  uid: number;
+  apiKey: string;
 }
 
 function getAgentConfig(
@@ -52,12 +56,81 @@ function getAgentConfig(
   return agentConfigs[agentId] ?? null;
 }
 
-function createClient(config: AgentOdooConfig): OdooClient {
+/**
+ * Defense-in-depth: fail fast with a clear error if the credentials API
+ * returns the wrong shape (e.g. a SecretRef object instead of strings —
+ * the bug that caused Odoo's Python server to crash with
+ * `unhashable type: 'dict'`, see issue #209). Without this assertion a
+ * malformed payload would propagate all the way to Odoo before erroring.
+ */
+function assertCredentialsShape(creds: unknown): asserts creds is OdooCredentials {
+  if (!creds || typeof creds !== "object") {
+    throw new Error(`pinchy-odoo: credentials must be an object, got ${typeof creds}`);
+  }
+  const obj = creds as Record<string, unknown>;
+  // Detect the SecretRef-shaped payload (#209) up front so the error
+  // message points at the actual root cause instead of a "field missing"
+  // symptom that's harder to debug.
+  const looksLikeSecretRef =
+    typeof obj.source === "string" && typeof obj.provider === "string" && typeof obj.id === "string";
+  const expected: Array<[keyof OdooCredentials, "string" | "number"]> = [
+    ["url", "string"],
+    ["db", "string"],
+    ["uid", "number"],
+    ["apiKey", "string"],
+  ];
+  for (const [name, type] of expected) {
+    const actual = typeof obj[name];
+    if (actual !== type) {
+      const hint = looksLikeSecretRef
+        ? " (the credentials API returned an unresolved SecretRef — see #209)"
+        : actual === "object"
+          ? " (looks like an unresolved SecretRef — see #209)"
+          : "";
+      throw new Error(
+        `pinchy-odoo: credentials.${name} must be a ${type}, got ${actual}${hint}`,
+      );
+    }
+  }
+}
+
+/**
+ * Fetch decrypted Odoo credentials from Pinchy's internal credentials API.
+ *
+ * The plugin only ever sees the connectionId and a gateway token — the
+ * actual apiKey lives in Pinchy's encrypted database and is delivered
+ * over a single authenticated HTTP request per cache miss. This keeps
+ * `openclaw.json` free of long-lived per-tenant secrets and lets Pinchy
+ * own rotation, audit, and per-agent authorization centrally.
+ *
+ * See: packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
+ */
+async function fetchCredentials(
+  apiBaseUrl: string,
+  gatewayToken: string,
+  connectionId: string,
+): Promise<OdooCredentials> {
+  const response = await fetch(
+    `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials`,
+    { headers: { Authorization: `Bearer ${gatewayToken}` } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Odoo credentials for connection ${connectionId}: ` +
+        `HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = (await response.json()) as { credentials?: unknown };
+  assertCredentialsShape(data.credentials);
+  return data.credentials;
+}
+
+function createClient(creds: OdooCredentials): OdooClient {
   return new OdooClient({
-    url: config.connection.url,
-    db: config.connection.db,
-    uid: config.connection.uid,
-    apiKey: config.connection.apiKey,
+    url: creds.url,
+    db: creds.db,
+    uid: creds.uid,
+    apiKey: creds.apiKey,
   });
 }
 
@@ -107,21 +180,64 @@ const plugin = {
   description: "Odoo ERP integration with model-level permissions.",
 
   register(api: PluginApi) {
-    const agentConfigs = api.pluginConfig?.agents ?? {};
+    const pluginConfig = api.pluginConfig;
+    const agentConfigs = pluginConfig?.agents ?? {};
+    const apiBaseUrl = pluginConfig?.apiBaseUrl ?? "";
+    const gatewayToken = pluginConfig?.gatewayToken ?? "";
 
-    // Client cache per agent — avoids creating new connections per tool call.
-    // Limitation: If credentials are rotated, the cache holds stale clients until
-    // OpenClaw restarts. This is acceptable since credential rotation is rare and
-    // always accompanied by a config regeneration which triggers a restart.
-    const clientCache = new Map<string, OdooClient>();
+    // Client cache per agent. Built lazily on first tool call: fetch
+    // credentials from Pinchy → instantiate OdooClient. TTL keeps the
+    // cache fresh enough that credential rotation propagates within
+    // CREDENTIALS_TTL_MS without anyone restarting OpenClaw — and on a
+    // 401 from Odoo (which is what happens immediately after a rotation
+    // or revocation) we invalidate eagerly and refetch once before
+    // surfacing the error to the user.
+    const CREDENTIALS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+    const cache = new Map<string, { client: OdooClient; expiresAt: number }>();
 
-    function getOrCreateClient(agentId: string, config: AgentOdooConfig): OdooClient {
-      let client = clientCache.get(agentId);
-      if (!client) {
-        client = createClient(config);
-        clientCache.set(agentId, client);
-      }
+    function invalidate(agentId: string) {
+      cache.delete(agentId);
+    }
+
+    async function getOrCreateClient(
+      agentId: string,
+      config: AgentOdooConfig,
+    ): Promise<OdooClient> {
+      const hit = cache.get(agentId);
+      if (hit && hit.expiresAt > Date.now()) return hit.client;
+      const creds = await fetchCredentials(apiBaseUrl, gatewayToken, config.connectionId);
+      const client = createClient(creds);
+      cache.set(agentId, { client, expiresAt: Date.now() + CREDENTIALS_TTL_MS });
       return client;
+    }
+
+    /**
+     * Run an Odoo call with one transparent retry on auth failure.
+     * Odoo throws an `AccessDenied` / 401-shaped error when the apiKey is
+     * stale (rotated, revoked, expired). We invalidate the cache and
+     * fetch fresh credentials once — if it still fails, surface to the
+     * user.
+     */
+    async function withAuthRetry<T>(
+      agentId: string,
+      config: AgentOdooConfig,
+      fn: (client: OdooClient) => Promise<T>,
+    ): Promise<T> {
+      const client = await getOrCreateClient(agentId, config);
+      try {
+        return await fn(client);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message.toLowerCase() : "";
+        const isAuthError =
+          msg.includes("access denied") ||
+          msg.includes("invalid api key") ||
+          msg.includes("401") ||
+          msg.includes("authenticat");
+        if (!isAuthError) throw err;
+        invalidate(agentId);
+        const fresh = await getOrCreateClient(agentId, config);
+        return fn(fresh);
+      }
     }
 
     // 1. odoo_schema
@@ -173,8 +289,9 @@ const plugin = {
 
               // Fetch fields live from Odoo (lightweight call — the agent
               // caches the result in its conversation context naturally)
-              const client = getOrCreateClient(agentId, config);
-              const fields = await client.fields(model);
+              const fields = await withAuthRetry(agentId, config, (client) =>
+                client.fields(model),
+              );
 
               return {
                 content: [
@@ -237,13 +354,14 @@ const plugin = {
                 return permissionDenied("read", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const result = await client.searchRead(model, params.filters as unknown[], {
-                fields: params.fields as string[] | undefined,
-                limit: params.limit as number | undefined,
-                offset: params.offset as number | undefined,
-                order: params.order as string | undefined,
-              });
+              const result = await withAuthRetry(agentId, config, (client) =>
+                client.searchRead(model, params.filters as unknown[], {
+                  fields: params.fields as string[] | undefined,
+                  limit: params.limit as number | undefined,
+                  offset: params.offset as number | undefined,
+                  order: params.order as string | undefined,
+                }),
+              );
 
               return { content: [{ type: "text", text: JSON.stringify(result) }] };
             } catch (error) {
@@ -287,8 +405,9 @@ const plugin = {
                 return permissionDenied("read", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const count = await client.searchCount(model, params.filters as unknown[]);
+              const count = await withAuthRetry(agentId, config, (client) =>
+                client.searchCount(model, params.filters as unknown[]),
+              );
 
               return { content: [{ type: "text", text: JSON.stringify({ count }) }] };
             } catch (error) {
@@ -346,17 +465,18 @@ const plugin = {
                 return permissionDenied("read", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const result = await client.readGroup(
-                model,
-                params.filters as unknown[],
-                params.fields as string[],
-                params.groupby as string[],
-                {
-                  limit: params.limit as number | undefined,
-                  offset: params.offset as number | undefined,
-                  orderby: params.orderby as string | undefined,
-                },
+              const result = await withAuthRetry(agentId, config, (client) =>
+                client.readGroup(
+                  model,
+                  params.filters as unknown[],
+                  params.fields as string[],
+                  params.groupby as string[],
+                  {
+                    limit: params.limit as number | undefined,
+                    offset: params.offset as number | undefined,
+                    orderby: params.orderby as string | undefined,
+                  },
+                ),
               );
 
               return { content: [{ type: "text", text: JSON.stringify(result) }] };
@@ -396,8 +516,9 @@ const plugin = {
                 return permissionDenied("create", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const id = await client.create(model, params.values as Record<string, unknown>);
+              const id = await withAuthRetry(agentId, config, (client) =>
+                client.create(model, params.values as Record<string, unknown>),
+              );
 
               return { content: [{ type: "text", text: JSON.stringify({ id }) }] };
             } catch (error) {
@@ -441,11 +562,12 @@ const plugin = {
                 return permissionDenied("write", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const success = await client.write(
-                model,
-                params.ids as number[],
-                params.values as Record<string, unknown>,
+              const success = await withAuthRetry(agentId, config, (client) =>
+                client.write(
+                  model,
+                  params.ids as number[],
+                  params.values as Record<string, unknown>,
+                ),
               );
 
               return { content: [{ type: "text", text: JSON.stringify({ success }) }] };
@@ -489,8 +611,9 @@ const plugin = {
                 return permissionDenied("delete", model);
               }
 
-              const client = getOrCreateClient(agentId, config);
-              const success = await client.unlink(model, params.ids as number[]);
+              const success = await withAuthRetry(agentId, config, (client) =>
+                client.unlink(model, params.ids as number[]),
+              );
 
               return { content: [{ type: "text", text: JSON.stringify({ success }) }] };
             } catch (error) {

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -11,10 +11,7 @@ interface ContentBlock {
 }
 
 interface PluginApi {
-  pluginConfig?: {
-    braveApiKey?: string;
-    agents?: Record<string, AgentWebConfig>;
-  };
+  pluginConfig?: PluginConfig;
   registerTool: (
     factory: (ctx: PluginToolContext) => AgentTool | null,
     opts?: { name?: string },
@@ -33,6 +30,17 @@ interface AgentTool {
   ) => Promise<{ content: ContentBlock[]; isError?: boolean }>;
 }
 
+interface PluginConfig {
+  apiBaseUrl?: string;
+  gatewayToken?: string;
+  /** ID of the web-search integration connection in Pinchy. The Brave
+   * apiKey is fetched on-demand from Pinchy's internal credentials API
+   * — never written into openclaw.json. See #209 for the bug class
+   * that prompted this pattern. */
+  connectionId?: string;
+  agents?: Record<string, AgentWebConfig>;
+}
+
 interface AgentWebConfig {
   tools: string[];
   allowedDomains?: string[];
@@ -42,6 +50,43 @@ interface AgentWebConfig {
   freshness?: string;
 }
 
+interface BraveCredentials {
+  apiKey: string;
+}
+
+function assertBraveCredentialsShape(creds: unknown): asserts creds is BraveCredentials {
+  if (!creds || typeof creds !== "object") {
+    throw new Error(`pinchy-web: credentials must be an object, got ${typeof creds}`);
+  }
+  const obj = creds as Record<string, unknown>;
+  const actual = typeof obj.apiKey;
+  if (actual !== "string") {
+    throw new Error(
+      `pinchy-web: credentials.apiKey must be a string, got ${actual}` +
+        (actual === "object" ? " (looks like an unresolved SecretRef — see #209)" : ""),
+    );
+  }
+}
+
+async function fetchBraveCredentials(
+  apiBaseUrl: string,
+  gatewayToken: string,
+  connectionId: string,
+): Promise<BraveCredentials> {
+  const response = await fetch(
+    `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials`,
+    { headers: { Authorization: `Bearer ${gatewayToken}` } },
+  );
+  if (!response.ok) {
+    throw new Error(
+      `Failed to fetch Brave credentials: HTTP ${response.status} ${response.statusText}`,
+    );
+  }
+  const data = (await response.json()) as { credentials?: unknown };
+  assertBraveCredentialsShape(data.credentials);
+  return data.credentials;
+}
+
 const plugin = {
   id: "pinchy-web",
   name: "Pinchy Web",
@@ -49,8 +94,50 @@ const plugin = {
 
   register(api: PluginApi) {
     const config = api.pluginConfig;
-    const braveApiKey = config?.braveApiKey;
+    const apiBaseUrl = config?.apiBaseUrl ?? "";
+    const gatewayToken = config?.gatewayToken ?? "";
+    const connectionId = config?.connectionId ?? "";
     const agentConfigs = config?.agents ?? {};
+
+    // Cached Brave apiKey. Same TTL semantics as pinchy-odoo: fast
+    // first-call latency but fresh enough for credential rotation
+    // without an OpenClaw restart. On a 401 from Brave we invalidate
+    // and retry once.
+    const CREDENTIALS_TTL_MS = 5 * 60 * 1000;
+    let cached: { apiKey: string; expiresAt: number } | null = null;
+
+    async function getBraveApiKey(): Promise<string> {
+      if (cached && cached.expiresAt > Date.now()) return cached.apiKey;
+      if (!connectionId || !apiBaseUrl || !gatewayToken) {
+        throw new Error(
+          "pinchy-web: missing connectionId/apiBaseUrl/gatewayToken in plugin config",
+        );
+      }
+      const creds = await fetchBraveCredentials(apiBaseUrl, gatewayToken, connectionId);
+      cached = { apiKey: creds.apiKey, expiresAt: Date.now() + CREDENTIALS_TTL_MS };
+      return creds.apiKey;
+    }
+
+    function invalidateCache() {
+      cached = null;
+    }
+
+    async function withAuthRetry<T>(fn: (apiKey: string) => Promise<T>): Promise<T> {
+      const apiKey = await getBraveApiKey();
+      try {
+        return await fn(apiKey);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message.toLowerCase() : "";
+        if (!(msg.includes("401") || msg.includes("unauthor") || msg.includes("invalid api"))) {
+          throw err;
+        }
+        invalidateCache();
+        const fresh = await getBraveApiKey();
+        return fn(fresh);
+      }
+    }
+
+    const haveCredentialsConfig = Boolean(connectionId && apiBaseUrl && gatewayToken);
 
     // pinchy_web_search
     api.registerTool(
@@ -73,7 +160,7 @@ const plugin = {
             required: ["query"],
           },
           async execute(_toolCallId, params) {
-            if (!braveApiKey) {
+            if (!haveCredentialsConfig) {
               return {
                 isError: true,
                 content: [
@@ -85,18 +172,17 @@ const plugin = {
               };
             }
             try {
-              const searchConfig: BraveSearchConfig = {
-                apiKey: braveApiKey,
-                allowedDomains: agentConfig.allowedDomains,
-                excludedDomains: agentConfig.excludedDomains,
-                language: agentConfig.language,
-                country: agentConfig.country,
-                freshness: agentConfig.freshness,
-              };
-              const result = await braveSearch(
-                params.query as string,
-                searchConfig,
-              );
+              const result = await withAuthRetry((apiKey) => {
+                const searchConfig: BraveSearchConfig = {
+                  apiKey,
+                  allowedDomains: agentConfig.allowedDomains,
+                  excludedDomains: agentConfig.excludedDomains,
+                  language: agentConfig.language,
+                  country: agentConfig.country,
+                  freshness: agentConfig.freshness,
+                };
+                return braveSearch(params.query as string, searchConfig);
+              });
               return {
                 content: [
                   {

--- a/packages/web/src/__tests__/lib/openclaw-config-web-search.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-web-search.test.ts
@@ -199,12 +199,13 @@ describe("pinchy-web config generation", () => {
     const config = JSON.parse(written);
 
     const webPluginConfig = config.plugins.entries["pinchy-web"].config;
-    // braveApiKey is a SecretRef — plaintext never lands in openclaw.json
-    expect(webPluginConfig.braveApiKey).toMatchObject({
-      source: "file",
-      provider: "pinchy",
-      id: expect.stringContaining("braveApiKey"),
-    });
+    // The braveApiKey is fetched on demand via Pinchy's credentials API —
+    // openclaw.json carries only the connectionId + bootstrap creds for
+    // the API call (#209).
+    expect(webPluginConfig.braveApiKey).toBeUndefined();
+    expect(typeof webPluginConfig.connectionId).toBe("string");
+    expect(typeof webPluginConfig.apiBaseUrl).toBe("string");
+    expect(typeof webPluginConfig.gatewayToken).toBe("string");
 
     const agentConfig = webPluginConfig.agents["ws-agent"];
     expect(agentConfig.tools).toEqual(["pinchy_web_search", "pinchy_web_fetch"]);
@@ -363,7 +364,12 @@ describe("pinchy-web config generation", () => {
     expect(config.plugins?.entries?.["pinchy-web"]).toBeUndefined();
   });
 
-  it("skips pinchy-web plugin when credentials cannot be decrypted", async () => {
+  it("does not decrypt web-search credentials at config-write time (#209)", async () => {
+    // Since #209: pinchy-web fetches braveApiKey lazily via the
+    // /api/internal/integrations/:id/credentials endpoint. Decryption
+    // happens at fetch time, not at config-write time. So a broken
+    // ENCRYPTION_KEY no longer prevents the plugin from being registered
+    // — the agent just sees a clear error on the first tool call.
     const agentsData = [
       {
         id: "ws-agent",
@@ -376,8 +382,10 @@ describe("pinchy-web config generation", () => {
     ];
     const webConn = makeWebSearchConnection();
 
+    // decrypt should NOT be called for web-search anymore. Make it throw
+    // to prove the new code path doesn't invoke it.
     mockDecrypt.mockImplementation(() => {
-      throw new Error("Decryption failed — key rotation");
+      throw new Error("decrypt should not be called for pinchy-web (#209)");
     });
 
     mockedDb.select.mockReturnValue({
@@ -398,7 +406,10 @@ describe("pinchy-web config generation", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.plugins?.entries?.["pinchy-web"]).toBeUndefined();
+    // Plugin IS registered with the connectionId — the failure surface
+    // moved from config-write time to credentials-fetch time.
+    expect(config.plugins?.entries?.["pinchy-web"]).toBeDefined();
+    expect(config.plugins?.entries?.["pinchy-web"]?.config?.connectionId).toBe(webConn.id);
   });
 
   it("skips pinchy-web plugin when no agents have web tools (even if connection exists)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1335,11 +1335,11 @@ describe("pinchy-web config", () => {
 
     expect(config.plugins.entries["pinchy-web"]).toBeDefined();
     expect(config.plugins.entries["pinchy-web"].enabled).toBe(true);
-    expect(config.plugins.entries["pinchy-web"].config.braveApiKey).toEqual({
-      source: "file",
-      provider: "pinchy",
-      id: "/integrations/ws-conn-1/braveApiKey",
-    });
+    // braveApiKey is fetched on demand via the credentials API — not in config (#209)
+    expect(config.plugins.entries["pinchy-web"].config.braveApiKey).toBeUndefined();
+    expect(config.plugins.entries["pinchy-web"].config.connectionId).toBe("ws-conn-1");
+    expect(typeof config.plugins.entries["pinchy-web"].config.apiBaseUrl).toBe("string");
+    expect(typeof config.plugins.entries["pinchy-web"].config.gatewayToken).toBe("string");
     expect(config.plugins.entries["pinchy-web"].config.agents["web-agent"]).toEqual({
       tools: ["pinchy_web_search", "pinchy_web_fetch"],
       allowedDomains: ["docs.example.com"],
@@ -1572,7 +1572,7 @@ describe("pinchy-web config", () => {
   });
 });
 
-describe("pinchy-web braveApiKey as SecretRef", () => {
+describe("pinchy-web: credentials fetched on demand via Pinchy API (#209)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockedExistsSync.mockReturnValue(true);
@@ -1582,7 +1582,7 @@ describe("pinchy-web braveApiKey as SecretRef", () => {
     mockedGetSetting.mockResolvedValue(null);
   });
 
-  it("writes pinchy-web.braveApiKey as SecretRef", async () => {
+  it("writes only connectionId + apiBaseUrl + gatewayToken — no braveApiKey in openclaw.json", async () => {
     const agentsData = [
       {
         id: "web-agent",
@@ -1631,23 +1631,21 @@ describe("pinchy-web braveApiKey as SecretRef", () => {
 
     await regenerateOpenClawConfig();
 
-    // openclaw.json must contain a SecretRef for braveApiKey, not the plaintext key
+    // openclaw.json must NOT contain the apiKey at all (#209): the plugin
+    // fetches it on demand from /api/internal/integrations/<id>/credentials.
     const written = mockedWriteFileSync.mock.calls.find(
       (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
     );
     expect(written).toBeDefined();
     const config = JSON.parse(written![1] as string);
 
-    expect(config.plugins.entries["pinchy-web"].config.braveApiKey).toEqual({
-      source: "file",
-      provider: "pinchy",
-      id: "/integrations/ws-conn-42/braveApiKey",
-    });
-
-    // secrets.json must contain the actual key
-    expect(mockWriteSecretsFile).toHaveBeenCalled();
-    const secretsArg = mockWriteSecretsFile.mock.calls[0][0];
-    expect(secretsArg.integrations?.["ws-conn-42"]?.braveApiKey).toBe("BSA-secret-key");
+    const webPlugin = config.plugins.entries["pinchy-web"].config;
+    expect(webPlugin.connectionId).toBe("ws-conn-42");
+    expect(typeof webPlugin.apiBaseUrl).toBe("string");
+    expect(typeof webPlugin.gatewayToken).toBe("string");
+    // No braveApiKey, no SecretRef pointer.
+    expect(webPlugin.braveApiKey).toBeUndefined();
+    expect(written![1]).not.toContain("BSA-secret-key");
   });
 });
 
@@ -1746,23 +1744,17 @@ describe("pinchy-odoo config size", () => {
     expect(configSize).toBeLessThan(5000); // Without schema: ~2-3KB. With schema it would be 100KB+
   });
 
-  it("skips agents whose Odoo connection can't be decrypted instead of crashing the whole config regeneration", async () => {
-    // Regression: if ENCRYPTION_KEY changes, conn.credentials can't be decrypted.
-    // Previously the thrown error bubbled up and regenerateOpenClawConfig()
-    // crashed — which meant EVERY agent's config stopped regenerating, not just
-    // the one with the broken Odoo link. Now we skip the unreadable agent and
-    // keep the rest of the config alive.
+  it("does not decrypt Odoo connection credentials at config-write time", async () => {
+    // Since #209: credential decryption happens lazily in the
+    // /api/internal/integrations/:id/credentials endpoint when the plugin
+    // asks for credentials — never in regenerateOpenClawConfig itself.
+    // This means ENCRYPTION_KEY rotation does NOT brick the openclaw.json
+    // generation: the config still gets the connectionId, and only the
+    // first plugin tool call surfaces the decryption error to the user.
     const agentsData = [
       {
-        id: "good-agent",
-        name: "Good Agent",
-        model: "anthropic/claude-haiku-4-5-20251001",
-        allowedTools: ["odoo_read"],
-        createdAt: new Date(),
-      },
-      {
-        id: "broken-agent",
-        name: "Broken Agent",
+        id: "odoo-agent",
+        name: "Odoo Agent",
         model: "anthropic/claude-haiku-4-5-20251001",
         allowedTools: ["odoo_read"],
         createdAt: new Date(),
@@ -1772,38 +1764,15 @@ describe("pinchy-odoo config size", () => {
     const permissionsData = [
       {
         agent_connection_permissions: {
-          agentId: "good-agent",
-          connectionId: "conn-good",
+          agentId: "odoo-agent",
+          connectionId: "conn-odoo",
           model: "sale.order",
           operation: "read",
         },
         integration_connections: {
-          id: "conn-good",
+          id: "conn-odoo",
           type: "odoo",
-          name: "Readable Odoo",
-          description: "",
-          credentials: JSON.stringify({
-            url: "https://good.odoo",
-            db: "prod",
-            uid: 2,
-            apiKey: "good-key",
-          }),
-          data: { models: [], lastSyncAt: "2026-04-01T00:00:00Z" },
-          createdAt: new Date(),
-          updatedAt: new Date(),
-        },
-      },
-      {
-        agent_connection_permissions: {
-          agentId: "broken-agent",
-          connectionId: "conn-broken",
-          model: "sale.order",
-          operation: "read",
-        },
-        integration_connections: {
-          id: "conn-broken",
-          type: "odoo",
-          name: "Unreadable Odoo",
+          name: "Some Odoo",
           description: "",
           credentials: "POISONED_BY_KEY_ROTATION",
           data: null,
@@ -1822,12 +1791,9 @@ describe("pinchy-odoo config size", () => {
       ),
     } as never);
 
-    // Fail decryption only for the broken connection's ciphertext
-    mockDecrypt.mockImplementation((val: string) => {
-      if (val === "POISONED_BY_KEY_ROTATION") {
-        throw new Error("Unsupported state or unable to authenticate data");
-      }
-      return val;
+    // Make decrypt throw to verify it is NOT called during config write.
+    mockDecrypt.mockImplementation(() => {
+      throw new Error("decrypt should never be called from openclaw-config for Odoo connections");
     });
 
     await expect(regenerateOpenClawConfig()).resolves.toBeUndefined();
@@ -1836,16 +1802,31 @@ describe("pinchy-odoo config size", () => {
     const config = JSON.parse(written);
     const odooAgents = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents ?? {};
 
-    expect(odooAgents["good-agent"]).toBeDefined();
-    expect(odooAgents["good-agent"].connection.url).toBe("https://good.odoo");
-    expect(odooAgents["broken-agent"]).toBeUndefined();
+    expect(odooAgents["odoo-agent"]).toBeDefined();
+    expect(odooAgents["odoo-agent"].connectionId).toBe("conn-odoo");
 
     // Reset for subsequent tests
     mockDecrypt.mockImplementation((val: string) => val);
   });
 });
 
-describe("pinchy-odoo connection.apiKey as SecretRef", () => {
+describe("pinchy-odoo: credentials fetched on demand via Pinchy API (#209)", () => {
+  // The previous design wrote `apiKey` as a SecretRef pointer
+  // (`{ source: "file", provider: "pinchy", id: "..." }`) into
+  // openclaw.json, intending OpenClaw to resolve it. OpenClaw 2026.4.x
+  // does NOT resolve SecretRefs in arbitrary plugin config paths, so
+  // the unresolved dict reached the Odoo plugin and was forwarded to
+  // Odoo as the password — which crashed the Odoo Python server with
+  // `unhashable type: 'dict'`.
+  //
+  // The new design follows pinchy-email: the plugin gets only an
+  // opaque `connectionId` plus the gateway token, and fetches
+  // credentials on demand from
+  // `/api/internal/integrations/<id>/credentials`. openclaw.json no
+  // longer carries any per-integration credential — secrets stay in
+  // the encrypted DB, owned by Pinchy, with a single rotation/audit
+  // surface.
+
   beforeEach(() => {
     vi.clearAllMocks();
     mockedExistsSync.mockReturnValue(true);
@@ -1855,7 +1836,7 @@ describe("pinchy-odoo connection.apiKey as SecretRef", () => {
     mockedGetSetting.mockResolvedValue(null);
   });
 
-  it("writes odoo connection.apiKey as SecretRef keyed by connection id", async () => {
+  it("writes only connectionId + apiBaseUrl + gatewayToken — no credentials in openclaw.json", async () => {
     const agentsData = [
       {
         id: "odoo-agent",
@@ -1903,29 +1884,31 @@ describe("pinchy-odoo connection.apiKey as SecretRef", () => {
 
     await regenerateOpenClawConfig();
 
-    // openclaw.json must contain a SecretRef for apiKey, not the plaintext key
     const written = mockedWriteFileSync.mock.calls.find(
       (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
     );
     expect(written).toBeDefined();
     const config = JSON.parse(written![1] as string);
 
-    const odooConfig = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents?.["odoo-agent"];
-    expect(odooConfig).toBeDefined();
-    expect(odooConfig.connection.apiKey).toEqual({
-      source: "file",
-      provider: "pinchy",
-      id: "/integrations/conn-odoo-1/odooApiKey",
-    });
-    // Other connection fields must still be present in plaintext
-    expect(odooConfig.connection.url).toBe("https://odoo.example.com");
-    expect(odooConfig.connection.db).toBe("mydb");
-    expect(odooConfig.connection.uid).toBe(2);
+    const odooPlugin = config.plugins?.entries?.["pinchy-odoo"]?.config;
+    expect(odooPlugin).toBeDefined();
+    // Plugin-level: apiBaseUrl + gatewayToken are present so the plugin
+    // can reach Pinchy.
+    expect(typeof odooPlugin.apiBaseUrl).toBe("string");
+    expect(odooPlugin.apiBaseUrl).toContain("/");
+    expect(typeof odooPlugin.gatewayToken).toBe("string");
 
-    // secrets.json must contain the actual key
-    expect(mockWriteSecretsFile).toHaveBeenCalled();
-    const secretsArg = mockWriteSecretsFile.mock.calls[0][0];
-    expect(secretsArg.integrations?.["conn-odoo-1"]?.odooApiKey).toBe("secret-odoo-key");
+    const odooAgent = odooPlugin.agents?.["odoo-agent"];
+    expect(odooAgent).toBeDefined();
+    expect(odooAgent.connectionId).toBe("conn-odoo-1");
+    // Critical: no credentials at all in the agent config. No `connection`
+    // object, no `apiKey`, no SecretRef pointer. The plugin will fetch
+    // credentials from Pinchy on first tool call.
+    expect(odooAgent.connection).toBeUndefined();
+    expect(JSON.stringify(odooAgent)).not.toContain("secret-odoo-key");
+
+    // The whole openclaw.json must not leak the apiKey under any path.
+    expect(written![1]).not.toContain("secret-odoo-key");
   });
 });
 

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -18,7 +18,6 @@ import {
   channelLinks,
 } from "@/db/schema";
 import { getSetting } from "@/lib/settings";
-import { decrypt } from "@/lib/encryption";
 import { computeDeniedGroups } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
@@ -423,22 +422,6 @@ export async function regenerateOpenClawConfig() {
 
     const conn = firstConnection.connection;
 
-    // Robust against key rotation: if this connection's credentials can't be
-    // decrypted, skip it — the alternative is crashing the whole config
-    // regeneration, which leaves every agent broken. The admin can see and
-    // delete the orphaned row via Settings → Integrations.
-    let decryptedCreds: { url: string; db: string; uid: number; apiKey: string };
-    try {
-      decryptedCreds = JSON.parse(decrypt(conn.credentials));
-    } catch (err) {
-      console.warn(
-        `[openclaw-config] Skipping agent ${agentId}'s Odoo connection ${conn.id} ` +
-          `(${conn.name}) — credentials can't be decrypted. ENCRYPTION_KEY may have ` +
-          `changed. Admin must delete and re-add the integration.`,
-        err
-      );
-      continue;
-    }
     const permissions: Record<string, string[]> = {};
     for (const [model, ops] of firstConnection.ops) {
       permissions[model] = ops;
@@ -460,20 +443,16 @@ export async function regenerateOpenClawConfig() {
       }
     }
 
-    integrationSecrets[conn.id] = {
-      ...(integrationSecrets[conn.id] || {}),
-      odooApiKey: decryptedCreds.apiKey,
-    };
-
+    // No credentials in plugin config. The plugin fetches them on demand
+    // from /api/internal/integrations/<connectionId>/credentials with the
+    // gateway token. See packages/plugins/pinchy-odoo/index.ts and
+    // packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts.
+    // This keeps openclaw.json free of long-lived per-tenant secrets and
+    // lets Pinchy own rotation, audit, and per-agent authorization
+    // centrally — same pattern as pinchy-email. See #209 for the bug
+    // that motivated the migration away from SecretRef-in-plugin-config.
     odooAgentConfigs[agentId] = {
-      connection: {
-        name: conn.name,
-        description: conn.description,
-        url: decryptedCreds.url,
-        db: decryptedCreds.db,
-        uid: decryptedCreds.uid,
-        apiKey: secretRef(`/integrations/${conn.id}/odooApiKey`),
-      },
+      connectionId: conn.id,
       permissions,
       modelNames,
     };
@@ -483,6 +462,9 @@ export async function regenerateOpenClawConfig() {
     entries["pinchy-odoo"] = {
       enabled: true,
       config: {
+        apiBaseUrl:
+          process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
+        gatewayToken: gatewayTokenString,
         agents: odooAgentConfigs,
       },
     };
@@ -497,53 +479,37 @@ export async function regenerateOpenClawConfig() {
   if (webSearchConnections.length > 0) {
     const webConn = webSearchConnections[0];
 
-    // Robust against key rotation: skip the web-search plugin entirely if the
-    // stored credentials can't be decrypted. Without a valid API key the
-    // plugin would crash on every tool call — better to disable it and let
-    // the admin delete/re-add the connection via Settings → Integrations.
-    let decryptedWebCreds: { apiKey: string } | null = null;
-    try {
-      decryptedWebCreds = JSON.parse(decrypt(webConn.credentials));
-    } catch (err) {
-      console.warn(
-        `[openclaw-config] Skipping Web Search integration ${webConn.id} (${webConn.name}) — ` +
-          `credentials can't be decrypted. ENCRYPTION_KEY may have changed. Admin must ` +
-          `delete and re-add the integration.`,
-        err
-      );
+    const webAgentConfigs: Record<string, Record<string, unknown>> = {};
+
+    for (const agent of allAgents) {
+      const allowedTools = (agent.allowedTools as string[]) || [];
+      const hasWebSearch = allowedTools.includes("pinchy_web_search");
+      const hasWebFetch = allowedTools.includes("pinchy_web_fetch");
+
+      if (hasWebSearch || hasWebFetch) {
+        const webConfig = (agent.pluginConfig as AgentPluginConfig)?.["pinchy-web"] ?? {};
+        const tools: string[] = [];
+        if (hasWebSearch) tools.push("pinchy_web_search");
+        if (hasWebFetch) tools.push("pinchy_web_fetch");
+
+        webAgentConfigs[agent.id] = { tools, ...webConfig };
+      }
     }
 
-    if (decryptedWebCreds) {
-      const webAgentConfigs: Record<string, Record<string, unknown>> = {};
-
-      for (const agent of allAgents) {
-        const allowedTools = (agent.allowedTools as string[]) || [];
-        const hasWebSearch = allowedTools.includes("pinchy_web_search");
-        const hasWebFetch = allowedTools.includes("pinchy_web_fetch");
-
-        if (hasWebSearch || hasWebFetch) {
-          const webConfig = (agent.pluginConfig as AgentPluginConfig)?.["pinchy-web"] ?? {};
-          const tools: string[] = [];
-          if (hasWebSearch) tools.push("pinchy_web_search");
-          if (hasWebFetch) tools.push("pinchy_web_fetch");
-
-          webAgentConfigs[agent.id] = { tools, ...webConfig };
-        }
-      }
-
-      if (Object.keys(webAgentConfigs).length > 0) {
-        integrationSecrets[webConn.id] = {
-          ...(integrationSecrets[webConn.id] || {}),
-          braveApiKey: decryptedWebCreds.apiKey,
-        };
-        entries["pinchy-web"] = {
-          enabled: true,
-          config: {
-            braveApiKey: secretRef(`/integrations/${webConn.id}/braveApiKey`),
-            agents: webAgentConfigs,
-          },
-        };
-      }
+    if (Object.keys(webAgentConfigs).length > 0) {
+      // No braveApiKey in plugin config. The plugin fetches it on demand
+      // from the credentials API — same pattern as pinchy-odoo / pinchy-email.
+      // See #209 for the bug class motivated this migration.
+      entries["pinchy-web"] = {
+        enabled: true,
+        config: {
+          apiBaseUrl:
+            process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
+          gatewayToken: gatewayTokenString,
+          connectionId: webConn.id,
+          agents: webAgentConfigs,
+        },
+      };
     }
   }
 


### PR DESCRIPTION
Closes #209. Supersedes #210.

## Why

OpenClaw 2026.4.x only resolves SecretRef pointers in a hand-coded set of config paths. It does **not** walk arbitrary plugin config trees. So when Pinchy wrote \`pinchy-odoo.config.agents.<id>.connection.apiKey\` as a SecretRef object, the unresolved \`{ source, provider, id }\` dict reached the Odoo plugin, was forwarded to \`odoo-node\` as the password, and Odoo's Python server crashed with \`unhashable type: 'dict'\`. Same broken pattern in \`pinchy-web.config.braveApiKey\`.

#210 patched it by writing the apiKey as plaintext. That works but creates a **plaintext-secrets-in-config-file** debt. After ultra-thinking the alternatives, this PR ships the architecturally right answer.

## The architecture

Three secret-handling patterns, classified by **who reads the secret at runtime**:

| Pattern | Use for | Mechanism |
|--|--|--|
| **A — OpenClaw built-ins** | LLM provider keys, gateway auth, env templates | SecretRef in OpenClaw's hand-coded paths |
| **B — Pinchy plugins** | Per-tenant integration credentials (Odoo, Brave, Stripe, …) | Plugin fetches via Pinchy API on demand, with TTL cache + refetch-on-401 |
| **C — Bootstrap** | gatewayToken, gateway.auth.token | Plaintext (chicken-and-egg, no other path) |

Documented in \`CLAUDE.md § Secrets Handling\`.

This PR migrates **pinchy-odoo** and **pinchy-web** from broken Pattern A to Pattern B — the same path \`pinchy-email\` has used since launch.

## What changes

- **\`packages/web/src/lib/openclaw-config.ts\`**: pinchy-odoo and pinchy-web blocks rewritten — write \`apiBaseUrl\` + \`gatewayToken\` + \`connectionId\` per agent (or top-level for pinchy-web), no credentials anywhere. Removed the now-unused \`secretRef\` integration entries and \`decrypt\` import.
- **\`packages/plugins/pinchy-odoo/index.ts\`**: \`AgentOdooConfig\` shrunk to \`{ connectionId, permissions, modelNames }\`. New \`fetchCredentials()\` + \`assertCredentialsShape()\` + \`withAuthRetry()\` (5-min TTL cache, refetch on 401).
- **\`packages/plugins/pinchy-web/index.ts\`**: same Pattern B, single connection (Brave is global).

## Four guardrail layers (per the project rule on production-bug fixes)

1. **Pinchy unit tests.** \`openclaw-config.test.ts\` asserts no credential string appears anywhere in the generated config.
2. **Plugin runtime validation.** Both plugins call \`assertCredentialsShape\` on the API response — if a future regression sends a SecretRef-shaped dict, the plugin fails fast with a clear \`apiKey must be a string, got object\` error pointing at #209.
3. **Plugin unit tests.** Cache hit/miss, refetch on 401, SecretRef shape rejection.
4. **Plugin integration test.** Boots in-process mock-odoo + a tiny mock-pinchy HTTP server, runs the real chain end-to-end. Includes a regression case that pushes the SecretRef dict through the full path and asserts the plugin rejects at the boundary (the request never reaches Odoo with the broken payload).

\`config/odoo-mock/server.js\` exports a \`start({port})\` function for in-process tests; CLI auto-start preserved.

## Test plan

- [x] 3344 unit tests pass (5 new integration tests)
- [x] \`tsc --noEmit\` clean
- [ ] CI green
- [ ] After merge + redeploy staging: Piper / Sales Analyst tool calls succeed
- [ ] Same for pinchy-web (web-search agent works)

## Related

- #209 — the bug
- #210 — earlier plaintext-fix attempt, superseded