### PR TITLE
fix: drop kimi-k2-thinking + actionable model-error UX (closes #305)

### DIFF
--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -34,6 +34,14 @@ Pinchy waits 2 seconds before showing the Disconnected state. During those 2 sec
 
 You can type your next message while the agent is still generating a reply. Only the **Send** button and the **Retry** button are disabled during a response — the text input stays active so you can prepare follow-up questions.
 
+## Model-unavailable errors
+
+When the model itself is the problem — not the connection — Pinchy shows a dedicated **model-unavailable bubble** in the chat thread. This is distinct from the connection-state indicators above: the agent runtime is reachable, but the upstream provider returned a server error (HTTP 5xx) that signals the model is offline or discontinued.
+
+The bubble shows the affected agent name, the model identifier, and a plain-English explanation. A **Switch model →** link takes you straight to the agent's model settings so you can pick a replacement without leaving the chat.
+
+See [Manage LLM Providers — Model-unavailable errors](/guides/llm-providers/#model-unavailable-errors) for step-by-step instructions and the list of removed models.
+
 ---
 
 See also: [Message Delivery & Retry](/guides/retry-messages) for how to recover from failed messages.

--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -71,6 +71,25 @@ Tokens used through every provider are recorded in the [Usage Dashboard](/guides
 
 When a provider returns an error, Pinchy shows it directly in the chat as a distinct error card with the agent name and the provider's error message. Admins see a hint pointing to **Settings → LLM Provider**; non-admin users see a prompt to contact their administrator. Transient errors (rate limits, timeouts) suggest trying again.
 
+### Model-unavailable errors
+
+When the provider returns a server error (HTTP 5xx) that Pinchy recognises as a model availability problem — for example, the model has been discontinued or is temporarily offline — the chat shows a structured **model-unavailable bubble** instead of a raw error message. The bubble includes:
+
+- The agent name and the model identifier that failed
+- A short plain-English explanation of what happened
+- A collapsible section with the raw technical details if you need them for support
+- A **Switch model →** link that takes you directly to the agent's model settings so you can pick a replacement in one click
+
+This avoids having to hunt through menus when a model goes down.
+
+### Removed model: `ollama-cloud/kimi-k2-thinking`
+
+`ollama-cloud/kimi-k2-thinking` has been removed from Pinchy's supported model list. Agents that used this model will show the model-unavailable bubble the next time they receive a message. To resolve it:
+
+1. Click **Switch model →** in the error bubble, or open the agent's settings manually (gear icon → **General → Model**).
+2. Select a replacement — `ollama-cloud/deepseek-v4-pro` is a good like-for-like option for reasoning-heavy workloads.
+3. Click **Save**. The agent is ready immediately.
+
 **"Invalid API key"** — Double-check the key with the provider's own dashboard. Anthropic keys start with `sk-ant-`, OpenAI keys with `sk-`, Google keys are typically `AIza...`.
 
 **"Your credit balance is too low"** — The provider account has run out of credits. Top up on the provider's billing page.

--- a/packages/web/e2e/15-model-error-ux.spec.ts
+++ b/packages/web/e2e/15-model-error-ux.spec.ts
@@ -235,9 +235,7 @@ test.describe("model-unavailable error UX", () => {
     const switchModelLink = page.getByRole("link", { name: /switch model/i });
     await expect(switchModelLink).toBeVisible({ timeout: 5000 });
     const href = await switchModelLink.getAttribute("href");
-    expect(href).toMatch(/\/settings\?tab=general#model$/);
-    // Verify the link is agent-scoped (contains the agentId)
-    expect(href).toContain(agentId);
+    expect(href).toBe(`/chat/${agentId}/settings?tab=general#model`);
 
     // 6c. "Technical details" collapsible is present but collapsed
     const technicalDetailsButton = page.getByRole("button", { name: /technical details/i });

--- a/packages/web/e2e/15-model-error-ux.spec.ts
+++ b/packages/web/e2e/15-model-error-ux.spec.ts
@@ -153,7 +153,11 @@ test.describe("model-unavailable error UX", () => {
                   data: JSON.stringify({
                     type: "history",
                     messages: [],
-                    sessionKnown: false,
+                    // sessionKnown: true signals the server knows this session
+                    // but it has no history yet. This sets knownEmptyHistory=true
+                    // in useWsRuntime so hasInitialContent becomes true, allowing
+                    // chatStatus to transition to "ready" and enabling the Send button.
+                    sessionKnown: true,
                   }),
                 });
               }, 5);

--- a/packages/web/e2e/15-model-error-ux.spec.ts
+++ b/packages/web/e2e/15-model-error-ux.spec.ts
@@ -1,0 +1,258 @@
+/**
+ * Model-unavailable UX test — Issue #305.
+ *
+ * Verifies that when the server sends an `error` frame with a `modelUnavailable`
+ * payload (produced by client-router.ts when OpenClaw returns an upstream 5xx),
+ * the chat UI renders the structured "model unavailable" bubble correctly:
+ *
+ *   1. The headline contains "couldn't respond"
+ *   2. A "Switch model →" link pointing to the agent's model settings is visible
+ *   3. Clicking "Technical details" reveals the raw provider error string
+ *   4. (Optional) The settings deep link navigates to the correct URL
+ *
+ * Mock WebSocket strategy:
+ *   - Uses page.addInitScript() to inject a MockWebSocket before the page loads
+ *   - The Pinchy client connects to `/api/ws?agentId=<id>` — the mock intercepts
+ *     this URL and replaces it with a controlled implementation
+ *   - Next.js dev tooling sockets (/_next/ prefix) are forwarded to the real
+ *     WebSocket so HMR/hydration isn't broken
+ *   - On receiving the client's `history` request, the mock responds with an
+ *     empty history and openclaw_status=true
+ *   - On receiving the client's `message` request, the mock immediately sends an
+ *     `error` frame with a synthetic modelUnavailable payload, matching exactly
+ *     what client-router.ts produces for an upstream 5xx
+ *
+ * MockWebSocket is intentionally not shared from a helper module — page.addInitScript()
+ * serializes the function to a string for injection into the browser context,
+ * so imports and outer-scope references are not available inside the callback.
+ */
+
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig } from "./helpers";
+
+const MODEL_ID = "ollama-cloud/deepseek-v4-pro";
+const PROVIDER_ERROR = 'HTTP 500: "Internal Server Error (ref: e2e-model-error-1)"';
+const ERROR_REF = "e2e-model-error-1";
+const AGENT_NAME = "Smithers";
+
+test.describe("model-unavailable error UX", () => {
+  test("structured bubble shows headline, switch-model link, and technical details", async ({
+    page,
+    request,
+  }) => {
+    // ── 1. Setup: register admin + seed provider config (idempotent) ──────────
+    const setupRes = await request.post("/api/setup", {
+      data: {
+        name: "Test Admin",
+        email: "admin@test.local",
+        password: "test-password-123",
+      },
+    });
+    expect([201, 403]).toContain(setupRes.status());
+
+    await seedProviderConfig();
+
+    // ── 2. Fetch the default agent id so we can build the correct WS URL ─────
+    //    We do this via page.request so the session cookie is included.
+    //    addInitScript runs before the page navigates, but we need the agentId
+    //    injected into the mock *before* the WS connection is attempted.
+    //    Strategy: do a quick login via the auth API first to get a session
+    //    cookie, fetch the agents list, then inject the init script, then
+    //    navigate to the chat page.
+    await page.goto("/login");
+    await page.getByLabel(/email/i).fill("admin@test.local");
+    await page.getByLabel("Password", { exact: true }).fill("test-password-123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+
+    // Extract agentId from the URL that we were redirected to
+    const chatUrl = page.url();
+    const agentIdMatch = chatUrl.match(/\/chat\/([^/?#]+)/);
+    expect(agentIdMatch).toBeTruthy();
+    const agentId = agentIdMatch![1];
+
+    // ── 3. Inject mock WebSocket *before* navigating to the chat page ─────────
+    //    We must call addInitScript before page.goto so the mock is in place
+    //    when the React component mounts and calls `new WebSocket(...)`.
+    await page.addInitScript(
+      ({
+        targetAgentId,
+        modelId,
+        providerError,
+        errorRef,
+        agentName,
+      }: {
+        targetAgentId: string;
+        modelId: string;
+        providerError: string;
+        errorRef: string;
+        agentName: string;
+      }) => {
+        type ClientMessage = {
+          type?: string;
+          clientMessageId?: string;
+        };
+
+        const RealWebSocket = window.WebSocket;
+
+        class MockWebSocket {
+          static CONNECTING = 0;
+          static OPEN = 1;
+          static CLOSING = 2;
+          static CLOSED = 3;
+
+          CONNECTING = 0;
+          OPEN = 1;
+          CLOSING = 2;
+          CLOSED = 3;
+
+          onopen: (() => void) | null = null;
+          onmessage: ((event: { data: string }) => void) | null = null;
+          onclose: (() => void) | null = null;
+          onerror: (() => void) | null = null;
+          readyState = 1;
+          binaryType: string = "blob";
+
+          constructor(url: string) {
+            // Forward Next.js HMR/dev sockets to the real WebSocket
+            if (url.includes("/_next/")) {
+              return new RealWebSocket(url) as unknown as MockWebSocket;
+            }
+            // Forward connections to any agent other than the one under test
+            if (!url.includes(targetAgentId)) {
+              return new RealWebSocket(url) as unknown as MockWebSocket;
+            }
+            queueMicrotask(() => this.onopen?.());
+          }
+
+          addEventListener() {
+            // No-op: avoids TypeErrors from dev-tooling code that subscribes
+            // via addEventListener rather than the onXxx properties.
+          }
+
+          removeEventListener() {
+            // No-op
+          }
+
+          send(raw: string) {
+            const message = JSON.parse(raw) as ClientMessage;
+
+            if (message.type === "history") {
+              // Respond with empty history + openclaw_status connected so the
+              // chat considers itself fully ready without waiting for real OpenClaw.
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({
+                    type: "openclaw_status",
+                    connected: true,
+                  }),
+                });
+              }, 0);
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({
+                    type: "history",
+                    messages: [],
+                    sessionKnown: false,
+                  }),
+                });
+              }, 5);
+              return;
+            }
+
+            if (message.type === "message") {
+              const clientMessageId = message.clientMessageId;
+
+              // Ack the user message so it transitions from "sending" to "sent"
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({ type: "ack", clientMessageId }),
+                });
+              }, 0);
+
+              // Inject the model-unavailable error frame matching exactly what
+              // client-router.ts emits for an upstream 5xx from OpenClaw.
+              setTimeout(() => {
+                this.onmessage?.({
+                  data: JSON.stringify({
+                    type: "error",
+                    agentName: agentName,
+                    providerError: providerError,
+                    modelUnavailable: {
+                      kind: "model_unavailable",
+                      model: modelId,
+                      httpStatus: 500,
+                      ref: errorRef,
+                    },
+                    messageId: "e2e-error-msg-1",
+                  }),
+                });
+              }, 10);
+            }
+          }
+
+          close() {
+            this.readyState = 3;
+            this.onclose?.();
+          }
+        }
+
+        Object.defineProperty(window, "WebSocket", {
+          configurable: true,
+          writable: true,
+          value: MockWebSocket,
+        });
+      },
+      {
+        targetAgentId: agentId,
+        modelId: MODEL_ID,
+        providerError: PROVIDER_ERROR,
+        errorRef: ERROR_REF,
+        agentName: AGENT_NAME,
+      }
+    );
+
+    // ── 4. Navigate to the chat page (mock WS is now installed) ──────────────
+    await page.goto(`/chat/${agentId}`);
+    await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10000 });
+
+    // Wait for the input to appear — confirms the chat is mounted and ready
+    const input = page.getByLabel("Message input");
+    await expect(input).toBeVisible({ timeout: 10000 });
+
+    // ── 5. Send a message — the mock will respond with the error frame ────────
+    await input.fill("Hello, are you there?");
+    await page.getByRole("button", { name: "Send message" }).click();
+
+    // ── 6. Assertions ─────────────────────────────────────────────────────────
+
+    // 6a. Error bubble headline: "{agentName} couldn't respond"
+    const errorBubble = page.locator('[role="alert"]');
+    await expect(errorBubble).toBeVisible({ timeout: 10000 });
+    await expect(errorBubble).toContainText("couldn't respond");
+
+    // 6b. "Switch model →" link must be visible and point to the model settings
+    const switchModelLink = page.getByRole("link", { name: /switch model/i });
+    await expect(switchModelLink).toBeVisible({ timeout: 5000 });
+    const href = await switchModelLink.getAttribute("href");
+    expect(href).toMatch(/\/settings\?tab=general#model$/);
+    // Verify the link is agent-scoped (contains the agentId)
+    expect(href).toContain(agentId);
+
+    // 6c. "Technical details" collapsible is present but collapsed
+    const technicalDetailsButton = page.getByRole("button", { name: /technical details/i });
+    await expect(technicalDetailsButton).toBeVisible({ timeout: 5000 });
+
+    // Before clicking: providerError text is NOT visible
+    await expect(page.getByText("HTTP 500")).not.toBeVisible();
+
+    // 6d. Click "Technical details" — the collapsible opens and shows the raw error
+    await technicalDetailsButton.click();
+    await expect(page.getByText(/HTTP 500/)).toBeVisible({ timeout: 5000 });
+    await expect(page.getByText(new RegExp(ERROR_REF))).toBeVisible();
+
+    // 6e. (Optional) Click "Switch model →" and verify navigation to settings
+    await switchModelLink.click();
+    await expect(page).toHaveURL(/\/settings\?tab=general#model/, { timeout: 10000 });
+  });
+});

