### PR TITLE
fix(audit): stop swallowing audit-log failures via .catch(console.error) (#231)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -132,6 +132,10 @@ pinchy/
 ### Audit Trail Guidelines
 Every admin action that changes state MUST be logged via `appendAuditLog()`. The `detail` JSON field must follow these rules:
 
+- **Never fire-and-forget.** `appendAuditLog(...).catch(console.error)` is forbidden by ESLint (`pinchy/require-audit-log` rule, see #231) — silently swallowed audit failures break the compliance contract. Pick one of three patterns:
+  - `await appendAuditLog(...)` — preferred for **idempotent** state changes (PUT/PATCH/DELETE on existing resources). If the audit write fails, the route returns 500 and the client retries — same end state.
+  - `deferAuditLog(...)` from `@/lib/audit-deferred` — for **non-rollbackable** side effects that already happened (POST creating a row, OAuth tokens persisted, schema synced). Wraps `after()` so the audit runs after the response. Failures increment a process-wide counter and emit a structured `event: "audit_log_write_failed"` JSON line. Request scope only — throws outside route handlers.
+  - `try { await appendAuditLog(...) } catch (err) { recordAuditFailure(err, entry) }` — for **WebSocket / cron / non-request contexts** where `after()` isn't available. Same structured failure signal as `deferAuditLog`, but synchronous and never throws.
 - **Every `appendAuditLog` call must specify `outcome: 'success' | 'failure'`.** TypeScript enforces this at the call site. For events that by construction represent a completed action (`*.created`, `*.updated`, `*.deleted`, `auth.login`, `auth.logout`, `config.changed`, etc.), pass `outcome: 'success'`. For intrinsic-failure events like `auth.failed` and `tool.denied`, pass `outcome: 'failure'` and an `error: { message }` object describing why.
 - **Snapshot human-readable names alongside IDs.** IDs alone are useless after an entity is deleted. Always include `{ id, name }` pairs for referenced entities (groups, users, agents).
 - **Log what changed, not just that something changed.** Bad: `{ changes: ["visibility"] }`. Good: `{ changes: { visibility: { from: "all", to: "restricted" }, allowedGroups: { added: [{ id, name }], removed: [{ id, name }] } } }`.
@@ -156,13 +160,14 @@ Example patterns:
 
 ### Checklist for API Routes with State Changes
 When creating or modifying any POST/PUT/PATCH/DELETE endpoint:
-1. `appendAuditLog()` call present? If not needed: add `// audit-exempt: <reason>` comment
-2. Event type uses a valid `AuditResource` prefix (agent, group, user, settings, config)?
-3. Detail payload uses the correct base type (`UpdateDetail` for `*.updated`, `DeleteDetail` for `*.deleted`, `MembershipDetail` for `*.members_updated`)?
-4. All referenced entities snapshotted as `{ id, name }` pairs (`EntityRef`)?
-5. Test exists that verifies the `appendAuditLog` call with correct payload?
-6. `outcome` field set correctly? `'success'` for the happy path (default), `'failure'` for error paths that still deserve an audit entry?
-7. No plaintext email or other PII in `detail`? If you need to identify an email, use `redactEmail()` from `@/lib/audit`. If the resource already encodes the userId, log the display name only.
+1. `appendAuditLog()` or `deferAuditLog()` call present? If not needed: add `// audit-exempt: <reason>` comment
+2. Pattern matches the action shape — `await appendAuditLog` for idempotent ops, `deferAuditLog` for non-rollbackable side effects? (See "Never fire-and-forget" above.)
+3. Event type uses a valid `AuditResource` prefix (agent, group, user, settings, config)?
+4. Detail payload uses the correct base type (`UpdateDetail` for `*.updated`, `DeleteDetail` for `*.deleted`, `MembershipDetail` for `*.members_updated`)?
+5. All referenced entities snapshotted as `{ id, name }` pairs (`EntityRef`)?
+6. Test exists that verifies the `appendAuditLog` call with correct payload?
+7. `outcome` field set correctly? `'success'` for the happy path (default), `'failure'` for error paths that still deserve an audit entry?
+8. No plaintext email or other PII in `detail`? If you need to identify an email, use `redactEmail()` from `@/lib/audit`. If the resource already encodes the userId, log the display name only.
 
 ### Error & Notification Display Policy
 User feedback (errors, success confirmations) must use the correct display pattern. Using the wrong one creates inconsistent UX.

--- a/packages/web/eslint-rules/require-audit-log.js
+++ b/packages/web/eslint-rules/require-audit-log.js
@@ -4,19 +4,43 @@ module.exports = {
     type: "problem",
     docs: {
       description:
-        "Require appendAuditLog() in API route mutation handlers (POST/PUT/PATCH/DELETE)",
+        "Require appendAuditLog() / deferAuditLog() in API route mutation handlers (POST/PUT/PATCH/DELETE) and forbid fire-and-forget .catch() on appendAuditLog",
     },
     messages: {
       missingAuditLog:
-        "Mutation handler '{{method}}' must call appendAuditLog(). If this endpoint doesn't need auditing, add a file-level comment: // audit-exempt: <reason>",
+        "Mutation handler '{{method}}' must call appendAuditLog() or deferAuditLog(). If this endpoint doesn't need auditing, add a file-level comment: // audit-exempt: <reason>",
       missingExemptReason: "audit-exempt comment must include a reason: // audit-exempt: <reason>",
+      noFireAndForgetAudit:
+        "Do not chain .catch() onto appendAuditLog(): silently swallowed audit failures break the audit-trail contract (see #231). Either `await appendAuditLog(...)` (fail-closed, returns 500) or wrap with `deferAuditLog(...)` from @/lib/audit-deferred (deferred + structured failure signal).",
     },
     schema: [],
   },
   create(context) {
     const filename = context.filename || context.getFilename();
-    if (!filename.includes("/app/api/") || !filename.endsWith("route.ts")) {
-      return {};
+    const isRouteFile = filename.includes("/app/api/") && filename.endsWith("route.ts");
+
+    // The .catch() ban applies to every file, not just route handlers — the
+    // pattern is wrong everywhere it appears, and the fix is the same.
+    const fireAndForgetVisitors = {
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "catch" &&
+          node.callee.object.type === "CallExpression" &&
+          node.callee.object.callee.type === "Identifier" &&
+          node.callee.object.callee.name === "appendAuditLog"
+        ) {
+          context.report({
+            node,
+            messageId: "noFireAndForgetAudit",
+          });
+        }
+      },
+    };
+
+    if (!isRouteFile) {
+      return fireAndForgetVisitors;
     }
 
     const sourceCode = context.sourceCode || context.getSourceCode();
@@ -31,12 +55,13 @@ module.exports = {
           messageId: "missingExemptReason",
         });
       }
