### PR TITLE
refactor(api): standardize request-body validation with Zod (#232)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -160,14 +160,15 @@ Example patterns:
 
 ### Checklist for API Routes with State Changes
 When creating or modifying any POST/PUT/PATCH/DELETE endpoint:
-1. `appendAuditLog()` or `deferAuditLog()` call present? If not needed: add `// audit-exempt: <reason>` comment
-2. Pattern matches the action shape — `await appendAuditLog` for idempotent ops, `deferAuditLog` for non-rollbackable side effects? (See "Never fire-and-forget" above.)
-3. Event type uses a valid `AuditResource` prefix (agent, group, user, settings, config)?
-4. Detail payload uses the correct base type (`UpdateDetail` for `*.updated`, `DeleteDetail` for `*.deleted`, `MembershipDetail` for `*.members_updated`)?
-5. All referenced entities snapshotted as `{ id, name }` pairs (`EntityRef`)?
-6. Test exists that verifies the `appendAuditLog` call with correct payload?
-7. `outcome` field set correctly? `'success'` for the happy path (default), `'failure'` for error paths that still deserve an audit entry?
-8. No plaintext email or other PII in `detail`? If you need to identify an email, use `redactEmail()` from `@/lib/audit`. If the resource already encodes the userId, log the display name only.
+1. **Body validation via `parseRequestBody(schema, request)`** from `@/lib/api-validation`? Never call `await request.json()` directly — that throws 500 on malformed JSON, and ad-hoc `typeof` checks drift across routes. Define a Zod schema at the top of the route, then `const parsed = await parseRequestBody(schema, request); if ("error" in parsed) return parsed.error;`. Validation failures return `{ error: "Validation failed", details: <flatten> }` with status 400 — clients can read `details.fieldErrors.<name>` to render inline errors. Routes that take no body (e.g. DELETE on a path-param resource) are exempt.
+2. `appendAuditLog()` or `deferAuditLog()` call present? If not needed: add `// audit-exempt: <reason>` comment
+3. Pattern matches the action shape — `await appendAuditLog` for idempotent ops, `deferAuditLog` for non-rollbackable side effects? (See "Never fire-and-forget" above.)
+4. Event type uses a valid `AuditResource` prefix (agent, group, user, settings, config)?
+5. Detail payload uses the correct base type (`UpdateDetail` for `*.updated`, `DeleteDetail` for `*.deleted`, `MembershipDetail` for `*.members_updated`)?
+6. All referenced entities snapshotted as `{ id, name }` pairs (`EntityRef`)?
+7. Test exists that verifies the `appendAuditLog` call with correct payload?
+8. `outcome` field set correctly? `'success'` for the happy path (default), `'failure'` for error paths that still deserve an audit entry?
+9. No plaintext email or other PII in `detail`? If you need to identify an email, use `redactEmail()` from `@/lib/audit`. If the resource already encodes the userId, log the display name only.
 
 ### Error & Notification Display Policy
 User feedback (errors, success confirmations) must use the correct display pattern. Using the wrong one creates inconsistent UX.

--- a/packages/web/eslint-rules/require-parse-request-body.js
+++ b/packages/web/eslint-rules/require-parse-request-body.js
@@ -1,0 +1,48 @@
+/**
+ * Forbid `request.json()` / `req.json()` in API route handlers — every state-mutating
+ * route must go through `parseRequestBody()` from `@/lib/api-validation`. Catches
+ * regressions where a new route would skip Zod validation, return 500 on malformed
+ * JSON, or drift away from the shared error contract.
+ *
+ * @type {import('eslint').Rule.RuleModule}
+ */
+module.exports = {
+  meta: {
+    type: "problem",
+    docs: {
+      description:
+        "Forbid request.json() in API route handlers — use parseRequestBody() from @/lib/api-validation instead",
+    },
+    messages: {
+      directJsonCall:
+        "Do not call `{{callee}}.json()` directly in API routes. Define a Zod schema and use `parseRequestBody(schema, {{callee}})` from @/lib/api-validation. This guarantees a structured 400 on shape mismatch and on malformed JSON (instead of 500), and keeps the error contract consistent across routes.",
+    },
+    schema: [],
+  },
+  create(context) {
+    const filename = context.filename || context.getFilename();
+    if (!filename.includes("/app/api/") || !filename.endsWith("route.ts")) {
+      return {};
+    }
+
+    return {
+      CallExpression(node) {
+        if (
+          node.callee.type === "MemberExpression" &&
+          !node.callee.computed &&
+          node.callee.property.type === "Identifier" &&
+          node.callee.property.name === "json" &&
+          node.callee.object.type === "Identifier" &&
+          (node.callee.object.name === "request" || node.callee.object.name === "req") &&
+          node.arguments.length === 0
+        ) {
+          context.report({
+            node,
+            messageId: "directJsonCall",
+            data: { callee: node.callee.object.name },
+          });
+        }
+      },
+    };
+  },
+};

--- a/packages/web/eslint.config.mjs
+++ b/packages/web/eslint.config.mjs
@@ -3,6 +3,7 @@ import nextVitals from "eslint-config-next/core-web-vitals";
 import nextTs from "eslint-config-next/typescript";
 import security from "eslint-plugin-security";
 import requireAuditLog from "./eslint-rules/require-audit-log.js";
+import requireParseRequestBody from "./eslint-rules/require-parse-request-body.js";
 import noDirectSession from "./eslint-rules/no-direct-session.js";
 import noPiiInAuditDetail from "./eslint-rules/no-pii-in-audit-detail.js";
 
@@ -11,6 +12,7 @@ const pinchyPlugin = {
     "require-audit-log": requireAuditLog,
     "no-direct-session": noDirectSession,
     "no-pii-in-audit-detail": noPiiInAuditDetail,
+    "require-parse-request-body": requireParseRequestBody,
   },
 };
 
