### PR TITLE
[codex] Pass BETTER_AUTH_URL through compose

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -19,6 +19,11 @@ PINCHY_VERSION=v0.5.0
 
 # ─────────────────────────────────────────────────────────────
 # Optional
+# Public HTTPS URL for production deployments behind a reverse proxy.
+# Set this after HTTPS is live so password resets, OAuth callbacks, and
+# Telegram pairing redirects point back to your canonical Pinchy domain.
+# Example: BETTER_AUTH_URL=https://pinchy.example.com
+# BETTER_AUTH_URL=
 # PINCHY_PORT=0.0.0.0:7777   # default: 127.0.0.1:7777
 # PINCHY_ENTERPRISE_KEY=
 # PINCHY_ADMIN_EMAIL=admin@example.com

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -561,6 +561,7 @@ jobs:
           {
             echo "PINCHY_VERSION=test-${SHORT_SHA}"
             echo "DB_PASSWORD=$(openssl rand -hex 32)"
+            echo "BETTER_AUTH_URL=https://pinchy.example.test"
           } > .env
           # BETTER_AUTH_SECRET + ENCRYPTION_KEY remain unset on purpose —
           # tests Pinchy's auto-generation path (used by end-users who
@@ -590,6 +591,16 @@ jobs:
           docker compose ps
           docker compose logs
           exit 1