-      return {};
+      return fireAndForgetVisitors;
     }
 
     const MUTATION_METHODS = ["POST", "PUT", "PATCH", "DELETE"];
 
     return {
+      ...fireAndForgetVisitors,
       ExportNamedDeclaration(node) {
         const decl = node.declaration;
         if (!decl) return;
@@ -60,11 +85,15 @@ module.exports = {
       },
     };
 
+    function bodyMentionsAudit(text) {
+      return text.includes("appendAuditLog") || text.includes("deferAuditLog");
+    }
+
     function checkFunctionBody(ctx, body, methodName) {
       if (!body) return;
       const source = ctx.sourceCode || ctx.getSourceCode();
       const text = source.getText(body);
-      if (!text.includes("appendAuditLog")) {
+      if (!bodyMentionsAudit(text)) {
         ctx.report({
           node: body,
           messageId: "missingAuditLog",
@@ -77,7 +106,7 @@ module.exports = {
       if (!init) return;
       const source = ctx.sourceCode || ctx.getSourceCode();
       const text = source.getText(init);
-      if (!text.includes("appendAuditLog")) {
+      if (!bodyMentionsAudit(text)) {
         ctx.report({
           node: init,
           messageId: "missingAuditLog",

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -35,7 +35,8 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
-  // Pinchy custom rules — broad scope.
+  // Pinchy custom rules — broad scope (PII detection wherever appendAuditLog
+  // is called):
   // - no-pii-in-audit-detail: forbid plaintext `email:` / `emailAddress:`
   //   keys inside appendAuditLog(...) detail (GDPR Art. 17 — see #238).
   //   Applies to API routes, lib/, and server/ because appendAuditLog is
@@ -47,17 +48,30 @@ const eslintConfig = defineConfig([
       "pinchy/no-pii-in-audit-detail": "error",
     },
   },
+  // Pinchy custom rules — repo-wide (the fire-and-forget ban must reach
+  // every source file, not just route handlers):
+  // - require-audit-log: every state-changing route handler must call
+  //   appendAuditLog or deferAuditLog (or set a // audit-exempt: <reason>
+  //   file comment). Also forbids fire-and-forget `.catch()` chained
+  //   directly onto appendAuditLog calls in any source file (see #231).
+  //   The route-handler check is gated by file path inside the rule itself;
+  //   the fire-and-forget check applies to every source file.
+  {
+    files: ["src/**/*.{ts,tsx}"],
+    plugins: { pinchy: pinchyPlugin },
+    rules: {
+      "pinchy/require-audit-log": "error",
+    },
+  },
   // Pinchy custom rules — API route handlers only:
-  // - require-audit-log: every state-changing handler must call appendAuditLog
-  //   (or set a // audit-exempt: <reason> file comment)
   // - no-direct-session: every protected route must use the centralized
   //   helpers in @/lib/api-auth (withAuth / withAdmin / requireAdmin) instead
   //   of calling getSession or auth.api.getSession directly
   //   (opt out with a // auth-direct: <reason> file comment)
   {
     files: ["src/app/api/**/route.ts"],
+    plugins: { pinchy: pinchyPlugin },
     rules: {
-      "pinchy/require-audit-log": "error",
       "pinchy/no-direct-session": "error",
     },
   },

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -175,7 +175,6 @@ import {
   writeIdentityFile,
 } from "@/lib/workspace";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
-import { appendAuditLog } from "@/lib/audit";
 
 describe("POST /api/agents", () => {
   beforeEach(() => {

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -429,6 +429,43 @@ describe("POST /api/integrations", () => {
       })
     );
   });
+
+  it("still returns 201 and emits a structured failure signal when the deferred audit write fails (#231)", async () => {
+    const { POST } = await import("@/app/api/integrations/route");
+    const { getAuditWriteFailedCount, resetAuditWriteFailedCount } =
+      await import("@/lib/audit-deferred");
+    resetAuditWriteFailedCount();
+    const consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    mockAppendAuditLog.mockRejectedValueOnce(new Error("DB unreachable"));
+
+    const request = makeRequest("/api/integrations", {
+      method: "POST",
+      body: JSON.stringify({
+        type: "odoo",
+        name: "Prod Odoo",
+        credentials: validCredentials,
+      }),
+    });
+    const response = await POST(request);
+    // Flush the deferred after() callback's microtasks.
+    await new Promise((r) => setImmediate(r));
+
+    // The connection was created; audit failure must NOT roll that back.
+    expect(response.status).toBe(201);
+    // The structured failure signal must fire so alerts can hook into it.
+    expect(getAuditWriteFailedCount()).toBe(1);
+    const structured = consoleErrorSpy.mock.calls.find((call) => {
+      try {
+        return JSON.parse(call[0] as string).event === "audit_log_write_failed";
+      } catch {
+        return false;
+      }
+    });
+    expect(structured).toBeDefined();
+
+    consoleErrorSpy.mockRestore();
+    resetAuditWriteFailedCount();
+  });
 });
 
 describe("GET /api/integrations/[connectionId]", () => {

--- a/packages/web/src/__tests__/eslint/require-audit-log.test.ts
+++ b/packages/web/src/__tests__/eslint/require-audit-log.test.ts
@@ -30,6 +30,14 @@ tester.run("require-audit-log", rule, {
       code: `export const POST = async (req) => { appendAuditLog({ eventType: "test" }); }`,
       filename: "/app/api/groups/route.ts",
     },
+    {
+      code: `export async function POST(req) { await appendAuditLog({ eventType: "test" }); }`,
+      filename: "/app/api/groups/route.ts",
+    },
+    {
+      code: `export async function POST(req) { deferAuditLog({ eventType: "test" }); }`,
+      filename: "/app/api/groups/route.ts",
+    },
   ],
   invalid: [
     {
@@ -61,6 +69,21 @@ tester.run("require-audit-log", rule, {
       code: `export async function PATCH(req) { return "ok"; }`,
       filename: "/app/api/users/route.ts",
       errors: [{ messageId: "missingAuditLog" }],
+    },
+    {
+      code: `export async function POST(req) { appendAuditLog({ eventType: "test" }).catch(console.error); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "noFireAndForgetAudit" }],
+    },
+    {
+      code: `export async function DELETE(req) { appendAuditLog({ eventType: "test" }).catch(() => {}); }`,
+      filename: "/app/api/groups/[id]/route.ts",
+      errors: [{ messageId: "noFireAndForgetAudit" }],
+    },
+    {
+      code: `export const PATCH = async (req) => { appendAuditLog({ eventType: "test" }).catch(console.error); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "noFireAndForgetAudit" }],
     },
   ],
 });

--- a/packages/web/src/__tests__/lib/audit-deferred.test.ts
+++ b/packages/web/src/__tests__/lib/audit-deferred.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+const mockAppendAuditLog = vi.fn();
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
+}));
+
+import {
+  deferAuditLog,
+  recordAuditFailure,
+  getAuditWriteFailedCount,
+  resetAuditWriteFailedCount,
+} from "@/lib/audit-deferred";
+
+const validEntry = {
+  actorType: "user" as const,
+  actorId: "user-1",
+  eventType: "config.changed" as const,
+  resource: "integration:abc",
+  detail: { action: "integration_created", type: "odoo", name: "Test" },
+  outcome: "success" as const,
+};
+
+describe("deferAuditLog", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    mockAppendAuditLog.mockReset();
+    resetAuditWriteFailedCount();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("invokes appendAuditLog with the entry", async () => {
+    mockAppendAuditLog.mockResolvedValue(undefined);
+    deferAuditLog(validEntry);
+    // The test-setup `after()` mock runs callbacks synchronously, but the
+    // inner appendAuditLog is async — flush microtasks.
+    await new Promise((r) => setImmediate(r));
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(validEntry);
+  });
+
+  it("does not increment failure counter on success", async () => {
+    mockAppendAuditLog.mockResolvedValue(undefined);
+    deferAuditLog(validEntry);
+    await new Promise((r) => setImmediate(r));
+    expect(getAuditWriteFailedCount()).toBe(0);
+  });
+
+  it("increments failure counter when appendAuditLog rejects", async () => {
+    mockAppendAuditLog.mockRejectedValue(new Error("DB unreachable"));
+    deferAuditLog(validEntry);
+    await new Promise((r) => setImmediate(r));
+    expect(getAuditWriteFailedCount()).toBe(1);
+  });
+
+  it("emits a structured JSON log line on failure (not a plain console.error message)", async () => {
+    mockAppendAuditLog.mockRejectedValue(new Error("DB unreachable"));
+    deferAuditLog(validEntry);
+    await new Promise((r) => setImmediate(r));
+
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const arg = consoleErrorSpy.mock.calls[0][0];
+    expect(typeof arg).toBe("string");
+    const parsed = JSON.parse(arg as string);
+    expect(parsed).toMatchObject({
+      level: "error",
+      event: "audit_log_write_failed",
+      eventType: "config.changed",
+      actorId: "user-1",
+      resource: "integration:abc",
+      outcome: "success",
+      error: { message: "DB unreachable" },
+    });
+  });
+
+  it("does not throw when appendAuditLog rejects (failure stays inside after())", async () => {
+    mockAppendAuditLog.mockRejectedValue(new Error("DB unreachable"));
+    expect(() => deferAuditLog(validEntry)).not.toThrow();
+    await new Promise((r) => setImmediate(r));
+  });
+
+  it("counts multiple failures cumulatively", async () => {
+    mockAppendAuditLog.mockRejectedValue(new Error("boom"));
+    deferAuditLog(validEntry);
+    deferAuditLog(validEntry);
+    deferAuditLog(validEntry);
+    await new Promise((r) => setImmediate(r));
+    expect(getAuditWriteFailedCount()).toBe(3);
+  });
+
+  it("resetAuditWriteFailedCount clears the counter", async () => {
+    mockAppendAuditLog.mockRejectedValue(new Error("boom"));
+    deferAuditLog(validEntry);
+    await new Promise((r) => setImmediate(r));
+    expect(getAuditWriteFailedCount()).toBe(1);
+    resetAuditWriteFailedCount();
+    expect(getAuditWriteFailedCount()).toBe(0);
+  });
+});
+
+describe("recordAuditFailure", () => {
+  let consoleErrorSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    resetAuditWriteFailedCount();
+    consoleErrorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    consoleErrorSpy.mockRestore();
+  });
+
+  it("increments the failure counter", () => {
+    recordAuditFailure(new Error("boom"), validEntry);
+    expect(getAuditWriteFailedCount()).toBe(1);
+  });
+
+  it("emits a structured JSON log line", () => {
+    recordAuditFailure(new Error("DB unreachable"), validEntry);
+    expect(consoleErrorSpy).toHaveBeenCalledTimes(1);
+    const parsed = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+    expect(parsed).toMatchObject({
+      level: "error",
+      event: "audit_log_write_failed",
+      eventType: "config.changed",
+      actorType: "user",
+      actorId: "user-1",
+      resource: "integration:abc",
+      outcome: "success",
+      error: { message: "DB unreachable" },
+    });
+  });
+
+  it("stringifies non-Error throws", () => {
+    recordAuditFailure("string error", validEntry);
+    const parsed = JSON.parse(consoleErrorSpy.mock.calls[0][0] as string);
+    expect(parsed.error.message).toBe("string error");
+  });
+
+  it("does not throw", () => {
+    expect(() => recordAuditFailure(new Error("boom"), validEntry)).not.toThrow();
+  });
+});

--- a/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -155,7 +155,7 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
       .filter((p) => !newSet.has(`${p.model}:${p.operation}`))
       .map((p) => ({ model: p.model, operation: p.operation }));
 
-    appendAuditLog({
+    await appendAuditLog({
       actorType: "user",
       actorId: session.user.id!,
       eventType: "config.changed",
@@ -167,7 +167,7 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
         changes: { added, removed },
       },
       outcome: "success",
-    }).catch(console.error);
+    });
 
     return NextResponse.json({ success: true });
   } catch (err) {
@@ -201,7 +201,7 @@ export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) 
   // Audit log
   const removed = existingPerms.map((p) => ({ model: p.model, operation: p.operation }));
 
-  appendAuditLog({
+  await appendAuditLog({
     actorType: "user",
     actorId: session.user.id!,
     eventType: "config.changed",
@@ -212,7 +212,7 @@ export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) 
       removed,
     },
     outcome: "success",
-  }).catch(console.error);
+  });
 
   return NextResponse.json({ success: true });
 });

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -23,6 +23,7 @@ import { type ProviderName } from "@/lib/providers";
 import { getDefaultModel } from "@/lib/provider-models";
 import { resolveModelForTemplate, TemplateCapabilityUnavailableError } from "@/lib/model-resolver";
 import { appendAuditLog } from "@/lib/audit";
