### PR TITLE
fix(odoo-e2e): unblock Tier 2 prod-image switch, bypass Better Auth rate limit

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -762,8 +762,8 @@ jobs:
     # The earlier attempt to land this (PR #195) reverted because Playwright's
     # browser-form login flow hit Better Auth's NODE_ENV=production rate
     # limit (3 sign-ins / 10s per IP) — the loginViaUI calls across odoo
-    # specs blew through it after 3-4 attempts. PINCHY_E2E_TESTING=1 in
-    # docker-compose.e2e.yml disables that limit only for this E2E stack.
+    # specs blew through it after 3-4 attempts. PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT=1
+    # in docker-compose.e2e.yml disables that limit only for this E2E stack.
     env:
       PINCHY_VERSION: latest
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,11 +753,17 @@ jobs:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest
 
-    # Dev-mode CI test: images are built by compose via docker-compose.dev.yml.
-    # Should ideally match telegram-e2e and run against the production image,
-    # but the Odoo UI login flow hits a NODE_ENV=production-specific quirk
-    # that I couldn't immediately root-cause. Tracked in #196 with the rest
-    # of the dev/prod parity work.
+    # Production-image CI test (Tier 2 of the dev/prod parity work, #196):
+    # images are built locally via docker-compose.e2e.yml using the
+    # production Dockerfile.pinchy (uid 999 demotion via entrypoint.sh),
+    # matching what end users actually run. Catches uid/permission
+    # mismatches between Pinchy (uid 999) and OpenClaw (root).
+    #
+    # The earlier attempt to land this (PR #195) reverted because Playwright's
+    # browser-form login flow hit Better Auth's NODE_ENV=production rate
+    # limit (3 sign-ins / 10s per IP) — the loginViaUI calls across odoo
+    # specs blew through it after 3-4 attempts. PINCHY_E2E_TESTING=1 in
+    # docker-compose.e2e.yml disables that limit only for this E2E stack.
     env:
       PINCHY_VERSION: latest
 
@@ -782,7 +788,7 @@ jobs:
       - run: pnpm install --frozen-lockfile
 
       - name: Start test stack with mock Odoo
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml up --build -d
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -797,7 +803,7 @@ jobs:
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy not healthy after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy
               exit 1
             fi
             sleep 2
@@ -810,20 +816,20 @@ jobs:
             fi
             if [ "$i" -eq 15 ]; then
               echo "::error::Mock Odoo not healthy after 30s"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for OpenClaw connection..."
           for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
               echo "OpenClaw connected (attempt $i)"
               break
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy openclaw
               exit 1
             fi
             sleep 2
@@ -841,15 +847,15 @@ jobs:
         if: failure()
         run: |
           echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
           echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
           echo "=== Mock Odoo logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.dev.yml -f docker-compose.odoo-test.yml down -v
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml down -v
 
   telegram-e2e:
     name: Telegram E2E Tests

--- a/config/telegram-mock/server.js
+++ b/config/telegram-mock/server.js
@@ -38,6 +38,13 @@ const bots = new Map();
 // Pending updates for each bot (simulated incoming messages from users)
 const pendingUpdates = new Map(); // token -> update[]
 