--- a/packages/web/e2e/15-model-error-ux.spec.ts
+++ b/packages/web/e2e/15-model-error-ux.spec.ts
@@ -231,7 +231,15 @@ test.describe("model-unavailable error UX", () => {
     // ── 6. Assertions ─────────────────────────────────────────────────────────
 
     // 6a. Error bubble headline: "{agentName} couldn't respond"
-    const errorBubble = page.locator('[role="alert"]');
+    //
+    // Filter by hasText to disambiguate from other role="alert" elements that
+    // can appear in the same DOM:
+    //   - the amber enterprise-license banner ("Your Pinchy instance is not …"),
+    //     present in CI runs that don't set PINCHY_ENTERPRISE_KEY
+    //   - Next.js's empty `__next-route-announcer__` div
+    // A bare `[role="alert"]` locator triggers Playwright's strict mode and
+    // fails the run even when the bubble itself rendered correctly.
+    const errorBubble = page.getByRole("alert").filter({ hasText: "couldn't respond" });
     await expect(errorBubble).toBeVisible({ timeout: 10000 });
     await expect(errorBubble).toContainText("couldn't respond");
 

--- a/packages/web/src/__tests__/components/agent-settings-general.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-general.test.tsx
@@ -256,6 +256,105 @@ describe("AgentSettingsGeneral", () => {
     });
   });
 
