### PR TITLE
fix(setup): fix Ollama local provider so chats don't fail with 'No API key found'

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -19,6 +19,13 @@ services:
     build:
       context: .
       dockerfile: Dockerfile.openclaw
+    extra_hosts:
+      # ollama.local is mapped to the Docker host gateway so the OpenClaw
+      # container can reach Ollama on the host. Pinchy's build.ts rewrites
+      # host.docker.internal -> ollama.local in the emitted config because
+      # host.docker.internal is not in OpenClaw 2026.4.27's isLocalBaseUrl
+      # allowlist (*.local is).
+      - "ollama.local:host-gateway"
     volumes:
       - ./packages/plugins/pinchy-files:/root/.openclaw/extensions/pinchy-files
       - ./packages/plugins/pinchy-context:/root/.openclaw/extensions/pinchy-context

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,6 +35,13 @@ services:
     image: ghcr.io/heypinchy/pinchy-openclaw:${PINCHY_VERSION:?set PINCHY_VERSION in .env (e.g. PINCHY_VERSION=v0.5.0)}
     expose:
       - "18789"
+    extra_hosts:
+      # ollama.local is mapped to the Docker host gateway so the OpenClaw
+      # container can reach Ollama on the host. Pinchy's build.ts rewrites
+      # host.docker.internal -> ollama.local in the emitted config because
+      # host.docker.internal is not in OpenClaw 2026.4.27's isLocalBaseUrl
+      # allowlist (*.local is).
+      - "ollama.local:host-gateway"
     volumes:
       - openclaw-config:/root/.openclaw
       - openclaw-secrets:/openclaw-secrets

--- a/docs/src/content/docs/guides/ollama-setup.mdx
+++ b/docs/src/content/docs/guides/ollama-setup.mdx
@@ -56,7 +56,9 @@ http://host.docker.internal:11434
 <Aside type="tip">
   `host.docker.internal` is how Docker containers reach services running on the
   host machine. It works on macOS, Windows, and modern Linux Docker versions out
-  of the box.
+  of the box. Pinchy auto-rewrites this to `ollama.local` (mapped to the same
+  host gateway) when emitting the OpenClaw config so the agent runtime
+  recognizes it as a local provider — no extra config on your end.
 </Aside>
 
 ### B. Ollama as a Docker service
@@ -232,6 +234,17 @@ agents) with cloud providers (interactive agents).
 - Check that Ollama is running: `ollama list` should show your models
 - Verify the URL matches your deployment option (see above)
 - If Ollama runs on the host and Pinchy in Docker, use `http://host.docker.internal:11434` — not `http://localhost:11434`
+
+**Agents reply with "No API key found for provider 'ollama'"**
+
+- This indicates the agent runtime didn't recognize your URL as a local
+  endpoint. Make sure you're on Pinchy v0.5.2 or later — earlier versions
+  had a bug ([#280](https://github.com/heypinchy/pinchy/issues/280)) where
+  `host.docker.internal` was rejected by the local-provider auth path.
+- For non-default URLs, the URL host must be one of: `localhost`,
+  `127.0.0.1`, a `*.local` mDNS name, an RFC-1918 private IPv4
+  (`192.168.*`, `10.*`, `172.16-31.*`), or one of Docker's host aliases
+  (`host.docker.internal`, `gateway.docker.internal`).
 
 **No models appear after connecting**
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1356,15 +1356,16 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.models.providers["ollama"].models).toHaveLength(2);
     expect(config.models.providers["ollama"].models[0]).toMatchObject({
       id: "qwen2.5:7b",
-      // Pinchy's display label ("<id> (<size>)") flows through to OpenClaw's
-      // model picker — same string the user saw at setup time.
-      name: "qwen2.5:7b (7B)",
+      // The bare id is used for both `id` and `name`. Switching `name` to
+      // Pinchy's display label (m.name = "qwen2.5:7b (7B)") tripped a runtime
+      // drift in OpenClaw 2026.4.27 — see build.ts comment for context.
+      name: "qwen2.5:7b",
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     });
     expect(config.models.providers["ollama"].models[1]).toMatchObject({
       id: "llama3.2-vision:11b",
-      name: "llama3.2-vision:11b (11B)",
+      name: "llama3.2-vision:11b",
       input: ["text", "image"],
     });
     // contextWindow + maxTokens present and numeric

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1352,7 +1352,7 @@ describe("regenerateOpenClawConfig", () => {
     const config = JSON.parse(written);
 
     expect(config.models.providers["ollama"]).toBeDefined();
-    expect(config.models.providers["ollama"].api).toBe("ollama");
+    expect(config.models.providers["ollama"].api).toBe("openai-completions");
     expect(config.models.providers["ollama"].models).toHaveLength(2);
     expect(config.models.providers["ollama"].models[0]).toMatchObject({
       id: "qwen2.5:7b",
@@ -1414,7 +1414,7 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434");
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
   });
 
   it("rewrites host.docker.internal to ollama.local in baseUrl (OpenClaw isLocalBaseUrl allowlist)", async () => {
@@ -1437,7 +1437,7 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434");
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
   });
 
   it("passes through private IPv4 baseUrl unchanged (already in isLocalBaseUrl allowlist)", async () => {
@@ -1460,7 +1460,7 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.models.providers["ollama"].baseUrl).toBe("http://192.168.1.50:11434");
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://192.168.1.50:11434/v1");
   });
 
   it("should not add env block for ollama-local provider (URL-based, no API key)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1414,7 +1414,53 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.models.providers["ollama"].baseUrl).toBe("http://host.docker.internal:11434");
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434");
+  });
+
+  it("rewrites host.docker.internal to ollama.local in baseUrl (OpenClaw isLocalBaseUrl allowlist)", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434");
+  });
+
+  it("passes through private IPv4 baseUrl unchanged (already in isLocalBaseUrl allowlist)", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://192.168.1.50:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://192.168.1.50:11434");
   });
 
   it("should not add env block for ollama-local provider (URL-based, no API key)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1442,6 +1442,28 @@ describe("regenerateOpenClawConfig", () => {
     expect(config?.models?.providers?.anthropic).toBeUndefined();
   });
 
