### PR TITLE
fix(auth): clarify BETTER_AUTH_URL callback role

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -17,6 +17,14 @@ PINCHY_VERSION=v0.5.0
 # BETTER_AUTH_SECRET=
 # ENCRYPTION_KEY=
 
+# Better Auth callback base URL.
+# Set this to your public HTTPS origin after configuring a domain, e.g.
+# BETTER_AUTH_URL=https://pinchy.example.com
+#
+# Domain Lock is configured in Settings → Security. This env var is separate:
+# it lets Better Auth build absolute callback and redirect URLs.
+# BETTER_AUTH_URL=
+
 # ─────────────────────────────────────────────────────────────
 # Optional
 # Public HTTPS URL for production deployments behind a reverse proxy.

--- a/README.md
+++ b/README.md
@@ -100,7 +100,7 @@ Read the full story on [heypinchy.com](https://heypinchy.com/blog/building-pinch
 
 We care about how Pinchy _feels_, not just what it does. Security + Ease is our core tension — enterprise-grade protection that feels light, not intimidating. Smart defaults everywhere, personality templates instead of blank slates, zero-config setup, and full customization when you need it.
 
-Read more in our [Philosophy docs](https://docs.heypinchy.com/concepts/philosophy) and [`PERSONALITY.md`](PERSONALITY.md).
+Read more in our [Philosophy docs](https://docs.heypinchy.com/concepts/philosophy/) and [`PERSONALITY.md`](PERSONALITY.md).
 
 ## Contributing
 

--- a/docs/src/content/docs/guides/deploy-hetzner.mdx
+++ b/docs/src/content/docs/guides/deploy-hetzner.mdx
@@ -253,6 +253,16 @@ After a few seconds, visit `https://pinchy.example.com` — Caddy automatically 
   point from the internet. No `PINCHY_PORT` changes needed.
 </Aside>
 
+Set the public Better Auth callback origin to the same HTTPS domain:
+
+```bash
+cd /opt/pinchy
+printf '\nBETTER_AUTH_URL=https://pinchy.example.com\n' >> .env
+docker compose up -d
+```
+
+`BETTER_AUTH_URL` is separate from Domain Lock. It is used for absolute callback and redirect URLs such as password reset, OAuth, and Telegram pairing.
+
 ### Lock your domain
 
 Once HTTPS is working, open **Settings → Security** in the Pinchy web UI and enter your domain (e.g. `pinchy.example.com`).

--- a/docs/src/content/docs/guides/domain-lock.mdx
+++ b/docs/src/content/docs/guides/domain-lock.mdx
@@ -125,6 +125,14 @@ You don't have to configure any of these individually — locking the domain fli
 
 From this point on, only the locked domain can reach the app. Use the same hostname for the lock and for `BETTER_AUTH_URL`; the lock controls which host Pinchy accepts, while `BETTER_AUTH_URL` controls the absolute URLs Better Auth generates.
 
+<Aside type="note">
+  Domain Lock and `BETTER_AUTH_URL` are related but separate. Domain Lock
+  rejects requests for the wrong host. `BETTER_AUTH_URL` tells Better Auth which
+  public HTTPS origin to use when it builds callback and redirect URLs. In
+  production, set `BETTER_AUTH_URL=https://pinchy.example.com` in your `.env`
+  and restart Pinchy.
+</Aside>
+
 ## Remove the lock
 
 If the business needs change (different domain, temporary maintenance URL, etc.):

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -65,7 +65,7 @@ DB_PASSWORD=your-secure-password
 # Better Auth session secret (auto-generated if omitted)
 BETTER_AUTH_SECRET=your-random-secret
 
-# Public HTTPS origin for generated auth links/callbacks (set after HTTPS is live)
+# Public HTTPS origin for Better Auth callback and redirect URLs
 BETTER_AUTH_URL=https://pinchy.example.com
 
 # Encryption key for API keys — 64 hex characters (auto-generated if omitted)
@@ -82,7 +82,7 @@ PINCHY_ENTERPRISE_KEY=
 
 **`BETTER_AUTH_SECRET`** — Used by Better Auth for session security. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 
-**`BETTER_AUTH_URL`** — Public HTTPS origin for generated auth links and callbacks. Set this on production deployments behind a reverse proxy once HTTPS is live, using the same hostname you lock in **Settings → Security**.
+**`BETTER_AUTH_URL`** — Public HTTPS origin used by Better Auth to build callback and redirect URLs, for example password reset, OAuth, and Telegram pairing flows. Set this to the same origin users visit, such as `https://pinchy.example.com`. Domain Lock is configured separately in **Settings → Security**; when you lock a domain, use the same hostname here.
 
 <Aside type="caution">
   The v0.4.4 `docker-compose.yml` shown above does not pass `BETTER_AUTH_URL`

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -20,8 +20,12 @@ import { startUsagePoller, stopUsagePoller } from "./src/lib/usage-poller";
 import { registerShutdownHandlers } from "./src/lib/shutdown";
 import { seedSessionCache } from "./src/server/session-cache-seeder";
 import { readGatewayToken } from "./src/lib/gateway-token-reader";
+import { getBetterAuthUrlStartupWarning } from "./src/lib/auth-env-warning";
 
 logCapture.install();
+
+const betterAuthUrlWarning = getBetterAuthUrlStartupWarning();
+if (betterAuthUrlWarning) console.warn(betterAuthUrlWarning);
 
 if (process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT === "1") {
   // Surface this loud at startup. Production deployments must NEVER set this

--- a/packages/web/src/__tests__/lib/auth-env-warning.test.ts
+++ b/packages/web/src/__tests__/lib/auth-env-warning.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from "vitest";
+import { getBetterAuthUrlStartupWarning } from "@/lib/auth-env-warning";
+
+describe("getBetterAuthUrlStartupWarning", () => {
+  it("does not warn when BETTER_AUTH_URL is unset or empty", () => {
+    expect(getBetterAuthUrlStartupWarning({})).toBeNull();
+    expect(getBetterAuthUrlStartupWarning({ BETTER_AUTH_URL: "" })).toBeNull();
+  });
+
+  it("explains that BETTER_AUTH_URL still controls callback URLs", () => {
+    const warning = getBetterAuthUrlStartupWarning({
+      BETTER_AUTH_URL: "https://pinchy.example.com",
+    });
+
+    expect(warning).toContain("Domain Lock is configured via Settings");
+    expect(warning).toContain("still controls Better Auth callback URLs");
+  });
+
+  it("does not say BETTER_AUTH_URL is unused", () => {
+    const warning = getBetterAuthUrlStartupWarning({
+      BETTER_AUTH_URL: "https://pinchy.example.com",
+    });
+
+    expect(warning).not.toContain("no longer used");
+  });
+});

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -85,8 +85,12 @@ describe("auth config consistency", () => {
     );
   });
 
-  it("server.ts should not warn that BETTER_AUTH_URL is unused", () => {
-    const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/server.ts"), "utf-8");
+  it("startup warning should explain BETTER_AUTH_URL still controls Better Auth callbacks", () => {
+    const content = readFileSync(
+      resolve(PROJECT_ROOT, "packages/web/src/lib/auth-env-warning.ts"),
+      "utf-8"
+    );
+    expect(content).toContain("still controls Better Auth callback URLs");
     expect(content).not.toContain("BETTER_AUTH_URL is set but no longer used");
   });
 

--- a/packages/web/src/lib/auth-env-warning.ts
+++ b/packages/web/src/lib/auth-env-warning.ts
@@ -1,0 +1,10 @@
+export function getBetterAuthUrlStartupWarning(
+  env: NodeJS.ProcessEnv = process.env
+): string | null {
+  if (!env.BETTER_AUTH_URL) return null;
+
+  return (
+    "⚠ BETTER_AUTH_URL is set. Domain Lock is configured via Settings → Security; " +
+    "BETTER_AUTH_URL still controls Better Auth callback URLs."
+  );
+}


### PR DESCRIPTION
## Summary
- clarify the BETTER_AUTH_URL startup warning so it no longer says the env var is unused
- pass BETTER_AUTH_URL through docker-compose.yml for Better Auth callback URLs
- document the split between Domain Lock and Better Auth callback base URL
- add TDD coverage for the warning text and compose passthrough

Fixes #284
Related #282

## Tests
- pnpm --dir packages/web exec vitest run src/__tests__/lib/auth-env-warning.test.ts src/__tests__/security/auth-config-consistency.test.ts
- pnpm --dir packages/web test (rerun outside sandbox due local Odoo mock port binding)
- pnpm --dir packages/web exec tsc --noEmit
- pnpm --dir packages/web exec eslint server.ts src/lib/auth-env-warning.ts src/__tests__/lib/auth-env-warning.test.ts src/__tests__/security/auth-config-consistency.test.ts
- pnpm --dir packages/web exec prettier --check server.ts src/lib/auth-env-warning.ts src/__tests__/lib/auth-env-warning.test.ts src/__tests__/security/auth-config-consistency.test.ts ../../docs/src/content/docs/installation.mdx ../../docs/src/content/docs/guides/domain-lock.mdx ../../docs/src/content/docs/guides/deploy-hetzner.mdx ../../.env.example
- pnpm --dir packages/web build (rerun outside sandbox for next/font network access)
- git diff --check