### PR TITLE
fix(plugins): align pinchy-odoo + pinchy-web manifests with API-callback shape

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -255,6 +255,18 @@ Instead:
      `packages/plugins/pinchy-odoo/__tests__/integration.test.ts` for
      the canonical example.
    - Manual on staging.
+6. **Manifest contract:** every Pinchy plugin's `openclaw.plugin.json#configSchema`
+   must declare every field `regenerateOpenClawConfig()` writes (including
+   top-level `apiBaseUrl`, `gatewayToken`, and any per-agent fields), and use
+   `additionalProperties: false`. A contract test
+   (`packages/plugins/<plugin>/config-schema.test.ts`) validates a representative
+   emitted config against the manifest using Ajv. The build-time validator
+   `validateBuiltConfig()` in `packages/web/src/lib/openclaw-config/validate-built-config.ts`
+   enforces this at runtime — `regenerateOpenClawConfig()` refuses to write a config
+   that doesn't match every plugin's manifest. When onboarding a new plugin, update:
+   - `KNOWN_PINCHY_PLUGINS` in `plugin-manifest-loader.ts`
+   - The plugin's `openclaw.plugin.json#configSchema`
+   - A new `config-schema.test.ts` in the plugin directory
 
 #### Pattern C — Bootstrap credentials (plaintext, single source)
 
@@ -272,6 +284,15 @@ restarting OpenClaw.
 `sk-ant-…`, OpenAI `sk-…`, Gemini `AIza…`, etc.). Add a pattern there
 when you onboard any new provider whose secret has a recognisable
 prefix — even if you're following Pattern B.
