### PR TITLE
fix(openclaw-config): stable plugins.allow ordering to break #193 cascade

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2650,6 +2650,11 @@ describe("restart-state integration", () => {
     // diff'd against its own file sees `plugins.allow` as changed and triggers
     // a full gateway restart.
     expect(config.plugins.allow).toEqual(existingAllow);
+    // Stronger property: the output must be self-consistently sorted regardless
+    // of what OpenClaw wrote. Without this, the test above could pass simply
+    // because the test fixture happens to be alphabetical — masking the case
+    // where a future OpenClaw version uses a different deterministic order.
+    expect(config.plugins.allow).toEqual([...config.plugins.allow].sort());
   });
 
   it("regenerateOpenClawConfig is byte-idempotent against its own previous output (#193)", async () => {
@@ -2659,6 +2664,11 @@ describe("restart-state integration", () => {
     // depending on which paths differ. This test specifically catches the
     // class of bug where Pinchy's regenerate strips fields it doesn't know
     // about that OpenClaw legitimately wrote back.
+    //
+    // Note: this test alone is insufficient — it only proves Pinchy → Pinchy
+    // idempotency, not Pinchy ↔ OpenClaw idempotency. The "plugins.allow order
+    // is stable" test above covers the harder case where OpenClaw rewrites
+    // arrays in its own deterministic order between Pinchy generates.
     mockedDb.select.mockReturnValue({
       from: mockFrom([
         {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2581,6 +2581,77 @@ describe("restart-state integration", () => {
     expect(sentEnv.OPENAI_API_KEY).toBe("${OPENAI_API_KEY}");
   });
 
+  it("plugins.allow order is stable when existing config has different ordering (#193)", async () => {
+    // CI repro (run 25222907678 on commit d091c6f): OpenClaw writes the
+    // `plugins.allow` array back to openclaw.json with its own ordering
+    // (typically alphabetical because telegram is auto-enabled after the
+    // pinchy-* entries are inserted, then the whole map is serialised).
+    //
+    // The previous regenerate built `allowedPlugins` as
+    // `[...new Set([...openClawPlugins, ...ourPlugins])]` which puts
+    // OpenClaw-managed plugins (telegram) FIRST and pinchy-* in entries
+    // insertion order — completely different from what OpenClaw wrote.
+    //
+    // OpenClaw's reload engine treats array order as significant for
+    // `plugins.allow` and emits "config change requires gateway restart
+    // (plugins.allow)" whenever the order differs, even if the set of
+    // plugins is identical. Result: every settings save / agent create
+    // triggers a 15-30s "Agent runtime is not available" banner.
+    //
+    // Fix: produce a stable ordering (alphabetical) that does not depend
+    // on insertion order, so two consecutive regenerates emit identical
+    // arrays regardless of what OpenClaw wrote in between.
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "smithers-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          pluginConfig: null,
+          allowedTools: ["pinchy_save_user_context"],
+          ownerId: "user-1",
+          isPersonal: true,
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:smithers-1") return "123456:ABC-token";
+      return null;
+    });
+
+    // Existing config matches what OpenClaw writes back after auto-enabling
+    // telegram: alphabetical order across the full union (pinchy-* + telegram).
+    const existingAllow = ["pinchy-audit", "pinchy-context", "pinchy-docs", "telegram"];
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan", auth: { token: "gw-token" } },
+        plugins: {
+          allow: existingAllow,
+          entries: {
+            telegram: { enabled: true },
+          },
+        },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+    );
+    expect(written).toBeDefined();
+    const config = JSON.parse(written![1] as string);
+
+    // The set of plugins must match (sanity check).
+    expect(new Set(config.plugins.allow)).toEqual(new Set(existingAllow));
+    // The order must be identical to what OpenClaw wrote — otherwise OpenClaw
+    // diff'd against its own file sees `plugins.allow` as changed and triggers
+    // a full gateway restart.
+    expect(config.plugins.allow).toEqual(existingAllow);
+  });
+
   it("regenerateOpenClawConfig is byte-idempotent against its own previous output (#193)", async () => {
     // Hardest assertion: two consecutive generates with identical DB state
     // must produce identical openclaw.json content. If they don't, OpenClaw

--- a/packages/web/src/lib/openclaw-config.ts
+++ b/packages/web/src/lib/openclaw-config.ts
@@ -576,7 +576,13 @@ export async function regenerateOpenClawConfig() {
   const pinchyPluginPrefixes = ["pinchy-"];
   const isPinchyPlugin = (p: string) => pinchyPluginPrefixes.some((prefix) => p.startsWith(prefix));
   const openClawPlugins = existingAllow.filter((p) => !isPinchyPlugin(p));
-  const allowedPlugins = [...new Set([...openClawPlugins, ...ourPlugins])];
+  // Sort for byte-stable output: OpenClaw treats `plugins.allow` array order
+  // as significant in its reload diff and triggers a full gateway restart
+  // when ordering changes. Without this sort, our insertion-order ([...openClaw,
+  // ...ours]) doesn't match what OpenClaw writes back after auto-enabling
+  // telegram (alphabetical-ish), and every regenerate triggers a 15-30s
+  // restart cascade. See #193.
+  const allowedPlugins = [...new Set([...openClawPlugins, ...ourPlugins])].sort();
 
   // Preserve OpenClaw-managed plugin entries that we don't write ourselves.
   // OpenClaw auto-enables each configured provider (anthropic, openai, google,


### PR DESCRIPTION
## Summary

- Roots out the `plugins.allow` cascade that's been failing `agent-create-no-restart.spec.ts` on main since PR #219
- Pinchy now produces a sorted, byte-stable `plugins.allow` array — no more "requires gateway restart" diffs against OpenClaw's auto-enabled writebacks

## Root cause

CI on main HEAD (`d091c6f`, run [25222463719](https://github.com/heypinchy/pinchy/actions/runs/25222463719)) shows the test failing with:

```
[reload] config change detected; evaluating reload (agents.list, plugins.allow)
[reload] config change requires gateway restart (plugins.allow)
[gateway] received SIGUSR1; restarting
```

This is a new cascade trigger that surfaced after PR #219 fixed `plugins.entries.telegram` non-idempotency. The previous code built `plugins.allow` as `[...new Set([...openClawPlugins, ...ourPlugins])]`, which puts non-pinchy plugins (telegram) FIRST and pinchy-* in entries insertion order. OpenClaw's auto-enable rewrites the array in alphabetical-ish order; Pinchy's next regenerate produces `[telegram, pinchy-docs, pinchy-context, pinchy-audit]` — same set, different order. OpenClaw's reload engine treats array order as significant → 15-30s "Agent runtime is not available" banner on every settings save.

## Fix

`.sort()` the final array. Stable, alphabetical, byte-identical across regenerate calls regardless of insertion order or what OpenClaw wrote back.

## Test plan

- [x] Unit test reproduces the exact CI fingerprint: existing `[pinchy-audit, pinchy-context, pinchy-docs, telegram]`, asserts written order matches
- [x] All 3390 existing tests still pass (`pnpm -C packages/web test`)
- [ ] Telegram E2E `agent-create-no-restart.spec.ts` turns green in CI
- [ ] Confirm on staging that no `requires gateway restart (plugins.allow)` lines appear after a settings save / agent create

Closes the dominant cause described in [#193 comment](https://github.com/heypinchy/pinchy/issues/193#issuecomment-4358266484) follow-up.