### PR TITLE
fix(audit): redact email addresses in audit detail (#238)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,6 +138,7 @@ Every admin action that changes state MUST be logged via `appendAuditLog()`. The
 - **Use added/removed diffs for membership changes.** Don't just log the final count — log who/what was added and removed with `{ id, name }` pairs.
 - **Include the resource name in the detail** for delete events (the resource itself won't be queryable after deletion).
 - **Keep detail under 2048 bytes** (larger payloads are auto-truncated with `_truncated: true`). For bulk operations with many items, summarize if needed.
+- **Never write plaintext email addresses (or other PII) into `detail`.** The audit log is HMAC-signed and append-only — once an email lands in detail, GDPR Art. 17 erasure conflicts with row integrity. For events that need to identify a recipient/login attempt, spread `redactEmail(email)` from `@/lib/audit` (gives an `emailHash` + masked `emailPreview`). For `user.deleted` and similar events where the userId is already in `resource`, log only the display name.
 
 Example patterns:
 ```jsonc
@@ -145,8 +146,8 @@ Example patterns:
 { "added": [{ "id": "u1", "name": "Max" }], "removed": [{ "id": "u2", "name": "Anna" }], "memberCount": 5 }
 // Agent visibility change
 { "changes": { "visibility": { "from": "all", "to": "restricted" }, "allowedGroups": { "added": [{ "id": "g1", "name": "Engineering" }] } } }
-// User invited with groups
-{ "email": "max@example.com", "role": "member", "groups": [{ "id": "g1", "name": "Engineering" }] }
+// User invited with groups (email redacted)
+{ "emailHash": "<hex64>", "emailPreview": "ma…ax@example.com", "role": "member", "groups": [{ "id": "g1", "name": "Engineering" }] }
 // Telegram channel configured for agent
 { "agent": { "id": "a1", "name": "Support Bot" }, "channel": "telegram", "botUsername": "support_pinchy_bot" }
 // Telegram channel removed from agent
@@ -161,6 +162,7 @@ When creating or modifying any POST/PUT/PATCH/DELETE endpoint:
 4. All referenced entities snapshotted as `{ id, name }` pairs (`EntityRef`)?
 5. Test exists that verifies the `appendAuditLog` call with correct payload?
 6. `outcome` field set correctly? `'success'` for the happy path (default), `'failure'` for error paths that still deserve an audit entry?
+7. No plaintext email or other PII in `detail`? If you need to identify an email, use `redactEmail()` from `@/lib/audit`. If the resource already encodes the userId, log the display name only.
 
 ### Error & Notification Display Policy
 User feedback (errors, success confirmations) must use the correct display pattern. Using the wrong one creates inconsistent UX.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -138,7 +138,7 @@ Every admin action that changes state MUST be logged via `appendAuditLog()`. The
 - **Use added/removed diffs for membership changes.** Don't just log the final count — log who/what was added and removed with `{ id, name }` pairs.
 - **Include the resource name in the detail** for delete events (the resource itself won't be queryable after deletion).
 - **Keep detail under 2048 bytes** (larger payloads are auto-truncated with `_truncated: true`). For bulk operations with many items, summarize if needed.
-- **Never write plaintext email addresses (or other PII) into `detail`.** The audit log is HMAC-signed and append-only — once an email lands in detail, GDPR Art. 17 erasure conflicts with row integrity. For events that need to identify a recipient/login attempt, spread `redactEmail(email)` from `@/lib/audit` (gives an `emailHash` + masked `emailPreview`). For `user.deleted` and similar events where the userId is already in `resource`, log only the display name.
+- **Never write plaintext email addresses (or other PII) into `detail`.** The audit log is HMAC-signed and append-only — once an email lands in detail, GDPR Art. 17 erasure conflicts with row integrity. For events that need to identify a recipient/login attempt, spread `redactEmail(email)` from `@/lib/audit` (gives an `emailHash` + masked `emailPreview`). For `user.deleted` and similar events where the userId is already in `resource`, log only the display name. The ESLint rule `pinchy/no-pii-in-audit-detail` flags `email:` / `emailAddress:` keys inside `appendAuditLog(...)` at lint time as a regression guard. For multi-instance deployments, the same `AUDIT_HMAC_SECRET` must be shared across instances or `emailHash` will diverge between them.
 
 Example patterns:
 ```jsonc

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -142,9 +142,13 @@ Email addresses are personal data under GDPR. Because the audit log is HMAC-sign
 Pinchy avoids this by **never recording plaintext email addresses in `detail`**. Instead, events that need to identify an inviter, login attempt, or invited recipient store two derived fields:
 
 - **`emailHash`** — keyed HMAC-SHA256 of the lowercased+trimmed email, using the same `audit_hmac_secret` that signs each row. An admin holding a known address can recompute the hash and match against the log; a leaked log on its own does not yield the addresses back.
-- **`emailPreview`** — short masked form, e.g. `cl…lm@devcraft.academy` (first 2 + last 2 characters of the local part, plus the full domain). Enough for a human auditor to recognise an address they already know, not enough for bulk re-identification.
+- **`emailPreview`** — short masked form, e.g. `cl…lm@devcraft.academy` (first 2 + last 2 characters of the local part, plus the full domain). Enough for a human auditor to recognise an address they already know, not enough for bulk re-identification. For very short local parts (≤4 characters), the preview equals the address — there is nothing useful to mask. The hash still provides one-way protection in that case.
 
 `user.deleted` events go further: they record only the user's display name. The `userId` is already in the `resource` field, and the audit log is not the right place to keep a deactivated user's contact details.
+
+#### Multi-instance deployments
+
+Hash determinism depends on every Pinchy instance using the **same** `audit_hmac_secret`. The default behaviour — auto-generate a secret file under `/app/secrets/.audit_hmac_secret` on first start — produces a different secret per instance. If you run more than one Pinchy instance against a shared Postgres (HA, blue/green, multiple replicas), set `AUDIT_HMAC_SECRET` explicitly via env var or mount the same secret file on every instance. Without this, the same email address will hash to different values on different instances, and an admin will not be able to look up its history from one place. The same prerequisite applies to row HMAC verification.
 
 ## How HMAC signing works
 

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -135,6 +135,17 @@ Sanitization runs at two layers:
 
 The redaction rules are built-in and require no configuration.
 
+### Email addresses (GDPR Art. 17)
+
+Email addresses are personal data under GDPR. Because the audit log is HMAC-signed and append-only, a raw email address written into a row would survive every right-to-erasure request — the row cannot be edited, and editing would invalidate its signature.
+
+Pinchy avoids this by **never recording plaintext email addresses in `detail`**. Instead, events that need to identify an inviter, login attempt, or invited recipient store two derived fields:
+
+- **`emailHash`** — keyed HMAC-SHA256 of the lowercased+trimmed email, using the same `audit_hmac_secret` that signs each row. An admin holding a known address can recompute the hash and match against the log; a leaked log on its own does not yield the addresses back.
+- **`emailPreview`** — short masked form, e.g. `cl…lm@devcraft.academy` (first 2 + last 2 characters of the local part, plus the full domain). Enough for a human auditor to recognise an address they already know, not enough for bulk re-identification.
+
+`user.deleted` events go further: they record only the user's display name. The `userId` is already in the `resource` field, and the audit log is not the right place to keep a deactivated user's contact details.
+
 ## How HMAC signing works
 
 Each audit log entry is signed with **HMAC-SHA256** to ensure integrity:

--- a/packages/web/eslint-rules/no-pii-in-audit-detail.js
+++ b/packages/web/eslint-rules/no-pii-in-audit-detail.js
@@ -1,0 +1,70 @@
+/**
+ * Forbid plaintext email keys (`email`, `emailAddress`) inside
+ * `appendAuditLog({ ..., detail: { ... } })`. The audit log is HMAC-signed
+ * and append-only — a raw email written into `detail` cannot be redacted
+ * later without breaking row integrity, which conflicts with GDPR Art. 17.
+ *
+ * Use `redactEmail(email)` from `@/lib/audit` instead — it returns
+ * `{ emailHash, emailPreview }` which are safe to log.
+ *
+ * Detection is purely structural and intentionally narrow:
+ * - We only look at the `detail` property of the first argument to
+ *   `appendAuditLog(...)`.
+ * - We flag a `Property` whose key is `email` or `emailAddress` (literal
+ *   identifier — not e.g. computed keys or `changes.email.from`).
+ * - Spread elements (`...redactEmail(email)`) are allowed.
+ */
+/** @type {import('eslint').Rule.RuleModule} */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid plaintext `email`/`emailAddress` keys in appendAuditLog detail (GDPR Art. 17 — use redactEmail() from @/lib/audit)",
+    },
+    messages: {
+      noPlaintextEmail:
+        "Do not write plaintext `{{key}}` into appendAuditLog `detail` — the row is HMAC-signed and cannot be redacted later (GDPR Art. 17). Use `...redactEmail(email)` from `@/lib/audit` instead.",
+    },
+    schema: [],
+  },
+  create(context) {
+    const FORBIDDEN_KEYS = new Set(["email", "emailAddress"]);
+
+    return {
+      CallExpression(node) {
+        if (node.callee.type !== "Identifier" || node.callee.name !== "appendAuditLog") {
+          return;
+        }
+        const arg = node.arguments[0];
+        if (!arg || arg.type !== "ObjectExpression") return;
+
+        const detailProp = arg.properties.find(
+          (p) =>
+            p.type === "Property" &&
+            !p.computed &&
+            ((p.key.type === "Identifier" && p.key.name === "detail") ||
+              (p.key.type === "Literal" && p.key.value === "detail"))
+        );
+        if (!detailProp || detailProp.value.type !== "ObjectExpression") return;
+
+        for (const prop of detailProp.value.properties) {
+          if (prop.type !== "Property" || prop.computed) continue;
+          const keyName =
+            prop.key.type === "Identifier"
+              ? prop.key.name
+              : prop.key.type === "Literal"
+                ? prop.key.value
+                : null;
+          if (typeof keyName === "string" && FORBIDDEN_KEYS.has(keyName)) {
+            context.report({
+              node: prop,
+              messageId: "noPlaintextEmail",
+              data: { key: keyName },
+            });
+          }
+        }
+      },
+    };
+  },
+};

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -4,6 +4,15 @@ import nextTs from "eslint-config-next/typescript";
 import security from "eslint-plugin-security";
 import requireAuditLog from "./eslint-rules/require-audit-log.js";
 import noDirectSession from "./eslint-rules/no-direct-session.js";