+import { deferAuditLog } from "@/lib/audit-deferred";
 import { getVisibleAgents } from "@/lib/visible-agents";
 import { validateOdooTemplate } from "@/lib/integrations/odoo-template-validation";
 import { detectEmailOperations } from "@/lib/tool-registry";
@@ -208,7 +209,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
 
         await db.insert(agentConnectionPermissions).values(permissionRows);
 
-        appendAuditLog({
+        deferAuditLog({
           actorType: "user",
           actorId: session.user.id!,
           eventType: "config.changed",
@@ -220,7 +221,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
             permissions: permissionRows.map((p) => ({ model: p.model, operation: p.operation })),
           },
           outcome: "success",
-        }).catch(console.error);
+        });
       }
     }
   }
@@ -239,7 +240,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
 
       await db.insert(agentConnectionPermissions).values(permissionRows);
 
-      appendAuditLog({
+      deferAuditLog({
         actorType: "user",
         actorId: session.user.id!,
         eventType: "config.changed",
@@ -251,7 +252,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
           permissions: permissionRows.map((p) => ({ model: p.model, operation: p.operation })),
         },
         outcome: "success",
-      }).catch(console.error);
+      });
     }
   }
 

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -118,14 +118,14 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
     .returning();
 
   if (Object.keys(changes).length > 0) {
-    appendAuditLog({
+    await appendAuditLog({
       actorType: "user",
       actorId: session.user.id!,
       eventType: "config.changed",
       resource: `integration:${connectionId}`,
       detail: { action: "integration_updated", id: connectionId, changes },
       outcome: "success",
-    }).catch(console.error);
+    });
   }
 
   return NextResponse.json({
@@ -160,14 +160,14 @@ export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) 
     }
   }
 
