### PR TITLE
chore(deps): bump openclaw 2026.4.12 → 2026.4.14

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.4.14
+RUN npm install -g openclaw@2026.4.27
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.4.12
+RUN npm install -g openclaw@2026.4.14
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.4.14
+RUN npm install -g openclaw@2026.4.15
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -15,7 +15,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.4.15
+RUN npm install -g openclaw@2026.4.14
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -179,8 +179,10 @@ fix_config_permissions() {
         chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
     fi
     # Per-agent auth-profiles.json files written by Pinchy (uid 999).
-    # OpenClaw's secrets-resolver requires file owner == process uid (root).
-    chown -R root:root /root/.openclaw/agents 2>/dev/null || true
+    # OpenClaw (root) can read uid-999-owned files directly — no chown needed.
+    # The agents/ directory must stay writable by Pinchy (uid 999) so new
+    # agent subdirectories can be created. Only secure the files themselves.
+    chown 999:999 /root/.openclaw/agents 2>/dev/null || true
     find /root/.openclaw/agents -name "auth-profiles.json" -type f -exec chmod 0600 {} \; 2>/dev/null || true
 }
 fix_config_permissions

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -178,6 +178,10 @@ fix_config_permissions() {
         chown root:root "$SECRETS_FILE" 2>/dev/null || true
         chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
     fi
+    # Per-agent auth-profiles.json files written by Pinchy (uid 999).
+    # OpenClaw's secrets-resolver requires file owner == process uid (root).
+    chown -R root:root /root/.openclaw/agents 2>/dev/null || true
+    find /root/.openclaw/agents -name "auth-profiles.json" -type f -exec chmod 0600 {} \; 2>/dev/null || true
 }
 fix_config_permissions
 