+import noPiiInAuditDetail from "./eslint-rules/no-pii-in-audit-detail.js";
+
+const pinchyPlugin = {
+  rules: {
+    "require-audit-log": requireAuditLog,
+    "no-direct-session": noDirectSession,
+    "no-pii-in-audit-detail": noPiiInAuditDetail,
+  },
+};
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -26,7 +35,19 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
-  // Pinchy custom rules for API route handlers:
+  // Pinchy custom rules — broad scope.
+  // - no-pii-in-audit-detail: forbid plaintext `email:` / `emailAddress:`
+  //   keys inside appendAuditLog(...) detail (GDPR Art. 17 — see #238).
+  //   Applies to API routes, lib/, and server/ because appendAuditLog is
+  //   also called from helpers (e.g. lib/auth.ts, server/client-router.ts).
+  {
+    files: ["src/app/api/**/route.ts", "src/lib/**/*.ts", "src/server/**/*.ts"],
+    plugins: { pinchy: pinchyPlugin },
+    rules: {
+      "pinchy/no-pii-in-audit-detail": "error",
+    },
+  },
+  // Pinchy custom rules — API route handlers only:
   // - require-audit-log: every state-changing handler must call appendAuditLog
   //   (or set a // audit-exempt: <reason> file comment)
   // - no-direct-session: every protected route must use the centralized
