### PR TITLE
fix(chat): surface silent OpenClaw stream-end as retry-able error

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -147,7 +147,7 @@ When an agent's model call returns a 5xx from the upstream provider, the chat no
 
 #### Silent model timeouts now surface a retry-able error
 
-Previously, a run that ended without producing any assistant text — typically a model that timed out inside OpenClaw's embedded layer on a cold-path tool call — left the chat indistinguishable from a successful empty reply: spinner gone, no error, no retry button. The chat now detects when a stream completes with no consumer-visible output and shows the standard error bubble with a **Retry** button, so the user isn't left guessing whether anything is still happening.
+Previously, a run that ended without producing any assistant text — typically a model that timed out inside OpenClaw's embedded layer on a cold-path tool call — left the chat indistinguishable from a successful empty reply: spinner gone, no error, no retry button. The chat now detects when a stream completes with no consumer-visible output and shows the standard error bubble with a **Retry** button plus the "Try again in a moment." hint, so the user isn't left guessing whether anything is still happening. Each silent timeout also writes a `chat.silent_stream` audit entry (throttled per `(agentId, model)` so a flaky provider can't flood the trail through user retries), giving admins an operational signal that an embedded run terminated without producing output.
 
 #### Per-agent chat runtimes survive in-app navigation
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -145,6 +145,10 @@ Existing agents that pinned `kimi-k2-thinking` explicitly keep loading from the 
 
 When an agent's model call returns a 5xx from the upstream provider, the chat now shows a structured error bubble (`<Agent> couldn't respond.` + provider/model + a deep-link to the agent's model picker) instead of the raw `HTTP 500: "Internal Server Error (ref: …)"` string. The original error stays available under a collapsible **Technical details** section so support requests can still cite the upstream `ref` ID. Every flip into this error state writes an `agent.model_unavailable` audit entry.
 
+#### Silent model timeouts now surface a retry-able error
+
+Previously, a run that ended without producing any assistant text — typically a model that timed out inside OpenClaw's embedded layer on a cold-path tool call — left the chat indistinguishable from a successful empty reply: spinner gone, no error, no retry button. The chat now detects when a stream completes with no consumer-visible output and shows the standard error bubble with a **Retry** button, so the user isn't left guessing whether anything is still happening.
+
 #### Per-agent chat runtimes survive in-app navigation
 
 Switching between agents in the sidebar no longer tears down and recreates the chat runtime: a new `ChatSessionProvider` mounts one runtime per agent at the `(app)` layout level, so streams in-flight on agent A keep running while you read agent B's history. The sidebar shows a subtle pulse on agents with an active turn and a red dot on agents that ended in an error, so background activity is visible without opening every chat.

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2130,6 +2130,116 @@ describe("ClientRouter", () => {
     consoleSpy.mockRestore();
   });
 
+  // Defensive safety-net for issue #320: OpenClaw's embedded runner silently
+  // falls through to `continue_normal` when `surface_error` fires with
+  // `params.timedOut === true` (see pi-embedded-runner/run/assistant-failover.ts).
+  // No `lifecycle.phase=error` event reaches openclaw-node, so Pinchy's
+  // forwarder never sees an error chunk. From the user's perspective the
+  // stream ends silently — no error bubble, no retry button. We detect this
+  // server-side by tracking whether any consumer-visible output (text or
+  // error chunk) reached the client, and emit a synthetic error frame when
+  // the stream ends with nothing visible.
+  describe("silent stream-end safety net (issue #320)", () => {
+    it("emits a retry-able error frame when stream ends without any text or error chunk", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      // Mimics the OC surface_error+timedOut path: no text, no error chunk,
+      // run just terminates with a bare `done`.
+      async function* fakeStream() {
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      const errorMsg = messages.find((m: any) => m.type === "error");
+      expect(errorMsg).toBeDefined();
+      expect(errorMsg.agentName).toBe("Smithers");
+      expect(errorMsg.providerError).toMatch(/no response|timed out|timeout/i);
+      expect(errorMsg.messageId).toBeTruthy();
+
+      // The synthetic error must precede `complete` so the client's
+      // error handler runs before the spinner is cleared.
+      const errorIdx = messages.findIndex((m: any) => m.type === "error");
+      const completeIdx = messages.findIndex((m: any) => m.type === "complete");
+      expect(errorIdx).toBeGreaterThanOrEqual(0);
+      expect(completeIdx).toBeGreaterThan(errorIdx);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT emit a synthetic error when the stream produced any text", async () => {
+      const clientWs = createMockClientWs();
+
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m: any) => m.type === "error")).toBe(false);
+      expect(messages.some((m: any) => m.type === "chunk")).toBe(true);
+    });
+
+    it("does NOT emit a synthetic error for an intentional silent reply", async () => {
+      const clientWs = createMockClientWs();
+
+      // SILENT_REPLY_TOKEN = "NO_REPLY" is a legitimate "agent chose silence"
+      // signal — text chunks did arrive, they're just suppressed at flush time.
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "NO_REPLY" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m: any) => m.type === "error")).toBe(false);
+    });
+
+    it("does NOT emit a second error frame when the stream already emitted an error chunk", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      async function* fakeStream() {
+        yield { type: "error" as const, text: "Rate limit exceeded" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      const errorMessages = messages.filter((m: any) => m.type === "error");
+      expect(errorMessages).toHaveLength(1);
+      expect(errorMessages[0].providerError).toContain("Rate limit exceeded");
+
+      consoleSpy.mockRestore();
+    });
+  });
+
   describe("per-user context injection for shared agents", () => {
     it("should include user context in extraSystemPrompt for shared agents", async () => {
       mockUserFindFirst.mockResolvedValue({

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -11,6 +11,7 @@ const {
   mockGetUserGroupIds,
   mockGetAgentGroupIds,
   mockShouldEmitModelUnavailableAudit,
+  mockShouldEmitSilentStreamAudit,
 } = vi.hoisted(() => ({
   mockChat: vi.fn(),
   mockSessionsHistory: vi.fn(),
@@ -21,6 +22,7 @@ const {
   mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
   mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
   mockShouldEmitModelUnavailableAudit: vi.fn().mockReturnValue(true),
+  mockShouldEmitSilentStreamAudit: vi.fn().mockReturnValue(true),
 }));
 
 vi.mock("@/lib/agent-access", async (importOriginal) => {
@@ -89,6 +91,7 @@ vi.mock("@/lib/groups", () => ({
 vi.mock("@/server/model-unavailable-throttle", () => ({
   shouldEmitModelUnavailableAudit: (...args: unknown[]) =>
     mockShouldEmitModelUnavailableAudit(...args),
+  shouldEmitSilentStreamAudit: (...args: unknown[]) => mockShouldEmitSilentStreamAudit(...args),
 }));
 
 vi.mock("@/lib/upload-validation", () => ({
@@ -2140,7 +2143,7 @@ describe("ClientRouter", () => {
   // error chunk) reached the client, and emit a synthetic error frame when
   // the stream ends with nothing visible.
   describe("silent stream-end safety net (issue #320)", () => {
-    it("emits a retry-able error frame when stream ends without any text or error chunk", async () => {
+    it("emits a retry-able error frame with the standard transient hint when stream ends without any text or error chunk", async () => {
       const clientWs = createMockClientWs();
       const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
 
@@ -2161,7 +2164,14 @@ describe("ClientRouter", () => {
       const errorMsg = messages.find((m: any) => m.type === "error");
       expect(errorMsg).toBeDefined();
       expect(errorMsg.agentName).toBe("Smithers");
-      expect(errorMsg.providerError).toMatch(/no response|timed out|timeout/i);
+      expect(errorMsg.providerError).toBe(
+        "The model did not produce a response. It may have timed out."
+      );
+      // The "timed out" phrasing must match TRANSIENT_PATTERN in error-hints.ts
+      // so the user gets the standard retry suggestion. If the message phrasing
+      // drifts away from a transient-matching word, the hint silently goes
+      // null — locking it down here so future copy edits stay in sync.
+      expect(errorMsg.hint).toBe("Try again in a moment.");
       expect(errorMsg.messageId).toBeTruthy();
 
       // The synthetic error must precede `complete` so the client's
@@ -2170,6 +2180,74 @@ describe("ClientRouter", () => {
       const completeIdx = messages.findIndex((m: any) => m.type === "complete");
       expect(errorIdx).toBeGreaterThanOrEqual(0);
       expect(completeIdx).toBeGreaterThan(errorIdx);
+
+      consoleSpy.mockRestore();
+    });
+
+    it("writes a chat.silent_stream audit log with outcome failure when stream ends silently", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+      });
+      mockShouldEmitSilentStreamAudit.mockReturnValue(true);
+
+      async function* fakeStream() {
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockAppendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: "user",
+          actorId: "user-1",
+          eventType: "chat.silent_stream",
+          resource: "agent:agent-1",
+          outcome: "failure",
+          detail: expect.objectContaining({
+            agent: { id: "agent-1", name: "Smithers" },
+            model: "ollama-cloud/deepseek-v4-pro",
+            providerError: "The model did not produce a response. It may have timed out.",
+            reason: "silent_stream_end",
+          }),
+        })
+      );
+
+      consoleSpy.mockRestore();
+    });
+
+    it("does NOT write a silent-stream audit when the throttle suppresses it", async () => {
+      const clientWs = createMockClientWs();
+      const consoleSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+      mockShouldEmitSilentStreamAudit.mockReturnValue(false);
+
+      async function* fakeStream() {
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // The retry-able error frame must still reach the client — only the
+      // audit-log write is throttled.
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m: any) => m.type === "error")).toBe(true);
+      expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+        expect.objectContaining({ eventType: "chat.silent_stream" })
+      );
 
       consoleSpy.mockRestore();
     });

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -28,6 +28,8 @@ describe("getErrorHint", () => {
       "Rate limit exceeded",
       "Too many requests",
       "Request timeout",
+      "Request timed out",
+      "The model did not produce a response. It may have timed out.",
       "The server is overloaded",
       "529 overloaded",
     ];

--- a/packages/web/src/__tests__/server/model-unavailable-throttle.test.ts
+++ b/packages/web/src/__tests__/server/model-unavailable-throttle.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect, beforeEach } from "vitest";
 import {
   shouldEmitModelUnavailableAudit,
+  shouldEmitSilentStreamAudit,
   __resetModelUnavailableThrottleForTests,
 } from "@/server/model-unavailable-throttle";
 
@@ -23,5 +24,35 @@ describe("shouldEmitModelUnavailableAudit", () => {
     expect(shouldEmitModelUnavailableAudit("agent-1", "openai/gpt-x", now)).toBe(true);
     expect(shouldEmitModelUnavailableAudit("agent-2", "openai/gpt-x", now)).toBe(true);
     expect(shouldEmitModelUnavailableAudit("agent-1", "openai/gpt-y", now)).toBe(true);
+  });
+});
+
+describe("shouldEmitSilentStreamAudit", () => {
+  beforeEach(() => {
+    __resetModelUnavailableThrottleForTests();
+  });
+
+  it("emits the first event and suppresses repeats within TTL", () => {
+    const now = Date.now();
+    expect(shouldEmitSilentStreamAudit("agent-1", "ollama-cloud/x", now)).toBe(true);
+    expect(shouldEmitSilentStreamAudit("agent-1", "ollama-cloud/x", now + 60_000)).toBe(false);
+    expect(shouldEmitSilentStreamAudit("agent-1", "ollama-cloud/x", now + 6 * 60_000)).toBe(true);
+  });
+
+  it("tracks (agentId, model) pairs independently", () => {
+    const now = Date.now();
+    expect(shouldEmitSilentStreamAudit("agent-1", "openai/gpt-x", now)).toBe(true);
+    expect(shouldEmitSilentStreamAudit("agent-2", "openai/gpt-x", now)).toBe(true);
+    expect(shouldEmitSilentStreamAudit("agent-1", "openai/gpt-y", now)).toBe(true);
+  });
+
+  it("is independent from the model-unavailable throttle", () => {
+    // Two failure modes for the same (agentId, model) within TTL must both
+    // audit — they're distinct operational signals (5xx error chunk vs.
+    // silent stream-end with no event at all). A shared throttle would lose
+    // the second signal.
+    const now = Date.now();
+    expect(shouldEmitModelUnavailableAudit("agent-1", "openai/gpt-x", now)).toBe(true);
+    expect(shouldEmitSilentStreamAudit("agent-1", "openai/gpt-x", now + 60_000)).toBe(true);
   });
 });

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -5,7 +5,10 @@ import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { isEnterprise } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
-import { shouldEmitModelUnavailableAudit } from "@/server/model-unavailable-throttle";
+import {
+  shouldEmitModelUnavailableAudit,
+  shouldEmitSilentStreamAudit,
+} from "@/server/model-unavailable-throttle";
 import { SessionCache } from "@/server/session-cache";
 import { getErrorHint } from "@/server/error-hints";
 import { classifyModelError } from "@/server/model-error-classifier";
@@ -650,6 +653,30 @@ export class ClientRouter {
           hint: getErrorHint(providerError, this.userRole),
           messageId,
         });
+
+        // Operational signal: a silent timeout shouldn't be invisible to
+        // admins reviewing the audit trail. Throttled per (agentId, model)
+        // so a degraded provider can't flood the log via user retries.
+        if (shouldEmitSilentStreamAudit(agent.id, agent.model ?? "")) {
+          const auditEntry = {
+            actorType: "user" as const,
+            actorId: this.userId,
+            eventType: "chat.silent_stream" as const,
+            resource: `agent:${agent.id}`,
+            detail: {
+              agent: { id: agent.id, name: agent.name },
+              model: agent.model ?? null,
+              providerError,
+              reason: "silent_stream_end" as const,
+            },
+            outcome: "failure" as const,
+          };
+          try {
+            await appendAuditLog(auditEntry);
+          } catch (err) {
+            recordAuditFailure(err, auditEntry);
+          }
+        }
       }
 
       // Tell the client the entire request is finished. Unlike "done" events

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -501,6 +501,17 @@ export class ClientRouter {
     // suppress it when the turn ends.
     let textBuffer = "";
 
+    // Safety net for issue #320: OpenClaw's embedded runner falls through to
+    // `continue_normal` when `surface_error` fires with `params.timedOut`,
+    // emitting no lifecycle error event. The stream ends silently and the
+    // user is left with no error bubble and no retry button. We track
+    // whether any consumer-visible output reached the client and synthesize
+    // an error frame if the stream ends with nothing visible. Heartbeats
+    // and lifecycle/tool chunks don't count — only text the user would see
+    // or an explicit error chunk closes the safety net.
+    let sawText = false;
+    let sawError = false;
+
     // Heartbeat is intentionally deferred until the first chunk arrives.
     // Starting it immediately would reset the client-side stuck timer even
     // when OpenClaw's stream hangs before producing any output (e.g. after a
@@ -551,6 +562,7 @@ export class ClientRouter {
               clientMessageId: chunk.clientMessageId,
             });
           } else if (chunk.type === "text") {
+            sawText = true;
             textBuffer = stripFinalEnvelope(textBuffer + chunk.text);
             const safeLen = safeEmitLength(textBuffer);
             if (safeLen > 0) {
@@ -559,6 +571,7 @@ export class ClientRouter {
               this.sendToClient(clientWs, { type: "chunk", content: emit, messageId });
             }
           } else if (chunk.type === "error") {
+            sawError = true;
             const modelUnavailable = classifyModelError(chunk.text, agent.model ?? "");
             this.sendToClient(clientWs, {
               type: "error",
@@ -620,6 +633,23 @@ export class ClientRouter {
           textBuffer = "";
           messageId = crypto.randomUUID();
         }
+      }
+
+      // Issue #320 safety net: stream ended without any consumer-visible
+      // output. Surface a retry-able error so the user isn't stranded with
+      // an empty assistant turn (most likely cause: OC's embedded runner
+      // swallowed a `surface_error reason=timeout` into `continue_normal`).
+      // Must precede the `complete` frame so the client's error handler
+      // runs before the spinner is cleared.
+      if (!sawText && !sawError && clientWs.readyState === WS_OPEN) {
+        const providerError = "The model did not produce a response. It may have timed out.";
+        this.sendToClient(clientWs, {
+          type: "error",
+          agentName: agent.name,
+          providerError,
+          hint: getErrorHint(providerError, this.userRole),
+          messageId,
+        });
       }
 
       // Tell the client the entire request is finished. Unlike "done" events

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -1,7 +1,7 @@
 const PROVIDER_CONFIG_PATTERN =
   /credit|balance|api[_ ]?key|invalid.*key|authenticat|unauthorized|quota|exceeded/i;
 
-const TRANSIENT_PATTERN = /rate[_ ]?limit|too many requests|timeout|overloaded|529/i;
+const TRANSIENT_PATTERN = /rate[_ ]?limit|too many requests|time[_ ]?d?[_ ]?out|overloaded|529/i;
 
 export const PROVIDER_SETTINGS_HINT = "Go to Settings > Providers to check your API configuration.";
 

--- a/packages/web/src/server/model-unavailable-throttle.ts
+++ b/packages/web/src/server/model-unavailable-throttle.ts
@@ -16,6 +16,7 @@
  *     `(agent_id, model, bucket)` to make this race a no-op.
  */
 const lastEmittedAt = new Map<string, number>();
+const lastSilentStreamAt = new Map<string, number>();
 const TTL_MS = 5 * 60 * 1000;
 
 export function shouldEmitModelUnavailableAudit(
@@ -30,6 +31,26 @@ export function shouldEmitModelUnavailableAudit(
   return true;
 }
 
+/**
+ * Throttle for `chat.silent_stream` audit events (issue #320). Kept separate
+ * from the 5xx throttle so two different failure modes for the same
+ * `(agentId, model)` pair within the TTL still both audit — they're distinct
+ * operational signals (one is a provider-side error event, the other is a
+ * silent timeout where no event ever arrives).
+ */
+export function shouldEmitSilentStreamAudit(
+  agentId: string,
+  model: string,
+  now: number = Date.now()
+): boolean {
+  const key = `${agentId}:${model}`;
+  const last = lastSilentStreamAt.get(key);
+  if (last !== undefined && now - last < TTL_MS) return false;
+  lastSilentStreamAt.set(key, now);
+  return true;
+}
+
 export function __resetModelUnavailableThrottleForTests(): void {
   lastEmittedAt.clear();
+  lastSilentStreamAt.clear();
 }


### PR DESCRIPTION
## Summary

- When OpenClaw's embedded runner logs `decision=surface_error reason=timeout`, the failover-policy branch in `pi-embedded-runner/run/assistant-failover.ts` falls through to `continue_normal` instead of throwing, so no `lifecycle.phase=error` event ever reaches openclaw-node. The chat stream ends silently — no error bubble, no retry button, spinner just quietly stops.
- Server-side safety net in `pipeStream`: track whether any consumer-visible output (text or error chunk) reached the client. If the stream ends with nothing visible, emit a synthesized `type: "error"` frame before `complete` so the existing client-side error UI renders the standard bubble + retry.
- This is the user-visible defect carved out of #302 (cascade root cause closed as won't-fix).

Closes #320

## Why not extend the forwarder shape

The forwarder at `client-router.ts:572-590` already handles every shape the openclaw-node SDK can yield (`{ type: "error", text }`). Reading the bundled OpenClaw source confirmed OC doesn't emit anything else on `surface_error` + `timedOut` — it just logs and returns. So the gap is "no chunk at all," and the right defense is a stream-end safety net rather than a richer forwarder.

## Upstream OpenClaw bug to file

In `openclaw@2026.4.27` (`dist/pi-embedded-CLyF5vpj.js`), `handleAssistantFailover` only throws when `!params.externalAbort && !params.timedOut`:

```js
if (decision.action === "surface_error") {
  if (...idleTimedOut...) return sameModelIdleTimeoutRetry();
  params.logAssistantFailoverDecision("surface_error");
  if (!params.externalAbort && !params.timedOut) {
    return { action: "throw", error: new FailoverError(...) };
  }
}
return { action: "continue_normal", overloadProfileRotations };
```

When `params.timedOut === true` (the actual timeout case), the decision is only logged and the run continues "normally" — silently producing no further events for the user-visible turn. This should still throw / emit a lifecycle error. Will file upstream separately.

## Test plan

- [x] New unit tests in `client-router.test.ts`:
  - `emits a retry-able error frame when stream ends without any text or error chunk` (the bug case)
  - `does NOT emit a synthetic error when the stream produced any text` (negative)
  - `does NOT emit a synthetic error for an intentional silent reply` (`SILENT_REPLY_TOKEN` negative)
  - `does NOT emit a second error frame when the stream already emitted an error chunk` (no double-error)
- [x] Full `client-router.test.ts` suite: 111/111 green
- [x] Lint: no new warnings or errors
- [ ] Manual repro on staging: slow provider or cold tool-call after permission change should now show the error bubble with retry