### PR TITLE
fix(onboarding-prompt): reference tools by their prefixed names

### DIFF
--- a/packages/web/src/__tests__/lib/onboarding-prompt.test.ts
+++ b/packages/web/src/__tests__/lib/onboarding-prompt.test.ts
@@ -5,17 +5,30 @@ describe("getOnboardingPrompt", () => {
   it("returns user-only prompt for non-admin", () => {
     const prompt = getOnboardingPrompt(false);
 
-    expect(prompt).toContain("save_user_context");
-    expect(prompt).not.toContain("save_org_context");
+    expect(prompt).toContain("pinchy_save_user_context");
+    expect(prompt).not.toContain("pinchy_save_org_context");
     expect(prompt).not.toContain("organization");
   });
 
   it("returns user + org prompt for admin", () => {
     const prompt = getOnboardingPrompt(true);
 
-    expect(prompt).toContain("save_user_context");
-    expect(prompt).toContain("save_org_context");
+    expect(prompt).toContain("pinchy_save_user_context");
+    expect(prompt).toContain("pinchy_save_org_context");
     expect(prompt).toContain("organization");
+  });
+
+  // The tools are registered in pinchy-context as `pinchy_save_user_context`
+  // and `pinchy_save_org_context`. Referring to them in the prompt without the
+  // `pinchy_` prefix breaks weaker tool-using models (e.g. Gemini 3 Flash
+  // Preview) that follow the prompt literally and call a non-existent tool.
+  it("uses the prefixed tool names so models call the registered tools", () => {
+    const userPrompt = getOnboardingPrompt(false);
+    const adminPrompt = getOnboardingPrompt(true);
+
+    expect(userPrompt).not.toMatch(/(?<!pinchy_)save_user_context/);
+    expect(adminPrompt).not.toMatch(/(?<!pinchy_)save_user_context/);
+    expect(adminPrompt).not.toMatch(/(?<!pinchy_)save_org_context/);
   });
 
   it("does not ask for the user's name (name is already known from system context)", () => {

--- a/packages/web/src/lib/onboarding-prompt.ts
+++ b/packages/web/src/lib/onboarding-prompt.ts
@@ -28,9 +28,9 @@ them. This is your primary task right now.
 
 ### Saving
 
-Once you have enough details, use the save_user_context tool to save a
-structured summary in Markdown. After saving, let the user know they can
-review and edit their context anytime in **Settings → Context**.`;
+Once you have enough details, use the pinchy_save_user_context tool to
+save a structured summary in Markdown. After saving, let the user know
+they can review and edit their context anytime in **Settings → Context**.`;
 
 const ORG_ONBOARDING = `
 
@@ -39,9 +39,9 @@ const ORG_ONBOARDING = `
 After saving the user's personal context, learn about their organization:
 company name, what they do, team structure, domain-specific terminology,
 conventions. Again, be conversational — don't interrogate. Once you have
-enough, use the save_org_context tool to save an organization summary in
-Markdown. Let them know the organization context can be edited in
-**Settings → Context** as well.`;
+enough, use the pinchy_save_org_context tool to save an organization
+summary in Markdown. Let them know the organization context can be edited
+in **Settings → Context** as well.`;
 
 export const ONBOARDING_GREETING =
   "Good day, {user}. I'm Smithers — your personal assistant. Before we dive in, I'd love to learn a bit about you so I can be as helpful as possible. What do you do, and how do you prefer to work?";


### PR DESCRIPTION
## Summary
- Smithers' onboarding prompt told the model to call `save_user_context` / `save_org_context`, but the `pinchy-context` plugin registers these tools under the prefixed names `pinchy_save_user_context` / `pinchy_save_org_context`. Stronger models silently re-mapped the unprefixed names; weaker tool-using models (e.g. Gemini 3 Flash Preview via Ollama Cloud) followed the prompt literally and emitted no tool call, leaving onboarding stuck and `ONBOARDING.md` undeleted.
- Strengthened `onboarding-prompt` tests so they require the prefixed names and forbid the unprefixed ones via lookbehind. The previous tests only checked `toContain("save_user_context")`, which silently passed because the unprefixed name is a substring of the prefixed one.

Closes #178

## Test plan
- [x] `pnpm -C packages/web test -- onboarding-prompt` — confirmed the new assertions fail against the buggy prompt, then pass after the fix.
- [x] `pnpm -C packages/web test -- onboarding-prompt personal-agent migrate-onboarding pinchy-context` — full related suite green (3796 passed, 12 skipped).
- [x] `pnpm -C packages/web lint` — 0 errors.
- [ ] Manual verify in dev: sign in fresh, run onboarding with a known weak-tool-use model, confirm `tool.pinchy_save_user_context` appears in the audit trail and `ONBOARDING.md` is removed.