+  describe("deprecated model (no longer available)", () => {
+    const allowlistedProviders = [
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        models: [
+          { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4" },
+          { id: "anthropic/claude-opus-4-20250514", name: "Claude Opus 4" },
+        ],
+      },
+    ];
+
+    it("should NOT inject a synthetic option when agent.model is in the allowlist", async () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "anthropic/claude-sonnet-4-6" }}
+          providers={allowlistedProviders}
+          onChange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole("combobox"));
+
+      const options = screen.getAllByRole("option");
+      const noLongerAvailableOption = options.find((o) =>
+        o.textContent?.includes("no longer available")
+      );
+      expect(noLongerAvailableOption).toBeUndefined();
+    });
+
+    it("should inject a synthetic option at the top when agent.model is NOT in the allowlist", async () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/kimi-k2-thinking" }}
+          providers={allowlistedProviders}
+          onChange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole("combobox"));
+
+      const options = screen.getAllByRole("option");
+      expect(options[0]).toHaveTextContent("ollama-cloud/kimi-k2-thinking (no longer available)");
+    });
+
+    it("should show the deprecated model as the currently selected value when it is not in the allowlist", () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/kimi-k2-thinking" }}
+          providers={allowlistedProviders}
+          onChange={vi.fn()}
+        />
+      );
+
+      // The combobox trigger should show the deprecated model label
+      expect(screen.getByRole("combobox")).toHaveTextContent(
+        "ollama-cloud/kimi-k2-thinking (no longer available)"
+      );
+    });
+
+    it("should allow selecting a different model, replacing the deprecated one", async () => {
+      const onChange = vi.fn();
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/kimi-k2-thinking" }}
+          providers={allowlistedProviders}
+          onChange={onChange}
+        />
+      );
+
+      await userEvent.click(screen.getByRole("combobox"));
+      const options = screen.getAllByRole("option");
+      const sonnetOption = options.find((o) => o.textContent?.includes("Claude Sonnet 4"));
+      expect(sonnetOption).toBeDefined();
+      await userEvent.click(sonnetOption!);
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalledWith(
+          expect.objectContaining({ model: "anthropic/claude-sonnet-4-6" }),
+          true
+        );
+      });
+    });
+  });
+
+  describe("model picker anchor", () => {
+    it("should have id='model' on the model picker wrapper", () => {
+      render(
+        <AgentSettingsGeneral
+          agent={defaultAgent}
+          providers={defaultProviders}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(document.getElementById("model")).toBeInTheDocument();
+    });
+  });
+
   describe("onChange behavior", () => {
     it("should NOT render a Save button", () => {
       const onChange = vi.fn();

--- a/packages/web/src/__tests__/components/chat-error-message.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-message.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { ChatErrorMessage } from "@/components/assistant-ui/chat-error-message";
 
@@ -12,6 +12,7 @@ describe("ChatErrorMessage", () => {
           providerError: "Your credit balance is too low.",
           hint: "Go to Settings > Providers to check your API configuration.",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -33,6 +34,7 @@ describe("ChatErrorMessage", () => {
           agentName: "Smithers",
           providerError: "Your credit balance is too low.",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -53,6 +55,7 @@ describe("ChatErrorMessage", () => {
           agentName: "Smithers",
           providerError: "Your credit balance is too low.",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -72,6 +75,7 @@ describe("ChatErrorMessage", () => {
           providerError: "Something unexpected",
           hint: null,
         }}
+        agentId="agent-1"
       />
     );
 
@@ -85,6 +89,7 @@ describe("ChatErrorMessage", () => {
         error={{
           message: "Access denied",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -99,6 +104,7 @@ describe("ChatErrorMessage", () => {
           agentName: "Smithers",
           providerError: "Error text",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -114,6 +120,7 @@ describe("ChatErrorMessage", () => {
           agentName: "Smithers",
           providerError: "Error text",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -127,6 +134,7 @@ describe("ChatErrorMessage", () => {
           agentName: "Smithers",
           providerError: "Error text",
         }}
+        agentId="agent-1"
       />
     );
 
@@ -150,5 +158,56 @@ describe("ChatErrorMessage", () => {
     ).toBeInTheDocument();
     // The too-large icon must be rendered
     expect(screen.getByTestId("too-large-icon")).toBeInTheDocument();
+  });
+});
+
+describe("ChatErrorMessage — modelUnavailable", () => {
+  const baseError = {
+    agentName: "Smithers",
+    providerError: 'HTTP 500: "Internal Server Error (ref: abc-123)"',
+    modelUnavailable: {
+      kind: "model_unavailable" as const,
+      model: "ollama-cloud/kimi-k2-thinking",
+      httpStatus: 500,
+      ref: "abc-123",
+    },
+  };
+
+  it("renders the agent name and model", () => {
+    render(<ChatErrorMessage error={baseError} agentId="agent-1" />);
+    expect(screen.getByText(/Smithers couldn't respond/i)).toBeInTheDocument();
+    expect(screen.getByText(/ollama-cloud\/kimi-k2-thinking/)).toBeInTheDocument();
+  });
+
+  it("renders 'Switch model' link to settings with model anchor", () => {
+    render(<ChatErrorMessage error={baseError} agentId="agent-1" />);
+    const link = screen.getByRole("link", { name: /switch model/i });
+    expect(link).toHaveAttribute("href", "/chat/agent-1/settings?tab=general#model");
+  });
+
+  it("hides raw providerError behind a collapsible 'Technical details'", () => {
+    render(<ChatErrorMessage error={baseError} agentId="agent-1" />);
+    // Radix Collapsible does not render children when closed in JSDOM
+    const technicalDetailsBtn = screen.getByRole("button", { name: /technical details/i });
+    expect(technicalDetailsBtn).toBeInTheDocument();
+    // Content is not rendered before clicking
+    expect(screen.queryByText(/HTTP 500/)).not.toBeInTheDocument();
+    fireEvent.click(technicalDetailsBtn);
+    expect(screen.getByText(/HTTP 500/)).toBeInTheDocument();
+  });
+
+  it("falls back to legacy raw render when modelUnavailable absent", () => {
+    render(
+      <ChatErrorMessage
+        error={{ agentName: "Smithers", providerError: "Network down" }}
+        agentId="agent-1"
+      />
+    );
+    expect(screen.getByText(/Network down/)).toBeInTheDocument();
+  });
+
+  it("uses role=alert for screen readers", () => {
+    render(<ChatErrorMessage error={baseError} agentId="agent-1" />);
+    expect(screen.getByRole("alert")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/chat-error-message.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-message.test.tsx
@@ -210,4 +210,16 @@ describe("ChatErrorMessage — modelUnavailable", () => {
     render(<ChatErrorMessage error={baseError} agentId="agent-1" />);
     expect(screen.getByRole("alert")).toBeInTheDocument();
   });
+
+  it("hides the 'Switch model' link when agentId is empty (defensive: no broken /chat//settings link)", () => {
+    // Defensive guard: AgentIdContext is always populated in real usage, but
+    // if it ever returns undefined the parent passes "" as a fallback. Render
+    // the rest of the bubble (so the user still sees the error) but suppress
+    // the deep link rather than producing href="/chat//settings?tab=general#model".
+    render(<ChatErrorMessage error={baseError} agentId="" />);
+    expect(screen.queryByRole("link", { name: /switch model/i })).not.toBeInTheDocument();
+    // The headline and technical-details affordance still render
+    expect(screen.getByText(/Smithers couldn't respond/i)).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /technical details/i })).toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/lib/model-vision.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.test.ts
@@ -73,7 +73,7 @@ describe("isModelVisionCapable", () => {
       expect(isModelVisionCapable("ollama-cloud/glm-4.7")).toBe(false);
       expect(isModelVisionCapable("ollama-cloud/nemotron-3-nano:30b")).toBe(false);
       expect(isModelVisionCapable("ollama-cloud/gpt-oss:20b")).toBe(false);
-      expect(isModelVisionCapable("ollama-cloud/kimi-k2-thinking")).toBe(false);
+      // kimi-k2-thinking removed from allowlist (#305) — vision check is moot
       expect(isModelVisionCapable("ollama-cloud/qwen3-coder:480b")).toBe(false);
       expect(isModelVisionCapable("ollama-cloud/qwen3-coder-next")).toBe(false);
     });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1134,7 +1134,6 @@ describe("regenerateOpenClawConfig", () => {
         "glm-5.1",
         "gpt-oss:120b",
         "gpt-oss:20b",
-        "kimi-k2-thinking",
         "kimi-k2.5",
         "kimi-k2.6",
         "minimax-m2",
@@ -1199,7 +1198,6 @@ describe("regenerateOpenClawConfig", () => {
     // 256K — the most common class
     expect(ctx["devstral-2:123b"]).toBe(262144);
     expect(ctx["gemma4:31b"]).toBe(262144);
-    expect(ctx["kimi-k2-thinking"]).toBe(262144);
     expect(ctx["kimi-k2.5"]).toBe(262144);
     expect(ctx["kimi-k2.6"]).toBe(262144);
     expect(ctx["ministral-3:3b"]).toBe(262144);
@@ -1284,7 +1282,6 @@ describe("regenerateOpenClawConfig", () => {
       "glm-5.1",
       "gpt-oss:20b",
       "gpt-oss:120b",
-      "kimi-k2-thinking",
       "kimi-k2.5",
       "kimi-k2.6",
       "minimax-m2",

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -324,7 +324,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/glm-5.1",
         "ollama-cloud/gpt-oss:20b",
         "ollama-cloud/gpt-oss:120b",
-        "ollama-cloud/kimi-k2-thinking",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
         "ollama-cloud/minimax-m2",
@@ -346,7 +345,9 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/rnj-1:8b",
       ])
     );
-    expect(ids).toHaveLength(34);
+    // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
+    expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
+    expect(ids).toHaveLength(33);
 
     // Non-tool-capable models are filtered out
     expect(ids).not.toContain("ollama-cloud/kimi-k2:1t");
@@ -392,7 +393,9 @@ describe("fetchProviderModels", () => {
     const ollama = result.find((p) => p.id === "ollama-cloud");
     expect(ollama).toBeDefined();
     const ids = ollama!.models.map((m) => m.id);
-    expect(ids).toHaveLength(34);
+    // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
+    expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
+    expect(ids).toHaveLength(33);
     expect(ids).toEqual(
       expect.arrayContaining([
         "ollama-cloud/deepseek-v3.1:671b",
@@ -409,7 +412,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/glm-5.1",
         "ollama-cloud/gpt-oss:20b",
         "ollama-cloud/gpt-oss:120b",
-        "ollama-cloud/kimi-k2-thinking",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
         "ollama-cloud/minimax-m2",

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -270,6 +270,7 @@ describe("fetchProviderModels", () => {
             { id: "glm-5.1" },
             { id: "gpt-oss:20b" },
             { id: "gpt-oss:120b" },
+            // kimi-k2-thinking: still returned by Ollama API but removed from Pinchy allowlist (#305)
             { id: "kimi-k2-thinking" },
             { id: "kimi-k2.5" },
             { id: "kimi-k2.6" },

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2947,5 +2947,50 @@ describe("ClientRouter", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("does NOT include modelUnavailable and does NOT audit when agent.model is null even on HTTP 5xx", async () => {
+      // Edge case: an agent in the DB with model=null falls through to the
+      // provider's default at runtime. classifyModelError requires a non-empty
+      // model identifier (we can't tell the user *which* model failed if we
+      // don't know it), so it returns null. As a result no modelUnavailable
+      // payload is added to the error frame and no audit is written.
+      // This pins the contract: null model + 5xx = legacy plain error path.
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: null,
+      });
+      mockShouldEmitModelUnavailableAudit.mockReturnValue(true);
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: 'HTTP 500: "Internal Server Error (ref: x-2)"',
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // Error frame is sent, but without a modelUnavailable payload
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      const errorMsg = messages.find((m: any) => m.type === "error");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg).not.toHaveProperty("modelUnavailable");
+
+      // No audit entry of this type
+      expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "agent.model_unavailable" })
+      );
+
+      consoleSpy.mockRestore();
+    });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -10,6 +10,7 @@ const {
   mockAppendAuditLog,
   mockGetUserGroupIds,
   mockGetAgentGroupIds,
+  mockShouldEmitModelUnavailableAudit,
 } = vi.hoisted(() => ({
   mockChat: vi.fn(),
   mockSessionsHistory: vi.fn(),
@@ -19,6 +20,7 @@ const {
   mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
   mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
   mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
+  mockShouldEmitModelUnavailableAudit: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("@/lib/agent-access", async (importOriginal) => {
@@ -82,6 +84,11 @@ vi.mock("@/lib/audit", () => ({
 vi.mock("@/lib/groups", () => ({
   getUserGroupIds: (...args: unknown[]) => mockGetUserGroupIds(...args),
   getAgentGroupIds: (...args: unknown[]) => mockGetAgentGroupIds(...args),
+}));
+
+vi.mock("@/server/model-unavailable-throttle", () => ({
+  shouldEmitModelUnavailableAudit: (...args: unknown[]) =>
+    mockShouldEmitModelUnavailableAudit(...args),
 }));
 
 import { ClientRouter } from "@/server/client-router";
@@ -2790,6 +2797,155 @@ describe("ClientRouter", () => {
       // would still pass on outcome, but the test would no longer be pinning
       // the cache-hit branch specifically.)
       expect(mockSessionsList).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("agent.model_unavailable audit log", () => {
+    it("writes audit log with eventType agent.model_unavailable and outcome failure when HTTP 5xx error chunk arrives", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+      mockShouldEmitModelUnavailableAudit.mockReturnValue(true);
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: 'HTTP 503: "Service Unavailable (ref: err-42)"',
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockAppendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: "user",
+          actorId: "user-1",
+          eventType: "agent.model_unavailable",
+          resource: "agent:agent-1",
+          outcome: "failure",
+          detail: expect.objectContaining({
+            agent: { id: "agent-1", name: "Smithers" },
+            model: "ollama-cloud/deepseek-v4-pro",
+            providerError: expect.stringContaining("HTTP 503"),
+            httpStatus: 503,
+            ref: "err-42",
+          }),
+        })
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT write audit log when throttle suppresses the event", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+      mockShouldEmitModelUnavailableAudit.mockReturnValue(false);
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: 'HTTP 500: "Internal Server Error"',
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "agent.model_unavailable" })
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT write audit log when error chunk is not HTTP 5xx (no modelUnavailable)", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: "Your credit balance is too low to access the API",
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "agent.model_unavailable" })
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("truncates providerError to 1024 chars in audit detail", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/x",
+      });
+      mockShouldEmitModelUnavailableAudit.mockReturnValue(true);
+
+      const longError = `HTTP 500: "${"x".repeat(2000)}"`;
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield { type: "error" as const, text: longError };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockAppendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          eventType: "agent.model_unavailable",
+          detail: expect.objectContaining({
+            providerError: expect.stringMatching(/^.{1,1024}$/),
+          }),
+        })
+      );
+      const call = mockAppendAuditLog.mock.calls.find(
+        (c: any[]) => c[0]?.eventType === "agent.model_unavailable"
+      );
+      expect(call![0].detail.providerError.length).toBeLessThanOrEqual(1024);
+
+      consoleSpy.mockRestore();
     });
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2460,6 +2460,75 @@ describe("ClientRouter", () => {
 
       consoleSpy.mockRestore();
     });
+
+    it("should include modelUnavailable in error frame when error chunk signals HTTP 5xx", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: 'HTTP 500: "Internal Server Error (ref: x-1)"',
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      const errorMsg = messages.find((m: any) => m.type === "error");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg.modelUnavailable).toEqual({
+        kind: "model_unavailable",
+        model: "ollama-cloud/deepseek-v4-pro",
+        httpStatus: 500,
+        ref: "x-1",
+      });
+
+      consoleSpy.mockRestore();
+    });
+
+    it("should NOT include modelUnavailable in error frame when error is not HTTP 5xx", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+
+      mockChat.mockImplementation(() => {
+        return (async function* () {
+          yield {
+            type: "error" as const,
+            text: "Your credit balance is too low to access the API",
+          };
+        })();
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      const errorMsg = messages.find((m: any) => m.type === "error");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg).not.toHaveProperty("modelUnavailable");
+
+      consoleSpy.mockRestore();
+    });
   });
 
   describe("pipeStream — consumer disconnect", () => {

--- a/packages/web/src/__tests__/server/model-error-classifier.test.ts
+++ b/packages/web/src/__tests__/server/model-error-classifier.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { classifyModelError } from "@/server/model-error-classifier";
+
+describe("classifyModelError", () => {
+  it("matches HTTP 500 with ref and returns model_unavailable", () => {
+    const result = classifyModelError(
+      'HTTP 500: "Internal Server Error (ref: abc-123)"',
+      "ollama-cloud/kimi-k2-thinking"
+    );
+    expect(result).toEqual({
+      kind: "model_unavailable",
+      model: "ollama-cloud/kimi-k2-thinking",
+      httpStatus: 500,
+      ref: "abc-123",
+    });
+  });
+
+  it.each([502, 503, 504])("matches HTTP %i", (status) => {
+    const result = classifyModelError(`HTTP ${status}: upstream error`, "anthropic/claude-x");
+    expect(result?.kind).toBe("model_unavailable");
+    expect(result?.httpStatus).toBe(status);
+  });
+
+  it("returns null for 4xx errors (those are auth/config, handled elsewhere)", () => {
+    expect(classifyModelError("HTTP 401: Unauthorized", "openai/gpt-x")).toBeNull();
+    expect(classifyModelError("HTTP 429: Too Many Requests", "openai/gpt-x")).toBeNull();
+  });
+
+  it("returns null when error text has no HTTP status", () => {
+    expect(classifyModelError("Network unreachable", "openai/gpt-x")).toBeNull();
+  });
+
+  it("returns null for empty model identifier", () => {
+    expect(classifyModelError("HTTP 500: oops", "")).toBeNull();
+  });
+
+  it("matches HTTP 5xx without ref (some providers omit it)", () => {
+    const result = classifyModelError("HTTP 503: Service Unavailable", "google/gemini-2");
+    expect(result).toEqual({
+      kind: "model_unavailable",
+      model: "google/gemini-2",
+      httpStatus: 503,
+      ref: undefined,
+    });
+  });
+
+  it("works for any provider prefix (provider-agnostic)", () => {
+    for (const model of [
+      "openai/gpt-5.5",
+      "anthropic/claude-opus-4-7",
+      "google/gemini-3-flash-preview",
+      "ollama-cloud/deepseek-v4-pro",
+    ]) {
+      const result = classifyModelError("HTTP 500: boom", model);
+      expect(result?.model).toBe(model);
+    }
+  });
+});

--- a/packages/web/src/__tests__/server/model-unavailable-throttle.test.ts
+++ b/packages/web/src/__tests__/server/model-unavailable-throttle.test.ts
@@ -1,0 +1,27 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  shouldEmitModelUnavailableAudit,
+  __resetModelUnavailableThrottleForTests,
+} from "@/server/model-unavailable-throttle";
+
+describe("shouldEmitModelUnavailableAudit", () => {
+  beforeEach(() => {
+    __resetModelUnavailableThrottleForTests();
+  });
+
+  it("emits the first event and suppresses repeats within TTL", () => {
+    const now = Date.now();
+    expect(shouldEmitModelUnavailableAudit("agent-1", "ollama-cloud/x", now)).toBe(true);
+    expect(shouldEmitModelUnavailableAudit("agent-1", "ollama-cloud/x", now + 60_000)).toBe(false);
+    expect(shouldEmitModelUnavailableAudit("agent-1", "ollama-cloud/x", now + 6 * 60_000)).toBe(
+      true
+    );
+  });
+
+  it("tracks (agentId, model) pairs independently", () => {
+    const now = Date.now();
+    expect(shouldEmitModelUnavailableAudit("agent-1", "openai/gpt-x", now)).toBe(true);
+    expect(shouldEmitModelUnavailableAudit("agent-2", "openai/gpt-x", now)).toBe(true);
+    expect(shouldEmitModelUnavailableAudit("agent-1", "openai/gpt-y", now)).toBe(true);
+  });
+});

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -142,11 +142,9 @@ export function AgentSettingsGeneral({
                   </FormControl>
                   <SelectContent>
                     {isDeprecatedModel && (
-                      <SelectGroup>
-                        <SelectItem value={agent.model}>
-                          {agent.model} (no longer available)
-                        </SelectItem>
-                      </SelectGroup>
+                      <SelectItem value={agent.model} className="text-muted-foreground">
+                        {agent.model} (no longer available)
+                      </SelectItem>
                     )}
                     {providersWithModels.map((provider) => (
                       <SelectGroup key={provider.id}>

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -85,6 +85,18 @@ export function AgentSettingsGeneral({
 
   const providersWithModels = providers.filter((p) => p.models.length > 0);
 
+  // Collect all model IDs from the allowlist to detect deprecated pinned models
+  const allAllowlistedModelIds = new Set(
+    providersWithModels.flatMap((p) => p.models.map((m) => m.id))
+  );
+  const isDeprecatedModel = agent.model !== "" && !allAllowlistedModelIds.has(agent.model);
+
+  useEffect(() => {
+    if (typeof window !== "undefined" && window.location.hash === "#model") {
+      document.getElementById("model")?.scrollIntoView({ behavior: "smooth", block: "center" });
+    }
+  }, []);
+
   return (
     <div className="space-y-6">
       <Form {...form}>
@@ -120,7 +132,7 @@ export function AgentSettingsGeneral({
             control={form.control}
             name="model"
             render={({ field }) => (
-              <FormItem>
+              <FormItem id="model">
                 <FormLabel>Model</FormLabel>
                 <Select onValueChange={field.onChange} defaultValue={field.value}>
                   <FormControl>
@@ -129,6 +141,13 @@ export function AgentSettingsGeneral({
                     </SelectTrigger>
                   </FormControl>
                   <SelectContent>
+                    {isDeprecatedModel && (
+                      <SelectGroup>
+                        <SelectItem value={agent.model}>
+                          {agent.model} (no longer available)
+                        </SelectItem>
+                      </SelectGroup>
+                    )}
                     {providersWithModels.map((provider) => (
                       <SelectGroup key={provider.id}>
                         <SelectLabel>{provider.name}</SelectLabel>

--- a/packages/web/src/components/assistant-ui/chat-error-message.tsx
+++ b/packages/web/src/components/assistant-ui/chat-error-message.tsx
@@ -1,8 +1,12 @@
+"use client";
+
 import { AlertTriangle, Clock, WifiOff } from "lucide-react";
 import Link from "next/link";
-import type { FC, ReactNode } from "react";
+import { useState, type FC, type ReactNode } from "react";
 import { PROVIDER_SETTINGS_HINT } from "@/server/error-hints";
 import { ReportIssueLink } from "@/components/report-issue-link";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Button } from "@/components/ui/button";
 
 export interface ChatError {
   agentName?: string;
@@ -20,10 +24,13 @@ export interface ChatError {
   };
 }
 
-export const ChatErrorMessage: FC<{ error: ChatError; actionSlot?: ReactNode }> = ({
-  error,
-  actionSlot,
-}) => {
+export const ChatErrorMessage: FC<{
+  error: ChatError;
+  agentId: string;
+  actionSlot?: ReactNode;
+}> = ({ error, agentId, actionSlot }) => {
+  const [isOpen, setIsOpen] = useState(false);
+
   const wrapperClass =
     "rounded-md border border-destructive bg-destructive/10 p-3 text-sm dark:bg-destructive/5";
 
@@ -75,6 +82,40 @@ export const ChatErrorMessage: FC<{ error: ChatError; actionSlot?: ReactNode }> 
           You can send your message again to retry.{" "}
           <ReportIssueLink error="Agent timed out — no response after 60 seconds" />
         </p>
+      </div>
+    );
+  }
+
+  if (error.modelUnavailable) {
+    return (
+      <div role="alert" className={wrapperClass}>
+        <div className="flex items-center gap-2 font-medium text-destructive dark:text-red-200">
+          <AlertTriangle className="size-4 shrink-0" data-testid="error-warning-icon" />
+          <span className="flex-1">{`${error.agentName ?? "The agent"} couldn't respond`}</span>
+          {actionSlot}
+        </div>
+        <p className="mt-1.5 text-destructive/90 dark:text-red-300/90">
+          The model <code className="font-mono text-xs">{error.modelUnavailable.model}</code>{" "}
+          returned an error from its provider. This is usually transient — try again in a moment.
+        </p>
+        <p className="mt-1 text-destructive/75 dark:text-red-300/75">
+          If it keeps failing, the model may no longer be available.
+        </p>
+        <Button asChild variant="outline" size="sm" className="mt-2">
+          <Link href={`/chat/${agentId}/settings?tab=general#model`}>Switch model →</Link>
+        </Button>
+        <Collapsible open={isOpen} onOpenChange={setIsOpen} className="mt-3">
+          <CollapsibleTrigger asChild>
+            <Button variant="ghost" size="sm" className="text-xs">
+              Technical details
+            </Button>
+          </CollapsibleTrigger>
+          <CollapsibleContent>
+            <pre className="mt-1 text-xs text-destructive/75 dark:text-red-300/75 whitespace-pre-wrap break-words">
+              {error.providerError}
+            </pre>
+          </CollapsibleContent>
+        </Collapsible>
       </div>
     );
   }

--- a/packages/web/src/components/assistant-ui/chat-error-message.tsx
+++ b/packages/web/src/components/assistant-ui/chat-error-message.tsx
@@ -12,6 +12,12 @@ export interface ChatError {
   disconnected?: true;
   timedOut?: true;
   payloadTooLarge?: true;
+  modelUnavailable?: {
+    kind: "model_unavailable";
+    model: string;
+    httpStatus: number;
+    ref?: string;
+  };
 }
 
 export const ChatErrorMessage: FC<{ error: ChatError; actionSlot?: ReactNode }> = ({

--- a/packages/web/src/components/assistant-ui/chat-error-message.tsx
+++ b/packages/web/src/components/assistant-ui/chat-error-message.tsx
@@ -7,6 +7,7 @@ import { PROVIDER_SETTINGS_HINT } from "@/server/error-hints";
 import { ReportIssueLink } from "@/components/report-issue-link";
 import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
 import { Button } from "@/components/ui/button";
+import type { ModelUnavailableError } from "@/lib/schemas/chat-frames";
 
 export interface ChatError {
   agentName?: string;
@@ -16,12 +17,7 @@ export interface ChatError {
   disconnected?: true;
   timedOut?: true;
   payloadTooLarge?: true;
-  modelUnavailable?: {
-    kind: "model_unavailable";
-    model: string;
-    httpStatus: number;
-    ref?: string;
-  };
+  modelUnavailable?: ModelUnavailableError;
 }
 
 export const ChatErrorMessage: FC<{
@@ -101,9 +97,11 @@ export const ChatErrorMessage: FC<{
         <p className="mt-1 text-destructive/75 dark:text-red-300/75">
           If it keeps failing, the model may no longer be available.
         </p>
-        <Button asChild variant="outline" size="sm" className="mt-2">
-          <Link href={`/chat/${agentId}/settings?tab=general#model`}>Switch model →</Link>
-        </Button>
+        {agentId && (
+          <Button asChild variant="outline" size="sm" className="mt-2">
+            <Link href={`/chat/${agentId}/settings?tab=general#model`}>Switch model →</Link>
+          </Button>
+        )}
         <Collapsible open={isOpen} onOpenChange={setIsOpen} className="mt-3">
           <CollapsibleTrigger asChild>
             <Button variant="ghost" size="sm" className="text-xs">

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -315,9 +315,10 @@ const MessageError: FC = () => {
 
 const AssistantErrorOrContent: FC<{ actionSlot?: React.ReactNode }> = ({ actionSlot }) => {
   const error = useMessage((s) => s.metadata?.custom?.error as ChatError | undefined);
+  const agentId = useContext(AgentIdContext) ?? "";
 
   if (error) {
-    return <ChatErrorMessage error={error} actionSlot={actionSlot} />;
+    return <ChatErrorMessage error={error} agentId={agentId} actionSlot={actionSlot} />;
   }
 
   return (

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -512,6 +512,7 @@ export function useWsRuntime(agentId: string): {
                   agentName: data.agentName,
                   providerError: data.providerError,
                   hint: data.hint,
+                  modelUnavailable: data.modelUnavailable,
                 }
               : { message: data.message || "An unknown error occurred." };
 

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -48,6 +48,7 @@ export type AuditEventType =
   | "channel.created"
   | "channel.deleted"
   | "chat.retry_triggered"
+  | "agent.model_unavailable"
   | "audit.exported";
 
 interface HmacFieldsV1 {
@@ -219,6 +220,16 @@ export type AuditLogEntry =
   | (AuditLogBase & {
       eventType: `chat.${string}`;
       detail?: Record<string, unknown>;
+    })
+  | (AuditLogBase & {
+      eventType: "agent.model_unavailable";
+      detail: {
+        agent: { id: string; name: string };
+        model: string | null | undefined;
+        providerError: string;
+        ref?: string;
+        httpStatus: number;
+      };
     })
   | (AuditLogBase & {
       eventType: "audit.exported";

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from "vitest";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
 import { resolveOllamaCloud } from "../providers/ollama-cloud";
 
 describe("resolveOllamaCloud", () => {
@@ -27,6 +28,21 @@ describe("resolveOllamaCloud", () => {
   it("returns fallbackUsed=false when exact taskType match exists", () => {
     const r = resolveOllamaCloud({ tier: "balanced", taskType: "coder" });
     expect(r.fallbackUsed).toBe(false);
+  });
+});
+
+describe("resolveOllamaCloud — allowlist invariant", () => {
+  it("every resolver target is present in TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS", () => {
+    const allowlist = new Set<string>(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS);
+    const tiers = ["fast", "balanced", "reasoning"] as const;
+    const taskTypes = ["general", "coder", "vision", "reasoning"] as const;
+    for (const tier of tiers) {
+      for (const taskType of taskTypes) {
+        const { model } = resolveOllamaCloud({ tier, taskType });
+        const bareId = model.replace(/^ollama-cloud\//, "");
+        expect(allowlist.has(bareId)).toBe(true);
+      }
+    }
   });
 });
 

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -29,3 +29,17 @@ describe("resolveOllamaCloud", () => {
     expect(r.fallbackUsed).toBe(false);
   });
 });
+
+describe("resolveOllamaCloud — reasoning tier", () => {
+  it("falls through to deepseek-v4-pro when taskType=reasoning (kimi-k2-thinking removed in #305)", () => {
+    const result = resolveOllamaCloud({ tier: "reasoning", taskType: "reasoning" });
+    expect(result.model).toBe("ollama-cloud/deepseek-v4-pro");
+    expect(result.fallbackUsed).toBe(true);
+  });
+
+  it("keeps deepseek-v4-pro for tier=reasoning, taskType=general", () => {
+    const result = resolveOllamaCloud({ tier: "reasoning", taskType: "general" });
+    expect(result.model).toBe("ollama-cloud/deepseek-v4-pro");
+    expect(result.fallbackUsed).toBe(false);
+  });
+});

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -23,7 +23,6 @@ const BY_TIER_FAMILY: Record<
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",
-    reasoning: "ollama-cloud/kimi-k2-thinking",
   },
 };
 

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -94,13 +94,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   { id: "glm-5.1", contextWindow: 202752, maxTokens: 8192, reasoning: true, vision: false },
   { id: "gpt-oss:20b", contextWindow: 131072, maxTokens: 8192, reasoning: true, vision: false },
   { id: "gpt-oss:120b", contextWindow: 131072, maxTokens: 8192, reasoning: true, vision: false },
-  {
-    id: "kimi-k2-thinking",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-  },
   { id: "kimi-k2.5", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
   { id: "kimi-k2.6", contextWindow: 262144, maxTokens: 8192, reasoning: true, vision: true },
   { id: "minimax-m2", contextWindow: 204800, maxTokens: 8192, reasoning: true, vision: false },

--- a/packages/web/src/lib/schemas/chat-frames.ts
+++ b/packages/web/src/lib/schemas/chat-frames.ts
@@ -1,0 +1,32 @@
+/**
+ * Shared types for WebSocket frames exchanged between the Pinchy server
+ * (`server/client-router.ts`) and the browser runtime (`hooks/use-ws-runtime.ts`).
+ *
+ * AGENTS.md §"Shared Schemas And Typed Client" advises lifting cross-boundary
+ * shapes here so server-side emit and client-side render agree at compile time.
+ *
+ * This file currently exports only the model-unavailable error payload because
+ * it's the first frame field with semantic structure (rather than free-form
+ * strings). Other frame shapes (history, ack, chunk, …) can migrate here as
+ * they grow structure of their own.
+ */
+
+import { z } from "zod";
+
+/**
+ * Structured payload attached to an `error` frame when the upstream provider
+ * returns an HTTP 5xx for a known model. The browser renders a dedicated
+ * "model unavailable" bubble with a deep link to model settings; the server
+ * also writes an `agent.model_unavailable` audit entry (throttled).
+ *
+ * Produced by `server/model-error-classifier.ts:classifyModelError`.
+ * Consumed by `components/assistant-ui/chat-error-message.tsx`.
+ */
+export const modelUnavailableErrorSchema = z.object({
+  kind: z.literal("model_unavailable"),
+  model: z.string(),
+  httpStatus: z.number(),
+  ref: z.string().optional(),
+});
+
+export type ModelUnavailableError = z.infer<typeof modelUnavailableErrorSchema>;

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -458,6 +458,14 @@ export class ClientRouter {
               ...(modelUnavailable ? { modelUnavailable } : {}),
             });
             if (modelUnavailable && shouldEmitModelUnavailableAudit(agent.id, agent.model ?? "")) {
+              // PII note: `chunk.text` is the raw provider error string. For
+              // 5xx upstream failures (the only branch we audit here) the
+              // server failed before processing the request body, so it
+              // generally returns a generic error envelope without echoing
+              // the user's prompt. If a future provider starts including
+              // request fragments in 5xx error bodies, redact here before
+              // appending to the audit trail. AGENTS.md §"Audit logging
+              // rules" forbids plaintext PII in audit `detail`.
               const auditEntry = {
                 actorType: "user" as const,
                 actorId: this.userId,

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -7,6 +7,7 @@ import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { SessionCache } from "@/server/session-cache";
 import { getErrorHint } from "@/server/error-hints";
+import { classifyModelError } from "@/server/model-error-classifier";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
 import { eq } from "drizzle-orm";
@@ -385,7 +386,7 @@ export class ClientRouter {
   private async pipeStream(
     clientWs: WebSocket,
     stream: AsyncIterable<ChatChunk>,
-    agent: { id: string; name: string },
+    agent: { id: string; name: string; model?: string | null },
     sessionKey: string,
     initialMessageId: string
   ): Promise<void> {
@@ -446,13 +447,16 @@ export class ClientRouter {
               this.sendToClient(clientWs, { type: "chunk", content: cleaned, messageId });
             }
           } else if (chunk.type === "error") {
+            const modelUnavailable = classifyModelError(chunk.text, agent.model ?? "");
             this.sendToClient(clientWs, {
               type: "error",
               agentName: agent.name,
               providerError: chunk.text,
               hint: getErrorHint(chunk.text, this.userRole),
               messageId,
+              ...(modelUnavailable ? { modelUnavailable } : {}),
             });
+            // (audit-log call added in Task 7)
           } else if (chunk.type === "done") {
             this.sendToClient(clientWs, { type: "done", messageId });
           }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -5,6 +5,7 @@ import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { isEnterprise } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
+import { shouldEmitModelUnavailableAudit } from "@/server/model-unavailable-throttle";
 import { SessionCache } from "@/server/session-cache";
 import { getErrorHint } from "@/server/error-hints";
 import { classifyModelError } from "@/server/model-error-classifier";
@@ -456,7 +457,27 @@ export class ClientRouter {
               messageId,
               ...(modelUnavailable ? { modelUnavailable } : {}),
             });
-            // (audit-log call added in Task 7)
+            if (modelUnavailable && shouldEmitModelUnavailableAudit(agent.id, agent.model ?? "")) {
+              const auditEntry = {
+                actorType: "user" as const,
+                actorId: this.userId,
+                eventType: "agent.model_unavailable" as const,
+                resource: `agent:${agent.id}`,
+                detail: {
+                  agent: { id: agent.id, name: agent.name },
+                  model: agent.model,
+                  providerError: chunk.text.slice(0, 1024),
+                  ...(modelUnavailable.ref ? { ref: modelUnavailable.ref } : {}),
+                  httpStatus: modelUnavailable.httpStatus,
+                },
+                outcome: "failure" as const,
+              };
+              try {
+                await appendAuditLog(auditEntry);
+              } catch (err) {
+                recordAuditFailure(err, auditEntry);
+              }
+            }
           } else if (chunk.type === "done") {
             this.sendToClient(clientWs, { type: "done", messageId });
           }

--- a/packages/web/src/server/model-error-classifier.ts
+++ b/packages/web/src/server/model-error-classifier.ts
@@ -1,9 +1,6 @@
-export interface ModelUnavailableError {
-  kind: "model_unavailable";
-  model: string;
-  httpStatus: number;
-  ref?: string;
-}
+import type { ModelUnavailableError } from "@/lib/schemas/chat-frames";
+
+export type { ModelUnavailableError };
 
 const HTTP_5XX_PATTERN = /HTTP\s+(5\d\d)\b/i;
 const REF_PATTERN = /ref:\s*([\w-]+)/i;

--- a/packages/web/src/server/model-error-classifier.ts
+++ b/packages/web/src/server/model-error-classifier.ts
@@ -1,0 +1,22 @@
+export interface ModelUnavailableError {
+  kind: "model_unavailable";
+  model: string;
+  httpStatus: number;
+  ref?: string;
+}
+
+const HTTP_5XX_PATTERN = /HTTP\s+(5\d\d)\b/i;
+const REF_PATTERN = /ref:\s*([\w-]+)/i;
+
+export function classifyModelError(errorText: string, model: string): ModelUnavailableError | null {
+  if (!model) return null;
+  const statusMatch = HTTP_5XX_PATTERN.exec(errorText);
+  if (!statusMatch) return null;
+  const refMatch = REF_PATTERN.exec(errorText);
+  return {
+    kind: "model_unavailable",
+    model,
+    httpStatus: Number(statusMatch[1]),
+    ref: refMatch?.[1],
+  };
+}

--- a/packages/web/src/server/model-unavailable-throttle.ts
+++ b/packages/web/src/server/model-unavailable-throttle.ts
@@ -1,3 +1,20 @@
+/**
+ * In-memory throttle for `agent.model_unavailable` audit events.
+ *
+ * Limitations (intentional for this iteration; tracked as follow-ups in #305):
+ *
+ *  1. **Per-process state.** The Map is reset on container restart, so a
+ *     deploy clears the throttle and the next 5xx will emit fresh. Acceptable
+ *     because audit telemetry consumers should expect bursts at process start.
+ *
+ *  2. **Read-then-write race.** Two concurrent WS streams hitting the same
+ *     `(agentId, model)` pair within microseconds can both observe
+ *     `last === undefined` and both emit. JavaScript is single-threaded so this
+ *     only occurs across `await` boundaries in callers; the worst-case is a
+ *     handful of duplicates per restart, not a thundering herd. A DB-backed
+ *     throttle (the planned follow-up) will use a unique constraint on
+ *     `(agent_id, model, bucket)` to make this race a no-op.
+ */
 const lastEmittedAt = new Map<string, number>();
 const TTL_MS = 5 * 60 * 1000;
 

--- a/packages/web/src/server/model-unavailable-throttle.ts
+++ b/packages/web/src/server/model-unavailable-throttle.ts
@@ -1,0 +1,18 @@
+const lastEmittedAt = new Map<string, number>();
+const TTL_MS = 5 * 60 * 1000;
+
+export function shouldEmitModelUnavailableAudit(
+  agentId: string,
+  model: string,
+  now: number = Date.now()
+): boolean {
+  const key = `${agentId}:${model}`;
+  const last = lastEmittedAt.get(key);
+  if (last !== undefined && now - last < TTL_MS) return false;
+  lastEmittedAt.set(key, now);
+  return true;
+}
+
+export function __resetModelUnavailableThrottleForTests(): void {
+  lastEmittedAt.clear();
+}


### PR DESCRIPTION
## Summary

- **Drops `ollama-cloud/kimi-k2-thinking`** from the curated model allowlist and resolver. Companion to #304: Ollama Cloud silently returns HTTP 500 for this soft-deprecated model. Reasoning-tier fallback now routes to `ollama-cloud/deepseek-v4-pro` (`fallbackUsed: true`).
- **Structured "model unavailable" error bubble** replaces raw `HTTP 500: "Internal Server Error (ref: ...)"` text in chat. Shows agent name, model identifier, transient-error guidance, and a "Switch model →" link to the agent's model settings. Raw provider error stays accessible behind a collapsible "Technical details" section.
- **Audit log** gains `agent.model_unavailable` event (outcome: failure), throttled to once per 5 minutes per (agent, model) pair — in-memory, resets on container restart.
- **Deprecated-model badge** in model picker: if an agent is pinned to a model that's no longer in the allowlist, the picker surfaces `<model> (no longer available)` as the current selection so users can see what's broken and switch.
- **Provider-agnostic classifier**: the 5xx detection works for any provider prefix (`openai/`, `anthropic/`, `google/`, `ollama-cloud/`), not just Ollama.

## Test plan

- [ ] Unit: `classifyModelError` — 9 tests covering 5xx/4xx/empty-model cases
- [ ] Unit: `shouldEmitModelUnavailableAudit` — TTL suppression + independent pair tracking
- [ ] Unit: `ChatErrorMessage` — 5 tests: structured branch renders, link href, collapsible, legacy fallback, role=alert
- [ ] Unit: `agent-settings-general` — 5 tests: in-allowlist / not-in-allowlist / selected-value / model-switch / anchor
- [ ] Integration: `client-router.test.ts` — error frame includes `modelUnavailable`; audit log called with correct payload; throttle suppresses duplicates; non-5xx no-op
- [ ] Resolver invariant: all 12 tier×taskType combinations stay in allowlist
- [ ] E2E: `15-model-error-ux.spec.ts` — MockWebSocket injects 5xx error; bubble visible; Switch model link correct; Technical details collapsible works
- [ ] Full unit suite: 3801+ tests, 0 failures

## Out-of-scope follow-ups

- DB-backed audit throttle (survives container restarts) — filed separately
- Admin banner "N agents use deprecated models" — filed separately
- CI smoke test against Ollama Cloud `/v1/models` — filed separately