### PR TITLE
fix(chat): suppress NO_REPLY silent-reply sentinel from chat UI

### DIFF
--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -51,6 +51,33 @@ function stripMeta(raw: string): string {
   return JSON.stringify(parsed);
 }
 
+/**
+ * Read CONFIG_PATH with EACCES retry. Mirrors the production retry loop in
+ * `src/lib/openclaw-config/write.ts`: OpenClaw rewrites the file as
+ * `root:0600` on every internal SIGUSR1 restart, and start-openclaw.sh's
+ * chmod loop opens it back up to 0666 — so the test runner can hit a small
+ * window where the file exists but is unreadable. Without retry, a naked
+ * readFileSync fails the assertion even though the production code path
+ * tolerates this race.
+ */
+function readConfigSafely(): string {
+  for (let attempt = 0; attempt < 10; attempt++) {
+    try {
+      return readFileSync(CONFIG_PATH, "utf-8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException)?.code;
+      if (code !== "EACCES" || attempt === 9) throw err;
+      // Synchronous busy-wait. Async would require touching every call site.
+      const start = Date.now();
+      while (Date.now() - start < 100) {
+        // spin
+      }
+    }
+  }
+  // Unreachable — the loop either returns or throws.
+  throw new Error("readConfigSafely: exhausted retries");
+}
+
 function openClawLogsSince(sinceIso: string): string {
   return execSync(`docker compose ${COMPOSE_FILE} logs openclaw --since "${sinceIso}" 2>&1`, {
     encoding: "utf-8",
@@ -188,7 +215,7 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     //    (auto-enable markers, agents.defaults.*, gateway.controlUi.allowedOrigins,
     //    meta.lastTouchedAt etc.). This is the baseline we expect Pinchy to
     //    preserve byte-for-byte.
-    const before = readFileSync(CONFIG_PATH, "utf-8");
+    const before = readConfigSafely();
     const beforeMark = new Date(Date.now() - 1000).toISOString();
 
     // 3. Trigger a no-op state-change path. PATCH name to its current value.
@@ -209,7 +236,7 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     await new Promise((r) => setTimeout(r, 5000));
 
     // 5. Contract assertions.
-    const after = readFileSync(CONFIG_PATH, "utf-8");
+    const after = readConfigSafely();
     const logs = openClawLogsSince(beforeMark);
 
     // (a) Semantic equality, ignoring the entire `meta` block. OpenClaw
@@ -287,7 +314,7 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
     await waitForOpenClawQuiet();
 
     for (let i = 1; i <= 5; i++) {
-      const snapshot = readFileSync(CONFIG_PATH, "utf-8");
+      const snapshot = readConfigSafely();
       const beforeMark = new Date(Date.now() - 1000).toISOString();
 
       const patchRes = await fetch(`${PINCHY_URL}/api/agents/${smithersId}`, {
@@ -300,7 +327,7 @@ test.describe("regenerateOpenClawConfig — cold-start & idempotency contract", 
       // Allow enough time for the write + any potential restart to surface.
       await new Promise((r) => setTimeout(r, 5000));
 
-      const after = readFileSync(CONFIG_PATH, "utf-8");
+      const after = readConfigSafely();
       const logs = openClawLogsSince(beforeMark);
 
       if (stripMeta(snapshot) !== stripMeta(after)) {

--- a/packages/web/e2e/integration/00-config-idempotency.spec.ts
+++ b/packages/web/e2e/integration/00-config-idempotency.spec.ts
@@ -67,11 +67,9 @@ function readConfigSafely(): string {
     } catch (err) {
       const code = (err as NodeJS.ErrnoException)?.code;
       if (code !== "EACCES" || attempt === 9) throw err;
-      // Synchronous busy-wait. Async would require touching every call site.
-      const start = Date.now();
-      while (Date.now() - start < 100) {
-        // spin
-      }
+      // Sync sleep — keeps callers synchronous (every call site uses the
+      // result inline) without burning a CPU core in a busy-wait.
+      execSync("sleep 0.1");
     }
   }
   // Unreachable — the loop either returns or throws.

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -406,6 +406,33 @@ describe("ClientRouter", () => {
     expect(textChunks).toHaveLength(0);
   });
 
+  it("should strip <final> envelope even when split across chunk boundaries", async () => {
+    // The original chunk-level strip leaked partial tags ("<fin", "</fi")
+    // into the UI when OpenClaw fragmented the envelope across chunks.
+    // Buffer-level holding of <final>-/</final>-prefix suffixes prevents
+    // that — the tail is retained until it either completes the tag (then
+    // stripped) or proves to be unrelated text (then emitted).
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "<fin" };
+      yield { type: "text" as const, text: "al>Hello world</fi" };
+      yield { type: "text" as const, text: "nal>" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      agentId: "agent-1",
+      content: "hi",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const textChunks = messages.filter((m: any) => m.type === "chunk");
+    const allText = textChunks.map((c: any) => c.content).join("");
+    expect(allText).toBe("Hello world");
+  });
+
   it("should still emit text that begins with letters from NO_REPLY", async () => {
     // Buffering must not swallow legitimate replies that happen to start with
     // characters that are also a prefix of the NO_REPLY sentinel (e.g. "Now").

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -341,6 +341,94 @@ describe("ClientRouter", () => {
     expect(allText).toBe("Right away! How can I help?");
   });
 
+  it("should suppress NO_REPLY sentinel arriving as a single text chunk", async () => {
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "NO_REPLY" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      agentId: "agent-1",
+      content: "say nothing",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const textChunks = messages.filter((m: any) => m.type === "chunk");
+    expect(textChunks).toHaveLength(0);
+  });
+
+  it("should suppress NO_REPLY sentinel even when streamed across chunk boundaries", async () => {
+    // Reproduces the user-reported bug where "NO_REPL" leaked into the chat
+    // UI because OpenClaw streams the silent-reply token character-by-character
+    // and the truncated prefix flushed before the full sentinel was assembled.
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "NO" };
+      yield { type: "text" as const, text: "_REPL" };
+      yield { type: "text" as const, text: "Y" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      agentId: "agent-1",
+      content: "say nothing",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const textChunks = messages.filter((m: any) => m.type === "chunk");
+    expect(textChunks).toHaveLength(0);
+    const allText = textChunks.map((c: any) => c.content).join("");
+    expect(allText).not.toContain("NO_REPL");
+    expect(allText).not.toContain("NO_REPLY");
+  });
+
+  it("should suppress <final>NO_REPLY</final> envelope variant", async () => {
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "<final>NO_REPLY</final>" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      agentId: "agent-1",
+      content: "say nothing",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const textChunks = messages.filter((m: any) => m.type === "chunk");
+    expect(textChunks).toHaveLength(0);
+  });
+
+  it("should still emit text that begins with letters from NO_REPLY", async () => {
+    // Buffering must not swallow legitimate replies that happen to start with
+    // characters that are also a prefix of the NO_REPLY sentinel (e.g. "Now").
+    const clientWs = createMockClientWs();
+    async function* fakeStream() {
+      yield { type: "text" as const, text: "N" };
+      yield { type: "text" as const, text: "ow let me help." };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat.mockReturnValue(fakeStream());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      agentId: "agent-1",
+      content: "hi",
+    });
+
+    const messages = clientWs.sent.map((s) => JSON.parse(s));
+    const textChunks = messages.filter((m: any) => m.type === "chunk");
+    const allText = textChunks.map((c: any) => c.content).join("");
+    expect(allText).toBe("Now let me help.");
+  });
+
   it("should include consistent messageId within a single turn", async () => {
     const clientWs = createMockClientWs();
     async function* fakeStream() {

--- a/packages/web/src/__tests__/server/silent-reply-buffer.test.ts
+++ b/packages/web/src/__tests__/server/silent-reply-buffer.test.ts
@@ -50,6 +50,27 @@ describe("safeEmitLength", () => {
     // prefix — the longest matching suffix is 'N' (1 char).
     expect(safeEmitLength("Hello NOON")).toBe(9);
   });
+
+  it("holds back any <final>-prefix suffix so split opening tags get stripped", () => {
+    expect(safeEmitLength("Hello <")).toBe(6);
+    expect(safeEmitLength("Hello <fin")).toBe(6);
+    expect(safeEmitLength("Hello <fina")).toBe(6);
+    expect(safeEmitLength("Hello <final")).toBe(6);
+  });
+
+  it("holds back any </final>-prefix suffix so split closing tags get stripped", () => {
+    expect(safeEmitLength("Hello </")).toBe(6);
+    expect(safeEmitLength("Hello </fin")).toBe(6);
+    expect(safeEmitLength("Hello </final")).toBe(6);
+  });
+
+  it("picks the longest hold across all patterns", () => {
+    // "Hello <fin" — `<fin` (4) is a <final>-prefix, longer than any
+    // NO_REPLY match (`n` is lowercase so the only candidate is empty).
+    expect(safeEmitLength("Hello <fin")).toBe(6);
+    // "Hello NO" — `NO` (2) is a NO_REPLY-prefix, no <final>-prefix.
+    expect(safeEmitLength("Hello NO")).toBe(6);
+  });
 });
 
 describe("stripFinalEnvelope", () => {

--- a/packages/web/src/__tests__/server/silent-reply-buffer.test.ts
+++ b/packages/web/src/__tests__/server/silent-reply-buffer.test.ts
@@ -1,0 +1,72 @@
+import { describe, it, expect } from "vitest";
+import {
+  SILENT_REPLY_TOKEN,
+  safeEmitLength,
+  stripFinalEnvelope,
+} from "@/server/silent-reply-buffer";
+
+describe("SILENT_REPLY_TOKEN", () => {
+  it("matches OpenClaw's silent-reply sentinel", () => {
+    expect(SILENT_REPLY_TOKEN).toBe("NO_REPLY");
+  });
+});
+
+describe("safeEmitLength", () => {
+  it("returns full length when no suffix could become the sentinel", () => {
+    expect(safeEmitLength("Hello world")).toBe(11);
+  });
+
+  it("returns 0 when the entire buffer is the sentinel", () => {
+    expect(safeEmitLength("NO_REPLY")).toBe(0);
+  });
+
+  it("holds back any sentinel-prefix suffix", () => {
+    expect(safeEmitLength("Hello NO_RE")).toBe(6);
+    expect(safeEmitLength("Hello N")).toBe(6);
+    expect(safeEmitLength("foo NO")).toBe(4);
+  });
+
+  it("holds back single sentinel-prefix characters", () => {
+    expect(safeEmitLength("N")).toBe(0);
+  });
+
+  it("does not hold back lowercase or unrelated characters", () => {
+    // 'n' is not a prefix character of 'NO_REPLY'.
+    expect(safeEmitLength("done.")).toBe(5);
+    expect(safeEmitLength("now")).toBe(3);
+  });
+
+  it("returns 0 for an empty buffer", () => {
+    expect(safeEmitLength("")).toBe(0);
+  });
+
+  it("handles a buffer that is longer than the sentinel and ends mid-sentinel", () => {
+    // The trailing "NO_R" could still grow into the sentinel.
+    expect(safeEmitLength("done. then NO_R")).toBe(11);
+  });
+
+  it("does not hold back when sentinel-like characters do not align as a suffix", () => {
+    // 'Hello NOON' contains 'NO' but ends with 'N' which IS a sentinel
+    // prefix — the longest matching suffix is 'N' (1 char).
+    expect(safeEmitLength("Hello NOON")).toBe(9);
+  });
+});
+
+describe("stripFinalEnvelope", () => {
+  it("removes opening and closing final tags", () => {
+    expect(stripFinalEnvelope("<final>Hello</final>")).toBe("Hello");
+  });
+
+  it("removes tags that span what would otherwise be split chunks", () => {
+    // Buffer-level stripping must catch tags assembled from multiple chunks.
+    expect(stripFinalEnvelope("<fin" + "al>" + "Hi" + "</fi" + "nal>")).toBe("Hi");
+  });
+
+  it("leaves text without tags unchanged", () => {
+    expect(stripFinalEnvelope("Hello world")).toBe("Hello world");
+  });
+
+  it("returns empty string for an empty buffer", () => {
+    expect(stripFinalEnvelope("")).toBe("");
+  });
+});

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -9,6 +9,11 @@ import { shouldEmitModelUnavailableAudit } from "@/server/model-unavailable-thro
 import { SessionCache } from "@/server/session-cache";
 import { getErrorHint } from "@/server/error-hints";
 import { classifyModelError } from "@/server/model-error-classifier";
+import {
+  SILENT_REPLY_TOKEN,
+  safeEmitLength,
+  stripFinalEnvelope,
+} from "@/server/silent-reply-buffer";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
 import { eq } from "drizzle-orm";
@@ -393,6 +398,11 @@ export class ClientRouter {
   ): Promise<void> {
     let messageId = initialMessageId;
 
+    // Per-turn rolling buffer for text chunks. We hold back any tail that
+    // could still grow into a SILENT_REPLY_TOKEN, then either flush or
+    // suppress it when the turn ends.
+    let textBuffer = "";
+
     // Heartbeat is intentionally deferred until the first chunk arrives.
     // Starting it immediately would reset the client-side stuck timer even
     // when OpenClaw's stream hangs before producing any output (e.g. after a
@@ -443,9 +453,12 @@ export class ClientRouter {
               clientMessageId: chunk.clientMessageId,
             });
           } else if (chunk.type === "text") {
-            const cleaned = chunk.text.replace(/<\/?final>/g, "");
-            if (cleaned) {
-              this.sendToClient(clientWs, { type: "chunk", content: cleaned, messageId });
+            textBuffer = stripFinalEnvelope(textBuffer + chunk.text);
+            const safeLen = safeEmitLength(textBuffer);
+            if (safeLen > 0) {
+              const emit = textBuffer.slice(0, safeLen);
+              textBuffer = textBuffer.slice(safeLen);
+              this.sendToClient(clientWs, { type: "chunk", content: emit, messageId });
             }
           } else if (chunk.type === "error") {
             const modelUnavailable = classifyModelError(chunk.text, agent.model ?? "");
@@ -487,6 +500,16 @@ export class ClientRouter {
               }
             }
           } else if (chunk.type === "done") {
+            // Flush remaining buffer at end-of-turn. If the entire turn
+            // resolved to the silent-reply sentinel, suppress it; otherwise
+            // emit whatever text was held back.
+            if (textBuffer && textBuffer !== SILENT_REPLY_TOKEN) {
+              this.sendToClient(clientWs, {
+                type: "chunk",
+                content: textBuffer,
+                messageId,
+              });
+            }
             this.sendToClient(clientWs, { type: "done", messageId });
           }
         }
@@ -496,6 +519,7 @@ export class ClientRouter {
         // or not the browser is listening (consistent with how OpenClaw
         // stores them in history).
         if (chunk.type === "done") {
+          textBuffer = "";
           messageId = crypto.randomUUID();
         }
       }

--- a/packages/web/src/server/silent-reply-buffer.ts
+++ b/packages/web/src/server/silent-reply-buffer.ts
@@ -5,26 +5,39 @@
 // token and only emit text once we know it can't.
 export const SILENT_REPLY_TOKEN = "NO_REPLY";
 
+// Patterns whose trailing prefixes must be held back so split sequences
+// across chunk boundaries can either complete (and be stripped/suppressed)
+// or be proven to be unrelated text (and emitted). Order is irrelevant —
+// the algorithm picks the longest hold across all patterns.
+const HOLDBACK_PATTERNS = [SILENT_REPLY_TOKEN, "<final>", "</final>"] as const;
+
 /**
  * Returns the number of leading characters in `buffer` that are safe to emit
- * without risk of leaking a partial SILENT_REPLY_TOKEN. The remaining suffix
- * is whatever could still grow into the sentinel — held back for the next
- * chunk or end-of-turn decision.
+ * without risk of leaking a partial pattern (silent-reply sentinel or
+ * `<final>` envelope tag). The remaining suffix — whatever could still grow
+ * into one of the patterns — is held back for the next chunk or
+ * end-of-turn decision.
  */
 export function safeEmitLength(buffer: string): number {
-  const max = Math.min(buffer.length, SILENT_REPLY_TOKEN.length);
-  for (let suffixLen = max; suffixLen > 0; suffixLen--) {
-    if (SILENT_REPLY_TOKEN.startsWith(buffer.slice(-suffixLen))) {
-      return buffer.length - suffixLen;
+  let longestHold = 0;
+  for (const pattern of HOLDBACK_PATTERNS) {
+    const max = Math.min(buffer.length, pattern.length);
+    for (let suffixLen = max; suffixLen > longestHold; suffixLen--) {
+      if (pattern.startsWith(buffer.slice(-suffixLen))) {
+        longestHold = suffixLen;
+        break;
+      }
     }
   }
-  return buffer.length;
+  return buffer.length - longestHold;
 }
 
 /**
  * Strips OpenClaw's `<final>...</final>` envelope from a buffered string.
- * Buffer-level rather than chunk-level so split tags (e.g. `<fina` then
- * `l>...`) get stripped correctly.
+ * Operates on the full buffer so tags assembled from multiple chunks (e.g.
+ * `<fina` then `l>...`) are stripped once the buffer has both halves —
+ * `safeEmitLength` retains the leading `<fin…` until the closing `>`
+ * arrives, at which point this regex fires.
  */
 export function stripFinalEnvelope(buffer: string): string {
   return buffer.replace(/<\/?final>/g, "");

--- a/packages/web/src/server/silent-reply-buffer.ts
+++ b/packages/web/src/server/silent-reply-buffer.ts
@@ -1,0 +1,31 @@
+// OpenClaw emits this sentinel when the agent decides to stay silent for a
+// turn. Streaming can split it across chunks (the user-reported screenshot
+// showed "NO_REPL" leaking into the chat UI before the trailing "Y"
+// arrived), so callers buffer any suffix that could still complete the
+// token and only emit text once we know it can't.
+export const SILENT_REPLY_TOKEN = "NO_REPLY";
+
+/**
+ * Returns the number of leading characters in `buffer` that are safe to emit
+ * without risk of leaking a partial SILENT_REPLY_TOKEN. The remaining suffix
+ * is whatever could still grow into the sentinel — held back for the next
+ * chunk or end-of-turn decision.
+ */
+export function safeEmitLength(buffer: string): number {
+  const max = Math.min(buffer.length, SILENT_REPLY_TOKEN.length);
+  for (let suffixLen = max; suffixLen > 0; suffixLen--) {
+    if (SILENT_REPLY_TOKEN.startsWith(buffer.slice(-suffixLen))) {
+      return buffer.length - suffixLen;
+    }
+  }
+  return buffer.length;
+}
+
+/**
+ * Strips OpenClaw's `<final>...</final>` envelope from a buffered string.
+ * Buffer-level rather than chunk-level so split tags (e.g. `<fina` then
+ * `l>...`) get stripped correctly.
+ */
+export function stripFinalEnvelope(buffer: string): string {
+  return buffer.replace(/<\/?final>/g, "");
+}


### PR DESCRIPTION
## What does this PR do?

Stops OpenClaw's silent-reply sentinel (`NO_REPLY`, optionally wrapped in `<final>...</final>`) from leaking into the chat UI. Users were seeing partial substrings like `NO_REPL` rendered as agent messages because the token streams in character-by-character and was forwarded before any suppression could decide.

The fix buffers a per-turn rolling tail in `pipeStream` and holds back any suffix that could still grow into the sentinel. On end-of-turn the buffer is either flushed (regular text) or suppressed entirely (when it equals `NO_REPLY` exactly). `<final>` envelopes are stripped buffer-level so split tags also work.

The matching logic is extracted into a new `silent-reply-buffer` module so it can be unit-tested in isolation. Integration coverage for the user-reported `["NO", "_REPL", "Y"]` streaming sequence sits alongside the existing client-router streaming tests.

Closes #

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Notes for reviewers

- Buffering only delays text by at most `NO_REPLY.length` (8 chars) — imperceptible at streaming speeds.
- Mid-text occurrences of `NO_REPLY` are intentionally preserved (per spec: only entire-turn sentinels are suppressed). A model emitting `Sure! NO_REPLY done.` would render as-is.
- The new "Now let me help." regression test ensures legitimate replies starting with sentinel-prefix characters (`N`, `NO`, ...) still flow through — the buffer flushes them on the next chunk or `done`.
- Pre-existing `<final>` chunk-level stripping is now buffer-level, which incidentally also fixes split-tag cases (e.g. `<fina` + `l>...`).

## Verification

- 3 new integration tests RED-confirmed before fix, all GREEN after.
- Full web test suite: 3847 passing, 12 skipped, 0 failing.
- Lint: 0 errors. Prettier: clean.