+
+      - name: Verify BETTER_AUTH_URL reaches Pinchy container
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          ACTUAL=$(docker compose exec -T pinchy printenv BETTER_AUTH_URL)
+          if [ "$ACTUAL" != "https://pinchy.example.test" ]; then
+            echo "::error::BETTER_AUTH_URL was not passed through to the Pinchy container. Expected https://pinchy.example.test, got '${ACTUAL:-<unset>}'."
+            docker compose config
+            exit 1
+          fi
 
       - name: Assert all services running
         working-directory: ${{ steps.install-dir.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -122,6 +122,7 @@ jobs:
           {
             echo "PINCHY_VERSION=${RELEASE_TAG}"
             echo "DB_PASSWORD=$(openssl rand -hex 32)"
+            echo "BETTER_AUTH_URL=https://pinchy.example.test"
           } > .env
           # BETTER_AUTH_SECRET + ENCRYPTION_KEY remain unset on purpose —
           # tests Pinchy's auto-generation path (used by end-users who
@@ -155,6 +156,16 @@ jobs:
           docker compose ps
           docker compose logs
           exit 1
+
+      - name: Verify BETTER_AUTH_URL reaches Pinchy container
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          ACTUAL=$(docker compose exec -T pinchy printenv BETTER_AUTH_URL)
+          if [ "$ACTUAL" != "https://pinchy.example.test" ]; then
+            echo "::error::BETTER_AUTH_URL was not passed through to the Pinchy container. Expected https://pinchy.example.test, got '${ACTUAL:-<unset>}'."
+            docker compose config
+            exit 1
+          fi
 
       - name: Assert all services running
         working-directory: ${{ steps.install-dir.outputs.path }}

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
     environment:
       - DATABASE_URL=postgresql://pinchy:${DB_PASSWORD:-pinchy_dev}@db:5432/pinchy
       - BETTER_AUTH_SECRET=${BETTER_AUTH_SECRET:-}
+      - BETTER_AUTH_URL=${BETTER_AUTH_URL:-}
       - OPENCLAW_WS_URL=ws://openclaw:18789
       - ENCRYPTION_KEY=${ENCRYPTION_KEY:-}
       - PINCHY_ENTERPRISE_KEY=${PINCHY_ENTERPRISE_KEY:-}

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -231,6 +231,13 @@ systemctl reload caddy
 
 Tell Pinchy its public HTTPS URL so auth callbacks and redirects are generated with your real domain. Use the same domain you put in the Caddyfile, including `https://` and no trailing slash:
 
+<Aside type="caution">
+  This only works when your `docker-compose.yml` passes `BETTER_AUTH_URL`
+  through to the `pinchy` service. If your server was installed with an older
+  compose file that does not include it, fetch a newer compose file or add the
+  environment variable via `docker-compose.override.yml` before restarting.
+</Aside>
+
 ```bash
 cd /opt/pinchy
 grep -q '^BETTER_AUTH_URL=' .env \

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -229,6 +229,16 @@ Save the file (Ctrl+O, Enter, Ctrl+X) and reload Caddy:
 systemctl reload caddy
 ```
 
+Tell Pinchy its public HTTPS URL so auth callbacks and redirects are generated with your real domain. Use the same domain you put in the Caddyfile, including `https://` and no trailing slash:
+
+```bash
+cd /opt/pinchy
+grep -q '^BETTER_AUTH_URL=' .env \
+  && sed -i 's|^BETTER_AUTH_URL=.*|BETTER_AUTH_URL=https://pinchy.example.com|' .env \
+  || echo 'BETTER_AUTH_URL=https://pinchy.example.com' >> .env
+docker compose up -d pinchy
+```
+
 After a few seconds, visit `https://pinchy.example.com` — Caddy automatically provisions a Let's Encrypt certificate. The loading-page fallback on `:9999` stays unchanged so users still see a friendly page if Pinchy ever becomes unreachable during an upgrade or restart.
 
 <Aside type="tip">
@@ -240,7 +250,7 @@ After a few seconds, visit `https://pinchy.example.com` — Caddy automatically 
 
 Once HTTPS is working, open **Settings → Security** in the Pinchy web UI and enter your domain (e.g. `pinchy.example.com`).
 
-After saving, Pinchy will reject requests from any other origin with a 403 error — including access via the raw server IP address.
+After saving, Pinchy will reject requests from any other origin with a 403 error — including access via the raw server IP address. The domain lock should match the hostname in `BETTER_AUTH_URL`; together they keep security checks and generated callback URLs on the same public origin.
 
 <Aside type="note">
   Secrets (database password, session secret, encryption key) were automatically

--- a/docs/src/content/docs/guides/domain-lock.mdx
+++ b/docs/src/content/docs/guides/domain-lock.mdx
@@ -70,6 +70,13 @@ Add your public URL, including `https://` and no trailing slash:
 BETTER_AUTH_URL=https://pinchy.example.com
 ```
 
+<Aside type="caution">
+  This setting only takes effect if your `docker-compose.yml` passes
+  `BETTER_AUTH_URL` through to the `pinchy` service. Older compose files may
+  need to be updated, or you can add the variable via
+  `docker-compose.override.yml`.
+</Aside>
+
 Restart the Pinchy container so Docker Compose passes the updated value through:
 
 ```bash

--- a/docs/src/content/docs/guides/domain-lock.mdx
+++ b/docs/src/content/docs/guides/domain-lock.mdx
@@ -54,6 +54,29 @@ Caddy automatically provisions Let's Encrypt certificates for your domain. After
   default `127.0.0.1:7777` binding so only Caddy can reach Pinchy.
 </Aside>
 
+### Set the public auth URL
+
+For production domains, set `BETTER_AUTH_URL` to the same HTTPS origin users visit. Better Auth uses it when it needs to build absolute links, including password resets, OAuth callbacks, and Telegram pairing redirects.
+
+Edit your Pinchy `.env` file:
+
+```bash
+nano /opt/pinchy/.env
+```
+
+Add your public URL, including `https://` and no trailing slash:
+
+```bash
+BETTER_AUTH_URL=https://pinchy.example.com
+```
+
+Restart the Pinchy container so Docker Compose passes the updated value through:
+
+```bash
+cd /opt/pinchy
+docker compose up -d pinchy
+```
+
 <details>
 <summary>What's a reverse proxy and why do I need one?</summary>
 
@@ -93,7 +116,7 @@ You don't have to configure any of these individually — locking the domain fli
 
 </Steps>
 
-From this point on, only the locked domain can reach the app.
+From this point on, only the locked domain can reach the app. Use the same hostname for the lock and for `BETTER_AUTH_URL`; the lock controls which host Pinchy accepts, while `BETTER_AUTH_URL` controls the absolute URLs Better Auth generates.
 
 ## Remove the lock
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -153,6 +153,16 @@ Without this, OpenClaw starts but cannot read its secrets, and every agent reque
 
 If you skip step 3, `docker compose up` fails loudly with a clear message telling you exactly what to add — this is by design, so a forgotten pin can't silently pull the wrong version.
 
+#### Recommended: set BETTER_AUTH_URL on HTTPS deployments
+
+If Pinchy is available on a public HTTPS domain, add the canonical URL to `/opt/pinchy/.env` before restarting:
+
+```bash
+BETTER_AUTH_URL=https://pinchy.example.com
+```
+
+The new `docker-compose.yml` passes this through to the Pinchy container. Better Auth uses it to generate absolute links for password resets, OAuth callbacks, and Telegram pairing redirects. Use the same hostname you lock in **Settings → Security**, without a trailing slash.
+
 #### Telegram: brief downtime on first start
 
 OpenClaw detects the new SecretRef config format and hot-reloads. Telegram channels may be unresponsive for roughly 30 seconds during this reload. They recover automatically — no restart or re-configuration needed.

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -65,6 +65,9 @@ DB_PASSWORD=your-secure-password
 # Better Auth session secret (auto-generated if omitted)
 BETTER_AUTH_SECRET=your-random-secret
 
+# Public HTTPS origin for generated auth links/callbacks (set after HTTPS is live)
+BETTER_AUTH_URL=https://pinchy.example.com
+
 # Encryption key for API keys — 64 hex characters (auto-generated if omitted)
 ENCRYPTION_KEY=
 
@@ -78,6 +81,8 @@ PINCHY_ENTERPRISE_KEY=
 **`DB_PASSWORD`** — Password for the PostgreSQL `pinchy` user. Defaults to `pinchy_dev` in Docker Compose.
 
 **`BETTER_AUTH_SECRET`** — Used by Better Auth for session security. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
+
+**`BETTER_AUTH_URL`** — Public HTTPS origin for generated auth links and callbacks. Set this on production deployments behind a reverse proxy once HTTPS is live, using the same hostname you lock in **Settings → Security**.
 
 **`ENCRYPTION_KEY`** — Used to encrypt provider API keys at rest (AES-256-GCM). Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -84,6 +84,14 @@ PINCHY_ENTERPRISE_KEY=
 
 **`BETTER_AUTH_URL`** — Public HTTPS origin for generated auth links and callbacks. Set this on production deployments behind a reverse proxy once HTTPS is live, using the same hostname you lock in **Settings → Security**.
 
+<Aside type="caution">
+  The v0.4.4 `docker-compose.yml` shown above does not pass `BETTER_AUTH_URL`
+  through. If your compose file does not include
+  `BETTER_AUTH_URL=${BETTER_AUTH_URL:-}` under the `pinchy` service
+  `environment:` block, upgrade to a newer compose file or add it via
+  `docker-compose.override.yml`.
+</Aside>
+
 **`ENCRYPTION_KEY`** — Used to encrypt provider API keys at rest (AES-256-GCM). Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 
 **`AUDIT_HMAC_SECRET`** — Used to sign audit trail entries with HMAC-SHA256. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. Set explicitly if you need consistent signatures across deployments.

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -23,13 +23,6 @@ import { readGatewayToken } from "./src/lib/gateway-token-reader";
 
 logCapture.install();
 
-if (process.env.BETTER_AUTH_URL) {
-  console.warn(
-    "⚠ BETTER_AUTH_URL is set but no longer used. " +
-      "Go to Settings → Security to lock your domain."
-  );
-}
-
 if (process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT === "1") {
   // Surface this loud at startup. Production deployments must NEVER set this
   // — it disables Better Auth's brute-force protection on /sign-in/*. The

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -73,6 +73,18 @@ describe("auth config consistency", () => {
     expect(content).toContain("BETTER_AUTH_URL=");
   });
 
+  it("installation docs should scope BETTER_AUTH_URL when the guide is pinned to older compose files", () => {
+    const content = readFileSync(
+      resolve(PROJECT_ROOT, "docs/src/content/docs/installation.mdx"),
+      "utf-8"
+    );
+    if (!content.includes("v0.4.4") || !content.includes("BETTER_AUTH_URL")) return;
+
+    expect(content).toMatch(
+      /The v0\.4\.4 `docker-compose\.yml` shown above does not pass `BETTER_AUTH_URL`\s+through/
+    );
+  });
+
   it("server.ts should not warn that BETTER_AUTH_URL is unused", () => {
     const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/server.ts"), "utf-8");
     expect(content).not.toContain("BETTER_AUTH_URL is set but no longer used");

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -25,7 +25,6 @@ const LEGACY_PATTERNS = [
   { pattern: /NEXTAUTH_URL/g, replacement: "N/A (configure domain via Settings → Security)" },
   { pattern: /AUTH_TRUST_HOST/g, replacement: "N/A (not needed by Better Auth)" },
   { pattern: /(?<![A-Z_])AUTH_SECRET(?![A-Z_])/g, replacement: "BETTER_AUTH_SECRET" },
-  { pattern: /BETTER_AUTH_URL/g, replacement: "N/A (configure domain via Settings → Security)" },
 ];
 
 describe("auth config consistency", () => {
@@ -62,6 +61,21 @@ describe("auth config consistency", () => {
   it("docker-compose.dev.yml should set BETTER_AUTH_SECRET", () => {
     const content = readFileSync(resolve(PROJECT_ROOT, "docker-compose.dev.yml"), "utf-8");
     expect(content).toContain("BETTER_AUTH_SECRET");
+  });
+
+  it("docker-compose.yml should pass BETTER_AUTH_URL through when configured", () => {
+    const content = readFileSync(resolve(PROJECT_ROOT, "docker-compose.yml"), "utf-8");
+    expect(content).toContain("BETTER_AUTH_URL=${BETTER_AUTH_URL:-}");
+  });
+
+  it(".env.example should document BETTER_AUTH_URL", () => {
+    const content = readFileSync(resolve(PROJECT_ROOT, ".env.example"), "utf-8");
+    expect(content).toContain("BETTER_AUTH_URL=");
+  });
+
+  it("server.ts should not warn that BETTER_AUTH_URL is unused", () => {
+    const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/server.ts"), "utf-8");
+    expect(content).not.toContain("BETTER_AUTH_URL is set but no longer used");
   });
 
   it("auth.ts should configure trustedOrigins for dynamic origin detection", () => {


### PR DESCRIPTION
## Summary

Fixes #282.

- Pass `BETTER_AUTH_URL` from `.env` into the Pinchy container in the default `docker-compose.yml`.
- Remove the stale startup warning that said `BETTER_AUTH_URL` was no longer used.
- Document the variable in `.env.example`, installation docs, Hetzner deploy, Domain Lock, and upgrade notes.
- Extend CI clean-install workflows to set `BETTER_AUTH_URL` and assert it reaches the running Pinchy container.

## Root Cause

The default compose file only passed `BETTER_AUTH_SECRET`, not `BETTER_AUTH_URL`, so production installs behind a reverse proxy could configure the public URL in `.env` but Better Auth never saw it inside the container.

## Validation

- `pnpm -C packages/web exec vitest run src/__tests__/security/auth-config-consistency.test.ts src/__tests__/config/cloud-init.test.ts src/__tests__/config/cloud-init-next.test.ts`
- `pnpm test:scripts`
- `env PINCHY_VERSION=test docker compose config --quiet`
- Pre-push `pnpm --filter @pinchy/web build` hook passed