### PR TITLE
refactor(api-auth): centralize auth/role checks via withAuth/withAdmin (#228)

### DIFF
--- a/packages/web/eslint-rules/no-direct-session.js
+++ b/packages/web/eslint-rules/no-direct-session.js
@@ -1,0 +1,84 @@
+/**
+ * Reject direct `getSession` / `auth.api.getSession` usage inside API
+ * `route.ts` files. Every protected route should go through the centralized
+ * helpers in `@/lib/api-auth` (`withAuth`, `withAdmin`, or `requireAdmin`) so
+ * the auth shape, error bodies, and future cross-cutting concerns (rate
+ * limits, structured logging, audit hooks) live in one place.
+ *
+ * Opt-out: add a file-level comment `// auth-direct: <reason>` for the rare
+ * case where the wrappers don't fit (browser-flow endpoints that must render
+ * auth failure as a redirect, not JSON — e.g. OAuth callbacks).
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid direct getSession / auth.api.getSession in API route handlers — use withAuth / withAdmin / requireAdmin from @/lib/api-auth.",
+    },
+    messages: {
+      directGetSession:
+        "Do not call getSession or auth.api.getSession directly in API route handlers. Use withAuth(), withAdmin(), or requireAdmin() from @/lib/api-auth. If this route legitimately needs the inline pattern (e.g. redirect on auth failure), add a file-level comment: // auth-direct: <reason>",
+      missingDirectReason: "auth-direct comment must include a reason: // auth-direct: <reason>",
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (!filename.includes("/app/api/") || !filename.endsWith("route.ts")) {
+      return {};
+    }
+
+    const sourceCode = context.sourceCode || context.getSourceCode();
+    const comments = sourceCode.getAllComments();
+    const exemptComment = comments.find((c) => c.value.trim().startsWith("auth-direct"));
+
+    if (exemptComment) {
+      const text = exemptComment.value.trim();
+      if (!text.match(/^auth-direct:\s*\S/)) {
+        context.report({
+          node: exemptComment,
+          messageId: "missingDirectReason",
+        });
+      }
+      // File opted out — skip the rest.
+      return {};
+    }
+
+    return {
+      // Catch: import { getSession } from "@/lib/auth"
+      ImportDeclaration(node) {
+        if (node.source.value !== "@/lib/auth") return;
+        for (const spec of node.specifiers) {
+          if (
+            spec.type === "ImportSpecifier" &&
+            spec.imported &&
+            spec.imported.name === "getSession"
+          ) {
+            context.report({ node: spec, messageId: "directGetSession" });
+          }
+        }
+      },
+      // Catch: auth.api.getSession(...)
+      MemberExpression(node) {
+        if (
+          node.property &&
+          node.property.type === "Identifier" &&
+          node.property.name === "getSession" &&
+          node.object &&
+          node.object.type === "MemberExpression" &&
+          node.object.property &&
+          node.object.property.type === "Identifier" &&
+          node.object.property.name === "api" &&
+          node.object.object &&
+          node.object.object.type === "Identifier" &&
+          node.object.object.name === "auth"
+        ) {
+          context.report({ node, messageId: "directGetSession" });
+        }
+      },
+    };
+  },
+};

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -3,6 +3,7 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import security from "eslint-plugin-security";
 import requireAuditLog from "./eslint-rules/require-audit-log.js";
+import noDirectSession from "./eslint-rules/no-direct-session.js";
 
 const eslintConfig = defineConfig([
   ...nextVitals,
@@ -25,18 +26,26 @@ const eslintConfig = defineConfig([
       "@typescript-eslint/no-explicit-any": "off",
     },
   },
-  // Require appendAuditLog() in API route mutation handlers
+  // Pinchy custom rules for API route handlers:
+  // - require-audit-log: every state-changing handler must call appendAuditLog
+  //   (or set a // audit-exempt: <reason> file comment)
+  // - no-direct-session: every protected route must use the centralized
+  //   helpers in @/lib/api-auth (withAuth / withAdmin / requireAdmin) instead
+  //   of calling getSession or auth.api.getSession directly
+  //   (opt out with a // auth-direct: <reason> file comment)
   {
     files: ["src/app/api/**/route.ts"],
     plugins: {
       pinchy: {
         rules: {
           "require-audit-log": requireAuditLog,
+          "no-direct-session": noDirectSession,
         },
       },
     },
     rules: {
       "pinchy/require-audit-log": "error",
+      "pinchy/no-direct-session": "error",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -22,12 +22,13 @@ vi.mock("@/lib/workspace", () => ({
   writeWorkspaceFile: vi.fn(),
 }));
 
-const { mockAssertAgentWriteAccess } = vi.hoisted(() => ({
-  mockAssertAgentWriteAccess: vi.fn(),
+const { mockRequireAgentWriteAccess } = vi.hoisted(() => ({
+  // Returns null when write is allowed; returns a NextResponse(403) when denied.
+  mockRequireAgentWriteAccess: vi.fn(),
 }));
 vi.mock("@/lib/agent-access", () => ({
   getAgentWithAccess: vi.fn(),
-  assertAgentWriteAccess: mockAssertAgentWriteAccess,
+  requireAgentWriteAccess: mockRequireAgentWriteAccess,
 }));
 
 import { auth } from "@/lib/auth";
@@ -190,6 +191,8 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
       user: { id: "1", email: "admin@test.com" },
     } as any);
     vi.mocked(getAgentWithAccess).mockResolvedValue(defaultAgent);
+    // Default: write is allowed. Individual tests override to simulate denial.
+    mockRequireAgentWriteAccess.mockReturnValue(null);
   });
 
   it("should write file content and return success", async () => {
@@ -310,9 +313,9 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
   });
 
   it("should return 403 when non-admin tries to modify shared agent files", async () => {
-    mockAssertAgentWriteAccess.mockImplementationOnce(() => {
-      throw new Error("Access denied");
-    });
+    mockRequireAgentWriteAccess.mockReturnValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
 
     const request = makePutRequest("agent-1", "AGENTS.md", {
       content: "# Hacked instructions",
@@ -325,8 +328,8 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
     expect(writeWorkspaceFile).not.toHaveBeenCalled();
   });
 
-  it("should allow write when assertAgentWriteAccess passes", async () => {
-    mockAssertAgentWriteAccess.mockImplementationOnce(() => {});
+  it("should allow write when requireAgentWriteAccess passes", async () => {
+    mockRequireAgentWriteAccess.mockReturnValueOnce(null);
 
     const request = makePutRequest("agent-1", "AGENTS.md", {
       content: "# Valid update",

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -199,7 +199,7 @@ describe("POST /api/agents", () => {
     const response = await POST(request);
     expect(response.status).toBe(403);
     const body = await response.json();
-    expect(body.error).toBe("Admin access required");
+    expect(body.error).toBe("Forbidden");
   });
 
   it("should create an agent from a knowledge-base template", async () => {

--- a/packages/web/src/__tests__/api/oauth-start.test.ts
+++ b/packages/web/src/__tests__/api/oauth-start.test.ts
@@ -76,25 +76,36 @@ describe("GET /api/integrations/oauth/start", () => {
     mockGetOAuthSettings.mockResolvedValue(oauthSettings);
   });
 
-  it("returns 401 when not authenticated", async () => {
+  it("redirects to /settings with unauthorized error when not authenticated", async () => {
+    // Browser-driven endpoint: auth failures must redirect, not return JSON,
+    // so the user lands somewhere meaningful instead of seeing raw JSON.
     mockGetSession.mockResolvedValueOnce(null);
     const { GET } = await import("@/app/api/integrations/oauth/start/route");
     const res = await GET(makeRequest());
-    expect(res.status).toBe(401);
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/settings");
+    expect(location).toContain("error=unauthorized");
   });
 
-  it("returns 403 when not admin", async () => {
+  it("redirects to /settings with unauthorized error when not admin", async () => {
     mockGetSession.mockResolvedValueOnce({ user: { id: "user-2", role: "member" } });
     const { GET } = await import("@/app/api/integrations/oauth/start/route");
     const res = await GET(makeRequest());
-    expect(res.status).toBe(403);
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/settings");
+    expect(location).toContain("error=unauthorized");
   });
 
-  it("returns 400 when OAuth not configured", async () => {
+  it("redirects to /settings with not_configured error when OAuth not configured", async () => {
     mockGetOAuthSettings.mockResolvedValueOnce(null);
     const { GET } = await import("@/app/api/integrations/oauth/start/route");
     const res = await GET(makeRequest());
-    expect(res.status).toBe(400);
+    expect(res.status).toBe(302);
+    const location = res.headers.get("location") ?? "";
+    expect(location).toContain("/settings");
+    expect(location).toContain("error=not_configured");
   });
 
   it("deletes the user's previous pending record when oauth_pending_id cookie is present", async () => {

--- a/packages/web/src/__tests__/api/users-password.test.ts
+++ b/packages/web/src/__tests__/api/users-password.test.ts
@@ -11,6 +11,11 @@ vi.mock("@/lib/auth", () => {
   const mockGetSession = vi.fn();
   const mockChangePassword = vi.fn();
   return {
+    // `getSession` is the standalone helper used by `withAuth` from `@/lib/api-auth`.
+    // `auth.api.getSession` is the underlying Better Auth method, kept for tests
+    // that exercise the route directly. Both share the same mock so `mockResolvedValueOnce`
+    // calls applied via either alias continue to work.
+    getSession: mockGetSession,
     auth: {
       api: {
         getSession: mockGetSession,

--- a/packages/web/src/__tests__/eslint/no-direct-session.test.ts
+++ b/packages/web/src/__tests__/eslint/no-direct-session.test.ts
@@ -1,0 +1,63 @@
+import { RuleTester } from "eslint";
+import rule from "../../../eslint-rules/no-direct-session.js";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("no-direct-session", rule, {
+  valid: [
+    // Routes using the centralized helpers — fine.
+    {
+      code: `import { withAuth } from "@/lib/api-auth"; export const GET = withAuth(async () => {});`,
+      filename: "/app/api/foo/route.ts",
+    },
+    {
+      code: `import { withAdmin } from "@/lib/api-auth"; export const POST = withAdmin(async () => {});`,
+      filename: "/app/api/foo/route.ts",
+    },
+    {
+      code: `import { requireAdmin } from "@/lib/api-auth"; export async function GET() { await requireAdmin(); }`,
+      filename: "/app/api/foo/route.ts",
+    },
+    // Non-route files may use getSession freely (e.g. lib/api-auth.ts itself,
+    // server components, server-side actions).
+    {
+      code: `import { getSession } from "@/lib/auth"; export async function helper() { return getSession(); }`,
+      filename: "/lib/api-auth.ts",
+    },
+    {
+      code: `import { auth } from "@/lib/auth"; export async function helper() { return auth.api.getSession(); }`,
+      filename: "/lib/some-helper.ts",
+    },
+    // A route file with a documented opt-out is allowed (e.g. OAuth callback
+    // that needs a redirect on failure rather than the wrapper's JSON 401).
+    {
+      code: `// auth-direct: redirect on failure, wrappers return JSON\nimport { getSession } from "@/lib/auth"; export async function GET() { await getSession(); }`,
+      filename: "/app/api/integrations/oauth/callback/route.ts",
+    },
+  ],
+  invalid: [
+    // Direct named import of getSession from @/lib/auth in a route.ts
+    {
+      code: `import { getSession } from "@/lib/auth"; export async function GET() { await getSession(); }`,
+      filename: "/app/api/foo/route.ts",
+      errors: [{ messageId: "directGetSession" }],
+    },
+    // auth.api.getSession member access in a route.ts
+    {
+      code: `import { auth } from "@/lib/auth"; export async function GET() { await auth.api.getSession(); }`,
+      filename: "/app/api/foo/route.ts",
+      errors: [{ messageId: "directGetSession" }],
+    },
+    // auth-direct comment without a reason is a stub — must explain why
+    {
+      code: `// auth-direct\nimport { getSession } from "@/lib/auth"; export async function GET() { await getSession(); }`,
+      filename: "/app/api/foo/route.ts",
+      errors: [{ messageId: "missingDirectReason" }],
+    },
+  ],
+});

--- a/packages/web/src/__tests__/lib/agent-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-access.test.ts
@@ -3,6 +3,7 @@ import { NextResponse } from "next/server";
 import {
   assertAgentAccess,
   assertAgentWriteAccess,
+  requireAgentWriteAccess,
   getAgentWithAccess,
   effectiveVisibility,
 } from "@/lib/agent-access";
@@ -93,6 +94,34 @@ describe("assertAgentWriteAccess", () => {
   it("denies non-owner from modifying personal agent", () => {
     const agent = { id: "a1", ownerId: "user-1", isPersonal: true };
     expect(() => assertAgentWriteAccess(agent, "other-user", "member")).toThrow("Access denied");
+  });
+});
+
+describe("requireAgentWriteAccess", () => {
+  it("returns null when admin modifies any agent (write allowed)", () => {
+    const agent = { id: "a1", ownerId: "other", isPersonal: false };
+    expect(requireAgentWriteAccess(agent, "admin-user", "admin")).toBeNull();
+  });
+
+  it("returns null when owner modifies their personal agent", () => {
+    const agent = { id: "a1", ownerId: "user-1", isPersonal: true };
+    expect(requireAgentWriteAccess(agent, "user-1", "member")).toBeNull();
+  });
+
+  it("returns 403 'Forbidden' NextResponse when non-admin modifies shared agent", async () => {
+    const agent = { id: "a1", ownerId: null, isPersonal: false };
+    const result = requireAgentWriteAccess(agent, "user-1", "member");
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+    expect(await (result as NextResponse).json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 403 'Forbidden' NextResponse when non-owner modifies personal agent", async () => {
+    const agent = { id: "a1", ownerId: "user-1", isPersonal: true };
+    const result = requireAgentWriteAccess(agent, "other-user", "member");
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+    expect(await (result as NextResponse).json()).toEqual({ error: "Forbidden" });
   });
 });
 

--- a/packages/web/src/__tests__/lib/api-auth.test.ts
+++ b/packages/web/src/__tests__/lib/api-auth.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const { mockGetSession, mockHeaders } = vi.hoisted(() => ({
   mockGetSession: vi.fn(),
@@ -19,7 +19,7 @@ vi.mock("next/headers", () => ({
   headers: mockHeaders,
 }));
 
-import { requireAdmin } from "@/lib/api-auth";
+import { requireAdmin, withAuth, withAdmin } from "@/lib/api-auth";
 
 describe("requireAdmin (api-auth)", () => {
   beforeEach(() => {
@@ -55,5 +55,123 @@ describe("requireAdmin (api-auth)", () => {
     const result = await requireAdmin();
     expect(result).not.toBeInstanceOf(NextResponse);
     expect(result).toEqual(session);
+  });
+
+  it("returns 403 with standardized 'Forbidden' body for non-admin", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-1", role: "member" },
+      session: { expiresAt: "" },
+    });
+
+    const result = (await requireAdmin()) as NextResponse;
+    expect(result.status).toBe(403);
+    expect(await result.json()).toEqual({ error: "Forbidden" });
+  });
+
+  it("returns 401 with standardized 'Unauthorized' body when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+
+    const result = (await requireAdmin()) as NextResponse;
+    expect(result.status).toBe(401);
+    expect(await result.json()).toEqual({ error: "Unauthorized" });
+  });
+});
+
+describe("withAuth (api-auth)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 with 'Unauthorized' body when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const handler = vi.fn();
+    const wrapped = withAuth(handler);
+
+    const req = new NextRequest("http://localhost/x");
+    const res = await wrapped(req, {});
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("invokes handler with session when authenticated", async () => {
+    const session = {
+      user: { id: "user-1", role: "member" },
+      session: { expiresAt: "" },
+    };
+    mockGetSession.mockResolvedValue(session);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = withAuth(handler);
+
+    const req = new NextRequest("http://localhost/x");
+    const ctx = { params: Promise.resolve({ id: "abc" }) };
+    const res = await wrapped(req, ctx);
+
+    expect(handler).toHaveBeenCalledWith(req, ctx, session);
+    expect(res.status).toBe(200);
+  });
+
+  it("invokes handler with admin session too (no role gating)", async () => {
+    const session = {
+      user: { id: "admin-1", role: "admin" },
+      session: { expiresAt: "" },
+    };
+    mockGetSession.mockResolvedValue(session);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = withAuth(handler);
+
+    await wrapped(new NextRequest("http://localhost/x"), {});
+    expect(handler).toHaveBeenCalled();
+  });
+});
+
+describe("withAdmin (api-auth)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("returns 401 'Unauthorized' when no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+
+    const res = await wrapped(new NextRequest("http://localhost/x"), {});
+
+    expect(res.status).toBe(401);
+    expect(await res.json()).toEqual({ error: "Unauthorized" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("returns 403 'Forbidden' when authenticated but not admin", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-1", role: "member" },
+      session: { expiresAt: "" },
+    });
+    const handler = vi.fn();
+    const wrapped = withAdmin(handler);
+
+    const res = await wrapped(new NextRequest("http://localhost/x"), {});
+
+    expect(res.status).toBe(403);
+    expect(await res.json()).toEqual({ error: "Forbidden" });
+    expect(handler).not.toHaveBeenCalled();
+  });
+
+  it("invokes handler with admin session", async () => {
+    const session = {
+      user: { id: "admin-1", role: "admin" },
+      session: { expiresAt: "" },
+    };
+    mockGetSession.mockResolvedValue(session);
+    const handler = vi.fn().mockResolvedValue(NextResponse.json({ ok: true }));
+    const wrapped = withAdmin(handler);
+
+    const req = new NextRequest("http://localhost/x");
+    const ctx = { params: Promise.resolve({ id: "abc" }) };
+    const res = await wrapped(req, ctx);
+
+    expect(handler).toHaveBeenCalledWith(req, ctx, session);
+    expect(res.status).toBe(200);
   });
 });

--- a/packages/web/src/__tests__/security/api-auth-check.test.ts
+++ b/packages/web/src/__tests__/security/api-auth-check.test.ts
@@ -8,6 +8,7 @@ import { resolve, relative } from "path";
  * Every API route must use either:
  * - getSession() from @/lib/auth
  * - requireAdmin() from @/lib/api-auth
+ * - withAuth()/withAdmin() from @/lib/api-auth
  * - requireAuth() from @/lib/require-auth
  *
  * Routes that are intentionally public must be listed in PUBLIC_ROUTES.
@@ -17,6 +18,8 @@ const AUTH_PATTERNS = [
   /\bauth\.api\.getSession\(/,
   /\bgetSession\(/,
   /\brequireAdmin\(\)/,
+  /\bwithAuth\b/,
+  /\bwithAdmin\b/,
   /\brequireAuth\(\)/,
   /\bgetAgentWithAccess\(/,
   /\bvalidateGatewayToken\(/,

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -1,18 +1,12 @@
 // audit-exempt: knowledge base file edits are per-agent content changes, not admin actions
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
 import { getAgentWithAccess, assertAgentWriteAccess } from "@/lib/agent-access";
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
-export async function GET(request: NextRequest, { params }: Params) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth<Params>(async (_req, { params }, session) => {
   const { agentId, filename } = await params;
 
   const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
@@ -25,14 +19,9 @@ export async function GET(request: NextRequest, { params }: Params) {
     const message = error instanceof Error ? error.message : "Invalid file";
     return NextResponse.json({ error: message }, { status: 400 });
   }
-}
+});
 
-export async function PUT(request: NextRequest, { params }: Params) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const PUT = withAuth<Params>(async (request, { params }, session) => {
   const { agentId, filename } = await params;
 
   const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
@@ -58,4 +47,4 @@ export async function PUT(request: NextRequest, { params }: Params) {
     const message = error instanceof Error ? error.message : "Invalid file";
     return NextResponse.json({ error: message }, { status: 400 });
   }
-}
+});

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -2,7 +2,7 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
-import { getAgentWithAccess, assertAgentWriteAccess } from "@/lib/agent-access";
+import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
@@ -28,11 +28,8 @@ export const PUT = withAuth<Params>(async (request, { params }, session) => {
   if (agentOrError instanceof NextResponse) return agentOrError;
 
   // Only admins or personal agent owners can modify agent files
-  try {
-    assertAgentWriteAccess(agentOrError, session.user.id!, session.user.role);
-  } catch {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const denied = requireAgentWriteAccess(agentOrError, session.user.id!, session.user.role);
+  if (denied) return denied;
 
   const { content } = await request.json();
 

--- a/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -1,28 +1,18 @@
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { eq, and } from "drizzle-orm";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
 
 /**
  * GET /api/agents/[agentId]/integrations
  *
  * Returns current integration permissions for this agent, grouped by connection.
  */
-export async function GET(
-  _request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
   const { agentId } = await params;
 
   // Join permissions with connections
@@ -72,25 +62,14 @@ export async function GET(
   }
 
   return NextResponse.json(Array.from(grouped.values()));
-}
+});
 
 /**
  * PUT /api/agents/[agentId]/integrations
  *
  * Replace all permissions for this agent on a given connection.
  */
-export async function PUT(
-  request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const PUT = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
 
   let body: Record<string, unknown>;
@@ -196,25 +175,14 @@ export async function PUT(
     const message = err instanceof Error ? err.message : "Internal server error";
     return NextResponse.json({ error: message }, { status: 500 });
   }
-}
+});
 
 /**
  * DELETE /api/agents/[agentId]/integrations
  *
  * Remove ALL integration permissions for this agent (used when connection is cleared).
  */
-export async function DELETE(
-  _request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
 
   // Get existing permissions for audit log
@@ -247,4 +215,4 @@ export async function DELETE(
   }).catch(console.error);
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -3,7 +3,7 @@ import { revalidatePath } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
 import { updateAgent, deleteAgent, AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
 import { withAuth, withAdmin } from "@/lib/api-auth";
-import { getAgentWithAccess, assertAgentWriteAccess } from "@/lib/agent-access";
+import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
 import { appendAuditLog } from "@/lib/audit";
 import type { UpdateDetail } from "@/lib/audit";
 import { isEnterprise } from "@/lib/enterprise";
@@ -39,11 +39,8 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   const existingAgent = existingAgentOrError;
 
   // Only admins or personal agent owners can modify agents
-  try {
-    assertAgentWriteAccess(existingAgent, session.user.id!, session.user.role);
-  } catch {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
+  const denied = requireAgentWriteAccess(existingAgent, session.user.id!, session.user.role);
+  if (denied) return denied;
 
   const body = await request.json();
 

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -1,9 +1,8 @@
-import { NextRequest, NextResponse, after } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
 import { updateAgent, deleteAgent, AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
-import { getSession } from "@/lib/auth";
+import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getAgentWithAccess, assertAgentWriteAccess } from "@/lib/agent-access";
 import { appendAuditLog } from "@/lib/audit";
 import type { UpdateDetail } from "@/lib/audit";
@@ -15,15 +14,9 @@ import { getAgentGroupIds } from "@/lib/groups";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
 import { validatePinchyWebConfig } from "@/lib/domain-validation";
 
-export async function GET(
-  request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
+type RouteContext = { params: Promise<{ agentId: string }> };
 
+export const GET = withAuth<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
 
   const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
@@ -32,17 +25,9 @@ export async function GET(
 
   const groupIds = await getAgentGroupIds(agentId);
   return NextResponse.json({ ...agent, groupIds });
-}
+});
 
-export async function PATCH(
-  request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const PATCH = withAuth<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
 
   const existingAgentOrError = await getAgentWithAccess(
@@ -250,20 +235,9 @@ export async function PATCH(
   }
 
   return NextResponse.json(agent);
-}
+});
 
-export async function DELETE(
-  request: NextRequest,
-  { params }: { params: Promise<{ agentId: string }> }
-) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
-  }
-
+export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { agentId } = await params;
 
   const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
@@ -290,4 +264,4 @@ export async function DELETE(
   revalidatePath("/", "layout");
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse, after } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
-import { getSession } from "@/lib/auth";
+import { withAuth, withAdmin } from "@/lib/api-auth";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { agents, agentConnectionPermissions, integrationConnections } from "@/db/schema";
@@ -28,26 +27,12 @@ import { getVisibleAgents } from "@/lib/visible-agents";
 import { validateOdooTemplate } from "@/lib/integrations/odoo-template-validation";
 import { detectEmailOperations } from "@/lib/tool-registry";
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async (_req, _ctx, session) => {
   const visibleAgents = await getVisibleAgents(session.user.id!, session.user.role ?? "member");
   return NextResponse.json(visibleAgents);
-}
+});
 
-export async function POST(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin(async (request, _ctx, session) => {
   const body = await request.json();
   const { name, templateId, tagline, pluginConfig, connectionId } = body;
 
@@ -292,4 +277,4 @@ export async function POST(request: NextRequest) {
   revalidatePath("/", "layout");
 
   return NextResponse.json(agent, { status: 201 });
-}
+});

--- a/packages/web/src/app/api/data-directories/route.ts
+++ b/packages/web/src/app/api/data-directories/route.ts
@@ -1,16 +1,10 @@
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { auth } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { readFileSync } from "fs";
 
 const DATA_DIRECTORIES_JSON = "/openclaw-config/data-directories.json";
 
-export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async () => {
   try {
     const json = readFileSync(DATA_DIRECTORIES_JSON, "utf-8");
     const data = JSON.parse(json);
@@ -23,4 +17,4 @@ export async function GET() {
     }
     return NextResponse.json({ directories: [] });
   }
-}
+});

--- a/packages/web/src/app/api/diagnostics/route.ts
+++ b/packages/web/src/app/api/diagnostics/route.ts
@@ -1,3 +1,7 @@
+// auth-direct: public diagnostics endpoint — the session lookup is OPTIONAL,
+// used only to decide whether to include server logs in the response.
+// withAuth/withAdmin would force a 401 on unauthenticated requests, which
+// would break the public health-check use case.
 import { NextResponse } from "next/server";
 import { logCapture } from "@/lib/log-capture";
 import { getSession } from "@/lib/auth";

--- a/packages/web/src/app/api/enterprise/status/route.ts
+++ b/packages/web/src/app/api/enterprise/status/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
 import { getSeatUsage } from "@/lib/seat-usage";
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async () => {
   const status = await getLicenseStatus();
   const usage = status.active ? await getSeatUsage(status) : null;
   return NextResponse.json({
@@ -22,4 +16,4 @@ export async function GET() {
     seatsUsed: usage?.used ?? 0,
     maxUsers: status.maxUsers,
   });
-}
+});

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
@@ -24,15 +23,7 @@ const credentialSchemas: Record<string, z.ZodType> = {
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
-export async function GET(request: NextRequest, { params }: RouteContext) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
   const { connectionId } = await params;
   const [connection] = await db
     .select()
@@ -47,17 +38,9 @@ export async function GET(request: NextRequest, { params }: RouteContext) {
     ...connection,
     credentials: maskConnectionCredentials(connection.type, connection.credentials, decrypt),
   });
-}
+});
 
-export async function PATCH(request: NextRequest, { params }: RouteContext) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const PATCH = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { connectionId } = await params;
 
   // Load existing connection
@@ -149,17 +132,9 @@ export async function PATCH(request: NextRequest, { params }: RouteContext) {
     ...updated,
     credentials: maskConnectionCredentials(updated.type, updated.credentials, decrypt),
   });
-}
+});
 
-export async function DELETE(request: NextRequest, { params }: RouteContext) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { connectionId } = await params;
 
   // Load connection for audit log (need name + type before deletion)
@@ -195,4 +170,4 @@ export async function DELETE(request: NextRequest, { params }: RouteContext) {
   }).catch(console.error);
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { decrypt } from "@/lib/encryption";
@@ -12,15 +11,7 @@ import { validateExternalUrl } from "@/lib/integrations/url-validation";
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
-export async function POST(request: NextRequest, { params }: RouteContext) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { connectionId } = await params;
 
   const [connection] = await db
@@ -80,4 +71,4 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     const message = error instanceof Error ? error.message : "Sync failed";
     return NextResponse.json({ success: false, error: message }, { status: 200 });
   }
-}
+});

--- a/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
@@ -2,11 +2,10 @@
 // stored uid when the first successful authenticate returns a different value
 // (one-time bootstrap), which is intentional and not user-initiated state
 // change — no separate audit entry is written for that self-heal path.
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { OdooClient } from "odoo-node";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { decrypt, encrypt } from "@/lib/encryption";
@@ -14,15 +13,7 @@ import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
-export async function POST(request: NextRequest, { params }: RouteContext) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin<RouteContext>(async (_req, { params }) => {
   const { connectionId } = await params;
 
   const [connection] = await db
@@ -98,4 +89,4 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     const message = error instanceof Error ? error.message : "Connection failed";
     return NextResponse.json({ success: false, error: message }, { status: 200 });
   }
-}
+});

--- a/packages/web/src/app/api/integrations/list-databases/route.ts
+++ b/packages/web/src/app/api/integrations/list-databases/route.ts
@@ -1,23 +1,14 @@
 // audit-exempt: read-only database list, no state changes
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 
 const listDatabasesSchema = z.object({
   url: z.string().url(),
 });
 
-export async function POST(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin(async (request) => {
   const body = await request.json();
   const parsed = listDatabasesSchema.safeParse(body);
   if (!parsed.success) {
@@ -50,4 +41,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ success: false, error: "Could not list databases" });
   }
-}
+});

--- a/packages/web/src/app/api/integrations/oauth/callback/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/callback/route.ts
@@ -1,3 +1,7 @@
+// auth-direct: browser-flow callback. The user has just bounced through
+// Google's OAuth consent screen; on auth failure we render a redirect to
+// /settings, not a JSON 401, so they don't dead-end on raw JSON. The
+// withAuth/withAdmin wrappers always return JSON, which doesn't fit here.
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { getSession } from "@/lib/auth";

--- a/packages/web/src/app/api/integrations/oauth/start/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/start/route.ts
@@ -1,6 +1,12 @@
+// auth-direct: Browser-driven OAuth entry point. The user clicks
+// "Connect Google" on /settings and Next.js navigates them here, so on auth
+// failure we must redirect (not return JSON) — symmetric with oauth/callback.
+// The api-auth wrappers always return JSON, so this route uses an inline
+// session check.
 import { NextResponse } from "next/server";
+import { headers } from "next/headers";
 import { randomBytes } from "crypto";
-import { withAdmin } from "@/lib/api-auth";
+import { getSession } from "@/lib/auth";
 import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
@@ -13,10 +19,30 @@ const GOOGLE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
 ].join(" ");
 
-export const GET = withAdmin(async (request) => {
+function errorRedirect(origin: string, error: string) {
+  const url = new URL("/settings", origin);
+  url.searchParams.set("tab", "integrations");
+  url.searchParams.set("error", error);
+  return NextResponse.redirect(url.toString(), 302);
+}
+
+export async function GET(request: Request) {
+  const requestUrl = new URL(request.url);
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0].trim();
+  const forwardedHost = request.headers.get("x-forwarded-host") || request.headers.get("host");
+  const origin =
+    forwardedProto && forwardedHost ? `${forwardedProto}://${forwardedHost}` : requestUrl.origin;
+
+  // Validate admin session — render failures as redirects, not JSON, because
+  // this is reached via browser navigation.
+  const session = await getSession({ headers: await headers() });
+  if (!session?.user || session.user.role !== "admin") {
+    return errorRedirect(origin, "unauthorized");
+  }
+
   const settings = await getOAuthSettings("google");
   if (!settings) {
-    return NextResponse.json({ error: "Google OAuth not configured" }, { status: 400 });
+    return errorRedirect(origin, "not_configured");
   }
 
   // Clean up the user's own previous pending record (if any) before starting a new flow.
@@ -52,11 +78,6 @@ export const GET = withAdmin(async (request) => {
 
   const state = randomBytes(32).toString("hex");
 
-  const requestUrl = new URL(request.url);
-  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0].trim();
-  const forwardedHost = request.headers.get("x-forwarded-host") || request.headers.get("host");
-  const origin =
-    forwardedProto && forwardedHost ? `${forwardedProto}://${forwardedHost}` : requestUrl.origin;
   const redirectUri = `${origin}/api/integrations/oauth/callback`;
 
   const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
@@ -86,4 +107,4 @@ export const GET = withAdmin(async (request) => {
   });
 
   return response;
-});
+}

--- a/packages/web/src/app/api/integrations/oauth/start/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/start/route.ts
@@ -1,7 +1,6 @@
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
 import { randomBytes } from "crypto";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
@@ -14,15 +13,7 @@ const GOOGLE_OAUTH_SCOPES = [
   "https://www.googleapis.com/auth/userinfo.email",
 ].join(" ");
 
-export async function GET(request: Request) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const GET = withAdmin(async (request) => {
   const settings = await getOAuthSettings("google");
   if (!settings) {
     return NextResponse.json({ error: "Google OAuth not configured" }, { status: 400 });
@@ -95,4 +86,4 @@ export async function GET(request: Request) {
   });
 
   return response;
-}
+});

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -1,8 +1,7 @@
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { z } from "zod";
 import { eq } from "drizzle-orm";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { encrypt, decrypt } from "@/lib/encryption";
@@ -27,15 +26,7 @@ const createIntegrationSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const GET = withAdmin(async () => {
   const connections = await db.select().from(integrationConnections);
 
   // Decrypt per row and isolate failures: if ENCRYPTION_KEY changed (e.g. an
@@ -71,17 +62,9 @@ export async function GET() {
   });
 
   return NextResponse.json(masked);
-}
+});
 
