### PR TITLE
perf(openclaw): cut cold-start ~50s by pre-warming runtime deps and disabling unused plugins

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -45,58 +45,17 @@ RUN cd /tmp/pinchy-email && npm install --omit=dev && \
     cp -r /tmp/pinchy-email/node_modules /opt/pinchy-email-deps/ && \
     rm -rf /tmp/pinchy-email
 
-# Pre-warm the bundled-plugin runtime-deps cache so the first container
-# start doesn't spend ~48 s in `[plugins] staging bundled runtime deps`
-# (observed on 2-vCPU staging — blocks the gateway HTTP listener and
-# stalls Pinchy's first sessions.list/chat.history calls). We boot the
-# gateway once with a minimal config that disables the four plugins
-# Pinchy never uses (acpx, bonjour, device-pair, phone-control), so
-# OpenClaw materializes only the deps we actually need under
-# /root/.openclaw/plugin-runtime-deps/<openclaw-version>-<hash>/. After
-# the cache is built we kill the gateway and strip every other build-
-# artefact under /root/.openclaw — only plugin-runtime-deps survives
-# into the image. On first user start, Docker populates the openclaw-
-# config named volume from this image (volumes inherit image contents
-# only when empty), giving the warm cache to fresh installs without
-# leaking the prewarm gateway-token, devices/, or agents/ state.
+# Pre-warm the bundled-plugin runtime-deps cache. Rationale and full
+# behaviour live in config/prewarm-openclaw.sh; in short: boot the
+# gateway once at build time so the npm install of ~15 plugin runtime
+# deps lands in /root/.openclaw/plugin-runtime-deps/ before any user
+# starts the container. Saves ~48s of `[plugins] staging bundled
+# runtime deps` on first boot, observed on 2-vCPU staging.
 COPY config/openclaw-prewarm.json /tmp/openclaw-prewarm.json
-# bash explicit because we use `/dev/tcp/...` to wait for the gateway
-# port; on debian-slim `RUN` uses dash by default, which has no
-# /dev/tcp emulation and would silently never see the port open.
-RUN bash -c '\
-    set -euo pipefail; \
-    mkdir -p /root/.openclaw; \
-    cp /tmp/openclaw-prewarm.json /root/.openclaw/openclaw.json; \
-    openclaw gateway --port 18789 >/tmp/prewarm.log 2>&1 & \
-    gw_pid=$!; \
-    ready=0; \
-    for i in $(seq 1 180); do \
-      if (echo > /dev/tcp/127.0.0.1/18789) 2>/dev/null; then \
-        ready=1; \
-        echo "[prewarm] gateway ready after ${i}s"; \
-        break; \
-      fi; \
-      sleep 1; \
-    done; \
-    if [ "$ready" = "0" ]; then \
-      echo "[prewarm] gateway did not come up in 180s; log tail:"; \
-      tail -60 /tmp/prewarm.log; \
-      kill $gw_pid 2>/dev/null || true; \
-      exit 1; \
-    fi; \
-    sleep 2; \
-    kill $gw_pid 2>/dev/null || true; \
-    wait $gw_pid 2>/dev/null || true; \
-    echo "[prewarm] gateway stopped"; \
-    find /root/.openclaw -mindepth 1 -maxdepth 1 \
-      ! -name plugin-runtime-deps -exec rm -rf {} +; \
-    rm -f /tmp/openclaw-prewarm.json /tmp/prewarm.log; \
-    if ! ls -d /root/.openclaw/plugin-runtime-deps/openclaw-* >/dev/null 2>&1; then \
-      echo "[prewarm] FATAL: plugin-runtime-deps cache was not produced"; \
-      exit 1; \
-    fi; \
-    du -sh /root/.openclaw/plugin-runtime-deps/openclaw-*/ \
-'
+COPY config/prewarm-openclaw.sh /tmp/prewarm-openclaw.sh
+RUN chmod +x /tmp/prewarm-openclaw.sh && \
+    /tmp/prewarm-openclaw.sh /tmp/openclaw-prewarm.json && \
+    rm -f /tmp/prewarm-openclaw.sh /tmp/openclaw-prewarm.json
 
 COPY config/openclaw.json /root/.openclaw/openclaw.json
 COPY config/start-openclaw.sh /start-openclaw.sh

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -45,6 +45,59 @@ RUN cd /tmp/pinchy-email && npm install --omit=dev && \
     cp -r /tmp/pinchy-email/node_modules /opt/pinchy-email-deps/ && \
     rm -rf /tmp/pinchy-email
 
