### PR TITLE
fix(openclaw): lean down for container deployment + idempotency tests

### DIFF
--- a/config/ensure-gateway-token.js
+++ b/config/ensure-gateway-token.js
@@ -60,4 +60,16 @@ if (!config.secrets) {
     },
   };
 }
+// Disable mDNS announcer before the gateway boots. In Docker bridge networks
+// multicast doesn't route out of the container; OpenClaw's Bonjour announcer
+// hangs in `state=announcing` and after ~16 s the internal watchdog SIGTERMs
+// the gateway, costing ~30 s of "Reconnecting to the agent…" downtime
+// (observed staging 2026-05-03). We connect Pinchy → OpenClaw via
+// OPENCLAW_WS_URL on the bridge network and never need mDNS, so turning it
+// off in this bootstrap pass is safe and prevents the watchdog from ever
+// firing. Pinchy's regenerateOpenClawConfig() also writes this field, so it
+// stays off across config rewrites.
+if (!config.discovery) config.discovery = {};
+if (!config.discovery.mdns) config.discovery.mdns = {};
+if (!config.discovery.mdns.mode) config.discovery.mdns.mode = "off";
 writeAtomic(configPath, JSON.stringify(config, null, 2), 0o644);

--- a/config/ensure-gateway-token.js
+++ b/config/ensure-gateway-token.js
@@ -60,16 +60,48 @@ if (!config.secrets) {
     },
   };
 }
-// Disable mDNS announcer before the gateway boots. In Docker bridge networks
-// multicast doesn't route out of the container; OpenClaw's Bonjour announcer
-// hangs in `state=announcing` and after ~16 s the internal watchdog SIGTERMs
-// the gateway, costing ~30 s of "Reconnecting to the agent…" downtime
-// (observed staging 2026-05-03). We connect Pinchy → OpenClaw via
-// OPENCLAW_WS_URL on the bridge network and never need mDNS, so turning it
-// off in this bootstrap pass is safe and prevents the watchdog from ever
-// firing. Pinchy's regenerateOpenClawConfig() also writes this field, so it
-// stays off across config rewrites.
+// Disable OpenClaw features that have no purpose in the Pinchy stack
+// BEFORE the gateway boots, so the gateway starts already-tuned and
+// no restart-classified config changes get triggered later.
+//
+// Each of these is restart-kind in OpenClaw's reload classifier, so
+// writing them in the bootstrap (this file, before `openclaw gateway`
+// runs) avoids the SIGUSR1 that would fire if Pinchy's later
+// regenerate were the first writer.
+//
+//   - discovery.mdns.mode=off — Bonjour announcer hangs in
+//     state=announcing inside Docker bridge networks (no multicast
+//     routing); the watchdog SIGTERMs the gateway after ~16 s, costing
+//     ~30 s of "Reconnecting to the agent…" downtime per cold start
+//     (observed staging 2026-05-03). Pinchy connects via OPENCLAW_WS_URL
+//     on the bridge and never needs mDNS.
+//
+//   - update.checkOnStart=false — Pinchy controls the OpenClaw version
+//     via the Docker image tag; the npm-version check on every gateway
+//     boot is wasted I/O.
+//
+//   - gateway.controlUi.enabled=false — Pinchy is the external control
+//     surface (running its own UI on port 7777); OpenClaw's
+//     `/__openclaw__/control/*` routes on port 18789 are unused, cost
+//     memory, and add an attack surface we don't need.
+//
+//   - canvasHost.enabled=false — Pinchy doesn't render OpenClaw canvases
+//     anywhere in its UI; keep the canvas host server off to reduce
+//     exposed local services.
+//
+// Pinchy's regenerateOpenClawConfig() writes these same fields on every
+// regenerate as an idempotent backstop, so they stay off across rewrites.
 if (!config.discovery) config.discovery = {};
 if (!config.discovery.mdns) config.discovery.mdns = {};
 if (!config.discovery.mdns.mode) config.discovery.mdns.mode = "off";
+
+if (!config.update) config.update = {};
+if (config.update.checkOnStart === undefined) config.update.checkOnStart = false;
+
+if (!config.gateway.controlUi) config.gateway.controlUi = {};
+if (config.gateway.controlUi.enabled === undefined) config.gateway.controlUi.enabled = false;
+
+if (!config.canvasHost) config.canvasHost = {};
+if (config.canvasHost.enabled === undefined) config.canvasHost.enabled = false;
+
 writeAtomic(configPath, JSON.stringify(config, null, 2), 0o644);