-export async function POST(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin(async (request, _ctx, session) => {
   const body = await request.json();
   const parsed = createIntegrationSchema.safeParse(body);
   if (!parsed.success) {
@@ -144,4 +127,4 @@ export async function POST(request: NextRequest) {
     },
     { status: 201 }
   );
-}
+});

--- a/packages/web/src/app/api/integrations/sync-preview/route.ts
+++ b/packages/web/src/app/api/integrations/sync-preview/route.ts
@@ -1,8 +1,7 @@
 // audit-exempt: read-only preview, no state changes
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { z } from "zod";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 
@@ -17,15 +16,7 @@ const syncPreviewSchema = z.object({
   }),
 });
 
-export async function POST(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin(async (request) => {
   const body = await request.json();
   const parsed = syncPreviewSchema.safeParse(body);
   if (!parsed.success) {
@@ -44,4 +35,4 @@ export async function POST(request: NextRequest) {
 
   const result = await fetchOdooSchema(credentials);
   return NextResponse.json(result);
-}
+});

--- a/packages/web/src/app/api/integrations/test-credentials/route.ts
+++ b/packages/web/src/app/api/integrations/test-credentials/route.ts
@@ -1,9 +1,8 @@
 // audit-exempt: read-only credential test, no state changes
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { z } from "zod";
 import { OdooClient } from "odoo-node";
-import { getSession } from "@/lib/auth";
+import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 
 const testCredentialsSchema = z.discriminatedUnion("type", [
@@ -24,15 +23,7 @@ const testCredentialsSchema = z.discriminatedUnion("type", [
   }),
 ]);
 
-export async function POST(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const POST = withAdmin(async (request) => {
   const body = await request.json();
   const parsed = testCredentialsSchema.safeParse(body);
   if (!parsed.success) {
@@ -89,4 +80,4 @@ export async function POST(request: NextRequest) {
     const message = error instanceof Error ? error.message : "Connection failed";
     return NextResponse.json({ success: false, error: message });
   }
-}
+});

--- a/packages/web/src/app/api/providers/models/route.ts
+++ b/packages/web/src/app/api/providers/models/route.ts
@@ -1,15 +1,8 @@
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { auth } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { fetchProviderModels } from "@/lib/provider-models";
 
-export async function GET() {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async () => {
   const providers = await fetchProviderModels();
-
   return NextResponse.json({ providers });
-}
+});

--- a/packages/web/src/app/api/settings/context/route.ts
+++ b/packages/web/src/app/api/settings/context/route.ts
@@ -1,30 +1,15 @@
 // audit-exempt: org context editing is a content change, not a security-sensitive admin action
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const GET = withAdmin(async () => {
   const content = await getSetting("org_context");
   return NextResponse.json({ content: content ?? "" });
-}
+});
 
-export async function PUT(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
-  if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Admin access required" }, { status: 403 });
-  }
-
+export const PUT = withAdmin(async (request) => {
   const { content } = await request.json();
 
   if (typeof content !== "string") {
@@ -36,4 +21,4 @@ export async function PUT(request: NextRequest) {
   await syncOrgContextToWorkspaces();
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/settings/providers/route.ts
+++ b/packages/web/src/app/api/settings/providers/route.ts
@@ -1,8 +1,6 @@
 // audit-exempt: provider removal is a settings change, audit logging planned for a future PR
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
-import { requireAdmin } from "@/lib/api-auth";
+import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
@@ -13,12 +11,7 @@ import { eq } from "drizzle-orm";
 
 const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async (_req, _ctx, session) => {
   const isAdmin = session.user.role === "admin";
   const defaultProvider = await getSetting("default_provider");
 
@@ -34,12 +27,9 @@ export async function GET() {
   }
 
   return NextResponse.json({ defaultProvider, providers });
-}
+});
 
-export async function DELETE(request: Request) {
-  const sessionOrError = await requireAdmin();
-  if (sessionOrError instanceof NextResponse) return sessionOrError;
-
+export const DELETE = withAdmin(async (request) => {
   const body = await request.json();
   const provider = body.provider as ProviderName;
 
@@ -101,4 +91,4 @@ export async function DELETE(request: Request) {
   await regenerateOpenClawConfig();
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/settings/telegram/bots/route.ts
+++ b/packages/web/src/app/api/settings/telegram/bots/route.ts
@@ -1,15 +1,9 @@
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { getSetting } from "@/lib/settings";
 import { db } from "@/db";
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async () => {
   // No visibility filtering — this endpoint answers "which Telegram bots exist?"
   // for the pairing UI. All authenticated users need to see available bots to
   // link their Telegram account, regardless of agent access permissions.
@@ -36,4 +30,4 @@ export async function GET() {
   bots.sort((a, b) => (a.isPersonal === b.isPersonal ? 0 : a.isPersonal ? -1 : 1));
 
   return NextResponse.json({ bots });
-}
+});

--- a/packages/web/src/app/api/settings/telegram/route.ts
+++ b/packages/web/src/app/api/settings/telegram/route.ts
@@ -1,7 +1,6 @@
 // audit-exempt: User self-service action (linking own Telegram account), not an admin operation
 import { NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { resolvePairingCode } from "@/lib/telegram-pairing";
 import { updateIdentityLinks } from "@/lib/openclaw-config";
 import { recalculateTelegramAllowStores, removePairingRequest } from "@/lib/telegram-allow-store";
@@ -27,12 +26,7 @@ async function buildIdentityLinks(): Promise<Record<string, string[]>> {
   return identityLinks;
 }
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async (_req, _ctx, session) => {
   const link = await db.query.channelLinks.findFirst({
     where: and(eq(channelLinks.userId, session.user.id), eq(channelLinks.channel, "telegram")),
   });
@@ -41,14 +35,9 @@ export async function GET() {
     linked: !!link,
     channelUserId: link?.channelUserId ?? null,
   });
-}
+});
 
-export async function POST(req: Request) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const POST = withAuth(async (req, _ctx, session) => {
   const { code } = await req.json();
   if (!code || typeof code !== "string") {
     return NextResponse.json({ error: "Pairing code is required" }, { status: 400 });
@@ -92,14 +81,9 @@ export async function POST(req: Request) {
   updateIdentityLinks(await buildIdentityLinks());
 
   return NextResponse.json({ linked: true, telegramUserId });
-}
+});
 
-export async function DELETE() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const DELETE = withAuth(async (_req, _ctx, session) => {
   // Find the user's telegram ID before deleting
   const existingLink = await db.query.channelLinks.findFirst({
     where: and(eq(channelLinks.userId, session.user.id), eq(channelLinks.channel, "telegram")),
@@ -121,4 +105,4 @@ export async function DELETE() {
   updateIdentityLinks(await buildIdentityLinks());
 
   return NextResponse.json({ linked: false });
-}
+});

--- a/packages/web/src/app/api/templates/route.ts
+++ b/packages/web/src/app/api/templates/route.ts
@@ -1,7 +1,6 @@
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
+import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
-import { auth } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
@@ -11,12 +10,7 @@ import { getSetting } from "@/lib/settings";
 import { type ProviderName } from "@/lib/providers";
 import { resolveModelForTemplate, TemplateCapabilityUnavailableError } from "@/lib/model-resolver";
 
-export async function GET(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-  }
-
+export const GET = withAuth(async () => {
   const odooConnections = await db
     .select({ id: integrationConnections.id })
     .from(integrationConnections)
@@ -91,4 +85,4 @@ export async function GET(request: NextRequest) {
   );
 
   return NextResponse.json({ templates });
-}
+});

--- a/packages/web/src/app/api/users/me/context/route.ts
+++ b/packages/web/src/app/api/users/me/context/route.ts
@@ -1,27 +1,20 @@
 // audit-exempt: users editing their own context is a self-service action
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 
-export async function GET() {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+export const GET = withAuth(async (_req, _ctx, session) => {
   const user = await db.query.users.findFirst({
     where: eq(users.id, session.user.id),
   });
 
   return NextResponse.json({ content: user?.context ?? "" });
-}
+});
 
-export async function PUT(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+export const PUT = withAuth(async (request, _ctx, session) => {
   const { content } = await request.json();
 
   if (typeof content !== "string") {
@@ -33,4 +26,4 @@ export async function PUT(request: NextRequest) {
   await syncUserContextToWorkspaces(session.user.id);
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/app/api/users/me/password/route.ts
+++ b/packages/web/src/app/api/users/me/password/route.ts
@@ -1,12 +1,10 @@
 // audit-exempt: users changing their own password is a self-service action
-import { NextRequest, NextResponse } from "next/server";
+import { NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { auth } from "@/lib/auth";
+import { withAuth } from "@/lib/api-auth";
 
-export async function POST(request: NextRequest) {
-  const session = await auth.api.getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+export const POST = withAuth(async (request) => {
   const { currentPassword, newPassword } = await request.json();
 
   if (!currentPassword) {
@@ -32,4 +30,4 @@ export async function POST(request: NextRequest) {
   } catch {
     return NextResponse.json({ error: "Current password is incorrect" }, { status: 403 });
   }
-}
+});

--- a/packages/web/src/app/api/users/me/route.ts
+++ b/packages/web/src/app/api/users/me/route.ts
@@ -1,15 +1,11 @@
 // audit-exempt: users updating their own profile is a self-service action
-import { NextRequest, NextResponse } from "next/server";
-import { headers } from "next/headers";
-import { getSession } from "@/lib/auth";
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 
-export async function PATCH(request: NextRequest) {
-  const session = await getSession({ headers: await headers() });
-  if (!session?.user?.id) return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
-
+export const PATCH = withAuth(async (request, _ctx, session) => {
   const { name } = await request.json();
 
   if (!name || typeof name !== "string" || !name.trim()) {
@@ -19,4 +15,4 @@ export async function PATCH(request: NextRequest) {
   await db.update(users).set({ name: name.trim() }).where(eq(users.id, session.user.id));
 
   return NextResponse.json({ success: true });
-}
+});

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -79,6 +79,31 @@ export function assertAgentWriteAccess(
   throw new Error("Access denied");
 }
 
+/**
+ * Same as `assertAgentWriteAccess` but built for API route handlers: returns
+ * `null` when the user may write, or a standardized 403 `NextResponse` when
+ * they may not. Lets handlers do
+ *
+ *   const denied = requireAgentWriteAccess(agent, userId, role);
+ *   if (denied) return denied;
+ *
+ * instead of repeating the `try { assertAgentWriteAccess(...) } catch { return 403 }`
+ * boilerplate. Mirrors the `getAgentWithAccess` shape (returns
+ * `NextResponse | T`).
+ */
+export function requireAgentWriteAccess(
+  agent: AgentForAccess,
+  userId: string,
+  userRole: string
+): NextResponse | null {
+  try {
+    assertAgentWriteAccess(agent, userId, userRole);
+    return null;
+  } catch {
+    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+  }
+}
+
 export async function getAgentWithAccess(agentId: string, userId: string, userRole: string) {
   const rows = await db.select().from(activeAgents).where(eq(activeAgents.id, agentId));
   const agent = rows[0];

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -14,9 +14,12 @@ const forbidden = () => NextResponse.json({ error: "Forbidden" }, { status: 403 
  * Returns the session if the user is an admin, or a NextResponse error otherwise.
  *
  * Prefer `withAdmin()` for new code — it removes the `instanceof NextResponse`
- * branch from every handler. Use `requireAdmin()` only when the handler needs
- * to act on the session before any wrapper logic runs (e.g. early returns
- * before the admin check, custom 403 handling).
+ * branch from every handler. Reach for `requireAdmin()` (or an inline check)
+ * only when the wrapper shape doesn't fit, for example:
+ *   - the handler must act on the session before the admin check (rare)
+ *   - the handler needs to render auth failure as a redirect (browser-flow
+ *     endpoints like OAuth callbacks) rather than a JSON response — wrappers
+ *     always return JSON.
  */
 export async function requireAdmin(): Promise<Session | NextResponse> {
   const session = await getSession({

--- a/packages/web/src/lib/api-auth.ts
+++ b/packages/web/src/lib/api-auth.ts
@@ -1,20 +1,71 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { getSession, type Session } from "@/lib/auth";
 
 /**
+ * Standardized API auth error responses. Use these instead of inline
+ * `NextResponse.json(...)` so every protected route returns the same shape.
+ */
+const unauthorized = () => NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+const forbidden = () => NextResponse.json({ error: "Forbidden" }, { status: 403 });
+
+/**
  * Check auth + admin role for API routes.
  * Returns the session if the user is an admin, or a NextResponse error otherwise.
+ *
+ * Prefer `withAdmin()` for new code — it removes the `instanceof NextResponse`
+ * branch from every handler. Use `requireAdmin()` only when the handler needs
+ * to act on the session before any wrapper logic runs (e.g. early returns
+ * before the admin check, custom 403 handling).
  */
 export async function requireAdmin(): Promise<Session | NextResponse> {
   const session = await getSession({
     headers: await headers(),
   });
   if (!session?.user) {
-    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+    return unauthorized();
   }
   if (session.user.role !== "admin") {
-    return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    return forbidden();
   }
   return session;
+}
+
+type AuthedHandler<C> = (
+  req: NextRequest,
+  ctx: C,
+  session: Session
+) => Promise<NextResponse> | NextResponse;
+
+/**
+ * Wraps an authenticated route handler. Resolves the session, returns a
+ * standardized 401 on missing auth, otherwise calls
+ * `handler(req, ctx, session)`.
+ *
+ * Example:
+ *   export const GET = withAuth(async (req, _ctx, session) => {
+ *     return NextResponse.json({ id: session.user.id });
+ *   });
+ */
+export function withAuth<C = unknown>(handler: AuthedHandler<C>) {
+  return async (req: NextRequest, ctx: C): Promise<NextResponse> => {
+    const session = await getSession({ headers: await headers() });
+    if (!session?.user) {
+      return unauthorized();
+    }
+    return handler(req, ctx, session);
+  };
+}
+
+/**
+ * Same as `withAuth` plus a role check; returns a standardized 403 on
+ * non-admin.
+ */
+export function withAdmin<C = unknown>(handler: AuthedHandler<C>) {
+  return withAuth<C>((req, ctx, session) => {
+    if (session.user.role !== "admin") {
+      return forbidden();
+    }
+    return handler(req, ctx, session);
+  });
 }


### PR DESCRIPTION
Closes #228.

## Summary

- Adds `withAuth(handler)` and `withAdmin(handler)` higher-order wrappers to `packages/web/src/lib/api-auth.ts` next to the existing `requireAdmin()`.
- Migrates 22 route files in `packages/web/src/app/api/` off the duplicated `if (!session?.user)` / `session.user.role !== "admin"` boilerplate.
- Standardizes 401 to \`{ error: "Unauthorized" }\` and 403 to \`{ error: "Forbidden" }\` everywhere — drops the inconsistent \`"Admin access required"\` string the issue called out.
- Updates the security test (\`api-auth-check.test.ts\`) to recognize the new wrappers as valid auth patterns, so future routes can use them without tripping the guard.

## Carve-outs (intentional)

- \`integrations/oauth/callback\`: returns a *redirect* on auth failure (the user just bounced through Google's OAuth flow); JSON 401 would dead-end them. Wrappers return JSON, so the inline check stays.
- \`agents/[agentId]\` PATCH: nested \`role !== "admin"\` checks remain because they gate specific *fields* (\`allowedTools\`, \`visibility\`) for non-admins, not the request itself. The route is wrapped with \`withAuth\`; these are business rules, not auth gates.

## Test plan

- [x] \`pnpm test src/__tests__/lib/api-auth.test.ts\` — covers no-session, non-admin, and admin paths for both new wrappers; asserts both status codes and bodies.
- [x] \`pnpm test src/__tests__/security/api-auth-check.test.ts\` — every \`route.ts\` under \`api/\` still has a recognized auth check.
- [x] \`pnpm test\` (full suite): 3407 passed, 12 skipped, 3 todo.
- [x] \`npx tsc --noEmit\`: clean.
- [x] \`pnpm lint\`: 0 errors.
- [x] Verified zero remaining occurrences of \`"Admin access required"\` in the repo.
- [x] Verified zero remaining inline \`if (!session?.user)\` 401 checks in API routes (other than the documented OAuth callback carve-out).