+# Pre-warm the bundled-plugin runtime-deps cache so the first container
+# start doesn't spend ~48 s in `[plugins] staging bundled runtime deps`
+# (observed on 2-vCPU staging — blocks the gateway HTTP listener and
+# stalls Pinchy's first sessions.list/chat.history calls). We boot the
+# gateway once with a minimal config that disables the four plugins
+# Pinchy never uses (acpx, bonjour, device-pair, phone-control), so
+# OpenClaw materializes only the deps we actually need under
+# /root/.openclaw/plugin-runtime-deps/<openclaw-version>-<hash>/. After
+# the cache is built we kill the gateway and strip every other build-
+# artefact under /root/.openclaw — only plugin-runtime-deps survives
+# into the image. On first user start, Docker populates the openclaw-
+# config named volume from this image (volumes inherit image contents
+# only when empty), giving the warm cache to fresh installs without
+# leaking the prewarm gateway-token, devices/, or agents/ state.
+COPY config/openclaw-prewarm.json /tmp/openclaw-prewarm.json
+# bash explicit because we use `/dev/tcp/...` to wait for the gateway
+# port; on debian-slim `RUN` uses dash by default, which has no
+# /dev/tcp emulation and would silently never see the port open.
+RUN bash -c '\
+    set -euo pipefail; \
+    mkdir -p /root/.openclaw; \
+    cp /tmp/openclaw-prewarm.json /root/.openclaw/openclaw.json; \
+    openclaw gateway --port 18789 >/tmp/prewarm.log 2>&1 & \
+    gw_pid=$!; \
+    ready=0; \
+    for i in $(seq 1 180); do \
+      if (echo > /dev/tcp/127.0.0.1/18789) 2>/dev/null; then \
+        ready=1; \
+        echo "[prewarm] gateway ready after ${i}s"; \
+        break; \
+      fi; \
+      sleep 1; \
+    done; \
+    if [ "$ready" = "0" ]; then \
+      echo "[prewarm] gateway did not come up in 180s; log tail:"; \
+      tail -60 /tmp/prewarm.log; \
+      kill $gw_pid 2>/dev/null || true; \
+      exit 1; \
+    fi; \
+    sleep 2; \
+    kill $gw_pid 2>/dev/null || true; \
+    wait $gw_pid 2>/dev/null || true; \
+    echo "[prewarm] gateway stopped"; \
+    find /root/.openclaw -mindepth 1 -maxdepth 1 \
+      ! -name plugin-runtime-deps -exec rm -rf {} +; \
+    rm -f /tmp/openclaw-prewarm.json /tmp/prewarm.log; \
+    if ! ls -d /root/.openclaw/plugin-runtime-deps/openclaw-* >/dev/null 2>&1; then \
+      echo "[prewarm] FATAL: plugin-runtime-deps cache was not produced"; \
+      exit 1; \
+    fi; \
+    du -sh /root/.openclaw/plugin-runtime-deps/openclaw-*/ \
+'
+
 COPY config/openclaw.json /root/.openclaw/openclaw.json
 COPY config/start-openclaw.sh /start-openclaw.sh
 RUN chmod +x /start-openclaw.sh

--- a/config/openclaw-prewarm.json
+++ b/config/openclaw-prewarm.json
@@ -1,0 +1,30 @@
+{
+  "$schema": "https://schemas.openclaw.ai/openclaw.json",
+  "gateway": {
+    "mode": "local",
+    "bind": "loopback",
+    "auth": {
+      "token": "prewarmprewarmprewarmprewarmprewarmprewarmprewarm12"
+    }
+  },
+  "discovery": {
+    "mdns": {
+      "mode": "off"
+    }
+  },
+  "update": {
+    "checkOnStart": false
+  },
+  "canvasHost": {
+    "enabled": false
+  },
+  "plugins": {
+    "allow": ["browser", "memory-core", "talk-voice"],
+    "entries": {
+      "acpx": { "enabled": false },
+      "bonjour": { "enabled": false },
+      "device-pair": { "enabled": false },
+      "phone-control": { "enabled": false }
+    }
+  }
+}

--- a/config/openclaw-prewarm.json
+++ b/config/openclaw-prewarm.json
@@ -19,12 +19,6 @@
     "enabled": false
   },
   "plugins": {
-    "allow": ["browser", "memory-core", "talk-voice"],
-    "entries": {
-      "acpx": { "enabled": false },
-      "bonjour": { "enabled": false },
-      "device-pair": { "enabled": false },
-      "phone-control": { "enabled": false }
-    }
+    "allow": ["browser", "memory-core", "talk-voice"]
   }
 }

