### PR TITLE
test(setup-provider): guard against process.exit regression (#177)

### DIFF
--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -437,6 +437,46 @@ describe("POST /api/setup/provider", () => {
     });
   });
 
+  // ── #177 regression: saving a provider key must NOT restart Pinchy ──────
+  // The original bug (v0.4.4) was that this route called process.exit(0) to
+  // force a restart so OpenClaw could pick up the new key. That broke open
+  // browser tabs: their Server Action IDs no longer matched the freshly-built
+  // server, so the chat panel reverted to its initial empty state. The fix
+  // was to rely on OpenClaw's hot-reload of the regenerated config instead.
+  // This guard fails fast if anyone re-introduces a process.exit (or its
+  // equivalent) into the api-key or url-based code path.
+  it("does not call process.exit on api-key provider save (regression for #177)", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    try {
+      const response = await POST(
+        makeRequest({
+          provider: "anthropic",
+          apiKey: "sk-ant-key",
+        }) as any
+      );
+      expect(response.status).toBe(200);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
+  it("does not call process.exit on url-based provider save (regression for #177)", async () => {
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation((() => {}) as never);
+    try {
+      const response = await POST(
+        makeRequest({
+          provider: "ollama-local",
+          url: "http://host.docker.internal:11434",
+        }) as any
+      );
+      expect(response.status).toBe(200);
+      expect(exitSpy).not.toHaveBeenCalled();
+    } finally {
+      exitSpy.mockRestore();
+    }
+  });
+
   it("writes an audit log entry for a url-based provider without leaking the URL", async () => {
     await POST(
       makeRequest({


### PR DESCRIPTION
## Summary
- Add regression tests on `POST /api/setup/provider` that spy on `process.exit` and fail if it is ever called on the api-key or url-based code path.
- Closes #177.

## Why
Issue #177 (v0.4.4) reported that adding a new provider key wiped the open Smithers chat panel. The root cause was `process.exit(0)` in the provider routes — Pinchy restarted, fresh Server Action IDs no longer matched the still-mounted browser tab, and the chat reverted to its initial empty state.

The exit was removed since: provider routes now rely solely on OpenClaw's hot-reload of the regenerated config. But no test asserted the absence, so the bug could silently come back.

## Test plan
- [x] `pnpm -C packages/web exec vitest run src/__tests__/api/setup-provider.test.ts` → 25/25 green
- [x] Sanity check: temporarily re-introduced `process.exit(0)` after `regenerateOpenClawConfig()` — both new guards (and 11 collateral assertions) failed as expected; reverted, all green again.
- [x] `prettier --check` + `eslint` clean