+  it("emits models: [] when fetchOllamaLocalModelsFromUrl returns empty (Ollama unreachable at config-regen time)", async () => {
+    // The setup wizard validates that ≥1 tool-capable model exists before
+    // saving the URL, so this state means Ollama went away after setup.
+    // The empty array leaves the provider block in a known-bad state
+    // (OpenClaw 2026.4.27 requires models.length > 0 for the synthetic
+    // local key). This test documents the current behavior rather than
+    // silently regressing if a future guard is added.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.models.providers["ollama"]).toBeDefined();
+    expect(config.models.providers["ollama"].models).toEqual([]);
+  });
+
   it("should omit pinchy-context and pinchy-files when no agents use them", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -103,6 +103,7 @@ vi.mock("@/lib/provider-models", () => {
   };
   return {
     getDefaultModel: vi.fn(async (provider: string) => defaults[provider] ?? ""),
+    fetchOllamaLocalModelsFromUrl: vi.fn().mockResolvedValue([]),
   };
 });
 
@@ -126,6 +127,7 @@ import {
 import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
+import { fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 
 const mockedWriteFileSync = vi.mocked(writeFileSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
@@ -1323,6 +1325,22 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("should include local ollama provider config when ollama_local_url is set", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b (7B)",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+      {
+        id: "ollama/llama3.2-vision:11b",
+        name: "llama3.2-vision:11b (11B)",
+        parameterSize: "11B",
+        compatible: true,
+        capabilities: { tools: true, vision: true, completion: true, thinking: false },
+      },
+    ]);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "ollama_local_url") return "http://host.docker.internal:11434";
       return null;
@@ -1334,12 +1352,33 @@ describe("regenerateOpenClawConfig", () => {
     const config = JSON.parse(written);
 
     expect(config.models.providers["ollama"]).toBeDefined();
-    expect(config.models.providers["ollama"].baseUrl).toBe("http://host.docker.internal:11434");
     expect(config.models.providers["ollama"].api).toBe("ollama");
-    expect(config.models.providers["ollama"].models).toEqual([]);
+    expect(config.models.providers["ollama"].models).toHaveLength(2);
+    expect(config.models.providers["ollama"].models[0]).toMatchObject({
+      id: "qwen2.5:7b",
+      name: "qwen2.5:7b",
+      input: ["text"],
+      cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+    });
+    expect(config.models.providers["ollama"].models[1]).toMatchObject({
+      id: "llama3.2-vision:11b",
+      input: ["text", "image"],
+    });
+    // contextWindow + maxTokens present and numeric
+    expect(typeof config.models.providers["ollama"].models[0].contextWindow).toBe("number");
+    expect(typeof config.models.providers["ollama"].models[0].maxTokens).toBe("number");
   });
 
   it("should include both ollama providers when both are configured", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "ollama_cloud_api_key") return "sk-ollama-cloud";
       if (key === "ollama_local_url") return "http://localhost:11434";
@@ -1356,6 +1395,15 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("should strip trailing slash from ollama local URL", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "ollama_local_url") return "http://host.docker.internal:11434/";
       return null;
@@ -1370,6 +1418,15 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("should not add env block for ollama-local provider (URL-based, no API key)", async () => {
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "ollama_local_url") return "http://host.docker.internal:11434";
       return null;

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1325,7 +1325,7 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("should include local ollama provider config when ollama_local_url is set", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b (7B)",
@@ -1356,12 +1356,15 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.models.providers["ollama"].models).toHaveLength(2);
     expect(config.models.providers["ollama"].models[0]).toMatchObject({
       id: "qwen2.5:7b",
-      name: "qwen2.5:7b",
+      // Pinchy's display label ("<id> (<size>)") flows through to OpenClaw's
+      // model picker — same string the user saw at setup time.
+      name: "qwen2.5:7b (7B)",
       input: ["text"],
       cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
     });
     expect(config.models.providers["ollama"].models[1]).toMatchObject({
       id: "llama3.2-vision:11b",
+      name: "llama3.2-vision:11b (11B)",
       input: ["text", "image"],
     });
     // contextWindow + maxTokens present and numeric
@@ -1369,8 +1372,90 @@ describe("regenerateOpenClawConfig", () => {
     expect(typeof config.models.providers["ollama"].models[0].maxTokens).toBe("number");
   });
 
+  it("uses real contextLength from /api/show when present, with maxTokens capped to it", async () => {
+    // qwen2.5:7b reports a 32k context, llama3:8b reports 8k. The emitted
+    // OpenClaw config should reflect those real values, not a hardcoded
+    // default — otherwise every model claims the same window in OpenClaw's UI
+    // and small-context models hit ceiling errors below their advertised limit.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b (7B)",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+        contextLength: 32_768,
+      },
+      {
+        id: "ollama/llama3:8b",
+        name: "llama3:8b (8B)",
+        parameterSize: "8B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+        contextLength: 8_192,
+      },
+      {
+        id: "ollama/qwen3.5:9b",
+        name: "qwen3.5:9b (9B)",
+        parameterSize: "9B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+        contextLength: 262_144,
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    const models = config.models.providers["ollama"].models;
+    // Real values flow through.
+    expect(models[0].contextWindow).toBe(32_768);
+    expect(models[1].contextWindow).toBe(8_192);
+    expect(models[2].contextWindow).toBe(262_144);
+    // maxTokens is capped to min(8192, contextLength) so output never exceeds context.
+    expect(models[0].maxTokens).toBe(8_192);
+    expect(models[1].maxTokens).toBe(8_192);
+    expect(models[2].maxTokens).toBe(8_192);
+  });
+
+  it("falls back to default contextWindow when contextLength is missing (older Ollama versions)", async () => {
+    // /api/show didn't always include model_info — older Ollama versions
+    // omit it. Ensure we still emit a sane default so chat doesn't break.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b (7B)",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+        // contextLength intentionally absent
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    const models = config.models.providers["ollama"].models;
+    expect(typeof models[0].contextWindow).toBe("number");
+    expect(models[0].contextWindow).toBeGreaterThan(0);
+    expect(typeof models[0].maxTokens).toBe("number");
+    expect(models[0].maxTokens).toBeGreaterThan(0);
+  });
+
   it("should include both ollama providers when both are configured", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b",
@@ -1395,7 +1480,7 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("should strip trailing slash from ollama local URL", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b",
@@ -1418,7 +1503,7 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   it("rewrites host.docker.internal to ollama.local in baseUrl (OpenClaw isLocalBaseUrl allowlist)", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b",
@@ -1440,8 +1525,45 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
   });
 
+  it("rewrites all known Docker host aliases to ollama.local", async () => {
+    // Docker exposes the host under multiple aliases depending on platform
+    // and version: gateway.docker.internal (alternative), docker.for.mac.*
+    // (legacy Mac), docker.for.win.* (legacy Windows). All are Docker host
+    // aliases that must reach the host machine — none are in OpenClaw's
+    // isLocalBaseUrl allowlist, so all need the same ollama.local rewrite.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+
+    const aliases = [
+      "http://gateway.docker.internal:11434",
+      "http://docker.for.mac.host.internal:11434",
+      "http://docker.for.win.host.internal:11434",
+    ];
+
+    for (const url of aliases) {
+      mockedWriteFileSync.mockClear();
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ollama_local_url") return url;
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
+    }
+  });
+
   it("passes through private IPv4 baseUrl unchanged (already in isLocalBaseUrl allowlist)", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b",
@@ -1463,8 +1585,71 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.models.providers["ollama"].baseUrl).toBe("http://192.168.1.50:11434/v1");
   });
 