--- a/config/prewarm-openclaw.sh
+++ b/config/prewarm-openclaw.sh
@@ -1,0 +1,77 @@
+#!/bin/bash
+# Pre-warm the bundled-plugin runtime-deps cache for the OpenClaw image.
+#
+# OpenClaw 2026.4.x runs `npm install` of ~15 packages into
+# /root/.openclaw/plugin-runtime-deps/<openclaw-version>-<hash>/ on the
+# first gateway boot. On a 2-vCPU host this took ~48 s, blocking the
+# gateway HTTP listener and stalling Pinchy's first sessions.list /
+# chat.history calls.
+#
+# We do that install at image build time by booting the gateway once
+# with a minimal allow-listed config (browser/memory-core/talk-voice
+# only — see ../packages/web/src/lib/openclaw-config/build.ts for why
+# we disable acpx/bonjour/device-pair/phone-control) so OpenClaw
+# materializes only the deps Pinchy actually needs. After the cache is
+# built we kill the gateway and strip every other build-artefact under
+# /root/.openclaw — only plugin-runtime-deps/ survives into the image.
+#
+# On first user start, Docker populates the openclaw-config named
+# volume from this image (volumes inherit image contents only when
+# empty), giving the warm cache to fresh installs without leaking the
+# prewarm gateway-token, devices/, or agents/ state.
+#
+# bash explicit because we use `/dev/tcp/...` to wait for the gateway
+# port; on debian-slim `RUN` uses dash by default, which has no
+# /dev/tcp emulation and would silently never see the port open.
+set -euo pipefail
+
+PREWARM_CONFIG="${1:?usage: $0 <prewarm-config-path>}"
+GATEWAY_PORT=18789
+READY_TIMEOUT_S=180
+
+mkdir -p /root/.openclaw
+cp "$PREWARM_CONFIG" /root/.openclaw/openclaw.json
+
+openclaw gateway --port "$GATEWAY_PORT" >/tmp/prewarm.log 2>&1 &
+gw_pid=$!
+
+ready=0
+for i in $(seq 1 "$READY_TIMEOUT_S"); do
+  if (echo > "/dev/tcp/127.0.0.1/$GATEWAY_PORT") 2>/dev/null; then
+    ready=1
+    echo "[prewarm] gateway ready after ${i}s"
+    break
+  fi
+  sleep 1
+done
+
+if [ "$ready" = "0" ]; then
+  echo "[prewarm] gateway did not come up in ${READY_TIMEOUT_S}s; log tail:"
+  tail -60 /tmp/prewarm.log
+  kill "$gw_pid" 2>/dev/null || true
+  exit 1
+fi
+
+# Give plugin loading a beat to settle past the listening-but-not-quite-
+# ready window before we tear down. Two seconds is plenty in practice
+# (CI prewarm typically completes in 5-15 s total).
+sleep 2
+
+kill "$gw_pid" 2>/dev/null || true
+wait "$gw_pid" 2>/dev/null || true
+echo "[prewarm] gateway stopped"
+
+# Strip everything except the runtime-deps cache. Pinchy regenerates
+# openclaw.json on first boot via regenerateOpenClawConfig(); leaving
+# the prewarm token / devices / agents state behind would either leak
+# build-time secrets into runtime or confuse the cold-start cascade.
+find /root/.openclaw -mindepth 1 -maxdepth 1 \
+  ! -name plugin-runtime-deps -exec rm -rf {} +
+rm -f /tmp/prewarm.log
+
+if ! ls -d /root/.openclaw/plugin-runtime-deps/openclaw-* >/dev/null 2>&1; then
+  echo "[prewarm] FATAL: plugin-runtime-deps cache was not produced"
+  exit 1
+fi
+
+du -sh /root/.openclaw/plugin-runtime-deps/openclaw-*/

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -338,44 +338,46 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.discovery?.mdns?.mode).toBe("off");
   });
 