+// Tokens whose bot has actually polled (called getUpdates at least once).
+// Distinct from `bots` (registered via getMe) — a registered bot may not
+// have started polling yet, especially during OpenClaw channel restarts
+// when adding a second bot account. Tests use this to wait for a SPECIFIC
+// bot to be live, instead of "any bot is registered".
+const pollingTokens = new Set();
+
 // ── Anthropic API mock (for model prewarm) ─────────────────────────────
 
 function handleAnthropicRequest(url, body) {
@@ -82,6 +89,11 @@ function notifyUpdateListeners(token) {
 
 // getUpdates is async (long-poll) — handled separately
 async function handleGetUpdates(token, body) {
+  // Mark this bot as actively polling. Tests rely on this to verify a
+  // specific bot's channel has come up, which is more reliable than the
+  // generic getMe-based registration count.
+  pollingTokens.add(token);
+
   const timeout = Math.min(parseInt(body?.timeout || "30", 10), 30);
   const offset = parseInt(body?.offset || "0", 10);
 
@@ -317,6 +329,7 @@ function startControlServer() {
         botResponses.length = 0;
         pendingUpdates.clear();
         bots.clear();
+        pollingTokens.clear();
         messageIdCounter = 1000;
         updateIdCounter = 100;
         res.writeHead(200);
@@ -332,6 +345,7 @@ function startControlServer() {
           JSON.stringify({
             ok: true,
             bots: [...bots.keys()].length,
+            pollingTokens: [...pollingTokens],
             pendingUpdates: [...pendingUpdates.values()].flat().length,
             responses: botResponses.length,
           })

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -24,8 +24,9 @@ services:
       # The limit is on by default in NODE_ENV=production and locks Playwright
       # form-login flows out after the third sign-in within the window. Only
       # ever set in this E2E overlay; production deploys leave it unset and
-      # keep the rate limit enabled.
-      PINCHY_E2E_TESTING: "1"
+      # keep the rate limit enabled. `auth-config-consistency.test.ts` blocks
+      # this var from being added to `docker-compose.yml` or `.dev.yml`.
+      PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT: "1"
   openclaw:
     build:
       context: .

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -19,6 +19,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.pinchy
+    environment:
+      # Disable Better Auth's per-IP rate limit on /sign-in/* (3 req / 10s).
+      # The limit is on by default in NODE_ENV=production and locks Playwright
+      # form-login flows out after the third sign-in within the window. Only
+      # ever set in this E2E overlay; production deploys leave it unset and
+      # keep the rate limit enabled.
+      PINCHY_E2E_TESTING: "1"
   openclaw:
     build:
       context: .

--- a/packages/web/.prettierignore
+++ b/packages/web/.prettierignore
@@ -4,3 +4,5 @@ build/
 node_modules/
 coverage/
 pnpm-lock.yaml
+test-results/
+playwright-report/

--- a/packages/web/e2e/odoo/odoo-wizard.spec.ts
+++ b/packages/web/e2e/odoo/odoo-wizard.spec.ts
@@ -150,14 +150,19 @@ test.describe.serial("Odoo Wizard Flow", () => {
     // Wait for the connection to appear in the list
     await expect(page.getByText("Connected")).toBeVisible({ timeout: 10000 });
 
-    // Get the connection name before deletion for later assertion
-    const connectionCard = page.locator(".rounded-lg.border.p-4").first();
+    // Scope to the visible tabpanel. The settings page uses keepMounted so
+    // every other tab (Groups, License, etc.) is also in the DOM but hidden.
+    // The Groups tab's EnterpriseFeatureCard has the same .rounded-lg.border.p-4
+    // classes as a connection card, and in production builds it consistently
+    // hits the DOM before the integrations content — so a global `.first()`
+    // matched the wrong (hidden) card. `getByRole("tabpanel")` only returns
+    // accessibility-visible panels (display:none ones drop out of the tree).
+    const integrationsPanel = page.getByRole("tabpanel");
+    const connectionCard = integrationsPanel.locator(".rounded-lg.border.p-4").first();
     const connectionName = await connectionCard.locator(".font-medium").first().textContent();
 
-    // Open the dropdown menu (three dots). Targeting data-slot is stable
-    // across shadcn theme changes and prod-build class transformations —
-    // the previous `getByRole("button").filter({ has: svg })` matched
-    // ambiguously against the production build.
+    // Open the dropdown menu (three dots). data-slot is shadcn/ui's canonical
+    // anchor — stable across theme tweaks and prod-build class transformations.
     await connectionCard.locator("[data-slot='dropdown-menu-trigger']").click();
 
     // Click Delete in the dropdown

--- a/packages/web/e2e/odoo/odoo-wizard.spec.ts
+++ b/packages/web/e2e/odoo/odoo-wizard.spec.ts
@@ -154,11 +154,11 @@ test.describe.serial("Odoo Wizard Flow", () => {
     const connectionCard = page.locator(".rounded-lg.border.p-4").first();
     const connectionName = await connectionCard.locator(".font-medium").first().textContent();
 
-    // Open the dropdown menu (three dots)
-    await connectionCard
-      .getByRole("button")
-      .filter({ has: page.locator("svg") })
-      .click();
+    // Open the dropdown menu (three dots). Targeting data-slot is stable
+    // across shadcn theme changes and prod-build class transformations —
+    // the previous `getByRole("button").filter({ has: svg })` matched
+    // ambiguously against the production build.
+    await connectionCard.locator("[data-slot='dropdown-menu-trigger']").click();
 
     // Click Delete in the dropdown
     await page.getByRole("menuitem", { name: /delete/i }).click();

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -351,13 +351,13 @@ export async function waitForTelegramPolling(timeout = 30000): Promise<void> {
     try {
       const res = await fetch(`${MOCK_TELEGRAM_URL}/control/health`);
       const data = await res.json();
-      // Once any bot has actually polled (called getUpdates), the channel is
-      // live. Note: `bots > 0` would also pass after a getMe-only validation,
-      // but that doesn't mean the bot is receiving messages. Use
-      // pollingTokens (populated on getUpdates) as the real readiness signal.
-      if (Array.isArray(data.pollingTokens) && data.pollingTokens.length > 0) return;
-      // Backwards-compat for older mocks that don't expose pollingTokens.
-      if (!("pollingTokens" in data) && data.bots > 0) return;
+      // `bots > 0` means at least one bot has been registered (called getMe).
+      // For most tests this is enough — the immediate next assertion
+      // (e.g. "send a message and expect a pairing response") has its own
+      // generous waitForBotResponse timeout that absorbs the brief gap
+      // between getMe and the first getUpdates. Multi-bot scenarios that
+      // need a SPECIFIC bot to be live should use waitForBotPolling instead.
+      if (data.bots > 0) return;
     } catch {
       // Not ready yet
     }

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -351,12 +351,39 @@ export async function waitForTelegramPolling(timeout = 30000): Promise<void> {
     try {
       const res = await fetch(`${MOCK_TELEGRAM_URL}/control/health`);
       const data = await res.json();
-      // Once bots > 0, OpenClaw has started polling (sent at least one getUpdates)
-      if (data.bots > 0) return;
+      // Once any bot has actually polled (called getUpdates), the channel is
+      // live. Note: `bots > 0` would also pass after a getMe-only validation,
+      // but that doesn't mean the bot is receiving messages. Use
+      // pollingTokens (populated on getUpdates) as the real readiness signal.
+      if (Array.isArray(data.pollingTokens) && data.pollingTokens.length > 0) return;
+      // Backwards-compat for older mocks that don't expose pollingTokens.
+      if (!("pollingTokens" in data) && data.bots > 0) return;
     } catch {
       // Not ready yet
     }
     await new Promise((r) => setTimeout(r, 1000));
   }
   throw new Error(`Telegram polling not started within ${timeout}ms`);
+}
+
+/**
+ * Wait for a specific bot token to start polling. Use this in multi-bot
+ * scenarios where a generic "any bot is polling" check would pass on the
+ * first bot while a newly-connected second bot is still spinning up — that
+ * race causes test #10 in the multi-bot suite to flake when OpenClaw is
+ * mid-restart from the channel-reload triggered by the bot connect.
+ */
+export async function waitForBotPolling(token: string, timeout = 120000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(`${MOCK_TELEGRAM_URL}/control/health`);
+      const data = await res.json();
+      if (Array.isArray(data.pollingTokens) && data.pollingTokens.includes(token)) return;
+    } catch {
+      // Not ready yet
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Bot ${token.slice(0, 6)}... did not start polling within ${timeout}ms`);
 }

--- a/packages/web/e2e/telegram/telegram-flow.spec.ts
+++ b/packages/web/e2e/telegram/telegram-flow.spec.ts
@@ -25,6 +25,7 @@ import {
   waitForMockTelegram,
   waitForOpenClawConnected,
   waitForTelegramPolling,
+  waitForBotPolling,
   seedSetup,
 } from "./helpers";
 
@@ -246,8 +247,13 @@ test.describe.serial("Multi-Bot Telegram", () => {
     expect(result.botUsername).toBeTruthy();
     console.log(`[multi-bot] Second bot: @${result.botUsername} for agent ${secondAgentId}`);
 
-    // Wait for OpenClaw to start polling the second bot
-    await waitForTelegramPolling();
+    // Wait for OpenClaw to start polling THE SECOND bot specifically. The
+    // generic waitForTelegramPolling() returns as soon as Smithers' polling
+    // resumes, which can happen well before the new bot's channel comes up
+    // — and adding a second account triggers an OpenClaw channel restart
+    // (openclaw#47458). Without this wait, test 10 sends a message to a bot
+    // that isn't listening yet.
+    await waitForBotPolling(SECOND_BOT_TOKEN);
   });
 
   test("second bot responds to unlinked user with pairing code", async () => {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -30,6 +30,18 @@ if (process.env.BETTER_AUTH_URL) {
   );
 }
 
+if (process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT === "1") {
+  // Surface this loud at startup. Production deployments must NEVER set this
+  // — it disables Better Auth's brute-force protection on /sign-in/*. The
+  // only legitimate setter is docker-compose.e2e.yml, which is itself only
+  // ever layered on top of docker-compose.yml during CI E2E runs.
+  console.warn(
+    "⚠ PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT=1 — auth rate limiting is OFF. " +
+      "This must only ever be set in E2E test stacks. If you see this in " +
+      "production logs, unset the env var and restart immediately."
+  );
+}
+
 const dev = process.env.NODE_ENV !== "production";
 const app = next({ dev });
 const handle = app.getRequestHandler();

--- a/packages/web/src/__tests__/lib/auth.test.ts
+++ b/packages/web/src/__tests__/lib/auth.test.ts
@@ -58,34 +58,34 @@ describe("auth configuration", () => {
 
 describe("getAuthRateLimitConfig", () => {
   it("returns undefined by default — uses Better Auth's NODE_ENV-driven default (enabled in prod)", () => {
-    const original = process.env.PINCHY_E2E_TESTING;
-    delete process.env.PINCHY_E2E_TESTING;
+    const original = process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
+    delete process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
     try {
       expect(getAuthRateLimitConfig()).toBeUndefined();
     } finally {
-      if (original !== undefined) process.env.PINCHY_E2E_TESTING = original;
+      if (original !== undefined) process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT = original;
     }
   });
 
-  it("returns { enabled: false } when PINCHY_E2E_TESTING=1 — bypasses /sign-in/* rate limit (3 req / 10s) so Playwright form-login tests don't lock themselves out against the production image", () => {
-    const original = process.env.PINCHY_E2E_TESTING;
-    process.env.PINCHY_E2E_TESTING = "1";
+  it("returns { enabled: false } when PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT=1 — bypasses /sign-in/* rate limit (3 req / 10s) so Playwright form-login tests don't lock themselves out against the production image", () => {
+    const original = process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
+    process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT = "1";
     try {
       expect(getAuthRateLimitConfig()).toEqual({ enabled: false });
     } finally {
-      if (original === undefined) delete process.env.PINCHY_E2E_TESTING;
-      else process.env.PINCHY_E2E_TESTING = original;
+      if (original === undefined) delete process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
+      else process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT = original;
     }
   });
 
   it("treats values other than '1' as not set — guard against accidentally disabling rate limiting in production", () => {
-    const original = process.env.PINCHY_E2E_TESTING;
-    process.env.PINCHY_E2E_TESTING = "true";
+    const original = process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
+    process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT = "true";
     try {
       expect(getAuthRateLimitConfig()).toBeUndefined();
     } finally {
-      if (original === undefined) delete process.env.PINCHY_E2E_TESTING;
-      else process.env.PINCHY_E2E_TESTING = original;
+      if (original === undefined) delete process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT;
+      else process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT = original;
     }
   });
 });

--- a/packages/web/src/__tests__/lib/auth.test.ts
+++ b/packages/web/src/__tests__/lib/auth.test.ts
@@ -43,7 +43,7 @@ vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn(),
 }));
 
-import { auth } from "@/lib/auth";
+import { auth, getAuthRateLimitConfig } from "@/lib/auth";
 
 describe("auth configuration", () => {
   it("should export auth instance", () => {
@@ -53,5 +53,39 @@ describe("auth configuration", () => {
   it("should have api.getSession method", () => {
     expect(auth.api).toBeDefined();
     expect(typeof auth.api.getSession).toBe("function");
+  });
+});
+
+describe("getAuthRateLimitConfig", () => {
+  it("returns undefined by default — uses Better Auth's NODE_ENV-driven default (enabled in prod)", () => {
+    const original = process.env.PINCHY_E2E_TESTING;
+    delete process.env.PINCHY_E2E_TESTING;
+    try {
+      expect(getAuthRateLimitConfig()).toBeUndefined();
+    } finally {
+      if (original !== undefined) process.env.PINCHY_E2E_TESTING = original;
+    }
+  });
+
+  it("returns { enabled: false } when PINCHY_E2E_TESTING=1 — bypasses /sign-in/* rate limit (3 req / 10s) so Playwright form-login tests don't lock themselves out against the production image", () => {
+    const original = process.env.PINCHY_E2E_TESTING;
+    process.env.PINCHY_E2E_TESTING = "1";
+    try {
+      expect(getAuthRateLimitConfig()).toEqual({ enabled: false });
+    } finally {
+      if (original === undefined) delete process.env.PINCHY_E2E_TESTING;
+      else process.env.PINCHY_E2E_TESTING = original;
+    }
+  });
+
+  it("treats values other than '1' as not set — guard against accidentally disabling rate limiting in production", () => {
+    const original = process.env.PINCHY_E2E_TESTING;
+    process.env.PINCHY_E2E_TESTING = "true";
+    try {
+      expect(getAuthRateLimitConfig()).toBeUndefined();
+    } finally {
+      if (original === undefined) delete process.env.PINCHY_E2E_TESTING;
+      else process.env.PINCHY_E2E_TESTING = original;
+    }
   });
 });

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -68,4 +68,30 @@ describe("auth config consistency", () => {
     const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/src/lib/auth.ts"), "utf-8");
     expect(content).toContain("trustedOrigins");
   });
+
+  describe("PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT — security guardrail", () => {
+    // The env var disables Better Auth's rate limit on /sign-in/* (3 req / 10s
+    // per IP). It MUST only ever appear in the E2E-only compose overlay, never
+    // in production compose, so a misplaced copy-paste can't accidentally turn
+    // off brute-force protection on a live deployment.
+    const ENV_VAR = "PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT";
+
+    it(`docker-compose.yml must NOT set ${ENV_VAR} (production compose)`, () => {
+      const content = readFileSync(resolve(PROJECT_ROOT, "docker-compose.yml"), "utf-8");
+      expect(
+        content,
+        `${ENV_VAR} found in docker-compose.yml — that file deploys to production. Move it to docker-compose.e2e.yml.`
+      ).not.toContain(ENV_VAR);
+    });
+
+    it(`docker-compose.dev.yml must NOT set ${ENV_VAR} (dev compose; rate limit is off in dev anyway)`, () => {
+      const content = readFileSync(resolve(PROJECT_ROOT, "docker-compose.dev.yml"), "utf-8");
+      expect(content).not.toContain(ENV_VAR);
+    });
+
+    it(`docker-compose.e2e.yml DOES set ${ENV_VAR} (the only legitimate location)`, () => {
+      const content = readFileSync(resolve(PROJECT_ROOT, "docker-compose.e2e.yml"), "utf-8");
+      expect(content).toContain(ENV_VAR);
+    });
+  });
 });

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -76,14 +76,20 @@ export const auditAfterHook = createAuthMiddleware(async (ctx) => {
  * (`enabled: NODE_ENV === "production"`, with a /sign-in/* limit of
  * 3 req / 10s per IP).
  *
- * `PINCHY_E2E_TESTING=1` disables it. We set this in
+ * `PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT=1` disables it. We set this in
  * `docker-compose.e2e.yml` so Playwright form-login flows can exercise
  * the production image without the test runner locking itself out
  * after a few `loginViaUI` calls. Production deployments never set
- * this env var.
+ * this env var, and `auth-config-consistency.test.ts` blocks anyone
+ * from accidentally adding it to `docker-compose.yml`.
+ *
+ * Evaluated once at module load (when `auth` is constructed). Changing
+ * the env var at runtime has no effect on the live `auth` instance —
+ * the container restarts whenever the value changes, which is fine
+ * because Docker injects env at process start.
  */
 export function getAuthRateLimitConfig(): { enabled: false } | undefined {
-  if (process.env.PINCHY_E2E_TESTING === "1") {
+  if (process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT === "1") {
     return { enabled: false };
   }
   return undefined;

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -69,7 +69,28 @@ export const auditAfterHook = createAuthMiddleware(async (ctx) => {
   }
 });
 
+/**
+ * Decide whether to override Better Auth's default rate limiting.
+ *
+ * Default: returns `undefined` so Better Auth uses its own behaviour
+ * (`enabled: NODE_ENV === "production"`, with a /sign-in/* limit of
+ * 3 req / 10s per IP).
+ *
+ * `PINCHY_E2E_TESTING=1` disables it. We set this in
+ * `docker-compose.e2e.yml` so Playwright form-login flows can exercise
+ * the production image without the test runner locking itself out
+ * after a few `loginViaUI` calls. Production deployments never set
+ * this env var.
+ */
+export function getAuthRateLimitConfig(): { enabled: false } | undefined {
+  if (process.env.PINCHY_E2E_TESTING === "1") {
+    return { enabled: false };
+  }
+  return undefined;
+}
+
 export const auth = betterAuth({
+  rateLimit: getAuthRateLimitConfig(),
   trustedOrigins: (request) => {
     const domain = getCachedDomain();
     if (domain) {


### PR DESCRIPTION
## Summary
- Root-cause and fix for the dev/prod parity gap left open in #196 after #195 reverted the Tier 2 (Odoo E2E) prod-image switch.
- Cause: Better Auth defaults `rateLimit.enabled` to `NODE_ENV === "production"` with a `/sign-in/*` cap of **3 req / 10s per IP**. The Odoo specs blow through that across `beforeAll` API logins + per-test `loginViaUI` calls, so by the third or fourth sign-in everything starts coming back 429 — which the login page surfaces as a stuck `/login` (the symptom that masked the cause originally).
- Confirmed by rebuilding the prod image locally and rerunning the suite: `Login failed — no set-cookie header (status 429)`.

## Changes
- `packages/web/src/lib/auth.ts` — `getAuthRateLimitConfig()` returns `{ enabled: false }` only when `PINCHY_E2E_TESTING=1`, otherwise `undefined` (Better Auth's default behaviour preserved).
- `packages/web/src/__tests__/lib/auth.test.ts` — three unit tests cover default / E2E-on / accidental-other-truthy-string.
- `docker-compose.e2e.yml` — sets `PINCHY_E2E_TESTING=1`. Production deploys don't include this overlay, so prod rate limiting is unchanged.
- `.github/workflows/ci.yml` — `odoo-e2e` switches from `docker-compose.dev.yml` to `docker-compose.e2e.yml` (matches `telegram-e2e` Tier 1). Comment block rewritten with the actual root cause.
- `packages/web/.prettierignore` — drive-by: `test-results/` + `playwright-report/` so `format:check` after a local Playwright run doesn't fail on auto-generated artifacts.

## Out of scope
**Tier 3 (Integration Tests on prod image)** stays on `dev.yml`/local Node for now — that suite spawns Pinchy as a host-side Node process and would need a larger restructure to dockerise. Tracked in #196 as separate follow-up work; doing it here would balloon the PR.

## Test plan
- [x] `pnpm --filter @pinchy/web test` — full suite green (3347 passed).
- [x] `pnpm --filter @pinchy/web exec vitest run src/__tests__/lib/auth.test.ts` — 5/5 including the three new rate-limit-config tests.
- [x] Lint + format clean.
- [x] Reproduced the 429 against a fresh prod image build to verify the diagnosis.
- [ ] CI is the canonical verification for the dev/prod parity switch (local prod-image rerun was interrupted by an unrelated host-disk issue, not a fix problem).