### PR TITLE
fix(docs): align openclaw-secrets tmpfs docs with v0.5.0 compose (#281)

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -52,7 +52,7 @@ HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
   CMD node -e "fetch('http://localhost:7777/api/health').then(r=>{if(!r.ok)process.exit(1)}).catch(()=>process.exit(1))"
 
 # Create non-root user (entrypoint drops privileges after fixing volume permissions)
-RUN groupadd -r pinchy && useradd -r -g pinchy -d /app pinchy
+RUN groupadd -r -g 999 pinchy && useradd -r -u 999 -g pinchy -d /app pinchy
 RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces
 
 COPY entrypoint.sh /entrypoint.sh

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -120,17 +120,30 @@ If you need to roll back after an upgrade:
 
 None for the standard upgrade path — the new `docker-compose.yml` you download below already contains the `openclaw-secrets` tmpfs block needed by the new SecretRef architecture.
 
-If you maintain a **custom `docker-compose.yml`** (e.g. for a non-standard deployment, a different orchestrator profile, or a downstream fork), you must add this `tmpfs` block to the `openclaw` service definition before starting %%PINCHY_VERSION%%:
+If you maintain a **custom `docker-compose.yml`** (e.g. for a non-standard deployment, a different orchestrator profile, or a downstream fork), you must add a tmpfs-backed named volume for `/openclaw-secrets` and mount it into **both** the `pinchy` and `openclaw` services before starting %%PINCHY_VERSION%%:
 
 ```yaml
 services:
+  pinchy:
+    volumes:
+      - openclaw-secrets:/openclaw-secrets
+      # …rest of the pinchy volumes
+
   openclaw:
-    tmpfs:
-      - /openclaw-secrets:mode=0700,uid=1000,gid=1000
-    # …rest of the service definition
+    volumes:
+      - openclaw-secrets:/openclaw-secrets
+      # …rest of the openclaw volumes
+
+volumes:
+  openclaw-secrets:
+    driver: local
+    driver_opts:
+      type: tmpfs
+      device: tmpfs
+      o: "mode=0770,uid=999,gid=999"
 ```
 
-Without this, OpenClaw starts but cannot read its secrets, and every agent request fails with an authentication error.
+The volume must be mounted into both services: Pinchy writes `secrets.json` (and needs `uid=999` ownership to rewrite it atomically), OpenClaw reads it. The `uid=999` value matches the `pinchy` system user created in `Dockerfile.pinchy`. Without this, Pinchy cannot write the secrets file and every agent request fails with an authentication error.
 
 ### Upgrade notes
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -143,7 +143,7 @@ volumes:
       o: "mode=0770,uid=999,gid=999"
 ```
 
-The volume must be mounted into both services: Pinchy writes `secrets.json` (and needs `uid=999` ownership to rewrite it atomically), OpenClaw reads it. The `uid=999` value matches the `pinchy` system user created in `Dockerfile.pinchy`. Without this, Pinchy cannot write the secrets file and every agent request fails with an authentication error.
+The volume must be mounted into both services: Pinchy writes and atomically replaces `secrets.json` (requires directory write permission — `uid=999` grants this as the `pinchy` system user); OpenClaw reads it. Without this, Pinchy cannot write the secrets file and every agent request fails with an authentication error.
 
 ### Upgrade notes
 

--- a/docs/src/content/docs/security/secrets.md
+++ b/docs/src/content/docs/security/secrets.md
@@ -55,7 +55,7 @@ openclaw-secrets:
     o: "mode=0770,uid=999,gid=999"
 ```
 
-The directory is owned by uid 999 / gid 999 (the `pinchy` system user inside the Pinchy container) with mode `0770`. Pinchy writes `secrets.json` as the owner; OpenClaw runs as root in its own container and reads the file regardless of ownership. Inside, `secrets.json` is written with mode `0600` (owner read/write only) as defense-in-depth: even a same-uid process that obtained directory access cannot read another tenant's file.
+The directory is owned by uid/gid 999 (the `pinchy` system user inside the Pinchy container) with mode `0770`. Pinchy writes `secrets.json` as the owner; OpenClaw runs as root in its own container and reads the file regardless of ownership. Inside, `secrets.json` is written with mode `0600` (owner read/write only) as defense-in-depth: even a same-uid process that obtained directory access cannot read another tenant's file.
 
 ## What this protects against
 

--- a/docs/src/content/docs/security/secrets.md
+++ b/docs/src/content/docs/security/secrets.md
@@ -52,10 +52,10 @@ openclaw-secrets:
   driver_opts:
     type: tmpfs
     device: tmpfs
-    o: "mode=0770,uid=1000,gid=1000"
+    o: "mode=0770,uid=999,gid=999"
 ```
 
-The directory is mode `0770` and owned by uid/gid 1000 — only the OpenClaw and Pinchy processes (both run as uid 1000) can enter it. Inside, `secrets.json` is written with mode `0600` (owner read/write only) as defense-in-depth: even a same-uid process that obtained directory access cannot read another tenant's file.
+The directory is owned by uid 999 / gid 999 (the `pinchy` system user inside the Pinchy container) with mode `0770`. Pinchy writes `secrets.json` as the owner; OpenClaw runs as root in its own container and reads the file regardless of ownership. Inside, `secrets.json` is written with mode `0600` (owner read/write only) as defense-in-depth: even a same-uid process that obtained directory access cannot read another tenant's file.
 
 ## What this protects against
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -22,7 +22,7 @@ if [ ! -f /openclaw-config/openclaw.json ]; then
 fi
 
 # Give pinchy user ownership of the secrets tmpfs so it can read/write
-# secrets.json. The tmpfs is initially owned by root (or uid=1000 per the
+# secrets.json. The tmpfs is initially owned by root (or uid=999 per the
 # volume driver opts); ensure the pinchy user is the directory owner so
 # it can enter the directory and rename files atomically.
 chown pinchy:pinchy /openclaw-secrets 2>/dev/null || true

--- a/packages/web/src/__tests__/docs/openclaw-secrets-drift.test.ts
+++ b/packages/web/src/__tests__/docs/openclaw-secrets-drift.test.ts
@@ -12,13 +12,14 @@ const upgrading = readFileSync(upgradingPath, "utf-8");
 const secretsDoc = readFileSync(secretsDocPath, "utf-8");
 
 function extractTmpfsOptions(): string {
-  // Matches the `o: "mode=...,uid=...,gid=..."` line under the
-  // openclaw-secrets volume in docker-compose.yml.
-  const match = compose.match(/openclaw-secrets:\s*\n[\s\S]*?o:\s*"([^"]+)"/);
-  if (!match?.[1]) {
+  // Matches the `o:` line under the openclaw-secrets volume in docker-compose.yml.
+  // Handles both quoted (`o: "mode=..."`) and unquoted (`o: mode=...`) YAML values.
+  const match = compose.match(/openclaw-secrets:\s*\n[\s\S]*?o:\s*(?:"([^"]+)"|(\S+))/);
+  const options = match?.[1] ?? match?.[2];
+  if (!options) {
     throw new Error("Could not extract tmpfs options for openclaw-secrets from docker-compose.yml");
   }
-  return match[1];
+  return options;
 }
 
 describe("openclaw-secrets tmpfs documentation drift", () => {
@@ -55,7 +56,7 @@ describe("openclaw-secrets tmpfs documentation drift", () => {
     const uidMatch = options.match(/uid=(\d+)/);
     expect(uidMatch?.[1], "uid not found in compose options").toBeDefined();
     const uid = uidMatch![1]!;
-    expect(secretsDoc).toContain(`uid ${uid}`);
+    expect(secretsDoc).toMatch(new RegExp(`uid[^\\d]*${uid}\\b`));
     // And must NOT mention the previous, drifted value.
     expect(secretsDoc).not.toMatch(/uid 1000\b/);
   });

--- a/packages/web/src/__tests__/docs/openclaw-secrets-drift.test.ts
+++ b/packages/web/src/__tests__/docs/openclaw-secrets-drift.test.ts
@@ -1,0 +1,62 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const repoRoot = resolve(__dirname, "../../../../..");
+const composePath = resolve(repoRoot, "docker-compose.yml");
+const upgradingPath = resolve(repoRoot, "docs/src/content/docs/guides/upgrading.mdx");
+const secretsDocPath = resolve(repoRoot, "docs/src/content/docs/security/secrets.md");
+
+const compose = readFileSync(composePath, "utf-8");
+const upgrading = readFileSync(upgradingPath, "utf-8");
+const secretsDoc = readFileSync(secretsDocPath, "utf-8");
+
+function extractTmpfsOptions(): string {
+  // Matches the `o: "mode=...,uid=...,gid=..."` line under the
+  // openclaw-secrets volume in docker-compose.yml.
+  const match = compose.match(/openclaw-secrets:\s*\n[\s\S]*?o:\s*"([^"]+)"/);
+  if (!match?.[1]) {
+    throw new Error("Could not extract tmpfs options for openclaw-secrets from docker-compose.yml");
+  }
+  return match[1];
+}
+
+describe("openclaw-secrets tmpfs documentation drift", () => {
+  it("upgrading.mdx custom-compose snippet matches docker-compose.yml options", () => {
+    // Regression guard for #281: a custom-compose maintainer who copies the
+    // snippet verbatim must end up with the same tmpfs options as the
+    // canonical docker-compose.yml. Drift here breaks every agent request
+    // with an EACCES on writeSecretsFile().
+    const options = extractTmpfsOptions();
+    expect(upgrading).toContain(options);
+  });
+
+  it("upgrading.mdx custom-compose snippet mounts the volume into both services", () => {
+    // The named volume must be referenced under BOTH `pinchy:` and `openclaw:`
+    // service blocks in the breaking-changes section. Mounting only into
+    // openclaw is the exact failure mode #281 documents.
+    const breakingChanges = upgrading
+      .split(/^##\s+Upgrading from v0\.4\.4/m)[1]
+      ?.split(/^##\s+Upgrading from v0\.4\.3/m)[0];
+    expect(breakingChanges, "breaking-changes section not found").toBeDefined();
+    expect(breakingChanges!).toMatch(/pinchy:[\s\S]*openclaw-secrets/);
+    expect(breakingChanges!).toMatch(/openclaw:[\s\S]*openclaw-secrets/);
+  });
+
+  it("security/secrets.md yaml block matches docker-compose.yml options", () => {
+    const options = extractTmpfsOptions();
+    expect(secretsDoc).toContain(options);
+  });
+
+  it("security/secrets.md prose references the actual Pinchy uid", () => {
+    // The descriptive paragraph claims a specific uid for the directory
+    // owner. It must match the value baked into docker-compose.yml.
+    const options = extractTmpfsOptions();
+    const uidMatch = options.match(/uid=(\d+)/);
+    expect(uidMatch?.[1], "uid not found in compose options").toBeDefined();
+    const uid = uidMatch![1]!;
+    expect(secretsDoc).toContain(`uid ${uid}`);
+    // And must NOT mention the previous, drifted value.
+    expect(secretsDoc).not.toMatch(/uid 1000\b/);
+  });
+});


### PR DESCRIPTION
## Summary
- Fix the custom-compose snippet in `Upgrading from v0.4.4 → Breaking changes` so it matches the actual v0.5.0 `docker-compose.yml` (named volume with tmpfs `driver_opts`, mounted into **both** `pinchy` and `openclaw`, `mode=0770,uid=999,gid=999`).
- Fix the YAML excerpt and surrounding prose in `Security → Secrets & API Key Storage` (uid 999 not 1000; OpenClaw runs as root, not "uid 1000").
- Pin `uid=999,gid=999` explicitly in `Dockerfile.pinchy` so the docker-compose.yml configuration is guaranteed to match.
- Add a drift-detection regression test that parses `docker-compose.yml` and asserts both doc files stay in sync — same failure mode cannot ship again.

Closes #281.

## Test plan
- [ ] `pnpm -C packages/web test -- src/__tests__/docs/openclaw-secrets-drift.test.ts` → 4 / 4 green
- [ ] `pnpm -C packages/web test` → no regressions
- [ ] `cd docs && pnpm build` → docs build succeeds
- [ ] Visual check: `/guides/upgrading/#breaking-changes` and `/security/secrets/` render cleanly with corrected snippets