### PR TITLE
fix(screenshots): bump chat-ready timeout to 90s

### DIFF
--- a/screenshots/capture.ts
+++ b/screenshots/capture.ts
@@ -79,7 +79,12 @@ test.describe("Feature screenshots", () => {
     // flips to "Connected" once useChatStatus reaches `ready`, and every
     // agent's greetingMessage renders a `[data-role="assistant"]` bubble
     // immediately after that.
-    await page.getByRole("button", { name: "Connected" }).waitFor({ timeout: 30000 });
+    //
+    // 90s timeout: OpenClaw cold-start in CI compounds plugin warmup, schema
+    // introspection, and config-change restarts (see #302). 30s wasn't
+    // enough on the v0.5.2 release — failed twice with the indicator never
+    // flipping to "Connected" within budget.
+    await page.getByRole("button", { name: "Connected" }).waitFor({ timeout: 90000 });
     await page
       .locator('[data-role="assistant"]')
       .first()


### PR DESCRIPTION
## Summary

The "02 chat interface" screenshot capture test waits for the chat connection indicator to flip from "Starting" to "Connected" before screenshotting. Bumps the wait from 30s to 90s.

## Why

The v0.5.2 release workflow failed because this exact wait timed out — both the initial attempt and the Playwright auto-retry hit the 30s budget without the indicator turning "Connected". 13 of 14 capture tests passed; only this one tripped on cold-start.

OpenClaw cold-start in CI compounds plugin warmup, schema introspection, and config-change restarts. We tracked the underlying latency in [#302](https://github.com/heypinchy/pinchy/issues/302). Until that lands, the test-side defensive bump keeps the docs-deploy step from blocking releases on flake.

## Why 90s specifically

- 3x headroom over the previous 30s — covers the worst case we observed.
- Still bounded — unbounded `waitFor` hides real connection-state regressions.
- Well under Playwright's default test-level timeout.
- Other timeouts in `capture.ts` stay as-is (5-10s for post-connection tab clicks, 30s for the login URL wait) — they exercise UI that has no cold-start dependency.

## Test plan

- [x] Local diff reviewed — only the chat-ready waitFor changed; comment block updated to record why.
- [ ] CI re-run on the v0.5.2 Release workflow before merge to confirm the rerun clears (independent of this PR).
- [ ] Next release runs the new timeout — first signal of success.

## Out of scope

- The actual cold-start fix is tracked in [#302](https://github.com/heypinchy/pinchy/issues/302) (restart cascade on permission changes + OpenClaw model timeout extension). Closing the latency gap there would let us tighten this back down.