### PR TITLE
docs(ollama): fix option B/C URL — bare service name fails OpenClaw allowlist

### DIFF
--- a/docs/src/content/docs/guides/ollama-setup.mdx
+++ b/docs/src/content/docs/guides/ollama-setup.mdx
@@ -69,6 +69,10 @@ Run Ollama alongside Pinchy in Docker. Create a `docker-compose.override.yml` in
 services:
   ollama:
     image: ollama/ollama
+    networks:
+      default:
+        aliases:
+          - ollama.docker.local
     volumes:
       - ollama_data:/root/.ollama
 
@@ -85,8 +89,17 @@ docker compose up -d
 In Pinchy, set the URL to:
 
 ```
-http://ollama:11434
+http://ollama.docker.local:11434
 ```
+
+<Aside type="tip">
+  The `ollama.docker.local` alias matters — Pinchy's agent runtime only treats
+  URLs whose host ends in `.local` (or is loopback / RFC-1918 private) as local
+  providers that don't need an API key. The bare service name `ollama` would be
+  rejected. We can't reuse `ollama.local` itself because that name is already
+  mapped to the host gateway in `docker-compose.yml` for option A, and
+  `/etc/hosts` wins over Docker DNS aliases.
+</Aside>
 
 <Aside type="note">
   You'll still need to pull models inside the container: `docker compose exec
