### PR TITLE
test: replace wall-clock setTimeout waits with deterministic alternatives (#236)

### DIFF
--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -413,12 +413,19 @@ describe("AgentSettingsPage", () => {
     let integrationPutResolved = false;
     let patchStartedBeforePutResolved = false;
 
+    // Hold the PUT pending on a controllable deferred instead of a real
+    // wall-clock setTimeout — gives a deterministic window for detecting
+    // parallelism without slowing the suite or relying on CI scheduling.
+    let resolveIntegrationPut!: () => void;
+    const integrationPutPending = new Promise<void>((r) => {
+      resolveIntegrationPut = r;
+    });
+
     fetchSpy.mockImplementation(async (url, opts) => {
       const urlStr = typeof url === "string" ? url : url.toString();
       const method = (opts as RequestInit)?.method ?? "GET";
       if (urlStr.includes("/api/agents/agent-1/integrations") && method === "PUT") {
-        // Simulate async work to create a window for detecting parallelism
-        await new Promise((r) => setTimeout(r, 50));
+        await integrationPutPending;
         integrationPutResolved = true;
       } else if (urlStr.includes("/api/agents/agent-1") && method === "PATCH") {
         if (!integrationPutResolved) {
@@ -432,6 +439,19 @@ describe("AgentSettingsPage", () => {
     await waitFor(() => screen.getByText(/apply changes and restart/i));
     const confirmButtons = screen.getAllByRole("button", { name: /save & restart/i });
     await userEvent.click(confirmButtons[confirmButtons.length - 1]);
+
+    // Wait until the PUT has been dispatched (and is now suspended on the
+    // deferred). If the save handler dispatches in parallel, the PATCH
+    // would also have been called by this point and the flag would be set;
+    // sequential dispatch leaves PATCH unfired until we resolve the PUT.
+    await waitFor(() =>
+      expect(fetchSpy).toHaveBeenCalledWith(
+        expect.stringContaining("/api/agents/agent-1/integrations"),
+        expect.objectContaining({ method: "PUT" })
+      )
+    );
+
+    resolveIntegrationPut();
 
     await waitFor(() => {
       expect(integrationPutResolved).toBe(true);

--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -428,6 +428,12 @@ describe("AgentSettingsPage", () => {
         await integrationPutPending;
         integrationPutResolved = true;
       } else if (urlStr.includes("/api/agents/agent-1") && method === "PATCH") {
+        // Invariant: this branch must run synchronously up to `return` —
+        // no `await` before the flag check. The detection logic relies on
+        // the PATCH mock body executing fully in the same synchronous
+        // invocation as the fetch call, so that "PATCH in parallel with
+        // PUT" produces a deterministic flag set before the test code
+        // resumes after the `waitFor(PUT was called)` below.
         if (!integrationPutResolved) {
           patchStartedBeforePutResolved = true;
         }

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -194,8 +194,12 @@ describe("EnterpriseBanner", () => {
         document.dispatchEvent(new Event("visibilitychange"));
       });
 
-      // Give any stray promises a chance to land
-      await new Promise((resolve) => setTimeout(resolve, 10));
+      // Flush any microtasks the visibility handler may have scheduled —
+      // a stray re-fetch would land on the microtask queue, not after a
+      // real wall-clock delay.
+      await act(async () => {
+        await Promise.resolve();
+      });
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -196,10 +196,13 @@ describe("EnterpriseBanner", () => {
 
       // Flush any microtasks the visibility handler may have scheduled —
       // a stray re-fetch would land on the microtask queue, not after a
-      // real wall-clock delay.
-      await act(async () => {
-        await Promise.resolve();
-      });
+      // real wall-clock delay. Several rounds in case the handler chains
+      // multiple awaits before reaching `fetch(...)`.
+      for (let i = 0; i < 5; i++) {
+        await act(async () => {
+          await Promise.resolve();
+        });
+      }
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
 

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -42,13 +42,18 @@ describe("validateLicense", () => {
 
   it("returns active=false for an expired token", async () => {
     const { validateLicense } = await import("@/lib/license");
-    // Create a token that expires immediately
-    const token = await createTestToken({}, "1s");
-    // Wait for it to expire
-    await new Promise((r) => setTimeout(r, 1500));
-    const status = await validateLicense(token, testPublicKeyPem);
-    expect(status.active).toBe(false);
-    expect(status.features).toEqual([]);
+    // jose checks exp against the current clock — advance the system clock
+    // past the token's expiry instead of waiting in real time.
+    vi.useFakeTimers();
+    try {
+      const token = await createTestToken({}, "1s");
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.active).toBe(false);
+      expect(status.features).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns active=false for an invalid signature", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1164,11 +1164,15 @@ describe("regenerateOpenClawConfig", () => {
 
       await regenerateOpenClawConfig();
 
-      // The push is fire-and-forget — flush microtasks until the
-      // background coroutine has reached config.apply (or give up).
-      for (let i = 0; i < 50 && mockConfigApply.mock.calls.length === 0; i++) {
-        await new Promise((r) => setTimeout(r, 10));
-      }
+      // The push is fire-and-forget — wait for the background coroutine
+      // to reach config.apply rather than spinning on real time.
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      // Drain remaining microtasks so the coroutine's final `return`
+      // executes before the next test's beforeEach runs — otherwise an
+      // unsettled continuation can call into mocks that the next test
+      // has already reconfigured (cross-test pollution).
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
 
       expect(mockConfigApply).toHaveBeenCalledOnce();
       const applyArgs = mockConfigApply.mock.calls[0];
@@ -1194,8 +1198,10 @@ describe("regenerateOpenClawConfig", () => {
       // path. We must still write the file (verified above) but must NOT
       // attempt the RPC.
       await regenerateOpenClawConfig();
-      // Background coroutine bails immediately when client unavailable.
-      await new Promise((r) => setTimeout(r, 50));
+      // Background coroutine bails immediately when client unavailable —
+      // flush microtasks so the bail path completes, no real wait needed.
+      await new Promise((r) => setImmediate(r));
+      await new Promise((r) => setImmediate(r));
 
       expect(mockConfigGet).not.toHaveBeenCalled();
       expect(mockConfigApply).not.toHaveBeenCalled();

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -144,6 +144,21 @@ function mockFrom(data: unknown[] = []) {
   );
 }
 
+/**
+ * Drain `regenerateOpenClawConfig`'s fire-and-forget background coroutine
+ * (see `pushConfigInBackground` in openclaw-config.ts) before continuing.
+ *
+ * Two `setImmediate` rounds are enough for the success path: round 1 lets
+ * the dynamic `import()` resolve; round 2 lets the `await client.config.get`
+ * → `await client.config.apply` → `return` chain settle. Without this
+ * drain, an unsettled continuation can call into mocks that the *next*
+ * test's `beforeEach` has already reconfigured (cross-test pollution).
+ */
+async function drainBackgroundCoroutine(): Promise<void> {
+  await new Promise((r) => setImmediate(r));
+  await new Promise((r) => setImmediate(r));
+}
+
 describe("regenerateOpenClawConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1165,14 +1180,11 @@ describe("regenerateOpenClawConfig", () => {
       await regenerateOpenClawConfig();
 
       // The push is fire-and-forget — wait for the background coroutine
-      // to reach config.apply rather than spinning on real time.
+      // to reach config.apply rather than spinning on real time, then
+      // drain the remaining continuation so it doesn't bleed into the
+      // next test (see drainBackgroundCoroutine docs).
       await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
-      // Drain remaining microtasks so the coroutine's final `return`
-      // executes before the next test's beforeEach runs — otherwise an
-      // unsettled continuation can call into mocks that the next test
-      // has already reconfigured (cross-test pollution).
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
+      await drainBackgroundCoroutine();
 
       expect(mockConfigApply).toHaveBeenCalledOnce();
       const applyArgs = mockConfigApply.mock.calls[0];
@@ -1198,10 +1210,9 @@ describe("regenerateOpenClawConfig", () => {
       // path. We must still write the file (verified above) but must NOT
       // attempt the RPC.
       await regenerateOpenClawConfig();
-      // Background coroutine bails immediately when client unavailable —
-      // flush microtasks so the bail path completes, no real wait needed.
-      await new Promise((r) => setImmediate(r));
-      await new Promise((r) => setImmediate(r));
+      // Background coroutine bails immediately when client unavailable;
+      // drain to confirm no microtask-deferred RPC slipped through.
+      await drainBackgroundCoroutine();
 
       expect(mockConfigGet).not.toHaveBeenCalled();
       expect(mockConfigApply).not.toHaveBeenCalled();
@@ -2440,8 +2451,7 @@ describe("restart-state integration", () => {
 
     // Drain the first generate's background coroutine. Without this, its
     // delayed config.apply call would race with the post-test assertion.
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await drainBackgroundCoroutine();
     const applyCallsBeforeSecondGenerate = mockConfigApply.mock.calls.length;
 
     // Now simulate OpenClaw having stamped a NEW lastTouchedAt onto the file
@@ -2456,8 +2466,7 @@ describe("restart-state integration", () => {
 
     await regenerateOpenClawConfig();
     // Drain any background work the second generate might have scheduled.
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await drainBackgroundCoroutine();
 
     // No openclaw.json write (the only diff was OpenClaw-managed metadata).
     const secondConfigWrite = mockedWriteFileSync.mock.calls.find(
@@ -2529,8 +2538,7 @@ describe("restart-state integration", () => {
 
     await regenerateOpenClawConfig();
     // Drain background coroutine.
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await drainBackgroundCoroutine();
 
     expect(mockConfigApply).toHaveBeenCalledTimes(1);
     const [payload] = mockConfigApply.mock.calls[0];
@@ -2573,8 +2581,7 @@ describe("restart-state integration", () => {
     });
 
     await regenerateOpenClawConfig();
-    await new Promise((r) => setImmediate(r));
-    await new Promise((r) => setImmediate(r));
+    await drainBackgroundCoroutine();
 
     expect(mockConfigApply).toHaveBeenCalledTimes(1);
     const [payload] = mockConfigApply.mock.calls[0];

--- a/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-secrets.test.ts
@@ -55,19 +55,19 @@ describe("writeSecretsFile", () => {
     expect(existsSync(`${process.env.OPENCLAW_SECRETS_PATH!}.tmp`)).toBe(false);
   });
 
-  it("does not rewrite the file when content is unchanged (mtime preserved)", async () => {
+  it("does not rewrite the file when content is unchanged (inode preserved)", () => {
     // Without this, every regenerateOpenClawConfig() bumps secrets.json's
     // mtime, and the inotify watcher in start-openclaw.sh would uselessly
-    // restart the OpenClaw gateway on every Pinchy startup.
+    // restart the OpenClaw gateway on every Pinchy startup. We check the
+    // inode rather than mtime so we don't depend on filesystem mtime
+    // granularity (or wall-clock waits) to detect a rewrite — the atomic
+    // rename pattern always allocates a new inode when it does write.
     writeSecretsFile(bundle);
     const path = process.env.OPENCLAW_SECRETS_PATH!;
-    const mtimeBefore = statSync(path).mtimeMs;
-    // Sleep long enough that even coarse-granularity filesystems would record
-    // a different mtime if we did rewrite.
-    await new Promise((resolve) => setTimeout(resolve, 50));
+    const inoBefore = statSync(path).ino;
     writeSecretsFile(bundle);
-    const mtimeAfter = statSync(path).mtimeMs;
-    expect(mtimeAfter).toBe(mtimeBefore);
+    const inoAfter = statSync(path).ino;
+    expect(inoAfter).toBe(inoBefore);
   });
 
   it("does rewrite the file when content changes", () => {

--- a/packages/web/src/__tests__/lib/shutdown.test.ts
+++ b/packages/web/src/__tests__/lib/shutdown.test.ts
@@ -54,26 +54,35 @@ describe("registerShutdownHandlers", () => {
   });
 
   it("awaits async stopFns before exiting", async () => {
-    const order: string[] = [];
-    const stopA = vi.fn().mockImplementation(async () => {
-      await new Promise((resolve) => setTimeout(resolve, 10));
-      order.push("A");
-    });
-    const stopB = vi.fn().mockImplementation(() => {
-      order.push("B");
-    });
-    const exit = vi.fn().mockImplementation(() => {
-      order.push("exit");
-    });
+    vi.useFakeTimers();
+    try {
+      const order: string[] = [];
+      const stopA = vi.fn().mockImplementation(async () => {
+        // Async work scheduled on the timer queue — handler must await it
+        // before moving on to stopB and exit.
+        await new Promise((resolve) => setTimeout(resolve, 10));
+        order.push("A");
+      });
+      const stopB = vi.fn().mockImplementation(() => {
+        order.push("B");
+      });
+      const exit = vi.fn().mockImplementation(() => {
+        order.push("exit");
+      });
 
-    const dispose = registerShutdownHandlers([stopA, stopB], { exit });
-    disposers.push(dispose);
+      const dispose = registerShutdownHandlers([stopA, stopB], { exit });
+      disposers.push(dispose);
 
-    process.emit("SIGTERM", "SIGTERM");
-    await new Promise((resolve) => setTimeout(resolve, 30));
+      process.emit("SIGTERM", "SIGTERM");
+      // Drive stopA's setTimeout via the fake clock; the handler chain then
+      // runs stopB and exit synchronously after stopA resolves.
+      await vi.advanceTimersByTimeAsync(10);
 
-    // Exit must come strictly after both stop fns finished
-    expect(order).toEqual(["A", "B", "exit"]);
+      // Exit must come strictly after both stop fns finished
+      expect(order).toEqual(["A", "B", "exit"]);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 
   it("returns a disposer that removes the signal handlers", async () => {


### PR DESCRIPTION
## What does this PR do?

Replaces eight wall-clock `setTimeout` waits in the unit-test suite with deterministic alternatives (fake timers, microtask drains, controlled deferreds, inode comparison). These waits were the suite's slowest and flakiest segments — the test didn't control time, the OS scheduler did.

Closes #236

## Type of change

- [x] 🧪 Tests

## What changed

| File | Before | After |
|---|---|---|
| `license.test.ts:48` | 1500 ms real-time wait for JWT to expire | `vi.useFakeTimers()` + `vi.setSystemTime(Date.now() + 1500)` (jose validates `exp` against the system clock — no real wait needed) |
| `openclaw-secrets.test.ts:67` | 50 ms sleep + mtime comparison (defeats coarse-granularity FS) | Inode comparison — the atomic-rename pattern always allocates a new inode on rewrite, no time involved |
| `openclaw-config.test.ts:1170` | 50-iteration polling loop (`setTimeout(10)` each) waiting for fire-and-forget RPC | `vi.waitFor()` + microtask drain |
| `openclaw-config.test.ts:1198` | 50 ms "wait for nothing to happen" check | 2× `setImmediate` (matches the file's existing drain pattern) |
| `shutdown.test.ts:59 + :73` | 10 ms inner `setTimeout` in stopFn + 30 ms outer wait | `vi.useFakeTimers()` + `vi.advanceTimersByTimeAsync(10)` (driven from outside) |
| `agent-settings-page.test.tsx:421` | 50 ms `setTimeout` inside fetch mock to simulate async parallelism window | Controllable deferred — PUT awaits `integrationPutPending` until the test resolves it; gives a deterministic window without waiting |
| `enterprise-banner.test.tsx:198` | 10 ms sleep to "give any stray promises a chance to land" | `await Promise.resolve()` inside `act()` — flushes microtasks deterministically |

## Why this matters

The headline case (`license.test.ts`) signed a JWT with a 1-second expiry and then **slept 1.5 s of real time** before re-validating. On a hot CI runner this works; on a busy one a 200 ms scheduling hiccup can leave the token still valid. Cumulatively, the eight waits added ≥1.7 s of unavoidable wall-clock time per `vitest run` and were the dominant flake source on slow GitHub Actions runners.

## A note on cross-test pollution

The first iteration of the `vi.waitFor()` change for `openclaw-config.test.ts:1170` exited as soon as `apply` had been called once — but **before** the background coroutine's final `return` had executed. That left a partially-resumed coroutine that could leak into a later test (`redacts unchanged env values to OpenClaw sentinel`), causing intermittent `expected 1 call, got 2` failures. Reproduced 2-out-of-4 times locally on this branch; never on `main` across 3 runs. Fixed by adding two `setImmediate` drains after `vi.waitFor` so the coroutine fully completes before the next test's `beforeEach` reconfigures the shared mock. See the inline comment in the test for context.

## Checklist

- [x] My code follows the project's style
- [x] All existing tests pass

## Test plan

- [x] `pnpm -C packages/web test` — all 3407 tests green
- [x] Re-ran the full suite **four consecutive times** locally to verify the cross-test flake is gone
- [ ] CI green