@@ -35,14 +56,6 @@ const eslintConfig = defineConfig([
   //   (opt out with a // auth-direct: <reason> file comment)
   {
     files: ["src/app/api/**/route.ts"],
-    plugins: {
-      pinchy: {
-        rules: {
-          "require-audit-log": requireAuditLog,
-          "no-direct-session": noDirectSession,
-        },
-      },
-    },
     rules: {
       "pinchy/require-audit-log": "error",
       "pinchy/no-direct-session": "error",

--- a/packages/web/src/__tests__/api/invites.test.ts
+++ b/packages/web/src/__tests__/api/invites.test.ts
@@ -23,9 +23,13 @@ vi.mock("@/lib/invites", () => ({
   createInvite: vi.fn(),
 }));
 
-vi.mock("@/lib/audit", () => ({
-  appendAuditLog: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 // Default to inactive license so existing tests are unaffected by seat-cap logic
 vi.mock("@/lib/enterprise", () => ({
@@ -79,6 +83,7 @@ describe("POST /api/users/invite", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
     const mod = await import("@/app/api/users/invite/route");
     POST = mod.POST;
   });
@@ -303,7 +308,8 @@ describe("POST /api/users/invite", () => {
       eventType: "user.invited",
       outcome: "success",
       detail: {
-        email: "grouped@test.com",
+        emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        emailPreview: "gr…ed@test.com",
         role: "member",
         groups: [
           { id: "group-1", name: "Engineering" },
@@ -347,7 +353,8 @@ describe("POST /api/users/invite", () => {
       eventType: "user.invited",
       outcome: "success",
       detail: {
-        email: "solo@test.com",
+        emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        emailPreview: "solo@test.com",
         role: "member",
       },
     });

--- a/packages/web/src/__tests__/api/oauth-callback.test.ts
+++ b/packages/web/src/__tests__/api/oauth-callback.test.ts
@@ -56,9 +56,13 @@ vi.mock("@/lib/encryption", () => ({
   getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
 }));
 
-vi.mock("@/lib/audit", () => ({
-  appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
-}));
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
+  };
+});
 
 const mockConnection = {
   id: "conn-new-123",
@@ -399,7 +403,8 @@ describe("GET /api/integrations/oauth/callback", () => {
       );
     });
 
-    it("calls appendAuditLog with correct payload", async () => {
+    it("calls appendAuditLog with redacted email (no plaintext PII per GDPR Art. 17)", async () => {
+      vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
       await GET(
         makeRequest({ code: "auth-code-123", state: VALID_STATE }, `oauth_state=${VALID_STATE}`)
       );
@@ -412,11 +417,19 @@ describe("GET /api/integrations/oauth/callback", () => {
         detail: {
           action: "integration_created",
           type: "google",
-          name: "user@gmail.com",
-          emailAddress: "user@gmail.com",
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "user@gmail.com",
         },
         outcome: "success",
       });
+
+      // The fields that previously carried plaintext PII must not exist.
+      // Note: for short local parts (≤4 chars) the emailPreview legitimately
+      // equals the raw address per redactEmail's spec — the hash still
+      // provides one-way protection. See docs/concepts/audit-trail.mdx.
+      const detail = mockAppendAuditLog.mock.calls[0][0].detail;
+      expect(detail).not.toHaveProperty("emailAddress");
+      expect(detail).not.toHaveProperty("name");
     });
 
     it("deletes oauth_state cookie", async () => {

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -3,9 +3,13 @@ import { NextRequest, NextResponse } from "next/server";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
-vi.mock("@/lib/audit", () => ({
-  appendAuditLog: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock("@/lib/api-auth", () => ({
   requireAdmin: vi.fn(),
@@ -145,7 +149,8 @@ describe("audit: POST /api/users/invite", () => {
     POST = mod.POST;
   });
 
-  it("logs user.invited audit event on successful invite", async () => {
+  it("logs user.invited audit event with redacted email (no plaintext PII)", async () => {
+    vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
     const request = new NextRequest("http://localhost:7777/api/users/invite", {
       method: "POST",
       body: JSON.stringify({ email: "newuser@test.com", role: "member" }),
@@ -159,7 +164,11 @@ describe("audit: POST /api/users/invite", () => {
       actorId: "admin-1",
       eventType: "user.invited",
       outcome: "success",
-      detail: { email: "newuser@test.com", role: "member" },
+      detail: {
+        emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+        emailPreview: "ne…er@test.com",
+        role: "member",
+      },
     });
   });
 
@@ -199,11 +208,14 @@ describe("audit: DELETE /api/users/[userId]", () => {
       }),
     } as never);
 
-    // Mock: update returns the deactivated user with email
+    // Mock: update returns the deactivated user (name only — email must NOT
+    // surface in audit detail per GDPR Art. 17).
     vi.mocked(db.update).mockReturnValueOnce({
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: "user-1", email: "deleted@test.com" }]),
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: "user-1", name: "Deleted User", email: "deleted@test.com" }]),
       }),
     } as never);
 
@@ -220,7 +232,7 @@ describe("audit: DELETE /api/users/[userId]", () => {
       eventType: "user.deleted",
       resource: "user:user-1",
       outcome: "success",
-      detail: { email: "deleted@test.com" },
+      detail: { name: "Deleted User" },
     });
   });
 

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -15,9 +15,13 @@ vi.mock("@/lib/invites", () => ({
   createInvite: vi.fn(),
 }));
 
-vi.mock("@/lib/audit", () => ({
-  appendAuditLog: vi.fn().mockResolvedValue(undefined),
-}));
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: vi.fn().mockResolvedValue(undefined),
+  };
+});
 
 vi.mock("@/lib/enterprise", () => ({
   getLicenseStatus: vi.fn(),
@@ -114,6 +118,7 @@ describe("POST /api/users/invite — seat cap", () => {
       activeUsers: 5,
       pendingInvites: 0,
     });
+    vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
     await POST(makeRequest({ email: "new@test.com", role: "member" }));
     // after() runs synchronously in tests (see test-setup.ts)
     expect(appendAuditLog).toHaveBeenCalledWith(
@@ -124,7 +129,8 @@ describe("POST /api/users/invite — seat cap", () => {
         outcome: "failure",
         error: { message: "Seat cap reached" },
         detail: expect.objectContaining({
-          email: "new@test.com",
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "new@test.com",
           role: "member",
           reason: "seat_cap",
           seatsUsed: 5,
@@ -132,6 +138,12 @@ describe("POST /api/users/invite — seat cap", () => {
         }),
       })
     );
+
+    const call = vi
+      .mocked(appendAuditLog)
+      .mock.calls.find(([entry]) => entry.eventType === "user.invite_blocked");
+    const detail = call![0].detail as Record<string, unknown>;
+    expect(detail).not.toHaveProperty("email");
   });
 
   it("creates the invite when below the cap", async () => {
@@ -152,6 +164,36 @@ describe("POST /api/users/invite — seat cap", () => {
     const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
     expect(res.status).toBe(201);
     expect(createInvite).toHaveBeenCalled();
+  });
+
+  it("logs user.invited with redacted email (GDPR Art. 17 — no plaintext PII in audit detail)", async () => {
+    vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: false,
+      ver: 1,
+      maxUsers: 0,
+      features: [],
+    });
+    await POST(makeRequest({ email: "alice.example@company.com", role: "member" }));
+
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "user.invited",
+        outcome: "success",
+        detail: expect.objectContaining({
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "al…le@company.com",
+          role: "member",
+        }),
+      })
+    );
+
+    const call = vi
+      .mocked(appendAuditLog)
+      .mock.calls.find(([entry]) => entry.eventType === "user.invited");
+    const detail = call![0].detail as Record<string, unknown>;
+    expect(detail).not.toHaveProperty("email");
+    expect(JSON.stringify(detail)).not.toContain("alice.example@company.com");
   });
 
   it("does not check seat usage when license is unlimited", async () => {

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -293,7 +293,9 @@ describe("DELETE /api/users/[userId]", () => {
     const mockUpdate = {
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnValue({
-        returning: vi.fn().mockResolvedValue([{ id: "user-1", email: "u@test.com" }]),
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: "user-1", name: "Test User", email: "u@test.com" }]),
       }),
     };
     vi.mocked(db.update).mockReturnValueOnce(mockUpdate as never);
@@ -308,8 +310,44 @@ describe("DELETE /api/users/[userId]", () => {
     );
     expect(db.delete).not.toHaveBeenCalled();
     expect(appendAuditLog).toHaveBeenCalledWith(
-      expect.objectContaining({ eventType: "user.deleted" })
+      expect.objectContaining({
+        eventType: "user.deleted",
+        detail: { name: "Test User" },
+      })
     );
+  });
+
+  it("does not record the user's email in the user.deleted audit detail (GDPR Art. 17)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as never);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as never);
+
+    vi.mocked(db.update).mockReturnValueOnce({
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: "user-1", name: "Test User", email: "secret@example.com" }]),
+      }),
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", { method: "DELETE" });
+    await DELETE(request, { params: Promise.resolve({ userId: "user-1" }) });
+
+    const call = vi
+      .mocked(appendAuditLog)
+      .mock.calls.find(([entry]) => entry.eventType === "user.deleted");
+    expect(call).toBeDefined();
+    const detail = call![0].detail as Record<string, unknown>;
+    expect(detail).not.toHaveProperty("email");
+    expect(JSON.stringify(detail)).not.toContain("secret@example.com");
   });
 
   it("returns 404 when user not found", async () => {

--- a/packages/web/src/__tests__/eslint/no-pii-in-audit-detail.test.ts
+++ b/packages/web/src/__tests__/eslint/no-pii-in-audit-detail.test.ts
@@ -1,0 +1,56 @@
+import { RuleTester } from "eslint";
+import rule from "../../../eslint-rules/no-pii-in-audit-detail.js";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-pii-in-audit-detail", rule, {
+  valid: [
+    // Spreading redactEmail() is the canonical way to identify an address.
+    {
+      code: `appendAuditLog({ eventType: "auth.login", detail: { ...redactEmail(email) } });`,
+    },
+    {
+      code: `appendAuditLog({ eventType: "user.invited", detail: { ...redactEmail(email), role: "member" } });`,
+    },
+    // Detail without any email-shaped key is fine.
+    {
+      code: `appendAuditLog({ eventType: "agent.created", detail: { name: "Smithers" } });`,
+    },
+    // Hash + preview written explicitly (e.g. by the helper) is fine.
+    {
+      code: `appendAuditLog({ eventType: "auth.login", detail: { emailHash: h, emailPreview: p } });`,
+    },
+    // Plain `email` outside an audit call is unrelated.
+    {
+      code: `const payload = { email: user.email };`,
+    },
+    // Email as a *value* (not a key) is fine — only the key matters here.
+    {
+      code: `appendAuditLog({ eventType: "user.updated", detail: { changes: { email: { from: a, to: b } } } });`,
+    },
+  ],
+  invalid: [
+    {
+      code: `appendAuditLog({ eventType: "user.deleted", detail: { name: "x", email: deactivated.email } });`,
+      errors: [{ messageId: "noPlaintextEmail" }],
+    },
+    {
+      code: `appendAuditLog({ eventType: "auth.login", detail: { email } });`,
+      errors: [{ messageId: "noPlaintextEmail" }],
+    },
+    {
+      code: `appendAuditLog({ eventType: "config.changed", detail: { type: "google", emailAddress } });`,
+      errors: [{ messageId: "noPlaintextEmail" }],
+    },
+    // Even with redactEmail spread, an additional `email:` key is suspicious — flag it.
+    {
+      code: `appendAuditLog({ eventType: "auth.login", detail: { ...redactEmail(email), email } });`,
+      errors: [{ messageId: "noPlaintextEmail" }],
+    },
+  ],
+});

--- a/packages/web/src/__tests__/lib/audit.test.ts
+++ b/packages/web/src/__tests__/lib/audit.test.ts
@@ -1,9 +1,11 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { createHmac } from "crypto";
 import {
   computeRowHmacV1,
   computeRowHmacV2,
   ROW_HMAC_VERIFIERS,
   truncateDetail,
+  redactEmail,
 } from "@/lib/audit";
 
 describe("computeRowHmac", () => {
@@ -227,5 +229,66 @@ describe("truncateDetail", () => {
     const large = { data: "x".repeat(3000) };
     const result = truncateDetail(large) as Record<string, unknown>;
     expect(result._truncated).toBe(true);
+  });
+});
+
+describe("redactEmail", () => {
+  const SECRET_HEX = "f".repeat(64);
+  const expectedHash = (email: string) =>
+    createHmac("sha256", Buffer.from(SECRET_HEX, "hex"))
+      .update(email.trim().toLowerCase())
+      .digest("hex");
+
+  beforeEach(() => {
+    vi.stubEnv("AUDIT_HMAC_SECRET", SECRET_HEX);
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns emailHash and emailPreview, but never the raw email", () => {
+    const result = redactEmail("clemens.helm@devcraft.academy");
+    expect(result).toEqual({
+      emailHash: expectedHash("clemens.helm@devcraft.academy"),
+      emailPreview: "cl…lm@devcraft.academy",
+    });
+    expect(JSON.stringify(result)).not.toContain("clemens.helm@devcraft.academy");
+  });
+
+  it("normalises email to lowercase + trimmed before hashing (so case variations collide)", () => {
+    const a = redactEmail("Foo.Bar@Example.com");
+    const b = redactEmail("  foo.bar@example.com  ");
+    expect(a.emailHash).toBe(b.emailHash);
+    expect(a.emailHash).toBe(expectedHash("foo.bar@example.com"));
+  });
+
+  it("produces different hashes for different emails", () => {
+    const a = redactEmail("alice@example.com");
+    const b = redactEmail("bob@example.com");
+    expect(a.emailHash).not.toBe(b.emailHash);
+  });
+
+  it("preview format uses first-2 + ellipsis + last-2 of local part for long locals", () => {
+    expect(redactEmail("clemens.helm@devcraft.academy").emailPreview).toBe(
+      "cl…lm@devcraft.academy"
+    );
+    expect(redactEmail("alexander@x.io").emailPreview).toBe("al…er@x.io");
+  });
+
+  it("preview keeps short local parts intact (no ellipsis below 5 chars)", () => {
+    // Truncating "ab@x.com" to "ab…ab" reveals nothing — leave it as-is.
+    expect(redactEmail("ab@x.com").emailPreview).toBe("ab@x.com");
+    expect(redactEmail("john@test.io").emailPreview).toBe("john@test.io");
+  });
+
+  it("handles invalid email shape (no @) without throwing", () => {
+    const result = redactEmail("unknown");
+    expect(result.emailHash).toBe(expectedHash("unknown"));
+    expect(result.emailPreview).toBe("unknown");
+  });
+
+  it("preview uses lowercased domain (mirrors hashing input)", () => {
+    expect(redactEmail("Alice@EXAMPLE.com").emailPreview).toBe("al…ce@example.com");
   });
 });

--- a/packages/web/src/__tests__/lib/auth-audit.test.ts
+++ b/packages/web/src/__tests__/lib/auth-audit.test.ts
@@ -4,9 +4,13 @@ const { mockAppendAuditLog } = vi.hoisted(() => ({
   mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
-vi.mock("@/lib/audit", () => ({
-  appendAuditLog: mockAppendAuditLog,
-}));
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return {
+    ...actual,
+    appendAuditLog: mockAppendAuditLog,
+  };
+});
 
 vi.mock("@/db", () => ({
   db: {},
@@ -64,10 +68,11 @@ function createMockContext(overrides: Record<string, unknown> = {}) {
 describe("auth audit logging (Better Auth hooks)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
   });
 
   describe("sign-in hooks", () => {
-    it("should log auth.login on successful sign-in", async () => {
+    it("should log auth.login on successful sign-in with redacted email (no plaintext PII)", async () => {
       const ctx = createMockContext({
         context: {
           newSession: {
@@ -90,11 +95,17 @@ describe("auth audit logging (Better Auth hooks)", () => {
         actorId: "user-123",
         eventType: "auth.login",
         outcome: "success",
-        detail: { email: "admin@example.com" },
+        detail: {
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "ad…in@example.com",
+        },
       });
+
+      const detail = mockAppendAuditLog.mock.calls[0][0].detail;
+      expect(detail).not.toHaveProperty("email");
     });
 
-    it("should log auth.failed on failed sign-in", async () => {
+    it("should log auth.failed on failed sign-in with redacted email (no plaintext PII)", async () => {
       const ctx = createMockContext({
         context: {
           newSession: null,
@@ -111,11 +122,19 @@ describe("auth audit logging (Better Auth hooks)", () => {
         eventType: "auth.failed",
         outcome: "failure",
         error: { message: "Invalid credentials" },
-        detail: { email: "unknown@example.com", reason: "invalid_credentials" },
+        detail: {
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "un…wn@example.com",
+          reason: "invalid_credentials",
+        },
       });
+
+      const detail = mockAppendAuditLog.mock.calls[0][0].detail;
+      expect(detail).not.toHaveProperty("email");
+      expect(JSON.stringify(detail)).not.toContain("unknown@example.com");
     });
 
-    it("should use 'unknown' email when body has no email", async () => {
+    it("should use 'unknown' placeholder when body has no email", async () => {
       const ctx = createMockContext({
         context: {
           newSession: null,
@@ -132,7 +151,11 @@ describe("auth audit logging (Better Auth hooks)", () => {
         eventType: "auth.failed",
         outcome: "failure",
         error: { message: "Invalid credentials" },
-        detail: { email: "unknown", reason: "invalid_credentials" },
+        detail: {
+          emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
+          emailPreview: "unknown",
+          reason: "invalid_credentials",
+        },
       });
     });
 

--- a/packages/web/src/app/api/integrations/oauth/callback/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/callback/route.ts
@@ -9,7 +9,7 @@ import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
 import { encrypt } from "@/lib/encryption";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
-import { appendAuditLog } from "@/lib/audit";
+import { appendAuditLog, redactEmail } from "@/lib/audit";
 import { eq, and } from "drizzle-orm";
 
 function errorRedirect(origin: string, error: string) {
@@ -185,6 +185,11 @@ export async function GET(request: Request) {
   }
 
   // 9. Audit log
+  // GDPR Art. 17: never record the plaintext Gmail address. The audit row
+  // is HMAC-signed, so we cannot redact later. redactEmail() gives us a
+  // keyed hash + masked preview; the connectionId in `resource` is enough
+  // to look up the live mailbox name from the integrations table while it
+  // exists.
   appendAuditLog({
     actorType: "user",
     actorId: session.user.id!,
@@ -193,8 +198,7 @@ export async function GET(request: Request) {
     detail: {
       action: "integration_created",
       type: "google",
-      name: emailAddress,
-      emailAddress,
+      ...redactEmail(emailAddress),
     },
     outcome: "success",
   }).catch(console.error);

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -106,7 +106,10 @@ export async function DELETE(
       actorId: session.user.id!,
       eventType: "user.deleted",
       resource: `user:${userId}`,
-      detail: { name: deactivated.name, email: deactivated.email },
+      // GDPR Art. 17: never record the email here. The audit log is
+      // HMAC-signed and append-only, so we cannot redact later. userId
+      // is in `resource`; name is enough for human-readable diffing.
+      detail: { name: deactivated.name },
       outcome: "success",
     })
   );

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -52,7 +52,7 @@ export async function PATCH(
   }
 
   // Update role
-  const [updated] = await db.update(users).set({ role }).where(eq(users.id, userId)).returning();
+  await db.update(users).set({ role }).where(eq(users.id, userId));
 
   after(() =>
     appendAuditLog({

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -1,7 +1,7 @@
 import { NextRequest, NextResponse, after } from "next/server";
 import { requireAdmin } from "@/lib/api-auth";
 import { createInvite } from "@/lib/invites";
-import { appendAuditLog } from "@/lib/audit";
+import { appendAuditLog, redactEmail } from "@/lib/audit";
 import { getLicenseStatus } from "@/lib/enterprise";
 import { getSeatUsage } from "@/lib/seat-usage";
 import { db } from "@/db";
@@ -29,7 +29,7 @@ export async function POST(request: NextRequest) {
           actorId: session.user.id!,
           eventType: "user.invite_blocked",
           detail: {
-            email,
+            ...redactEmail(email),
             role,
             reason: "seat_cap",
             seatsUsed: usage.used,
@@ -69,7 +69,7 @@ export async function POST(request: NextRequest) {
       actorId: session.user.id!,
       eventType: "user.invited",
       detail: {
-        email,
+        ...redactEmail(email),
         role,
         ...(auditGroups.length > 0 ? { groups: auditGroups } : {}),
       },

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -121,6 +121,50 @@ export const ROW_HMAC_VERIFIERS: Record<
   2: (secret, fields) => computeRowHmacV2(secret, fields as HmacFieldsV2),
 };
 
+/**
+ * GDPR redaction for email addresses going into audit `detail` payloads.
+ *
+ * The audit log is HMAC-signed and append-only — once an email lands in
+ * detail, GDPR Art. 17 erasure conflicts with integrity. So we never
+ * write the raw address. Instead we derive:
+ *
+ * - `emailHash`: keyed HMAC-SHA256 of the lowercased+trimmed email,
+ *   so an admin holding a known address can match it against the log,
+ *   but a leaked log on its own does not yield the addresses back.
+ * - `emailPreview`: short masked form for human readability,
+ *   `cl…lm@devcraft.academy` (first 2 + last 2 of local + domain).
+ *
+ * For very short local parts (≤4 chars) the masking would reveal more
+ * than it hides, so we keep them intact.
+ */
+export type RedactedEmail = {
+  emailHash: string;
+  emailPreview: string;
+};
+
+export function redactEmail(email: string): RedactedEmail {
+  const normalized = email.trim().toLowerCase();
+  const secret = getOrCreateSecret("audit_hmac_secret");
+  const emailHash = createHmac("sha256", secret).update(normalized).digest("hex");
+
+  const atIndex = normalized.indexOf("@");
+  if (atIndex === -1) {
+    return { emailHash, emailPreview: normalized };
+  }
+
+  const local = normalized.slice(0, atIndex);
+  const domain = normalized.slice(atIndex + 1);
+
+  if (local.length <= 4) {
+    return { emailHash, emailPreview: `${local}@${domain}` };
+  }
+
+  return {
+    emailHash,
+    emailPreview: `${local.slice(0, 2)}…${local.slice(-2)}@${domain}`,
+  };
+}
+
 const MAX_DETAIL_BYTES = 2048;
 
 export function truncateDetail(detail: AuditDetail | null | undefined): AuditDetail | null {

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -6,7 +6,7 @@ import { verifyPassword as verifyScrypt } from "better-auth/crypto";
 import bcrypt from "bcryptjs";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
-import { appendAuditLog } from "@/lib/audit";
+import { appendAuditLog, redactEmail } from "@/lib/audit";
 import { getCachedDomain } from "@/lib/domain";
 
 /**
@@ -28,7 +28,10 @@ export const auditAfterHook = createAuthMiddleware(async (ctx) => {
           actorType: "user",
           actorId: newSession.user.id,
           eventType: "auth.login",
-          detail: { email },
+          // GDPR Art. 17: never log plaintext email — the audit row is
+          // HMAC-signed and cannot be redacted later. redactEmail()
+          // gives us a keyed hash + masked preview instead.
+          detail: redactEmail(email),
           outcome: "success",
         });
       } catch {
@@ -41,7 +44,7 @@ export const auditAfterHook = createAuthMiddleware(async (ctx) => {
           actorType: "system",
           actorId: "system",
           eventType: "auth.failed",
-          detail: { email, reason: "invalid_credentials" },
+          detail: { ...redactEmail(email), reason: "invalid_credentials" },
           outcome: "failure",
           error: { message: "Invalid credentials" },
         });


### PR DESCRIPTION
## Summary
- Adds `redactEmail()` helper in `@/lib/audit` that returns a keyed `emailHash` (HMAC-SHA256 of the lowercased+trimmed address using the existing `audit_hmac_secret`) plus a short masked `emailPreview` (`cl…lm@devcraft.academy`).
- Migrates the five call sites that previously wrote plaintext emails into `detail`:
  - `user.deleted` — drops the email entirely; the userId is already in `resource`, the display name is enough for a human-readable diff.
  - `user.invited`, `user.invite_blocked` — spread `redactEmail(email)`.
  - `auth.login`, `auth.failed` — spread `redactEmail(email)`.
- Updates CLAUDE.md (audit trail guidelines + checklist) and the audit-trail concept doc so future call sites follow the same pattern.

## Why
The audit log is HMAC-signed and append-only — once an email lands in `detail`, GDPR Art. 17 right-to-erasure conflicts with row integrity. Editing the row to scrub the email would invalidate its signature; not editing it leaves PII immortal in the log. For an enterprise-targeted product where a CISO must sign off, the safer default is to never record the plaintext.

Closes #238.

## Test plan
- [x] Tests added for `redactEmail()` covering hash determinism, case-/whitespace-normalisation, preview format, short-local-part handling, and missing `@`.
- [x] Existing tests for `user.deleted`, `user.invited`, `user.invite_blocked`, `auth.login`, `auth.failed` tightened (not weakened) to assert the new shape and that the raw email never appears in serialised detail.
- [x] Full Vitest suite green (3408 passed).
- [x] Lint + format clean.
- [x] Type check clean (`tsc --noEmit`).