-  appendAuditLog({
+  await appendAuditLog({
     actorType: "user",
     actorId: session.user.id!,
     eventType: "config.changed",
     resource: `integration:${connectionId}`,
     detail: { action: "integration_deleted", type: existing.type, name: existing.name },
     outcome: "success",
-  }).catch(console.error);
+  });
 
   return NextResponse.json({ success: true });
 });

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -5,7 +5,7 @@ import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { decrypt } from "@/lib/encryption";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
-import { appendAuditLog } from "@/lib/audit";
+import { deferAuditLog } from "@/lib/audit-deferred";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 
@@ -48,7 +48,7 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
       .set({ data: result.data, updatedAt: new Date() })
       .where(eq(integrationConnections.id, connectionId));
 
-    appendAuditLog({
+    deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
       eventType: "config.changed",
@@ -60,7 +60,7 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
         modelCount: result.models,
       },
       outcome: "success",
-    }).catch(console.error);
+    });
 
     return NextResponse.json({
       success: true,

--- a/packages/web/src/app/api/integrations/oauth/callback/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/callback/route.ts
@@ -9,7 +9,8 @@ import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
 import { encrypt } from "@/lib/encryption";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
-import { appendAuditLog, redactEmail } from "@/lib/audit";
+import { redactEmail } from "@/lib/audit";
+import { deferAuditLog } from "@/lib/audit-deferred";
 import { eq, and } from "drizzle-orm";
 
 function errorRedirect(origin: string, error: string) {
@@ -78,7 +79,7 @@ export async function GET(request: Request) {
   });
 
   if (!tokenResponse.ok) {
-    appendAuditLog({
+    deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
       eventType: "config.changed",
@@ -89,7 +90,7 @@ export async function GET(request: Request) {
         error: { message: "token_exchange_failed" },
       },
       outcome: "failure",
-    }).catch(console.error);
+    });
     return errorRedirect(origin, "token_exchange_failed");
   }
 