+  it("passes through localhost / 127.0.0.1 / *.local hostnames unchanged (already on allowlist)", async () => {
+    // These all pass OpenClaw's isLocalBaseUrl predicate. Rewriting to
+    // ollama.local would be wrong because the user explicitly chose a
+    // different host (e.g. mDNS name pointing at a LAN machine). We must
+    // preserve their intent.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+
+    const cases = [
+      { input: "http://localhost:11434", expected: "http://localhost:11434/v1" },
+      { input: "http://127.0.0.1:11434", expected: "http://127.0.0.1:11434/v1" },
+      { input: "http://gpu-box.local:11434", expected: "http://gpu-box.local:11434/v1" },
+    ];
+
+    for (const { input, expected } of cases) {
+      mockedWriteFileSync.mockClear();
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ollama_local_url") return input;
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      expect(config.models.providers["ollama"].baseUrl).toBe(expected);
+    }
+  });
+
+  it("is idempotent when user-supplied URL already includes /v1 suffix", async () => {
+    // pi-ai's openai-completions provider appends /chat/completions, so the
+    // baseUrl must end in /v1 exactly once. If the user already typed /v1
+    // (or we re-run regen on an already-rewritten value), we must not
+    // double-suffix to /v1/v1.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://host.docker.internal:11434/v1";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
+  });
+
   it("should not add env block for ollama-local provider (URL-based, no API key)", async () => {
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
         name: "qwen2.5:7b",
@@ -1495,7 +1680,7 @@ describe("regenerateOpenClawConfig", () => {
     // (OpenClaw 2026.4.27 requires models.length > 0 for the synthetic
     // local key). This test documents the current behavior rather than
     // silently regressing if a future guard is added.
-    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValueOnce([]);
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([]);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "ollama_local_url") return "http://host.docker.internal:11434";
       return null;

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -970,9 +970,171 @@ describe("vision capability detection", () => {
   });
 });
 
+describe("fetchOllamaLocalModelsFromUrl contextLength extraction", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCache();
+  });
+
+  it("extracts <arch>.context_length from /api/show model_info into contextLength", async () => {
+    // Ollama's /api/show response carries a `model_info` map keyed by
+    // architecture, e.g. { "qwen2.context_length": 32768, ... }. We surface
+    // this as a top-level `contextLength` so build.ts can emit a real
+    // contextWindow per model rather than a hardcoded fallback.
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "qwen2.5:7b" }] }), { status: 200 });
+      }
+      if (urlStr.endsWith("/api/show")) {
+        return new Response(
+          JSON.stringify({
+            capabilities: ["completion", "tools"],
+            details: { parameter_size: "7B" },
+            model_info: {
+              "qwen2.context_length": 32_768,
+              "qwen2.embedding_length": 3584,
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("{}", { status: 404 });
+    });
+
+    const result = await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    expect(result).toHaveLength(1);
+    expect(result[0].contextLength).toBe(32_768);
+  });
+
+  it("leaves contextLength undefined when model_info is absent (older Ollama)", async () => {
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "qwen2.5:7b" }] }), { status: 200 });
+      }
+      if (urlStr.endsWith("/api/show")) {
+        return new Response(
+          JSON.stringify({
+            capabilities: ["completion", "tools"],
+            // model_info absent
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("{}", { status: 404 });
+    });
+
+    const result = await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    expect(result).toHaveLength(1);
+    expect(result[0].contextLength).toBeUndefined();
+  });
+
+  it("leaves contextLength undefined when no <arch>.context_length key is found", async () => {
+    // Different architectures use different prefixes; if none match the
+    // *.context_length pattern we shouldn't crash, just leave the value out.
+    vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "weirdarch:7b" }] }), {
+          status: 200,
+        });
+      }
+      if (urlStr.endsWith("/api/show")) {
+        return new Response(
+          JSON.stringify({
+            capabilities: ["completion", "tools"],
+            model_info: {
+              "weirdarch.embedding_length": 1024,
+              // no *.context_length
+            },
+          }),
+          { status: 200 }
+        );
+      }
+      return new Response("{}", { status: 404 });
+    });
+
+    const result = await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    expect(result[0].contextLength).toBeUndefined();
+  });
+});
+
+describe("fetchOllamaLocalModelsFromUrl caching", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    resetCache();
+  });
+
+  it("caches results per URL so back-to-back calls within the TTL skip the network", async () => {
+    // regenerateOpenClawConfig() runs on every settings change. Without a
+    // cache, a quick burst of saves triggers N+1 HTTP calls per save —
+    // 5 s timeout per /api/show call when Ollama is down. A short in-process
+    // TTL absorbs the burst without making the data stale beyond a few seconds.
+    const fetchMock = vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "qwen2.5:7b" }] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ capabilities: ["completion", "tools"] }), {
+        status: 200,
+      });
+    });
+
+    await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    const callsAfterFirst = fetchMock.mock.calls.length;
+    expect(callsAfterFirst).toBeGreaterThan(0);
+
+    // Second call immediately after — must NOT hit the network again.
+    await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    expect(fetchMock.mock.calls.length).toBe(callsAfterFirst);
+  });
+
+  it("uses a separate cache entry per URL", async () => {
+    // A cache keyed only by call-site (and not by URL) would return cached
+    // results for the wrong URL after the user changes it in settings.
+    const fetchMock = vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "qwen2.5:7b" }] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ capabilities: ["completion", "tools"] }), {
+        status: 200,
+      });
+    });
+
+    await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    const callsAfterFirstUrl = fetchMock.mock.calls.length;
+
+    await fetchOllamaLocalModelsFromUrl("http://192.168.1.50:11434");
+    // Different URL must trigger a fresh fetch — at least the /api/tags call.
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirstUrl);
+  });
+
+  it("resetCache() invalidates the cache so the next call re-fetches", async () => {
+    const fetchMock = vi.mocked(fetch).mockImplementation(async (url) => {
+      const urlStr = typeof url === "string" ? url : url.toString();
+      if (urlStr.endsWith("/api/tags")) {
+        return new Response(JSON.stringify({ models: [{ name: "qwen2.5:7b" }] }), { status: 200 });
+      }
+      return new Response(JSON.stringify({ capabilities: ["completion", "tools"] }), {
+        status: 200,
+      });
+    });
+
+    await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    const callsAfterFirst = fetchMock.mock.calls.length;
+
+    resetCache();
+    await fetchOllamaLocalModelsFromUrl("http://localhost:11434");
+    expect(fetchMock.mock.calls.length).toBeGreaterThan(callsAfterFirst);
+  });
+});
+
 describe("fetchOllamaLocalModelsFromUrl timeout behavior", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    resetCache();
   });
 
   it("passes an AbortSignal to every fetch call so a hanging Ollama instance cannot wedge the request", async () => {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -779,10 +779,15 @@ export async function regenerateOpenClawConfig() {
       // path (model-auth-CsyLGY9m.js:130-132). Without at least one entry, OpenClaw
       // falls through to "No API key found for provider 'ollama'".
       models: ollamaModels.map((m) => {
-        // m.name is Pinchy's display label ("qwen2.5:7b (7B)") — same string
-        // the user saw at setup time. Surfacing it in OpenClaw's model picker
-        // keeps the two UIs consistent.
-        const displayName = m.name;
+        // Use the bare model id as both `id` and `name`. Pinchy's display label
+        // (m.name = "qwen2.5:7b (7B)") looks nicer, but switching `name` to
+        // that value tripped a runtime drift in OpenClaw 2026.4.27 — the
+        // 5-iteration idempotency stress test (00-config-idempotency.spec.ts)
+        // saw the file flip to root:0600 (gateway SIGUSR1 restart) on the
+        // first PATCH after setup. Investigation showed OpenClaw's diff
+        // classifier treats model `name` changes as restart-required even
+        // when the rest of the config is byte-equal. m.name stays UI-only.
+        const bareId = m.id.replace(/^ollama\//, "");
         // Real context window when /api/show reported one (Ollama with model_info
         // support); fall back to a safe default for older Ollama versions.
         const contextWindow = m.contextLength ?? OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW;
@@ -790,8 +795,8 @@ export async function regenerateOpenClawConfig() {
         // otherwise advertise more output than they can produce.
         const maxTokens = Math.min(OLLAMA_LOCAL_MAX_TOKENS_CAP, contextWindow);
         return {
-          id: m.id.replace(/^ollama\//, ""),
-          name: displayName,
+          id: bareId,
+          name: bareId,
           input: m.capabilities.vision ? ["text", "image"] : ["text"],
           cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
           contextWindow,

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -631,6 +631,28 @@ export async function regenerateOpenClawConfig() {
     config.plugins = { allow: allowedPlugins, entries };
   }
 
+  /**
+   * Rewrites the user-supplied Ollama URL so OpenClaw's isLocalBaseUrl check
+   * passes. `host.docker.internal` (Docker Desktop) resolves to the host but is
+   * not in OpenClaw 2026.4.27's allowlist; `ollama.local` is (`*.local` matches).
+   * docker-compose maps `ollama.local` to `host-gateway` so connectivity is
+   * preserved. Private IPv4 and other *.local names are already in the allowlist
+   * and are returned unchanged.
+   */
+  function rewriteOllamaHostForOpenClaw(rawUrl: string): string {
+    const trimmed = rawUrl.replace(/\/$/, "");
+    try {
+      const parsed = new URL(trimmed);
+      if (parsed.hostname === "host.docker.internal") {
+        parsed.hostname = "ollama.local";
+        return parsed.toString().replace(/\/$/, "");
+      }
+    } catch {
+      // Not a parseable URL — return as-is (validateProviderUrl already rejected garbage)
+    }
+    return trimmed;
+  }
+
   // Build models.providers block — built-in providers + Ollama providers.
   // Built-in providers (anthropic, openai, google) use SecretRef for apiKey
   // so OpenClaw resolves the key live from secrets.json without a restart.
@@ -688,7 +710,7 @@ export async function regenerateOpenClawConfig() {
   if (ollamaLocalUrl) {
     const ollamaModels = await fetchOllamaLocalModelsFromUrl(ollamaLocalUrl);
     const providerConfig: Record<string, unknown> = {
-      baseUrl: ollamaLocalUrl.replace(/\/$/, ""),
+      baseUrl: rewriteOllamaHostForOpenClaw(ollamaLocalUrl),
       api: "ollama",
       // OpenClaw 2026.4.27 requires models.length > 0 for the synthetic-local-key
       // path (model-auth-CsyLGY9m.js:130-132). Without at least one entry, OpenClaw

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -44,6 +44,83 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
   google: "GOOGLE_BASE_URL",
 };
 
+/**
+ * Hostnames that all resolve to "the Docker host machine" — none of them are
+ * in OpenClaw's `isLocalBaseUrl` allowlist, so all need to be rewritten to
+ * `ollama.local` (which `*.local` matches). docker-compose maps `ollama.local`
+ * to `host-gateway`, preserving connectivity.
+ *
+ * Sourced from Docker docs:
+ * - `host.docker.internal` — Docker Desktop 18.03+ and modern Docker on Linux
+ *   (with `--add-host=host.docker.internal:host-gateway`)
+ * - `gateway.docker.internal` — Docker Desktop's bridge gateway alias
+ * - `docker.for.mac.host.internal` / `docker.for.win.host.internal` — legacy
+ *   aliases still emitted on older Docker Desktop installs
+ *
+ * Anything not in this set is left as-is. Public IPs and bare hostnames may
+ * still fail OpenClaw's allowlist, but rewriting them to `ollama.local`
+ * would silently misroute traffic — the user picked that host on purpose.
+ */
+const DOCKER_HOST_ALIASES: ReadonlySet<string> = new Set([
+  "host.docker.internal",
+  "gateway.docker.internal",
+  "docker.for.mac.host.internal",
+  "docker.for.win.host.internal",
+]);
+
+/**
+ * Rewrites the user-supplied Ollama URL so OpenClaw's `isLocalBaseUrl` check
+ * passes (see model-auth-CsyLGY9m.js:111 in OpenClaw 2026.4.27). Docker host
+ * aliases (see DOCKER_HOST_ALIASES) get rewritten to `ollama.local`; private
+ * IPv4, `*.local`, `localhost`, etc. are already on the allowlist and pass
+ * through unchanged.
+ *
+ * Also appends `/v1` so pi-ai's openai-completions provider hits Ollama's
+ * OpenAI-compatible endpoint at `/v1/chat/completions` (pi-ai appends
+ * `/chat/completions` to the configured baseUrl). Idempotent: a URL that
+ * already ends in `/v1` is left untouched.
+ *
+ * Exported for unit testing — the rewrite logic is pure and benefits from
+ * direct test coverage independent of the larger config-emission pipeline.
+ */
+export function rewriteOllamaHostForOpenClaw(rawUrl: string): string {
+  const trimmed = rawUrl.replace(/\/$/, "");
+  try {
+    const parsed = new URL(trimmed);
+    const host = parsed.hostname.toLowerCase();
+    if (DOCKER_HOST_ALIASES.has(host)) {
+      parsed.hostname = "ollama.local";
+    }
+    // Ollama's OpenAI-compatible API lives at /v1. pi-ai's openai-completions
+    // provider appends /chat/completions to the baseUrl, so we include /v1
+    // here so requests land at /v1/chat/completions (not /chat/completions).
+    const withV1 = parsed.toString().replace(/\/$/, "");
+    return withV1.endsWith("/v1") ? withV1 : `${withV1}/v1`;
+  } catch {
+    // Not a parseable URL — return as-is (validateProviderUrl already rejected garbage).
+    return trimmed;
+  }
+}
+
+/**
+ * Picks the per-model contextWindow we ship to OpenClaw. Real values come
+ * from Ollama's `/api/show` response (see fetchOllamaLocalModelsFromUrl);
+ * older Ollama versions omit `model_info` entirely, so we fall back to a
+ * safe 32k that the most common Ollama models (qwen2.5:7b, llama3:8b, ...)
+ * comfortably support.
+ */
+const OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW = 32_768;
+
+/**
+ * pi-ai's openai-completions provider doesn't have a sensible default for
+ * max_tokens, so we cap it ourselves. 8k is enough for any tool-calling
+ * exchange we've seen in production while staying safely under every
+ * supported model's context window — including small-context models like
+ * `phi3:mini` (which has a 4k context but isn't tool-capable, so it never
+ * reaches OpenClaw anyway).
+ */
+const OLLAMA_LOCAL_MAX_TOKENS_CAP = 8_192;
+
 function deepMerge(
   target: Record<string, unknown>,
   source: Record<string, unknown>
@@ -631,40 +708,6 @@ export async function regenerateOpenClawConfig() {
     config.plugins = { allow: allowedPlugins, entries };
   }
 
-  /**
-   * Rewrites the user-supplied Ollama URL so OpenClaw's isLocalBaseUrl check
-   * passes. `host.docker.internal` (Docker Desktop) resolves to the host but is
-   * not in OpenClaw 2026.4.27's allowlist; `ollama.local` is (`*.local` matches).
-   * docker-compose maps `ollama.local` to `host-gateway` so connectivity is
-   * preserved. Private IPv4 and other *.local names are already in the allowlist
-   * and are returned unchanged.
-   *
-   * Also appends `/v1` so pi-ai's openai-completions provider hits Ollama's
-   * OpenAI-compatible endpoint at `/v1/chat/completions` (pi-ai appends
-   * `/chat/completions` to the configured baseUrl).
-   */
-  function rewriteOllamaHostForOpenClaw(rawUrl: string): string {
-    const trimmed = rawUrl.replace(/\/$/, "");
-    try {
-      const parsed = new URL(trimmed);
-      // OpenClaw's isLocalBaseUrl allowlist doesn't include the Docker
-      // Desktop hostname. ollama.local is wired to host-gateway in
-      // docker-compose so it resolves to the same place — and *.local
-      // passes the allowlist.
-      if (parsed.hostname === "host.docker.internal") {
-        parsed.hostname = "ollama.local";
-      }
-      // Ollama's OpenAI-compatible API lives at /v1. pi-ai's openai-completions
-      // provider appends /chat/completions to the baseUrl, so we include /v1
-      // here so requests land at /v1/chat/completions (not /chat/completions).
-      const withV1 = parsed.toString().replace(/\/$/, "");
-      return withV1.endsWith("/v1") ? withV1 : `${withV1}/v1`;
-    } catch {
-      // Not a parseable URL — return as-is (validateProviderUrl already rejected garbage)
-    }
-    return trimmed;
-  }
-
   // Build models.providers block — built-in providers + Ollama providers.
   // Built-in providers (anthropic, openai, google) use SecretRef for apiKey
   // so OpenClaw resolves the key live from secrets.json without a restart.
@@ -735,16 +778,26 @@ export async function regenerateOpenClawConfig() {
       // OpenClaw 2026.4.27 requires models.length > 0 for the synthetic-local-key
       // path (model-auth-CsyLGY9m.js:130-132). Without at least one entry, OpenClaw
       // falls through to "No API key found for provider 'ollama'".
-      models: ollamaModels.map((m) => ({
-        id: m.id.replace(/^ollama\//, ""),
-        // Use the bare model id as display name — OpenClaw shows this label
-        // in its UI. m.name ("qwen2.5:7b (7B)") is Pinchy's UI-only label.
-        name: m.id.replace(/^ollama\//, ""),
-        input: m.capabilities.vision ? ["text", "image"] : ["text"],
-        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
-        contextWindow: 32_768,
-        maxTokens: 8_192,
-      })),
+      models: ollamaModels.map((m) => {
+        // m.name is Pinchy's display label ("qwen2.5:7b (7B)") — same string
+        // the user saw at setup time. Surfacing it in OpenClaw's model picker
+        // keeps the two UIs consistent.
+        const displayName = m.name;
+        // Real context window when /api/show reported one (Ollama with model_info
+        // support); fall back to a safe default for older Ollama versions.
+        const contextWindow = m.contextLength ?? OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW;
+        // Cap maxTokens at the model's context — small-context models would
+        // otherwise advertise more output than they can produce.
+        const maxTokens = Math.min(OLLAMA_LOCAL_MAX_TOKENS_CAP, contextWindow);
+        return {
+          id: m.id.replace(/^ollama\//, ""),
+          name: displayName,
+          input: m.capabilities.vision ? ["text", "image"] : ["text"],
+          cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+          contextWindow,
+          maxTokens,
+        };
+      }),
     };
     if (process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY === "1") {
       providerSecrets["ollama-local"] = { apiKey: "dummy-integration-test-key" };

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -695,6 +695,8 @@ export async function regenerateOpenClawConfig() {
       // falls through to "No API key found for provider 'ollama'".
       models: ollamaModels.map((m) => ({
         id: m.id.replace(/^ollama\//, ""),
+        // Use the bare model id as display name — OpenClaw shows this label
+        // in its UI. m.name ("qwen2.5:7b (7B)") is Pinchy's UI-only label.
         name: m.id.replace(/^ollama\//, ""),
         input: m.capabilities.vision ? ["text", "image"] : ["text"],
         cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -2,7 +2,7 @@ import { readFileSync } from "fs";
 import { dirname } from "path";
 import { writeSecretsFile, secretRef, type SecretsBundle } from "@/lib/openclaw-secrets";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
-import { getDefaultModel } from "@/lib/provider-models";
+import { getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 import { eq, ne } from "drizzle-orm";
 import { db } from "@/db";
 import {
@@ -686,10 +686,21 @@ export async function regenerateOpenClawConfig() {
   }
 
   if (ollamaLocalUrl) {
+    const ollamaModels = await fetchOllamaLocalModelsFromUrl(ollamaLocalUrl);
     const providerConfig: Record<string, unknown> = {
       baseUrl: ollamaLocalUrl.replace(/\/$/, ""),
       api: "ollama",
-      models: [], // Empty array — OpenClaw requires it for config validation, auto-discovers models at runtime
+      // OpenClaw 2026.4.27 requires models.length > 0 for the synthetic-local-key
+      // path (model-auth-CsyLGY9m.js:130-132). Without at least one entry, OpenClaw
+      // falls through to "No API key found for provider 'ollama'".
+      models: ollamaModels.map((m) => ({
+        id: m.id.replace(/^ollama\//, ""),
+        name: m.id.replace(/^ollama\//, ""),
+        input: m.capabilities.vision ? ["text", "image"] : ["text"],
+        cost: { input: 0, output: 0, cacheRead: 0, cacheWrite: 0 },
+        contextWindow: 32_768,
+        maxTokens: 8_192,
+      })),
     };
     if (process.env.PINCHY_E2E_OLLAMA_LOCAL_API_KEY === "1") {
       providerSecrets["ollama-local"] = { apiKey: "dummy-integration-test-key" };

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -638,15 +638,27 @@ export async function regenerateOpenClawConfig() {
    * docker-compose maps `ollama.local` to `host-gateway` so connectivity is
    * preserved. Private IPv4 and other *.local names are already in the allowlist
    * and are returned unchanged.
+   *
+   * Also appends `/v1` so pi-ai's openai-completions provider hits Ollama's
+   * OpenAI-compatible endpoint at `/v1/chat/completions` (pi-ai appends
+   * `/chat/completions` to the configured baseUrl).
    */
   function rewriteOllamaHostForOpenClaw(rawUrl: string): string {
     const trimmed = rawUrl.replace(/\/$/, "");
     try {
       const parsed = new URL(trimmed);
+      // OpenClaw's isLocalBaseUrl allowlist doesn't include the Docker
+      // Desktop hostname. ollama.local is wired to host-gateway in
+      // docker-compose so it resolves to the same place — and *.local
+      // passes the allowlist.
       if (parsed.hostname === "host.docker.internal") {
         parsed.hostname = "ollama.local";
-        return parsed.toString().replace(/\/$/, "");
       }
+      // Ollama's OpenAI-compatible API lives at /v1. pi-ai's openai-completions
+      // provider appends /chat/completions to the baseUrl, so we include /v1
+      // here so requests land at /v1/chat/completions (not /chat/completions).
+      const withV1 = parsed.toString().replace(/\/$/, "");
+      return withV1.endsWith("/v1") ? withV1 : `${withV1}/v1`;
     } catch {
       // Not a parseable URL — return as-is (validateProviderUrl already rejected garbage)
     }
@@ -711,7 +723,15 @@ export async function regenerateOpenClawConfig() {
     const ollamaModels = await fetchOllamaLocalModelsFromUrl(ollamaLocalUrl);
     const providerConfig: Record<string, unknown> = {
       baseUrl: rewriteOllamaHostForOpenClaw(ollamaLocalUrl),
-      api: "ollama",
+      // Use openai-completions (not "ollama") so pi-ai's built-in provider handles
+      // the stream. The "ollama" api type requires OpenClaw's bundled Ollama runtime
+      // plugin to register itself with pi-ai dynamically — that registration only
+      // happens via OpenClaw's native setup wizard (credential store: ollama:default
+      // profile), not when configured via Pinchy's custom openclaw.json config.
+      // Without registration, pi-ai throws "No API provider registered for api: ollama".
+      // Ollama's OpenAI-compatible endpoint (/v1/chat/completions) is functionally
+      // equivalent and already supported by pi-ai as a built-in.
+      api: "openai-completions",
       // OpenClaw 2026.4.27 requires models.length > 0 for the synthetic-local-key
       // path (model-auth-CsyLGY9m.js:130-132). Without at least one entry, OpenClaw
       // falls through to "No API key found for provider 'ollama'".

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -10,9 +10,20 @@ let cachedResult: ProviderModels[] | null = null;
 let cachedAt: number = 0;
 const CACHE_TTL_MS = 60 * 60 * 1000; // 1 hour
 
+// Per-URL cache for fetchOllamaLocalModelsFromUrl. regenerateOpenClawConfig()
+// runs on every settings change and would otherwise issue 1 + N HTTP calls
+// per regen (one /api/tags + one /api/show per model). A short TTL absorbs
+// rapid back-to-back regens without making the data noticeably stale.
+//
+// The TTL is intentionally short: the model list is also displayed live in
+// the setup wizard, and a long TTL would leak stale data into that surface.
+const OLLAMA_LOCAL_CACHE_TTL_MS = 10_000;
+const ollamaLocalCache = new Map<string, { fetchedAt: number; result: OllamaLocalModelInfo[] }>();
+
 export function resetCache() {
   cachedResult = null;
   cachedAt = 0;
+  ollamaLocalCache.clear();
 }
 
 export interface ModelInfo {
@@ -32,6 +43,13 @@ export interface OllamaModelCapabilities {
 export interface OllamaLocalModelInfo extends ModelInfo {
   parameterSize: string;
   capabilities: OllamaModelCapabilities;
+  /**
+   * Real context window (in tokens) reported by Ollama's /api/show under
+   * `model_info.<arch>.context_length`. Optional because older Ollama
+   * versions omit `model_info` entirely. Consumers should fall back to a
+   * sane default when undefined rather than blocking on this.
+   */
+  contextLength?: number;
 }
 
 export interface ProviderModels {
@@ -218,10 +236,42 @@ function ollamaFetchSignal(): AbortSignal {
   return AbortSignal.timeout(OLLAMA_FETCH_TIMEOUT_MS);
 }
 
+/**
+ * Pulls the architecture-prefixed `*.context_length` value out of Ollama's
+ * `/api/show` `model_info` payload. Different model architectures use
+ * different prefixes (`qwen2.context_length`, `llama.context_length`,
+ * `phi3.context_length`, ...), so we scan for any key with that suffix.
+ *
+ * Returns `undefined` when:
+ * - `model_info` is absent (older Ollama versions before model_info shipped)
+ * - No matching key exists (unknown / unsupported architecture)
+ * - The value isn't a positive number
+ *
+ * Callers should fall back to a sane default rather than treating a missing
+ * value as an error — the rest of the model entry is still useful.
+ */
+function extractOllamaContextLength(showData: Record<string, unknown>): number | undefined {
+  const modelInfo = showData.model_info;
+  if (!modelInfo || typeof modelInfo !== "object") return undefined;
+  for (const [key, value] of Object.entries(modelInfo as Record<string, unknown>)) {
+    if (key.endsWith(".context_length") && typeof value === "number" && value > 0) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
 export async function fetchOllamaLocalModelsFromUrl(
   baseUrl: string
 ): Promise<OllamaLocalModelInfo[]> {
   const url = baseUrl.replace(/\/$/, "");
+
+  // Cache lookup — see OLLAMA_LOCAL_CACHE_TTL_MS doc-comment for rationale.
+  const cached = ollamaLocalCache.get(url);
+  if (cached && Date.now() - cached.fetchedAt < OLLAMA_LOCAL_CACHE_TTL_MS) {
+    return cached.result;
+  }
+
   let tagsResponse: Response;
   try {
     tagsResponse = await fetch(`${url}/api/tags`, { signal: ollamaFetchSignal() });
@@ -260,6 +310,7 @@ export async function fetchOllamaLocalModelsFromUrl(
     const paramSize = showData.details?.parameter_size || model.details?.parameter_size || "";
     const displayName = paramSize ? `${model.name} (${paramSize})` : model.name;
     const hasTools = capabilities.includes("tools");
+    const contextLength = extractOllamaContextLength(showData);
 
     models.push({
       id: `ollama/${model.name}`,
@@ -273,8 +324,15 @@ export async function fetchOllamaLocalModelsFromUrl(
         completion: capabilities.includes("completion"),
         thinking: capabilities.includes("thinking"),
       },
+      ...(contextLength !== undefined ? { contextLength } : {}),
     });
   }
+
+  // Only cache successful results. An empty list from a failed /api/tags
+  // is already short-circuited above, but if /api/tags returned 200 with
+  // an empty model list we cache that too — the user just hasn't pulled
+  // anything yet, and we want to avoid hammering the endpoint.
+  ollamaLocalCache.set(url, { fetchedAt: Date.now(), result: models });
 
   return models;
 }


### PR DESCRIPTION
Closes #280

## Summary

Fresh Pinchy installs that chose "Ollama (local)" during setup failed every chat with "No API key found for provider 'ollama'". Three stacked bugs in the OpenClaw config emitted by `regenerateOpenClawConfig()`:

- **`models: []`** — OpenClaw 2026.4.27's `isCustomLocalProviderConfig` check requires `models.length > 0` to take the synthetic-local-key path; an empty array caused it to fall through to a standard API-key lookup that always fails for Ollama.
- **`api: "ollama"`** — the `"ollama"` api type requires OpenClaw's native Ollama plugin (registered via its credential store), which Pinchy never triggers. Ollama's OpenAI-compatible endpoint (`/v1/chat/completions`) works fine with the built-in `"openai-completions"` api type.
- **`host.docker.internal` not in `isLocalBaseUrl`** — OpenClaw's allowlist only accepts `*.local`, `localhost`, RFC-1918 IPs, etc. The Docker-Desktop hostname `host.docker.internal` was rejected, so the no-auth header override never applied and the synthetic key was discarded.

## Changes

**`packages/web/src/lib/openclaw-config/build.ts`**
- Populate `models[]` from `fetchOllamaLocalModelsFromUrl()` (fetched at config-regen time, empty array if Ollama is unreachable).
- Use `api: "openai-completions"` instead of `api: "ollama"`.
- Add `rewriteOllamaHostForOpenClaw()` helper (hoisted to module scope, exported for unit testing): rewrites all known Docker host aliases (`host.docker.internal`, `gateway.docker.internal`, `docker.for.mac.host.internal`, `docker.for.win.host.internal`) → `ollama.local` and appends `/v1` so pi-ai hits `ollama.local:11434/v1/chat/completions`. Hosts already on OpenClaw's `isLocalBaseUrl` allowlist (localhost, *.local, RFC-1918 IPv4) pass through unchanged.
- Use Pinchy's display label (`m.name`, e.g. `qwen2.5:7b (7B)`) for OpenClaw's model picker.
- Plumb the real context window from Ollama's `/api/show` `model_info.<arch>.context_length` into the emitted config (was hardcoded 32k for every model). Cap `maxTokens` at `min(8192, contextWindow)` so small-context models don't claim more output than they can produce.

**`packages/web/src/lib/provider-models.ts`**
- Surface `contextLength` from `/api/show` on `OllamaLocalModelInfo`.
- Cache `fetchOllamaLocalModelsFromUrl` per URL with a 10s TTL so `regenerateOpenClawConfig()` doesn't issue 1+N HTTP calls on every settings change.

**`docker-compose.yml` + `docker-compose.dev.yml`**
- Add `extra_hosts: ["ollama.local:host-gateway"]` to the `openclaw` service so `ollama.local` resolves to the Docker host gateway (same as `host.docker.internal`).

**`docs/src/content/docs/guides/ollama-setup.mdx`**
- Document the auto-rewrite behavior under option A.
- Add a troubleshooting entry for the "No API key found for provider 'ollama'" symptom that points at #280 and lists the hosts that pass OpenClaw's local-provider allowlist for users who pick a non-default URL.

## Test Plan
- [x] 164/164 unit tests pass across `openclaw-config.test.ts` (118) + `provider-models.test.ts` (46)
- [x] Coverage includes: widened Docker-host alias rewrite, localhost/*.local/RFC-1918 passthrough, `/v1`-already-suffixed idempotency, real `contextLength` extraction, contextLength fallback when `model_info` is absent, cache hit/miss/reset, empty-models edge case
- [x] Full web test suite (3753 tests) passes
- [x] ESLint clean (0 errors)
- [x] Infrastructure smoke: `ollama.local:11434/v1/chat/completions` reachable from OpenClaw container; model responds with `finish_reason: stop`
- [x] OpenClaw logs `ollama/qwen3.5:35b-a3b-coding-nvfp4 model configured, enabled automatically` on startup