### PR TITLE
ci: close Docker Hub rate-limit gaps and mirror node base via gcr

### DIFF
--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -17,6 +17,12 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build Pinchy image
         run: docker build -f Dockerfile.pinchy -t pinchy:sbom .
 

--- a/.github/workflows/sbom.yml
+++ b/.github/workflows/sbom.yml
@@ -17,12 +17,6 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
-
       - name: Build Pinchy image
         run: docker build -f Dockerfile.pinchy -t pinchy:sbom .
 

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -49,6 +49,12 @@ jobs:
             --org "Acme Corp (Screenshots)" --type trial --days 14)
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
       - name: Build production images locally
         run: |
           docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -49,11 +49,7 @@ jobs:
             --org "Acme Corp (Screenshots)" --type trial --days 14)
           echo "token=$TOKEN" >> "$GITHUB_OUTPUT"
 
-      - name: Log in to Docker Hub
-        uses: docker/login-action@v3
-        with:
-          username: ${{ secrets.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_TOKEN }}
+      - uses: ./.github/actions/docker-mirror
 
       - name: Build production images locally
         run: |

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
+# anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
+# pull-through cache for `library/*` images on Docker Hub.
+FROM mirror.gcr.io/library/node:22-slim
 
 # python3 + build-essential are needed for native npm modules (better-sqlite3
 # in pinchy-files) to compile from source when the prebuilt binary doesn't

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
+# anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
+# pull-through cache for `library/*` images on Docker Hub.
+FROM mirror.gcr.io/library/node:22-slim
 
 # Cache pnpm in a shared location so the non-root pinchy user can use it
 # without re-downloading on every container start.

--- a/Dockerfile.pinchy.dev
+++ b/Dockerfile.pinchy.dev
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
+# anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
+# pull-through cache for `library/*` images on Docker Hub.
+FROM mirror.gcr.io/library/node:22-slim
 
 RUN corepack enable
 

--- a/config/odoo-mock/Dockerfile
+++ b/config/odoo-mock/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
+# anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
+# pull-through cache for `library/*` images on Docker Hub.
+FROM mirror.gcr.io/library/node:22-slim
 WORKDIR /app
 COPY server.js .
 EXPOSE 8069 9002

--- a/config/telegram-mock/Dockerfile
+++ b/config/telegram-mock/Dockerfile
@@ -1,4 +1,7 @@
-FROM node:22-slim
+# Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
+# anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
+# pull-through cache for `library/*` images on Docker Hub.
+FROM mirror.gcr.io/library/node:22-slim
 
 RUN apt-get update && apt-get install -y openssl && rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
## Summary
CI was hitting Docker Hub anonymous-pull limits (100/6h shared across the GitHub Actions runner IP range), blocking workflows. Two changes:

- **Dockerfile base images** → `mirror.gcr.io/library/node:22-slim`. Pinchy already uses [`./.github/actions/docker-mirror`](.github/actions/docker-mirror/action.yml) (added in d68c7ae7e) which pre-pulls compose library images from `mirror.gcr.io` — but that action only auto-discovers images in `docker-compose*.yml`, not `FROM` lines in Dockerfiles. The `FROM` switch closes the gap so `docker build` no longer reaches `docker.io`. Affects `Dockerfile.pinchy`, `Dockerfile.pinchy.dev`, `Dockerfile.openclaw`, `config/telegram-mock/Dockerfile`, `config/odoo-mock/Dockerfile`.

- **`screenshots.yml`** — added `./.github/actions/docker-mirror`, matching the pattern used 6× in `ci.yml`. The job runs `docker compose up`, which pulls `postgres:17` and `caddy:2` from `docker.io`; the composite action handles those.

- **`sbom.yml`** — no changes needed beyond the Dockerfile base-image switch. The job only does `docker build -f Dockerfile.pinchy`, no compose, so after the `FROM` switch there is zero `docker.io` traffic.

Production `docker-compose.yml` images (`postgres:17`, `caddy:2`) intentionally untouched — end users shouldn't pull through a hidden Google dependency. The `docker-mirror` action is CI-only.

### Why no `docker/login-action`?
Per a218f1905: `docker/login-action` stores creds for `docker.io` in `~/.docker/config.json`, causing Docker to send authenticated requests directly to `docker.io` and bypass any registry mirror. The `docker-mirror` composite action is the established alternative.

## Test plan
- [ ] CI passes — `screenshots` workflow doesn't error on `postgres:17` / `caddy:2` pulls
- [ ] `sbom` workflow builds successfully with no `docker.io` traffic
- [ ] Verify `docker build -f Dockerfile.pinchy .` locally still pulls successfully via `mirror.gcr.io`
- [ ] Watch CI runs over the next 24h for any Docker Hub `toomanyrequests` errors