--- a/config/ensure-gateway-token.js
+++ b/config/ensure-gateway-token.js
@@ -91,9 +91,12 @@ if (!config.secrets) {
 //
 // Pinchy's regenerateOpenClawConfig() writes these same fields on every
 // regenerate as an idempotent backstop, so they stay off across rewrites.
+// Use `=== undefined` for all four guards so a deliberate `mode: "off"` or
+// `enabled: false` set externally isn't re-overwritten on subsequent boots —
+// only fill in the field when it's truly absent.
 if (!config.discovery) config.discovery = {};
 if (!config.discovery.mdns) config.discovery.mdns = {};
-if (!config.discovery.mdns.mode) config.discovery.mdns.mode = "off";
+if (config.discovery.mdns.mode === undefined) config.discovery.mdns.mode = "off";
 
 if (!config.update) config.update = {};
 if (config.update.checkOnStart === undefined) config.update.checkOnStart = false;

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -5,6 +5,10 @@
 services:
   openclaw:
     image: ghcr.io/heypinchy/pinchy-openclaw:latest
+    # Image is published amd64-only. Pin platform so Mac/arm64 dev machines
+    # pull and run the amd64 variant under Rosetta instead of failing with
+    # "no matching manifest for linux/arm64/v8".
+    platform: linux/amd64
     ports:
       - "18790:18789"
     environment:

--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -1,0 +1,233 @@
+/**
+ * Architectural regression: regenerateOpenClawConfig() must be byte-stable
+ * on a stable stack.
+ *
+ * History this test exists to close out:
+ *   - #193 (channels.telegram.enabled stripped → restart cascade)
+ *   - #200 (secrets.json owner race during reload)
+ *   - #237 (plugins.allow reorder → restart)
+ *   - openclaw#47458 (agents.defaults.* enrichment race)
+ *   - openclaw#75534 (env diff false-positive)
+ *   - 2026-05-03 staging incident: gateway.controlUi-Drift triggers
+ *     SIGUSR1 on every Pinchy startup, ~5 min cold-start.
+ *
+ * Each historical fix added one missing field to Pinchy's preserve-list.
+ * None prevented the *next* OpenClaw-enriched field from triggering the
+ * same restart-cascade. The pattern is the bug; the field is the symptom.
+ *
+ * The contract this test enforces:
+ *
+ *   GIVEN a stable system (no restart markers in OpenClaw logs for 30 s)
+ *   WHEN  Pinchy regenerates the config without any DB change
+ *   THEN  openclaw.json on disk is byte-equal before and after
+ *   AND   no "requires gateway restart" / SIGUSR1 / SIGTERM marker appears
+ *
+ * Failure shape interpretation:
+ *   - byte equality fails → Pinchy is missing a preserve-list entry for
+ *     some OpenClaw-enriched field (look at the diff).
+ *   - byte equality passes but restart marker fires → diff classifier in
+ *     openclaw#75534 territory; check `pushConfigInBackground` payload
+ *     vs file-watcher payload.
+ *
+ * Trigger: PATCH /api/agents/<smithers-id> with `{ name: "Smithers" }`.
+ * That's a no-op DB write but routes through `updateAgent →
+ * regenerateOpenClawConfig` (because `name` is in `OPENCLAW_CONFIG_FIELDS`)
+ * — the exact production code path that fires on every settings save.
+ */
+
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+const REPO_ROOT = resolve(__dirname, "../../../..");
+const COMPOSE_FILE = "-f docker-compose.integration.yml";
+const CONFIG_PATH = "/tmp/pinchy-integration-openclaw/openclaw.json";
+const PINCHY_URL = "http://localhost:7779";
+
+function openClawLogsSince(sinceIso: string): string {
+  return execSync(`docker compose ${COMPOSE_FILE} logs openclaw --since "${sinceIso}" 2>&1`, {
+    encoding: "utf-8",
+    cwd: REPO_ROOT,
+    maxBuffer: 16 * 1024 * 1024,
+  });
+}
+
+/**
+ * Wait until OpenClaw has been free of restart-cascade markers for `quietMs`.
+ * Markers we treat as "restart happened":
+ *   - `[gateway] received SIGUSR1; restarting`
+ *   - `[reload] config change requires gateway restart`
+ *   - `[gateway] received SIGTERM; shutting down`
+ *   - `[gateway] ready (` — trailing edge of any restart; ensures we
+ *     wait `quietMs` AFTER the gateway is back up, not just after SIGUSR1.
+ */
+async function waitForOpenClawQuiet(quietMs = 30000, timeout = 240000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    const logs = openClawLogsSince(new Date(Date.now() - quietMs - 5000).toISOString());
+    const restartMarkers = logs
+      .split("\n")
+      .filter((l) =>
+        /received SIGUSR1|received SIGTERM|requires gateway restart|\[gateway\] ready \(/.test(l)
+      );
+    if (restartMarkers.length === 0) return;
+    await new Promise((r) => setTimeout(r, 1000));
+  }
+  throw new Error(`OpenClaw never quiet for ${quietMs}ms within ${timeout}ms`);
+}
+
+let sessionCookie: string | null = null;
+
+async function login(): Promise<void> {
+  const res = await fetch(`${PINCHY_URL}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Origin: PINCHY_URL,
+    },
+    body: JSON.stringify({
+      email: "admin@integration.local",
+      password: "integration-password-123",
+    }),
+    redirect: "manual",
+  });
+  const setCookie = res.headers.get("set-cookie");
+  if (setCookie) sessionCookie = setCookie.split(";")[0];
+  if (!sessionCookie) throw new Error(`Login failed: ${res.status} ${await res.text()}`);
+}
+
+function authHeaders(): Record<string, string> {
+  return {
+    "Content-Type": "application/json",
+    Origin: PINCHY_URL,
+    ...(sessionCookie ? { Cookie: sessionCookie } : {}),
+  };
+}
+
+async function getSmithersId(): Promise<string> {
+  const res = await fetch(`${PINCHY_URL}/api/agents`, { headers: authHeaders() });
+  const agents = (await res.json()) as Array<{ id: string; name: string }>;
+  const smithers = agents.find((a) => a.name === "Smithers");
+  if (!smithers) throw new Error(`Smithers not found among ${agents.length} agents`);
+  return smithers.id;
+}
+
+test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", () => {
+  /**
+   * Cold-start cascade test. Reproduces the user-visible "Smithers takes
+   * >1 minute to start" complaint from the 2026-05-03 staging incident.
+   *
+   * Every full gateway restart costs 10-20 s of "Reconnecting to the
+   * agent…" downtime. The bootstrap is allowed *one* restart (Pinchy's
+   * first regenerate writes paths OpenClaw's bootstrap config didn't
+   * have — agents.list, plugins.entries.pinchy-*, etc. — and a single
+   * SIGUSR1 to absorb that is unavoidable until we land Phase 2's
+   * "Pinchy is sole writer" architecture).
+   *
+   * Anything beyond that is a cascade and degrades user experience
+   * proportionally. Staging on 2026-05-03 had two: the bootstrap
+   * regenerate restart AND a separate Bonjour-watchdog SIGTERM. The
+   * second-restart class is what this test guards against in the
+   * Pinchy-side code paths.
+   *
+   * Counts `received SIGUSR1` markers — each is one full restart.
+   * Bonjour-induced SIGTERMs surface as `received SIGTERM` and would
+   * also be caught here (we currently expect zero of those on the
+   * integration stack since Bonjour is a container-environment quirk
+   * that doesn't fire here, but we assert on it so a future env change
+   * doesn't silently regress).
+   *
+   * NOTE on baseline. globalSetup intentionally writes a fresh OpenClaw
+   * container, runs the setup wizard, and waits for reconnect. By the
+   * time this test runs, the bootstrap restart has already happened
+   * exactly once. We assert "≤ 1" on the SIGUSR1 count to allow that
+   * single bootstrap restart while flagging any extra.
+   */
+  test("cold-start cascade: at most one gateway restart in setup", async () => {
+    test.setTimeout(120000);
+    const logs = openClawLogsSince(new Date(Date.now() - 600000).toISOString());
+
+    const sigusrCount = (logs.match(/received SIGUSR1/g) ?? []).length;
+    const sigtermCount = (logs.match(/received SIGTERM/g) ?? []).length;
+    const fullRestartCount = (logs.match(/full process restart/g) ?? []).length;
+
+    // Helpful triage: list every restart trigger reason found.
+    const restartReasons = logs
+      .split("\n")
+      .filter((l) => /requires gateway restart/.test(l))
+      .map((l) => l.replace(/^.*requires gateway restart /, "").trim());
+
+    expect(
+      sigusrCount,
+      `Expected ≤1 SIGUSR1 (bootstrap only), got ${sigusrCount}.\nRestart reasons:\n${restartReasons.join("\n")}`
+    ).toBeLessThanOrEqual(1);
+    expect(sigtermCount, "Bonjour or external SIGTERM during setup").toBe(0);
+    expect(fullRestartCount, "Multiple full process restarts during setup").toBeLessThanOrEqual(1);
+  });
+
+  test("PATCH agent with no DB change must not modify openclaw.json or trigger restart", async () => {
+    test.setTimeout(360000);
+
+    await login();
+    const smithersId = await getSmithersId();
+
+    // 1. Wait for the cold-start cascade to fully settle. globalSetup
+    //    restarted OpenClaw and Pinchy reconnected; depending on what
+    //    OpenClaw enriched between Pinchy's writes, we may still be
+    //    inside a restart chain. Quiet means no restart marker for 30 s.
+    await waitForOpenClawQuiet();
+
+    // 2. Snapshot openclaw.json *after* OpenClaw has stamped its enrichments
+    //    (auto-enable markers, agents.defaults.*, gateway.controlUi.allowedOrigins,
+    //    meta.lastTouchedAt etc.). This is the baseline we expect Pinchy to
+    //    preserve byte-for-byte.
+    const before = readFileSync(CONFIG_PATH, "utf-8");
+    const beforeMark = new Date(Date.now() - 1000).toISOString();
+
+    // 3. Trigger a no-op state-change path. PATCH name to its current value.
+    //    `name` is in `OPENCLAW_CONFIG_FIELDS`, so updateAgent calls
+    //    regenerateOpenClawConfig. The DB row does not change content, so
+    //    a contract-compliant Pinchy short-circuits the file write
+    //    (`if (existing === newContent) return`).
+    const patchRes = await fetch(`${PINCHY_URL}/api/agents/${smithersId}`, {
+      method: "PATCH",
+      headers: authHeaders(),
+      body: JSON.stringify({ name: "Smithers" }),
+    });
+    expect(patchRes.status, await patchRes.text()).toBeLessThan(300);
+
+    // 4. Give the background config.apply RPC time to land. A real restart
+    //    surfaces in OpenClaw logs within ~2 s of SIGUSR1; 5 s comfortably
+    //    covers transient WS queueing + the Bonjour-watchdog grace window.
+    await new Promise((r) => setTimeout(r, 5000));
+
+    // 5. Contract assertions.
+    const after = readFileSync(CONFIG_PATH, "utf-8");
+    const logs = openClawLogsSince(beforeMark);
+
+    // (a) Byte equality. If this fails, Pinchy's regenerate produced a
+    //     different file even though the user-level state didn't change —
+    //     Pinchy is missing a preserve-list entry for an OpenClaw-enriched
+    //     field. The diff between `before` and `after` localizes which one.
+    if (after !== before) {
+      // Compact diff for fast triage. Avoids dumping 20 KB of JSON.
+      const diff = execSync(
+        `diff <(printf %s ${JSON.stringify(before)}) <(printf %s ${JSON.stringify(after)}) || true`,
+        { encoding: "utf-8", shell: "/bin/bash" }
+      );
+      throw new Error(
+        `openclaw.json changed despite no DB change — preserve-list incomplete.\n` +
+          `Diff (before → after):\n${diff}`
+      );
+    }
+
+    // (b) No full-restart trigger fired. If this fails despite (a) passing,
+    //     the issue is in `pushConfigInBackground` or in the diff classifier
+    //     (openclaw#75534) — file is semantically equal but the RPC payload
+    //     was sent and OpenClaw re-classified it as restart-required.
+    expect(logs, logs).not.toMatch(/requires gateway restart/);
+    expect(logs, logs).not.toMatch(/received SIGUSR1/);
+    expect(logs, logs).not.toMatch(/full process restart/);
+  });
+});

--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -206,33 +206,32 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     const after = readFileSync(CONFIG_PATH, "utf-8");
     const logs = openClawLogsSince(beforeMark);
 
-    // (a) Semantic equality, ignoring `meta.lastTouchedAt`. OpenClaw stamps
-    //     that timestamp on every write *it* performs (config.apply RPC,
-    //     internal restart bookkeeping) — independent of any Pinchy or
-    //     user action — so a strict byte-equality assertion here would be
-    //     racy: between our `before` and `after` reads, OpenClaw could have
-    //     re-stamped the file as part of routine reload-subsystem work even
-    //     when Pinchy itself wrote nothing. We instead diff the JSON modulo
-    //     that single field, mirroring `configsAreEquivalentUpToOpenClawMetadata`
-    //     in `packages/web/src/lib/openclaw-config/normalize.ts` (the same
-    //     workaround Pinchy applies to short-circuit redundant writes;
-    //     openclaw#75534).
+    // (a) Semantic equality, ignoring the entire `meta` block. OpenClaw
+    //     stamps `meta.lastTouchedAt`, `meta.lastTouchedVersion`, and
+    //     potentially other meta fields on every write IT performs
+    //     (config.apply RPC, internal restart bookkeeping) — independent
+    //     of any Pinchy or user action — so a strict byte-equality
+    //     assertion here would be racy: between our `before` and `after`
+    //     reads, OpenClaw could have re-stamped the file as part of
+    //     routine reload-subsystem work even when Pinchy itself wrote
+    //     nothing. Pinchy never writes `meta` (only preserves it from
+    //     existing), so the entire block is OpenClaw-owned and outside
+    //     our semantic contract here. Stripping the whole block is more
+    //     robust than enumerating individual stamp fields and avoids
+    //     false failures whenever upstream adds another stamp.
     //
     //     If THIS fails, Pinchy's regenerate produced a different file
     //     even though the user-level state didn't change — Pinchy is
     //     missing a preserve-list entry for an OpenClaw-enriched field
     //     (the kind of bug that produced #193, #200, #237). The diff
     //     localizes which field.
-    const stripMetaTimestamp = (raw: string): string => {
-      const parsed = JSON.parse(raw) as { meta?: Record<string, unknown> };
-      if (parsed.meta && typeof parsed.meta === "object") {
-        delete parsed.meta.lastTouchedAt;
-        if (Object.keys(parsed.meta).length === 0) delete parsed.meta;
-      }
+    const stripMeta = (raw: string): string => {
+      const parsed = JSON.parse(raw) as Record<string, unknown>;
+      delete parsed.meta;
       return JSON.stringify(parsed);
     };
-    const beforeNorm = stripMetaTimestamp(before);
-    const afterNorm = stripMetaTimestamp(after);
+    const beforeNorm = stripMeta(before);
+    const afterNorm = stripMeta(after);
     if (beforeNorm !== afterNorm) {
       // Compact diff for fast triage. Avoids dumping 20 KB of JSON.
       const diff = execSync(

--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -206,11 +206,34 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     const after = readFileSync(CONFIG_PATH, "utf-8");
     const logs = openClawLogsSince(beforeMark);
 
-    // (a) Byte equality. If this fails, Pinchy's regenerate produced a
-    //     different file even though the user-level state didn't change —
-    //     Pinchy is missing a preserve-list entry for an OpenClaw-enriched
-    //     field. The diff between `before` and `after` localizes which one.
-    if (after !== before) {
+    // (a) Semantic equality, ignoring `meta.lastTouchedAt`. OpenClaw stamps
+    //     that timestamp on every write *it* performs (config.apply RPC,
+    //     internal restart bookkeeping) — independent of any Pinchy or
+    //     user action — so a strict byte-equality assertion here would be
+    //     racy: between our `before` and `after` reads, OpenClaw could have
+    //     re-stamped the file as part of routine reload-subsystem work even
+    //     when Pinchy itself wrote nothing. We instead diff the JSON modulo
+    //     that single field, mirroring `configsAreEquivalentUpToOpenClawMetadata`
+    //     in `packages/web/src/lib/openclaw-config/normalize.ts` (the same
+    //     workaround Pinchy applies to short-circuit redundant writes;
+    //     openclaw#75534).
+    //
+    //     If THIS fails, Pinchy's regenerate produced a different file
+    //     even though the user-level state didn't change — Pinchy is
+    //     missing a preserve-list entry for an OpenClaw-enriched field
+    //     (the kind of bug that produced #193, #200, #237). The diff
+    //     localizes which field.
+    const stripMetaTimestamp = (raw: string): string => {
+      const parsed = JSON.parse(raw) as { meta?: Record<string, unknown> };
+      if (parsed.meta && typeof parsed.meta === "object") {
+        delete parsed.meta.lastTouchedAt;
+        if (Object.keys(parsed.meta).length === 0) delete parsed.meta;
+      }
+      return JSON.stringify(parsed);
+    };
+    const beforeNorm = stripMetaTimestamp(before);
+    const afterNorm = stripMetaTimestamp(after);
+    if (beforeNorm !== afterNorm) {
       // Compact diff for fast triage. Avoids dumping 20 KB of JSON.
       const diff = execSync(
         `diff <(printf %s ${JSON.stringify(before)}) <(printf %s ${JSON.stringify(after)}) || true`,

--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -233,10 +233,21 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     const beforeNorm = stripMeta(before);
     const afterNorm = stripMeta(after);
     if (beforeNorm !== afterNorm) {
-      // Compact diff for fast triage. Avoids dumping 20 KB of JSON.
+      // Compact diff for fast triage. Write both snapshots to tmp files and
+      // diff them — passing the whole config inline via `printf %s ...` would
+      // hit ARG_MAX (~256 KB on macOS) once telegram bindings + many users
+      // grow the config, silently producing an empty diff message instead.
+      const { writeFileSync: write, mkdtempSync } = await import("fs");
+      const { tmpdir } = await import("os");
+      const { join } = await import("path");
+      const dir = mkdtempSync(join(tmpdir(), "pinchy-idempotency-"));
+      write(join(dir, "before.json"), before);
+      write(join(dir, "after.json"), after);
       const diff = execSync(
-        `diff <(printf %s ${JSON.stringify(before)}) <(printf %s ${JSON.stringify(after)}) || true`,
-        { encoding: "utf-8", shell: "/bin/bash" }
+        `diff "${join(dir, "before.json")}" "${join(dir, "after.json")}" || true`,
+        {
+          encoding: "utf-8",
+        }
       );
       throw new Error(
         `openclaw.json changed despite no DB change — preserve-list incomplete.\n` +

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -212,6 +212,48 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.agents.defaults?.heartbeat).toBeUndefined();
   });
 
+  it("should disable OpenClaw features that have no purpose in a containerized Pinchy deployment", async () => {
+    // Three OpenClaw features serve no purpose in the Pinchy server stack
+    // (Pinchy is the user-facing UI on port 7777 and the only operator
+    // surface; OpenClaw runs inside a Docker container with no human ever
+    // hitting its HTTP port directly):
+    //
+    //   - update.checkOnStart=true (default): runs `npm view openclaw versions`
+    //     on every gateway boot to surface "update available" log lines.
+    //     Pinchy controls the OpenClaw version through the Docker image tag
+    //     and ignores the notice; the network call is wasted I/O at startup.
+    //
+    //   - gateway.controlUi.enabled=true (default): exposes OpenClaw's own
+    //     web UI under /__openclaw__/control/* on the gateway HTTP port.
+    //     Pinchy IS the external control surface (per the schema's own
+    //     guidance: "disable when an external control surface replaces it").
+    //     Disabling cuts memory + reduces the attack surface — and makes
+    //     the controlUi.dangerously* sub-toggles moot.
+    //
+    //   - canvasHost.enabled=true (default): hosts OpenClaw's "canvas"
+    //     artifact server. Pinchy doesn't render OpenClaw canvases anywhere
+    //     in its UI; the schema says "Keep disabled when canvas workflows
+    //     are inactive to reduce exposed local services."
+    //
+    // All three are written in the bootstrap (ensure-gateway-token.js) so
+    // they're in place BEFORE the first gateway boot — disabling them
+    // there avoids the restart that would happen if Pinchy's later
+    // regenerate were the first writer (these paths are restart-classified
+    // by OpenClaw). regenerateOpenClawConfig() emits the same values as an
+    // idempotent backstop.
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      update?: { checkOnStart?: boolean };
+      gateway?: { controlUi?: { enabled?: boolean } };
+      canvasHost?: { enabled?: boolean };
+    };
+    expect(config.update?.checkOnStart).toBe(false);
+    expect(config.gateway?.controlUi?.enabled).toBe(false);
+    expect(config.canvasHost?.enabled).toBe(false);
+  });
+
   it("should disable mDNS discovery so the Bonjour watchdog can't kill the gateway", async () => {
     // Rationale: OpenClaw's gateway tries to advertise itself via mDNS
     // (Bonjour) on startup. In Docker bridge networks multicast doesn't

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -212,6 +212,31 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.agents.defaults?.heartbeat).toBeUndefined();
   });
 
+  it("should disable mDNS discovery so the Bonjour watchdog can't kill the gateway", async () => {
+    // Rationale: OpenClaw's gateway tries to advertise itself via mDNS
+    // (Bonjour) on startup. In Docker bridge networks multicast doesn't
+    // route out of the container, so OpenClaw's announcer hangs in
+    // `state=announcing`. After 16 s its internal watchdog raises a
+    // SIGTERM ("[bonjour] restarting advertiser (service stuck in
+    // announcing for 16622ms)") and forces a full gateway restart —
+    // costing ~30 s of "Reconnecting to the agent…" downtime per cold
+    // start (observed on staging 2026-05-03).
+    //
+    // Pinchy always runs OpenClaw inside a container, so mDNS is never
+    // useful for us — we connect via OPENCLAW_WS_URL on the bridge
+    // network. Writing `discovery.mdns.mode = "off"` into the config
+    // disables the announcer up-front, the watchdog never fires, no
+    // restart cascade.
+    //
+    // Schema reference (openclaw 2026.4.x):
+    //   discovery.mdns.mode: "off" | "minimal" | "full"
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as { discovery?: { mdns?: { mode?: string } } };
+    expect(config.discovery?.mdns?.mode).toBe("off");
+  });
+
   it("should write agents.list with all agents from DB", async () => {
     const agentsData = [
       {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -254,6 +254,57 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.canvasHost?.enabled).toBe(false);
   });
 
+  it("preserves OpenClaw-enriched sub-fields under discovery, update, canvasHost across regenerate (C1)", async () => {
+    // Regression guard for review feedback on PR #269: writing
+    // `discovery`, `update`, `canvasHost` as fresh objects without
+    // spreading `existing.<field>` first re-introduces the same bug
+    // class this PR is meant to close (#193, #237). If OpenClaw enriches
+    // a sub-field under any of these three new top-level paths and we
+    // strip it on the next regenerate, OpenClaw re-stamps it on the
+    // following reload — endless restart cascade.
+    //
+    // We seed `existing` with one OpenClaw-style enrichment under each
+    // path and assert it survives Pinchy's regenerate.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
+        discovery: {
+          mdns: { mode: "minimal", lastAnnouncedAt: "2026-05-03T00:00:00Z" },
+          lan: { discoveredPeers: ["peer-1"] },
+        },
+        update: { lastCheckedAt: "2026-05-03T00:00:00Z", channel: "stable" },
+        canvasHost: { enabled: true, boundPort: 18792 },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      discovery?: {
+        mdns?: { mode?: string; lastAnnouncedAt?: string };
+        lan?: { discoveredPeers?: string[] };
+      };
+      update?: { checkOnStart?: boolean; lastCheckedAt?: string; channel?: string };
+      canvasHost?: { enabled?: boolean; boundPort?: number };
+    };
+
+    // Pinchy's intent: mode=off, checkOnStart=false, enabled=false (the
+    // disables this PR adds).
+    expect(config.discovery?.mdns?.mode).toBe("off");
+    expect(config.update?.checkOnStart).toBe(false);
+    expect(config.canvasHost?.enabled).toBe(false);
+
+    // OpenClaw's enrichments must survive byte-for-byte. If any of these
+    // assertions fail, regenerate is stripping them and the cascade is
+    // back.
+    expect(config.discovery?.mdns?.lastAnnouncedAt).toBe("2026-05-03T00:00:00Z");
+    expect(config.discovery?.lan?.discoveredPeers).toEqual(["peer-1"]);
+    expect(config.update?.lastCheckedAt).toBe("2026-05-03T00:00:00Z");
+    expect(config.update?.channel).toBe("stable");
+    expect(config.canvasHost?.boundPort).toBe(18792);
+  });
+
   it("should disable mDNS discovery so the Bonjour watchdog can't kill the gateway", async () => {
     // Rationale: OpenClaw's gateway tries to advertise itself via mDNS
     // (Bonjour) on startup. In Docker bridge networks multicast doesn't

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -75,6 +75,12 @@ export async function regenerateOpenClawConfig() {
     );
   }
 
+  // Disable OpenClaw's built-in Control UI. Pinchy IS the external control
+  // surface (running its own UI on port 7777); OpenClaw's `/__openclaw__/control/*`
+  // routes on port 18789 are unused, cost memory, and add an attack surface
+  // we don't need. Per OpenClaw's own schema guidance: "disable when an
+  // external control surface replaces it."
+  const existingControlUi = (existingGateway.controlUi as Record<string, unknown>) || {};
   const gateway: Record<string, unknown> = {
     ...existingGateway,
     mode: "local",
@@ -82,6 +88,10 @@ export async function regenerateOpenClawConfig() {
     auth: {
       mode: "token",
       token: gatewayTokenValue || "",
+    },
+    controlUi: {
+      ...existingControlUi,
+      enabled: false,
     },
   };
 
@@ -181,6 +191,14 @@ export async function regenerateOpenClawConfig() {
     // We connect via OPENCLAW_WS_URL on the bridge network and never need
     // mDNS, so turning it off is safe.
     discovery: { mdns: { mode: "off" } },
+    // Skip the npm "update available" check on every gateway boot.
+    // Pinchy controls the OpenClaw version via the Docker image tag and
+    // ignores the notice; the network call is wasted I/O at startup.
+    update: { checkOnStart: false },
+    // OpenClaw's "canvas" artifact host. Pinchy doesn't render OpenClaw
+    // canvases anywhere in its UI; per schema: "Keep disabled when canvas
+    // workflows are inactive to reduce exposed local services."
+    canvasHost: { enabled: false },
     env,
     secrets: {
       providers: {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -171,6 +171,16 @@ export async function regenerateOpenClawConfig() {
   const existingAgents = (existing.agents as Record<string, unknown>) || {};
   const config: Record<string, unknown> = {
     gateway,
+    // Disable OpenClaw's mDNS announcer. Pinchy always runs OpenClaw inside
+    // a container; multicast doesn't route out of Docker bridge networks,
+    // so the announcer hangs in `state=announcing`. After ~16 s OpenClaw's
+    // internal Bonjour watchdog declares the service stuck and SIGTERMs the
+    // gateway, costing ~30 s of "Reconnecting to the agent…" downtime per
+    // cold start (observed staging 2026-05-03; see openclaw-integration.log
+    // entries `[bonjour] restarting advertiser (service stuck in announcing)`).
+    // We connect via OPENCLAW_WS_URL on the bridge network and never need
+    // mDNS, so turning it off is safe.
+    discovery: { mdns: { mode: "off" } },
     env,
     secrets: {
       providers: {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -179,6 +179,18 @@ export async function regenerateOpenClawConfig() {
   // (contextPruning, heartbeat, models, compaction) that may not yet be
   // in the config file right after a full restart.
   const existingAgents = (existing.agents as Record<string, unknown>) || {};
+
+  // Spread existing.<field> for each top-level we touch so OpenClaw-enriched
+  // sub-fields survive the regenerate. Without this, Pinchy strips whatever
+  // OpenClaw stamps under these paths (lastAnnouncedAt, lastCheckedAt,
+  // boundPort, peer lists, etc.), the diff classifier flags it as a change,
+  // and we get exactly the cascade this PR is meant to close (#193, #237).
+  // Same shape as the `existingControlUi` spread on the gateway block above.
+  const existingDiscovery = (existing.discovery as Record<string, unknown>) || {};
+  const existingMdns = (existingDiscovery.mdns as Record<string, unknown>) || {};
+  const existingUpdate = (existing.update as Record<string, unknown>) || {};
+  const existingCanvasHost = (existing.canvasHost as Record<string, unknown>) || {};
+
   const config: Record<string, unknown> = {
     gateway,
     // Disable OpenClaw's mDNS announcer. Pinchy always runs OpenClaw inside
@@ -190,15 +202,15 @@ export async function regenerateOpenClawConfig() {
     // entries `[bonjour] restarting advertiser (service stuck in announcing)`).
     // We connect via OPENCLAW_WS_URL on the bridge network and never need
     // mDNS, so turning it off is safe.
-    discovery: { mdns: { mode: "off" } },
+    discovery: { ...existingDiscovery, mdns: { ...existingMdns, mode: "off" } },
     // Skip the npm "update available" check on every gateway boot.
     // Pinchy controls the OpenClaw version via the Docker image tag and
     // ignores the notice; the network call is wasted I/O at startup.
-    update: { checkOnStart: false },
+    update: { ...existingUpdate, checkOnStart: false },
     // OpenClaw's "canvas" artifact host. Pinchy doesn't render OpenClaw
     // canvases anywhere in its UI; per schema: "Keep disabled when canvas
     // workflows are inactive to reduce exposed local services."
-    canvasHost: { enabled: false },
+    canvasHost: { ...existingCanvasHost, enabled: false },
     env,
     secrets: {
       providers: {


### PR DESCRIPTION
## Summary

Two-part change targeting the staging cold-start cascade observed 2026-05-03:

**1. Disables four OpenClaw features that have no purpose in the Pinchy server stack** — written in OpenClaw's bootstrap (`ensure-gateway-token.js`) before the gateway boots, with `regenerateOpenClawConfig` as an idempotent backstop. All four are restart-classified by OpenClaw, so writing them in the bootstrap avoids the SIGUSR1 that would fire if Pinchy's later regenerate were the first writer.

| Feature | Default | Why disable |
|---|---|---|
| `discovery.mdns.mode` | `minimal` | mDNS doesn't route out of Docker bridge networks; the Bonjour announcer hangs in `state=announcing` and after ~16 s OpenClaw's internal watchdog SIGTERMs the gateway, costing ~30 s of "Reconnecting to the agent…" downtime per cold start. Pinchy connects via `OPENCLAW_WS_URL` on the bridge — mDNS is never useful for our topology. |
| `update.checkOnStart` | `true` | Runs `npm view openclaw versions` on every gateway boot. Pinchy controls the OpenClaw version via the Docker image tag and ignores the notice. |
| `gateway.controlUi.enabled` | `true` | Exposes OpenClaw's own web UI on the gateway HTTP port. **Pinchy IS the external control surface** (per the schema's own guidance). Disabling cuts memory + reduces attack surface — and makes the `controlUi.dangerously*` sub-toggles moot. |
| `canvasHost.enabled` | `true` | OpenClaw's "canvas" artifact server. Pinchy doesn't render OpenClaw canvases anywhere in its UI. |

**2. Adds three architectural-contract tests** (`e2e/integration/00-config-idempotency.spec.ts` + a unit test in `openclaw-config.test.ts`) that pin the recurring restart-loop bug class (#193, #200, #237, openclaw#47458, openclaw#75534) so the next drift surfaces in CI instead of staging.

Plus: `docker-compose.integration.yml` pinned to `linux/amd64` so Mac/arm64 dev machines pull the OpenClaw image under Rosetta instead of failing with `no matching manifest`.

## Tests added

| Test | Catches |
|---|---|
| `cold-start cascade: at most one gateway restart in setup` (E2E) | Bonjour-watchdog SIGTERM, any future field-drift cascade |
| `PATCH agent with no DB change must not modify openclaw.json or trigger restart` (E2E) | Drift bugs where Pinchy's preserve-list misses a new OpenClaw-enriched field; ignores `meta.*` (OpenClaw-owned timestamps) for race-stability |
| `should disable mDNS discovery so the Bonjour watchdog can't kill the gateway` (unit) | Regression of the regenerate side of the mDNS fix |
| `should disable OpenClaw features that have no purpose in a containerized Pinchy deployment` (unit) | Regression of the regenerate side of the four disables |
| `preserves OpenClaw-enriched sub-fields under discovery, update, canvasHost across regenerate (C1)` (unit) | New top-level paths must spread `existing.<field>` so OpenClaw enrichments survive — the exact preserve-list bug class this PR is meant to close |

## Expected impact on staging cold-start

~5 min → ~30 s. Bonjour-restart (~30 s) gone, controlUi/canvasHost reduce gateway memory footprint and exposed services, update-check eliminates one npm round-trip per boot. The remaining ~10 s bootstrap restart (legitimate `agents.list` change for the first agent) and the ~26 s `chat.history` cold call (upstream-addressed in OpenClaw 2026.5.2 changelog: "session listing + gateway startup hot paths leaner") are out of scope here.

## First-deploy caveat

The bootstrap-pre-write only takes effect once the **OpenClaw** image also includes the updated `ensure-gateway-token.js` (next OpenClaw image build). On the first deploy where only the Pinchy image is updated and the OpenClaw image is the previous tag, Pinchy's regenerate is the first writer for all four fields and incurs **one extra one-time SIGUSR1 cascade** as those restart-classified paths get added. Steady-state after both images update has none.

## Forward compatibility

All four schema fields are stable across OpenClaw 2026.4.x and 2026.5.2+. The fix is unaffected by the upcoming bump and stays load-bearing afterwards.

## Test plan

- [x] Unit suite: 91/91 vitest pass
- [x] Integration suite locally: 2/2 pass with single SIGUSR1 in setup, zero SIGTERM, no Bonjour-watchdog log markers
- [x] Lint + typecheck clean
- [ ] CI green (in progress)
- [ ] Verify on staging: cold-start time before vs after deploy