+
+`packages/web/src/lib/openclaw-config/validate-built-config.ts`
+validates every emitted plugin entry against its manifest before
+`regenerateOpenClawConfig()` writes the config. This catches manifest /
+build.ts drift at startup so it can't surface as a silent `INVALID_CONFIG`
+rejection at OpenClaw hot-reload time (see staging incident 2026-05-04 —
+the pinchy-odoo staging block). Update the manifest, the `KNOWN_PINCHY_PLUGINS`
+list in `plugin-manifest-loader.ts`, and the contract test together when
+adding a new plugin.
 
 ### Documentation
 - **Docs site**: `docs/` directory, built with Astro Starlight. Deployed to [docs.heypinchy.com](https://docs.heypinchy.com).

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -17,6 +17,16 @@ RUN pnpm install --frozen-lockfile
 
 COPY packages/web packages/web
 
+# plugin-manifest-loader.ts imports these JSON manifests at Next.js build time
+# (static imports bundled by Turbopack). They must be present before `pnpm build`.
+COPY packages/plugins/pinchy-files/openclaw.plugin.json packages/plugins/pinchy-files/
+COPY packages/plugins/pinchy-context/openclaw.plugin.json packages/plugins/pinchy-context/
+COPY packages/plugins/pinchy-audit/openclaw.plugin.json packages/plugins/pinchy-audit/
+COPY packages/plugins/pinchy-docs/openclaw.plugin.json packages/plugins/pinchy-docs/
+COPY packages/plugins/pinchy-email/openclaw.plugin.json packages/plugins/pinchy-email/
+COPY packages/plugins/pinchy-odoo/openclaw.plugin.json packages/plugins/pinchy-odoo/
+COPY packages/plugins/pinchy-web/openclaw.plugin.json packages/plugins/pinchy-web/
+
 RUN cd packages/web && pnpm build
 
 EXPOSE 7777

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -11,6 +11,10 @@ services:
       - ./packages/web:/app/packages/web
       - /app/packages/web/node_modules
       - /app/packages/web/.next
+      # plugin-manifest-loader.ts resolves openclaw.plugin.json files at
+      # ../../../../plugins/<name>/ relative to web/src/lib/openclaw-config/.
+      # Mount read-only so the dev server can import them without a rebuild.
+      - ./packages/plugins:/app/packages/plugins:ro
   openclaw:
     build:
       context: .

--- a/packages/plugins/pinchy-audit/config-schema.test.ts
+++ b/packages/plugins/pinchy-audit/config-schema.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-audit");
+
+// Mirrors build.ts:314-320 — pinchy-audit has no per-agent config, just credentials.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+};
+
+describe("pinchy-audit manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl and gatewayToken", () => {
+    expect(validatePluginEntry(manifest, {}).ok).toBe(false);
+    expect(validatePluginEntry(manifest, { apiBaseUrl: "x" }).ok).toBe(false);
+    expect(validatePluginEntry(manifest, { gatewayToken: "x" }).ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-context/config-schema.test.ts
+++ b/packages/plugins/pinchy-context/config-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-context");
+
+// Mirrors build.ts:300-310 — apiBaseUrl/gatewayToken top-level, per-agent tools+userId.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+  agents: {
+    "agent-uuid": {
+      tools: ["save_user_context", "save_org_context"],
+      userId: "user-uuid",
+    },
+  },
+};
+
+describe("pinchy-context manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl, gatewayToken, agents at the top level", () => {
+    const partial = validatePluginEntry(manifest, { agents: {} });
+    expect(partial.ok).toBe(false);
+  });
+
+  it("requires tools and userId per agent", () => {
+    const result = validatePluginEntry(manifest, {
+      apiBaseUrl: "http://pinchy:7777",
+      gatewayToken: "test-token",
+      agents: { "agent-uuid": { tools: ["save_user_context"] } },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false at the top level", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-docs/config-schema.test.ts
+++ b/packages/plugins/pinchy-docs/config-schema.test.ts
@@ -1,0 +1,30 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-docs");
+
+// Mirrors build.ts:289-296 — agents map to empty objects.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  docsPath: "/pinchy-docs",
+  agents: {
+    "agent-uuid": {},
+  },
+};
+
+describe("pinchy-docs manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires docsPath and agents", () => {
+    expect(validatePluginEntry(manifest, { agents: {} }).ok).toBe(false);
+    expect(validatePluginEntry(manifest, { docsPath: "/x" }).ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-email/config-schema.test.ts
+++ b/packages/plugins/pinchy-email/config-schema.test.ts
@@ -23,8 +23,14 @@ describe("pinchy-email manifest contract", () => {
     expect(result.ok).toBe(true);
   });
 
-  it("requires apiBaseUrl, gatewayToken, agents at the top level", () => {
+  it("requires apiBaseUrl and gatewayToken (missing either fails)", () => {
     expect(validatePluginEntry(manifest, { agents: {} }).ok).toBe(false);
+  });
+
+  it("requires agents at the top level (missing agents fails)", () => {
+    expect(
+      validatePluginEntry(manifest, { apiBaseUrl: "http://x", gatewayToken: "t" }).ok,
+    ).toBe(false);
   });
 
   it("requires connectionId and permissions per agent", () => {

--- a/packages/plugins/pinchy-email/config-schema.test.ts
+++ b/packages/plugins/pinchy-email/config-schema.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-email");
+
+// Mirrors build.ts:507-517 — top-level api fields, per-agent connectionId+permissions.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+  agents: {
+    "agent-uuid": {
+      connectionId: "conn-uuid",
+      permissions: { "messages.send": ["send"] },
+    },
+  },
+};
+
+describe("pinchy-email manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl, gatewayToken, agents at the top level", () => {
+    expect(validatePluginEntry(manifest, { agents: {} }).ok).toBe(false);
+  });
+
+  it("requires connectionId and permissions per agent", () => {
+    expect(
+      validatePluginEntry(manifest, {
+        apiBaseUrl: "http://x",
+        gatewayToken: "t",
+        agents: { "a-1": { connectionId: "c-1" } },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-email/openclaw.plugin.json
+++ b/packages/plugins/pinchy-email/openclaw.plugin.json
@@ -4,6 +4,7 @@
   "description": "Email integration (Gmail, Outlook, IMAP) with per-agent permissions.",
   "configSchema": {
     "type": "object",
+    "additionalProperties": false,
     "properties": {
       "apiBaseUrl": { "type": "string" },
       "gatewayToken": { "type": "string" },
@@ -11,6 +12,7 @@
         "type": "object",
         "additionalProperties": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "connectionId": { "type": "string" },
             "permissions": { "type": "object" }

--- a/packages/plugins/pinchy-files/config-schema.test.ts
+++ b/packages/plugins/pinchy-files/config-schema.test.ts
@@ -1,3 +1,15 @@
+/**
+ * Validates that the pinchy-files plugin configSchema declares all fields
+ * that Pinchy's regenerateOpenClawConfig() writes into it.
+ *
+ * OpenClaw rejects config reloads when the config contains properties not
+ * declared in the plugin schema (additionalProperties: false). When that
+ * happens, agents created after the last successful reload are unknown to
+ * OpenClaw — they can't receive messages.
+ *
+ * This test catches schema/config divergence at CI time rather than at
+ * runtime, where it would silently block all config hot-reloads.
+ */
 import { describe, it, expect } from "vitest";
 import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
 import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";

--- a/packages/plugins/pinchy-files/config-schema.test.ts
+++ b/packages/plugins/pinchy-files/config-schema.test.ts
@@ -1,53 +1,36 @@
-/**
- * Validates that the pinchy-files plugin configSchema declares all fields
- * that Pinchy's regenerateOpenClawConfig() writes into it.
- *
- * OpenClaw rejects config reloads when the config contains properties not
- * declared in the plugin schema (additionalProperties: false). When that
- * happens, agents created after the last successful reload are unknown to
- * OpenClaw — they can't receive messages.
- *
- * This test catches schema/config divergence at CI time rather than at
- * runtime, where it would silently block all config hot-reloads.
- */
 import { describe, it, expect } from "vitest";
-import { readFileSync } from "fs";
-import { resolve, dirname } from "path";
-import { fileURLToPath } from "url";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
 
-const __dirname = dirname(fileURLToPath(import.meta.url));
+const manifest = loadPluginManifest("pinchy-files");
 
-const manifest = JSON.parse(
-  readFileSync(resolve(__dirname, "openclaw.plugin.json"), "utf-8"),
-);
-const configSchema = manifest.configSchema as {
-  type: string;
-  additionalProperties: boolean;
-  properties: Record<string, unknown>;
-  required?: string[];
+// Mirrors the shape regenerateOpenClawConfig() emits at packages/web/src/lib/openclaw-config/build.ts:260-270.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+  agents: {
+    "agent-uuid": {
+      allowed_paths: ["/data/knowledge-base"],
+    },
+  },
 };
 
-describe("pinchy-files configSchema", () => {
-  it("has additionalProperties: false (OpenClaw enforces this)", () => {
-    // If this changes, OpenClaw will stop enforcing the schema contract.
-    expect(configSchema.additionalProperties).toBe(false);
+describe("pinchy-files manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
   });
 
-  it("allows apiBaseUrl — written by regenerateOpenClawConfig() for usage reporting", () => {
-    // Pinchy writes this field so the plugin can POST token usage to
-    // /api/internal/usage/record after vision API calls (PDF scanning).
-    // Without it in the schema, OpenClaw rejects every config reload.
-    expect(configSchema.properties).toHaveProperty("apiBaseUrl");
+  it("rejects an empty config (agents is required)", () => {
+    const result = validatePluginEntry(manifest, {
+      apiBaseUrl: "http://pinchy:7777",
+      gatewayToken: "test-token",
+    });
+    expect(result.ok).toBe(false);
   });
 
-  it("allows gatewayToken — written by regenerateOpenClawConfig() for internal auth", () => {
-    // Pinchy writes this field alongside apiBaseUrl so the plugin can
-    // authenticate against Pinchy's internal API.
-    expect(configSchema.properties).toHaveProperty("gatewayToken");
-  });
-
-  it("requires agents property", () => {
-    expect(configSchema.required).toContain("agents");
-    expect(configSchema.properties).toHaveProperty("agents");
+  it("uses additionalProperties: false at the top level", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
   });
 });

--- a/packages/plugins/pinchy-odoo/config-schema.test.ts
+++ b/packages/plugins/pinchy-odoo/config-schema.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-odoo");
+
+// Mirrors build.ts:403-419 exactly — connectionId (NOT connection), permissions, modelNames.
+// Plus top-level apiBaseUrl + gatewayToken used by the plugin's credential-fetch path.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+  agents: {
+    "agent-uuid": {
+      connectionId: "conn-uuid",
+      permissions: {
+        "crm.lead": ["read", "create"],
+        "res.partner": ["read"],
+      },
+      modelNames: {
+        "crm.lead": "Leads & Opportunities",
+        "res.partner": "Contacts",
+      },
+    },
+  },
+};
+
+describe("pinchy-odoo manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl, gatewayToken, agents at the top level", () => {
+    expect(validatePluginEntry(manifest, { agents: {} }).ok).toBe(false);
+  });
+
+  it("requires connectionId and permissions per agent (modelNames optional)", () => {
+    const noConnId = validatePluginEntry(manifest, {
+      apiBaseUrl: "x",
+      gatewayToken: "t",
+      agents: { "a-1": { permissions: {} } },
+    });
+    expect(noConnId.ok).toBe(false);
+
+    const noPerms = validatePluginEntry(manifest, {
+      apiBaseUrl: "x",
+      gatewayToken: "t",
+      agents: { "a-1": { connectionId: "c-1" } },
+    });
+    expect(noPerms.ok).toBe(false);
+
+    const noModelNames = validatePluginEntry(manifest, {
+      apiBaseUrl: "x",
+      gatewayToken: "t",
+      agents: { "a-1": { connectionId: "c-1", permissions: {} } },
+    });
+    expect(noModelNames.ok).toBe(true);
+  });
+
+  it("rejects the legacy connection (object) field that pre-#209 builds wrote", () => {
+    const result = validatePluginEntry(manifest, {
+      apiBaseUrl: "x",
+      gatewayToken: "t",
+      agents: {
+        "a-1": {
+          connection: { url: "x", db: "x", uid: 1, apiKey: "x" },
+          permissions: {},
+        },
+      },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-odoo/openclaw.plugin.json
+++ b/packages/plugins/pinchy-odoo/openclaw.plugin.json
@@ -1,23 +1,27 @@
 {
   "id": "pinchy-odoo",
   "name": "Pinchy Odoo",
-  "description": "Odoo ERP integration with model-level permissions.",
+  "description": "Odoo ERP integration with model-level permissions. Credentials are fetched at runtime from Pinchy's internal credentials API — never stored in this config.",
   "configSchema": {
     "type": "object",
+    "additionalProperties": false,
     "properties": {
+      "apiBaseUrl": { "type": "string" },
+      "gatewayToken": { "type": "string" },
       "agents": {
         "type": "object",
         "additionalProperties": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
-            "connection": { "type": "object" },
+            "connectionId": { "type": "string" },
             "permissions": { "type": "object" },
-            "schema": { "type": "object" }
+            "modelNames": { "type": "object" }
           },
-          "required": ["connection", "permissions"]
+          "required": ["connectionId", "permissions"]
         }
       }
     },
-    "required": ["agents"]
+    "required": ["apiBaseUrl", "gatewayToken", "agents"]
   }
 }

--- a/packages/plugins/pinchy-web/config-schema.test.ts
+++ b/packages/plugins/pinchy-web/config-schema.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-web");
+
+// Mirrors build.ts:452-461 — top-level apiBaseUrl + gatewayToken + connectionId,
+// per-agent tools (required) plus optional domain/locale filters.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+  connectionId: "conn-uuid",
+  agents: {
+    "agent-uuid": {
+      tools: ["pinchy_web_search", "pinchy_web_fetch"],
+      allowedDomains: ["example.com"],
+      excludedDomains: ["spam.example"],
+      language: "de",
+      country: "AT",
+      freshness: "month",
+    },
+  },
+};
+
+describe("pinchy-web manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl, gatewayToken, connectionId, agents at the top level", () => {
+    expect(validatePluginEntry(manifest, { agents: {} }).ok).toBe(false);
+  });
+
+  it("requires tools per agent", () => {
+    expect(
+      validatePluginEntry(manifest, {
+        apiBaseUrl: "x",
+        gatewayToken: "t",
+        connectionId: "c",
+        agents: { "a-1": {} },
+      }).ok,
+    ).toBe(false);
+  });
+
+  it("rejects the legacy braveApiKey field (pre-#209)", () => {
+    const result = validatePluginEntry(manifest, {
+      apiBaseUrl: "x",
+      gatewayToken: "t",
+      connectionId: "c",
+      braveApiKey: "sk-...",
+      agents: { "a-1": { tools: [] } },
+    });
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-web/openclaw.plugin.json
+++ b/packages/plugins/pinchy-web/openclaw.plugin.json
@@ -1,28 +1,26 @@
 {
   "id": "pinchy-web",
   "name": "Pinchy Web",
-  "description": "Web search and page fetching with domain filtering.",
+  "description": "Web search and page fetching with domain filtering. Credentials are fetched at runtime from Pinchy's internal credentials API — never stored in this config.",
   "configSchema": {
     "type": "object",
+    "additionalProperties": false,
     "properties": {
-      "braveApiKey": { "type": "string" },
+      "apiBaseUrl": { "type": "string" },
+      "gatewayToken": { "type": "string" },
+      "connectionId": { "type": "string" },
       "agents": {
         "type": "object",
         "additionalProperties": {
           "type": "object",
+          "additionalProperties": false,
           "properties": {
             "tools": {
               "type": "array",
               "items": { "type": "string" }
             },
-            "allowedDomains": {
-              "type": "array",
-              "items": { "type": "string" }
-            },
-            "excludedDomains": {
-              "type": "array",
-              "items": { "type": "string" }
-            },
+            "allowedDomains": { "type": "array", "items": { "type": "string" } },
+            "excludedDomains": { "type": "array", "items": { "type": "string" } },
             "language": { "type": "string" },
             "country": { "type": "string" },
             "freshness": { "type": "string" }
@@ -31,6 +29,6 @@
         }
       }
     },
-    "required": ["braveApiKey", "agents"]
+    "required": ["apiBaseUrl", "gatewayToken", "connectionId", "agents"]
   }
 }

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -131,6 +131,48 @@ test.describe("Odoo Agent Chat", () => {
     });
   });
 
+  test("OpenClaw accepts the regenerated config when an Odoo agent gets permissions and tools", async () => {
+    // This is the regression guard for the staging block (2026-05-04).
+    // Pre-fix: setting Odoo permissions caused regenerateOpenClawConfig() to write a
+    // config that OpenClaw rejected with INVALID_CONFIG (manifest required 'connection'
+    // object, build.ts wrote 'connectionId' string since the API-callback migration).
+    // Post-fix: the manifest matches the emitted shape; OpenClaw accepts the config.
+
+    // Grant permissions — triggers regenerateOpenClawConfig() on the server.
+    const putRes = await setAgentPermissions(cookie, agentId, connectionId, [
+      { model: "crm.lead", operation: "read" },
+    ]);
+    expect(putRes.status).toBe(200);
+
+    // Grant Odoo tools — a second config regen, this time plugins.entries["pinchy-odoo"] is emitted.
+    const patchRes = await pinchyPatch(
+      `/api/agents/${agentId}`,
+      { allowedTools: ["odoo_schema", "odoo_read", "odoo_count"] },
+      cookie
+    );
+    expect(patchRes.status).toBe(200);
+
+    // Give OpenClaw time to pick up the hot-reload via inotify and re-validate the config.
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // Verify the gateway is still connected. If the old broken manifest was in place,
+    // OpenClaw would log INVALID_CONFIG and may disconnect from the Pinchy WebSocket bridge.
+    const healthRes = await pinchyGet("/api/health/openclaw", cookie);
+    expect(healthRes.status).toBe(200);
+    const health = await healthRes.json();
+    expect(health.connected).toBe(true);
+
+    // Double-check: the integration data has the connectionId shape (not legacy 'connection' object).
+    const intRes = await pinchyGet(`/api/agents/${agentId}/integrations`, cookie);
+    expect(intRes.status).toBe(200);
+    const integrations = await intRes.json();
+    const odooInt = integrations.find(
+      (i: { connectionId: string }) => i.connectionId === connectionId
+    );
+    expect(odooInt).toBeTruthy();
+    expect(typeof odooInt.connectionId).toBe("string");
+  });
+
   test("audit trail records tool usage via internal endpoint", async () => {
     // The tool-use audit endpoint requires a gateway token. We call it
     // directly with an Authorization header to verify the endpoint works.

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -14,6 +14,20 @@ import {
 
 const MOCK_ODOO_URL = process.env.MOCK_ODOO_URL || "http://localhost:9002";
 
+/** Poll /api/health/openclaw until `connected` is true or the timeout elapses. */
+async function pollUntilOpenClawConnected(cookie: string, maxMs: number): Promise<boolean> {
+  const deadline = Date.now() + maxMs;
+  while (Date.now() < deadline) {
+    const res = await pinchyGet("/api/health/openclaw", cookie);
+    if (res.ok) {
+      const body = (await res.json()) as { connected?: boolean };
+      if (body.connected) return true;
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  return false;
+}
+
 test.describe("Odoo Agent Chat", () => {
   let cookie: string;
   let connectionId: string;
@@ -152,15 +166,12 @@ test.describe("Odoo Agent Chat", () => {
     );
     expect(patchRes.status).toBe(200);
 
-    // Give OpenClaw time to pick up the hot-reload via inotify and re-validate the config.
-    await new Promise((r) => setTimeout(r, 3000));
-
-    // Verify the gateway is still connected. If the old broken manifest was in place,
-    // OpenClaw would log INVALID_CONFIG and may disconnect from the Pinchy WebSocket bridge.
-    const healthRes = await pinchyGet("/api/health/openclaw", cookie);
-    expect(healthRes.status).toBe(200);
-    const health = await healthRes.json();
-    expect(health.connected).toBe(true);
+    // Poll /api/health/openclaw until OpenClaw reports connected=true after the
+    // inotify hot-reload, with a generous timeout for slow CI environments.
+    // The inotifywait grace period in start-openclaw.sh is 30 s; 10 s is enough
+    // in practice (reload happens within ~1–2 s after the file write).
+    const connected = await pollUntilOpenClawConnected(cookie, 10_000);
+    expect(connected).toBe(true);
 
     // Double-check: the integration data has the connectionId shape (not legacy 'connection' object).
     const intRes = await pinchyGet(`/api/agents/${agentId}/integrations`, cookie);

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -32,6 +32,7 @@
     "@dicebear/fun-emoji": "^9.4.2",
     "@hookform/resolvers": "^5.2.2",
     "@types/pdfkit": "^0.17.6",
+    "ajv": "^8.20.0",
     "bcryptjs": "^3.0.3",
     "better-auth": "^1.6.9",
     "class-variance-authority": "^0.7.1",

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -63,6 +63,14 @@ vi.mock("@/server/restart-state", () => ({
   restartState: { notifyRestart: vi.fn() },
 }));
 
+const { mockValidateBuiltConfig } = vi.hoisted(() => ({
+  mockValidateBuiltConfig: vi.fn().mockReturnValue({ ok: true }),
+}));
+
+vi.mock("@/lib/openclaw-config/validate-built-config", () => ({
+  validateBuiltConfig: mockValidateBuiltConfig,
+}));
+
 const { mockedGetOrCreateGatewayToken } = vi.hoisted(() => ({
   mockedGetOrCreateGatewayToken: vi.fn().mockResolvedValue("test-gateway-token"),
 }));
@@ -4003,5 +4011,22 @@ describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support Se
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
     expect(config.channels.telegram.accounts["agent-99"].botToken).toBe("tg-secret-token");
+  });
+});
+
+describe("regenerateOpenClawConfig validation guard", () => {
+  beforeEach(() => {
+    mockValidateBuiltConfig.mockReturnValue({ ok: true });
+    mockedReadFileSync.mockReturnValue("");
+  });
+
+  it("throws when validateBuiltConfig reports an invalid plugin config", async () => {
+    mockValidateBuiltConfig.mockReturnValueOnce({
+      ok: false,
+      errors: ["pinchy-odoo: agents: injected test error"],
+    });
+    await expect(regenerateOpenClawConfig()).rejects.toThrow(
+      /Refusing to write invalid plugin config/
+    );
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config/plugin-manifest-loader.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/plugin-manifest-loader.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import {
+  loadPluginManifest,
+  KNOWN_PINCHY_PLUGINS,
+} from "@/lib/openclaw-config/plugin-manifest-loader";
+
+describe("loadPluginManifest", () => {
+  it.each(KNOWN_PINCHY_PLUGINS)("loads the %s manifest with id and configSchema", (id) => {
+    const manifest = loadPluginManifest(id);
+    expect(manifest.id).toBe(id);
+    expect(manifest.configSchema).toBeDefined();
+    expect(typeof manifest.configSchema).toBe("object");
+  });
+
+  it("throws when the plugin id is unknown", () => {
+    expect(() => loadPluginManifest("pinchy-does-not-exist" as never)).toThrow(/unknown.*pinchy/i);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/plugin-schema.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/plugin-schema.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "@/lib/openclaw-config/plugin-schema";
+
+const FAKE_MANIFEST = {
+  id: "pinchy-fake",
+  name: "Pinchy Fake",
+  description: "Test plugin",
+  configSchema: {
+    type: "object",
+    additionalProperties: false,
+    properties: {
+      apiBaseUrl: { type: "string" },
+      agents: {
+        type: "object",
+        additionalProperties: {
+          type: "object",
+          properties: { connectionId: { type: "string" } },
+          required: ["connectionId"],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ["apiBaseUrl", "agents"],
+  },
+};
+
+describe("validatePluginEntry", () => {
+  it("returns ok=true for a config that matches the schema", () => {
+    const result = validatePluginEntry(FAKE_MANIFEST, {
+      apiBaseUrl: "http://pinchy:7777",
+      agents: { "agent-1": { connectionId: "conn-1" } },
+    });
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok=false with errors when a required field is missing", () => {
+    const result = validatePluginEntry(FAKE_MANIFEST, {
+      agents: { "agent-1": { connectionId: "conn-1" } },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]).toContain("apiBaseUrl");
+    }
+  });
+
+  it("returns ok=false when an undeclared property is present", () => {
+    const result = validatePluginEntry(FAKE_MANIFEST, {
+      apiBaseUrl: "http://pinchy:7777",
+      agents: {},
+      bogus: 42,
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.join(" ")).toMatch(/bogus|additional/i);
+    }
+  });
+
+  it("formats errors with the dotted instance path", () => {
+    const result = validatePluginEntry(FAKE_MANIFEST, {
+      apiBaseUrl: "http://pinchy:7777",
+      agents: { "agent-1": {} },
+    });
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors[0]).toMatch(/agents\.agent-1.*connectionId/);
+    }
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
@@ -58,6 +58,25 @@ describe("validateBuiltConfig", () => {
     expect(validateBuiltConfig({ plugins: { allow: [], entries: {} } }).ok).toBe(true);
   });
 
+  it("returns ok=false when a known plugin entry has no config block (build.ts regression)", () => {
+    // If build.ts accidentally omits the config block for a known plugin, the guard
+    // must catch it — not silently pass it through to OpenClaw.
+    const config = {
+      plugins: {
+        allow: ["pinchy-audit"],
+        entries: {
+          "pinchy-audit": { enabled: true },
+          // no `config` key at all
+        },
+      },
+    };
+    const result = validateBuiltConfig(config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.join("\n")).toMatch(/pinchy-audit/);
+    }
+  });
+
   it("validates every Pinchy plugin entry, not just the first failing one", () => {
     const config = {
       plugins: {

--- a/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from "vitest";
+import { validateBuiltConfig } from "@/lib/openclaw-config/validate-built-config";
+
+describe("validateBuiltConfig", () => {
+  it("returns ok=true when every emitted plugin entry matches its manifest", () => {
+    const config = {
+      plugins: {
+        allow: ["pinchy-audit"],
+        entries: {
+          "pinchy-audit": {
+            enabled: true,
+            config: {
+              apiBaseUrl: "http://pinchy:7777",
+              gatewayToken: "t",
+            },
+          },
+        },
+      },
+    };
+    const result = validateBuiltConfig(config);
+    expect(result.ok).toBe(true);
+  });
+
+  it("returns ok=false with plugin-id-tagged errors when an entry doesn't match its manifest", () => {
+    const config = {
+      plugins: {
+        allow: ["pinchy-odoo"],
+        entries: {
+          "pinchy-odoo": {
+            enabled: true,
+            config: {},
+          },
+        },
+      },
+    };
+    const result = validateBuiltConfig(config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(result.errors.join("\n")).toMatch(/pinchy-odoo/);
+    }
+  });
+
+  it("ignores non-Pinchy plugins (e.g. anthropic, telegram)", () => {
+    const config = {
+      plugins: {
+        allow: ["anthropic", "telegram"],
+        entries: {
+          anthropic: { enabled: true },
+          telegram: { enabled: true, config: { whatever: 1 } },
+        },
+      },
+    };
+    expect(validateBuiltConfig(config).ok).toBe(true);
+  });
+
+  it("returns ok=true when there are no plugins at all (empty entries)", () => {
+    expect(validateBuiltConfig({}).ok).toBe(true);
+    expect(validateBuiltConfig({ plugins: { allow: [], entries: {} } }).ok).toBe(true);
+  });
+
+  it("validates every Pinchy plugin entry, not just the first failing one", () => {
+    const config = {
+      plugins: {
+        allow: ["pinchy-odoo", "pinchy-web"],
+        entries: {
+          "pinchy-odoo": { enabled: true, config: {} },
+          "pinchy-web": { enabled: true, config: {} },
+        },
+      },
+    };
+    const result = validateBuiltConfig(config);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      const joined = result.errors.join("\n");
+      expect(joined).toMatch(/pinchy-odoo/);
+      expect(joined).toMatch(/pinchy-web/);
+    }
+  });
+});

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -26,6 +26,7 @@ import {
   readGatewayTokenFromConfig,
 } from "./secrets-bundle";
 import { writeAgentAuthProfiles, type AuthProfilesProvider } from "./agent-auth-profiles";
+import { validateBuiltConfig } from "./validate-built-config";
 
 function deepMerge(
   target: Record<string, unknown>,
@@ -755,6 +756,18 @@ export async function regenerateOpenClawConfig() {
     integrations: integrationSecrets,
   });
   writeSecretsFile(secretsBundle);
+
+  // Defense in depth: validate every emitted Pinchy plugin entry against its
+  // manifest before writing. Catches manifest/build.ts drift at startup rather
+  // than letting OpenClaw silently reject the config at hot-reload time.
+  const validation = validateBuiltConfig(config);
+  if (!validation.ok) {
+    throw new Error(
+      "[openclaw-config] Refusing to write invalid plugin config:\n  - " +
+        validation.errors.join("\n  - ") +
+        "\nFix the plugin manifest or what build.ts emits."
+    );
+  }
 
   // Only write if content actually changed — prevents unnecessary OpenClaw restarts.
   // Format must match what OpenClaw's writeConfigFile produces (trimEnd + "\n")

--- a/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
@@ -1,0 +1,44 @@
+import pinchyFilesManifest from "../../../../plugins/pinchy-files/openclaw.plugin.json";
+import pinchyContextManifest from "../../../../plugins/pinchy-context/openclaw.plugin.json";
+import pinchyAuditManifest from "../../../../plugins/pinchy-audit/openclaw.plugin.json";
+import pinchyDocsManifest from "../../../../plugins/pinchy-docs/openclaw.plugin.json";
+import pinchyEmailManifest from "../../../../plugins/pinchy-email/openclaw.plugin.json";
+import pinchyOdooManifest from "../../../../plugins/pinchy-odoo/openclaw.plugin.json";
+import pinchyWebManifest from "../../../../plugins/pinchy-web/openclaw.plugin.json";
+
+export const KNOWN_PINCHY_PLUGINS = [
+  "pinchy-files",
+  "pinchy-context",
+  "pinchy-audit",
+  "pinchy-docs",
+  "pinchy-email",
+  "pinchy-odoo",
+  "pinchy-web",
+] as const;
+
+export type KnownPinchyPlugin = (typeof KNOWN_PINCHY_PLUGINS)[number];
+
+export interface PluginManifest {
+  id: KnownPinchyPlugin;
+  name: string;
+  description?: string;
+  configSchema: Record<string, unknown>;
+}
+
+const MANIFESTS: Record<KnownPinchyPlugin, PluginManifest> = {
+  "pinchy-files": pinchyFilesManifest as unknown as PluginManifest,
+  "pinchy-context": pinchyContextManifest as unknown as PluginManifest,
+  "pinchy-audit": pinchyAuditManifest as unknown as PluginManifest,
+  "pinchy-docs": pinchyDocsManifest as unknown as PluginManifest,
+  "pinchy-email": pinchyEmailManifest as unknown as PluginManifest,
+  "pinchy-odoo": pinchyOdooManifest as unknown as PluginManifest,
+  "pinchy-web": pinchyWebManifest as unknown as PluginManifest,
+};
+
+export function loadPluginManifest(id: KnownPinchyPlugin): PluginManifest {
+  const manifest = MANIFESTS[id];
+  if (!manifest) {
+    throw new Error(`Unknown Pinchy plugin id: ${id}`);
+  }
+  return manifest;
+}

--- a/packages/web/src/lib/openclaw-config/plugin-schema.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-schema.ts
@@ -1,17 +1,18 @@
 import Ajv, { type ErrorObject } from "ajv";
 
-interface PluginManifest {
-  id: string;
-  configSchema: Record<string, unknown>;
-}
-
 export type ValidationResult = { ok: true } | { ok: false; errors: string[] };
 
+// strict: false suppresses Ajv warnings about unknown keywords that appear in
+// OpenClaw plugin manifests (e.g. vendor extensions). Without it, every
+// compilation emits noisy console warnings.
 const ajv = new Ajv({ allErrors: true, strict: false });
 
 const compiledByPluginId = new Map<string, ReturnType<typeof ajv.compile>>();
 
-export function validatePluginEntry(manifest: PluginManifest, config: unknown): ValidationResult {
+export function validatePluginEntry(
+  manifest: { id: string; configSchema: Record<string, unknown> },
+  config: unknown
+): ValidationResult {
   let validate = compiledByPluginId.get(manifest.id);
   if (!validate) {
     validate = ajv.compile(manifest.configSchema);

--- a/packages/web/src/lib/openclaw-config/plugin-schema.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-schema.ts
@@ -1,0 +1,35 @@
+import Ajv, { type ErrorObject } from "ajv";
+
+interface PluginManifest {
+  id: string;
+  configSchema: Record<string, unknown>;
+}
+
+export type ValidationResult = { ok: true } | { ok: false; errors: string[] };
+
+const ajv = new Ajv({ allErrors: true, strict: false });
+
+const compiledByPluginId = new Map<string, ReturnType<typeof ajv.compile>>();
+
+export function validatePluginEntry(manifest: PluginManifest, config: unknown): ValidationResult {
+  let validate = compiledByPluginId.get(manifest.id);
+  if (!validate) {
+    validate = ajv.compile(manifest.configSchema);
+    compiledByPluginId.set(manifest.id, validate);
+  }
+  const ok = validate(config);
+  if (ok) return { ok: true };
+  return {
+    ok: false,
+    errors: (validate.errors ?? []).map(formatAjvError),
+  };
+}
+
+function formatAjvError(err: ErrorObject): string {
+  const path = err.instancePath
+    ? err.instancePath.replace(/^\//, "").replace(/\//g, ".")
+    : "<root>";
+  const detail =
+    err.params && Object.keys(err.params).length ? ` (${JSON.stringify(err.params)})` : "";
+  return `${path}: ${err.message ?? "invalid"}${detail}`;
+}

--- a/packages/web/src/lib/openclaw-config/validate-built-config.ts
+++ b/packages/web/src/lib/openclaw-config/validate-built-config.ts
@@ -1,0 +1,33 @@
+import { validatePluginEntry } from "./plugin-schema";
+import {
+  loadPluginManifest,
+  KNOWN_PINCHY_PLUGINS,
+  type KnownPinchyPlugin,
+} from "./plugin-manifest-loader";
+
+const KNOWN = new Set<string>(KNOWN_PINCHY_PLUGINS);
+
+export type BuiltConfigValidationResult = { ok: true } | { ok: false; errors: string[] };
+
+export function validateBuiltConfig(config: unknown): BuiltConfigValidationResult {
+  if (!config || typeof config !== "object") return { ok: true };
+  const plugins = (config as Record<string, unknown>).plugins as
+    | { entries?: Record<string, unknown> }
+    | undefined;
+  const entries = plugins?.entries ?? {};
+
+  const errors: string[] = [];
+  for (const [pluginId, rawEntry] of Object.entries(entries)) {
+    if (!KNOWN.has(pluginId)) continue;
+    const entry = rawEntry as { config?: unknown } | undefined;
+    if (!entry || entry.config === undefined) continue;
+    const manifest = loadPluginManifest(pluginId as KnownPinchyPlugin);
+    const result = validatePluginEntry(manifest, entry.config);
+    if (!result.ok) {
+      for (const err of result.errors) {
+        errors.push(`${pluginId}: ${err}`);
+      }
+    }
+  }
+  return errors.length ? { ok: false, errors } : { ok: true };
+}

--- a/packages/web/src/lib/openclaw-config/validate-built-config.ts
+++ b/packages/web/src/lib/openclaw-config/validate-built-config.ts
@@ -20,7 +20,10 @@ export function validateBuiltConfig(config: unknown): BuiltConfigValidationResul
   for (const [pluginId, rawEntry] of Object.entries(entries)) {
     if (!KNOWN.has(pluginId)) continue;
     const entry = rawEntry as { config?: unknown } | undefined;
-    if (!entry || entry.config === undefined) continue;
+    if (!entry) continue;
+    // entry.config may be undefined if build.ts accidentally omits the config block.
+    // Pass it through to validatePluginEntry — the schema (type: "object", required: [...])
+    // will reject it, so the guard catches the regression rather than silently skipping it.
     const manifest = loadPluginManifest(pluginId as KnownPinchyPlugin);
     const result = validatePluginEntry(manifest, entry.config);
     if (!result.ok) {

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -10,8 +10,13 @@ export default defineConfig({
     globals: true,
     include: [
       "src/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-odoo/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-audit/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-context/**/*.{test,spec}.?(c|m)[jt]s?(x)",
       "../plugins/pinchy-docs/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-email/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-files/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-odoo/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-web/**/*.{test,spec}.?(c|m)[jt]s?(x)",
     ],
     // Integration tests run against a real PostgreSQL database via
     // vitest.integration.config.ts (`pnpm test:db`). Excluded here so

--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -10,13 +10,16 @@ export default defineConfig({
     globals: true,
     include: [
       "src/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-audit/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-context/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      // Contract tests for all Pinchy plugins — validate the emitted config shape
+      // against each plugin's openclaw.plugin.json manifest. These files only import
+      // from @pinchy/web helpers and have no heavy plugin-specific native deps.
+      "../plugins/pinchy-audit/config-schema.test.ts",
+      "../plugins/pinchy-context/config-schema.test.ts",
       "../plugins/pinchy-docs/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-email/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-files/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-email/config-schema.test.ts",
+      "../plugins/pinchy-files/config-schema.test.ts",
       "../plugins/pinchy-odoo/**/*.{test,spec}.?(c|m)[jt]s?(x)",
-      "../plugins/pinchy-web/**/*.{test,spec}.?(c|m)[jt]s?(x)",
+      "../plugins/pinchy-web/config-schema.test.ts",
     ],
     // Integration tests run against a real PostgreSQL database via
     // vitest.integration.config.ts (`pnpm test:db`). Excluded here so

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -52,6 +52,9 @@ importers:
       '@types/pdfkit':
         specifier: ^0.17.6
         version: 0.17.6
+      ajv:
+        specifier: ^8.20.0
+        version: 8.20.0
       bcryptjs:
         specifier: ^3.0.3
         version: 3.0.3
@@ -2490,6 +2493,9 @@ packages:
   ajv@6.14.0:
     resolution: {integrity: sha512-IWrosm/yrn43eiKqkfkHis7QioDleaXQHdDVPKg0FSwwd/DuvyX79TZnFOnYpB7dcsFAMmtFztZuXPDvSePkFw==}
 
+  ajv@8.20.0:
+    resolution: {integrity: sha512-Thbli+OlOj+iMPYFBVBfJ3OmCAnaSyNn4M1vz9T6Gka5Jt9ba/HIR56joy65tY6kx/FCF5VXNB819Y7/GUrBGA==}
+
   ansi-escapes@7.3.0:
     resolution: {integrity: sha512-BvU8nYgGQBxcmMuEeUEmNTvrMVjJNSH7RgW24vXexN4Ven6qCvy4TntnvlnwnMLTVlcRQQdbRY8NKnaIoeWDNg==}
     engines: {node: '>=18'}
@@ -3293,6 +3299,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-uri@3.1.0:
+    resolution: {integrity: sha512-iPeeDKJSWf4IEOasVVrknXpaBV0IApz/gp7S2bb7Z4Lljbl2MGJRqInZiUrQwV16cpzw/D3S5j5Julj/gT52AA==}
+
   fastq@1.20.1:
     resolution: {integrity: sha512-GGToxJ/w1x32s/D2EKND7kTil4n8OVk/9mycTc4VDza13lOvpUZTGX3mFSCtV9ksdGBVzvsyAVLM6mHFThxXxw==}
 
@@ -3677,6 +3686,9 @@ packages:
 
   json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
+
+  json-schema-traverse@1.0.0:
+    resolution: {integrity: sha512-NM8/P9n3XjXhIZn1lLhkFaACTOURQXjWhV4BA/RnOv8xvgqtqpAX9IO4mRQxSx1Rlo4tqzeqb0sOlruaOy3dug==}
 
   json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}
@@ -7094,6 +7106,13 @@ snapshots:
       json-schema-traverse: 0.4.1
       uri-js: 4.4.1
 
+  ajv@8.20.0:
+    dependencies:
+      fast-deep-equal: 3.1.3
+      fast-uri: 3.1.0
+      json-schema-traverse: 1.0.0
+      require-from-string: 2.0.2
+
   ansi-escapes@7.3.0:
     dependencies:
       environment: 1.1.0
@@ -7964,6 +7983,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-uri@3.1.0: {}
+
   fastq@1.20.1:
     dependencies:
       reusify: 1.1.0
@@ -8366,6 +8387,8 @@ snapshots:
   json-buffer@3.0.1: {}
 
   json-schema-traverse@0.4.1: {}
+
+  json-schema-traverse@1.0.0: {}
 
   json-stable-stringify-without-jsonify@1.0.1: {}
 


### PR DESCRIPTION
## Summary

Fixes the staging blocker where Odoo agents couldn't respond due to an `INVALID_CONFIG` error from OpenClaw:

```
Error: Invalid config at /root/.openclaw/openclaw.json:
  - plugins.entries.pinchy-odoo.config.agents.c38fced5.connection:
    invalid config: must have required property 'connection': code=INVALID_CONFIG
```

**Root cause:** After the API-callback migration (#209), `build.ts` writes `connectionId: string` into the pinchy-odoo config, but the plugin's `openclaw.plugin.json` manifest still required the old pre-migration `connection: object` field. Same issue existed in pinchy-web (required `braveApiKey` from the old shape).

## What changed

### Layer 1 — Fix the broken manifests (the actual bug fix)
- **`pinchy-odoo/openclaw.plugin.json`**: Updated `configSchema` to require `apiBaseUrl`, `gatewayToken`, `agents` (with `connectionId` per agent) — matches what `build.ts` actually writes. Removed old `connection` + `permissions` top-level required fields.
- **`pinchy-web/openclaw.plugin.json`**: Updated to require `apiBaseUrl`, `gatewayToken`, `connectionId`, `agents` — removes old `braveApiKey` requirement.
- **`pinchy-email/openclaw.plugin.json`**: Tightened with `additionalProperties: false` at root and per-agent levels.

### Layer 2 — Per-plugin Ajv contract tests (CI catches future drift)
Added `config-schema.test.ts` for all 7 plugins, each validating a representative config emitted by `build.ts` against the manifest schema using Ajv. Includes regression guards against the exact legacy shapes that caused the staging incident.

### Layer 3 — Build-time runtime guard
- Added `validateBuiltConfig()` in `packages/web/src/lib/openclaw-config/validate-built-config.ts` — validates every plugin config entry against its manifest using Ajv before writing.
- Wired into `regenerateOpenClawConfig()` in `build.ts`: throws before writing if any plugin entry violates its manifest. OpenClaw never sees the bad config.
- Helper `validatePluginEntry()` in `plugin-schema.ts` with compiled Ajv validators (cached per plugin ID).
- Manifests loaded via static JSON imports (bundled at Next.js build time, not `readFileSync`) so they're available in production Docker where `packages/plugins/` isn't mounted.

### Layer 4 — E2E smoke test
Added test in `odoo-agent-chat.spec.ts` that sets Odoo permissions + grants tools, waits for hot-reload, then asserts OpenClaw stays `connected: true` and the integration data carries `connectionId` as a string (not the legacy `connection` object).

### Supporting changes
- `packages/web/package.json`: added `ajv@^8` as production dependency (needed server-side in `validateBuiltConfig`).
- `packages/web/vitest.config.ts`: extended to include plugin `config-schema.test.ts` files; narrowed to per-file patterns for plugins with heavy native deps (`better-sqlite3`, `googleapis`, `@mozilla/readability`) not installed in `@pinchy/web`.
- `CLAUDE.md`: documented the plugin manifest contract requirement (Pattern B bullet 6 + `validateBuiltConfig` in defense-in-depth section).

## Reviewer notes

- The vitest include patterns in `vitest.config.ts` intentionally use broad `**/*.test.ts` only for pinchy-docs and pinchy-odoo (which have no heavy native deps). All other plugins are narrowed to `config-schema.test.ts` to avoid import failures from deps not in `@pinchy/web`'s node_modules.
- The `validateBuiltConfig` mock in the existing `openclaw-config.test.ts` defaults to `{ ok: true }` to not affect the 100+ existing tests, with `mockReturnValueOnce` in the specific guard test.
- No changes to the API-callback fetch logic itself — this PR is purely manifest/validation hygiene.