### PR TITLE
Fix Domain Lock blocking internal healthcheck

### DIFF
--- a/packages/web/src/__tests__/config/deployment-healthcheck.test.ts
+++ b/packages/web/src/__tests__/config/deployment-healthcheck.test.ts
@@ -1,0 +1,50 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/domain-cache", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/domain-cache")>();
+  return {
+    ...actual,
+    getCachedDomain: vi.fn(),
+  };
+});
+
+import { getCachedDomain } from "@/lib/domain-cache";
+import { isHostAllowed } from "@/server/host-check";
+
+const composePath = resolve(__dirname, "../../../../../docker-compose.yml");
+const compose = readFileSync(composePath, "utf-8");
+
+function extractPinchyHealthcheckPath(): string {
+  const match = compose.match(/http:\/\/localhost:7777([^'"`)\s]+)/);
+  if (!match?.[1]) {
+    throw new Error("Could not find the Pinchy localhost healthcheck URL in docker-compose.yml");
+  }
+  return match[1];
+}
+
+describe("deployment healthcheck smoke", () => {
+  beforeEach(() => {
+    vi.mocked(getCachedDomain).mockReset();
+  });
+
+  it("keeps the Compose healthcheck compatible with Domain Lock", () => {
+    // Regression guard for #283: production Compose probes Pinchy via
+    // localhost from inside the container. If the healthcheck path is not
+    // exempt from Domain Lock, a locked instance returns 403, Pinchy is marked
+    // unhealthy, and OpenClaw never starts.
+    const healthcheckPath = extractPinchyHealthcheckPath();
+
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+
+    expect(healthcheckPath).toBe("/api/internal/openclaw-config-ready");
+    expect(isHostAllowed("localhost:7777", healthcheckPath)).toBe(true);
+  });
+
+  it("keeps OpenClaw gated on the Pinchy healthcheck", () => {
+    expect(compose).toMatch(
+      /openclaw:[\s\S]*depends_on:[\s\S]*pinchy:[\s\S]*condition: service_healthy/
+    );
+  });
+});

--- a/packages/web/src/__tests__/middleware/domain-restriction.test.ts
+++ b/packages/web/src/__tests__/middleware/domain-restriction.test.ts
@@ -46,6 +46,18 @@ describe("domain restriction host check", () => {
     expect(isHostAllowed("evil.example.com", "/api/setup/status")).toBe(true);
   });
 
+  it("always allows the internal OpenClaw config healthcheck regardless of host", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("localhost:7777", "/api/internal/openclaw-config-ready")).toBe(true);
+  });
+
+  it("always allows internal service callbacks regardless of host", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(
+      isHostAllowed("localhost:7777", "/api/internal/integrations/connection-1/credentials")
+    ).toBe(true);
+  });
+
   it("allows when host has default port 443 and domain does not", () => {
     vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
     expect(isHostAllowed("pinchy.example.com:443", "/dashboard")).toBe(true);

--- a/packages/web/src/server/host-check.ts
+++ b/packages/web/src/server/host-check.ts
@@ -1,8 +1,10 @@
 import { getCachedDomain, normalizeHost } from "@/lib/domain-cache";
 
 // Paths that bypass the domain-lock host check.
-// Health/status endpoints must remain accessible for monitoring and setup.
+// Health/status endpoints and internal service callbacks must remain reachable
+// from the Docker network even when the public host is locked.
 const EXEMPT_PATHS = ["/api/health", "/api/setup/status"];
+const EXEMPT_PREFIXES = ["/api/internal/"];
 
 /**
  * Check if a request should be blocked based on the locked domain.
@@ -13,6 +15,7 @@ export function isHostAllowed(host: string | undefined, pathname: string | null)
   if (!lockedDomain) return true;
 
   if (pathname && EXEMPT_PATHS.some((p) => pathname === p)) return true;
+  if (pathname && EXEMPT_PREFIXES.some((p) => pathname.startsWith(p))) return true;
 
   if (!host) return false;
 


### PR DESCRIPTION
## Summary
- exempt /api/internal/* from the Domain Lock host check
- add regression coverage for the OpenClaw config healthcheck and internal callbacks
- add a deployment smoke test that validates the real Compose healthcheck remains Domain Lock-compatible

Fixes #283

## Tests
- pnpm -C packages/web exec vitest run src/__tests__/config src/__tests__/middleware/domain-restriction.test.ts src/__tests__/api/openclaw-config-ready.test.ts
- pnpm -C packages/web exec eslint src/server/host-check.ts src/__tests__/middleware/domain-restriction.test.ts src/__tests__/config/deployment-healthcheck.test.ts
- pnpm -C packages/web exec prettier --check src/server/host-check.ts src/__tests__/middleware/domain-restriction.test.ts src/__tests__/config/deployment-healthcheck.test.ts
- pnpm --filter @pinchy/web build (pre-push hook)