### PR TITLE
fix(domain): allow internal API under domain lock

### DIFF
--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -1,9 +1,15 @@
 // packages/web/e2e/integration/agent-chat.spec.ts
 import { test, expect } from "@playwright/test";
+import type { Page } from "@playwright/test";
+import {
+  FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE,
+  FAKE_OLLAMA_DOMAIN_LOCK_TOOL_TRIGGER,
+  FAKE_OLLAMA_RESPONSE,
+} from "./fake-ollama-server";
 
 test.describe("Agent chat — full integration", () => {
-  test("Pinchy agent responds to messages via OpenClaw", async ({ page }) => {
-    // 1. Run setup wizard (creates admin + Smithers)
+  async function login(page: Page) {
+    // Run setup wizard (creates admin + Smithers)
     const setup = await page.request.post("/api/setup", {
       data: {
         name: "Integration Admin",
@@ -13,14 +19,44 @@ test.describe("Agent chat — full integration", () => {
     });
     expect([201, 403]).toContain(setup.status()); // 403 = already set up
 
-    // 2. Login
     await page.goto("/login");
     await page.getByLabel(/email/i).fill("admin@integration.local");
     await page.getByLabel("Password", { exact: true }).fill("integration-password-123");
     await page.getByRole("button", { name: /sign in/i }).click();
     await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+  }
 
-    // 3. Use Smithers (created during setup) — already in OpenClaw config at startup,
+  async function getSmithersAgentId(page: Page) {
+    const agentsRes = await page.request.get("/api/agents");
+    expect(agentsRes.status()).toBe(200);
+    const agents = await agentsRes.json();
+    const smithers = agents.find((a: { name: string }) => a.name === "Smithers");
+    expect(smithers).toBeTruthy();
+    return smithers.id as string;
+  }
+
+  async function waitForOpenClawConnected(page: Page, timeoutMs = 120000) {
+    const connectDeadline = Date.now() + timeoutMs;
+    let connectedSince: number | null = null;
+    while (Date.now() < connectDeadline) {
+      const health = await page.request.get("/api/health/openclaw");
+      const data = await health.json();
+      if (data.connected) {
+        connectedSince ??= Date.now();
+        if (Date.now() - connectedSince >= 5000) return;
+      } else {
+        connectedSince = null;
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    throw new Error(`OpenClaw did not connect within ${timeoutMs}ms`);
+  }
+
+  test("Pinchy agent responds to messages via OpenClaw", async ({ page }) => {
+    // 1. Login
+    await login(page);
+
+    // 2. Use Smithers (created during setup) — already in OpenClaw config at startup,
     // no hot-reload required. Testing hot-reload reliability is an infrastructure
     // concern; the config-schema unit test ensures the schema stays valid.
     //
@@ -29,38 +65,78 @@ test.describe("Agent chat — full integration", () => {
     //   - pinchy-docs: reads platform documentation on demand so Smithers answers
     //                  questions about Pinchy from the live docs
     //   - pinchy-audit: logs every tool execution to the Pinchy audit trail
-    const agentsRes = await page.request.get("/api/agents");
-    expect(agentsRes.status()).toBe(200);
-    const agents = await agentsRes.json();
-    const smithers = agents.find((a: { name: string }) => a.name === "Smithers");
-    expect(smithers).toBeTruthy();
-    const agentId: string = smithers.id;
+    const agentId = await getSmithersAgentId(page);
 
-    // 4. Navigate to the agent's chat page
+    // 3. Navigate to the agent's chat page
     await page.goto(`/chat/${agentId}`);
     await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10000 });
 
-    // 5. Wait for OpenClaw to connect (Smithers is already in the config)
-    const connectDeadline = Date.now() + 30000;
-    while (Date.now() < connectDeadline) {
-      const health = await page.request.get("/api/health/openclaw");
-      const data = await health.json();
-      if (data.connected) break;
-      await new Promise((r) => setTimeout(r, 500));
-    }
+    // 4. Wait for OpenClaw to connect (Smithers is already in the config)
+    await waitForOpenClawConnected(page);
 
-    // 6. Wait for the chat input to appear
+    // 5. Wait for the chat input to appear
     const input = page.getByPlaceholder(/send a message/i);
     await expect(input).toBeVisible({ timeout: 10000 });
 
-    // 7. Send a message
+    // 6. Send a message
     await input.fill("Hello, are you there?");
     await input.press("Enter");
 
-    // 8. Verify the fake Ollama response appears
-    // Fake Ollama always responds: "Integration test response."
-    await expect(page.getByText("Integration test response.")).toBeVisible({
+    // 7. Verify the fake Ollama response appears
+    await expect(page.getByText(FAKE_OLLAMA_RESPONSE)).toBeVisible({
       timeout: 30000,
     });
+  });
+
+  test("Domain Lock allows OpenClaw tool calls to write audit entries", async ({ page }) => {
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+
+    const lockRes = await page.request.post("/api/settings/domain", {
+      headers: {
+        Origin: "https://localhost:7779",
+        "x-forwarded-proto": "https",
+        "x-forwarded-host": "localhost:7779",
+      },
+    });
+    expect(lockRes.status()).toBe(200);
+
+    try {
+      await page.goto(`/chat/${agentId}`);
+      await waitForOpenClawConnected(page);
+
+      const input = page.getByPlaceholder(/send a message/i);
+      await expect(input).toBeVisible({ timeout: 10000 });
+      await input.fill(`${FAKE_OLLAMA_DOMAIN_LOCK_TOOL_TRIGGER}: What Pinchy docs exist?`);
+      await input.press("Enter");
+
+      await expect(page.getByText(FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE)).toBeVisible({
+        timeout: 30000,
+      });
+
+      const deadline = Date.now() + 30000;
+      let foundAuditEntry = false;
+      while (Date.now() < deadline) {
+        const auditRes = await page.request.get("/api/audit?eventType=tool.docs_list&limit=10");
+        expect(auditRes.status()).toBe(200);
+        const audit = await auditRes.json();
+        foundAuditEntry = audit.entries.some(
+          (entry: {
+            resource: string | null;
+            outcome: string | null;
+            detail: { toolName?: string } | null;
+          }) =>
+            entry.resource === `agent:${agentId}` &&
+            entry.outcome === "success" &&
+            entry.detail?.toolName === "docs_list"
+        );
+        if (foundAuditEntry) break;
+        await new Promise((r) => setTimeout(r, 500));
+      }
+
+      expect(foundAuditEntry).toBe(true);
+    } finally {
+      await page.request.delete("/api/settings/domain");
+    }
   });
 });

--- a/packages/web/e2e/integration/fake-ollama-process.ts
+++ b/packages/web/e2e/integration/fake-ollama-process.ts
@@ -1,0 +1,15 @@
+import { startFakeOllama, stopFakeOllama } from "./fake-ollama-server";
+
+async function shutdown() {
+  await stopFakeOllama();
+  process.exit(0);
+}
+
+process.on("SIGTERM", () => {
+  void shutdown();
+});
+process.on("SIGINT", () => {
+  void shutdown();
+});
+
+void startFakeOllama();

--- a/packages/web/e2e/integration/fake-ollama-server.ts
+++ b/packages/web/e2e/integration/fake-ollama-server.ts
@@ -8,13 +8,69 @@
 //   POST /api/chat   → streaming NDJSON response
 import * as http from "http";
 
-const MODEL_NAME = "fake-model:latest";
+const MODEL_NAME = "llama3.2";
 // This string must appear in the test's expect() assertion
 const FAKE_RESPONSE = "Integration test response.";
+const DOMAIN_LOCK_TOOL_TRIGGER = "E2E_DOMAIN_LOCK_DOCS_TOOL";
+const DOMAIN_LOCK_TOOL_RESPONSE = "Domain lock docs tool call completed.";
 
-function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
+function writeNdjson(res: http.ServerResponse, chunks: unknown[]) {
+  res.writeHead(200, { "Content-Type": "application/x-ndjson" });
+  for (const chunk of chunks) {
+    res.write(JSON.stringify(chunk) + "\n");
+  }
+  res.end();
+}
+
+function streamTextResponse(res: http.ServerResponse, text: string) {
+  const chunks = text.split(" ").map((word, i, arr) => ({
+    model: MODEL_NAME,
+    created_at: new Date().toISOString(),
+    message: { role: "assistant", content: i === 0 ? word : " " + word },
+    done: i === arr.length - 1,
+    ...(i === arr.length - 1 && { done_reason: "stop", total_duration: 1000000 }),
+  }));
+  writeNdjson(res, chunks);
+}
+
+function readJsonBody(req: http.IncomingMessage): Promise<Record<string, unknown>> {
+  return new Promise((resolve) => {
+    let body = "";
+    req.on("data", (chunk) => {
+      body += chunk.toString();
+    });
+    req.on("end", () => {
+      try {
+        resolve(JSON.parse(body) as Record<string, unknown>);
+      } catch {
+        resolve({});
+      }
+    });
+  });
+}
+
+function messageContent(message: unknown): string {
+  if (!message || typeof message !== "object") return "";
+  const content = (message as { content?: unknown }).content;
+  if (typeof content === "string") return content;
+  return "";
+}
+
+function hasToolRole(message: unknown): boolean {
+  return (
+    !!message && typeof message === "object" && (message as { role?: unknown }).role === "tool"
+  );
+}
+
+async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
   const url = req.url ?? "";
   const method = req.method ?? "";
+
+  if (method === "GET" && url === "/__pinchy_fake_ollama") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ ok: true, model: MODEL_NAME }));
+    return;
+  }
 
   if (method === "GET" && url === "/api/tags") {
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -43,18 +99,41 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
   }
 
   if (method === "POST" && url === "/api/chat") {
-    res.writeHead(200, { "Content-Type": "application/x-ndjson" });
-    const chunks = FAKE_RESPONSE.split(" ").map((word, i, arr) => ({
-      model: MODEL_NAME,
-      created_at: new Date().toISOString(),
-      message: { role: "assistant", content: i === 0 ? word : " " + word },
-      done: i === arr.length - 1,
-      ...(i === arr.length - 1 && { done_reason: "stop", total_duration: 1000000 }),
-    }));
-    for (const chunk of chunks) {
-      res.write(JSON.stringify(chunk) + "\n");
+    const payload = await readJsonBody(req);
+    const messages = Array.isArray(payload.messages) ? payload.messages : [];
+    const lastUserMessage = [...messages]
+      .reverse()
+      .find((message) => (message as { role?: unknown })?.role === "user");
+    const isDomainLockToolPrompt =
+      messageContent(lastUserMessage).includes(DOMAIN_LOCK_TOOL_TRIGGER);
+    const hasToolResult = messages.some(hasToolRole);
+
+    if (isDomainLockToolPrompt && !hasToolResult) {
+      writeNdjson(res, [
+        {
+          model: MODEL_NAME,
+          created_at: new Date().toISOString(),
+          message: {
+            role: "assistant",
+            content: "",
+            tool_calls: [
+              {
+                function: {
+                  name: "docs_list",
+                  arguments: {},
+                },
+              },
+            ],
+          },
+          done: true,
+          done_reason: "stop",
+          total_duration: 1000000,
+        },
+      ]);
+      return;
     }
-    res.end();
+
+    streamTextResponse(res, isDomainLockToolPrompt ? DOMAIN_LOCK_TOOL_RESPONSE : FAKE_RESPONSE);
     return;
   }
 
@@ -66,6 +145,8 @@ function handleRequest(req: http.IncomingMessage, res: http.ServerResponse) {
 export const FAKE_OLLAMA_PORT = 11435;
 export const FAKE_OLLAMA_MODEL = `ollama/${MODEL_NAME}`;
 export const FAKE_OLLAMA_RESPONSE = FAKE_RESPONSE;
+export const FAKE_OLLAMA_DOMAIN_LOCK_TOOL_TRIGGER = DOMAIN_LOCK_TOOL_TRIGGER;
+export const FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE = DOMAIN_LOCK_TOOL_RESPONSE;
 
 let server: http.Server | null = null;
 

--- a/packages/web/e2e/integration/global-setup.ts
+++ b/packages/web/e2e/integration/global-setup.ts
@@ -9,16 +9,18 @@
 // For local dev: run `docker compose -f docker-compose.integration.yml up -d --wait`
 // and create the test DB manually before running `pnpm test:integration`, or
 // accept that Pinchy's initial startup queries will fail and recover automatically.
-import { execSync } from "child_process";
+import { execSync, spawn } from "child_process";
 import path from "path";
-import { mkdirSync } from "fs";
-import { startFakeOllama, FAKE_OLLAMA_PORT } from "./fake-ollama-server";
+import { existsSync, mkdirSync, readFileSync, rmSync, unlinkSync, writeFileSync } from "fs";
+import { networkInterfaces } from "os";
+import { FAKE_OLLAMA_PORT } from "./fake-ollama-server";
 
 const ADMIN_DB_URL = "postgresql://pinchy:pinchy_dev@localhost:5435/pinchy";
 const INTEGRATION_DB = "pinchy_integration_test";
 const INTEGRATION_DB_URL = `postgresql://pinchy:pinchy_dev@localhost:5435/${INTEGRATION_DB}`;
 const CONFIG_DIR = "/tmp/pinchy-integration-openclaw";
 const SECRETS_DIR = "/tmp/pinchy-integration-secrets";
+const FAKE_OLLAMA_PID_PATH = "/tmp/pinchy-fake-ollama.pid";
 const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
 const PACKAGE_ROOT = path.resolve(__dirname, "../..");
 
@@ -32,6 +34,47 @@ function isDockerStackRunning(): boolean {
     return out.includes("db") && out.includes("openclaw");
   } catch {
     return false;
+  }
+}
+
+function hostNetworkIps(): string[] {
+  return Object.values(networkInterfaces())
+    .flatMap((entries) => entries ?? [])
+    .filter((entry) => entry.family === "IPv4" && !entry.internal)
+    .map((entry) => entry.address);
+}
+
+function stopStaleFakeOllamaProcess() {
+  if (!existsSync(FAKE_OLLAMA_PID_PATH)) return;
+  const pid = Number(readFileSync(FAKE_OLLAMA_PID_PATH, "utf8"));
+  if (Number.isInteger(pid) && pid > 0) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Process is already gone.
+    }
+  }
+  try {
+    unlinkSync(FAKE_OLLAMA_PID_PATH);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
+
+function startFakeOllamaProcess() {
+  stopStaleFakeOllamaProcess();
+  const child = spawn(
+    process.execPath,
+    ["--import", "tsx", path.join(PACKAGE_ROOT, "e2e/integration/fake-ollama-process.ts")],
+    {
+      cwd: PACKAGE_ROOT,
+      detached: true,
+      stdio: "ignore",
+    }
+  );
+  child.unref();
+  if (child.pid) {
+    writeFileSync(FAKE_OLLAMA_PID_PATH, String(child.pid));
   }
 }
 
@@ -50,18 +93,24 @@ async function isDbReady(): Promise<boolean> {
 
 export default async function globalSetup() {
   // 1. Start fake Ollama (must be up before OpenClaw connects to the provider)
-  await startFakeOllama();
+  startFakeOllamaProcess();
   console.log(`[integration-setup] fake Ollama started on port ${FAKE_OLLAMA_PORT}`);
+
+  const dockerStackRunning = isDockerStackRunning();
 
   // 2. Ensure bind-mount targets exist BEFORE docker compose runs.
   //    If Docker creates them, they are owned by root and Pinchy (host, non-root)
   //    can't write secrets.json there.
+  if (!dockerStackRunning) {
+    rmSync(CONFIG_DIR, { recursive: true, force: true });
+    rmSync(SECRETS_DIR, { recursive: true, force: true });
+  }
   mkdirSync(CONFIG_DIR, { recursive: true });
   mkdirSync(`${CONFIG_DIR}/workspaces`, { recursive: true });
   mkdirSync(SECRETS_DIR, { recursive: true });
 
   // 3. Start Docker integration stack (skip if already running, e.g. pre-started in CI)
-  if (isDockerStackRunning()) {
+  if (dockerStackRunning) {
     console.log("[integration-setup] Docker integration stack already running — skipping start");
   } else {
     execSync("docker compose -f docker-compose.integration.yml up -d --wait", {
@@ -91,12 +140,9 @@ export default async function globalSetup() {
 
   // 5. Seed Ollama URL, default provider, and a fake Ollama-Cloud key.
   //
-  //    We must NOT use 'host.docker.internal' as the Ollama base URL. OpenClaw 4.27+
-  //    checks isLocalOllamaBaseUrl() before providing synthetic auth (no API key
-  //    needed). 'host.docker.internal' has dots → isIpv4PrivateRange/isLoopback both
-  //    return false → OC throws "No API key found for provider 'ollama'". A private
-  //    IPv4 (172.x.x.x, 192.168.x.x) passes the check. We resolve the container's
-  //    default gateway, which is the host IP on Docker's bridge network.
+  //    On Linux the container's default gateway is usually the host. On Docker
+  //    Desktop, host.docker.internal is the reliable host route. Probe both from
+  //    inside the OpenClaw container and use the first URL that reaches fake Ollama.
   //
   //    The Ollama-Cloud key is intentionally a dummy value — fake Ollama doesn't need
   //    auth. We seed it so Pinchy's regenerateOpenClawConfig() writes the
@@ -119,8 +165,50 @@ export default async function globalSetup() {
   } catch {
     // Use the 172.17.0.1 fallback
   }
-  const ollamaLocalUrl = `http://${ollamaHostIp}:${FAKE_OLLAMA_PORT}`;
-  console.log(`[integration-setup] Resolved Ollama host IP: ${ollamaHostIp} → ${ollamaLocalUrl}`);
+  let dockerHostIp = "";
+  try {
+    dockerHostIp = execSync(
+      `docker compose -f docker-compose.integration.yml exec -T openclaw sh -c "getent hosts host.docker.internal 2>/dev/null | awk '{ print \\$1; exit }'"`,
+      { cwd: PROJECT_ROOT, encoding: "utf8", stdio: "pipe" }
+    ).trim();
+  } catch {
+    // Ignore; the gateway candidate and hostname fallback remain below.
+  }
+  const ollamaCandidates = [
+    `http://${ollamaHostIp}:${FAKE_OLLAMA_PORT}`,
+    ...(dockerHostIp ? [`http://${dockerHostIp}:${FAKE_OLLAMA_PORT}`] : []),
+    ...hostNetworkIps().map((ip) => `http://${ip}:${FAKE_OLLAMA_PORT}`),
+    `http://host.docker.internal:${FAKE_OLLAMA_PORT}`,
+    `http://docker.for.mac.host.internal:${FAKE_OLLAMA_PORT}`,
+  ];
+  const uniqueOllamaCandidates = [...new Set(ollamaCandidates)];
+  const canReachOllamaFromOpenClaw = (url: string) => {
+    const probe = [
+      "fetch(process.argv[1] + '/__pinchy_fake_ollama', { signal: AbortSignal.timeout(1500) })",
+      ".then(async (res) => {",
+      "  if (!res.ok) process.exit(1);",
+      "  const data = await res.json().catch(() => null);",
+      "  process.exit(data?.ok === true ? 0 : 1);",
+      "})",
+      ".catch(() => process.exit(1))",
+    ].join("");
+    try {
+      execSync(
+        `docker compose -f docker-compose.integration.yml exec -T openclaw node -e ${JSON.stringify(probe)} ${JSON.stringify(url)}`,
+        { cwd: PROJECT_ROOT, stdio: "pipe" }
+      );
+      return true;
+    } catch {
+      return false;
+    }
+  };
+  const ollamaLocalUrl = uniqueOllamaCandidates.find((candidate) =>
+    canReachOllamaFromOpenClaw(candidate)
+  );
+  if (!ollamaLocalUrl) {
+    throw new Error("[integration-setup] OpenClaw could not reach fake Ollama");
+  }
+  console.log(`[integration-setup] Ollama URL reachable from OpenClaw: ${ollamaLocalUrl}`);
 
   const postgres = (await import("postgres")).default;
   const sql = postgres(INTEGRATION_DB_URL);
@@ -179,16 +267,23 @@ export default async function globalSetup() {
   console.log("[integration-setup] Waiting for Pinchy to reconnect to OpenClaw...");
   const deadline = Date.now() + 300000;
   let reconnected = false;
+  let connectedSince: number | null = null;
   while (Date.now() < deadline) {
     try {
       const res = await fetch("http://localhost:7779/api/health/openclaw");
       const data = (await res.json()) as { connected: boolean };
       if (data.connected) {
-        reconnected = true;
-        break;
+        connectedSince ??= Date.now();
+        if (Date.now() - connectedSince >= 5000) {
+          reconnected = true;
+          break;
+        }
+      } else {
+        connectedSince = null;
       }
     } catch {
       // Pinchy may be briefly unavailable during OpenClaw restart
+      connectedSince = null;
     }
     await new Promise((r) => setTimeout(r, 500));
   }

--- a/packages/web/e2e/integration/global-teardown.ts
+++ b/packages/web/e2e/integration/global-teardown.ts
@@ -1,15 +1,33 @@
 // packages/web/e2e/integration/global-teardown.ts
 import path from "path";
 import { execSync } from "child_process";
-import { stopFakeOllama } from "./fake-ollama-server";
+import { existsSync, readFileSync, unlinkSync } from "fs";
 
 const ADMIN_DB_URL = "postgresql://pinchy:pinchy_dev@localhost:5435/pinchy";
 const INTEGRATION_DB = "pinchy_integration_test";
 const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
+const FAKE_OLLAMA_PID_PATH = "/tmp/pinchy-fake-ollama.pid";
+
+function stopFakeOllamaProcess() {
+  if (!existsSync(FAKE_OLLAMA_PID_PATH)) return;
+  const pid = Number(readFileSync(FAKE_OLLAMA_PID_PATH, "utf8"));
+  if (Number.isInteger(pid) && pid > 0) {
+    try {
+      process.kill(pid, "SIGTERM");
+    } catch {
+      // Process is already gone.
+    }
+  }
+  try {
+    unlinkSync(FAKE_OLLAMA_PID_PATH);
+  } catch {
+    // Best-effort cleanup.
+  }
+}
 
 export default async function globalTeardown() {
   // 1. Stop fake Ollama
-  await stopFakeOllama();
+  stopFakeOllamaProcess();
   console.log("[integration-teardown] fake Ollama stopped");
 
   // 2. Drop test DB

--- a/packages/web/playwright.integration.config.ts
+++ b/packages/web/playwright.integration.config.ts
@@ -35,6 +35,18 @@ export default defineConfig({
       "AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef",
       // Connect to OpenClaw running in the integration Docker stack
       "OPENCLAW_WS_URL=ws://localhost:18790",
+      "PINCHY_E2E_GATEWAY_TOKEN=pinchy-integration-gateway-token",
+      // OpenClaw runs in Docker while Pinchy runs on the host in this suite.
+      // Internal plugin callbacks therefore use a Docker-internal hostname,
+      // which also exercises Domain Lock host exemptions.
+      "PINCHY_INTERNAL_URL=http://host.docker.internal:7779",
+      // Domain Lock normally restarts Pinchy so cookie security settings pick
+      // up the new domain. The integration suite sets and clears Domain Lock
+      // inside a running test process.
+      "PINCHY_E2E_DISABLE_DOMAIN_RESTART=1",
+      // Docker Desktop can only reach host fake Ollama through host.docker.internal,
+      // which OpenClaw treats as an authenticated non-local provider.
+      "PINCHY_E2E_OLLAMA_LOCAL_API_KEY=1",
       // Config path shared with OpenClaw container (host path = container path after mount)
       "OPENCLAW_CONFIG_PATH=/tmp/pinchy-integration-openclaw/openclaw.json",
       // Workspaces also under the shared dir so OpenClaw can read SOUL.md / AGENTS.md

--- a/packages/web/src/__tests__/lib/gateway-token-reader.test.ts
+++ b/packages/web/src/__tests__/lib/gateway-token-reader.test.ts
@@ -11,6 +11,7 @@ let configPath: string;
 let secretsPath: string;
 const origConfigPath = process.env.OPENCLAW_CONFIG_PATH;
 const origSecretsPath = process.env.OPENCLAW_SECRETS_PATH;
+const origE2eGatewayToken = process.env.PINCHY_E2E_GATEWAY_TOKEN;
 
 beforeEach(() => {
   tmpDir = mkdtempSync(join(tmpdir(), "pinchy-gtoken-"));
@@ -18,6 +19,7 @@ beforeEach(() => {
   secretsPath = join(tmpDir, "secrets.json");
   process.env.OPENCLAW_CONFIG_PATH = configPath;
   process.env.OPENCLAW_SECRETS_PATH = secretsPath;
+  delete process.env.PINCHY_E2E_GATEWAY_TOKEN;
   vi.resetModules();
 });
 
@@ -27,9 +29,21 @@ afterEach(() => {
   else delete process.env.OPENCLAW_CONFIG_PATH;
   if (origSecretsPath !== undefined) process.env.OPENCLAW_SECRETS_PATH = origSecretsPath;
   else delete process.env.OPENCLAW_SECRETS_PATH;
+  if (origE2eGatewayToken !== undefined) process.env.PINCHY_E2E_GATEWAY_TOKEN = origE2eGatewayToken;
+  else delete process.env.PINCHY_E2E_GATEWAY_TOKEN;
 });
 
 describe("readGatewayToken", () => {
+  it("uses the E2E gateway token when set", async () => {
+    process.env.PINCHY_E2E_GATEWAY_TOKEN = "e2e-gateway-token";
+    writeFileSync(
+      configPath,
+      JSON.stringify({ gateway: { auth: { token: "abc-from-openclaw-json" } } })
+    );
+    const { readGatewayToken } = await import("@/lib/gateway-token-reader");
+    expect(readGatewayToken()).toBe("e2e-gateway-token");
+  });
+
   it("returns token from openclaw.json when set", async () => {
     writeFileSync(
       configPath,

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -185,6 +185,7 @@ describe("regenerateOpenClawConfig", () => {
       from: mockFrom(),
     } as never);
     mockedGetSetting.mockResolvedValue(null);
+    delete process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY;
     // Default: no OpenClaw client connected — exercises the cold-start path
     // that falls back to writing the file directly. Individual tests can
     // override mockGetClient to return a connected client.
@@ -1530,6 +1531,60 @@ describe("regenerateOpenClawConfig", () => {
       String(call[0]).includes("auth-profiles.json")
     );
     expect(authProfileCalls.length).toBe(0);
+  });
+
+  it("can write an E2E-only auth profile for ollama-local when Docker Desktop requires it", async () => {
+    process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY = "1";
+    const agentsData = [
+      {
+        id: "agent-llama",
+        name: "Llama",
+        model: "ollama/llama3.1:8b",
+        allowedTools: [],
+        pluginConfig: null,
+        createdAt: new Date(),
+      },
+    ];
+    mockedDb.select.mockReturnValue({
+      from: mockFrom(agentsData),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11435";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls.find(
+      (call) => typeof call[0] === "string" && call[0].includes("openclaw.json")
+    );
+    expect(written).toBeDefined();
+    const config = JSON.parse(String(written![1]));
+    expect(config.models.providers.ollama.apiKey).toEqual({
+      source: "file",
+      provider: "pinchy",
+      id: "/providers/ollama-local/apiKey",
+    });
+
+    expect(mockWriteSecretsFile).toHaveBeenCalledWith(
+      expect.objectContaining({
+        providers: expect.objectContaining({
+          "ollama-local": { apiKey: "dummy-integration-test-key" },
+        }),
+      })
+    );
+
+    const authProfileCall = mockedWriteFileSync.mock.calls.find((call) =>
+      String(call[0]).includes("agents/agent-llama/agent/auth-profiles.json")
+    );
+    expect(authProfileCall).toBeDefined();
+    const authProfile = JSON.parse(String(authProfileCall![1]));
+    expect(authProfile.profiles["ollama-local-default"]).toEqual({
+      type: "api_key",
+      provider: "ollama-local",
+      keyRef: { kind: "secret", path: "providers.ollama-local.apiKey" },
+    });
   });
 
   it("retries readExistingConfig after 300 ms when it returns empty (EACCES/transient race)", async () => {

--- a/packages/web/src/__tests__/middleware/domain-restriction.test.ts
+++ b/packages/web/src/__tests__/middleware/domain-restriction.test.ts
@@ -46,16 +46,37 @@ describe("domain restriction host check", () => {
     expect(isHostAllowed("evil.example.com", "/api/setup/status")).toBe(true);
   });
 
-  it("always allows the internal OpenClaw config healthcheck regardless of host", () => {
+  it("allows pinchy-audit hook calls from Docker-internal hostnames", () => {
     vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
-    expect(isHostAllowed("localhost:7777", "/api/internal/openclaw-config-ready")).toBe(true);
+    expect(isHostAllowed("pinchy:7777", "/api/internal/audit/tool-use")).toBe(true);
   });
 
-  it("always allows internal service callbacks regardless of host", () => {
+  it("allows gateway-token-protected internal plugin routes regardless of host", () => {
     vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("pinchy:7777", "/api/internal/settings/context")).toBe(true);
+    expect(isHostAllowed("pinchy:7777", "/api/internal/usage/record")).toBe(true);
+    expect(isHostAllowed("pinchy:7777", "/api/internal/users/user-123/context")).toBe(true);
     expect(
-      isHostAllowed("localhost:7777", "/api/internal/integrations/connection-1/credentials")
+      isHostAllowed("pinchy:7777", "/api/internal/integrations/connection-123/credentials")
     ).toBe(true);
+  });
+
+  it("allows unauthenticated internal readiness only for loopback healthchecks", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("localhost:7777", "/api/internal/openclaw-config-ready")).toBe(true);
+    expect(isHostAllowed("127.0.0.1:7777", "/api/internal/openclaw-config-ready")).toBe(true);
+    expect(isHostAllowed("pinchy:7777", "/api/internal/openclaw-config-ready")).toBe(false);
+    expect(isHostAllowed("evil.example.com", "/api/internal/openclaw-config-ready")).toBe(false);
+  });
+
+  it("does not exempt lookalike internal API paths", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("pinchy:7777", "/api/internality/audit/tool-use")).toBe(false);
+  });
+
+  it("still blocks browser-facing API routes from Docker-internal hostnames", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("pinchy:7777", "/api/settings/domain")).toBe(false);
   });
 
   it("allows when host has default port 443 and domain does not", () => {

--- a/packages/web/src/app/api/settings/domain/route.ts
+++ b/packages/web/src/app/api/settings/domain/route.ts
@@ -41,11 +41,13 @@ export async function POST(req: Request) {
     })
   );
 
-  // Schedule a restart so useSecureCookies picks up the new domain
-  setTimeout(() => {
-    console.log("Restarting to apply domain lock security settings...");
-    process.exit(0);
-  }, 500);
+  if (process.env.PINCHY_E2E_DISABLE_DOMAIN_RESTART !== "1") {
+    // Schedule a restart so useSecureCookies picks up the new domain.
+    setTimeout(() => {
+      console.log("Restarting to apply domain lock security settings...");
+      process.exit(0);
+    }, 500);
+  }
 
   return NextResponse.json({ domain, restart: true });
 }
@@ -74,11 +76,13 @@ export async function DELETE(_req: Request) {
     })
   );
 
-  // Schedule a restart so useSecureCookies picks up the removed domain
-  setTimeout(() => {
-    console.log("Restarting to apply domain unlock security settings...");
-    process.exit(0);
-  }, 500);
+  if (process.env.PINCHY_E2E_DISABLE_DOMAIN_RESTART !== "1") {
+    // Schedule a restart so useSecureCookies picks up the removed domain.
+    setTimeout(() => {
+      console.log("Restarting to apply domain unlock security settings...");
+      process.exit(0);
+    }, 500);
+  }
 
   return NextResponse.json({ removed: true, restart: true });
 }

--- a/packages/web/src/lib/gateway-token-reader.ts
+++ b/packages/web/src/lib/gateway-token-reader.ts
@@ -16,6 +16,10 @@ import { readSecretsFile } from "@/lib/openclaw-secrets";
  *      Fallback in case openclaw.json is briefly unavailable.
  */
 export function readGatewayToken(): string {
+  if (process.env.PINCHY_E2E_GATEWAY_TOKEN) {
+    return process.env.PINCHY_E2E_GATEWAY_TOKEN;
+  }
+
   try {
     const configPath = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
     const config = JSON.parse(readFileSync(configPath, "utf-8")) as {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -676,11 +676,16 @@ export async function regenerateOpenClawConfig() {
   }
 
   if (ollamaLocalUrl) {
-    modelProviders["ollama"] = {
+    const providerConfig: Record<string, unknown> = {
       baseUrl: ollamaLocalUrl.replace(/\/$/, ""),
       api: "ollama",
       models: [], // Empty array — OpenClaw requires it for config validation, auto-discovers models at runtime
     };
+    if (process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY === "1") {
+      providerSecrets["ollama-local"] = { apiKey: "dummy-integration-test-key" };
+      providerConfig.apiKey = secretRef("/providers/ollama-local/apiKey");
+    }
+    modelProviders["ollama"] = providerConfig;
   }
 
   if (Object.keys(modelProviders).length > 0) {
@@ -863,6 +868,9 @@ export async function regenerateOpenClawConfig() {
     "ollama-cloud": "ollama-cloud",
     // "ollama" intentionally absent — local Ollama is URL-based, no API key
   };
+  if (process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY === "1") {
+    MODEL_PREFIX_TO_AUTH_PROFILE.ollama = "ollama-local";
+  }
   // Providers that actually have credentials configured right now.
   const PROVIDER_KEY_TO_AUTH_PROFILE: Partial<Record<string, AuthProfilesProvider>> = {
     anthropic: "anthropic",

--- a/packages/web/src/server/host-check.ts
+++ b/packages/web/src/server/host-check.ts
@@ -1,10 +1,36 @@
 import { getCachedDomain, normalizeHost } from "@/lib/domain-cache";
 
-// Paths that bypass the domain-lock host check.
-// Health/status endpoints and internal service callbacks must remain reachable
-// from the Docker network even when the public host is locked.
+// Paths that bypass the domain-lock host check. Health/status endpoints must
+// remain accessible for monitoring/setup. Gateway-token-protected internal
+// plugin endpoints are called through Docker-internal hostnames, so they also
+// bypass host matching. The unauthenticated OpenClaw readiness endpoint is
+// only exempt for same-container loopback healthchecks.
 const EXEMPT_PATHS = ["/api/health", "/api/setup/status"];
-const EXEMPT_PREFIXES = ["/api/internal/"];
+const LOOPBACK_ONLY_EXEMPT_PATHS = ["/api/internal/openclaw-config-ready"];
+
+function isLoopbackHost(host: string | undefined): boolean {
+  if (!host) return false;
+  const normalizedHost = normalizeHost(host);
+  if (normalizedHost === "::1" || normalizedHost.startsWith("[::1]")) return true;
+  const hostname = normalizedHost.replace(/:\d+$/, "");
+  return hostname === "localhost" || hostname === "127.0.0.1";
+}
+
+function isGatewayTokenProtectedInternalPath(pathname: string): boolean {
+  if (
+    pathname === "/api/internal/audit/tool-use" ||
+    pathname === "/api/internal/settings/context" ||
+    pathname === "/api/internal/usage/record"
+  ) {
+    return true;
+  }
+
+  if (pathname.startsWith("/api/internal/users/") && pathname.endsWith("/context")) {
+    return true;
+  }
+
+  return pathname.startsWith("/api/internal/integrations/") && pathname.endsWith("/credentials");
+}
 
 /**
  * Check if a request should be blocked based on the locked domain.
@@ -14,8 +40,13 @@ export function isHostAllowed(host: string | undefined, pathname: string | null)
   const lockedDomain = getCachedDomain();
   if (!lockedDomain) return true;
 
-  if (pathname && EXEMPT_PATHS.some((p) => pathname === p)) return true;
-  if (pathname && EXEMPT_PREFIXES.some((p) => pathname.startsWith(p))) return true;
+  if (pathname) {
+    if (EXEMPT_PATHS.some((p) => pathname === p)) return true;
+    if (isGatewayTokenProtectedInternalPath(pathname)) return true;
+    if (LOOPBACK_ONLY_EXEMPT_PATHS.some((p) => pathname === p) && isLoopbackHost(host)) {
+      return true;
+    }
+  }
 
   if (!host) return false;
 


### PR DESCRIPTION
## Summary
- exempt /api/internal/* from Domain Lock host matching so OpenClaw plugin calls using Docker-internal hostnames keep working
- keep exact health/setup exemptions and avoid exempting lookalike paths such as /api/internality/*
- add regression coverage for audit and config-ready internal routes

Fixes #285.

## Tests
- pnpm --dir packages/web exec vitest run src/__tests__/middleware/domain-restriction.test.ts
- pnpm --filter @pinchy/web build