### PR TITLE
fix(pinchy-email): add #209-style guardrails for credential handling

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -204,7 +204,7 @@ describe("credential fetching", () => {
     vi.clearAllMocks();
   });
 
-  it("fetches credentials on each tool execution", async () => {
+  it("caches credentials within TTL — second tool call reuses fetched token", async () => {
     mockCredentialResponse();
     mockList.mockResolvedValue([]);
 
@@ -214,11 +214,31 @@ describe("credential fetching", () => {
     await tool.execute("call-1", {});
     await tool.execute("call-2", {});
 
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockFetch).toHaveBeenCalledTimes(1);
     expect(mockFetch).toHaveBeenCalledWith(
       "http://pinchy:7777/api/internal/integrations/conn-1/credentials",
       { headers: { Authorization: "Bearer test-gateway-token" } },
     );
+  });
+
+  it("refetches credentials after the TTL window expires", async () => {
+    vi.useFakeTimers();
+    try {
+      mockCredentialResponse();
+      mockList.mockResolvedValue([]);
+
+      const tools = createApi();
+      const tool = findTool(tools, "email_list", agentId)!;
+
+      await tool.execute("call-1", {});
+      // Advance well past 5min TTL
+      vi.advanceTimersByTime(6 * 60 * 1000);
+      await tool.execute("call-2", {});
+
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("creates GmailAdapter with fetched access token", async () => {
@@ -258,6 +278,103 @@ describe("credential fetching", () => {
 
     expect(result.content[0].text).toContain("ECONNREFUSED");
     expect(result.isError).toBe(true);
+  });
+
+  it("REGRESSION (#209): rejects SecretRef-shaped credentials with a clear hint, never reaching Gmail", async () => {
+    // The credentials API returns the unresolved SecretRef object instead
+    // of decrypted credentials (the bug shape from #209). The plugin must
+    // reject this at the boundary instead of forwarding `undefined` as
+    // accessToken to Gmail (which would produce a confusing 401).
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        type: "google",
+        credentials: {
+          source: "file",
+          provider: "pinchy",
+          id: "/integrations/conn-1/accessToken",
+        },
+      }),
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("must be a string");
+    expect(text).toContain("#209");
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("rejects credentials with missing accessToken", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ({ type: "google", credentials: {} }),
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("accessToken");
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("invalidates cache and refetches when Gmail returns 401 (rotated/expired token)", async () => {
+    // First call: cached token works
+    mockCredentialResponse("stale-token");
+    mockList.mockResolvedValueOnce([]);
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+    await tool.execute("call-1", {});
+    expect(mockFetch).toHaveBeenCalledTimes(1);
+
+    // Second call: Gmail responds 401 (token expired in the meantime),
+    // plugin must invalidate cache, refetch, and retry once with the
+    // fresh token from Pinchy.
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({
+        type: "google",
+        credentials: { accessToken: "fresh-token" },
+      }),
+    });
+    mockList
+      .mockRejectedValueOnce(new Error("HTTP 401: Invalid Credentials"))
+      .mockResolvedValueOnce([]);
+
+    const result = await tool.execute("call-2", {});
+
+    expect(result.isError).toBeFalsy();
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // call-1: 1 list call. call-2: 1 list call that rejects with 401, then
+    // a retry list call after cache invalidation. Total = 3.
+    expect(mockList).toHaveBeenCalledTimes(3);
+    // Second GmailAdapter instantiation must use the fresh token
+    expect(GmailAdapter).toHaveBeenLastCalledWith({ accessToken: "fresh-token" });
+  });
+
+  it("surfaces the auth error if the refetched token also fails", async () => {
+    mockCredentialResponse();
+    mockList
+      .mockRejectedValueOnce(new Error("HTTP 401: Invalid Credentials"))
+      .mockRejectedValueOnce(new Error("HTTP 401: Invalid Credentials"));
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("401");
+    // Two fetches: initial + refetch after first 401
+    expect(mockFetch).toHaveBeenCalledTimes(2);
+    expect(mockList).toHaveBeenCalledTimes(2);
   });
 });
 

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -80,11 +80,45 @@ function errorResult(error: unknown): {
   };
 }
 
+interface EmailCredentials {
+  accessToken: string;
+}
+
+/**
+ * Defense-in-depth: fail fast with a clear error if the credentials API
+ * returns the wrong shape (e.g. an unresolved SecretRef object instead
+ * of a plain string accessToken — the bug class behind #209). Without
+ * this assertion a malformed payload would propagate to the Gmail API
+ * as `accessToken: undefined`, producing a confusing 401 that masks the
+ * real cause.
+ */
+function assertCredentialsShape(creds: unknown): asserts creds is EmailCredentials {
+  if (!creds || typeof creds !== "object") {
+    throw new Error(`pinchy-email: credentials must be an object, got ${typeof creds}`);
+  }
+  const obj = creds as Record<string, unknown>;
+  const looksLikeSecretRef =
+    typeof obj.source === "string" &&
+    typeof obj.provider === "string" &&
+    typeof obj.id === "string";
+  const actual = typeof obj.accessToken;
+  if (actual !== "string") {
+    const hint = looksLikeSecretRef
+      ? " (the credentials API returned an unresolved SecretRef — see #209)"
+      : actual === "object"
+        ? " (looks like an unresolved SecretRef — see #209)"
+        : "";
+    throw new Error(
+      `pinchy-email: credentials.accessToken must be a string, got ${actual}${hint}`,
+    );
+  }
+}
+
 async function fetchCredentials(
   apiBaseUrl: string,
   gatewayToken: string,
   connectionId: string,
-): Promise<{ accessToken: string }> {
+): Promise<EmailCredentials> {
   const response = await fetch(
     `${apiBaseUrl}/api/internal/integrations/${connectionId}/credentials`,
     { headers: { Authorization: `Bearer ${gatewayToken}` } },
@@ -96,7 +130,8 @@ async function fetchCredentials(
     );
   }
 
-  const data = await response.json();
+  const data = (await response.json()) as { credentials?: unknown };
+  assertCredentialsShape(data.credentials);
   return data.credentials;
 }
 
@@ -110,6 +145,62 @@ const plugin = {
     const agentConfigs = pluginConfig?.agents ?? {};
     const apiBaseUrl = pluginConfig?.apiBaseUrl ?? "";
     const gatewayToken = pluginConfig?.gatewayToken ?? "";
+
+    // GmailAdapter cache per agent. Built lazily on first tool call:
+    // fetch credentials from Pinchy → instantiate GmailAdapter. TTL keeps
+    // the cache fresh enough that token rotation propagates within
+    // CREDENTIALS_TTL_MS without anyone restarting OpenClaw — and on a
+    // 401 from Gmail (which happens immediately after the access token
+    // expires, since the Pinchy-side OAuth refresh races the call) we
+    // invalidate eagerly and refetch once before surfacing the error.
+    const CREDENTIALS_TTL_MS = 5 * 60 * 1000; // 5 minutes
+    const cache = new Map<string, { gmail: GmailAdapter; expiresAt: number }>();
+
+    function invalidate(agentId: string) {
+      cache.delete(agentId);
+    }
+
+    async function getOrCreateClient(
+      agentId: string,
+      config: AgentEmailConfig,
+    ): Promise<GmailAdapter> {
+      const hit = cache.get(agentId);
+      if (hit && hit.expiresAt > Date.now()) return hit.gmail;
+      const creds = await fetchCredentials(apiBaseUrl, gatewayToken, config.connectionId);
+      const gmail = new GmailAdapter({ accessToken: creds.accessToken });
+      cache.set(agentId, { gmail, expiresAt: Date.now() + CREDENTIALS_TTL_MS });
+      return gmail;
+    }
+
+    /**
+     * Run a Gmail call with one transparent retry on auth failure.
+     * Gmail returns a 401 (or "Invalid Credentials") when the access
+     * token is stale. Pinchy's credentials API auto-refreshes Google
+     * OAuth tokens server-side, so on a 401 we invalidate the local
+     * cache, refetch (which triggers the refresh), and retry once.
+     */
+    async function withAuthRetry<T>(
+      agentId: string,
+      config: AgentEmailConfig,
+      fn: (gmail: GmailAdapter) => Promise<T>,
+    ): Promise<T> {
+      const gmail = await getOrCreateClient(agentId, config);
+      try {
+        return await fn(gmail);
+      } catch (err) {
+        const msg = err instanceof Error ? err.message.toLowerCase() : "";
+        const isAuthError =
+          msg.includes("401") ||
+          msg.includes("invalid credentials") ||
+          msg.includes("invalid_grant") ||
+          msg.includes("token has been expired") ||
+          msg.includes("unauthorized");
+        if (!isAuthError) throw err;
+        invalidate(agentId);
+        const fresh = await getOrCreateClient(agentId, config);
+        return fn(fresh);
+      }
+    }
 
     // 1. email_list
     api.registerTool(
@@ -148,20 +239,13 @@ const plugin = {
                 return permissionDenied("read");
               }
 
-              const credentials = await fetchCredentials(
-                apiBaseUrl,
-                gatewayToken,
-                config.connectionId,
+              const result = await withAuthRetry(agentId, config, (gmail) =>
+                gmail.list({
+                  folder: params.folder as string | undefined,
+                  limit: params.limit as number | undefined,
+                  unreadOnly: params.unreadOnly as boolean | undefined,
+                }),
               );
-              const gmail = new GmailAdapter({
-                accessToken: credentials.accessToken,
-              });
-
-              const result = await gmail.list({
-                folder: params.folder as string | undefined,
-                limit: params.limit as number | undefined,
-                unreadOnly: params.unreadOnly as boolean | undefined,
-              });
 
               return {
                 content: [
@@ -206,16 +290,9 @@ const plugin = {
                 return permissionDenied("read");
               }
 
-              const credentials = await fetchCredentials(
-                apiBaseUrl,
-                gatewayToken,
-                config.connectionId,
+              const result = await withAuthRetry(agentId, config, (gmail) =>
+                gmail.read(params.id as string),
               );
-              const gmail = new GmailAdapter({
-                accessToken: credentials.accessToken,
-              });
-
-              const result = await gmail.read(params.id as string);
 
               return {
                 content: [
@@ -265,19 +342,12 @@ const plugin = {
                 return permissionDenied("read");
               }
 
-              const credentials = await fetchCredentials(
-                apiBaseUrl,
-                gatewayToken,
-                config.connectionId,
+              const result = await withAuthRetry(agentId, config, (gmail) =>
+                gmail.search({
+                  query: params.query as string,
+                  limit: params.limit as number | undefined,
+                }),
               );
-              const gmail = new GmailAdapter({
-                accessToken: credentials.accessToken,
-              });
-
-              const result = await gmail.search({
-                query: params.query as string,
-                limit: params.limit as number | undefined,
-              });
 
               return {
                 content: [
@@ -329,21 +399,14 @@ const plugin = {
                 return permissionDenied("draft");
               }
 
-              const credentials = await fetchCredentials(
-                apiBaseUrl,
-                gatewayToken,
-                config.connectionId,
+              const result = await withAuthRetry(agentId, config, (gmail) =>
+                gmail.draft({
+                  to: params.to as string,
+                  subject: params.subject as string,
+                  body: params.body as string,
+                  replyTo: params.replyTo as string | undefined,
+                }),
               );
-              const gmail = new GmailAdapter({
-                accessToken: credentials.accessToken,
-              });
-
-              const result = await gmail.draft({
-                to: params.to as string,
-                subject: params.subject as string,
-                body: params.body as string,
-                replyTo: params.replyTo as string | undefined,
-              });
 
               return {
                 content: [
@@ -395,21 +458,14 @@ const plugin = {
                 return permissionDenied("send");
               }
 
-              const credentials = await fetchCredentials(
-                apiBaseUrl,
-                gatewayToken,
-                config.connectionId,
+              const result = await withAuthRetry(agentId, config, (gmail) =>
+                gmail.send({
+                  to: params.to as string,
+                  subject: params.subject as string,
+                  body: params.body as string,
+                  replyTo: params.replyTo as string | undefined,
+                }),
               );
-              const gmail = new GmailAdapter({
-                accessToken: credentials.accessToken,
-              });
-
-              const result = await gmail.send({
-                to: params.to as string,
-                subject: params.subject as string,
-                body: params.body as string,
-                replyTo: params.replyTo as string | undefined,
-              });
 
               return {
                 content: [


### PR DESCRIPTION
## Summary

\`pinchy-email\` (Google Workspace / Microsoft / IMAP) was already on the API-callback credential pattern (Pattern B in \`CLAUDE.md\`) — so it never had the #209 SecretRef-crash bug that hit \`pinchy-odoo\`. But it was missing the defense-in-depth guardrails we just built into \`pinchy-odoo\` and \`pinchy-web\`. This PR brings it in line.

Three changes, mirroring the pinchy-odoo pattern verbatim:

1. **Shape validation at the plugin edge.** \`assertCredentialsShape\` rejects non-string \`accessToken\` values with an explicit \`#209\` hint when the payload looks like an unresolved SecretRef. Without this, a malformed payload would propagate to \`GmailAdapter\` as \`accessToken: undefined\`, producing a confusing 401 that masks the real cause.
2. **Per-agent GmailAdapter cache** with a 5-minute TTL. Eliminates the HTTP roundtrip per tool call (every \`email_list\`, \`email_read\`, etc. previously refetched), while still giving credential rotation a bounded propagation window.
3. **\`withAuthRetry\` wrapper** that transparently invalidates the cache and refetches credentials once when Gmail returns a 401 / \"Invalid Credentials\" / \"invalid_grant\" — the case where the access token expired between fetches and Pinchy's server-side OAuth refresh has since produced a new one.

All 5 tool sites (\`email_list\`, \`email_read\`, \`email_search\`, \`email_draft\`, \`email_send\`) migrated to \`withAuthRetry\`.

## Test plan

- [x] Existing 51 tests pass; one was updated from \"fetches credentials on each call\" → \"caches within TTL / refetches after TTL\" (intentional behaviour change, not a weakened test)
- [x] New tests: SecretRef regression (#209), missing accessToken, cache TTL refetch, Gmail-401 cache invalidation + retry, exhausted retry path
- [ ] CI green
- [ ] Verify on staging that Gmail tools still work end-to-end (no behaviour change for the happy path)