@@ -68,11 +70,15 @@ const eslintConfig = defineConfig([
   //   helpers in @/lib/api-auth (withAuth / withAdmin / requireAdmin) instead
   //   of calling getSession or auth.api.getSession directly
   //   (opt out with a // auth-direct: <reason> file comment)
+  // - require-parse-request-body: every state-mutating handler must use
+  //   parseRequestBody() from @/lib/api-validation instead of calling
+  //   request.json() directly
   {
     files: ["src/app/api/**/route.ts"],
     plugins: { pinchy: pinchyPlugin },
     rules: {
       "pinchy/no-direct-session": "error",
+      "pinchy/require-parse-request-body": "error",
     },
   },
   // Override default ignores of eslint-config-next.

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -308,7 +308,8 @@ describe("PUT /api/agents/[agentId]/files/[filename]", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("content must be a string");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
     expect(writeWorkspaceFile).not.toHaveBeenCalled();
   });
 

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -238,7 +238,8 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("Bot token is required");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.botToken).toBeDefined();
   });
 
   it("returns 404 for non-existent agent", async () => {

--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -571,7 +571,8 @@ describe("PATCH /api/agents/[agentId] name length validation", () => {
     });
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toMatch(/name/i);
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("should accept name with exactly 30 characters", async () => {

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -267,6 +267,35 @@ describe("POST /api/agents", () => {
     );
   });
 
+  it("should reject whitespace-only name", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "   ", templateId: "custom" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
+  });
+
+  it("should reject pinchy-files.allowed_paths with non-string entries", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "Test",
+        templateId: "knowledge-base",
+        pluginConfig: { "pinchy-files": { allowed_paths: ["/data/", 42] } },
+      }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Validation failed");
+  });
+
   it("should reject name longer than 30 characters", async () => {
     const request = new NextRequest("http://localhost:7777/api/agents", {
       method: "POST",
@@ -279,7 +308,8 @@ describe("POST /api/agents", () => {
     const response = await POST(request);
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toMatch(/name/i);
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("should accept name with exactly 30 characters", async () => {

--- a/packages/web/src/__tests__/api/agents-patch-validation.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-validation.test.ts
@@ -92,7 +92,8 @@ describe("PATCH /api/agents/[agentId] — pluginConfig validation", () => {
     const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
     expect(res.status).toBe(400);
     const body = await res.json();
-    expect(body.error).toMatch(/pluginConfig/i);
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.pluginConfig).toBeDefined();
   });
 
   it("rejects invalid domains in pluginConfig['pinchy-web'].allowedDomains", async () => {
@@ -149,6 +150,77 @@ describe("PATCH /api/agents/[agentId] — pluginConfig validation", () => {
 
     const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
     expect(res.status).toBe(200);
+  });
+
+  it("rejects pinchy-files.allowed_paths that is not a string array", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const req = new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({
+        pluginConfig: { "pinchy-files": { allowed_paths: 42 } },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.pluginConfig).toBeDefined();
+  });
+
+  it("rejects pinchy-files.allowed_paths with non-string entries", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const req = new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({
+        pluginConfig: { "pinchy-files": { allowed_paths: ["/data/", 123] } },
+      }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+  });
+
+  it("rejects empty-string name on PATCH", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const req = new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "" }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
+  });
+
+  it("rejects whitespace-only name on PATCH", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const req = new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ name: "   " }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const res = await PATCH(req, { params: Promise.resolve({ agentId: "agent-1" }) });
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("accepts null pluginConfig (clears config)", async () => {

--- a/packages/web/src/__tests__/api/agents-visibility.test.ts
+++ b/packages/web/src/__tests__/api/agents-visibility.test.ts
@@ -222,7 +222,8 @@ describe("PATCH /api/agents/[agentId] visibility", () => {
     });
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("Invalid visibility value");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.visibility).toBeDefined();
   });
 
   it("cannot change visibility on personal agents (400)", async () => {

--- a/packages/web/src/__tests__/api/groups.test.ts
+++ b/packages/web/src/__tests__/api/groups.test.ts
@@ -184,7 +184,8 @@ describe("POST /api/groups", () => {
     const response = await POST(request);
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("Name is required");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("rejects empty name", async () => {
@@ -201,7 +202,8 @@ describe("POST /api/groups", () => {
     const response = await POST(request);
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("Name is required");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("rejects non-admin", async () => {
@@ -620,7 +622,8 @@ describe("PUT /api/groups/[groupId]/members", () => {
     });
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("userIds must be an array of strings");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors).toBeDefined();
   });
 
   it("returns 404 when group does not exist", async () => {
@@ -661,7 +664,8 @@ describe("PUT /api/groups/[groupId]/members", () => {
     });
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("userIds must be an array");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.userIds).toBeDefined();
   });
 
   it("returns 403 for non-admin", async () => {

--- a/packages/web/src/__tests__/api/invite-claim.integration.test.ts
+++ b/packages/web/src/__tests__/api/invite-claim.integration.test.ts
@@ -63,13 +63,19 @@ describe("POST /api/invite/claim (integration)", () => {
   it("returns 400 when token is missing", async () => {
     const response = await POST(makeRequest({ name: "Test User", password: "Br1ghtNova!2" }));
     expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: "Token is required" });
+    const body = await response.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.token).toBeDefined();
   });
 
   it("returns 400 when password is missing", async () => {
     const response = await POST(makeRequest({ token: "valid-token", name: "Test User" }));
     expect(response.status).toBe(400);
-    expect(await response.json()).toEqual({ error: "Password must be at least 12 characters" });
+    const body = await response.json();
+    // password is now schema-required (parseRequestBody catches the missing
+    // field before validatePassword() runs).
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.password).toBeDefined();
   });
 
   it("returns 400 when password is too short", async () => {
@@ -77,6 +83,8 @@ describe("POST /api/invite/claim (integration)", () => {
       makeRequest({ token: "valid-token", name: "Test User", password: "short" })
     );
     expect(response.status).toBe(400);
+    // Length is enforced post-parse by validatePassword(), so the freeform
+    // error string is preserved here (12-char policy from #234).
     expect(await response.json()).toEqual({ error: "Password must be at least 12 characters" });
   });
 
@@ -139,6 +147,9 @@ describe("POST /api/invite/claim (integration)", () => {
 
     const response = await POST(makeRequest({ token, password: "Br1ghtNova!2" }));
     expect(response.status).toBe(400);
+    // Name-required is enforced post-parse only when the invite type is
+    // "invite" (resets don't require it), so the legacy freeform error
+    // string is preserved here.
     expect(await response.json()).toEqual({ error: "Name is required" });
   });
 

--- a/packages/web/src/__tests__/api/invites.test.ts
+++ b/packages/web/src/__tests__/api/invites.test.ts
@@ -136,7 +136,8 @@ describe("POST /api/users/invite", () => {
     expect(response.status).toBe(400);
 
     const body = await response.json();
-    expect(body.error).toBe("Role must be 'admin' or 'member'");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.role).toBeDefined();
   });
 
   it("returns 400 when role is invalid", async () => {
@@ -154,7 +155,8 @@ describe("POST /api/users/invite", () => {
     expect(response.status).toBe(400);
 
     const body = await response.json();
-    expect(body.error).toBe("Role must be 'admin' or 'member'");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.role).toBeDefined();
   });
 
   it("returns 201 with invite data on success", async () => {

--- a/packages/web/src/__tests__/api/settings-context.test.ts
+++ b/packages/web/src/__tests__/api/settings-context.test.ts
@@ -138,7 +138,8 @@ describe("PUT /api/settings/context", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("content must be a string");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
   });
 
   it("should return 400 when content is missing", async () => {
@@ -146,6 +147,7 @@ describe("PUT /api/settings/context", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("content must be a string");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
   });
 });

--- a/packages/web/src/__tests__/api/settings-providers.test.ts
+++ b/packages/web/src/__tests__/api/settings-providers.test.ts
@@ -256,7 +256,8 @@ describe("DELETE /api/settings/providers", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Invalid provider");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.provider).toBeDefined();
   });
 
   it("should return 400 when trying to delete the last configured provider", async () => {

--- a/packages/web/src/__tests__/api/settings-route.test.ts
+++ b/packages/web/src/__tests__/api/settings-route.test.ts
@@ -157,6 +157,116 @@ describe("POST /api/settings", () => {
     expect(setSetting).toHaveBeenCalledWith("default_provider", "openai", false);
   });
 
+  it("returns 400 on missing key (no longer crashes with 500)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const { setSetting } = await import("@/lib/settings");
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ value: "anything" }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.key).toBeDefined();
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on non-string key", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const { setSetting } = await import("@/lib/settings");
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: 42, value: "x" }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on empty key", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const { setSetting } = await import("@/lib/settings");
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "", value: "x" }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on missing value", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const { setSetting } = await import("@/lib/settings");
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "some_key" }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    expect(setSetting).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on malformed JSON", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: "{not valid json",
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(400);
+    const body = await response.json();
+    expect(body.error).toBe("Invalid JSON body");
+  });
+
+  it("flags api_key fields as encrypted", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    const { setSetting } = await import("@/lib/settings");
+
+    const request = new NextRequest("http://localhost/api/settings", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ key: "anthropic_api_key", value: "sk-ant-..." }),
+    });
+    const response = await POST(request);
+    expect(response.status).toBe(200);
+    expect(setSetting).toHaveBeenCalledWith("anthropic_api_key", "sk-ant-...", true);
+  });
+
   it("schedules the audit log write via after() instead of fire-and-forget", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "admin-1", role: "admin" },

--- a/packages/web/src/__tests__/api/setup.test.ts
+++ b/packages/web/src/__tests__/api/setup.test.ts
@@ -181,7 +181,8 @@ describe("POST /api/setup", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("Name is required");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.name).toBeDefined();
   });
 
   it("should return 400 when name is empty whitespace", async () => {
@@ -194,7 +195,8 @@ describe("POST /api/setup", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("Name is required");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.name).toBeDefined();
   });
 
   it("should return 400 when email is invalid", async () => {
@@ -207,7 +209,8 @@ describe("POST /api/setup", () => {
     const data = await response.json();
 
     expect(response.status).toBe(400);
-    expect(data.error).toBe("A valid email address is required");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.email).toBeDefined();
   });
 
   it("should return 400 when password is too short", async () => {

--- a/packages/web/src/__tests__/api/user-context.test.ts
+++ b/packages/web/src/__tests__/api/user-context.test.ts
@@ -137,7 +137,8 @@ describe("PUT /api/users/me/context", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("content must be a string");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
   });
 
   it("should return 400 when content is missing", async () => {
@@ -145,6 +146,7 @@ describe("PUT /api/users/me/context", () => {
 
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("content must be a string");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.content).toBeDefined();
   });
 });

--- a/packages/web/src/__tests__/api/user-groups.test.ts
+++ b/packages/web/src/__tests__/api/user-groups.test.ts
@@ -144,7 +144,8 @@ describe("PUT /api/users/[userId]/groups", () => {
     });
     expect(response.status).toBe(400);
     const body = await response.json();
-    expect(body.error).toBe("groupIds must be an array");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.groupIds).toBeDefined();
   });
 
   it("returns 404 when user not found", async () => {

--- a/packages/web/src/__tests__/api/user-self-service.test.ts
+++ b/packages/web/src/__tests__/api/user-self-service.test.ts
@@ -79,7 +79,8 @@ describe("PATCH /api/users/me", () => {
     expect(response.status).toBe(400);
 
     const body = await response.json();
-    expect(body.error).toBe("Name is required");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("returns 400 when name is whitespace only", async () => {
@@ -94,7 +95,8 @@ describe("PATCH /api/users/me", () => {
     expect(response.status).toBe(400);
 
     const body = await response.json();
-    expect(body.error).toBe("Name is required");
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.name).toBeDefined();
   });
 
   it("returns 200 and updates user name on success", async () => {

--- a/packages/web/src/__tests__/api/users-password.test.ts
+++ b/packages/web/src/__tests__/api/users-password.test.ts
@@ -67,10 +67,13 @@ describe("POST /api/users/me/password", () => {
     const response = await POST(makePostRequest({ newPassword: "Br1ghtNova!2" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Current password is required");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.currentPassword).toBeDefined();
   });
 
   it("should return 400 when newPassword is too short", async () => {
+    // "short" is a valid string (passes Zod), then validatePassword() rejects
+    // it post-parse — that's where the freeform 12-char message comes from.
     const response = await POST(
       makePostRequest({ currentPassword: "oldpass1234567", newPassword: "short" })
     );
@@ -116,10 +119,12 @@ describe("POST /api/users/me/password", () => {
   });
 
   it("should return 400 when newPassword is missing", async () => {
+    // newPassword absent → caught by Zod (parseRequestBody) before validatePassword runs.
     const response = await POST(makePostRequest({ currentPassword: "oldpass1234567" }));
     expect(response.status).toBe(400);
     const data = await response.json();
-    expect(data.error).toBe("Password must be at least 12 characters");
+    expect(data.error).toBe("Validation failed");
+    expect(data.details.fieldErrors.newPassword).toBeDefined();
   });
 
   it("should return 403 when current password is incorrect", async () => {

--- a/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
+++ b/packages/web/src/__tests__/eslint/require-parse-request-body.test.ts
@@ -1,0 +1,58 @@
+import { RuleTester } from "eslint";
+import rule from "../../../eslint-rules/require-parse-request-body.js";
+
+const tester = new RuleTester({
+  languageOptions: {
+    ecmaVersion: 2022,
+    sourceType: "module",
+  },
+});
+
+tester.run("require-parse-request-body", rule, {
+  valid: [
+    {
+      code: `import { parseRequestBody } from "@/lib/api-validation";
+        export async function POST(request) {
+          const parsed = await parseRequestBody(schema, request);
+          if ("error" in parsed) return parsed.error;
+        }`,
+      filename: "/app/api/groups/route.ts",
+    },
+    // Helper itself is allowed to call request.json()
+    {
+      code: `export async function parseRequestBody(schema, request) {
+          const body = await request.json();
+        }`,
+      filename: "/lib/api-validation.ts",
+    },
+    // Outside /app/api/ paths the rule does not apply
+    {
+      code: `export async function handler(request) { const body = await request.json(); }`,
+      filename: "/lib/some-other-file.ts",
+    },
+    // Calls on objects with other names (e.g. an external fetch response) are fine
+    {
+      code: `export async function POST() { const data = await response.json(); }`,
+      filename: "/app/api/groups/route.ts",
+    },
+  ],
+  invalid: [
+    {
+      code: `export async function POST(request) { const body = await request.json(); }`,
+      filename: "/app/api/groups/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    {
+      code: `export async function PUT(req) { const { content } = await req.json(); }`,
+      filename: "/app/api/users/me/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+    {
+      code: `export async function PATCH(request) {
+          const { name } = await request.json();
+        }`,
+      filename: "/app/api/agents/[id]/route.ts",
+      errors: [{ messageId: "directJsonCall" }],
+    },
+  ],
+});

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -1,4 +1,5 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { validateTelegramBotToken, hasMainTelegramBot } from "@/lib/telegram";
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
@@ -11,6 +12,11 @@ import {
 import { db } from "@/db";
 import { agents, settings } from "@/db/schema";
 import { eq, like } from "drizzle-orm";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const setBotTokenSchema = z.object({
+  botToken: z.string().min(1),
+});
 
 export async function GET(req: Request, { params }: { params: Promise<{ agentId: string }> }) {
   const admin = await requireAdmin();
@@ -39,15 +45,13 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   return NextResponse.json({ configured: true, hint, mainBotConfigured });
 }
 
-export async function POST(req: Request, { params }: { params: Promise<{ agentId: string }> }) {
+export async function POST(req: NextRequest, { params }: { params: Promise<{ agentId: string }> }) {
   const admin = await requireAdmin();
   if (admin instanceof NextResponse) return admin;
   const { agentId } = await params;
-  const { botToken } = await req.json();
-
-  if (!botToken || typeof botToken !== "string") {
-    return NextResponse.json({ error: "Bot token is required" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(setBotTokenSchema, req);
+  if ("error" in parsed) return parsed.error;
+  const { botToken } = parsed.data;
 
   const agent = await db.query.agents.findFirst({
     where: eq(agents.id, agentId),

--- a/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/files/[filename]/route.ts
@@ -1,8 +1,12 @@
 // audit-exempt: knowledge base file edits are per-agent content changes, not admin actions
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const writeFileSchema = z.object({ content: z.string() });
 
 type Params = { params: Promise<{ agentId: string; filename: string }> };
 
@@ -31,11 +35,9 @@ export const PUT = withAuth<Params>(async (request, { params }, session) => {
   const denied = requireAgentWriteAccess(agentOrError, session.user.id!, session.user.role);
   if (denied) return denied;
 
-  const { content } = await request.json();
-
-  if (typeof content !== "string") {
-    return NextResponse.json({ error: "content must be a string" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(writeFileSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { content } = parsed.data;
 
   try {
     writeWorkspaceFile(agentId, filename, content);

--- a/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/integrations/route.ts
@@ -1,9 +1,16 @@
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { eq, and } from "drizzle-orm";
 import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { agentConnectionPermissions, integrationConnections } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const setAgentIntegrationsSchema = z.object({
+  connectionId: z.string().min(1),
+  permissions: z.array(z.object({ model: z.string().min(1), operation: z.string().min(1) })),
+});
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -72,27 +79,16 @@ export const GET = withAdmin<RouteContext>(async (_req, { params }) => {
 export const PUT = withAdmin<RouteContext>(async (request, { params }, session) => {
   const { agentId } = await params;
 
-  let body: Record<string, unknown>;
-  try {
-    body = await request.json();
-  } catch {
-    return NextResponse.json({ error: "Invalid JSON body" }, { status: 400 });
-  }
-
-  const { connectionId, permissions } = body;
-  if (!connectionId) {
-    return NextResponse.json({ error: "connectionId is required" }, { status: 400 });
-  }
-  if (!Array.isArray(permissions)) {
-    return NextResponse.json({ error: "permissions must be an array" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(setAgentIntegrationsSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { connectionId, permissions } = parsed.data;
 
   try {
     // Validate connection exists
     const connRows = await db
       .select()
       .from(integrationConnections)
-      .where(eq(integrationConnections.id, connectionId as string));
+      .where(eq(integrationConnections.id, connectionId));
     if (connRows.length === 0) {
       return NextResponse.json({ error: "Connection not found" }, { status: 404 });
     }
@@ -107,7 +103,7 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
         .where(
           and(
             eq(agentConnectionPermissions.agentId, agentId),
-            eq(agentConnectionPermissions.connectionId, connectionId as string)
+            eq(agentConnectionPermissions.connectionId, connectionId)
           )
         );
 
@@ -116,7 +112,7 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
         .where(
           and(
             eq(agentConnectionPermissions.agentId, agentId),
-            eq(agentConnectionPermissions.connectionId, connectionId as string)
+            eq(agentConnectionPermissions.connectionId, connectionId)
           )
         );
 
@@ -124,7 +120,7 @@ export const PUT = withAdmin<RouteContext>(async (request, { params }, session) 
         await tx.insert(agentConnectionPermissions).values(
           permissions.map((p: { model: string; operation: string }) => ({
             agentId,
-            connectionId: connectionId as string,
+            connectionId: connectionId,
             model: p.model,
             operation: p.operation,
           }))

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -1,6 +1,7 @@
 import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
 import { eq, inArray } from "drizzle-orm";
+import { z } from "zod";
 import { updateAgent, deleteAgent, AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getAgentWithAccess, requireAgentWriteAccess } from "@/lib/agent-access";
@@ -12,7 +13,26 @@ import { db } from "@/db";
 import { agentGroups, groups, type AgentPluginConfig } from "@/db/schema";
 import { getAgentGroupIds } from "@/lib/groups";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
-import { validatePinchyWebConfig } from "@/lib/domain-validation";
+import { validatePinchyWebConfig, pluginConfigSchema } from "@/lib/domain-validation";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateAgentSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(AGENT_NAME_MAX_LENGTH)
+    .refine((v) => v.trim().length > 0, "Name is required")
+    .optional(),
+  model: z.string().optional(),
+  allowedTools: z.array(z.string()).optional(),
+  pluginConfig: pluginConfigSchema.nullable().optional(),
+  greetingMessage: z.string().min(1, "Greeting message cannot be empty").optional(),
+  tagline: z.string().nullable().optional(),
+  avatarSeed: z.string().nullable().optional(),
+  personalityPresetId: z.string().nullable().optional(),
+  visibility: z.enum(["all", "restricted"]).optional(),
+  groupIds: z.array(z.string()).optional(),
+});
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -42,23 +62,14 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   const denied = requireAgentWriteAccess(existingAgent, session.user.id!, session.user.role);
   if (denied) return denied;
 
-  const body = await request.json();
+  const parsed = await parseRequestBody(updateAgentSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.data;
 
-  // Validate pluginConfig structure if provided
+  // Validate pluginConfig structure if provided (semantic validation beyond shape)
   const pluginConfigError = validatePinchyWebConfig(body.pluginConfig);
   if (pluginConfigError) {
     return NextResponse.json({ error: pluginConfigError }, { status: 400 });
-  }
-
-  if (
-    body.name !== undefined &&
-    typeof body.name === "string" &&
-    body.name.length > AGENT_NAME_MAX_LENGTH
-  ) {
-    return NextResponse.json(
-      { error: `Name must be ${AGENT_NAME_MAX_LENGTH} characters or less` },
-      { status: 400 }
-    );
   }
 
   // Only admins can change permissions on shared agents
@@ -82,9 +93,6 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     if (!(await isEnterprise())) {
       return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
     }
-    if (!["all", "restricted"].includes(body.visibility)) {
-      return NextResponse.json({ error: "Invalid visibility value" }, { status: 400 });
-    }
     if (existingAgent.isPersonal) {
       return NextResponse.json(
         { error: "Cannot change visibility for personal agents" },
@@ -93,11 +101,12 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     }
   }
 
-  // greetingMessage is required at the schema level — reject attempts to clear it
+  // greetingMessage cannot be a whitespace-only string (zod min(1) catches empty,
+  // but " " passes shape validation — reject to keep the field meaningful).
   if (
     body.greetingMessage !== undefined &&
-    (body.greetingMessage === null ||
-      (typeof body.greetingMessage === "string" && body.greetingMessage.trim() === ""))
+    typeof body.greetingMessage === "string" &&
+    body.greetingMessage.trim() === ""
   ) {
     return NextResponse.json({ error: "Greeting message cannot be empty" }, { status: 400 });
   }
@@ -162,14 +171,8 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
       ? await getAgentGroupIds(agentId)
       : [];
 
-  // Update group assignments if provided
+  // Update group assignments if provided (zod already validated string[])
   if (body.groupIds !== undefined && session.user.role === "admin") {
-    if (
-      !Array.isArray(body.groupIds) ||
-      !body.groupIds.every((id: unknown) => typeof id === "string")
-    ) {
-      return NextResponse.json({ error: "groupIds must be an array of strings" }, { status: 400 });
-    }
     await db.delete(agentGroups).where(eq(agentGroups.agentId, agentId));
     if (body.groupIds.length > 0) {
       await db
@@ -194,8 +197,9 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   } = { changes };
 
   if (body.groupIds !== undefined && session.user.role === "admin") {
-    const addedIds = body.groupIds.filter((id: string) => !oldGroupIds.includes(id));
-    const removedIds = oldGroupIds.filter((id: string) => !body.groupIds.includes(id));
+    const newIds = body.groupIds;
+    const addedIds = newIds.filter((id: string) => !oldGroupIds.includes(id));
+    const removedIds = oldGroupIds.filter((id: string) => !newIds.includes(id));
     if (addedIds.length > 0 || removedIds.length > 0) {
       const allGroupIds = [...new Set([...addedIds, ...removedIds])];
       const groupRows =

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -1,5 +1,6 @@
 import { NextResponse, after } from "next/server";
 import { revalidatePath } from "next/cache";
+import { z } from "zod";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { eq } from "drizzle-orm";
 import { db } from "@/db";
@@ -9,7 +10,8 @@ import { getPersonalityPreset, resolveGreetingMessage } from "@/lib/personality-
 import { generateAvatarSeed } from "@/lib/avatar";
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agents";
 import { validateAllowedPaths } from "@/lib/path-validation";
-import { validatePinchyWebConfig } from "@/lib/domain-validation";
+import { validatePinchyWebConfig, pluginConfigSchema } from "@/lib/domain-validation";
+import { parseRequestBody } from "@/lib/api-validation";
 import {
   ensureWorkspace,
   writeWorkspaceFile,
@@ -28,29 +30,27 @@ import { getVisibleAgents } from "@/lib/visible-agents";
 import { validateOdooTemplate } from "@/lib/integrations/odoo-template-validation";
 import { detectEmailOperations } from "@/lib/tool-registry";
 
+const createAgentSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .max(AGENT_NAME_MAX_LENGTH)
+    .refine((v) => v.trim().length > 0, "Name is required"),
+  templateId: z.string().min(1),
+  tagline: z.string().nullish(),
+  pluginConfig: pluginConfigSchema.nullish(),
+  connectionId: z.string().nullish(),
+});
+
 export const GET = withAuth(async (_req, _ctx, session) => {
   const visibleAgents = await getVisibleAgents(session.user.id!, session.user.role ?? "member");
   return NextResponse.json(visibleAgents);
 });
 
 export const POST = withAdmin(async (request, _ctx, session) => {
-  const body = await request.json();
-  const { name, templateId, tagline, pluginConfig, connectionId } = body;
-
-  if (!name || typeof name !== "string") {
-    return NextResponse.json({ error: "Name is required" }, { status: 400 });
-  }
-
-  if (name.length > AGENT_NAME_MAX_LENGTH) {
-    return NextResponse.json(
-      { error: `Name must be ${AGENT_NAME_MAX_LENGTH} characters or less` },
-      { status: 400 }
-    );
-  }
-
-  if (!templateId || typeof templateId !== "string") {
-    return NextResponse.json({ error: "Template is required" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(createAgentSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { name, templateId, tagline, pluginConfig, connectionId } = parsed.data;
 
   const template = getTemplate(templateId);
   if (!template) {
@@ -68,7 +68,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   // Only file-access plugin requires directory selection
   if (template.pluginId === "pinchy-files") {
     const paths = pluginConfig?.["pinchy-files"]?.allowed_paths;
-    if (!Array.isArray(paths) || paths.length === 0) {
+    if (!paths || paths.length === 0) {
       return NextResponse.json(
         { error: "At least one directory must be selected" },
         { status: 400 }

--- a/packages/web/src/app/api/enterprise/key/route.ts
+++ b/packages/web/src/app/api/enterprise/key/route.ts
@@ -1,10 +1,14 @@
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { setSetting, deleteSetting } from "@/lib/settings";
 import { clearLicenseCache, getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
 
-export async function PUT(req: Request) {
+const setLicenseKeySchema = z.object({ key: z.string().min(1) });
+
+export async function PUT(req: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
@@ -18,11 +22,9 @@ export async function PUT(req: Request) {
     );
   }
 
-  const body = await req.json();
-  const key = body.key;
-  if (!key || typeof key !== "string") {
-    return NextResponse.json({ error: "Missing key" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(setLicenseKeySchema, req);
+  if ("error" in parsed) return parsed.error;
+  const { key } = parsed.data;
 
   // Save the key encrypted, clear cache, then validate via production key path
   await setSetting("enterprise_key", key, true);

--- a/packages/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/packages/web/src/app/api/groups/[groupId]/members/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { db } from "@/db";
@@ -6,6 +7,11 @@ import { groups, userGroups, users } from "@/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const setMembersSchema = z.object({
+  userIds: z.array(z.string()),
+});
 
 async function groupExists(groupId: string): Promise<boolean> {
   const rows = await db.select({ id: groups.id }).from(groups).where(eq(groups.id, groupId));
@@ -50,15 +56,9 @@ export async function PUT(
   }
 
   const { groupId } = await params;
-  const { userIds } = await request.json();
-
-  if (!Array.isArray(userIds)) {
-    return NextResponse.json({ error: "userIds must be an array" }, { status: 400 });
-  }
-
-  if (!userIds.every((id) => typeof id === "string")) {
-    return NextResponse.json({ error: "userIds must be an array of strings" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(setMembersSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { userIds } = parsed.data;
 
   if (!(await groupExists(groupId))) {
     return NextResponse.json({ error: "Group not found" }, { status: 404 });

--- a/packages/web/src/app/api/groups/[groupId]/route.ts
+++ b/packages/web/src/app/api/groups/[groupId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { db } from "@/db";
@@ -6,6 +7,12 @@ import { groups } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { appendAuditLog, type UpdateDetail } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateGroupSchema = z.object({
+  name: z.string().optional(),
+  description: z.string().nullish(),
+});
 
 export async function PATCH(
   request: NextRequest,
@@ -20,7 +27,9 @@ export async function PATCH(
   }
 
   const { groupId } = await params;
-  const { name, description } = await request.json();
+  const parsed = await parseRequestBody(updateGroupSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { name, description } = parsed.data;
 
   const data: { name?: string; description?: string | null; updatedAt?: Date } = {
     updatedAt: new Date(),

--- a/packages/web/src/app/api/groups/route.ts
+++ b/packages/web/src/app/api/groups/route.ts
@@ -1,10 +1,21 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { db } from "@/db";
 import { groups, userGroups } from "@/db/schema";
 import { eq, count } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const createGroupSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .transform((v) => v.trim())
+    .refine((v) => v.length > 0, "Name is required"),
+  description: z.string().optional(),
+});
 
 export async function GET() {
   const sessionOrError = await requireAdmin();
@@ -39,15 +50,13 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
   }
 
-  const { name, description } = await request.json();
-
-  if (!name || typeof name !== "string" || !name.trim()) {
-    return NextResponse.json({ error: "Name is required" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(createGroupSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { name, description } = parsed.data;
 
   const [group] = await db
     .insert(groups)
-    .values({ name: name.trim(), description: description?.trim() || null })
+    .values({ name, description: description?.trim() || null })
     .returning();
 
   after(() =>

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -10,11 +10,15 @@ import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
 import { deleteOAuthSettings } from "@/lib/integrations/oauth-settings";
 import { z } from "zod";
+import { parseRequestBody, formatValidationError } from "@/lib/api-validation";
 
-const baseUpdateSchema = z.object({
-  name: z.string().min(1).max(100).optional(),
-  description: z.string().max(500).optional(),
-});
+const updateConnectionSchema = z
+  .object({
+    name: z.string().min(1).max(100).optional(),
+    description: z.string().max(500).optional(),
+    credentials: z.record(z.string(), z.unknown()).optional(),
+  })
+  .passthrough();
 
 const credentialSchemas: Record<string, z.ZodType> = {
   odoo: odooCredentialsSchema,
@@ -53,16 +57,9 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
     return NextResponse.json({ error: "Connection not found" }, { status: 404 });
   }
 
-  const body = await request.json();
-
-  // Validate base fields (name, description)
-  const baseParsed = baseUpdateSchema.safeParse(body);
-  if (!baseParsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: baseParsed.error.flatten() },
-      { status: 400 }
-    );
-  }
+  const parsed = await parseRequestBody(updateConnectionSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.data;
 
   // Validate credentials based on connection type
   const rawCredentials = body.credentials;
@@ -77,10 +74,7 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
     }
     const credResult = credSchema.safeParse(rawCredentials);
     if (!credResult.success) {
-      return NextResponse.json(
-        { error: "Validation failed", details: credResult.error.flatten() },
-        { status: 400 }
-      );
+      return formatValidationError(credResult.error);
     }
     parsedCredentials = credResult.data as Record<string, unknown>;
   }
@@ -88,16 +82,16 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
   const updateData: Record<string, unknown> = { updatedAt: new Date() };
   const changes: Record<string, { from: unknown; to: unknown }> = {};
 
-  if (baseParsed.data.name !== undefined) {
-    updateData.name = baseParsed.data.name;
-    if (baseParsed.data.name !== existing.name) {
-      changes.name = { from: existing.name, to: baseParsed.data.name };
+  if (body.name !== undefined) {
+    updateData.name = body.name;
+    if (body.name !== existing.name) {
+      changes.name = { from: existing.name, to: body.name };
     }
   }
-  if (baseParsed.data.description !== undefined) {
-    updateData.description = baseParsed.data.description;
-    if (baseParsed.data.description !== existing.description) {
-      changes.description = { from: existing.description, to: baseParsed.data.description };
+  if (body.description !== undefined) {
+    updateData.description = body.description;
+    if (body.description !== existing.description) {
+      changes.description = { from: existing.description, to: body.description };
     }
   }
   if (parsedCredentials !== undefined) {

--- a/packages/web/src/app/api/integrations/list-databases/route.ts
+++ b/packages/web/src/app/api/integrations/list-databases/route.ts
@@ -3,21 +3,15 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const listDatabasesSchema = z.object({
   url: z.string().url(),
 });
 
 export const POST = withAdmin(async (request) => {
-  const body = await request.json();
-  const parsed = listDatabasesSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400 }
-    );
-  }
-
+  const parsed = await parseRequestBody(listDatabasesSchema, request);
+  if ("error" in parsed) return parsed.error;
   const { url } = parsed.data;
 
   const urlCheck = validateExternalUrl(url);

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -9,6 +9,7 @@ import { deferAuditLog } from "@/lib/audit-deferred";
 import { odooCredentialsSchema, odooConnectionDataSchema } from "@/lib/integrations/odoo-schema";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const createIntegrationSchema = z.discriminatedUnion("type", [
   z.object({
@@ -65,15 +66,8 @@ export const GET = withAdmin(async () => {
 });
 
 export const POST = withAdmin(async (request, _ctx, session) => {
-  const body = await request.json();
-  const parsed = createIntegrationSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400 }
-    );
-  }
-
+  const parsed = await parseRequestBody(createIntegrationSchema, request);
+  if ("error" in parsed) return parsed.error;
   const { type, name, description, credentials } = parsed.data;
 
   // Singleton types: only one connection of this type allowed

--- a/packages/web/src/app/api/integrations/sync-preview/route.ts
+++ b/packages/web/src/app/api/integrations/sync-preview/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const syncPreviewSchema = z.object({
   type: z.literal("odoo"),
@@ -17,15 +18,8 @@ const syncPreviewSchema = z.object({
 });
 
 export const POST = withAdmin(async (request) => {
-  const body = await request.json();
-  const parsed = syncPreviewSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400 }
-    );
-  }
-
+  const parsed = await parseRequestBody(syncPreviewSchema, request);
+  if ("error" in parsed) return parsed.error;
   const { credentials } = parsed.data;
 
   const urlCheck = validateExternalUrl(credentials.url);

--- a/packages/web/src/app/api/integrations/test-credentials/route.ts
+++ b/packages/web/src/app/api/integrations/test-credentials/route.ts
@@ -4,6 +4,7 @@ import { z } from "zod";
 import { OdooClient } from "odoo-node";
 import { withAdmin } from "@/lib/api-auth";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const testCredentialsSchema = z.discriminatedUnion("type", [
   z.object({
@@ -24,14 +25,8 @@ const testCredentialsSchema = z.discriminatedUnion("type", [
 ]);
 
 export const POST = withAdmin(async (request) => {
-  const body = await request.json();
-  const parsed = testCredentialsSchema.safeParse(body);
-  if (!parsed.success) {
-    return NextResponse.json(
-      { error: "Validation failed", details: parsed.error.flatten() },
-      { status: 400 }
-    );
-  }
+  const parsed = await parseRequestBody(testCredentialsSchema, request);
+  if ("error" in parsed) return parsed.error;
 
   if (parsed.data.type === "web-search") {
     try {

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -1,21 +1,9 @@
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { appendAuditLog } from "@/lib/audit";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
-
-interface ToolAuditPayload {
-  phase: "start" | "end";
-  toolName: string;
-  agentId: string;
-  runId?: string;
-  toolCallId?: string;
-  sessionKey?: string;
-  sessionId?: string;
-  params?: unknown;
-  result?: unknown;
-  error?: string;
-  durationMs?: number;
-}
+import { parseRequestBody } from "@/lib/api-validation";
 
 function isObject(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
@@ -35,71 +23,63 @@ function extractFirstTextContent(result: Record<string, unknown>): string | null
   return typeof text === "string" && text.trim().length > 0 ? text : null;
 }
 
-function asNonEmptyString(value: unknown): string | undefined {
-  if (typeof value !== "string") return undefined;
-  const trimmed = value.trim();
-  return trimmed.length > 0 ? trimmed : undefined;
-}
-
-function extractAgentIdFromSessionKey(sessionKey?: string): string | undefined {
+function extractAgentIdFromSessionKey(sessionKey: string | undefined): string | undefined {
   if (!sessionKey) return undefined;
-  const match = /^agent:([^:]+):/.exec(sessionKey);
-  return match?.[1];
+  return /^agent:([^:]+):/.exec(sessionKey)?.[1];
 }
 
-function extractUserIdFromSessionKey(sessionKey?: string): string | undefined {
+function extractUserIdFromSessionKey(sessionKey: string | undefined): string | undefined {
   if (!sessionKey) return undefined;
-  const match = /^agent:[^:]+:direct:(.+)$/.exec(sessionKey);
-  return match?.[1];
+  return /^agent:[^:]+:direct:(.+)$/.exec(sessionKey)?.[1];
 }
 
-function parsePayload(value: unknown): ToolAuditPayload | null {
-  if (!isObject(value)) return null;
+// Trim and reject blank strings; turns "" or "   " into undefined so optional
+// fields stay optional in a meaningful way.
+const trimmedOptional = z
+  .string()
+  .optional()
+  .transform((v) => {
+    if (v === undefined) return undefined;
+    const trimmed = v.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  });
 
-  const phase = value.phase;
-  if (phase !== "start" && phase !== "end") return null;
-
-  const toolName = asNonEmptyString(value.toolName);
-  const sessionKey = asNonEmptyString(value.sessionKey);
-  const agentId =
-    asNonEmptyString(value.agentId) ?? extractAgentIdFromSessionKey(sessionKey) ?? "unknown-agent";
-  if (!toolName) return null;
-
-  const runId = asNonEmptyString(value.runId);
-  const toolCallId = asNonEmptyString(value.toolCallId);
-  const sessionId = asNonEmptyString(value.sessionId);
-  const error = asNonEmptyString(value.error);
-
-  const durationRaw = value.durationMs;
-  const durationMs =
-    typeof durationRaw === "number" && Number.isFinite(durationRaw) && durationRaw >= 0
-      ? durationRaw
-      : undefined;
-
-  return {
-    phase,
-    toolName,
-    agentId,
-    runId,
-    toolCallId,
-    sessionKey,
-    sessionId,
-    params: value.params,
-    result: value.result,
-    error,
-    durationMs,
-  };
-}
+const toolUsePayloadSchema = z
+  .object({
+    phase: z.enum(["start", "end"]),
+    toolName: z
+      .string()
+      .transform((v) => v.trim())
+      .refine((v) => v.length > 0, "toolName is required"),
+    agentId: trimmedOptional,
+    runId: trimmedOptional,
+    toolCallId: trimmedOptional,
+    sessionKey: trimmedOptional,
+    sessionId: trimmedOptional,
+    params: z.unknown().optional(),
+    result: z.unknown().optional(),
+    error: trimmedOptional,
+    durationMs: z
+      .number()
+      .nonnegative()
+      .finite()
+      .optional()
+      .transform((v) => (v === undefined ? undefined : v)),
+  })
+  .passthrough()
+  .transform((v) => ({
+    ...v,
+    agentId: v.agentId ?? extractAgentIdFromSessionKey(v.sessionKey) ?? "unknown-agent",
+  }));
 
 export async function POST(request: NextRequest) {
   if (!validateGatewayToken(request.headers)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const payload = parsePayload(await request.json());
-  if (!payload) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(toolUsePayloadSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const payload = parsed.data;
 
   // Change 1: Only log end phase — start phase carries no result/duration, skip it
   if (payload.phase === "start") {

--- a/packages/web/src/app/api/internal/settings/context/route.ts
+++ b/packages/web/src/app/api/internal/settings/context/route.ts
@@ -1,19 +1,21 @@
 // audit-exempt: internal endpoint called by OpenClaw plugin (Smithers), not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const internalOrgContextSchema = z.object({ content: z.string() });
 
 export async function PUT(request: NextRequest) {
   if (!validateGatewayToken(request.headers)) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const { content } = await request.json();
-
-  if (typeof content !== "string") {
-    return NextResponse.json({ error: "content must be a string" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(internalOrgContextSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { content } = parsed.data;
 
   await setSetting("org_context", content);
   await syncOrgContextToWorkspaces();

--- a/packages/web/src/app/api/internal/usage/record/route.ts
+++ b/packages/web/src/app/api/internal/usage/record/route.ts
@@ -1,64 +1,26 @@
 // audit-exempt: internal telemetry sink for OpenClaw plugins reporting LLM token usage, not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { tryAcquireUsageRecordSlot } from "@/lib/usage-record-rate-limiter";
 import { db } from "@/db";
 import { usageRecords } from "@/db/schema";
+import { parseRequestBody } from "@/lib/api-validation";
 
-interface UsagePayload {
-  agentId: string;
-  agentName: string;
-  userId: string;
-  sessionKey: string;
-  model?: string;
-  inputTokens: number;
-  outputTokens: number;
-}
-
-function isObject(value: unknown): value is Record<string, unknown> {
-  return typeof value === "object" && value !== null;
-}
-
-function parsePayload(value: unknown): UsagePayload | null {
-  if (!isObject(value)) return null;
-
-  const agentId = value.agentId;
-  const agentName = value.agentName;
-  const userId = value.userId;
-  const sessionKey = value.sessionKey;
-  const inputTokens = value.inputTokens;
-  const outputTokens = value.outputTokens;
-  const model = value.model;
-
-  if (
-    typeof agentId !== "string" ||
-    !agentId ||
-    typeof agentName !== "string" ||
-    !agentName ||
-    typeof userId !== "string" ||
-    !userId ||
-    typeof sessionKey !== "string" ||
-    !sessionKey ||
-    typeof inputTokens !== "number" ||
-    !Number.isFinite(inputTokens) ||
-    inputTokens < 0 ||
-    typeof outputTokens !== "number" ||
-    !Number.isFinite(outputTokens) ||
-    outputTokens < 0
-  ) {
-    return null;
-  }
-
-  return {
-    agentId,
-    agentName,
-    userId,
-    sessionKey,
-    model: typeof model === "string" && model ? model : undefined,
-    inputTokens,
-    outputTokens,
-  };
-}
+const usagePayloadSchema = z
+  .object({
+    agentId: z.string().min(1),
+    agentName: z.string().min(1),
+    userId: z.string().min(1),
+    sessionKey: z.string().min(1),
+    model: z
+      .string()
+      .optional()
+      .transform((v) => (v && v.length > 0 ? v : undefined)),
+    inputTokens: z.number().nonnegative().finite(),
+    outputTokens: z.number().nonnegative().finite(),
+  })
+  .passthrough();
 
 export async function POST(request: NextRequest) {
   // Defense-in-depth rate limit — runs BEFORE token validation so a brute
@@ -72,10 +34,9 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
-  const payload = parsePayload(await request.json());
-  if (!payload) {
-    return NextResponse.json({ error: "Invalid payload" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(usagePayloadSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const payload = parsed.data;
 
   await db.insert(usageRecords).values({
     userId: payload.userId,

--- a/packages/web/src/app/api/internal/users/[userId]/context/route.ts
+++ b/packages/web/src/app/api/internal/users/[userId]/context/route.ts
@@ -1,11 +1,15 @@
 // audit-exempt: internal endpoint called by OpenClaw plugin (Smithers), not a user-facing action
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
 import { getSetting } from "@/lib/settings";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const internalUserContextSchema = z.object({ content: z.string() });
 
 export async function PUT(
   request: NextRequest,
@@ -16,11 +20,9 @@ export async function PUT(
   }
 
   const { userId } = await params;
-  const { content } = await request.json();
-
-  if (typeof content !== "string") {
-    return NextResponse.json({ error: "content must be a string" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(internalUserContextSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { content } = parsed.data;
 
   await db.update(users).set({ context: content }).where(eq(users.id, userId));
   await syncUserContextToWorkspaces(userId);

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -1,5 +1,6 @@
 // audit-exempt: invite claim is a self-service action by the invited user, not an admin action
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { users, userGroups } from "@/db/schema";
@@ -8,13 +9,19 @@ import { validateInviteToken, claimInvite, getInviteGroupIds } from "@/lib/invit
 import { seedPersonalAgent } from "@/lib/personal-agent";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { validatePassword } from "@/lib/validate-password";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const claimInviteSchema = z.object({
+  token: z.string().min(1),
+  name: z.string().optional(),
+  password: z.string(),
+});
 
 export async function POST(request: NextRequest) {
-  const { token, name, password } = await request.json();
+  const parsed = await parseRequestBody(claimInviteSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { token, name, password } = parsed.data;
 
-  if (!token) {
-    return NextResponse.json({ error: "Token is required" }, { status: 400 });
-  }
   const passwordError = validatePassword(password);
   if (passwordError) {
     return NextResponse.json({ error: passwordError }, { status: 400 });

--- a/packages/web/src/app/api/settings/context/route.ts
+++ b/packages/web/src/app/api/settings/context/route.ts
@@ -1,8 +1,12 @@
 // audit-exempt: org context editing is a content change, not a security-sensitive admin action
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting } from "@/lib/settings";
 import { syncOrgContextToWorkspaces } from "@/lib/context-sync";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateOrgContextSchema = z.object({ content: z.string() });
 
 export const GET = withAdmin(async () => {
   const content = await getSetting("org_context");
@@ -10,11 +14,9 @@ export const GET = withAdmin(async () => {
 });
 
 export const PUT = withAdmin(async (request) => {
-  const { content } = await request.json();
-
-  if (typeof content !== "string") {
-    return NextResponse.json({ error: "content must be a string" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(updateOrgContextSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { content } = parsed.data;
 
   await setSetting("org_context", content);
 

--- a/packages/web/src/app/api/settings/oauth/route.ts
+++ b/packages/web/src/app/api/settings/oauth/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   getOAuthSettings,
@@ -6,6 +7,7 @@ import {
   GOOGLE_OAUTH_SETTINGS_KEY,
 } from "@/lib/integrations/oauth-settings";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const SUPPORTED_PROVIDERS = ["google"] as const;
 type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
@@ -13,6 +15,12 @@ type SupportedProvider = (typeof SUPPORTED_PROVIDERS)[number];
 function isSupportedProvider(value: unknown): value is SupportedProvider {
   return typeof value === "string" && SUPPORTED_PROVIDERS.includes(value as SupportedProvider);
 }
+
+const saveOAuthSchema = z.object({
+  provider: z.enum(SUPPORTED_PROVIDERS),
+  clientId: z.string().min(1),
+  clientSecret: z.string().min(1),
+});
 
 export async function GET(request: NextRequest) {
   const sessionOrError = await requireAdmin();
@@ -38,20 +46,9 @@ export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const body = await request.json();
-  const { provider, clientId, clientSecret } = body;
-
-  if (!provider || !isSupportedProvider(provider)) {
-    return NextResponse.json({ error: "Invalid or missing provider" }, { status: 400 });
-  }
-
-  if (!clientId || typeof clientId !== "string") {
-    return NextResponse.json({ error: "Client ID is required" }, { status: 400 });
-  }
-
-  if (!clientSecret || typeof clientSecret !== "string") {
-    return NextResponse.json({ error: "Client Secret is required" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(saveOAuthSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { provider, clientId, clientSecret } = parsed.data;
 
   await saveOAuthSettings(provider, { clientId, clientSecret });
 

--- a/packages/web/src/app/api/settings/providers/route.ts
+++ b/packages/web/src/app/api/settings/providers/route.ts
@@ -1,4 +1,5 @@
 import { NextResponse, after } from "next/server";
+import { z } from "zod";
 import { withAuth, withAdmin } from "@/lib/api-auth";
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
@@ -8,8 +9,13 @@ import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
+
+const deleteProviderSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS as [ProviderName, ...ProviderName[]]),
+});
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const isAdmin = session.user.role === "admin";
@@ -30,12 +36,9 @@ export const GET = withAuth(async (_req, _ctx, session) => {
 });
 
 export const DELETE = withAdmin(async (request, _ctx, session) => {
-  const body = await request.json();
-  const provider = body.provider as ProviderName;
-
-  if (!VALID_PROVIDERS.includes(provider)) {
-    return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(deleteProviderSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { provider } = parsed.data;
 
   const config = PROVIDERS[provider];
 

--- a/packages/web/src/app/api/settings/route.ts
+++ b/packages/web/src/app/api/settings/route.ts
@@ -1,7 +1,14 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { getAllSettings, setSetting } from "@/lib/settings";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const setSettingSchema = z.object({
+  key: z.string().min(1),
+  value: z.string(),
+});
 
 export async function GET() {
   const sessionOrError = await requireAdmin();
@@ -19,7 +26,10 @@ export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const { key, value } = await request.json();
+  const parsed = await parseRequestBody(setSettingSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { key, value } = parsed.data;
+
   await setSetting(key, value, key.includes("api_key"));
 
   after(() =>

--- a/packages/web/src/app/api/settings/telegram/route.ts
+++ b/packages/web/src/app/api/settings/telegram/route.ts
@@ -1,5 +1,6 @@
 // audit-exempt: User self-service action (linking own Telegram account), not an admin operation
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { resolvePairingCode } from "@/lib/telegram-pairing";
 import { updateIdentityLinks } from "@/lib/openclaw-config";
@@ -7,6 +8,9 @@ import { recalculateTelegramAllowStores, removePairingRequest } from "@/lib/tele
 import { db } from "@/db";
 import { channelLinks } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const linkTelegramSchema = z.object({ code: z.string().min(1) });
 
 /**
  * Build identityLinks map from all telegram channel links in DB.
@@ -38,10 +42,9 @@ export const GET = withAuth(async (_req, _ctx, session) => {
 });
 
 export const POST = withAuth(async (req, _ctx, session) => {
-  const { code } = await req.json();
-  if (!code || typeof code !== "string") {
-    return NextResponse.json({ error: "Pairing code is required" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(linkTelegramSchema, req);
+  if ("error" in parsed) return parsed.error;
+  const { code } = parsed.data;
 
   // Resolve pairing code to Telegram user ID by reading OpenClaw's pairing file
   const pairing = resolvePairingCode(code);

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import {
   validateProviderKey,
@@ -13,26 +14,31 @@ import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
+import { parseRequestBody } from "@/lib/api-validation";
 
 const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
+
+const setupProviderSchema = z.object({
+  provider: z.enum(VALID_PROVIDERS as [ProviderName, ...ProviderName[]]),
+  url: z.string().min(1).optional(),
+  apiKey: z.string().min(1).optional(),
+});
 
 export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  const body = await request.json();
+  const parsed = await parseRequestBody(setupProviderSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const body = parsed.data;
   const { provider } = body;
 
-  if (!provider || !VALID_PROVIDERS.includes(provider)) {
-    return NextResponse.json({ error: "Invalid provider" }, { status: 400 });
-  }
-
-  const config = PROVIDERS[provider as ProviderName];
+  const config = PROVIDERS[provider];
 
   if (config.authType === "url") {
     // URL-based provider (ollama-local)
     const { url } = body;
-    if (!url || typeof url !== "string") {
+    if (!url) {
       return NextResponse.json({ error: "URL is required" }, { status: 400 });
     }
 
@@ -73,7 +79,7 @@ export async function POST(request: NextRequest) {
   } else {
     // API-key-based provider (existing logic)
     const { apiKey } = body;
-    if (!apiKey || typeof apiKey !== "string") {
+    if (!apiKey) {
       return NextResponse.json({ error: "API key is required" }, { status: 400 });
     }
 
@@ -139,15 +145,14 @@ export async function POST(request: NextRequest) {
   // provider name alongside its id, and never log secrets. For URL-based
   // providers, log only the host:port (not the full URL) so internal
   // hostnames don't leak verbatim into the audit trail.
-  const providerName = provider as ProviderName;
   const detail: Record<string, unknown> = {
-    provider: { id: providerName, name: PROVIDERS[providerName].name },
+    provider: { id: provider, name: PROVIDERS[provider].name },
     authType: config.authType,
   };
-  if (config.authType === "url" && typeof body.url === "string") {
+  if (config.authType === "url" && body.url) {
     try {
-      const parsed = new URL(body.url);
-      detail.host = parsed.host;
+      const parsedUrl = new URL(body.url);
+      detail.host = parsedUrl.host;
     } catch {
       // Invalid URL — this would have been rejected by validateProviderUrl
       // already, so this branch is only reached in tests.

--- a/packages/web/src/app/api/setup/route.ts
+++ b/packages/web/src/app/api/setup/route.ts
@@ -1,27 +1,33 @@
 // audit-exempt: initial setup runs before any users exist, no actor to audit
 import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
 import { createAdmin } from "@/lib/setup";
 import { validatePassword } from "@/lib/validate-password";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const setupSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .transform((v) => v.trim())
+    .refine((v) => v.length > 0, "Name is required"),
+  email: z.string().email("A valid email address is required"),
+  password: z.string(),
+});
 
 export async function POST(request: NextRequest) {
   try {
-    const { name, email, password } = await request.json();
+    const parsed = await parseRequestBody(setupSchema, request);
+    if ("error" in parsed) return parsed.error;
+    const { name, email, password } = parsed.data;
 
-    if (!name || typeof name !== "string" || !name.trim()) {
-      return NextResponse.json({ error: "Name is required" }, { status: 400 });
-    }
-
-    const emailRegex = /^[^\s@]+@[^\s@]+\.[^\s@]+$/;
-    if (!email || !emailRegex.test(email)) {
-      return NextResponse.json({ error: "A valid email address is required" }, { status: 400 });
-    }
     const passwordError = validatePassword(password);
     if (passwordError) {
       return NextResponse.json({ error: passwordError }, { status: 400 });
     }
 
-    const user = await createAdmin(name.trim(), email, password);
+    const user = await createAdmin(name, email, password);
     // Write OpenClaw config with the newly created Smithers agent so OpenClaw
     // knows about it when the container restarts or the file watcher picks it up.
     await regenerateOpenClawConfig().catch((err) => {

--- a/packages/web/src/app/api/users/[userId]/groups/route.ts
+++ b/packages/web/src/app/api/users/[userId]/groups/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { db } from "@/db";
@@ -6,6 +7,11 @@ import { users, groups, userGroups } from "@/db/schema";
 import { eq, inArray } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateUserGroupsSchema = z.object({
+  groupIds: z.array(z.string()),
+});
 
 export async function PUT(
   request: NextRequest,
@@ -20,15 +26,9 @@ export async function PUT(
   }
 
   const { userId } = await params;
-  const { groupIds } = await request.json();
-
-  if (!Array.isArray(groupIds)) {
-    return NextResponse.json({ error: "groupIds must be an array" }, { status: 400 });
-  }
-
-  if (!groupIds.every((id) => typeof id === "string")) {
-    return NextResponse.json({ error: "groupIds must be an array of strings" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(updateUserGroupsSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { groupIds } = parsed.data;
 
   // 1. Fetch user (verify exists, get name for audit)
   const userRows = await db

--- a/packages/web/src/app/api/users/[userId]/route.ts
+++ b/packages/web/src/app/api/users/[userId]/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users, agents } from "@/db/schema";
@@ -7,6 +8,11 @@ import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { deleteWorkspace } from "@/lib/workspace";
 import { appendAuditLog } from "@/lib/audit";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateUserSchema = z.object({
+  role: z.enum(["admin", "member"]),
+});
 
 export async function PATCH(
   request: NextRequest,
@@ -17,12 +23,9 @@ export async function PATCH(
   const session = sessionOrError;
 
   const { userId } = await params;
-  const { role } = await request.json();
-
-  // Validate role value
-  if (role !== "admin" && role !== "member") {
-    return NextResponse.json({ error: "Role must be 'admin' or 'member'" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(updateUserSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { role } = parsed.data;
 
   // Cannot change own role
   if (userId === session.user.id) {

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -1,4 +1,5 @@
 import { NextRequest, NextResponse, after } from "next/server";
+import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { createInvite } from "@/lib/invites";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
@@ -7,17 +8,22 @@ import { getSeatUsage } from "@/lib/seat-usage";
 import { db } from "@/db";
 import { groups } from "@/db/schema";
 import { inArray } from "drizzle-orm";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const inviteUserSchema = z.object({
+  email: z.string().email().optional(),
+  role: z.enum(["admin", "member"]),
+  groupIds: z.array(z.string()).optional(),
+});
 
 export async function POST(request: NextRequest) {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
   const session = sessionOrError;
 
-  const { email, role, groupIds } = await request.json();
-
-  if (!role || !["admin", "member"].includes(role)) {
-    return NextResponse.json({ error: "Role must be 'admin' or 'member'" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(inviteUserSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { email, role, groupIds } = parsed.data;
 
   const license = await getLicenseStatus();
   if (license.active && license.maxUsers > 0) {
@@ -29,7 +35,7 @@ export async function POST(request: NextRequest) {
           actorId: session.user.id!,
           eventType: "user.invite_blocked",
           detail: {
-            ...redactEmail(email),
+            ...(email ? redactEmail(email) : {}),
             role,
             reason: "seat_cap",
             seatsUsed: usage.used,
@@ -54,7 +60,7 @@ export async function POST(request: NextRequest) {
   const invite = await createInvite({ email, role, createdBy: session.user.id, groupIds });
 
   let auditGroups: Array<{ id: string; name: string }> = [];
-  if (groupIds?.length > 0) {
+  if (groupIds && groupIds.length > 0) {
     const groupRows = await db
       .select({ id: groups.id, name: groups.name })
       .from(groups)
@@ -69,7 +75,7 @@ export async function POST(request: NextRequest) {
       actorId: session.user.id!,
       eventType: "user.invited",
       detail: {
-        ...redactEmail(email),
+        ...(email ? redactEmail(email) : {}),
         role,
         ...(auditGroups.length > 0 ? { groups: auditGroups } : {}),
       },

--- a/packages/web/src/app/api/users/me/context/route.ts
+++ b/packages/web/src/app/api/users/me/context/route.ts
@@ -1,10 +1,16 @@
 // audit-exempt: users editing their own context is a self-service action
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { syncUserContextToWorkspaces } from "@/lib/context-sync";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateContextSchema = z.object({
+  content: z.string(),
+});
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const user = await db.query.users.findFirst({
@@ -15,11 +21,9 @@ export const GET = withAuth(async (_req, _ctx, session) => {
 });
 
 export const PUT = withAuth(async (request, _ctx, session) => {
-  const { content } = await request.json();
-
-  if (typeof content !== "string") {
-    return NextResponse.json({ error: "content must be a string" }, { status: 400 });
-  }
+  const parsed = await parseRequestBody(updateContextSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { content } = parsed.data;
 
   await db.update(users).set({ context: content }).where(eq(users.id, session.user.id));
 

--- a/packages/web/src/app/api/users/me/password/route.ts
+++ b/packages/web/src/app/api/users/me/password/route.ts
@@ -1,16 +1,25 @@
 // audit-exempt: users changing their own password is a self-service action
 import { NextResponse } from "next/server";
 import { headers } from "next/headers";
+import { z } from "zod";
 import { auth } from "@/lib/auth";
 import { withAuth } from "@/lib/api-auth";
+import { parseRequestBody } from "@/lib/api-validation";
 import { validatePassword } from "@/lib/validate-password";
 
-export const POST = withAuth(async (request) => {
-  const { currentPassword, newPassword } = await request.json();
+// Shape only — length/breach-list policy is enforced post-parse via
+// validatePassword() so the same rules apply to setup, invite-claim, and
+// password-change without drifting between routes.
+const changePasswordSchema = z.object({
+  currentPassword: z.string().min(1),
+  newPassword: z.string(),
+});
 
-  if (!currentPassword) {
-    return NextResponse.json({ error: "Current password is required" }, { status: 400 });
-  }
+export const POST = withAuth(async (request) => {
+  const parsed = await parseRequestBody(changePasswordSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { currentPassword, newPassword } = parsed.data;
+
   const passwordError = validatePassword(newPassword);
   if (passwordError) {
     return NextResponse.json({ error: passwordError }, { status: 400 });

--- a/packages/web/src/app/api/users/me/route.ts
+++ b/packages/web/src/app/api/users/me/route.ts
@@ -1,18 +1,26 @@
 // audit-exempt: users updating their own profile is a self-service action
 import { NextResponse } from "next/server";
+import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { db } from "@/db";
 import { users } from "@/db/schema";
 import { eq } from "drizzle-orm";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const updateMeSchema = z.object({
+  name: z
+    .string()
+    .min(1)
+    .transform((v) => v.trim())
+    .refine((v) => v.length > 0, "Name is required"),
+});
 
 export const PATCH = withAuth(async (request, _ctx, session) => {
-  const { name } = await request.json();
+  const parsed = await parseRequestBody(updateMeSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { name } = parsed.data;
 
-  if (!name || typeof name !== "string" || !name.trim()) {
-    return NextResponse.json({ error: "Name is required" }, { status: 400 });
-  }
-
-  await db.update(users).set({ name: name.trim() }).where(eq(users.id, session.user.id));
+  await db.update(users).set({ name }).where(eq(users.id, session.user.id));
 
   return NextResponse.json({ success: true });
 });

--- a/packages/web/src/lib/__tests__/api-validation.test.ts
+++ b/packages/web/src/lib/__tests__/api-validation.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it } from "vitest";
+import { NextRequest } from "next/server";
+import { z } from "zod";
+import { parseRequestBody } from "../api-validation";
+
+function makeRequest(body: string | object | undefined, contentType = "application/json") {
+  const init: RequestInit = { method: "POST", headers: { "content-type": contentType } };
+  if (body !== undefined) {
+    init.body = typeof body === "string" ? body : JSON.stringify(body);
+  }
+  return new NextRequest("http://localhost/api/test", init);
+}
+
+describe("parseRequestBody", () => {
+  const schema = z.object({ name: z.string().min(1), count: z.number().int() });
+
+  it("returns parsed data on valid input", async () => {
+    const req = makeRequest({ name: "Pinchy", count: 5 });
+    const result = await parseRequestBody(schema, req);
+    expect("data" in result).toBe(true);
+    if ("data" in result) {
+      expect(result.data).toEqual({ name: "Pinchy", count: 5 });
+    }
+  });
+
+  it("strips unknown fields by default (zod object behavior)", async () => {
+    const req = makeRequest({ name: "Pinchy", count: 5, evil: "<script>" });
+    const result = await parseRequestBody(schema, req);
+    expect("data" in result).toBe(true);
+    if ("data" in result) {
+      expect(result.data).toEqual({ name: "Pinchy", count: 5 });
+    }
+  });
+
+  it("returns 400 with details on schema mismatch", async () => {
+    const req = makeRequest({ name: "", count: "not a number" });
+    const result = await parseRequestBody(schema, req);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+      const json = await result.error.json();
+      expect(json.error).toBe("Validation failed");
+      expect(json.details).toBeDefined();
+      expect(json.details.fieldErrors).toBeDefined();
+    }
+  });
+
+  it("returns 400 on missing required fields", async () => {
+    const req = makeRequest({});
+    const result = await parseRequestBody(schema, req);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+    }
+  });
+
+  it("returns 400 on malformed JSON instead of throwing 500", async () => {
+    const req = makeRequest("{not valid json");
+    const result = await parseRequestBody(schema, req);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+      const json = await result.error.json();
+      expect(json.error).toBe("Invalid JSON body");
+    }
+  });
+
+  it("returns 400 on non-object body when schema expects object", async () => {
+    const req = makeRequest('"just a string"');
+    const result = await parseRequestBody(schema, req);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+    }
+  });
+
+  it("returns 400 on empty body", async () => {
+    const req = makeRequest(undefined);
+    const result = await parseRequestBody(schema, req);
+    expect("error" in result).toBe(true);
+    if ("error" in result) {
+      expect(result.error.status).toBe(400);
+      const json = await result.error.json();
+      expect(json.error).toBe("Invalid JSON body");
+    }
+  });
+});

--- a/packages/web/src/lib/api-validation.ts
+++ b/packages/web/src/lib/api-validation.ts
@@ -1,0 +1,44 @@
+import { NextRequest, NextResponse } from "next/server";
+import type { ZodError, ZodType } from "zod";
+
+export type ParseResult<T> = { data: T } | { error: NextResponse };
+
+/**
+ * Build the canonical 400 NextResponse for a failed Zod parse. Routes that
+ * cannot use `parseRequestBody` directly (e.g. routes that pick a sub-schema
+ * dynamically based on a DB lookup) should call this so the error contract
+ * stays identical to `parseRequestBody`'s.
+ */
+export function formatValidationError(error: ZodError): NextResponse {
+  return NextResponse.json(
+    { error: "Validation failed", details: error.flatten() },
+    { status: 400 }
+  );
+}
+
+/**
+ * Validate a JSON request body against a Zod schema. Returns either parsed
+ * data or a structured 400 NextResponse. Use this in every state-mutating
+ * API route instead of calling `request.json()` directly — it also catches
+ * malformed JSON (which would otherwise throw a 500).
+ */
+export async function parseRequestBody<T>(
+  schema: ZodType<T>,
+  request: NextRequest
+): Promise<ParseResult<T>> {
+  let body: unknown;
+  try {
+    body = await request.json();
+  } catch {
+    return {
+      error: NextResponse.json({ error: "Invalid JSON body" }, { status: 400 }),
+    };
+  }
+
+  const parsed = schema.safeParse(body);
+  if (!parsed.success) {
+    return { error: formatValidationError(parsed.error) };
+  }
+
+  return { data: parsed.data };
+}

--- a/packages/web/src/lib/domain-validation.ts
+++ b/packages/web/src/lib/domain-validation.ts
@@ -1,3 +1,5 @@
+import { z } from "zod";
+
 // Each label: 1-63 chars, alphanumeric + hyphens (not leading/trailing hyphen).
 // At least two labels required (no bare "localhost" etc.).
 const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?)+$/;
@@ -5,6 +7,31 @@ const DOMAIN_RE = /^[a-z0-9]([a-z0-9-]{0,61}[a-z0-9])?(\.[a-z0-9]([a-z0-9-]{0,61
 export function isValidDomain(domain: string): boolean {
   return DOMAIN_RE.test(domain.toLowerCase());
 }
+
+/**
+ * Zod schema for an agent's pluginConfig column. Mirrors the AgentPluginConfig
+ * type in @/db/schema and is the shape-of-truth for both POST and PATCH agent
+ * routes. Domain validity inside `pinchy-web` is layered on top via
+ * `validatePinchyWebConfig` (it's a content check, not a shape check).
+ */
+export const pluginConfigSchema = z
+  .object({
+    "pinchy-files": z
+      .object({
+        allowed_paths: z.array(z.string()),
+      })
+      .optional(),
+    "pinchy-web": z
+      .object({
+        allowedDomains: z.array(z.string()).optional(),
+        excludedDomains: z.array(z.string()).optional(),
+        language: z.string().optional(),
+        country: z.string().optional(),
+        freshness: z.string().optional(),
+      })
+      .optional(),
+  })
+  .strict();
 
 /**
  * Validate the `pinchy-web` entry inside an agent's pluginConfig. Returns an


### PR DESCRIPTION
## What does this PR do?

Standardizes request-body validation across all 31 state-mutating API
routes by introducing a single `parseRequestBody(schema, request)` helper
and migrating routes off ad-hoc `typeof` / truthiness checks.

Every state-mutating route now defines a Zod schema at the top of the
file and returns a structured 400 with field-level details on shape
mismatch:

```jsonc
{ "error": "Validation failed", "details": { "fieldErrors": { "name": ["..."] } } }
```

Clients can read `details.fieldErrors.<name>` to render inline errors.

### Bugs fixed along the way

- `POST /api/settings` crashed with **500** when `key` was missing
  (`key.includes("api_key")` on `undefined`). Now returns a structured
  400.
- All routes threw **500** on malformed JSON instead of 400. The helper
  catches the `SyntaxError` from `request.json()` and returns
  `{ error: "Invalid JSON body" }` with status 400.

### CLAUDE.md

API-route checklist gains a new first item: every new state-mutating
endpoint must use `parseRequestBody`. Routes that take no body (DELETE
on a path-param resource, etc.) are exempt.

Closes #232

## Type of change

- [x] ♻️ Refactor
- [x] 🐛 Bug fix (settings 500, malformed-JSON 500)
- [x] 📝 Documentation (CLAUDE.md checklist)

## Scope

40 route files were inventoried. **31 migrated**, 9 are exempt because
they take no body (DELETEs by path param, GETs only, OAuth redirects).

Routes touched (grouped):

- **agents**: `agents`, `agents/[id]`, `agents/[id]/channels/telegram`,
  `agents/[id]/files/[name]`, `agents/[id]/integrations`
- **groups**: `groups`, `groups/[id]`, `groups/[id]/members`
- **users**: `users/[id]`, `users/[id]/groups`, `users/invite`,
  `users/me`, `users/me/context`, `users/me/password`
- **settings**: `settings`, `settings/context`, `settings/oauth`,
  `settings/providers`, `settings/telegram`
- **setup**: `setup`, `setup/provider`
- **integrations**: `integrations`, `integrations/[id]`,
  `integrations/list-databases`, `integrations/sync-preview`,
  `integrations/test-credentials` (these already used Zod, migrated
  to use the shared helper for consistency)
- **internal** (gateway-token-authed): `internal/audit/tool-use`,
  `internal/settings/context`, `internal/usage/record`,
  `internal/users/[id]/context`
- **misc**: `invite/claim`, `enterprise/key`

## Verification

- [x] **Tests**: 3420 passing, 12 skipped, 3 todo (260 test files)
- [x] **TypeScript**: `tsc --noEmit` clean (0 errors)
- [x] **Lint**: 0 errors (warnings unchanged from `main`)

The helper itself is covered by 7 dedicated unit tests (TDD: written
red first, then implementation): valid input, unknown-field stripping,
schema mismatch with structured details, missing required fields,
malformed JSON, non-object body, empty body.

Existing route tests that asserted on the old freeform error strings
(`"Name is required"`, `"Role must be 'admin' or 'member'"`, etc.) were
updated to the new contract:

```ts
expect(body.error).toBe("Validation failed");
expect(body.details.fieldErrors.<field>).toBeDefined();
```

## Reviewer notes

- **Error response shape changes** for the validation 400 path. The
  happy-path response shape is unchanged. UIs that parse 400 errors
  by string match will need to be checked — none in this repo do (all
  surface `body.error` directly via toast/inline).
- **Out of scope** (per the issue): public happy-path response shapes,
  rewriting the integrations routes (already used Zod, just moved to
  the helper).
- **Optional follow-up** (mentioned in the issue): a CI grep check
  that fails on `await request.json()` outside the helper, to prevent
  regression. Not included here to keep this PR tight.

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (helper has 7 tests; each
  migrated route's existing tests verify the new behavior)
- [x] I've updated the documentation (CLAUDE.md checklist)
- [x] All existing tests pass