### PR TITLE
fix(openclaw-config): immediate retry on OpenClaw stale-hash error

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1800,6 +1800,119 @@ describe("regenerateOpenClawConfig", () => {
       // config.apply must NOT be called — guard returns early when payload lacks meta
       expect(mockConfigApply).not.toHaveBeenCalled();
     });
+
+    it("retries config.apply IMMEDIATELY (no backoff) when OC reports stale hash", async () => {
+      // Scenario: OpenClaw's file-watcher reloaded `openclaw.json` between
+      // our config.get and config.apply, so the hash we sent is stale.
+      // OC rejects with `INVALID_REQUEST: config changed since last load;
+      // re-run config.get and retry`. This is OC's explicit recovery hint —
+      // not a transient network error. Pinchy must refetch the hash and
+      // retry the apply WITHOUT waiting through the generic 100/250/500/...ms
+      // backoff ladder, otherwise under CI load (slow event loop, blocking
+      // sessions.list) the next backoff window can stack with another
+      // pushConfigInBackground call and the retry never completes.
+      //
+      // Test guarantees: with the immediate-retry path, the second apply
+      // call happens before any setTimeout fires — we drain microtasks only,
+      // never advance fake timers, and still see two apply calls.
+      vi.useFakeTimers();
+      try {
+        mockConfigGet
+          .mockResolvedValueOnce({ hash: "h-stale" })
+          .mockResolvedValueOnce({ hash: "h-fresh" });
+        mockConfigApply
+          .mockRejectedValueOnce(
+            new Error("config changed since last load; re-run config.get and retry")
+          )
+          .mockResolvedValueOnce(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
+
+        // Drain microtasks repeatedly without advancing timers. With the
+        // immediate-retry fix, the chain config.get → config.apply (fail) →
+        // refetch get → retry apply (success) settles entirely in microtasks.
+        // Without the fix, the retry path hits `setTimeout(100ms)` and the
+        // second apply never happens until we advance timers.
+        for (let i = 0; i < 10; i++) {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        expect(mockConfigApply).toHaveBeenCalledTimes(2);
+        expect(mockConfigApply.mock.calls[1][1]).toBe("h-fresh");
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("limits stale-hash immediate retries to a small budget (no infinite loop)", async () => {
+      // If OpenClaw is genuinely stuck (every config.get → apply round-trip
+      // races a file-watcher reload), Pinchy must NOT spin forever. Cap the
+      // immediate-retry budget at 3 so the function returns within tens of
+      // milliseconds and inotify takes over as the safety net.
+      vi.useFakeTimers();
+      try {
+        mockConfigGet.mockResolvedValue({ hash: "h-stale" });
+        mockConfigApply.mockRejectedValue(
+          new Error("config changed since last load; re-run config.get and retry")
+        );
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
+
+        // Drain microtasks without advancing timers (so generic backoff
+        // does NOT contribute). All immediate retries should fire here.
+        for (let i = 0; i < 20; i++) {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+
+        // Cap: at most 3 immediate retries on the stale-hash error before
+        // bailing out (so 1 initial + 3 retries = 4 calls, max).
+        expect(mockConfigApply.mock.calls.length).toBeLessThanOrEqual(4);
+        expect(mockConfigApply.mock.calls.length).toBeGreaterThanOrEqual(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("uses generic backoff (not the stale-hash bypass) for unrelated config.apply errors", async () => {
+      // Regression guard: only the OC-specific "config changed since last
+      // load" message gets the immediate-refetch path. Any other error
+      // (transient WS, INTERNAL_ERROR, generic network failure) must keep
+      // going through the existing exponential-backoff loop, otherwise we
+      // risk hammering OC during real outages.
+      vi.useFakeTimers();
+      try {
+        mockConfigGet.mockResolvedValue({ hash: "h1" });
+        mockConfigApply
+          .mockRejectedValueOnce(new Error("WebSocket disconnected"))
+          .mockResolvedValueOnce(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
+
+        // Drain microtasks first — initial apply fires and rejects.
+        for (let i = 0; i < 5; i++) {
+          await vi.advanceTimersByTimeAsync(0);
+        }
+        expect(mockConfigApply).toHaveBeenCalledTimes(1);
+
+        // Without timer advance, the second apply MUST NOT fire — the
+        // generic-error path waits backoffsMs[0] = 100ms.
+        // Now advance past the first backoff and the retry happens.
+        await vi.advanceTimersByTimeAsync(150);
+
+        expect(mockConfigApply).toHaveBeenCalledTimes(2);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });
 

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -82,6 +82,15 @@ export function _resetPushGeneration() {
   _pushGeneration = 0;
 }
 
+// OC's explicit recovery hint when the file-watcher reloaded openclaw.json
+// between our config.get and config.apply: the hash we sent is no longer
+// the latest. Refetch the hash and retry IMMEDIATELY — going through the
+// generic 100/250/500ms backoff stacks the retry window into the next
+// pushConfigInBackground call's territory and the apply never lands
+// (#193, agent-create-no-restart.spec.ts CI flake).
+const STALE_HASH_ERROR_FRAGMENT = "config changed since last load";
+const MAX_STALE_HASH_RETRIES = 3;
+
 export function pushConfigInBackground(newContent: string): void {
   const generation = ++_pushGeneration;
 
@@ -98,6 +107,7 @@ export function pushConfigInBackground(newContent: string): void {
     // probably down due to the cold-start cascade, and inotify will catch
     // up; no point keeping a background coroutine alive longer.
     const backoffsMs = [100, 250, 500, 1000, 2000];
+    let staleHashAttempts = 0;
     for (let i = 0; i < backoffsMs.length; i++) {
       // Check before each attempt — a newer pushConfigInBackground call
       // may have started while we were sleeping.
@@ -148,8 +158,22 @@ export function pushConfigInBackground(newContent: string): void {
         // so it is the canonical state. A newer call's payload will overwrite.
         return;
       } catch (err) {
+        const message = err instanceof Error ? err.message : String(err);
+
+        // Stale-hash bypass: OC explicitly tells us "re-run config.get and
+        // retry". Don't sleep on backoff — a fresh get+apply on the next
+        // iteration is the entire fix. Cap the budget so a genuinely-stuck
+        // gateway doesn't hot-loop; inotify is the safety net.
+        if (
+          message.includes(STALE_HASH_ERROR_FRAGMENT) &&
+          staleHashAttempts < MAX_STALE_HASH_RETRIES
+        ) {
+          staleHashAttempts++;
+          i--; // don't consume a backoff slot for OC's recovery hint
+          continue;
+        }
+
         if (i === backoffsMs.length - 1) {
-          const message = err instanceof Error ? err.message : String(err);
           console.warn(
             "[openclaw-config] background config.apply failed; relying on inotify:",
             message


### PR DESCRIPTION
## Summary

- `pushConfigInBackground` now treats OpenClaw's `INVALID_REQUEST: config changed since last load; re-run config.get and retry` as an explicit recovery hint and retries immediately (no backoff), capped at 3 attempts.
- Three new unit tests cover the immediate retry, the retry budget, and a regression guard ensuring unrelated errors still go through the existing exponential backoff.

## Background

`packages/web/src/lib/openclaw-config/write.ts` does `config.get` → `config.apply`. Under CI/production load OpenClaw's file-watcher can reload `openclaw.json` between the two RPCs, so the hash Pinchy passes to `apply()` is stale and OC rejects.

The existing retry loop did handle this — but only after a 100/250/500/...ms backoff. Under load that window stacked with the next `pushConfigInBackground` call, the apply never landed, and `agent-create-no-restart.spec.ts` flaked. CI run [25314217260](https://github.com/heypinchy/pinchy/actions/runs/25314217260) on commit `ebe156673` failed once and the rerun went green — confirming a timing-bound flake rather than a deterministic regression.

This fix is a v0.5.0 release blocker: with main CI red, `pnpm release 0.5.0` refuses to cut.

## Test plan

- [x] `pnpm exec vitest run src/__tests__/lib/openclaw-config.test.ts` — 106 passed
- [x] Full unit suite — 3675 passed | 12 skipped (no regressions; +3 new tests)
- [x] ESLint — 0 errors (only preexisting warnings)
- [x] `tsc --noEmit` — clean
- [ ] Telegram E2E in CI — confirms the original flake disappears