-  it("should disable bundled OpenClaw plugins that Pinchy never uses", async () => {
+  it("should keep bundled OpenClaw plugins Pinchy never uses out of plugins.allow without touching plugins.entries", async () => {
     // OpenClaw 2026.4.x ships seven plugins enabledByDefault:
     //   acpx, bonjour, browser, device-pair, memory-core, phone-control, talk-voice
     //
     // Pinchy uses none of acpx, bonjour, device-pair, phone-control:
-    //   - acpx: Agent Client Protocol for desktop chat clients (Claude.app,
-    //     Zed Codex). Pinchy talks to OpenClaw via its WebSocket gateway
-    //     (openclaw-node), not ACP — the plugin is dead weight.
-    //   - bonjour: mDNS service advertising for the gateway. Pinchy reaches
-    //     OpenClaw on the Docker bridge via OPENCLAW_WS_URL; multicast
-    //     doesn't route there. discovery.mdns.mode=off already silences
-    //     the watchdog, but the plugin itself still loads ~1MB of
-    //     @homebridge/ciao deps and starts an announcer.
+    //   - acpx: Agent Client Protocol bridge for desktop chat clients
+    //     (Claude.app, Zed Codex). Pinchy talks to OpenClaw via openclaw-
+    //     node over its WebSocket gateway, never via ACP.
+    //   - bonjour: mDNS gateway advertiser. Pinchy reaches OpenClaw on the
+    //     Docker bridge via OPENCLAW_WS_URL; multicast doesn't route there.
+    //     `discovery.mdns.mode=off` already silences the watchdog but
+    //     ~1 MB of @homebridge/ciao deps still load and an announcer starts.
     //   - device-pair: QR-code pairing flow. Pinchy auto-approves devices
-    //     via gateway-token auth in start-openclaw.sh.
+    //     with the gateway token in start-openclaw.sh.
     //   - phone-control: phone-node high-risk command arming. Pinchy has
     //     no phone integration.
-    //
-    // Disabling them shrinks the bundled runtime-deps install from ~48s on
-    // a cold container start (observed on 2-vCPU staging) to ~10–15s, and
-    // cuts a few hundred MB from /root/.openclaw/plugin-runtime-deps.
     //
     // browser, memory-core, talk-voice stay enabled: browser is a planned
     // feature (and gated by Pinchy's tool-registry deny-list anyway),
     // memory-core has activation.onStartup=false (zero startup cost),
-    // talk-voice is a leaf TTS picker we may want for future voice work.
+    // talk-voice is a tiny TTS picker.
     //
-    // Disable mechanism: plugins.allow is a hard whitelist
-    // ("when set, only listed plugins are eligible to load") — the unwanted
-    // plugin IDs must never appear there. plugins.entries.<id>.enabled=false
-    // is added as defense-in-depth in case some bundled-channel side path
-    // re-injects them.
+    // Disable mechanism: `plugins.allow` is a hard whitelist per the
+    // OpenClaw schema — "when set, only listed plugins are eligible to
+    // load". Filtering the four IDs out of `allow` blocks them entirely.
+    //
+    // We deliberately do NOT also stamp `plugins.entries.<id>.enabled =
+    // false`. OpenClaw enriches `plugins.entries.*` at runtime (e.g.
+    // sibling `hooks` blocks), and overwriting/removing entries surfaces
+    // as a `plugins` config-diff classification → full SIGUSR1 gateway
+    // restart (caught by agent-create-no-restart.spec.ts:207). Existing
+    // entries for disabled plugins are preserved byte-for-byte; the
+    // allowlist alone keeps them from loading and leftover entries are
+    // inert.
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
         gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
         plugins: {
           // Simulate OpenClaw having auto-populated allow with all bundled
-          // plugins after a previous boot; Pinchy must filter the four out.
+          // plugins after a previous boot.
           allow: [
             "acpx",
             "bonjour",
@@ -386,10 +388,11 @@ describe("regenerateOpenClawConfig", () => {
             "talk-voice",
           ],
           entries: {
-            acpx: { enabled: true },
+            // OpenClaw-side enrichment with a sibling field — Pinchy must
+            // NOT strip this on regenerate (would trigger the
+            // agent-create-no-restart fingerprint).
+            acpx: { enabled: true, hooks: { allowPromptInjection: true } },
             bonjour: { enabled: true },
-            "device-pair": { enabled: true },
-            "phone-control": { enabled: true },
           },
         },
       })
@@ -401,7 +404,7 @@ describe("regenerateOpenClawConfig", () => {
     const config = JSON.parse(written) as {
       plugins?: {
         allow?: string[];
-        entries?: Record<string, { enabled?: boolean }>;
+        entries?: Record<string, unknown>;
       };
     };
 
@@ -417,59 +420,14 @@ describe("regenerateOpenClawConfig", () => {
     expect(allow).toContain("memory-core");
     expect(allow).toContain("talk-voice");
 
-    expect(config.plugins?.entries?.acpx?.enabled).toBe(false);
-    expect(config.plugins?.entries?.bonjour?.enabled).toBe(false);
-    expect(config.plugins?.entries?.["device-pair"]?.enabled).toBe(false);
-    expect(config.plugins?.entries?.["phone-control"]?.enabled).toBe(false);
-  });
-
-  it("should keep disabled bundled plugins at their existing position in plugins.entries", async () => {
-    // Regression guard for #272 CI failures: an earlier draft of the
-    // disable logic appended acpx/bonjour/device-pair/phone-control at
-    // the end of `entries` even when they already existed at an earlier
-    // position. OpenClaw classifies any `plugins.entries` reorder as a
-    // config diff and reacts with a full SIGUSR1 gateway restart (caught
-    // by agent-create-no-restart.spec.ts), and the idempotency contract
-    // test (00-config-idempotency.spec.ts) reports the resulting
-    // openclaw.json drift directly. Both must stay green: writing
-    // { enabled: false } for a disabled plugin must overwrite in place,
-    // not move the key.
-    mockedReadFileSync.mockReturnValue(
-      JSON.stringify({
-        gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
-        plugins: {
-          allow: ["acpx", "bonjour", "ollama", "telegram"],
-          entries: {
-            acpx: { enabled: true },
-            bonjour: { enabled: true },
-            ollama: { enabled: true },
-            telegram: { enabled: true },
-          },
-        },
-      })
-    );
-
-    await regenerateOpenClawConfig();
-
-    const written = mockedWriteFileSync.mock.calls[0][1] as string;
-    const config = JSON.parse(written) as {
-      plugins?: { entries?: Record<string, unknown> };
-    };
-
-    const entryKeys = Object.keys(config.plugins?.entries ?? {});
-    const acpxIdx = entryKeys.indexOf("acpx");
-    const bonjourIdx = entryKeys.indexOf("bonjour");
-    const ollamaIdx = entryKeys.indexOf("ollama");
-    const telegramIdx = entryKeys.indexOf("telegram");
-
-    expect(acpxIdx).toBeGreaterThanOrEqual(0);
-    expect(bonjourIdx).toBeGreaterThanOrEqual(0);
-    // acpx and bonjour must stay before ollama and telegram (their
-    // original positions in the existing config), not get pushed after.
-    expect(acpxIdx).toBeLessThan(ollamaIdx);
-    expect(bonjourIdx).toBeLessThan(ollamaIdx);
-    expect(acpxIdx).toBeLessThan(telegramIdx);
-    expect(bonjourIdx).toBeLessThan(telegramIdx);
+    // Existing entries for disabled plugins are preserved byte-for-byte
+    // (including OpenClaw's sibling enrichments). Removing them would diff
+    // `plugins` and OpenClaw classifies that as restart-required.
+    expect(config.plugins?.entries?.acpx).toEqual({
+      enabled: true,
+      hooks: { allowPromptInjection: true },
+    });
+    expect(config.plugins?.entries?.bonjour).toEqual({ enabled: true });
   });
 
   it("should write agents.list with all agents from DB", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -428,6 +428,18 @@ describe("regenerateOpenClawConfig", () => {
       hooks: { allowPromptInjection: true },
     });
     expect(config.plugins?.entries?.bonjour).toEqual({ enabled: true });
+
+    // Insertion order matters too: a future refactor that sorted entries
+    // alphabetically (or otherwise reordered them) would still pass the
+    // byte-for-byte equality above but would surface as a `plugins` diff
+    // at runtime and trigger the SIGUSR1 cascade. Lock the order
+    // explicitly: existing non-pinchy keys keep their original positions
+    // after the (currently empty) pinchy-* prefix block.
+    const entryKeys = Object.keys(config.plugins?.entries ?? {});
+    const acpxIdx = entryKeys.indexOf("acpx");
+    const bonjourIdx = entryKeys.indexOf("bonjour");
+    expect(acpxIdx).toBeGreaterThanOrEqual(0);
+    expect(bonjourIdx).toBe(acpxIdx + 1);
   });
 
   it("should write agents.list with all agents from DB", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -338,6 +338,91 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.discovery?.mdns?.mode).toBe("off");
   });
 
+  it("should disable bundled OpenClaw plugins that Pinchy never uses", async () => {
+    // OpenClaw 2026.4.x ships seven plugins enabledByDefault:
+    //   acpx, bonjour, browser, device-pair, memory-core, phone-control, talk-voice
+    //
+    // Pinchy uses none of acpx, bonjour, device-pair, phone-control:
+    //   - acpx: Agent Client Protocol for desktop chat clients (Claude.app,
+    //     Zed Codex). Pinchy talks to OpenClaw via its WebSocket gateway
+    //     (openclaw-node), not ACP — the plugin is dead weight.
+    //   - bonjour: mDNS service advertising for the gateway. Pinchy reaches
+    //     OpenClaw on the Docker bridge via OPENCLAW_WS_URL; multicast
+    //     doesn't route there. discovery.mdns.mode=off already silences
+    //     the watchdog, but the plugin itself still loads ~1MB of
+    //     @homebridge/ciao deps and starts an announcer.
+    //   - device-pair: QR-code pairing flow. Pinchy auto-approves devices
+    //     via gateway-token auth in start-openclaw.sh.
+    //   - phone-control: phone-node high-risk command arming. Pinchy has
+    //     no phone integration.
+    //
+    // Disabling them shrinks the bundled runtime-deps install from ~48s on
+    // a cold container start (observed on 2-vCPU staging) to ~10–15s, and
+    // cuts a few hundred MB from /root/.openclaw/plugin-runtime-deps.
+    //
+    // browser, memory-core, talk-voice stay enabled: browser is a planned
+    // feature (and gated by Pinchy's tool-registry deny-list anyway),
+    // memory-core has activation.onStartup=false (zero startup cost),
+    // talk-voice is a leaf TTS picker we may want for future voice work.
+    //
+    // Disable mechanism: plugins.allow is a hard whitelist
+    // ("when set, only listed plugins are eligible to load") — the unwanted
+    // plugin IDs must never appear there. plugins.entries.<id>.enabled=false
+    // is added as defense-in-depth in case some bundled-channel side path
+    // re-injects them.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
+        plugins: {
+          // Simulate OpenClaw having auto-populated allow with all bundled
+          // plugins after a previous boot; Pinchy must filter the four out.
+          allow: [
+            "acpx",
+            "bonjour",
+            "browser",
+            "device-pair",
+            "memory-core",
+            "phone-control",
+            "talk-voice",
+          ],
+          entries: {
+            acpx: { enabled: true },
+            bonjour: { enabled: true },
+            "device-pair": { enabled: true },
+            "phone-control": { enabled: true },
+          },
+        },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      plugins?: {
+        allow?: string[];
+        entries?: Record<string, { enabled?: boolean }>;
+      };
+    };
+
+    const allow = config.plugins?.allow ?? [];
+    expect(allow).not.toContain("acpx");
+    expect(allow).not.toContain("bonjour");
+    expect(allow).not.toContain("device-pair");
+    expect(allow).not.toContain("phone-control");
+
+    // browser, memory-core, talk-voice must stay — they're either planned
+    // features or zero-cost lazily-activated plugins.
+    expect(allow).toContain("browser");
+    expect(allow).toContain("memory-core");
+    expect(allow).toContain("talk-voice");
+
+    expect(config.plugins?.entries?.acpx?.enabled).toBe(false);
+    expect(config.plugins?.entries?.bonjour?.enabled).toBe(false);
+    expect(config.plugins?.entries?.["device-pair"]?.enabled).toBe(false);
+    expect(config.plugins?.entries?.["phone-control"]?.enabled).toBe(false);
+  });
+
   it("should write agents.list with all agents from DB", async () => {
     const agentsData = [
       {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -423,6 +423,55 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.plugins?.entries?.["phone-control"]?.enabled).toBe(false);
   });
 
+  it("should keep disabled bundled plugins at their existing position in plugins.entries", async () => {
+    // Regression guard for #272 CI failures: an earlier draft of the
+    // disable logic appended acpx/bonjour/device-pair/phone-control at
+    // the end of `entries` even when they already existed at an earlier
+    // position. OpenClaw classifies any `plugins.entries` reorder as a
+    // config diff and reacts with a full SIGUSR1 gateway restart (caught
+    // by agent-create-no-restart.spec.ts), and the idempotency contract
+    // test (00-config-idempotency.spec.ts) reports the resulting
+    // openclaw.json drift directly. Both must stay green: writing
+    // { enabled: false } for a disabled plugin must overwrite in place,
+    // not move the key.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
+        plugins: {
+          allow: ["acpx", "bonjour", "ollama", "telegram"],
+          entries: {
+            acpx: { enabled: true },
+            bonjour: { enabled: true },
+            ollama: { enabled: true },
+            telegram: { enabled: true },
+          },
+        },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      plugins?: { entries?: Record<string, unknown> };
+    };
+
+    const entryKeys = Object.keys(config.plugins?.entries ?? {});
+    const acpxIdx = entryKeys.indexOf("acpx");
+    const bonjourIdx = entryKeys.indexOf("bonjour");
+    const ollamaIdx = entryKeys.indexOf("ollama");
+    const telegramIdx = entryKeys.indexOf("telegram");
+
+    expect(acpxIdx).toBeGreaterThanOrEqual(0);
+    expect(bonjourIdx).toBeGreaterThanOrEqual(0);
+    // acpx and bonjour must stay before ollama and telegram (their
+    // original positions in the existing config), not get pushed after.
+    expect(acpxIdx).toBeLessThan(ollamaIdx);
+    expect(bonjourIdx).toBeLessThan(ollamaIdx);
+    expect(acpxIdx).toBeLessThan(telegramIdx);
+    expect(bonjourIdx).toBeLessThan(telegramIdx);
+  });
+
   it("should write agents.list with all agents from DB", async () => {
     const agentsData = [
       {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -591,20 +591,25 @@ export async function regenerateOpenClawConfig() {
   const existingEntries =
     ((existing.plugins as Record<string, unknown>)?.entries as Record<string, unknown>) || {};
   for (const [pluginId, entry] of Object.entries(existingEntries)) {
-    if (
-      !isPinchyPlugin(pluginId) &&
-      !(pluginId in entries) &&
-      !DISABLED_OPENCLAW_PLUGINS.has(pluginId)
-    ) {
-      entries[pluginId] = entry;
-    }
+    if (isPinchyPlugin(pluginId) || pluginId in entries) continue;
+    // For disabled bundled plugins, overwrite the value but keep the key in
+    // its original insertion position. Appending these at the end of `entries`
+    // would shuffle ollama/telegram/etc. earlier on every regenerate, which
+    // OpenClaw classifies as a config diff and reacts to with a full SIGUSR1
+    // gateway restart (caught by the agent-create-no-restart e2e test) and
+    // also drives the idempotency test's openclaw.json drift assertion.
+    entries[pluginId] = DISABLED_OPENCLAW_PLUGINS.has(pluginId) ? { enabled: false } : entry;
   }
 
-  // Defense-in-depth: stamp `enabled: false` for the plugins we left out of
-  // the allowlist. If a future OpenClaw version adds a side path that
-  // injects bundled plugins past `plugins.allow`, this still blocks them.
+  // First-time case: when the existing config has no entry for a disabled
+  // plugin yet (e.g. fresh install, or a plugin OpenClaw hasn't auto-injected
+  // because allow filtered it out from the start), append it. Defense-in-
+  // depth: if a future OpenClaw version adds a side path that injects
+  // bundled plugins past `plugins.allow`, this still blocks them.
   for (const pluginId of DISABLED_OPENCLAW_PLUGINS) {
-    entries[pluginId] = { enabled: false };
+    if (!(pluginId in entries)) {
+      entries[pluginId] = { enabled: false };
+    }
   }
 
   if (allowedPlugins.length > 0 || Object.keys(entries).length > 0) {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -537,9 +537,18 @@ export async function regenerateOpenClawConfig() {
   // OpenClaw 2026.4.x ships several plugins enabledByDefault that Pinchy
   // never uses but whose runtime deps still get installed on the first
   // gateway boot (~48s on a 2-vCPU host, observed staging 2026-05-04).
-  // Keeping them out of `plugins.allow` (a hard whitelist per the schema)
-  // prevents the install entirely; the explicit `enabled: false` entries
-  // added below are defense-in-depth for any bundled-channel side path.
+  // `plugins.allow` is a hard whitelist per the OpenClaw schema:
+  // "when set, only listed plugins are eligible to load". Keeping these
+  // four IDs out of `allow` blocks load and the dep install entirely.
+  //
+  // We deliberately do NOT also stamp `plugins.entries.<id>.enabled = false`.
+  // OpenClaw enriches `plugins.entries.*` at runtime (sibling fields like
+  // hooks/subagent state); writing our own value over the existing entry
+  // would either drop those enrichments (-> next regenerate diffs `plugins`
+  // -> full SIGUSR1 gateway restart, caught by agent-create-no-restart.
+  // spec.ts:207) or write a new entry that wasn't there before (-> first
+  // regenerate diffs `plugins` -> restart). The allowlist alone is the
+  // correct mechanism here.
   //
   // Why each is safe to disable:
   //   - acpx: Agent Client Protocol bridge for desktop chat clients
@@ -590,25 +599,14 @@ export async function regenerateOpenClawConfig() {
   // the plugins.entries.* surface.
   const existingEntries =
     ((existing.plugins as Record<string, unknown>)?.entries as Record<string, unknown>) || {};
+  // Preserve all existing non-pinchy entries — including ones for plugins
+  // we've filtered out of `plugins.allow` (acpx/bonjour/...). Stripping
+  // them would diff `plugins` and OpenClaw classifies that as restart-
+  // required (caught by agent-create-no-restart.spec.ts:207). The allow
+  // whitelist alone keeps them from loading, so leftover entries are inert.
   for (const [pluginId, entry] of Object.entries(existingEntries)) {
-    if (isPinchyPlugin(pluginId) || pluginId in entries) continue;
-    // For disabled bundled plugins, overwrite the value but keep the key in
-    // its original insertion position. Appending these at the end of `entries`
-    // would shuffle ollama/telegram/etc. earlier on every regenerate, which
-    // OpenClaw classifies as a config diff and reacts to with a full SIGUSR1
-    // gateway restart (caught by the agent-create-no-restart e2e test) and
-    // also drives the idempotency test's openclaw.json drift assertion.
-    entries[pluginId] = DISABLED_OPENCLAW_PLUGINS.has(pluginId) ? { enabled: false } : entry;
-  }
-
-  // First-time case: when the existing config has no entry for a disabled
-  // plugin yet (e.g. fresh install, or a plugin OpenClaw hasn't auto-injected
-  // because allow filtered it out from the start), append it. Defense-in-
-  // depth: if a future OpenClaw version adds a side path that injects
-  // bundled plugins past `plugins.allow`, this still blocks them.
-  for (const pluginId of DISABLED_OPENCLAW_PLUGINS) {
-    if (!(pluginId in entries)) {
-      entries[pluginId] = { enabled: false };
+    if (!isPinchyPlugin(pluginId) && !(pluginId in entries)) {
+      entries[pluginId] = entry;
     }
   }
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -534,7 +534,34 @@ export async function regenerateOpenClawConfig() {
   const ourPlugins = new Set(Object.keys(entries));
   const pinchyPluginPrefixes = ["pinchy-"];
   const isPinchyPlugin = (p: string) => pinchyPluginPrefixes.some((prefix) => p.startsWith(prefix));
-  const isWanted = (p: string) => !isPinchyPlugin(p) || ourPlugins.has(p);
+  // OpenClaw 2026.4.x ships several plugins enabledByDefault that Pinchy
+  // never uses but whose runtime deps still get installed on the first
+  // gateway boot (~48s on a 2-vCPU host, observed staging 2026-05-04).
+  // Keeping them out of `plugins.allow` (a hard whitelist per the schema)
+  // prevents the install entirely; the explicit `enabled: false` entries
+  // added below are defense-in-depth for any bundled-channel side path.
+  //
+  // Why each is safe to disable:
+  //   - acpx: Agent Client Protocol bridge for desktop chat clients
+  //     (Claude.app, Zed Codex). Pinchy talks to OpenClaw via openclaw-node
+  //     over its WebSocket gateway, never via ACP.
+  //   - bonjour: mDNS gateway advertiser. Pinchy reaches OpenClaw on the
+  //     Docker bridge via OPENCLAW_WS_URL; multicast doesn't route there.
+  //     `discovery.mdns.mode = "off"` already silences the watchdog but
+  //     still loads ~1MB @homebridge/ciao deps and starts an announcer.
+  //   - device-pair: QR-code device pairing UX. Pinchy auto-approves
+  //     devices with the gateway token in start-openclaw.sh.
+  //   - phone-control: arms/disarms phone-node high-risk commands. Pinchy
+  //     has no phone integration.
+  //
+  // Plugins we keep on (despite Pinchy not using them yet):
+  //   - browser: planned feature; gated by tool-registry deny-list anyway
+  //     so users can't reach it without admin opt-in.
+  //   - memory-core: activation.onStartup=false; lazy and free at startup.
+  //   - talk-voice: leaf TTS-voice picker; tiny, future voice work.
+  const DISABLED_OPENCLAW_PLUGINS = new Set(["acpx", "bonjour", "device-pair", "phone-control"]);
+  const isWanted = (p: string) =>
+    !DISABLED_OPENCLAW_PLUGINS.has(p) && (!isPinchyPlugin(p) || ourPlugins.has(p));
   // Keep existing entries (in their current positions) that we still want.
   // Drops stale pinchy-* entries we no longer emit; preserves OpenClaw-
   // managed plugins as-is.
@@ -564,9 +591,20 @@ export async function regenerateOpenClawConfig() {
   const existingEntries =
     ((existing.plugins as Record<string, unknown>)?.entries as Record<string, unknown>) || {};
   for (const [pluginId, entry] of Object.entries(existingEntries)) {
-    if (!isPinchyPlugin(pluginId) && !(pluginId in entries)) {
+    if (
+      !isPinchyPlugin(pluginId) &&
+      !(pluginId in entries) &&
+      !DISABLED_OPENCLAW_PLUGINS.has(pluginId)
+    ) {
       entries[pluginId] = entry;
     }
+  }
+
+  // Defense-in-depth: stamp `enabled: false` for the plugins we left out of
+  // the allowlist. If a future OpenClaw version adds a side path that
+  // injects bundled plugins past `plugins.allow`, this still blocks them.
+  for (const pluginId of DISABLED_OPENCLAW_PLUGINS) {
+    entries[pluginId] = { enabled: false };
   }
 
   if (allowedPlugins.length > 0 || Object.keys(entries).length > 0) {


### PR DESCRIPTION
## Summary

A fresh OpenClaw container takes ~75 s before `[gateway] ready`, during which Pinchy's first `sessions.list` / `chat.history` / `config.get` calls back up behind a fully blocked Node event loop and surface to the user as a stuck "Checking infrastructure…" loader. Two complementary changes target this:

- **Disable four bundled plugins Pinchy never uses** — `acpx`, `bonjour`, `device-pair`, `phone-control` are filtered out of `plugins.allow`. The OpenClaw schema classifies `plugins.allow` as a hard whitelist (*"when set, only listed plugins are eligible to load"*), so this alone blocks load. An earlier draft also stamped `enabled: false` into `plugins.entries.<id>` as defense-in-depth, but that turned out to fight OpenClaw's runtime enrichment of `plugins.entries.*` (sibling fields like `hooks`) and triggered SIGUSR1 cascades (caught by `agent-create-no-restart.spec.ts:207`); see commit `991db6a1` for the full rationale. `browser`, `memory-core`, `talk-voice` stay on (planned features / lazy-activated / leaf TTS picker — see code comments for the per-plugin rationale).
- **Pre-warm the bundled-plugin runtime-deps cache in the image** — `config/prewarm-openclaw.sh` boots the gateway once at image build time with a minimal allow-only config, waits for ready, kills it, and keeps only `/root/.openclaw/plugin-runtime-deps/` in the final image. Docker populates the `openclaw-config` named volume from the image on first user start (volumes inherit image contents only when empty), so fresh installs get a warm cache without leaking the prewarm gateway-token, devices, or agents state.

With the disable in place the cache is ~116 MB instead of ~861 MB (the unused plugins' deps — `@homebridge/ciao`, `@agentclientprotocol/claude-agent-acp`, `@zed-industries/codex-acp`, `acpx` — are not even installed).

## Measurement

Measured on 2-vCPU staging, `pinchy_openclaw-config` volume wiped and re-created so the image populates it fresh:

| | Before | After |
|---|---|---|
| `[plugins] staging bundled runtime deps` | ~48 s | **does not run** |
| `[gateway] ready` after openclaw container start | ~75 s | ~48 s |

The remaining ~40 s gap between `auto-enabled plugins` and `starting HTTP server` is plugin-init time inside the gateway (high event-loop delay, low CPU) — orthogonal to runtime-deps install and not addressed here.

## Upgrade behaviour

On an existing installation (where `existing.plugins.allow` already contains acpx/bonjour/device-pair/phone-control from a previous OpenClaw boot), the **first** Pinchy regenerate after this change ships an `allow` array without those four IDs. OpenClaw classifies that as a `plugins` diff and triggers one SIGUSR1 gateway restart. Subsequent regenerates are idempotent. The cold-start cascade test (`00-config-idempotency.spec.ts:153`, *"at most one gateway restart in setup"*) still passes because the cascade resolves within the same setup window.

Fresh installs (volume populated from this image) get the new allow list on the first write and never see this transient.

## Test plan

- [x] New unit test in `openclaw-config.test.ts`: simulates an existing `openclaw.json` where OpenClaw has auto-populated `plugins.allow` with all seven bundled plugins and enriched `plugins.entries.acpx` with a sibling `hooks` block; asserts the four disabled IDs are filtered out of `allow`, `browser` / `memory-core` / `talk-voice` stay in, existing `plugins.entries.*` survive byte-for-byte, and their insertion order is preserved.
- [x] Full `packages/web` test suite (3625 tests) passes.
- [x] `Dockerfile.openclaw` builds locally (arm64) and cross-platform via `docker buildx --platform linux/amd64` (~14 s prewarm under qemu emulation).
- [x] Cross-built image deployed to staging, `pinchy_openclaw-config` volume wiped, fresh boot timed: no `staging bundled runtime deps` log, gateway ready ~48 s instead of ~75 s.

## Notes for reviewers

- Disable is enforced exclusively via `plugins.allow`. We deliberately do **not** stamp `plugins.entries.<id>.enabled = false`: OpenClaw enriches `plugins.entries.*` at runtime, and overwriting/removing entries surfaces as a `plugins` config diff → SIGUSR1 gateway restart on every Pinchy regenerate. The unit test asserts both the allow-filter and the entries-preservation halves.
- `config/prewarm-openclaw.sh` is invoked from `Dockerfile.openclaw`. The script is bash (not dash) because it uses `/dev/tcp/127.0.0.1/18789` to wait for the gateway port; debian-slim's default `RUN` shell has no `/dev/tcp` emulation and would silently never see the port open.
- The pre-warm config (`config/openclaw-prewarm.json`) is build-time-only. `prewarm-openclaw.sh` strips everything from `/root/.openclaw/` except `plugin-runtime-deps/` after the gateway shuts down, so the throwaway gateway token, generated devices, and any other build-time state never reaches the image.