### PR TITLE
fix(audit-export): address review round-2 findings

### DIFF
--- a/packages/web/src/__tests__/api/audit-export.test.ts
+++ b/packages/web/src/__tests__/api/audit-export.test.ts
@@ -20,6 +20,14 @@ vi.mock("@/lib/audit-sanitize", async () => {
   };
 });
 
+vi.mock("@/lib/audit-pdf", async () => {
+  const actual = await vi.importActual<typeof import("@/lib/audit-pdf")>("@/lib/audit-pdf");
+  return {
+    ...actual,
+    renderAuditPdf: vi.fn(actual.renderAuditPdf),
+  };
+});
+
 // Build chainable mock for select().from().leftJoin().leftJoin().leftJoin().where().orderBy()
 const mockOrderBy = vi.fn();
 const mockWhere = vi.fn().mockReturnValue({ orderBy: mockOrderBy });
@@ -75,6 +83,7 @@ vi.mock("drizzle-orm/pg-core", () => ({
 import { requireAdmin } from "@/lib/api-auth";
 import { appendAuditLog } from "@/lib/audit";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
+import { renderAuditPdf } from "@/lib/audit-pdf";
 
 const HEADER =
   "id,timestamp,actorType,actorId,actorName,eventType,resource,resourceName,detail,version,outcome,error,rowHmac";
@@ -584,12 +593,9 @@ describe("GET /api/audit/export", () => {
     expect(body).toContain('"user,with,commas"');
     expect(body).toContain('"tool.weird,name"');
     expect(body).toContain('"settings,with,commas"');
-    // Header has 12 commas separating 13 columns; the data row must too
-    const headerCommaCount = body.split("\n")[0].split(",").length;
-    const rowCommaCount = body.split("\n")[1].split(",").length;
-    // Equal number of CSV fields between header and row, even with commas in values
-    // (split on , doesn't account for quoted commas, but field count via simple parse should match)
-    // Use a quote-aware parse:
+    // RFC 4180 round-trip: a quote-aware parser must yield exactly 13
+    // fields for both the header and the data row, regardless of how many
+    // commas appear inside quoted values.
     const parseRow = (line: string): string[] => {
       const fields: string[] = [];
       let cur = "";
@@ -615,9 +621,6 @@ describe("GET /api/audit/export", () => {
     };
     expect(parseRow(body.split("\n")[0])).toHaveLength(13);
     expect(parseRow(body.split("\n")[1])).toHaveLength(13);
-    // Suppress unused-var warnings
-    void headerCommaCount;
-    void rowCommaCount;
   });
 
   // ── Strict status validation ─────────────────────────────────────────
@@ -664,6 +667,7 @@ describe("GET /api/audit/export", () => {
       ) as unknown as Parameters<typeof import("@/app/api/audit/export/route").GET>[0]
     );
 
+    expect(appendAuditLog).toHaveBeenCalledTimes(1);
     expect(appendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
         eventType: "audit.exported",
@@ -689,6 +693,7 @@ describe("GET /api/audit/export", () => {
       >[0]
     );
 
+    expect(appendAuditLog).toHaveBeenCalledTimes(1);
     expect(appendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
         eventType: "audit.exported",
@@ -696,6 +701,85 @@ describe("GET /api/audit/export", () => {
         detail: expect.objectContaining({ format: "pdf", rowCount: 0 }),
       })
     );
+  });
+
+  it("export still succeeds when audit-log infrastructure fails", async () => {
+    // Audit logging is fire-and-forget: if it throws, the export must
+    // still return the data. Otherwise the very compliance feature we
+    // added would itself become a single point of failure for exports.
+    mockOrderBy.mockResolvedValue([]);
+    vi.mocked(appendAuditLog).mockRejectedValueOnce(new Error("DB down"));
+    // Suppress the console.error the route emits in this scenario.
+    const errSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    const { GET } = await import("@/app/api/audit/export/route");
+    const response = await GET(
+      new Request("http://localhost/api/audit/export") as unknown as Parameters<
+        typeof import("@/app/api/audit/export/route").GET
+      >[0]
+    );
+
+    expect(response.status).toBe(200);
+    const body = await response.text();
+    expect(body).toContain(HEADER);
+    // The route should have logged the failure for operational visibility,
+    // not silently swallowed it.
+    expect(errSpy).toHaveBeenCalled();
+
+    errSpy.mockRestore();
+  });
+
+  // ── PDF-side: error.message reaches renderer already sanitized ───────
+
+  it("passes already-sanitized error.message to the PDF renderer", async () => {
+    mockOrderBy.mockResolvedValue([
+      {
+        id: 1,
+        timestamp: new Date("2026-03-01T10:00:00Z"),
+        actorType: "agent",
+        actorId: "agent-1",
+        eventType: "tool.web_fetch",
+        resource: "agent:agent-1",
+        detail: null,
+        rowHmac: "h",
+        version: 2,
+        outcome: "failure",
+        error: {
+          message: "Failed POST https://api.example.com with token sk-ant-abcdefghij1234567890XYZ",
+        },
+        actorName: null,
+        actorBanned: null,
+        resourceAgentName: null,
+        resourceAgentDeleted: null,
+        resourceUserName: null,
+        resourceUserBanned: null,
+      },
+    ]);
+
+    const { GET } = await import("@/app/api/audit/export/route");
+    await GET(
+      new Request("http://localhost/api/audit/export?format=pdf") as unknown as Parameters<
+        typeof import("@/app/api/audit/export/route").GET
+      >[0]
+    );
+
+    expect(renderAuditPdf).toHaveBeenCalledTimes(1);
+    const passedRows = vi.mocked(renderAuditPdf).mock.calls[0][0];
+    expect(passedRows[0].error?.message).not.toContain("sk-ant-abcdefghij1234567890XYZ");
+    expect(passedRows[0].error?.message).toContain("[REDACTED]");
+  });
+
+  // ── Empty-string status param is treated as no filter ────────────────
+
+  it("treats empty ?status= as no filter (returns 200, not 400)", async () => {
+    mockOrderBy.mockResolvedValue([]);
+    const { GET } = await import("@/app/api/audit/export/route");
+    const response = await GET(
+      new Request("http://localhost/api/audit/export?status=") as unknown as Parameters<
+        typeof import("@/app/api/audit/export/route").GET
+      >[0]
+    );
+    expect(response.status).toBe(200);
   });
 
   it("does not log audit.exported when format is invalid (400 path)", async () => {

--- a/packages/web/src/app/api/audit/export/route.ts
+++ b/packages/web/src/app/api/audit/export/route.ts
@@ -12,6 +12,15 @@ function csvField(value: string): string {
   return `"${value.replace(/"/g, '""')}"`;
 }
 
+function isErrorObject(value: unknown): value is { message: string } {
+  return (
+    typeof value === "object" &&
+    value !== null &&
+    "message" in value &&
+    typeof (value as { message: unknown }).message === "string"
+  );
+}
+
 function exportTimestamp(now: Date): string {
   const yyyy = now.getUTCFullYear();
   const mm = String(now.getUTCMonth() + 1).padStart(2, "0");
@@ -35,7 +44,11 @@ export async function GET(request: NextRequest) {
     );
   }
 
-  const status = url.searchParams.get("status");
+  // Treat empty-string `status=` the same as an absent param — common
+  // when forms serialize unset selects as `?status=`. Strict-validate
+  // any other unknown value, mirroring the `format=` validation above.
+  const statusRaw = url.searchParams.get("status");
+  const status = statusRaw === "" ? null : statusRaw;
   if (status !== null && status !== "success" && status !== "failure") {
     return NextResponse.json(
       { error: `Unsupported status '${status}'. Use 'success' or 'failure'.` },
@@ -109,8 +122,11 @@ export async function GET(request: NextRequest) {
     version: e.version,
     outcome: e.outcome === "success" || e.outcome === "failure" ? e.outcome : null,
     // sanitizeDetail walks the object: it leaves the `message` key intact
-    // but redacts known secret patterns inside the string itself.
-    error: e.error ? sanitizeDetail(e.error as { message: string }) : null,
+    // but redacts known secret patterns inside the string itself. The
+    // type guard is defense-in-depth — every row schema-validated to
+    // {message: string} | null today, but a future migration or manual
+    // backfill could violate that without TypeScript catching it.
+    error: isErrorObject(e.error) ? sanitizeDetail(e.error) : null,
     rowHmac: e.rowHmac,
   }));
 
@@ -165,7 +181,12 @@ export async function GET(request: NextRequest) {
   }
 
   // Audit the export itself (compliance requirement: who exported what, when).
-  // Wrapped in try/catch so audit-log infrastructure failures don't break exports.
+  // Wrapped in try/catch so audit-log infrastructure failures don't break
+  // exports — but logged loudly so a sustained outage of the audit-log
+  // path is operationally visible. Sequential await (not fire-and-forget)
+  // is intentional: an admin who clicks "Export" then immediately queries
+  // the audit log expects to see their own entry, and the latency cost
+  // of one INSERT is negligible compared to the export itself.
   try {
     await appendAuditLog({
       actorType: "user",
@@ -175,8 +196,8 @@ export async function GET(request: NextRequest) {
       outcome: "success",
       detail: { format, filterSummary, rowCount: rows.length },
     });
-  } catch {
-    // Fire-and-forget: the export succeeded, audit logging is best-effort.
+  } catch (err) {
+    console.error("[audit-export] failed to log audit.exported event", err);
   }
 
   return response;


### PR DESCRIPTION
## What does this PR do?

Round-2 follow-up to #222/#223. Self-review of the merged changes turned up a handful of operational and DX gaps. Each is small but worth fixing before they go cold.

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests

## What changed

### Operational visibility

- **Audit-log failures are now logged**, not silently swallowed. The whole point of the try/catch around \`appendAuditLog\` is \"don't break exports if audit-log infra fails\" — but a sustained outage of the audit-log path needs to be visible. Now: \`console.error(\"[audit-export] failed to log audit.exported event\", err)\`.

### DX / correctness

- **Empty-string \`?status=\` is now treated as no filter** (returns 200). Forms commonly serialize unset selects as \`?status=\` — strict-validating that case made callers' lives harder for no real gain. Unknown non-empty values still 400.
- **\`e.error as { message: string }\`** unchecked assertion replaced with an \`isErrorObject()\` type guard. The schema guarantees the shape today; defense in depth catches the case where a manual backfill or future migration violates it.
- **Comment explains the sequential \`await\` choice** on \`appendAuditLog\` — admin-immediately-queries-audit-log consistency, not fire-and-forget.

### Test coverage tightening

- \`appendAuditLog\` call assertions now use \`toHaveBeenCalledTimes(1)\` so a regression that fires the event twice (or zero times via an early-return) is caught immediately.
- New test: **export still returns 200 + valid CSV when \`appendAuditLog\` rejects**. Locks in the contract that motivated the try/catch in the first place.
- New test: **PDF renderer receives already-sanitized \`error.message\`**. Mocks \`renderAuditPdf\`, inspects the rows passed in, asserts the secret is replaced with \`[REDACTED]\` before reaching the renderer. Locks in the single-sanitization-point design — if someone later splits sanitization per-format and drops it from the PDF path, this fails.
- Removed two \`void\`-suppressed locals from the all-fields-quoted test; the parser-based assertion below them is the actual check.

## Verification

- 3410 tests pass (3 new since round 1).
- Lint: 0 errors.
- Build: clean.

## Reviewer notes

Single fix commit on top of current main. No production behavior change beyond:
- Empty \`?status=\` no longer 400.
- Audit-log failures now produce a console.error line.