### PR TITLE
fix(chat): keep draining OpenClaw stream after browser disconnect (#199 Layer B)

### DIFF
--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2525,6 +2525,85 @@ describe("ClientRouter", () => {
       expect(clientWs.send.mock.calls.length).toBe(sendCallsBeforeClose);
     });
 
+    it("logs OpenClaw error chunks even when the consumer has already disconnected", async () => {
+      // Observability invariant: with the drain-always loop, error chunks
+      // arriving after the browser navigates away are exactly the chunks an
+      // operator most needs to see — there's no UI to surface them. The
+      // server-side console.error must therefore be unconditional, not
+      // gated by readyState.
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        const clientWs = createMockClientWs();
+        mockChat.mockReturnValue(
+          steppedStream([
+            { type: "text" as const, text: "before-close" },
+            { type: "error" as const, text: "upstream provider exploded" },
+          ])
+        );
+
+        const handlePromise = router.handleMessage(clientWs as any, {
+          type: "message",
+          content: "Hi",
+          agentId: "agent-1",
+        });
+
+        // Allow the first chunk to be consumed, then close the WS before the
+        // error chunk arrives.
+        await new Promise((r) => setImmediate(r));
+        clientWs.readyState = 3; // CLOSED
+
+        await handlePromise;
+
+        const errorLogged = consoleSpy.mock.calls.some(
+          (call) =>
+            typeof call[0] === "string" &&
+            call[0].includes("OpenClaw error chunk:") &&
+            call[1] === "upstream provider exploded"
+        );
+        expect(errorLogged).toBe(true);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
+    it("does not record the session in cache when the turn errors without a done chunk", async () => {
+      // Errored turns are not "completed" from Pinchy's perspective —
+      // sessionCache only tracks turns that reached a done chunk. This
+      // test pins the behavior so a future drain-loop refactor can't
+      // accidentally cache failed turns.
+      const freshCache = new SessionCache();
+      const localRouter = new ClientRouter(
+        mockOpenClawClient as any,
+        "user-1",
+        "member",
+        freshCache
+      );
+
+      const clientWs = createMockClientWs();
+      mockChat.mockReturnValue(
+        steppedStream([
+          { type: "text" as const, text: "partial" },
+          { type: "error" as const, text: "upstream blew up" },
+        ])
+      );
+
+      // Suppress the now-unconditional console.error for cleanliness.
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      try {
+        await localRouter.handleMessage(clientWs as any, {
+          type: "message",
+          content: "Hi",
+          agentId: "agent-1",
+        });
+
+        expect(freshCache.has("agent:agent-1:direct:user-1")).toBe(false);
+      } finally {
+        consoleSpy.mockRestore();
+      }
+    });
+
     it("clears the keep-alive heartbeat interval even when the consumer disconnects mid-stream", async () => {
       // setInterval/clearInterval are called from inside pipeStream; we
       // observe via vi.useFakeTimers + getTimerCount(). When the heartbeat

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2524,5 +2524,40 @@ describe("ClientRouter", () => {
 
       expect(clientWs.send.mock.calls.length).toBe(sendCallsBeforeClose);
     });
+
+    it("clears the keep-alive heartbeat interval even when the consumer disconnects mid-stream", async () => {
+      // setInterval/clearInterval are called from inside pipeStream; we
+      // observe via vi.useFakeTimers + getTimerCount(). When the heartbeat
+      // is cleared, the active timer count returns to zero.
+      // Only fake setInterval/clearInterval so that steppedStream's
+      // setImmediate calls remain real and can be awaited normally.
+      vi.useFakeTimers({ toFake: ["setInterval", "clearInterval"] });
+
+      try {
+        const clientWs = createMockClientWs();
+        mockChat.mockReturnValue(
+          steppedStream([
+            { type: "text" as const, text: "first" },
+            { type: "done" as const, text: "" },
+          ])
+        );
+
+        const handlePromise = router.handleMessage(clientWs as any, {
+          type: "message",
+          content: "Hi",
+          agentId: "agent-1",
+        });
+
+        // Consume the first chunk under fake timers
+        await new Promise((r) => setImmediate(r));
+        clientWs.readyState = 3; // CLOSED
+        await handlePromise;
+
+        // After pipeStream's finally, no leftover intervals
+        expect(vi.getTimerCount()).toBe(0);
+      } finally {
+        vi.useRealTimers();
+      }
+    });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -105,6 +105,20 @@ const defaultAgent = {
   greetingMessage: "Hello.",
 };
 
+// Helper for tests that need to disconnect mid-stream. Yields each chunk
+// from `chunks` after one macrotask tick (setImmediate) — that gap is the
+// test's window to mutate clientWs.readyState before the next yield.
+// Using setImmediate rather than Promise.resolve() ensures the test's own
+// setImmediate fires in between stream chunks (microtasks wouldn't suffice
+// because the for-await loop drains all microtasks before yielding to the
+// event loop).
+async function* steppedStream<T>(chunks: T[]): AsyncGenerator<T> {
+  for (const chunk of chunks) {
+    await new Promise<void>((r) => setImmediate(r));
+    yield chunk;
+  }
+}
+
 function createMockOpenClawClient(connected = true) {
   const emitter = new EventEmitter();
   const client = Object.assign(emitter, {
@@ -2444,6 +2458,38 @@ describe("ClientRouter", () => {
       expect(messages.some((m: any) => m.type === "error")).toBe(true);
 
       consoleSpy.mockRestore();
+    });
+  });
+
+  describe("pipeStream — consumer disconnect", () => {
+    it("keeps draining the OpenClaw stream after the browser WS closes, so sessionCache records the completed turn", async () => {
+      // Fresh cache so the test proves the add() actually happens here, not
+      // pre-seeded by beforeEach.
+      const cache = new SessionCache();
+      const localRouter = new ClientRouter(mockOpenClawClient as any, "user-1", "member", cache);
+
+      const clientWs = createMockClientWs();
+      mockChat.mockReturnValue(
+        steppedStream([
+          { type: "text" as const, text: "tok-1" },
+          { type: "text" as const, text: "tok-2" },
+          { type: "done" as const, text: "" },
+        ])
+      );
+
+      const handlePromise = localRouter.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // Let the first chunk be consumed, then "the browser navigates away"
+      await new Promise((r) => setImmediate(r));
+      clientWs.readyState = 3; // CLOSED
+
+      await handlePromise;
+
+      expect(cache.has("agent:agent-1:direct:user-1")).toBe(true);
     });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2465,8 +2465,13 @@ describe("ClientRouter", () => {
     it("keeps draining the OpenClaw stream after the browser WS closes, so sessionCache records the completed turn", async () => {
       // Fresh cache so the test proves the add() actually happens here, not
       // pre-seeded by beforeEach.
-      const cache = new SessionCache();
-      const localRouter = new ClientRouter(mockOpenClawClient as any, "user-1", "member", cache);
+      const freshCache = new SessionCache();
+      const localRouter = new ClientRouter(
+        mockOpenClawClient as any,
+        "user-1",
+        "member",
+        freshCache
+      );
 
       const clientWs = createMockClientWs();
       mockChat.mockReturnValue(
@@ -2483,13 +2488,13 @@ describe("ClientRouter", () => {
         agentId: "agent-1",
       });
 
-      // Let the first chunk be consumed, then "the browser navigates away"
+      // Let at least one chunk be consumed, then "the browser navigates away"
       await new Promise((r) => setImmediate(r));
       clientWs.readyState = 3; // CLOSED
 
       await handlePromise;
 
-      expect(cache.has("agent:agent-1:direct:user-1")).toBe(true);
+      expect(freshCache.has("agent:agent-1:direct:user-1")).toBe(true);
     });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2497,5 +2497,32 @@ describe("ClientRouter", () => {
 
       expect(freshCache.has("agent:agent-1:direct:user-1")).toBe(true);
     });
+
+    it("does not send any frames to the browser WS after it has closed", async () => {
+      const clientWs = createMockClientWs();
+      mockChat.mockReturnValue(
+        steppedStream([
+          { type: "text" as const, text: "before-close" },
+          { type: "text" as const, text: "after-close-1" },
+          { type: "text" as const, text: "after-close-2" },
+          { type: "done" as const, text: "" },
+        ])
+      );
+
+      const handlePromise = router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // Allow the first chunk to be forwarded
+      await new Promise((r) => setImmediate(r));
+      const sendCallsBeforeClose = clientWs.send.mock.calls.length;
+      clientWs.readyState = 3; // CLOSED
+
+      await handlePromise;
+
+      expect(clientWs.send.mock.calls.length).toBe(sendCallsBeforeClose);
+    });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -691,7 +691,7 @@ describe("ClientRouter", () => {
     expect(clientWs.send).not.toHaveBeenCalled();
   });
 
-  it("should stop consuming stream early when client WebSocket closes mid-stream", async () => {
+  it("should drain the full stream even when the client WebSocket closes mid-stream, but only forward frames while WS is open", async () => {
     const clientWs = createMockClientWs();
     let chunksYielded = 0;
 
@@ -715,9 +715,10 @@ describe("ClientRouter", () => {
       agentId: "agent-1",
     });
 
-    // Should stop consuming after detecting the closed WS, not drain the entire stream
-    expect(chunksYielded).toBe(2);
-    // Only the first chunk should have been sent
+    // Stream must be drained to its natural end regardless of WS state
+    // (issue #199 Layer B — server-side accounting must keep up with OpenClaw).
+    expect(chunksYielded).toBe(4);
+    // Only frames sent while the WS was open should have reached the client
     const messages = clientWs.sent.map((s) => JSON.parse(s));
     const textChunks = messages.filter((m: any) => m.type === "chunk");
     expect(textChunks).toHaveLength(1);

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -376,7 +376,12 @@ export class ClientRouter {
 
   // Shared streaming loop used by handleMessage. Handles heartbeat, chunk
   // routing (text/error/done/userMessagePersisted), and the terminal "complete"
-  // frame.
+  // frame. The loop drains the OpenClaw stream to its natural end regardless
+  // of browser WS state — Pinchy-side accounting (sessionCache, messageId
+  // rotation) always runs; consumer-bound frames are gated by readyState so
+  // we don't write to a closed socket. This makes the assistant reply
+  // deterministically present in OpenClaw's session.jsonl by the time the
+  // user reconnects (issue #199 Layer B).
   private async pipeStream(
     clientWs: WebSocket,
     stream: AsyncIterable<ChatChunk>,
@@ -396,15 +401,10 @@ export class ClientRouter {
 
     try {
       for await (const chunk of stream) {
-        // Stop consuming the stream if the browser disconnected — frees
-        // server resources while letting OpenClaw finish on its side.
-        if (clientWs.readyState !== WS_OPEN) {
-          break;
-        }
-
-        // Start keep-alive heartbeats on the first chunk. Deferring until
-        // here ensures heartbeats only flow while OpenClaw is actively
-        // producing output — not while it may be hung before the first byte.
+        // Lazily start the keep-alive heartbeat on the first chunk. The
+        // interval callback already self-guards with readyState === WS_OPEN,
+        // so a heartbeat to a closed WS is a no-op until the finally block
+        // clears it.
         if (heartbeatInterval === null) {
           heartbeatInterval = setInterval(() => {
             if (clientWs.readyState === WS_OPEN) {
@@ -413,39 +413,46 @@ export class ClientRouter {
           }, THINKING_HEARTBEAT_MS);
         }
 
-        if (chunk.type === "userMessagePersisted") {
-          this.sendToClient(clientWs, {
-            type: "ack",
-            clientMessageId: chunk.clientMessageId,
-          });
-          continue;
+        // Pinchy-side accounting — runs regardless of consumer state. The
+        // browser may have navigated away, but OpenClaw is still streaming
+        // and persisting on its side; our local view of the session
+        // (sessionCache, per-turn messageId rotation) must keep up so the
+        // next history fetch / WS reconnect sees a coherent state.
+        if (chunk.type === "done") {
+          this.sessionCache.add(sessionKey);
         }
 
-        if (chunk.type === "text") {
-          const cleaned = chunk.text.replace(/<\/?final>/g, "");
-          if (cleaned) {
-            this.sendToClient(clientWs, { type: "chunk", content: cleaned, messageId });
+        // Consumer forwarding — only meaningful while the browser WS is open.
+        if (clientWs.readyState === WS_OPEN) {
+          if (chunk.type === "userMessagePersisted") {
+            this.sendToClient(clientWs, {
+              type: "ack",
+              clientMessageId: chunk.clientMessageId,
+            });
+          } else if (chunk.type === "text") {
+            const cleaned = chunk.text.replace(/<\/?final>/g, "");
+            if (cleaned) {
+              this.sendToClient(clientWs, { type: "chunk", content: cleaned, messageId });
+            }
+          } else if (chunk.type === "error") {
+            console.error("OpenClaw error chunk:", chunk.text);
+            this.sendToClient(clientWs, {
+              type: "error",
+              agentName: agent.name,
+              providerError: chunk.text,
+              hint: getErrorHint(chunk.text, this.userRole),
+              messageId,
+            });
+          } else if (chunk.type === "done") {
+            this.sendToClient(clientWs, { type: "done", messageId });
           }
         }
 
-        if (chunk.type === "error") {
-          console.error("OpenClaw error chunk:", chunk.text);
-          this.sendToClient(clientWs, {
-            type: "error",
-            agentName: agent.name,
-            providerError: chunk.text,
-            hint: getErrorHint(chunk.text, this.userRole),
-            messageId,
-          });
-        }
-
+        // Per-turn messageId rotation — runs after the optional `done`
+        // forwarding so the next agent turn starts with a fresh id whether
+        // or not the browser is listening (consistent with how OpenClaw
+        // stores them in history).
         if (chunk.type === "done") {
-          this.sessionCache.add(sessionKey);
-          this.sendToClient(clientWs, { type: "done", messageId });
-
-          // Next agent turn gets a fresh messageId so the browser
-          // creates a separate assistant message — consistent with
-          // how OpenClaw stores them in history.
           messageId = crypto.randomUUID();
         }
       }
@@ -455,7 +462,11 @@ export class ClientRouter {
       // iterator is exhausted, so the UI can confidently turn off the
       // thinking indicator only when no more chunks will arrive.
       // No messageId — this terminator is not tied to any specific turn.
-      this.sendToClient(clientWs, { type: "complete" });
+      // Skip if the consumer is gone — they'll get the natural state via
+      // history on reconnect.
+      if (clientWs.readyState === WS_OPEN) {
+        this.sendToClient(clientWs, { type: "complete" });
+      }
     } finally {
       if (heartbeatInterval !== null) {
         clearInterval(heartbeatInterval);

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -418,8 +418,19 @@ export class ClientRouter {
         // and persisting on its side; our local view of the session
         // (sessionCache, per-turn messageId rotation) must keep up so the
         // next history fetch / WS reconnect sees a coherent state.
+        // Note: errored turns intentionally do NOT update the cache — only
+        // turns that reach a `done` chunk count as completed sessions.
         if (chunk.type === "done") {
           this.sessionCache.add(sessionKey);
+        }
+
+        // Server-side error logging — unconditional. With the drain-always
+        // loop, error chunks arriving after the browser navigates away are
+        // exactly the chunks operators most need to see (no UI to surface
+        // them). Gating this on readyState would silently swallow upstream
+        // failures during nav-aways.
+        if (chunk.type === "error") {
+          console.error("OpenClaw error chunk:", chunk.text);
         }
 
         // Consumer forwarding — only meaningful while the browser WS is open.
@@ -435,7 +446,6 @@ export class ClientRouter {
               this.sendToClient(clientWs, { type: "chunk", content: cleaned, messageId });
             }
           } else if (chunk.type === "error") {
-            console.error("OpenClaw error chunk:", chunk.text);
             this.sendToClient(clientWs, {
               type: "error",
               agentName: agent.name,


### PR DESCRIPTION
Layer B of #199 — investigation results in [#199 comment 4376948717](https://github.com/heypinchy/pinchy/issues/199#issuecomment-4376948717).

## Summary

Replaces the early `break` in `pipeStream` (`client-router.ts:397-451`) with a forwarding gate. Server-side accounting (`sessionCache.add`, per-turn `messageId` rotation) now runs regardless of consumer state; consumer-bound frames (`ack`/`chunk`/`error`/`done`/`complete`) are gated by `clientWs.readyState === WS_OPEN`.

## Why

The investigation in #199 confirmed that OpenClaw runs every turn (incl. tool round-trips) to completion regardless of consumer detach. The early-break in pipeStream meant Pinchy stopped observing the `done` chunk → `sessionCache` got out of sync, and on browser reconnect the next `handleHistory` had to fall through to `sessions.list` to re-discover the session. With this change, the cache is updated synchronously alongside OpenClaw's flush; reconnects see a coherent state without the extra round-trip.

## Out of scope

- Layer A ("user message gone after reload" — comment 1) — needs its own brainstorm + investigation.
- Layer C (stale-indicator UX — comment 2) — needs an `openclaw-node` API extension first.
- The disconnect-error injection in `use-ws-runtime.ts:265-280`. Transient, replaced on reconnect by history. Cleaning up belongs with Layer A.

## Test plan

- [x] Unit: `client-router.test.ts` — three new tests in `describe("pipeStream — consumer disconnect")`:
  - `keeps draining the OpenClaw stream after the browser WS closes, so sessionCache records the completed turn`
  - `does not send any frames to the browser WS after it has closed`
  - `clears the keep-alive heartbeat interval even when the consumer disconnects mid-stream`
- [x] Full unit suite green
- [x] Manual smoke test: harness S2 against dev stack post-fix shows full assistant reply in session.jsonl (or model-drift truncation, noted in PR if so)