@@ -101,6 +114,10 @@ For GPU acceleration, install the [NVIDIA Container Toolkit](https://docs.nvidia
 services:
   ollama:
     image: ollama/ollama
+    networks:
+      default:
+        aliases:
+          - ollama.docker.local
     volumes:
       - ollama_data:/root/.ollama
     deploy:
@@ -115,7 +132,7 @@ volumes:
   ollama_data:
 ```
 
-Everything else is the same — Pinchy URL is `http://ollama:11434`.
+Everything else is the same — Pinchy URL is `http://ollama.docker.local:11434`. (See the option B note above for why the `.local` alias is required.)
 
 ### D. Ollama on a remote server
 
@@ -242,9 +259,13 @@ agents) with cloud providers (interactive agents).
   had a bug ([#280](https://github.com/heypinchy/pinchy/issues/280)) where
   `host.docker.internal` was rejected by the local-provider auth path.
 - For non-default URLs, the URL host must be one of: `localhost`,
-  `127.0.0.1`, a `*.local` mDNS name, an RFC-1918 private IPv4
+  `127.0.0.1`, a hostname ending in `.local`, an RFC-1918 private IPv4
   (`192.168.*`, `10.*`, `172.16-31.*`), or one of Docker's host aliases
   (`host.docker.internal`, `gateway.docker.internal`).
+- **Upgrading from `http://ollama:11434`?** Earlier docs recommended the
+  bare service name, which fails the check above. Switch to
+  [option B](#b-ollama-as-a-docker-service) — add an `ollama.docker.local`
+  network alias to your ollama service and update the URL.
 
 **No models appear after connecting**
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -174,6 +174,40 @@ async function drainBackgroundCoroutine(): Promise<void> {
   await new Promise((r) => setImmediate(r));
 }
 
+/**
+ * Mirror of OpenClaw 2026.4.27's `isLocalBaseUrl` predicate
+ * (model-auth-CsyLGY9m.js:111-118 + isPrivateIpv4Host:120-126). The function
+ * isn't exported through any of openclaw's public subpath exports, so the
+ * tests below re-implement it as a drift guard: if upstream changes the
+ * allowlist, this mirror diverges and the related tests should be updated
+ * (and the docs in ollama-setup.mdx revisited).
+ */
+function mirrorOpenClawIsLocalBaseUrl(baseUrl: string): boolean {
+  try {
+    let host = new URL(baseUrl).hostname.toLowerCase();
+    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "0.0.0.0" ||
+      host === "::1" ||
+      host === "::ffff:7f00:1" ||
+      host === "::ffff:127.0.0.1" ||
+      host.endsWith(".local") ||
+      mirrorIsPrivateIpv4Host(host)
+    );
+  } catch {
+    return false;
+  }
+}
+function mirrorIsPrivateIpv4Host(host: string): boolean {
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) return false;
+  const octets = host.split(".").map((o) => Number.parseInt(o, 10));
+  if (octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return false;
+  const [a, b] = octets;
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+}
+
 describe("regenerateOpenClawConfig", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -1647,6 +1681,86 @@ describe("regenerateOpenClawConfig", () => {
     const config = JSON.parse(written);
 
     expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
+  });
+
+  it("docs option B (Ollama as a sibling Docker service) URL pattern emits a baseUrl OpenClaw accepts (#280 follow-up)", async () => {
+    // Mirrors docs/src/content/docs/guides/ollama-setup.mdx options B+C:
+    // user adds `ollama.docker.local` as a Docker network alias on their
+    // ollama service and sets the URL to `http://ollama.docker.local:11434`.
+    // The chosen hostname must:
+    //   1. End in `.local` so OpenClaw's isLocalBaseUrl predicate accepts it
+    //      (model-auth-CsyLGY9m.js:115 — host.endsWith(".local")).
+    //   2. NOT be `ollama.local`. That hostname is mapped to host-gateway in
+    //      docker-compose.yml's openclaw `extra_hosts` (for option A), and
+    //      `/etc/hosts` wins over Docker DNS aliases on every Linux libc
+    //      resolver — so `ollama.local` from inside openclaw resolves to
+    //      the host gateway, never to a sibling container.
+    // build.ts leaves the URL untouched (it isn't in DOCKER_HOST_ALIASES) and
+    // only appends `/v1`. If this assertion ever drifts from the docs, fix
+    // the docs or the rewrite — don't weaken the test.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen3.5:9b",
+        name: "qwen3.5:9b",
+        parameterSize: "9B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://ollama.docker.local:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const baseUrl = config.models.providers["ollama"].baseUrl;
+
+    expect(baseUrl).toBe("http://ollama.docker.local:11434/v1");
+    // Asserts the round-trip property the docs rely on: the URL we tell
+    // option-B users to set still passes OpenClaw's local-provider gate.
+    expect(mirrorOpenClawIsLocalBaseUrl(baseUrl)).toBe(true);
+  });
+
+  it("bare service hostname (e.g. http://ollama:11434) is left untouched and would fail OpenClaw allowlist (#280 docs guard)", async () => {
+    // Pre-#280 docs told option-B users to set `http://ollama:11434`. The
+    // emitted baseUrl uses the raw service name, which fails OpenClaw's
+    // allowlist (no `.local`, not RFC-1918, not loopback) — chats fail with
+    // "No API key found for provider 'ollama'" at runtime.
+    //
+    // build.ts intentionally rewrites only known Docker host aliases
+    // (DOCKER_HOST_ALIASES); rewriting bare hostnames would silently
+    // misroute legitimate non-local URLs (e.g. http://my-server:11434
+    // pointing at a real LAN box). The docs migration to ollama.docker.local
+    // is the fix; this test pins the no-rewrite behavior so a future
+    // "smarter" rewrite doesn't regress unrelated setups.
+    vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
+      {
+        id: "ollama/qwen3.5:9b",
+        name: "qwen3.5:9b",
+        parameterSize: "9B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_local_url") return "http://ollama:11434";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const baseUrl = config.models.providers["ollama"].baseUrl;
+
+    expect(baseUrl).toBe("http://ollama:11434/v1");
+    // Documents the runtime failure mode bare hostnames would hit: this is
+    // why ollama-setup.mdx tells users to alias the service as
+    // `ollama.docker.local` (or any `*.local` hostname) instead.
+    expect(mirrorOpenClawIsLocalBaseUrl(baseUrl)).toBe(false);
   });
 
   it("should not add env block for ollama-local provider (URL-based, no API key)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -175,16 +175,24 @@ async function drainBackgroundCoroutine(): Promise<void> {
 }
 
 /**
- * Mirror of OpenClaw 2026.4.27's `isLocalBaseUrl` predicate
+ * Mirror of OpenClaw's `isLocalBaseUrl` predicate
  * (model-auth-CsyLGY9m.js:111-118 + isPrivateIpv4Host:120-126). The function
  * isn't exported through any of openclaw's public subpath exports, so the
  * tests below re-implement it as a drift guard: if upstream changes the
- * allowlist, this mirror diverges and the related tests should be updated
- * (and the docs in ollama-setup.mdx revisited).
+ * allowlist, this mirror won't auto-detect that — but anyone bumping the
+ * `openclaw` version pin should grep for `OPENCLAW_ISLOCAL_PIN` and
+ * re-verify the predicate, then update the docs in ollama-setup.mdx if
+ * the allowlist semantics changed.
+ *
+ * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump; see PR #279)
  */
 function mirrorOpenClawIsLocalBaseUrl(baseUrl: string): boolean {
   try {
     let host = new URL(baseUrl).hostname.toLowerCase();
+    // Defensive parity with upstream — on Node/V8 `URL.hostname` already
+    // returns IPv6 literals without brackets, so this branch is currently
+    // dead. Keep it so the mirror stays a 1:1 port of the upstream source
+    // and a future Node engine change can't silently diverge us.
     if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
     return (
       host === "localhost" ||


### PR DESCRIPTION
## Summary

- After [#280](https://github.com/heypinchy/pinchy/issues/280) shipped, the [Ollama setup guide](https://github.com/heypinchy/pinchy/blob/main/docs/src/content/docs/guides/ollama-setup.mdx) options B (Ollama as a Docker service) and C (Ollama with NVIDIA GPU) still recommended `http://ollama:11434`. That URL passes Pinchy's `validateProviderUrl` (Pinchy reaches the `/api/tags` endpoint via Docker DNS just fine) but the bare hostname `ollama` fails OpenClaw 2026.4.27's `isLocalBaseUrl` allowlist at chat time — agents respond with `"No API key found for provider 'ollama'"`.
- Updates options B and C to add a `ollama.docker.local` network alias to the user's ollama service and switches the documented URL to `http://ollama.docker.local:11434`. The `.local` suffix passes OpenClaw's allowlist; the `ollama.docker.` prefix avoids colliding with the `ollama.local:host-gateway` `extra_hosts` entry that the openclaw service already uses for option A.
- Adds two regression tests in `packages/web/src/__tests__/lib/openclaw-config.test.ts`:
  - `docs option B URL pattern emits a baseUrl OpenClaw accepts` — pins the option B contract.
  - `bare service hostname … is left untouched and would fail OpenClaw allowlist` — pins the no-rewrite behavior so a future "smarter" rewrite doesn't silently misroute legitimate non-local URLs.
- Both tests use a `mirrorOpenClawIsLocalBaseUrl` helper that re-implements OpenClaw's predicate — the upstream function isn't exported from any of openclaw's public subpath exports. The mirror doubles as a drift guard.

## Why approach (a) — docs change, not a `build.ts` rewrite extension

`build.ts` deliberately only rewrites known Docker host aliases (`host.docker.internal`, `gateway.docker.internal`, `docker.for.{mac,win}.host.internal`). The accompanying comment is right that rewriting an arbitrary bare hostname to `ollama.local` would silently misroute legitimate non-local hosts (`http://my-server:11434` pointing at a real LAN box would land at the host gateway instead). The negative regression test pins this on purpose.

## Why `ollama.docker.local` and not `ollama.local`

Empirically verified before picking the alias:

1. **DNS precedence**: `extra_hosts` writes to `/etc/hosts`, which the Linux libc resolver consults before Docker's embedded DNS (`hosts: files dns` in `nsswitch.conf`). Confirmed with a throwaway compose stack — a hostname listed in both places resolves to the `extra_hosts` entry.
2. **Conflict**: `docker-compose.yml` already maps `ollama.local` → `host-gateway` on the openclaw service for option A. Reusing `ollama.local` as a Docker network alias on the user's ollama service would be shadowed; openclaw would still resolve `ollama.local` to the host gateway, never to the sibling container.
3. **Solution**: Pick a different `*.local` hostname. `ollama.docker.local` is self-explanatory ("ollama running in Docker, accessed via the .local convention"), passes the allowlist, and resolves cleanly via Docker DNS without touching extra_hosts.

End-to-end DNS verification (real docker compose, two containers — extra_hosts on the openclaw side, network alias on the ollama side):

```
--- getent ollama.local (extra_hosts) ---     1.2.3.4
--- getent ollama.docker.local (alias) ---    192.168.147.2  (ollama container)
--- getent ollama (default Docker DNS) ---    192.168.147.2  (ollama container)
```

Option A and option B coexist conflict-free.

## Manual E2E verification

Spun up an isolated stack mirroring the doc verbatim (`docker compose --project-name pinchy-e2e-option-b -f docker-compose.yml -f docker-compose.dev.yml -f /tmp/.../override.yml up`) with the exact override from the docs option B compose snippet. Pulled `llama3.2:3b` into the sibling ollama container. Drove setup via API (`/api/setup` → `/api/auth/sign-in/email` → `/api/setup/provider` with `{"provider":"ollama-local","url":"http://ollama.docker.local:11434"}` → `200 {"success":true}`). Then sent a chat message through the Smithers UI.

**Pinchy emits the expected config:**
```json
{
  "baseUrl": "http://ollama.docker.local:11434/v1",
  "api": "openai-completions",
  "modelCount": 1
}
```

**OpenClaw accepts it without "No API key" error:** logs show `[reload] config hot reload applied (agents.defaults.model, agents.list, models)`. No new "No API key found for provider 'ollama'" entries after the config-apply (the only ones in the log were from the boot-time defaults before any provider was configured, where `provider="openai"`).

**Chat round-trip reaches Ollama and the model responds:** Ollama container access log (source IP is the openclaw container's IP on the Docker network, proving the alias resolved correctly):

```
[GIN] 20:19:16 | 200 |  1m34s | 192.168.147.6 | POST "/v1/chat/completions"
[GIN] 20:19:28 | 400 |  2.9ms | 192.168.147.6 | POST "/v1/chat/completions"
```

The 200 is the assistant inference completing successfully (1m34s on a 3B model is expected). The 400 on the second turn is an unrelated tool-calling format quirk specific to llama3.2:3b — the docs already warn about small models being unreliable for tool use ([ollama-setup.mdx aside on `qwen2.5:7b`](docs/src/content/docs/guides/ollama-setup.mdx)). It is not the pre-#295 "No API key" failure.

## Test plan

- [x] `pnpm test` — 3755 passed, 12 skipped, 0 failed
- [x] `pnpm --filter @pinchy/web exec vitest run src/__tests__/lib/openclaw-config.test.ts` — 120/120 passed (was 118 + 2 new)
- [x] `pnpm -C packages/web lint` — 0 errors (322 pre-existing warnings unchanged)
- [x] Docs build (`pnpm -C docs build`) — 38 pages, no errors
- [x] Empirical Docker DNS test (option A and B coexist conflict-free)
- [x] Manual E2E: a fresh install following docs option B can complete setup and reach Ollama through OpenClaw without the "No API key" failure (evidence above)

## Out of scope (notes for follow-ups)

- **`validateProviderUrl` guardrail** ([#296](https://github.com/heypinchy/pinchy/issues/296)): reject URLs whose host won't pass OpenClaw's allowlist at save time, with a clear error pointing at this guide. Defense in depth.
- **Ship a profile-gated `docker-compose.ollama.yml`**: would let option-B users opt in via `docker compose --profile ollama up` instead of copy-pasting YAML. Better UX, separate PR.