--- a/packages/web/e2e/integration/global-setup.ts
+++ b/packages/web/e2e/integration/global-setup.ts
@@ -155,7 +155,7 @@ export default async function globalSetup() {
   //    timer happens to fire while the gateway is healthy. 120s is well
   //    inside that envelope without masking real regressions.
   console.log("[integration-setup] Waiting for Pinchy to reconnect to OpenClaw...");
-  const deadline = Date.now() + 120000;
+  const deadline = Date.now() + 180000;
   let reconnected = false;
   while (Date.now() < deadline) {
     try {

--- a/packages/web/e2e/integration/global-setup.ts
+++ b/packages/web/e2e/integration/global-setup.ts
@@ -90,7 +90,13 @@ export default async function globalSetup() {
   }
 
   // 5. Seed Ollama URL, default provider, and a fake Ollama-Cloud key.
-  //    host.docker.internal reaches the fake Ollama from inside the OpenClaw container.
+  //
+  //    We must NOT use 'host.docker.internal' as the Ollama base URL. OpenClaw 4.27+
+  //    checks isLocalOllamaBaseUrl() before providing synthetic auth (no API key
+  //    needed). 'host.docker.internal' has dots → isIpv4PrivateRange/isLoopback both
+  //    return false → OC throws "No API key found for provider 'ollama'". A private
+  //    IPv4 (172.x.x.x, 192.168.x.x) passes the check. We resolve the container's
+  //    default gateway, which is the host IP on Docker's bridge network.
   //
   //    The Ollama-Cloud key is intentionally a dummy value — fake Ollama doesn't need
   //    auth. We seed it so Pinchy's regenerateOpenClawConfig() writes the
@@ -101,11 +107,26 @@ export default async function globalSetup() {
   //    architecture would otherwise leave untested. Without this seed, the integration
   //    stack passes even when secrets ownership is misconfigured, because no SecretRef
   //    reference ever forces OpenClaw to read secrets.json.
+  let ollamaHostIp = "172.17.0.1"; // Docker default Linux bridge gateway fallback
+  try {
+    const gwOutput = execSync(
+      `docker compose -f docker-compose.integration.yml exec openclaw sh -c "ip route show default 2>/dev/null | awk '/default/ { print \\$3; exit }'"`,
+      { cwd: PROJECT_ROOT, encoding: "utf8", stdio: "pipe" }
+    ).trim();
+    if (/^\d+\.\d+\.\d+\.\d+$/.test(gwOutput)) {
+      ollamaHostIp = gwOutput;
+    }
+  } catch {
+    // Use the 172.17.0.1 fallback
+  }
+  const ollamaLocalUrl = `http://${ollamaHostIp}:${FAKE_OLLAMA_PORT}`;
+  console.log(`[integration-setup] Resolved Ollama host IP: ${ollamaHostIp} → ${ollamaLocalUrl}`);
+
   const postgres = (await import("postgres")).default;
   const sql = postgres(INTEGRATION_DB_URL);
   await sql.unsafe(`
     INSERT INTO settings (key, value, encrypted) VALUES
-      ('ollama_local_url', 'http://host.docker.internal:11435', false),
+      ('ollama_local_url', '${ollamaLocalUrl}', false),
       ('default_provider', 'ollama-local', false),
       ('ollama_cloud_api_key', 'dummy-integration-test-key', false)
     ON CONFLICT (key) DO UPDATE SET value = EXCLUDED.value, encrypted = false

--- a/packages/web/e2e/integration/global-setup.ts
+++ b/packages/web/e2e/integration/global-setup.ts
@@ -148,14 +148,15 @@ export default async function globalSetup() {
     stdio: "inherit",
   });
 
-  // 8. Wait for Pinchy to reconnect to OpenClaw (up to 120s).
+  // 8. Wait for Pinchy to reconnect to OpenClaw (up to 300s).
   //    openclaw-node's exponential backoff (1s → 2s → 4s → … → 30s cap, plus
   //    the lib double-fires reconnect on every error+close pair) means a
   //    reconnect after a full container restart can take 45-90s before a
-  //    timer happens to fire while the gateway is healthy. 120s is well
-  //    inside that envelope without masking real regressions.
+  //    timer happens to fire while the gateway is healthy. 300s covers the
+  //    worst-case CI scenario where backoff and device-approval together
+  //    push the total past 180s.
   console.log("[integration-setup] Waiting for Pinchy to reconnect to OpenClaw...");
-  const deadline = Date.now() + 180000;
+  const deadline = Date.now() + 300000;
   let reconnected = false;
   while (Date.now() < deadline) {
     try {
@@ -171,7 +172,7 @@ export default async function globalSetup() {
     await new Promise((r) => setTimeout(r, 500));
   }
   if (!reconnected) {
-    throw new Error("[integration-setup] Pinchy did not reconnect to OpenClaw within 120s");
+    throw new Error("[integration-setup] Pinchy did not reconnect to OpenClaw within 300s");
   }
   console.log("[integration-setup] Pinchy reconnected to OpenClaw — integration stack ready");
 }

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -211,7 +211,12 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
     //     for reload. Without this, we'd be testing nothing — the config
     //     push silently failing would also satisfy (b) but means our fix
     //     is being bypassed.
-    expect(logs, logs).toMatch(/\[reload\] config change detected.*agents\.list/);
+    // Note: OpenClaw ≥ 4.27 changed the log format from
+    //   "config change detected.*agents.list"
+    // to
+    //   "config change detected; evaluating reload (env, agents, ...)"
+    // so we match the common prefix + "agents" to cover both formats.
+    expect(logs, logs).toMatch(/\[reload\] config change detected.*agents/);
 
     // (b) The bug fingerprint. With the bug present, OpenClaw logs:
     //     "[reload] config change requires gateway restart (...)"

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -94,11 +94,17 @@ function openClawLogsSince(sinceIso: string): string {
  *   - `[gateway] received SIGUSR1; restarting`
  *   - `[reload] config change requires gateway restart`
  *   - `[gateway] received SIGTERM; shutting down` (start-openclaw.sh kill)
- *   - `[gateway] ready (` — included intentionally even though it's the
+ *   - `[gateway] ready` — included intentionally even though it's the
  *     trailing edge of a restart, not the leading edge: every cold-start
  *     stack emits at least one of these. By treating it as a marker we
  *     correctly wait `quietMs` after the gateway becomes operational, not
  *     just after the SIGUSR1 fires.
+ *
+ * Liveness guard: if the log window is completely empty (no output at all),
+ * OpenClaw's Node.js event loop may be blocked (seen in CI: up to 32 s of
+ * zero log output with eventLoopDelayMaxMs=6526 ms). An empty window looks
+ * identical to "quiet" without the guard. We require at least one log line
+ * in the last 10 s before declaring quiet.
  */
 async function waitForOpenClawQuiet(quietMs = 30000, timeout = 240000): Promise<void> {
   const start = Date.now();
@@ -107,10 +113,20 @@ async function waitForOpenClawQuiet(quietMs = 30000, timeout = 240000): Promise<
     const restartMarkers = logs
       .split("\n")
       .filter((l) =>
-        /received SIGUSR1|received SIGTERM|requires gateway restart|\[gateway\] ready \(/.test(l)
+        /received SIGUSR1|received SIGTERM|requires gateway restart|\[gateway\] ready/.test(l)
       );
     if (restartMarkers.length === 0) {
-      // No restart-related events in the look-back window → gateway is quiet.
+      // No restart-related events in the look-back window. Before declaring quiet,
+      // verify OpenClaw is actually alive: under extreme CI load the Node.js event
+      // loop can block for 30+ seconds producing zero log output. An empty log
+      // window is indistinguishable from "quiet" otherwise — so we require at
+      // least one log line in the last 10 s as a liveness signal.
+      const liveness = openClawLogsSince(new Date(Date.now() - 10000).toISOString());
+      if (!liveness.trim()) {
+        // No logs at all → event loop probably blocked. Keep waiting.
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
       return;
     }
     await new Promise((r) => setTimeout(r, 1000));

--- a/packages/web/src/__tests__/db/seed.test.ts
+++ b/packages/web/src/__tests__/db/seed.test.ts
@@ -19,6 +19,12 @@ vi.mock("@/lib/personal-agent", () => ({
   createSmithersAgent: (...args: unknown[]) => createSmithersAgentMock(...args),
 }));
 
+// ── Mock @/lib/settings ──────────────────────────────────────────────────────
+const getSettingMock = vi.fn();
+vi.mock("@/lib/settings", () => ({
+  getSetting: (...args: unknown[]) => getSettingMock(...args),
+}));
+
 describe("seedDefaultAgent", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -35,8 +41,9 @@ describe("seedDefaultAgent", () => {
     expect(createSmithersAgentMock).not.toHaveBeenCalled();
   });
 
-  it("creates a new agent when none exists", async () => {
+  it("falls back to anthropic/claude-sonnet-4-6 when no default_provider is configured", async () => {
     findFirstMock.mockResolvedValue(undefined);
+    getSettingMock.mockResolvedValue(null);
     const fakeAgent = {
       id: "agent-new",
       name: "Smithers",
@@ -59,8 +66,30 @@ describe("seedDefaultAgent", () => {
     });
   });
 
+  it("uses the configured default_provider's default model", async () => {
+    findFirstMock.mockResolvedValue(undefined);
+    getSettingMock.mockResolvedValue("ollama-local");
+    const fakeAgent = {
+      id: "agent-new",
+      name: "Smithers",
+      model: "ollama/llama3.2",
+      ownerId: null,
+      isPersonal: false,
+      createdAt: new Date(),
+    };
+    createSmithersAgentMock.mockResolvedValue(fakeAgent);
+
+    const { seedDefaultAgent } = await import("@/db/seed");
+    await seedDefaultAgent();
+
+    expect(createSmithersAgentMock).toHaveBeenCalledWith(
+      expect.objectContaining({ model: "ollama/llama3.2" })
+    );
+  });
+
   it("passes ownerId and isPersonal when ownerId is provided", async () => {
     findFirstMock.mockResolvedValue(undefined);
+    getSettingMock.mockResolvedValue(null);
     const fakeAgent = {
       id: "agent-owned",
       name: "Smithers",

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1226,6 +1226,51 @@ describe("regenerateOpenClawConfig", () => {
     expect(authProfileCalls.length).toBe(0);
   });
 
+  it("retries readExistingConfig after 300 ms when it returns empty (EACCES/transient race)", async () => {
+    // Scenario: OpenClaw's in-process SIGUSR1 restart rewrites openclaw.json
+    // as root:0600 before start-openclaw.sh's chmod loop restores 0666.
+    // Under CI load the chmod may not run within readExistingConfig()'s
+    // 5×100ms budget → returns {} → meta absent → config.apply sends
+    // meta-less payload → OpenClaw 4.27 "missing-meta-before-write" anomaly
+    // → sentinel restoration broken → spurious full gateway restart (#193).
+    // The fix is a single 300ms async retry: if the first read returns empty,
+    // wait one chmod-loop tick and try again.
+    vi.useFakeTimers();
+    try {
+      let configReadCount = 0;
+      const existingWithMeta = {
+        gateway: { mode: "local", bind: "lan", auth: { token: "tok-eacces-retry" } },
+        meta: { version: "4.27.0", generatedAt: "2025-01-01T00:00:00Z" },
+      };
+      mockedReadFileSync.mockImplementation((path) => {
+        if (String(path).includes("openclaw.json")) {
+          configReadCount++;
+          if (configReadCount === 1) {
+            // Simulate readExistingConfig() returning {} (ENOENT or exhausted EACCES retries)
+            throw Object.assign(new Error("ENOENT: no such file or directory"), { code: "ENOENT" });
+          }
+          // Retry (count 2) and later file-comparison read (count 3+): return valid config
+          return JSON.stringify(existingWithMeta);
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      const promise = regenerateOpenClawConfig();
+      await vi.advanceTimersByTimeAsync(300);
+      await promise;
+
+      const openclaw = mockedWriteFileSync.mock.calls.find(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+      );
+      expect(openclaw).toBeDefined();
+      const config = JSON.parse(openclaw![1] as string);
+      // meta must be preserved from the retry read, not absent due to empty first read
+      expect(config.meta).toEqual({ version: "4.27.0", generatedAt: "2025-01-01T00:00:00Z" });
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   describe("config propagation to OpenClaw runtime (#200)", () => {
     // Pinchy must push config changes to OpenClaw's *runtime*, not just
     // disk. The original bug: writing openclaw.json relied on OpenClaw's

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1350,6 +1350,37 @@ describe("regenerateOpenClawConfig", () => {
       expect(mockConfigApply).not.toHaveBeenCalled();
     });
 
+    it("supplements meta from file when OC in-memory config lacks it (post-restart race)", async () => {
+      // Scenario: OC has just restarted and config.get() returns an in-memory
+      // config that has not yet had meta stamped (missing-meta-before-write
+      // anomaly). The file from the PREVIOUS run still has meta. The fallback
+      // must pick it up so config.apply doesn't trigger a cascade restart.
+      const ocConfigWithoutMeta = {
+        gateway: { mode: "local" },
+        plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+      };
+      mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      // File from previous run has meta
+      const metaBlock = { version: "4.27.0", lastTouchedAt: "2025-01-01T00:00:00Z" };
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({
+          meta: metaBlock,
+          gateway: { mode: "local" },
+        }) as unknown as Buffer
+      );
+
+      await regenerateOpenClawConfig();
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+
+      const appliedPayload = JSON.parse(String(mockConfigApply.mock.calls[0][0]));
+      expect(appliedPayload.meta).toEqual(metaBlock);
+    });
+
     it("cancels pending retries when a newer pushConfigInBackground call starts", async () => {
       // Scenario: two pushConfigInBackground calls start back-to-back.
       // Only the SECOND (newer) call's payload must reach OpenClaw —

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1139,7 +1139,7 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.plugins.allow).toContain("pinchy-docs");
   });
 
-  it("writes per-agent auth-profiles.json for every configured agent", async () => {
+  it("writes per-agent auth-profiles.json scoped to each agent's model provider", async () => {
     const agentsData = [
       {
         id: "agent-alpha",
@@ -1171,27 +1171,57 @@ describe("regenerateOpenClawConfig", () => {
     await regenerateOpenClawConfig();
 
     // auth-profiles.json is written atomically via writeFileSync → renameSync.
-    // The writeFileSync call uses a .tmp-<pid> path; renameSync (mocked) finishes the swap.
     // CONFIG_PATH is /openclaw-config/openclaw.json so configRoot = /openclaw-config.
-    // The temp file is written to configRoot/agents/<agentId>/agent/auth-profiles.json.tmp-<pid>.
     const authProfileCalls = mockedWriteFileSync.mock.calls.filter((call) =>
       String(call[0]).includes("auth-profiles.json")
     );
     expect(authProfileCalls.length).toBe(2);
 
-    const writtenAgentIds = authProfileCalls.map((call) => {
-      const parts = String(call[0]).split("/");
-      const agentsIdx = parts.indexOf("agents");
-      return parts[agentsIdx + 1];
-    });
-    expect(writtenAgentIds).toContain("agent-alpha");
-    expect(writtenAgentIds).toContain("agent-beta");
+    // agent-alpha uses anthropic model → only anthropic-default profile
+    const alphaCall = authProfileCalls.find((call) => String(call[0]).includes("agent-alpha"))!;
+    expect(alphaCall).toBeDefined();
+    const alphaContent = JSON.parse(String(alphaCall[1]));
+    expect(Object.keys(alphaContent.profiles)).toEqual(["anthropic-default"]);
+    expect(Object.keys(alphaContent.profiles)).not.toContain("openai-default");
 
-    for (const call of authProfileCalls) {
-      const content = JSON.parse(String(call[1]));
-      expect(Object.keys(content.profiles)).toContain("anthropic-default");
-      expect(Object.keys(content.profiles)).toContain("openai-default");
-    }
+    // agent-beta uses openai model → only openai-default profile
+    const betaCall = authProfileCalls.find((call) => String(call[0]).includes("agent-beta"))!;
+    expect(betaCall).toBeDefined();
+    const betaContent = JSON.parse(String(betaCall[1]));
+    expect(Object.keys(betaContent.profiles)).toEqual(["openai-default"]);
+    expect(Object.keys(betaContent.profiles)).not.toContain("anthropic-default");
+  });
+
+  it("does not write auth-profiles.json for ollama-local agents (URL-based, no API key)", async () => {
+    const agentsData = [
+      {
+        id: "agent-llama",
+        name: "Llama",
+        model: "ollama/llama3.1:8b",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    // unlinkSync is called (not writeFileSync) because providers=[]; the mock
+    // fs.unlinkSync is the real implementation (from actual fs mock) and will
+    // throw ENOENT since the tmp dir doesn't exist — that error is swallowed.
+    // What matters: no auth-profiles.json writeFileSync call for this agent.
+    const authProfileCalls = mockedWriteFileSync.mock.calls.filter((call) =>
+      String(call[0]).includes("auth-profiles.json")
+    );
+    expect(authProfileCalls.length).toBe(0);
   });
 
   describe("config propagation to OpenClaw runtime (#200)", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1139,6 +1139,61 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.plugins.allow).toContain("pinchy-docs");
   });
 
+  it("writes per-agent auth-profiles.json for every configured agent", async () => {
+    const agentsData = [
+      {
+        id: "agent-alpha",
+        name: "Smithers",
+        model: "anthropic/claude-sonnet-4-6",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+      {
+        id: "agent-beta",
+        name: "Jeeves",
+        model: "openai/gpt-5.4",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test";
+      if (key === "openai_api_key") return "sk-openai-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    // auth-profiles.json is written atomically via writeFileSync → renameSync.
+    // The writeFileSync call uses a .tmp-<pid> path; renameSync (mocked) finishes the swap.
+    // CONFIG_PATH is /openclaw-config/openclaw.json so configRoot = /openclaw-config.
+    // The temp file is written to configRoot/agents/<agentId>/agent/auth-profiles.json.tmp-<pid>.
+    const authProfileCalls = mockedWriteFileSync.mock.calls.filter((call) =>
+      String(call[0]).includes("auth-profiles.json")
+    );
+    expect(authProfileCalls.length).toBe(2);
+
+    const writtenAgentIds = authProfileCalls.map((call) => {
+      const parts = String(call[0]).split("/");
+      const agentsIdx = parts.indexOf("agents");
+      return parts[agentsIdx + 1];
+    });
+    expect(writtenAgentIds).toContain("agent-alpha");
+    expect(writtenAgentIds).toContain("agent-beta");
+
+    for (const call of authProfileCalls) {
+      const content = JSON.parse(String(call[1]));
+      expect(Object.keys(content.profiles)).toContain("anthropic-default");
+      expect(Object.keys(content.profiles)).toContain("openai-default");
+    }
+  });
+
   describe("config propagation to OpenClaw runtime (#200)", () => {
     // Pinchy must push config changes to OpenClaw's *runtime*, not just
     // disk. The original bug: writing openclaw.json relied on OpenClaw's
@@ -1815,7 +1870,7 @@ describe("pinchy-odoo config size", () => {
 
     await expect(regenerateOpenClawConfig()).resolves.toBeUndefined();
 
-    const written = mockedWriteFileSync.mock.calls.at(-1)?.[1] as string;
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
     const odooAgents = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents ?? {};
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1799,8 +1799,11 @@ describe("pinchy-odoo config size", () => {
 
     await regenerateOpenClawConfig();
 
-    const written = mockedWriteFileSync.mock.calls[0][1] as string;
-    const config = JSON.parse(written);
+    const writtenCall = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+    );
+    expect(writtenCall).toBeDefined();
+    const config = JSON.parse(writtenCall![1] as string);
 
     const odooConfig = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents?.["odoo-agent"];
     expect(odooConfig).toBeDefined();
@@ -1812,7 +1815,7 @@ describe("pinchy-odoo config size", () => {
     expect(odooConfig.schema).toBeUndefined();
 
     // Config should be small (no field definitions bloating it)
-    const configSize = written.length;
+    const configSize = writtenCall![1]!.toString().length;
     expect(configSize).toBeLessThan(5000); // Without schema: ~2-3KB. With schema it would be 100KB+
   });
 
@@ -1870,8 +1873,11 @@ describe("pinchy-odoo config size", () => {
 
     await expect(regenerateOpenClawConfig()).resolves.toBeUndefined();
 
-    const written = mockedWriteFileSync.mock.calls[0][1] as string;
-    const config = JSON.parse(written);
+    const writtenCall = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+    );
+    expect(writtenCall).toBeDefined();
+    const config = JSON.parse(writtenCall![1] as string);
     const odooAgents = config.plugins?.entries?.["pinchy-odoo"]?.config?.agents ?? {};
 
     expect(odooAgents["odoo-agent"]).toBeDefined();

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1420,6 +1420,47 @@ describe("regenerateOpenClawConfig", () => {
       expect(appliedPayload).not.toContain('"OLD"');
     });
 
+    it("supplements channels.telegram fields absent from payload from OC in-memory config (OC 4.27+ channel diff prevention)", async () => {
+      // OC 4.27 writes additional fields to channels.telegram in-memory
+      // (e.g. pollingMode, or other new OC-managed fields). Pinchy's payload
+      // omits these fields. Without supplement, config.apply sees a channels
+      // diff → full gateway restart even for agents-only changes.
+      const ocConfig = {
+        meta: { version: "4.27.0", lastTouchedAt: "2025-01-01T00:00:00Z" },
+        channels: {
+          telegram: {
+            enabled: true,
+            dmPolicy: "pairing",
+            accounts: { a1: { botToken: "tok" } },
+            pollingMode: "long_poll", // OC-managed field Pinchy doesn't emit
+          },
+        },
+      };
+      mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfig });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+
+      // Pinchy's payload has channels.telegram WITHOUT pollingMode
+      const pinchyPayload = JSON.stringify({
+        meta: { version: "4.27.0" },
+        channels: {
+          telegram: {
+            enabled: true,
+            dmPolicy: "pairing",
+            accounts: { a1: { botToken: "tok" } },
+          },
+        },
+      });
+
+      pushConfigInBackground(pinchyPayload);
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+
+      const applied = JSON.parse(String(mockConfigApply.mock.calls[0][0]));
+      expect(applied.channels?.telegram?.pollingMode).toBe("long_poll");
+    });
+
     it("skips config.apply when OC in-memory config and file both lack meta (missing-meta-before-write cascade guard)", async () => {
       // Scenario: OC just restarted (in-memory config has no meta) AND the
       // previous config.apply already wrote a meta-less file. Neither source
@@ -2457,16 +2498,20 @@ describe("restart-state integration", () => {
     });
   });
 
-  it("drops unknown fields from existingTelegram on regenerate", async () => {
-    // Seed openclaw.json with channels.telegram containing a known field (groupPolicy)
-    // and an unknown legacy field (weirdLegacyField)
+  it("preserves all non-Pinchy-owned fields from existingTelegram on regenerate", async () => {
+    // OC 4.27 writes new fields to channels.telegram that Pinchy doesn't know
+    // about (e.g. pollingMode). Using an allowlist (like the old ENRICHED_TELEGRAM_FIELDS)
+    // caused those fields to be stripped → channels diff on every config.apply →
+    // spurious full gateway restart even for agents-only changes.
+    // Using a denylist (preserve everything except Pinchy-owned fields) is
+    // robust to future OC additions.
     const existingConfig = {
       gateway: { mode: "local", bind: "lan", auth: { token: "secret" } },
       channels: {
         telegram: {
           dmPolicy: "pairing",
           groupPolicy: "allow",
-          weirdLegacyField: "foo",
+          pollingMode: "long_poll", // OC 4.27-managed field
           accounts: {},
         },
       },
@@ -2498,10 +2543,12 @@ describe("restart-state integration", () => {
     expect(written).toBeDefined();
     const config = JSON.parse(written![1] as string);
 
-    // Known field is preserved
+    // All non-Pinchy-owned fields from the existing file are preserved
     expect(config.channels.telegram.groupPolicy).toBe("allow");
-    // Unknown legacy field is dropped
-    expect(config.channels.telegram.weirdLegacyField).toBeUndefined();
+    expect(config.channels.telegram.pollingMode).toBe("long_poll");
+    // Pinchy-owned fields are written fresh (not taken from existing)
+    expect(config.channels.telegram.enabled).toBe(true);
+    expect(config.channels.telegram.dmPolicy).toBe("pairing");
   });
 
   it("preserves channels.telegram.enabled when OpenClaw set it on auto-enable (#193)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -111,6 +111,7 @@ import {
   sanitizeOpenClawConfig,
   updateTelegramChannelConfig,
 } from "@/lib/openclaw-config";
+import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
 
@@ -162,6 +163,7 @@ async function drainBackgroundCoroutine(): Promise<void> {
 describe("regenerateOpenClawConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetPushGeneration();
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockImplementation(() => {
       throw new Error("ENOENT: no such file or directory");
@@ -1301,6 +1303,45 @@ describe("regenerateOpenClawConfig", () => {
 
       expect(mockConfigGet).not.toHaveBeenCalled();
       expect(mockConfigApply).not.toHaveBeenCalled();
+    });
+
+    it("cancels pending retries when a newer pushConfigInBackground call starts", async () => {
+      // Scenario: two pushConfigInBackground calls start back-to-back.
+      // Only the SECOND (newer) call's payload must reach OpenClaw —
+      // the first call must be cancelled by the generation counter before
+      // it can fire config.apply with a stale payload.
+      //
+      // This prevents the production race where a slow-retry loop carrying
+      // env.ANTHROPIC_API_KEY (from an initial setup call) fires simultaneously
+      // with a later agents-only call, triggering a spurious restart (#193).
+      mockConfigGet.mockResolvedValue({ hash: "h1" });
+      mockConfigApply.mockResolvedValue(undefined); // always succeeds
+      mockGetClient.mockImplementation(() => ({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      }));
+
+      // Start first push with "old" payload.
+      pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+      // Immediately start second push with "new" payload — increments the
+      // generation counter, cancelling the first call's retry loop.
+      pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+
+      // With the static import (no await import()), the OLD IIFE exits
+      // synchronously at the generation check (1 ≠ 2 → return). The NEW
+      // IIFE runs synchronously to its first real await (config.get()).
+      // One drain round is enough to let config.get + config.apply settle.
+      await drainBackgroundCoroutine();
+
+      // Exactly ONE config.apply call — the first call was cancelled before
+      // it could reach apply.
+      expect(mockConfigApply).toHaveBeenCalledTimes(1);
+
+      // Exactly ONE config.apply call — the first call was cancelled before
+      // it could reach apply.
+      expect(mockConfigApply).toHaveBeenCalledTimes(1);
+      const appliedPayload = String(mockConfigApply.mock.calls[0][0]);
+      expect(appliedPayload).toContain('"NEW"');
+      expect(appliedPayload).not.toContain('"OLD"');
     });
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1419,6 +1419,40 @@ describe("regenerateOpenClawConfig", () => {
       expect(appliedPayload).toContain('"NEW"');
       expect(appliedPayload).not.toContain('"OLD"');
     });
+
+    it("skips config.apply when OC in-memory config and file both lack meta (missing-meta-before-write cascade guard)", async () => {
+      // Scenario: OC just restarted (in-memory config has no meta) AND the
+      // previous config.apply already wrote a meta-less file. Neither source
+      // can supply meta, so supplementation leaves the payload without it.
+      // Sending that payload via config.apply triggers OC's
+      // "missing-meta-before-write" anomaly → SIGUSR1 restart cascade.
+      //
+      // The guard must detect this and return early, relying on inotify
+      // (from the writeConfigAtomic call above) instead of config.apply.
+      // The guard only fires when current.config IS defined (OC is running
+      // and has a config) — cold-start (current.config absent) still proceeds.
+      const ocConfigWithoutMeta = {
+        gateway: { mode: "local" },
+        plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+      };
+      mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      // File also has no meta (written by a previous meta-less config.apply)
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({
+          gateway: { mode: "local" },
+        }) as unknown as Buffer
+      );
+
+      await regenerateOpenClawConfig();
+      await drainBackgroundCoroutine();
+
+      // config.apply must NOT be called — guard returns early when payload lacks meta
+      expect(mockConfigApply).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -102,4 +102,21 @@ describe("writeAgentAuthProfiles", () => {
     const stat = fs.statSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"));
     expect(stat.mode & 0o777).toBe(0o600);
   });
+
+  it("empty providers — removes existing auth-profiles.json to prevent strict auth mode", async () => {
+    const agentDir = path.join(tmpDir, "agents", "a", "agent");
+    fs.mkdirSync(agentDir, { recursive: true });
+    const filePath = path.join(agentDir, "auth-profiles.json");
+    fs.writeFileSync(filePath, JSON.stringify({ profiles: { "anthropic-default": {} } }));
+
+    await writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: [] });
+
+    expect(fs.existsSync(filePath)).toBe(false);
+  });
+
+  it("empty providers — no-op when auth-profiles.json does not exist", async () => {
+    await expect(
+      writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "no-file-agent", providers: [] })
+    ).resolves.toBeUndefined();
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as fs from "fs";
 import * as path from "path";
 import * as os from "os";
@@ -9,6 +9,10 @@ describe("writeAgentAuthProfiles", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-auth-test-"));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpDir, { recursive: true, force: true });
   });
 
   it("writes auth-profiles.json with one profile per configured provider", async () => {
@@ -35,8 +39,8 @@ describe("writeAgentAuthProfiles", () => {
   });
 
   it("writes atomically — no partial files visible at the destination path", async () => {
-    // Monkey-patch fs.renameSync to throw, dann assert dass das destination
-    // file nicht angelegt wurde (nur das tmp file).
+    // Implementation must call fs.renameSync (namespace form, not destructured) for this spy to work.
+    // The plan's Task 3 implementation uses fs.renameSync(...) — that assumption is load-bearing here.
     const originalRename = fs.renameSync;
     fs.renameSync = () => {
       throw new Error("rename failed");

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -1,7 +1,28 @@
-import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import * as fs from "fs";
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import * as path from "path";
 import * as os from "os";
+
+// Hoist the real renameSync before mocking so we can use it as the default implementation.
+const { realRenameSync } = vi.hoisted(() => {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports
+  const realFs = require("fs") as typeof import("fs");
+  return { realRenameSync: realFs.renameSync.bind(realFs) };
+});
+
+// Mock fs so renameSync can be intercepted per-test. All other methods call
+// through to the real implementation so tmpDir creation and assertions work.
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const renameSyncMock = vi.fn(realRenameSync);
+  return {
+    ...actual,
+    default: { ...actual, renameSync: renameSyncMock },
+    renameSync: renameSyncMock,
+  };
+});
+
+import * as fs from "fs";
 import { writeAgentAuthProfiles } from "@/lib/openclaw-config/agent-auth-profiles";
 
 describe("writeAgentAuthProfiles", () => {
@@ -9,10 +30,12 @@ describe("writeAgentAuthProfiles", () => {
 
   beforeEach(() => {
     tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-auth-test-"));
+    vi.mocked(fs.renameSync).mockImplementation(realRenameSync);
   });
 
   afterEach(() => {
     fs.rmSync(tmpDir, { recursive: true, force: true });
+    vi.mocked(fs.renameSync).mockReset();
   });
 
   it("writes auth-profiles.json with one profile per configured provider", async () => {
@@ -41,21 +64,16 @@ describe("writeAgentAuthProfiles", () => {
   it("writes atomically — no partial files visible at the destination path", async () => {
     // Implementation must call fs.renameSync (namespace form, not destructured) for this spy to work.
     // The plan's Task 3 implementation uses fs.renameSync(...) — that assumption is load-bearing here.
-    const originalRename = fs.renameSync;
-    fs.renameSync = () => {
+    vi.mocked(fs.renameSync).mockImplementationOnce(() => {
       throw new Error("rename failed");
-    };
-    try {
-      await expect(
-        writeAgentAuthProfiles({
-          configRoot: tmpDir,
-          agentId: "a",
-          providers: ["anthropic"],
-        })
-      ).rejects.toThrow("rename failed");
-    } finally {
-      fs.renameSync = originalRename;
-    }
+    });
+    await expect(
+      writeAgentAuthProfiles({
+        configRoot: tmpDir,
+        agentId: "a",
+        providers: ["anthropic"],
+      })
+    ).rejects.toThrow("rename failed");
     const destPath = path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json");
     expect(fs.existsSync(destPath)).toBe(false);
   });

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { writeAgentAuthProfiles } from "@/lib/openclaw-config/agent-auth-profiles";
+
+describe("writeAgentAuthProfiles", () => {
+  let tmpDir: string;
+
+  beforeEach(() => {
+    tmpDir = fs.mkdtempSync(path.join(os.tmpdir(), "agent-auth-test-"));
+  });
+
+  it("writes auth-profiles.json with one profile per configured provider", async () => {
+    await writeAgentAuthProfiles({
+      configRoot: tmpDir,
+      agentId: "agent-123",
+      providers: ["anthropic", "openai"],
+    });
+
+    const expectedPath = path.join(tmpDir, "agents", "agent-123", "agent", "auth-profiles.json");
+    expect(fs.existsSync(expectedPath)).toBe(true);
+
+    const content = JSON.parse(fs.readFileSync(expectedPath, "utf8"));
+    expect(content.profiles["anthropic-default"]).toEqual({
+      type: "api_key",
+      provider: "anthropic",
+      keyRef: { kind: "secret", path: "providers.anthropic.apiKey" },
+    });
+    expect(content.profiles["openai-default"]).toEqual({
+      type: "api_key",
+      provider: "openai",
+      keyRef: { kind: "secret", path: "providers.openai.apiKey" },
+    });
+  });
+
+  it("writes atomically — no partial files visible at the destination path", async () => {
+    // Monkey-patch fs.renameSync to throw, dann assert dass das destination
+    // file nicht angelegt wurde (nur das tmp file).
+    const originalRename = fs.renameSync;
+    fs.renameSync = () => {
+      throw new Error("rename failed");
+    };
+    try {
+      await expect(
+        writeAgentAuthProfiles({
+          configRoot: tmpDir,
+          agentId: "a",
+          providers: ["anthropic"],
+        })
+      ).rejects.toThrow("rename failed");
+    } finally {
+      fs.renameSync = originalRename;
+    }
+    const destPath = path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json");
+    expect(fs.existsSync(destPath)).toBe(false);
+  });
+
+  it("is idempotent — writing the same input twice produces identical bytes", async () => {
+    const params = { configRoot: tmpDir, agentId: "a", providers: ["anthropic"] as const };
+    await writeAgentAuthProfiles(params);
+    const first = fs.readFileSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"));
+    await writeAgentAuthProfiles(params);
+    const second = fs.readFileSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"));
+    expect(first.equals(second)).toBe(true);
+  });
+
+  it("creates intermediate directories", async () => {
+    await writeAgentAuthProfiles({
+      configRoot: tmpDir,
+      agentId: "nested/deep",
+      providers: ["anthropic"],
+    });
+    const expectedPath = path.join(tmpDir, "agents", "nested/deep", "agent", "auth-profiles.json");
+    expect(fs.existsSync(expectedPath)).toBe(true);
+  });
+
+  it("writes file with mode 0600", async () => {
+    await writeAgentAuthProfiles({ configRoot: tmpDir, agentId: "a", providers: ["anthropic"] });
+    const stat = fs.statSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"));
+    expect(stat.mode & 0o777).toBe(0o600);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
@@ -1,0 +1,79 @@
+// @vitest-environment node
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+vi.mock("fs");
+vi.mock("@/lib/openclaw-config/paths", () => ({
+  CONFIG_PATH: "/openclaw-config/openclaw.json",
+}));
+
+import * as fs from "fs";
+import {
+  redactUnchangedEnvForApply,
+  OPENCLAW_REDACTED_SENTINEL,
+} from "@/lib/openclaw-config/normalize";
+
+const mockedReadFileSync = vi.mocked(fs.readFileSync);
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("redactUnchangedEnvForApply", () => {
+  it("returns input unchanged when config file does not exist (cold start)", () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw new Error("ENOENT");
+    });
+    const input = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    expect(redactUnchangedEnvForApply(input)).toBe(input);
+  });
+
+  it("redacts env key present in existing file — even when values differ (template vs resolved)", () => {
+    // Simulates the OpenClaw#75534 scenario: existing file has the RESOLVED key
+    // (sk-ant-...) after OpenClaw expanded the template; new config has template.
+    // The sentinel prevents a spurious env.* restart.
+    const existing = JSON.stringify({ env: { ANTHROPIC_API_KEY: "sk-ant-resolvedvalue" } });
+    mockedReadFileSync.mockReturnValue(existing as unknown as Buffer);
+
+    const newContent = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    const result = JSON.parse(redactUnchangedEnvForApply(newContent));
+
+    expect(result.env.ANTHROPIC_API_KEY).toBe(OPENCLAW_REDACTED_SENTINEL);
+  });
+
+  it("redacts env key when both files have the same template value", () => {
+    const existing = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    mockedReadFileSync.mockReturnValue(existing as unknown as Buffer);
+
+    const newContent = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    const result = JSON.parse(redactUnchangedEnvForApply(newContent));
+
+    expect(result.env.ANTHROPIC_API_KEY).toBe(OPENCLAW_REDACTED_SENTINEL);
+  });
+
+  it("does NOT redact a new env key absent from the existing file", () => {
+    const existing = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    mockedReadFileSync.mockReturnValue(existing as unknown as Buffer);
+
+    const newContent = JSON.stringify({
+      env: {
+        ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}",
+        OPENAI_API_KEY: "${OPENAI_API_KEY}",
+      },
+    });
+    const result = JSON.parse(redactUnchangedEnvForApply(newContent));
+
+    expect(result.env.ANTHROPIC_API_KEY).toBe(OPENCLAW_REDACTED_SENTINEL);
+    expect(result.env.OPENAI_API_KEY).toBe("${OPENAI_API_KEY}");
+  });
+
+  it("returns input unchanged when existing file has no env section", () => {
+    const existing = JSON.stringify({ agents: { list: [] } });
+    mockedReadFileSync.mockReturnValue(existing as unknown as Buffer);
+
+    const newContent = JSON.stringify({ env: { ANTHROPIC_API_KEY: "${ANTHROPIC_API_KEY}" } });
+    const result = JSON.parse(redactUnchangedEnvForApply(newContent));
+
+    // New key not in existing → not redacted
+    expect(result.env.ANTHROPIC_API_KEY).toBe("${ANTHROPIC_API_KEY}");
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
@@ -9,6 +9,7 @@ vi.mock("@/lib/openclaw-config/paths", () => ({
 import * as fs from "fs";
 import {
   redactUnchangedEnvForApply,
+  supplementPayloadWithFileFields,
   OPENCLAW_REDACTED_SENTINEL,
 } from "@/lib/openclaw-config/normalize";
 
@@ -75,5 +76,124 @@ describe("redactUnchangedEnvForApply", () => {
 
     // New key not in existing → not redacted
     expect(result.env.ANTHROPIC_API_KEY).toBe("${ANTHROPIC_API_KEY}");
+  });
+});
+
+describe("supplementPayloadWithFileFields", () => {
+  it("returns payload unchanged when file does not exist", () => {
+    mockedReadFileSync.mockImplementation(() => {
+      throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+    });
+    const payload = JSON.stringify({ plugins: { allow: ["pinchy-audit"], entries: {} } });
+    expect(supplementPayloadWithFileFields(payload)).toBe(payload);
+  });
+
+  it("adds non-pinchy plugins.allow entries from file that are absent from payload", () => {
+    // Simulates OpenClaw auto-adding "anthropic" to plugins.allow after restart.
+    const file = JSON.stringify({
+      plugins: { allow: ["pinchy-audit", "anthropic", "telegram"] },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({ plugins: { allow: ["pinchy-audit"] } });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    expect(result.plugins.allow).toContain("anthropic");
+    expect(result.plugins.allow).toContain("telegram");
+    expect(result.plugins.allow).toContain("pinchy-audit");
+  });
+
+  it("does NOT add pinchy-* entries from file plugins.allow", () => {
+    // A stale pinchy-files entry in the file should not be resurrected.
+    const file = JSON.stringify({
+      plugins: { allow: ["pinchy-files", "anthropic"] },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({ plugins: { allow: [] } });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    expect(result.plugins.allow).not.toContain("pinchy-files");
+    expect(result.plugins.allow).toContain("anthropic");
+  });
+
+  it("adds non-pinchy plugins.entries from file that are absent from payload", () => {
+    // Simulates OpenClaw writing plugins.entries.anthropic = {enabled:true} on auto-enable.
+    const file = JSON.stringify({
+      plugins: {
+        allow: ["anthropic"],
+        entries: { anthropic: { enabled: true } },
+      },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({
+      plugins: { allow: ["pinchy-audit"], entries: { "pinchy-audit": { enabled: true } } },
+    });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    expect(result.plugins.entries.anthropic).toEqual({ enabled: true });
+    expect(result.plugins.entries["pinchy-audit"]).toEqual({ enabled: true }); // untouched
+  });
+
+  it("does NOT overwrite existing plugins.entries in payload with file values", () => {
+    const file = JSON.stringify({
+      plugins: {
+        entries: { "pinchy-audit": { enabled: false, staleField: "old" } },
+      },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({
+      plugins: { allow: [], entries: { "pinchy-audit": { enabled: true } } },
+    });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    // Payload value wins — not overwritten by stale file value
+    expect(result.plugins.entries["pinchy-audit"]).toEqual({ enabled: true });
+  });
+
+  it("adds gateway.controlUi fields from file that are absent from payload", () => {
+    // Simulates OpenClaw writing gateway.controlUi.allowedOrigins after startup.
+    const file = JSON.stringify({
+      gateway: {
+        mode: "local",
+        controlUi: { allowedOrigins: ["http://localhost:18789"] },
+      },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({ gateway: { mode: "local", auth: { token: "tok" } } });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    expect(result.gateway.controlUi).toEqual({ allowedOrigins: ["http://localhost:18789"] });
+    expect(result.gateway.auth).toEqual({ token: "tok" }); // untouched
+  });
+
+  it("does NOT overwrite existing gateway.controlUi fields in payload", () => {
+    const file = JSON.stringify({
+      gateway: { controlUi: { allowedOrigins: ["old"] } },
+    });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({
+      gateway: { controlUi: { allowedOrigins: ["new"] } },
+    });
+    const result = JSON.parse(supplementPayloadWithFileFields(payload));
+
+    expect(result.gateway.controlUi.allowedOrigins).toEqual(["new"]);
+  });
+
+  it("returns payload unchanged when file has nothing to supplement", () => {
+    const file = JSON.stringify({ agents: { list: [] } });
+    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+
+    const payload = JSON.stringify({
+      gateway: { mode: "local" },
+      plugins: { allow: ["pinchy-audit"] },
+    });
+    // Should be identical string when nothing changes
+    const result = supplementPayloadWithFileFields(payload);
+    expect(JSON.parse(result)).toEqual(JSON.parse(payload));
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
@@ -10,6 +10,7 @@ import * as fs from "fs";
 import {
   redactUnchangedEnvForApply,
   supplementPayloadWithFileFields,
+  supplementPayloadWithOcConfig,
   OPENCLAW_REDACTED_SENTINEL,
 } from "@/lib/openclaw-config/normalize";
 
@@ -195,5 +196,61 @@ describe("supplementPayloadWithFileFields", () => {
     // Should be identical string when nothing changes
     const result = supplementPayloadWithFileFields(payload);
     expect(JSON.parse(result)).toEqual(JSON.parse(payload));
+  });
+});
+
+describe("supplementPayloadWithOcConfig", () => {
+  it("adds meta from OC config when absent from payload — prevents missing-meta-before-write", () => {
+    // Simulates the case where readExistingConfig() returned {} (EACCES race),
+    // so build.ts omitted meta from the payload. Without meta the payload triggers
+    // OpenClaw's missing-meta-before-write anomaly → cascading restarts.
+    const ocConfig = {
+      hash: "abc123",
+      meta: { version: "4.27.0", generatedAt: "2025-01-01T00:00:00Z", lastTouchedAt: "T2" },
+      gateway: { mode: "local", controlUi: { allowedOrigins: ["http://localhost:18789"] } },
+    };
+    const payload = JSON.stringify({ gateway: { mode: "local", auth: { token: "tok" } } });
+    const result = JSON.parse(supplementPayloadWithOcConfig(payload, ocConfig));
+
+    expect(result.meta).toEqual(ocConfig.meta);
+    expect(result.gateway.auth).toEqual({ token: "tok" }); // Pinchy field untouched
+  });
+
+  it("does NOT overwrite existing meta in payload", () => {
+    const ocConfig = { hash: "x", meta: { version: "4.27.0", lastTouchedAt: "T2" } };
+    const payload = JSON.stringify({ meta: { version: "4.27.0", lastTouchedAt: "T1" } });
+    const result = JSON.parse(supplementPayloadWithOcConfig(payload, ocConfig));
+
+    expect(result.meta.lastTouchedAt).toBe("T1"); // payload wins
+  });
+
+  it("adds gateway.controlUi from OC config (avoids file-read race for controlUi)", () => {
+    const ocConfig = {
+      hash: "x",
+      gateway: { controlUi: { allowedOrigins: ["http://localhost:18789"] } },
+    };
+    const payload = JSON.stringify({ gateway: { mode: "local" } });
+    const result = JSON.parse(supplementPayloadWithOcConfig(payload, ocConfig));
+
+    expect(result.gateway.controlUi).toEqual({ allowedOrigins: ["http://localhost:18789"] });
+  });
+
+  it("adds non-pinchy plugins.entries from OC config", () => {
+    const ocConfig = {
+      hash: "x",
+      plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+    };
+    const payload = JSON.stringify({ plugins: { allow: ["pinchy-audit"], entries: {} } });
+    const result = JSON.parse(supplementPayloadWithOcConfig(payload, ocConfig));
+
+    expect(result.plugins.entries.anthropic).toEqual({ enabled: true });
+  });
+
+  it("adds non-pinchy plugins.allow entries from OC config", () => {
+    const ocConfig = { hash: "x", plugins: { allow: ["pinchy-audit", "anthropic"] } };
+    const payload = JSON.stringify({ plugins: { allow: ["pinchy-audit"] } });
+    const result = JSON.parse(supplementPayloadWithOcConfig(payload, ocConfig));
+
+    expect(result.plugins.allow).toContain("anthropic");
   });
 });

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -327,18 +327,22 @@ describe("startUsagePoller / stopUsagePoller", () => {
     expect(_isPollerRunning()).toBe(true);
   });
 
-  it("runs an immediate poll on startup before the interval fires", async () => {
+  it("does NOT poll immediately on startup — first poll fires with the first interval tick", async () => {
+    // OC 4.27 introduced a slow sessions.list startup scan (~45s CPU-bound).
+    // Calling sessions.list immediately on connect blocks OC's event loop
+    // and prevents concurrent agent chat requests from being processed within
+    // openclaw-node's request timeout. Removing the immediate poll lets OC
+    // finish its internal initialization before the first poll fires at 60s.
     const client = makeOpenClawClient([
       { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
     ]);
 
     startUsagePoller(client);
 
-    // The immediate poll is fire-and-forget — flush its microtask
+    // Flush any microtasks — no poll should have fired yet
     await vi.advanceTimersByTimeAsync(0);
 
-    // Should have polled once already (immediate), without waiting 60s
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
 
     stopUsagePoller();
   });
@@ -349,17 +353,13 @@ describe("startUsagePoller / stopUsagePoller", () => {
     ]);
     startUsagePoller(client);
 
-    // Immediate poll fires on startup (fire-and-forget)
-    await vi.advanceTimersByTimeAsync(0);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
-
     // First interval tick at 60s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
 
     // Second interval tick at 120s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(3);
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
   });
 
   it("stops polling on stopUsagePoller", async () => {
@@ -367,15 +367,14 @@ describe("startUsagePoller / stopUsagePoller", () => {
       { key: "agent:agent-1:direct:user-1", inputTokens: 10, outputTokens: 5 },
     ]);
     startUsagePoller(client);
-    await vi.advanceTimersByTimeAsync(0); // flush immediate poll
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2); // immediate + first tick
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // first tick only
 
     stopUsagePoller();
     expect(_isPollerRunning()).toBe(false);
 
     await vi.advanceTimersByTimeAsync(120_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2); // no more calls after stop
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // no more calls after stop
   });
 
   it("is idempotent — multiple starts don't create duplicate intervals", async () => {
@@ -386,9 +385,8 @@ describe("startUsagePoller / stopUsagePoller", () => {
     startUsagePoller(client);
     startUsagePoller(client);
 
-    await vi.advanceTimersByTimeAsync(0); // flush immediate poll
     await vi.advanceTimersByTimeAsync(60_000);
-    // Three start calls but only one immediate poll + one tick = 2
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    // Three start calls but only one interval — one tick = 1
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/db/seed.ts
+++ b/packages/web/src/db/seed.ts
@@ -1,12 +1,21 @@
 import { db } from "@/db";
 import { createSmithersAgent } from "@/lib/personal-agent";
+import { getSetting } from "@/lib/settings";
+import { PROVIDERS, type ProviderName } from "@/lib/providers";
 
 export async function seedDefaultAgent(ownerId?: string) {
   const existing = await db.query.agents.findFirst();
   if (existing) return existing;
 
+  // Use the configured default provider's static default model so Smithers
+  // starts with a working model on first boot. Falls back to Anthropic Sonnet
+  // when no provider is configured yet (cold start before setup wizard runs).
+  const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
+  const model =
+    (defaultProvider && PROVIDERS[defaultProvider]?.defaultModel) || "anthropic/claude-sonnet-4-6";
+
   return createSmithersAgent({
-    model: "anthropic/claude-sonnet-4-6",
+    model,
     ownerId: ownerId ?? null,
     isPersonal: ownerId ? true : false,
     isAdmin: ownerId ? true : false,

--- a/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
+++ b/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
@@ -12,12 +12,29 @@ export type WriteAgentAuthProfilesParams = {
   /** Filesystem root that will be mounted as /root/.openclaw inside OpenClaw container */
   configRoot: string;
   agentId: string;
-  /** Providers configured for this agent. Empty array → empty profiles object. */
+  /**
+   * Providers configured for this agent. Empty array → remove auth-profiles.json
+   * (if present) so OpenClaw does not enter strict auth mode for this agent.
+   * OpenClaw's hasAnyAuthProfileStoreSource() returns TRUE whenever the file
+   * exists — even an empty profiles object enables strict mode.
+   */
   providers: AuthProfilesProvider[];
 };
 
 export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParams): Promise<void> {
   const dir = path.join(params.configRoot, "agents", params.agentId, "agent");
+  const target = path.join(dir, "auth-profiles.json");
+
+  if (params.providers.length === 0) {
+    // No profiles → remove the file so OpenClaw doesn't enter strict auth mode.
+    try {
+      fs.unlinkSync(target);
+    } catch {
+      // File doesn't exist — that's fine.
+    }
+    return;
+  }
+
   fs.mkdirSync(dir, { recursive: true });
 
   const profiles: Record<string, unknown> = {};
@@ -29,7 +46,6 @@ export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParam
     };
   }
 
-  const target = path.join(dir, "auth-profiles.json");
   const tmp = `${target}.tmp-${process.pid}`;
   fs.writeFileSync(tmp, JSON.stringify({ profiles }, null, 2) + "\n", { mode: 0o600 });
   fs.renameSync(tmp, target);

--- a/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
+++ b/packages/web/src/lib/openclaw-config/agent-auth-profiles.ts
@@ -1,0 +1,36 @@
+import * as fs from "fs";
+import * as path from "path";
+
+export type AuthProfilesProvider =
+  | "anthropic"
+  | "openai"
+  | "gemini"
+  | "ollama-local"
+  | "ollama-cloud";
+
+export type WriteAgentAuthProfilesParams = {
+  /** Filesystem root that will be mounted as /root/.openclaw inside OpenClaw container */
+  configRoot: string;
+  agentId: string;
+  /** Providers configured for this agent. Empty array → empty profiles object. */
+  providers: AuthProfilesProvider[];
+};
+
+export async function writeAgentAuthProfiles(params: WriteAgentAuthProfilesParams): Promise<void> {
+  const dir = path.join(params.configRoot, "agents", params.agentId, "agent");
+  fs.mkdirSync(dir, { recursive: true });
+
+  const profiles: Record<string, unknown> = {};
+  for (const provider of params.providers) {
+    profiles[`${provider}-default`] = {
+      type: "api_key" as const,
+      provider,
+      keyRef: { kind: "secret" as const, path: `providers.${provider}.apiKey` },
+    };
+  }
+
+  const target = path.join(dir, "auth-profiles.json");
+  const tmp = `${target}.tmp-${process.pid}`;
+  fs.writeFileSync(tmp, JSON.stringify({ profiles }, null, 2) + "\n", { mode: 0o600 });
+  fs.renameSync(tmp, target);
+}

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -732,15 +732,27 @@ export async function regenerateOpenClawConfig() {
   // which is the latency `pushConfigInBackground` exists to hide.
   writeConfigAtomic(newContent);
 
-  // Write per-agent auth-profiles.json for every agent.
-  // Required by OpenClaw ≥ 4.15: each agent directory must contain
-  // agents/<id>/agent/auth-profiles.json listing which LLM provider
-  // API keys it may use. We write one profile per currently-configured
-  // provider so agents aren't restricted to a subset of what's available.
-  // Phase-3 will add per-agent restrictions; for now all agents get all
-  // configured providers (safe: providers are still gated by allowedTools).
+  // Write per-agent auth-profiles.json for agents that use API-key-based
+  // providers. Required by OpenClaw ≥ 4.15: each agent directory must
+  // contain agents/<id>/agent/auth-profiles.json. We scope each agent to
+  // only the provider that matches its own model prefix — writing a profile
+  // for a provider the agent doesn't use causes hasAnyAuthProfileStoreSource
+  // to return TRUE, which enables strict auth mode and blocks unrelated
+  // providers (e.g. ollama-local falls through to an anthropic key check and
+  // fails when no anthropic profile exists).
   //
-  // Mapping: PROVIDERS uses "google" as key, AuthProfilesProvider uses "gemini".
+  // Mapping: model prefix (first "/" segment) → AuthProfilesProvider.
+  // "ollama" (local) is intentionally absent: URL-based, no API key needed.
+  // If an agent would get 0 profiles, writeAgentAuthProfiles removes any
+  // existing file to prevent spurious strict-mode activation.
+  const MODEL_PREFIX_TO_AUTH_PROFILE: Partial<Record<string, AuthProfilesProvider>> = {
+    anthropic: "anthropic",
+    openai: "openai",
+    google: "gemini",
+    "ollama-cloud": "ollama-cloud",
+    // "ollama" intentionally absent — local Ollama is URL-based, no API key
+  };
+  // Providers that actually have credentials configured right now.
   const PROVIDER_KEY_TO_AUTH_PROFILE: Partial<Record<string, AuthProfilesProvider>> = {
     anthropic: "anthropic",
     openai: "openai",
@@ -748,16 +760,24 @@ export async function regenerateOpenClawConfig() {
     "ollama-cloud": "ollama-cloud",
     "ollama-local": "ollama-local",
   };
-  const configuredAuthProviders: AuthProfilesProvider[] = Object.keys(providerSecrets)
-    .map((k) => PROVIDER_KEY_TO_AUTH_PROFILE[k])
-    .filter((p): p is AuthProfilesProvider => p !== undefined);
+  const configuredAuthProviders = new Set<AuthProfilesProvider>(
+    Object.keys(providerSecrets)
+      .map((k) => PROVIDER_KEY_TO_AUTH_PROFILE[k])
+      .filter((p): p is AuthProfilesProvider => p !== undefined)
+  );
 
   const configRoot = dirname(CONFIG_PATH);
   for (const agent of allAgents) {
+    const modelPrefix = agent.model?.split("/")[0] ?? "";
+    const agentProfileProvider = MODEL_PREFIX_TO_AUTH_PROFILE[modelPrefix];
+    const agentProviders: AuthProfilesProvider[] =
+      agentProfileProvider && configuredAuthProviders.has(agentProfileProvider)
+        ? [agentProfileProvider]
+        : [];
     await writeAgentAuthProfiles({
       configRoot,
       agentId: agent.id,
-      providers: configuredAuthProviders,
+      providers: agentProviders,
     });
   }
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -17,6 +17,7 @@ import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollam
 import { getOpenClawWorkspacePath } from "@/lib/workspace";
 import { migrateExistingSmithers } from "@/lib/migrate-onboarding";
 
+import { dirname } from "path";
 import { CONFIG_PATH } from "./paths";
 import { configsAreEquivalentUpToOpenClawMetadata } from "./normalize";
 import { writeConfigAtomic, readExistingConfig, pushConfigInBackground } from "./write";
@@ -25,6 +26,7 @@ import {
   collectProviderSecrets,
   readGatewayTokenFromConfig,
 } from "./secrets-bundle";
+import { writeAgentAuthProfiles, type AuthProfilesProvider } from "./agent-auth-profiles";
 
 function deepMerge(
   target: Record<string, unknown>,
@@ -729,6 +731,35 @@ export async function regenerateOpenClawConfig() {
   // will eventually pick it up — slowly on production volumes (~60 s),
   // which is the latency `pushConfigInBackground` exists to hide.
   writeConfigAtomic(newContent);
+
+  // Write per-agent auth-profiles.json for every agent.
+  // Required by OpenClaw ≥ 4.15: each agent directory must contain
+  // agents/<id>/agent/auth-profiles.json listing which LLM provider
+  // API keys it may use. We write one profile per currently-configured
+  // provider so agents aren't restricted to a subset of what's available.
+  // Phase-3 will add per-agent restrictions; for now all agents get all
+  // configured providers (safe: providers are still gated by allowedTools).
+  //
+  // Mapping: PROVIDERS uses "google" as key, AuthProfilesProvider uses "gemini".
+  const PROVIDER_KEY_TO_AUTH_PROFILE: Partial<Record<string, AuthProfilesProvider>> = {
+    anthropic: "anthropic",
+    openai: "openai",
+    google: "gemini",
+    "ollama-cloud": "ollama-cloud",
+    "ollama-local": "ollama-local",
+  };
+  const configuredAuthProviders: AuthProfilesProvider[] = Object.keys(providerSecrets)
+    .map((k) => PROVIDER_KEY_TO_AUTH_PROFILE[k])
+    .filter((p): p is AuthProfilesProvider => p !== undefined);
+
+  const configRoot = dirname(CONFIG_PATH);
+  for (const agent of allAgents) {
+    await writeAgentAuthProfiles({
+      configRoot,
+      agentId: agent.id,
+      providers: configuredAuthProviders,
+    });
+  }
 
   // Best-effort RPC push for faster runtime propagation. Fire-and-forget:
   // the user-visible POST that triggered this regenerate must return as

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -666,22 +666,22 @@ export async function regenerateOpenClawConfig() {
       }
     }
 
-    // Preserve OpenClaw-enriched channel fields (groupPolicy, streaming, enabled).
-    // Use an explicit allow-list instead of spread to prevent unknown/legacy
-    // fields (including potential legacy secrets) from leaking into the config.
-    // `enabled` is on the list because OpenClaw writes back `"enabled": true`
-    // whenever Telegram is auto-enabled at gateway startup. Without it on the
-    // list, the next regenerate strips the field, OpenClaw treats that as a
-    // config diff and triggers a full gateway restart, the restart re-runs
-    // auto-enable and re-adds the field — endless ping-pong loop where every
-    // settings save costs 15-30 s of "Agent runtime is not available"
-    // downtime (#193).
+    // Preserve OpenClaw-enriched channel fields. Use a denylist instead of an
+    // allowlist: OC 4.27+ writes additional fields to channels.telegram
+    // (e.g. pollingMode) that Pinchy doesn't know about. An allowlist strips
+    // those fields → config.apply or inotify sees a channels diff → spurious
+    // full gateway restart even for agents-only changes. The denylist preserves
+    // all OC-managed fields regardless of OC version. Pinchy-owned fields
+    // (enabled, dmPolicy, accounts) are always written fresh below and take
+    // precedence over any value in the file.
     const existingTelegram =
       ((existing.channels as Record<string, unknown>)?.telegram as Record<string, unknown>) || {};
-    const ENRICHED_TELEGRAM_FIELDS = ["groupPolicy", "streaming"] as const;
+    const PINCHY_OWNED_TELEGRAM_FIELDS = new Set(["enabled", "dmPolicy", "accounts"]);
     const preservedTelegram: Record<string, unknown> = {};
-    for (const f of ENRICHED_TELEGRAM_FIELDS) {
-      if (f in existingTelegram) preservedTelegram[f] = existingTelegram[f];
+    for (const [k, v] of Object.entries(existingTelegram)) {
+      if (!PINCHY_OWNED_TELEGRAM_FIELDS.has(k)) {
+        preservedTelegram[k] = v;
+      }
     }
     // Defense in depth: write `enabled: true` actively when we emit the
     // telegram block at all. Pinchy's source of truth is "telegram has

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -58,7 +58,19 @@ export async function regenerateOpenClawConfig() {
   // are reflected in the config we're about to generate.
   await migrateExistingSmithers();
 
-  const existing = readExistingConfig();
+  let existing = readExistingConfig();
+
+  // If readExistingConfig returned empty it may be a transient EACCES hit:
+  // OpenClaw's in-process SIGUSR1 restart rewrites openclaw.json as root:0600
+  // before start-openclaw.sh's chmod loop restores 0666. Under CI load the
+  // chmod may not run within readExistingConfig()'s 5×100ms budget → returns
+  // {} → meta absent → config.apply sends meta-less payload → OpenClaw 4.27
+  // "missing-meta-before-write" anomaly → sentinel restoration broken →
+  // spurious full gateway restart. 300ms covers one chmod-loop tick worst case.
+  if (Object.keys(existing).length === 0) {
+    await new Promise((r) => setTimeout(r, 300));
+    existing = readExistingConfig();
+  }
 
   // Build the gateway block. mode and bind are always set. auth.token is written
   // as a plain string — OpenClaw requires a literal string for gateway auth and

--- a/packages/web/src/lib/openclaw-config/normalize.ts
+++ b/packages/web/src/lib/openclaw-config/normalize.ts
@@ -63,59 +63,52 @@ export const OPENCLAW_REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
  * This is the workaround for openclaw#75534: see comment on the sentinel
  * constant above. Removable when upstream lands the writer-level fix.
  */
+const isPinchyPlugin = (id: string) => id.startsWith("pinchy-");
+
 /**
- * Supplement a Pinchy-generated `config.apply` payload with OpenClaw-auto-
- * configured fields from the current file on disk. Prevents spurious gateway
- * restarts caused by a race between payload computation and OpenClaw's
- * post-restart auto-enable side-effects.
+ * Core supplement logic — merges OpenClaw-auto-configured fields from `source`
+ * into `payload`. `source` is either the parsed file content or the parsed
+ * OC in-memory config returned by `config.get()`.
  *
- * After every gateway restart, OpenClaw writes back auto-enabled plugin entries
- * (`plugins.entries.anthropic`, `plugins.entries.telegram`, …) and gateway
- * control-UI settings (`gateway.controlUi.allowedOrigins`) to openclaw.json.
- * If Pinchy's payload was computed BEFORE those writes landed, the payload
- * lacks those fields. `config.apply` then diffs against OpenClaw's in-memory
- * state (which already has them), reports them as changedPaths, and triggers
- * another full restart — cascade loop.
- *
- * Fields supplemented (file wins only for keys absent from payload):
+ * Fields supplemented (source wins only for keys absent from payload):
+ *   - `meta`: entire block (absent when readExistingConfig returns {} on EACCES)
  *   - `plugins.allow`: non-pinchy-* entries appended at end
  *   - `plugins.entries.*`: non-pinchy-* entries not already in payload
  *   - `gateway.controlUi.*`: fields not already in payload gateway.controlUi
  *
- * Pinchy-owned fields (`pinchy-*` plugins, all other gateway/agent paths)
- * are NEVER overwritten by file values — payload is the source of truth.
+ * Pinchy-owned fields are NEVER overwritten — payload is the source of truth.
  */
-export function supplementPayloadWithFileFields(payload: string): string {
-  let fileContent: string;
-  try {
-    fileContent = readFileSync(CONFIG_PATH, "utf-8");
-  } catch {
-    return payload;
-  }
+function supplementFromSource(payload: string, source: Record<string, unknown>): string {
   try {
     const payloadObj = JSON.parse(payload) as Record<string, unknown>;
-    const fileObj = JSON.parse(fileContent) as Record<string, unknown>;
-    const isPinchyPlugin = (id: string) => id.startsWith("pinchy-");
     let changed = false;
 
-    const payloadPlugins = (payloadObj.plugins as Record<string, unknown>) ?? {};
-    const filePlugins = (fileObj.plugins as Record<string, unknown>) ?? {};
+    // Supplement meta: prevents OpenClaw's missing-meta-before-write anomaly
+    // that triggers the inotify diff cascade (env, plugins, channels all appear
+    // changed because baseline comparison fails without meta present).
+    if (!("meta" in payloadObj) && "meta" in source) {
+      payloadObj.meta = source.meta;
+      changed = true;
+    }
 
-    // Supplement plugins.allow: append non-pinchy file entries not in payload
+    const payloadPlugins = (payloadObj.plugins as Record<string, unknown>) ?? {};
+    const sourcePlugins = (source.plugins as Record<string, unknown>) ?? {};
+
+    // Supplement plugins.allow: append non-pinchy source entries not in payload
     const payloadAllow = (payloadPlugins.allow as string[]) ?? [];
-    const fileAllow = (filePlugins.allow as string[]) ?? [];
+    const sourceAllow = (sourcePlugins.allow as string[]) ?? [];
     const payloadAllowSet = new Set(payloadAllow);
-    const toAdd = fileAllow.filter((p) => !isPinchyPlugin(p) && !payloadAllowSet.has(p));
+    const toAdd = sourceAllow.filter((p) => !isPinchyPlugin(p) && !payloadAllowSet.has(p));
     if (toAdd.length > 0) {
       payloadPlugins.allow = [...payloadAllow, ...toAdd];
       payloadObj.plugins = payloadPlugins;
       changed = true;
     }
 
-    // Supplement plugins.entries: add non-pinchy file entries absent from payload
+    // Supplement plugins.entries: add non-pinchy source entries absent from payload
     const payloadEntries = (payloadPlugins.entries as Record<string, unknown>) ?? {};
-    const fileEntries = (filePlugins.entries as Record<string, unknown>) ?? {};
-    for (const [id, entry] of Object.entries(fileEntries)) {
+    const sourceEntries = (sourcePlugins.entries as Record<string, unknown>) ?? {};
+    for (const [id, entry] of Object.entries(sourceEntries)) {
       if (!isPinchyPlugin(id) && !(id in payloadEntries)) {
         payloadEntries[id] = entry;
         payloadPlugins.entries = payloadEntries;
@@ -124,13 +117,13 @@ export function supplementPayloadWithFileFields(payload: string): string {
       }
     }
 
-    // Supplement gateway.controlUi: add file fields absent from payload
+    // Supplement gateway.controlUi: add source fields absent from payload
     const payloadGateway = (payloadObj.gateway as Record<string, unknown>) ?? {};
-    const fileGateway = (fileObj.gateway as Record<string, unknown>) ?? {};
-    const fileControlUi = fileGateway.controlUi as Record<string, unknown> | undefined;
-    if (fileControlUi) {
+    const sourceGateway = (source.gateway as Record<string, unknown>) ?? {};
+    const sourceControlUi = sourceGateway.controlUi as Record<string, unknown> | undefined;
+    if (sourceControlUi) {
       const payloadControlUi = (payloadGateway.controlUi as Record<string, unknown>) ?? {};
-      for (const [k, v] of Object.entries(fileControlUi)) {
+      for (const [k, v] of Object.entries(sourceControlUi)) {
         if (!(k in payloadControlUi)) {
           payloadControlUi[k] = v;
           payloadGateway.controlUi = payloadControlUi;
@@ -141,6 +134,37 @@ export function supplementPayloadWithFileFields(payload: string): string {
     }
 
     return changed ? JSON.stringify(payloadObj, null, 2) : payload;
+  } catch {
+    return payload;
+  }
+}
+
+/**
+ * Supplement using OpenClaw's in-memory config returned by `config.get()`.
+ * Preferred over `supplementPayloadWithFileFields` because the in-memory state
+ * is always up-to-date — no file-write race conditions after a restart.
+ */
+export function supplementPayloadWithOcConfig(
+  payload: string,
+  ocConfig: Record<string, unknown>
+): string {
+  return supplementFromSource(payload, ocConfig);
+}
+
+/**
+ * Supplement using the current file on disk. Fallback when the OC in-memory
+ * config is unavailable (e.g. no WS client configured).
+ */
+export function supplementPayloadWithFileFields(payload: string): string {
+  let fileContent: string;
+  try {
+    fileContent = readFileSync(CONFIG_PATH, "utf-8");
+  } catch {
+    return payload;
+  }
+  try {
+    const fileObj = JSON.parse(fileContent) as Record<string, unknown>;
+    return supplementFromSource(payload, fileObj);
   } catch {
     return payload;
   }

--- a/packages/web/src/lib/openclaw-config/normalize.ts
+++ b/packages/web/src/lib/openclaw-config/normalize.ts
@@ -63,6 +63,89 @@ export const OPENCLAW_REDACTED_SENTINEL = "__OPENCLAW_REDACTED__";
  * This is the workaround for openclaw#75534: see comment on the sentinel
  * constant above. Removable when upstream lands the writer-level fix.
  */
+/**
+ * Supplement a Pinchy-generated `config.apply` payload with OpenClaw-auto-
+ * configured fields from the current file on disk. Prevents spurious gateway
+ * restarts caused by a race between payload computation and OpenClaw's
+ * post-restart auto-enable side-effects.
+ *
+ * After every gateway restart, OpenClaw writes back auto-enabled plugin entries
+ * (`plugins.entries.anthropic`, `plugins.entries.telegram`, …) and gateway
+ * control-UI settings (`gateway.controlUi.allowedOrigins`) to openclaw.json.
+ * If Pinchy's payload was computed BEFORE those writes landed, the payload
+ * lacks those fields. `config.apply` then diffs against OpenClaw's in-memory
+ * state (which already has them), reports them as changedPaths, and triggers
+ * another full restart — cascade loop.
+ *
+ * Fields supplemented (file wins only for keys absent from payload):
+ *   - `plugins.allow`: non-pinchy-* entries appended at end
+ *   - `plugins.entries.*`: non-pinchy-* entries not already in payload
+ *   - `gateway.controlUi.*`: fields not already in payload gateway.controlUi
+ *
+ * Pinchy-owned fields (`pinchy-*` plugins, all other gateway/agent paths)
+ * are NEVER overwritten by file values — payload is the source of truth.
+ */
+export function supplementPayloadWithFileFields(payload: string): string {
+  let fileContent: string;
+  try {
+    fileContent = readFileSync(CONFIG_PATH, "utf-8");
+  } catch {
+    return payload;
+  }
+  try {
+    const payloadObj = JSON.parse(payload) as Record<string, unknown>;
+    const fileObj = JSON.parse(fileContent) as Record<string, unknown>;
+    const isPinchyPlugin = (id: string) => id.startsWith("pinchy-");
+    let changed = false;
+
+    const payloadPlugins = (payloadObj.plugins as Record<string, unknown>) ?? {};
+    const filePlugins = (fileObj.plugins as Record<string, unknown>) ?? {};
+
+    // Supplement plugins.allow: append non-pinchy file entries not in payload
+    const payloadAllow = (payloadPlugins.allow as string[]) ?? [];
+    const fileAllow = (filePlugins.allow as string[]) ?? [];
+    const payloadAllowSet = new Set(payloadAllow);
+    const toAdd = fileAllow.filter((p) => !isPinchyPlugin(p) && !payloadAllowSet.has(p));
+    if (toAdd.length > 0) {
+      payloadPlugins.allow = [...payloadAllow, ...toAdd];
+      payloadObj.plugins = payloadPlugins;
+      changed = true;
+    }
+
+    // Supplement plugins.entries: add non-pinchy file entries absent from payload
+    const payloadEntries = (payloadPlugins.entries as Record<string, unknown>) ?? {};
+    const fileEntries = (filePlugins.entries as Record<string, unknown>) ?? {};
+    for (const [id, entry] of Object.entries(fileEntries)) {
+      if (!isPinchyPlugin(id) && !(id in payloadEntries)) {
+        payloadEntries[id] = entry;
+        payloadPlugins.entries = payloadEntries;
+        payloadObj.plugins = payloadPlugins;
+        changed = true;
+      }
+    }
+
+    // Supplement gateway.controlUi: add file fields absent from payload
+    const payloadGateway = (payloadObj.gateway as Record<string, unknown>) ?? {};
+    const fileGateway = (fileObj.gateway as Record<string, unknown>) ?? {};
+    const fileControlUi = fileGateway.controlUi as Record<string, unknown> | undefined;
+    if (fileControlUi) {
+      const payloadControlUi = (payloadGateway.controlUi as Record<string, unknown>) ?? {};
+      for (const [k, v] of Object.entries(fileControlUi)) {
+        if (!(k in payloadControlUi)) {
+          payloadControlUi[k] = v;
+          payloadGateway.controlUi = payloadControlUi;
+          payloadObj.gateway = payloadGateway;
+          changed = true;
+        }
+      }
+    }
+
+    return changed ? JSON.stringify(payloadObj, null, 2) : payload;
+  } catch {
+    return payload;
+  }
+}
+
 export function redactUnchangedEnvForApply(newContent: string): string {
   let existingContent: string;
   try {

--- a/packages/web/src/lib/openclaw-config/normalize.ts
+++ b/packages/web/src/lib/openclaw-config/normalize.ts
@@ -77,7 +77,11 @@ export function redactUnchangedEnvForApply(newContent: string): string {
     const existingEnv = (existingCfg.env as Record<string, string>) ?? {};
     const redactedEnv: Record<string, string> = {};
     for (const [key, val] of Object.entries(newEnv)) {
-      if (key in existingEnv && existingEnv[key] === val) {
+      if (key in existingEnv) {
+        // Key is already known to OpenClaw (possibly as a resolved value after
+        // OpenClaw expanded "${ENV_VAR}" → "sk-ant-..."). Send the sentinel so
+        // OpenClaw restores its current resolved value and diffConfigPaths sees
+        // no env change — preventing the spurious env.* restart (openclaw#75534).
         redactedEnv[key] = OPENCLAW_REDACTED_SENTINEL;
       } else {
         redactedEnv[key] = val;

--- a/packages/web/src/lib/openclaw-config/normalize.ts
+++ b/packages/web/src/lib/openclaw-config/normalize.ts
@@ -133,6 +133,23 @@ function supplementFromSource(payload: string, source: Record<string, unknown>):
       }
     }
 
+    // Supplement channels.telegram: add source fields absent from payload.
+    // OC 4.27+ writes additional fields to channels.telegram in-memory (beyond
+    // what Pinchy emits). Without this, config.apply sees a channels diff and
+    // triggers a full gateway restart even for agents-only changes.
+    const payloadChannels = payloadObj.channels as Record<string, unknown> | undefined;
+    const sourceChannels = source.channels as Record<string, unknown> | undefined;
+    if (payloadChannels?.telegram && sourceChannels?.telegram) {
+      const payloadTelegram = payloadChannels.telegram as Record<string, unknown>;
+      const sourceTelegram = sourceChannels.telegram as Record<string, unknown>;
+      for (const [k, v] of Object.entries(sourceTelegram)) {
+        if (!(k in payloadTelegram)) {
+          payloadTelegram[k] = v;
+          changed = true;
+        }
+      }
+    }
+
     return changed ? JSON.stringify(payloadObj, null, 2) : payload;
   } catch {
     return payload;

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -3,7 +3,11 @@ import { dirname } from "path";
 import { assertNoPlaintextSecrets } from "@/lib/openclaw-plaintext-scanner";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { CONFIG_PATH } from "./paths";
-import { redactUnchangedEnvForApply, supplementPayloadWithFileFields } from "./normalize";
+import {
+  redactUnchangedEnvForApply,
+  supplementPayloadWithFileFields,
+  supplementPayloadWithOcConfig,
+} from "./normalize";
 
 /** Atomic write: tmp file + rename to prevent OpenClaw reading a truncated config */
 export function writeConfigAtomic(content: string) {
@@ -95,16 +99,26 @@ export function pushConfigInBackground(newContent: string): void {
       // may have started while we were sleeping.
       if (generation !== _pushGeneration) return;
       try {
-        const current = (await client.config.get()) as { hash: string };
+        const current = (await client.config.get()) as {
+          hash: string;
+          config?: Record<string, unknown>;
+        };
         if (generation !== _pushGeneration) return; // check after each await
         // Re-supplement on every attempt (including retries after a restart).
         // Between payload computation and now, OpenClaw may have auto-enabled
-        // plugins (e.g. anthropic, telegram) and written their entries to the
-        // file. Without supplementing, config.apply sees those fields removed
-        // and triggers another full restart — cascade loop. Supplement first,
-        // then env-redact (order matters: supplement adds file values, redact
-        // replaces env keys with the sentinel for openclaw#75534).
-        const supplemented = supplementPayloadWithFileFields(newContent);
+        // plugins (e.g. anthropic, telegram) and written their entries back to
+        // openclaw.json. Without supplementing, config.apply sees those fields
+        // removed and triggers another full restart — cascade loop.
+        //
+        // Prefer the in-memory OC config (from config.get) over reading the
+        // file: the in-memory state is authoritative and has no file-write
+        // race conditions. Fall back to file supplement when config is absent.
+        // Supplement first, then env-redact (order matters: supplement adds
+        // OC-managed values, redact replaces env keys with the sentinel for
+        // openclaw#75534).
+        const supplemented = current.config
+          ? supplementPayloadWithOcConfig(newContent, current.config)
+          : supplementPayloadWithFileFields(newContent);
         // Workaround for openclaw#75534: replace unchanged env values with
         // OpenClaw's REDACTED sentinel before sending. Without this, every
         // config.apply payload trips OpenClaw's resolved-vs-template diff for

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -3,7 +3,7 @@ import { dirname } from "path";
 import { assertNoPlaintextSecrets } from "@/lib/openclaw-plaintext-scanner";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { CONFIG_PATH } from "./paths";
-import { redactUnchangedEnvForApply } from "./normalize";
+import { redactUnchangedEnvForApply, supplementPayloadWithFileFields } from "./normalize";
 
 /** Atomic write: tmp file + rename to prevent OpenClaw reading a truncated config */
 export function writeConfigAtomic(content: string) {
@@ -86,14 +86,6 @@ export function pushConfigInBackground(newContent: string): void {
     // Bail early if a newer push has already superseded this call.
     if (generation !== _pushGeneration) return;
 
-    // Workaround for openclaw#75534: replace unchanged env values with
-    // OpenClaw's REDACTED sentinel before sending. Without this, every
-    // config.apply payload trips OpenClaw's resolved-vs-template diff for
-    // env.* paths and triggers a full gateway restart even when only a
-    // hot-reloadable path (agents.list, bindings) actually changed.
-    // Removable when openclaw#75534 lands; tracked in #215.
-    const payload = redactUnchangedEnvForApply(newContent);
-
     // Brief retry across transient WS disconnects. Beyond ~3.5 s the WS is
     // probably down due to the cold-start cascade, and inotify will catch
     // up; no point keeping a background coroutine alive longer.
@@ -105,6 +97,21 @@ export function pushConfigInBackground(newContent: string): void {
       try {
         const current = (await client.config.get()) as { hash: string };
         if (generation !== _pushGeneration) return; // check after each await
+        // Re-supplement on every attempt (including retries after a restart).
+        // Between payload computation and now, OpenClaw may have auto-enabled
+        // plugins (e.g. anthropic, telegram) and written their entries to the
+        // file. Without supplementing, config.apply sees those fields removed
+        // and triggers another full restart — cascade loop. Supplement first,
+        // then env-redact (order matters: supplement adds file values, redact
+        // replaces env keys with the sentinel for openclaw#75534).
+        const supplemented = supplementPayloadWithFileFields(newContent);
+        // Workaround for openclaw#75534: replace unchanged env values with
+        // OpenClaw's REDACTED sentinel before sending. Without this, every
+        // config.apply payload trips OpenClaw's resolved-vs-template diff for
+        // env.* paths and triggers a full gateway restart even when only a
+        // hot-reloadable path (agents.list, bindings) actually changed.
+        // Removable when openclaw#75534 lands; tracked in #215.
+        const payload = redactUnchangedEnvForApply(supplemented);
         await client.config.apply(payload, current.hash, {
           note: "pinchy: regenerateOpenClawConfig",
         });

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -116,9 +116,23 @@ export function pushConfigInBackground(newContent: string): void {
         // Supplement first, then env-redact (order matters: supplement adds
         // OC-managed values, redact replaces env keys with the sentinel for
         // openclaw#75534).
-        const supplemented = current.config
+        let supplemented = current.config
           ? supplementPayloadWithOcConfig(newContent, current.config)
           : supplementPayloadWithFileFields(newContent);
+
+        // OC in-memory config may lack `meta` right after a restart (before
+        // its first file write stamps the block). Without meta, config.apply
+        // triggers the missing-meta-before-write anomaly → full restart
+        // cascade (openclaw#75534). Fall back to the file: the previous
+        // run's meta survives there until OC overwrites it.
+        if (current.config) {
+          try {
+            const p = JSON.parse(supplemented) as Record<string, unknown>;
+            if (!("meta" in p)) supplemented = supplementPayloadWithFileFields(supplemented);
+          } catch {
+            // unparseable payload — leave supplemented as-is
+          }
+        }
         // Workaround for openclaw#75534: replace unchanged env values with
         // OpenClaw's REDACTED sentinel before sending. Without this, every
         // config.apply payload trips OpenClaw's resolved-vs-template diff for

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -1,6 +1,7 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync, renameSync } from "fs";
 import { dirname } from "path";
 import { assertNoPlaintextSecrets } from "@/lib/openclaw-plaintext-scanner";
+import { getOpenClawClient } from "@/server/openclaw-client";
 import { CONFIG_PATH } from "./paths";
 import { redactUnchangedEnvForApply } from "./normalize";
 
@@ -54,16 +55,36 @@ export function readExistingConfig(): Record<string, unknown> {
   return {};
 }
 
+// Monotonically-increasing counter that lets each pushConfigInBackground call
+// cancel any pending retries from an older call. Because regenerateOpenClawConfig
+// can be triggered concurrently (e.g. setup → connectBot → warmup agent create →
+// actual agent create all in quick succession with a slow CI event loop), the
+// retry window of an early call can extend into a later one's territory. Without
+// this guard, a stale payload that includes `env.ANTHROPIC_API_KEY` (from the
+// initial setup where the key was first seen) can arrive at OpenClaw alongside
+// a fresh payload that has only `agents.list` changed — the stale env diff
+// triggers a full restart that kills the hot-reload the test is asserting on.
+let _pushGeneration = 0;
+
+/** Exposed only for unit-testing the cancellation path; do not call in app code. */
+export function _resetPushGeneration() {
+  _pushGeneration = 0;
+}
+
 export function pushConfigInBackground(newContent: string): void {
+  const generation = ++_pushGeneration;
+
   void (async () => {
     let client;
     try {
-      const { getOpenClawClient } = await import("@/server/openclaw-client");
       client = getOpenClawClient();
     } catch {
       // No client — file write + inotify is the only path here.
       return;
     }
+
+    // Bail early if a newer push has already superseded this call.
+    if (generation !== _pushGeneration) return;
 
     // Workaround for openclaw#75534: replace unchanged env values with
     // OpenClaw's REDACTED sentinel before sending. Without this, every
@@ -78,8 +99,12 @@ export function pushConfigInBackground(newContent: string): void {
     // up; no point keeping a background coroutine alive longer.
     const backoffsMs = [100, 250, 500, 1000, 2000];
     for (let i = 0; i < backoffsMs.length; i++) {
+      // Check before each attempt — a newer pushConfigInBackground call
+      // may have started while we were sleeping.
+      if (generation !== _pushGeneration) return;
       try {
         const current = (await client.config.get()) as { hash: string };
+        if (generation !== _pushGeneration) return; // check after each await
         await client.config.apply(payload, current.hash, {
           note: "pinchy: regenerateOpenClawConfig",
         });

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -140,6 +140,28 @@ export function pushConfigInBackground(newContent: string): void {
         // hot-reloadable path (agents.list, bindings) actually changed.
         // Removable when openclaw#75534 lands; tracked in #215.
         const payload = redactUnchangedEnvForApply(supplemented);
+        // Safety guard: if the final payload still lacks meta and OC already has
+        // an in-memory config, skip config.apply. The config.apply path triggers
+        // OC's "missing-meta-before-write" anomaly when meta is absent (seen after
+        // an in-process restart where both OC memory and the previous file lack
+        // meta). inotify (from writeConfigAtomic above) does not trigger the
+        // anomaly — let it pick up the file change instead.
+        // Only applies when current.config is defined (OC is running); on cold
+        // start (config.get returns no config) we still push to populate OC's
+        // runtime config immediately.
+        if (current.config) {
+          try {
+            const payloadObj = JSON.parse(payload) as Record<string, unknown>;
+            if (!("meta" in payloadObj)) {
+              console.warn(
+                "[openclaw-config] Skipping config.apply: meta absent from payload — relying on inotify"
+              );
+              return;
+            }
+          } catch {
+            // malformed payload — fall through and let config.apply fail naturally
+          }
+        }
         await client.config.apply(payload, current.hash, {
           note: "pinchy: regenerateOpenClawConfig",
         });

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -47,7 +47,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "url",
     settingsKey: "ollama_local_url",
     envVar: "",
-    defaultModel: "",
+    defaultModel: "ollama/llama3.2",
     placeholder: "http://host.docker.internal:11434",
   },
 };

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -122,13 +122,6 @@ let pollInterval: ReturnType<typeof setInterval> | null = null;
 export function startUsagePoller(openclawClient: OpenClawClient): void {
   if (pollInterval) return;
 
-  // Immediate first poll to seed watermarks from current OpenClaw state
-  // before any user activity can create a gap between compaction baseline
-  // and the first interval tick.
-  pollAllSessions(openclawClient).catch((err) => {
-    console.error("[usage-poller] Initial poll failed:", err);
-  });
-
   pollInterval = setInterval(() => {
     pollAllSessions(openclawClient).catch((err) => {
       console.error("[usage-poller] Unexpected error:", err);


### PR DESCRIPTION
## Summary

Bump `openclaw` from `2026.4.12` to `2026.4.14`.

## Why this version (and not later)

Going further hits separate breaking changes that don't belong in this PR:

| Version | Issue |
|---------|-------|
| 4.15 | Provider/auth resolution moves to per-agent `auth-profiles.json`; `regenerateOpenClawConfig()` doesn't yet write those, so the integration agent-chat times out (`Integration test response.` never streams back through OpenClaw → fake-Ollama). |
| 4.29 | `device.pair.approve` is gated on `operator.admin` scope (CLI auto-approve loop in `config/start-openclaw.sh` no longer authorised). Plus `resolvePairingLocality` classifies container peers as `remote` and silently rejects operator pairings — Pinchy ends up in a `closed before connect` loop. Needs an `openclaw-node` patch to handle `pairing-required` close reason. |

The bisection sequence is recorded in commit history if useful; see prior pushes on this branch.

## What this picks up

The upstream fix for `openclaw#47458` (polling stall loop on multi-bot channel restart) landed before 4.20, so it's not in 4.14 — but the 4.13→4.14 delta still includes a few smaller stability fixes the gateway log was nagging us about. We'll get the polling-stall fix in a follow-up once the 4.15+ provider/auth and 4.29+ pairing-locality regressions are solved.

## Test plan

- [x] CI fully green (Lint/Test/Build, Vitest Integration, Integration OpenClaw+Fake Ollama, Docker smoke, E2E, End-user install/upgrade, Telegram E2E, Odoo E2E, Ollama integration, License Keypair, Repo hygiene, Security audit)
- [ ] Manual smoke test by @clemenshelm