@@ -102,7 +103,7 @@ export async function GET(request: Request) {
   });
 
   if (!profileResponse.ok) {
-    appendAuditLog({
+    deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
       eventType: "config.changed",
@@ -113,7 +114,7 @@ export async function GET(request: Request) {
         error: { message: "profile_fetch_failed" },
       },
       outcome: "failure",
-    }).catch(console.error);
+    });
     return errorRedirect(origin, "profile_fetch_failed");
   }
 
@@ -190,7 +191,7 @@ export async function GET(request: Request) {
   // keyed hash + masked preview; the connectionId in `resource` is enough
   // to look up the live mailbox name from the integrations table while it
   // exists.
-  appendAuditLog({
+  deferAuditLog({
     actorType: "user",
     actorId: session.user.id!,
     eventType: "config.changed",
@@ -201,7 +202,7 @@ export async function GET(request: Request) {
       ...redactEmail(emailAddress),
     },
     outcome: "success",
-  }).catch(console.error);
+  });
 
   // 10. Clean up cookies and redirect
   const successUrl = new URL("/settings", origin);

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -5,7 +5,7 @@ import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
-import { appendAuditLog } from "@/lib/audit";
+import { deferAuditLog } from "@/lib/audit-deferred";
 import { odooCredentialsSchema, odooConnectionDataSchema } from "@/lib/integrations/odoo-schema";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
@@ -111,14 +111,14 @@ export const POST = withAdmin(async (request, _ctx, session) => {
     })
     .returning();
 
-  appendAuditLog({
+  deferAuditLog({
     actorType: "user",
     actorId: session.user.id!,
     eventType: "config.changed",
     resource: `integration:${connection.id}`,
     detail: { action: "integration_created", type, name },
     outcome: "success",
-  }).catch(console.error);
+  });
 
   return NextResponse.json(
     {

--- a/packages/web/src/lib/audit-deferred.ts
+++ b/packages/web/src/lib/audit-deferred.ts
@@ -1,0 +1,73 @@
+import { after } from "next/server";
+import { appendAuditLog, type AuditLogEntry } from "@/lib/audit";
+
+// Process-wide counter for audit-log writes that failed inside a deferred
+// after() callback or via recordAuditFailure(). Exposed so health/metrics
+// endpoints (or alerts) can surface the gap — silent .catch(console.error)
+// is exactly what #231 forbids.
+//
+// Note: this is per-process state. Pinchy's Docker Compose deployment runs
+// a single Node process, so the counter is authoritative for the running
+// container. If we ever scale to multiple workers (Node cluster, multiple
+// containers), aggregation must happen in an external metric store.
+let writeFailedCount = 0;
+
+export function getAuditWriteFailedCount(): number {
+  return writeFailedCount;
+}
+
+export function resetAuditWriteFailedCount(): void {
+  writeFailedCount = 0;
+}
+
+/**
+ * Record an audit-log write failure as a structured signal.
+ *
+ * Increments the process-wide failure counter and emits a single JSON line
+ * to stderr with `event: "audit_log_write_failed"` so log shipping /
+ * alerting can hook into it. Use this anywhere an audit-log call must not
+ * throw upward (e.g. WebSocket message handlers where a chat retry should
+ * not fail just because the audit row didn't make it).
+ */
+export function recordAuditFailure(err: unknown, entry: AuditLogEntry): void {
+  writeFailedCount++;
+  const message = err instanceof Error ? err.message : String(err);
+  console.error(
+    JSON.stringify({
+      level: "error",
+      event: "audit_log_write_failed",
+      eventType: entry.eventType,
+      actorType: entry.actorType,
+      actorId: entry.actorId,
+      resource: entry.resource ?? null,
+      outcome: entry.outcome,
+      error: { message },
+    })
+  );
+}
+
+/**
+ * Schedule an audit-log write to run after the response is sent.
+ *
+ * REQUEST SCOPE ONLY. `after()` from `next/server` throws "called outside a
+ * request scope" when invoked from a WebSocket handler, cron job, or
+ * module-load code. Use `appendAuditLog()` directly + `recordAuditFailure()`
+ * in those contexts.
+ *
+ * Use only when the action's side effect cannot be rolled back if the audit
+ * write fails (OAuth token persisted, integration row already created, etc.).
+ * For idempotent state changes prefer `await appendAuditLog(...)` inside the
+ * handler so a failure surfaces as a 500.
+ *
+ * On failure: increments the failure counter and emits a structured JSON
+ * line via `recordAuditFailure()`. Never throws.
+ */
+export function deferAuditLog(entry: AuditLogEntry): void {
+  after(async () => {
+    try {
+      await appendAuditLog(entry);
+    } catch (err) {
+      recordAuditFailure(err, entry);
+    }
+  });
+}

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -4,6 +4,7 @@ import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { isEnterprise } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
 import { SessionCache } from "@/server/session-cache";
 import { getErrorHint } from "@/server/error-hints";
 import { db } from "@/db";
@@ -90,17 +91,20 @@ export class ClientRouter {
     try {
       assertAgentAccess(agent, this.userId, this.userRole, userGroupIds, agentGroupIds, enterprise);
     } catch {
-      appendAuditLog({
-        actorType: "user",
+      this.sendToClient(clientWs, { type: "error", message: "Access denied" });
+      const auditEntry = {
+        actorType: "user" as const,
         actorId: this.userId,
-        eventType: "tool.denied",
+        eventType: "tool.denied" as const,
         resource: `agent:${message.agentId}`,
         detail: { reason: "access_denied" },
-        outcome: "failure",
-      }).catch((err) => {
-        console.error("Failed to write audit log for tool.denied:", err);
-      });
-      this.sendToClient(clientWs, { type: "error", message: "Access denied" });
+        outcome: "failure" as const,
+      };
+      try {
+        await appendAuditLog(auditEntry);
+      } catch (err) {
+        recordAuditFailure(err, auditEntry);
+      }
       return;
     }
 
@@ -176,18 +180,26 @@ export class ClientRouter {
         const reason: RetryReason = ALLOWED_RETRY_REASONS.has(message.retryReason ?? "")
           ? (message.retryReason as RetryReason)
           : "send_failure";
-        appendAuditLog({
-          actorType: "user",
+        // Best-effort audit: a transient DB failure must not fail the chat
+        // retry the user explicitly asked for. recordAuditFailure() emits
+        // the structured signal so the gap stays observable.
+        const auditEntry = {
+          actorType: "user" as const,
           actorId: this.userId,
-          eventType: "chat.retry_triggered",
+          eventType: "chat.retry_triggered" as const,
           resource: `agent:${message.agentId}`,
           detail: {
             agent: { id: agent.id, name: agent.name },
             sessionKey,
             reason,
           },
-          outcome: "success",
-        }).catch((err) => console.error("Failed to write audit log:", err));
+          outcome: "success" as const,
+        };
+        try {
+          await appendAuditLog(auditEntry);
+        } catch (err) {
+          recordAuditFailure(err, auditEntry);
+        }
       }
 
       const stream = this.openclawClient.chat(text, chatOptions);


### PR DESCRIPTION
## Summary

Closes #231.

Audit-log writes were silently swallowed via `appendAuditLog(...).catch(console.error)` across **13 call sites** (11 from the issue + 2 additional in `server/client-router.ts` caught by the new lint rule). A failed audit row produced only a stderr line — no metric, no alert, no propagation — breaking the compliance-ready audit-trail contract.

## What changed

- **New helper `deferAuditLog()`** ([packages/web/src/lib/audit-deferred.ts](https://github.com/heypinchy/pinchy/blob/claude/gallant-fermi-742302/packages/web/src/lib/audit-deferred.ts)): wraps `appendAuditLog` in Next.js `after()`. On failure it increments a process-wide counter (`getAuditWriteFailedCount()`) and emits a structured `event: "audit_log_write_failed"` JSON line — log shipping / alerting can now hook into it.
- **11 issue-listed call sites migrated**:
  - `await appendAuditLog(...)` for idempotent state changes (fail-closed → 500): agent-integrations PUT/DELETE, integration PATCH/DELETE
  - `deferAuditLog(...)` for non-rollbackable side effects: integration POST, OAuth callback (3x), schema sync, agent-create permission auto-config (2x)
- **2 bonus sites** in `client-router.ts` (`tool.denied`, `chat.retry_triggered`) fixed — same anti-pattern, surfaced by the extended lint rule.
- **ESLint rule extended**: `pinchy/require-audit-log` now flags `appendAuditLog(...).catch(...)` repo-wide with a clear `noFireAndForgetAudit` violation, so the pattern cannot reappear.
- Pre-existing unused `appendAuditLog` import in `agents-create.test.ts` removed (cleanup).

## Test plan

- [x] `pnpm test` — 3411 passed, 12 skipped, 3 todo
- [x] `pnpm lint` — 0 errors
- [x] `pnpm exec tsc --noEmit` — clean
- [x] New `audit-deferred.test.ts` covers: invocation, success counter unchanged, failure counter increments, structured JSON log shape, no throw on failure, cumulative counts, counter reset
- [x] New ESLint cases cover: `await appendAuditLog`, `deferAuditLog`, and 3 invalid `.catch(...)` shapes