### PR TITLE
fix(chat): forward agent.model as provider/model to fix vision uploads

### DIFF
--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -50,7 +50,7 @@
     "next": "16.2.4",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
-    "openclaw-node": "0.7.0",
+    "openclaw-node": "0.9.0",
     "pdfkit": "^0.18.0",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2488,6 +2488,111 @@ describe("ClientRouter", () => {
     });
   });
 
+  describe("agent model override forwarded to openclaw.chat()", () => {
+    // Why: OpenClaw's `agent` RPC resolves the session model via
+    // `resolveSessionModelRef(cfg, entry, undefined)` — `agentId` is hard-coded
+    // to `undefined` inside server-methods, so the lookup falls back to the
+    // gateway-wide default model rather than the agent's configured one. That
+    // breaks the vision-capability check for image attachments on per-agent
+    // vision-capable models. Passing `provider` + `model` through
+    // openclaw-node ≥ 0.9 forces the Gateway to use the right pair.
+    it("splits agent.model on '/' and forwards as provider+model overrides", async () => {
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/gemini-3-flash-preview",
+      });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockChat).toHaveBeenCalledWith(
+        "Hi",
+        expect.objectContaining({
+          provider: "ollama-cloud",
+          model: "gemini-3-flash-preview",
+        })
+      );
+    });
+
+    it("omits provider/model when agent.model is missing", async () => {
+      mockFindFirst.mockResolvedValue({ ...defaultAgent, model: null });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const callArgs = mockChat.mock.calls[0][1] as Record<string, unknown>;
+      expect(callArgs).not.toHaveProperty("provider");
+      expect(callArgs).not.toHaveProperty("model");
+    });
+
+    it("omits provider/model when agent.model has no '/' (defensive — db invariant violated)", async () => {
+      // Legacy or hand-edited rows that store just the model id without a
+      // provider prefix would otherwise produce a malformed RPC call (empty
+      // provider). Treat as "no override" instead.
+      mockFindFirst.mockResolvedValue({ ...defaultAgent, model: "gpt-5-2025-08-07" });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const callArgs = mockChat.mock.calls[0][1] as Record<string, unknown>;
+      expect(callArgs).not.toHaveProperty("provider");
+      expect(callArgs).not.toHaveProperty("model");
+    });
+
+    it("handles model ids that contain slashes themselves (e.g. 'huggingface/microsoft/phi-3:mini')", async () => {
+      // The provider is everything before the FIRST slash; the model is
+      // everything after. Models with slashes in their id (HuggingFace,
+      // OpenRouter, ...) need this contract.
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "huggingface/microsoft/phi-3:mini",
+      });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hi" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      expect(mockChat).toHaveBeenCalledWith(
+        "Hi",
+        expect.objectContaining({
+          provider: "huggingface",
+          model: "microsoft/phi-3:mini",
+        })
+      );
+    });
+  });
+
   describe("clientMessageId forwarding", () => {
     it("forwards clientMessageId from browser WS frame to openclaw.chat()", async () => {
       async function* fakeStream() {

--- a/packages/web/src/components/assistant-ui/__tests__/attachment-preview.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/attachment-preview.test.tsx
@@ -1,5 +1,5 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor, act, cleanup } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import React from "react";
 
@@ -16,6 +16,26 @@ vi.mock("@assistant-ui/react", () => ({
   useMessagePartFile: () => mockUseMessagePartFile(),
 }));
 
+// All previewable MIME types go through a HEAD probe before the <embed>/<img>
+// is mounted (race-fix in #324). Default fetch mock returns 200 so the legacy
+// "rendered URL points at the API path" assertions still hold once the probe
+// resolves. Individual tests override the mock to exercise retry / failure
+// paths.
+function mockFetchOk() {
+  global.fetch = vi
+    .fn()
+    .mockResolvedValue(new Response(null, { status: 200 })) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  mockFetchOk();
+});
+
+afterEach(() => {
+  cleanup();
+  vi.restoreAllMocks();
+});
+
 async function renderWithAgent(agentId: string | null) {
   const { AgentIdContext } = await import("@/components/chat");
   const { AttachmentPreview } = await import("@/components/assistant-ui/attachment-preview");
@@ -27,17 +47,20 @@ async function renderWithAgent(agentId: string | null) {
 }
 
 describe("AttachmentPreview — PDF", () => {
-  it("renders an <embed> thumbnail pointing at the uploads API URL", async () => {
+  it("renders an <embed> thumbnail pointing at the uploads API URL after probe completes", async () => {
     mockUseMessagePartFile.mockReturnValue({
       mimeType: "application/pdf",
       filename: "Profile (38).pdf",
     });
     const { container } = await renderWithAgent("agent-1");
-    const embed = container.querySelector("embed");
-    expect(embed).toBeTruthy();
-    expect(embed!.getAttribute("type")).toBe("application/pdf");
+    const embed = await waitFor(() => {
+      const e = container.querySelector("embed");
+      if (!e) throw new Error("embed not yet mounted");
+      return e;
+    });
+    expect(embed.getAttribute("type")).toBe("application/pdf");
     // URL-encoded path with the agent id segment.
-    expect(embed!.getAttribute("src")).toBe("/api/agents/agent-1/uploads/Profile%20(38).pdf");
+    expect(embed.getAttribute("src")).toBe("/api/agents/agent-1/uploads/Profile%20(38).pdf");
   });
 
   it("opens a modal with a full-size PDF embed when the thumbnail is clicked", async () => {
@@ -48,7 +71,7 @@ describe("AttachmentPreview — PDF", () => {
     await renderWithAgent("agent-1");
     // The thumbnail itself is the trigger — the component uses shadcn/ui Dialog
     // from @/components/ui/dialog, not assistant-ui.
-    const trigger = screen.getByRole("button", { name: /preview invoice\.pdf/i });
+    const trigger = await screen.findByRole("button", { name: /preview invoice\.pdf/i });
     await userEvent.click(trigger);
     // Modal content uses a unique label so we can assert it's open.
     expect(screen.getByRole("dialog")).toBeInTheDocument();
@@ -67,21 +90,26 @@ describe("AttachmentPreview — PDF", () => {
     await renderWithAgent(null);
     expect(screen.queryByRole("button", { name: /preview/i })).toBeNull();
     expect(screen.getByText("invoice.pdf")).toBeInTheDocument();
+    // No probe is issued for the chip path — would be wasted network.
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 });
 
 describe("AttachmentPreview — image", () => {
-  it("renders an inline <img> pointing at the uploads API URL", async () => {
+  it("renders an inline <img> pointing at the uploads API URL after probe completes", async () => {
     mockUseMessagePartFile.mockReturnValue({
       mimeType: "image/png",
       filename: "photo.png",
     });
     const { container } = await renderWithAgent("agent-1");
-    const img = container.querySelector("img");
-    expect(img).toBeTruthy();
-    expect(img!.getAttribute("src")).toBe("/api/agents/agent-1/uploads/photo.png");
+    const img = await waitFor(() => {
+      const i = container.querySelector("img");
+      if (!i) throw new Error("img not yet mounted");
+      return i;
+    });
+    expect(img.getAttribute("src")).toBe("/api/agents/agent-1/uploads/photo.png");
     // Alt text must be the filename — screen-reader accessible.
-    expect(img!.getAttribute("alt")).toContain("photo.png");
+    expect(img.getAttribute("alt")).toContain("photo.png");
   });
 
   it("opens a modal with the full image when the thumbnail is clicked", async () => {
@@ -90,7 +118,8 @@ describe("AttachmentPreview — image", () => {
       filename: "selfie.jpg",
     });
     await renderWithAgent("agent-1");
-    await userEvent.click(screen.getByRole("button", { name: /preview selfie\.jpg/i }));
+    const trigger = await screen.findByRole("button", { name: /preview selfie\.jpg/i });
+    await userEvent.click(trigger);
     expect(screen.getByRole("dialog")).toBeInTheDocument();
     const modalImg = screen.getByRole("dialog").querySelector("img");
     expect(modalImg?.getAttribute("src")).toBe("/api/agents/agent-1/uploads/selfie.jpg");
@@ -117,6 +146,8 @@ describe("AttachmentPreview — fallback chip", () => {
     expect(container.querySelector("embed")).toBeNull();
     expect(container.querySelector("img")).toBeNull();
     expect(screen.getByText("archive.zip")).toBeInTheDocument();
+    // The chip path skips the probe entirely.
+    expect(global.fetch).not.toHaveBeenCalled();
   });
 
   it("renders a chip with a default filename when none is provided", async () => {
@@ -127,5 +158,117 @@ describe("AttachmentPreview — fallback chip", () => {
     await renderWithAgent("agent-1");
     // Without a filename we cannot build a URL — show a chip.
     expect(screen.getByText(/PDF document/i)).toBeInTheDocument();
+  });
+});
+
+// ── HEAD-probe race fix (#324) ──────────────────────────────────────────
+//
+// The server persists the uploaded file AFTER the WS message lands, but the
+// browser renders this component as soon as the user message hits local
+// state. A naive <embed src=…> would 404 against the still-pending file and
+// the user sees "Not found" until they reload. These tests pin the probe
+// behaviour that papers over that race for v0.5.3.
+describe("AttachmentPreview — HEAD-probe race fix", () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("does not mount the <embed> while the first HEAD probe is still pending", async () => {
+    global.fetch = vi
+      .fn()
+      .mockImplementation(() => new Promise(() => {})) as unknown as typeof fetch;
+    mockUseMessagePartFile.mockReturnValue({
+      mimeType: "application/pdf",
+      filename: "race.pdf",
+    });
+    const { container } = await renderWithAgent("agent-1");
+    expect(container.querySelector("embed")).toBeNull();
+    expect(global.fetch).toHaveBeenCalledWith(
+      "/api/agents/agent-1/uploads/race.pdf",
+      expect.objectContaining({ method: "HEAD" })
+    );
+  });
+
+  it("retries on 404 with exponential backoff and renders <embed> once reachable", async () => {
+    let call = 0;
+    global.fetch = vi.fn().mockImplementation(async () => {
+      call += 1;
+      if (call <= 2) return new Response(null, { status: 404 });
+      return new Response(null, { status: 200 });
+    }) as unknown as typeof fetch;
+    mockUseMessagePartFile.mockReturnValue({
+      mimeType: "application/pdf",
+      filename: "slow.pdf",
+    });
+
+    const { container } = await renderWithAgent("agent-1");
+
+    expect(global.fetch).toHaveBeenCalledTimes(1);
+    expect(container.querySelector("embed")).toBeNull();
+
+    // Backoff steps: 200, 400, 800, 1600 ms. Walk through the first two.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(200);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(2);
+    expect(container.querySelector("embed")).toBeNull();
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(400);
+    });
+    // Third probe resolves to 200 → component mounts the embed.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0);
+    });
+    expect(global.fetch).toHaveBeenCalledTimes(3);
+    expect(container.querySelector("embed")?.getAttribute("src")).toBe(
+      "/api/agents/agent-1/uploads/slow.pdf"
+    );
+  });
+
+  it("falls back to a chip after the retry budget is exhausted", async () => {
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 404 })) as unknown as typeof fetch;
+    mockUseMessagePartFile.mockReturnValue({
+      mimeType: "application/pdf",
+      filename: "missing.pdf",
+    });
+
+    const { container } = await renderWithAgent("agent-1");
+
+    // The schedule is 200 + 400 + 800 + 1600 = 3000 ms across 4 retries plus
+    // the initial probe — drain it generously.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    expect(container.querySelector("embed")).toBeNull();
+    // Filename remains visible to the user so the attachment is not silently lost.
+    expect(screen.getByText("missing.pdf")).toBeInTheDocument();
+  });
+
+  it("aborts the in-flight probe when the component unmounts", async () => {
+    const abortSpy = vi.fn();
+    const fetchSpy = vi.fn().mockImplementation((_url: string, init?: RequestInit) => {
+      init?.signal?.addEventListener("abort", abortSpy);
+      return new Promise(() => {});
+    });
+    global.fetch = fetchSpy as unknown as typeof fetch;
+    mockUseMessagePartFile.mockReturnValue({
+      mimeType: "application/pdf",
+      filename: "race.pdf",
+    });
+
+    const { unmount } = await renderWithAgent("agent-1");
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+
+    unmount();
+    expect(abortSpy).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
 import { sendingOpacityClass } from "@/components/assistant-ui/thread";
@@ -525,6 +525,12 @@ describe("ComposerAction Send/Stop mutual exclusion (#207)", () => {
 
 describe("FilePart component (re-exported AttachmentPreview)", () => {
   it("renders a PDF preview with embed thumbnail when MIME is application/pdf", async () => {
+    // AttachmentPreview HEAD-probes the upload URL before mounting <embed>;
+    // mock fetch so the probe resolves to 200 and the embed is rendered.
+    global.fetch = vi
+      .fn()
+      .mockResolvedValue(new Response(null, { status: 200 })) as unknown as typeof fetch;
+
     const { useMessagePartFile } = await import("@assistant-ui/react");
     vi.mocked(useMessagePartFile).mockReturnValue({
       mimeType: "application/pdf",
@@ -538,7 +544,9 @@ describe("FilePart component (re-exported AttachmentPreview)", () => {
         <FilePart />
       </AgentIdContext.Provider>
     );
-    expect(container.querySelector("embed[type='application/pdf']")).toBeTruthy();
+    await waitFor(() => {
+      expect(container.querySelector("embed[type='application/pdf']")).toBeTruthy();
+    });
   });
 
   it("renders a plain chip for an unknown MIME (regression: never silently drop the file)", async () => {

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -1,8 +1,8 @@
 "use client";
 
-import { useContext, type FC } from "react";
+import { useContext, useEffect, useRef, useState, type FC } from "react";
 import { useMessagePartFile } from "@assistant-ui/react";
-import { FileText } from "lucide-react";
+import { FileText, Loader2 } from "lucide-react";
 import { AgentIdContext } from "@/components/chat";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 
@@ -15,6 +15,76 @@ function buildUploadUrl(agentId: string, filename: string): string {
   return `/api/agents/${encodeURIComponent(agentId)}/uploads/${encodeURIComponent(filename)}`;
 }
 
+// Why a probe + retry? The server persists the uploaded file AFTER the WS
+// message lands (processIncomingAttachments runs the buffer write inline),
+// but the browser renders this component as soon as the user message hits
+// local state. A naive <embed src=…> hits the GET route before the file is
+// on disk and the browser paints "Not found". Page reload works only because
+// the message then replays from OpenClaw history with the file already there.
+// The structural fix lives in #324 (multipart pre-upload); this probe is the
+// hotfix that papers over the race for v0.5.3.
+const PROBE_SCHEDULE_MS = [200, 400, 800, 1600] as const;
+
+type ProbeState = "probing" | "ready" | "failed";
+
+/**
+ * Polls `HEAD <url>` with exponential backoff until the server returns a 2xx
+ * (file is on disk and serveable) or the schedule is exhausted. The first
+ * probe fires synchronously on mount so the happy path — reload, file already
+ * persisted — finishes in one round trip.
+ *
+ * Cancellation is via AbortController so a fast unmount or url change does
+ * not race the previous probe's setState into a discarded tree.
+ */
+function useUploadReadiness(url: string | null): ProbeState {
+  const [state, setState] = useState<ProbeState>(url ? "probing" : "ready");
+  const urlRef = useRef(url);
+
+  useEffect(() => {
+    urlRef.current = url;
+    if (!url) {
+      setState("ready");
+      return;
+    }
+    setState("probing");
+    const ctrl = new AbortController();
+    let attempt = 0;
+    let timer: ReturnType<typeof setTimeout> | null = null;
+
+    async function probe(): Promise<void> {
+      try {
+        const res = await fetch(url!, { method: "HEAD", signal: ctrl.signal });
+        if (ctrl.signal.aborted || urlRef.current !== url) return;
+        if (res.ok) {
+          setState("ready");
+          return;
+        }
+      } catch {
+        if (ctrl.signal.aborted) return;
+        // Network error counts as a failed probe — same backoff as 404.
+      }
+      const delay = PROBE_SCHEDULE_MS[attempt];
+      attempt += 1;
+      if (delay === undefined) {
+        setState("failed");
+        return;
+      }
+      timer = setTimeout(() => {
+        if (!ctrl.signal.aborted) probe();
+      }, delay);
+    }
+
+    probe();
+
+    return () => {
+      ctrl.abort();
+      if (timer) clearTimeout(timer);
+    };
+  }, [url]);
+
+  return state;
+}
+
 /**
  * Renders an attachment chip next to a chat message bubble. Branches by MIME:
  *
@@ -23,25 +93,38 @@ function buildUploadUrl(agentId: string, filename: string): string {
  * - `image/*` → inline `<img>`; click opens a modal with the full image.
  * - anything else (or missing agentId / filename) → a plain chip.
  *
- * The chip has zero JS dependencies — keeps the bundle thin and degrades
- * gracefully if the API endpoint is unreachable.
+ * For media previews the URL is HEAD-probed first to avoid the v0.5.3 race
+ * described on `useUploadReadiness`. The plain-chip path skips the probe
+ * because it never renders the URL.
  */
 export const AttachmentPreview: FC = () => {
   const { mimeType, filename } = useMessagePartFile();
   const agentId = useContext(AgentIdContext);
+
+  const isPreviewable =
+    !!agentId && !!filename && (mimeType === "application/pdf" || mimeType.startsWith("image/"));
+  const url = isPreviewable ? buildUploadUrl(agentId!, filename!) : null;
+  const readiness = useUploadReadiness(url);
 
   // Falls back to a chip when we don't have everything we need to build a URL.
   if (!agentId || !filename) {
     return <Chip filename={filename} mimeType={mimeType} />;
   }
 
-  const url = buildUploadUrl(agentId, filename);
+  // Probe budget exhausted → render the chip so the message still shows the
+  // filename and does not silently look attachment-less. A page reload re-runs
+  // the probe against the (by then persisted) file.
+  if (readiness === "failed") {
+    return <Chip filename={filename} mimeType={mimeType} />;
+  }
 
   if (mimeType === "application/pdf") {
-    return <PdfPreview url={url} filename={filename} />;
+    if (readiness === "probing") return <Probing filename={filename} />;
+    return <PdfPreview url={url!} filename={filename} />;
   }
   if (mimeType.startsWith("image/")) {
-    return <ImagePreview url={url} filename={filename} />;
+    if (readiness === "probing") return <Probing filename={filename} />;
+    return <ImagePreview url={url!} filename={filename} />;
   }
   return <Chip filename={filename} mimeType={mimeType} />;
 };
@@ -97,6 +180,17 @@ const ImagePreview: FC<{ url: string; filename: string }> = ({ url, filename }) 
       />
     </DialogContent>
   </Dialog>
+);
+
+const Probing: FC<{ filename: string }> = ({ filename }) => (
+  <div
+    className="my-2 flex max-w-sm items-center gap-2 rounded-lg border bg-muted/40 px-3 py-2"
+    aria-label={`Preparing preview of ${filename}`}
+    aria-busy="true"
+  >
+    <Loader2 className="size-4 shrink-0 animate-spin text-muted-foreground" />
+    <span className="truncate text-sm text-muted-foreground">{filename}</span>
+  </div>
 );
 
 const Chip: FC<{ filename: string | undefined; mimeType: string }> = ({ filename, mimeType }) => {

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -179,6 +179,19 @@ export class ClientRouter {
         agentId: message.agentId,
         sessionKey,
       };
+      // Forward the agent's configured provider/model so OpenClaw's `agent`
+      // RPC resolves capability checks (notably image-input support) against
+      // the right model. Without this, server-methods falls back to the
+      // gateway-wide default model — see #324 / openclaw-node 0.9.0.
+      // Split on the FIRST '/' only: provider is before, model is the
+      // rest (model ids can themselves contain '/', e.g. HuggingFace).
+      if (agent.model) {
+        const slashIdx = agent.model.indexOf("/");
+        if (slashIdx > 0 && slashIdx < agent.model.length - 1) {
+          chatOptions.provider = agent.model.slice(0, slashIdx);
+          chatOptions.model = agent.model.slice(slashIdx + 1);
+        }
+      }
       if (chatAttachments.length > 0) {
         chatOptions.attachments = chatAttachments;
       }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -102,8 +102,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       openclaw-node:
-        specifier: 0.7.0
-        version: 0.7.0
+        specifier: 0.9.0
+        version: 0.9.0
       pdfkit:
         specifier: ^0.18.0
         version: 0.18.0
@@ -1430,8 +1430,8 @@ packages:
       '@cfworker/json-schema':
         optional: true
 
-  '@mongodb-js/saslprep@1.4.9':
-    resolution: {integrity: sha512-RXSxsokhAF/4nWys8An8npsqOI33Ex1Hlzqjw2pZOO+GKtMAR2noGnUdsFiGwsaO/xXI+56mtjTmDA3JXJsvmA==}
+  '@mongodb-js/saslprep@1.4.11':
+    resolution: {integrity: sha512-o9rAHc0IpIjuPSxRutWpE1F62x7n+4mVS4rCNHkzhIUMQcc18bb6xEq5wd2NdN0WjepIyXIppRshYI2kQDOZVA==}
 
   '@napi-rs/wasm-runtime@0.2.12':
     resolution: {integrity: sha512-ZVWUcfwY4E/yPitQJl481FjFo3K22D6qF0DuFH6Y/nbnE11GY5uguDxZMGXPQ8WQ0128MXQD7TnfHyK4oWoIJQ==}
@@ -5248,8 +5248,8 @@ packages:
       zod:
         optional: true
 
-  openclaw-node@0.7.0:
-    resolution: {integrity: sha512-vKGK8g8EP220WEF1PwOPs+EYS2TID1BBk/VxbJvvcMMUXfKsQeHpZIu/RozJFPN1LFjQe5VfKpHp0VCphu6Wug==}
+  openclaw-node@0.9.0:
+    resolution: {integrity: sha512-8g8C+yqDKCOFjYfsivCw7FFM3kvi0JDzBTeOtlN+sOQTpvkx2wBWyp9LKN6kdiV1/9t0F3bzSZi5Z51OwY12nw==}
     engines: {node: '>=20.0.0'}
 
   openclaw@2026.4.27:
@@ -7916,7 +7916,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@mongodb-js/saslprep@1.4.9':
+  '@mongodb-js/saslprep@1.4.11':
     dependencies:
       sparse-bitfield: 3.0.3
     optional: true
@@ -11919,7 +11919,7 @@ snapshots:
 
   mongodb@7.1.0(socks@2.8.8):
     dependencies:
-      '@mongodb-js/saslprep': 1.4.9
+      '@mongodb-js/saslprep': 1.4.11
       bson: 7.2.0
       mongodb-connection-string-url: 7.0.1
     optionalDependencies:
@@ -12064,7 +12064,7 @@ snapshots:
       ws: 8.20.0
       zod: 4.3.6
 
-  openclaw-node@0.7.0:
+  openclaw-node@0.9.0:
     optionalDependencies:
       ws: 8.20.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Why this is a v0.5.3 blocker

During v0.5.3 staging click-through, image uploads to Smithers (configured with the vision-capable \`ollama-cloud/gemini-3-flash-preview\`) failed with:

\`\`\`
UnsupportedAttachmentError: attachment upload: active model does not accept image inputs
\`\`\`

The image pipeline is one of the headline features of this release, so this has to ship working.

## Root cause (verified on staging)

OpenClaw's \`agent\` RPC inside \`server-methods\` resolves the session model with \`resolveSessionModelRef(cfg, entry, undefined)\` — \`agentId\` is hard-coded to \`undefined\`. Without an override the lookup therefore falls back to the gateway-wide default model rather than the agent's configured one. On staging that default was \`ollama-cloud/deepseek-v4-flash\` (\`vision: false\`) → image attachment rejected, even though the agent itself runs on a vision-capable model.

Reproduced on staging with a live \`loadModelCatalog\` dump:

\`\`\`
resolveSessionModelRef(cfg, undefined, undefined) → ollama-cloud/deepseek-v4-flash
resolveGatewayModelSupportsImages(ollama-cloud, gemini-3-flash-preview) → true   ✓
resolveGatewayModelSupportsImages(ollama-cloud, deepseek-v4-flash)      → false  ← what the agent RPC actually consults
\`\`\`

## Fix

Two-part change across packages we own:

1. **\`openclaw-node\`** (already shipped as 0.9.0): \`ChatOptions\` gains \`provider\` and \`model\` overrides forwarded into the \`agent\` RPC \`params\`. The Gateway's existing \`providerOverride || baseProvider\` (and \`modelOverride || baseModel\`) fallback then consults the right pair. See [openclaw-node#25](https://github.com/heypinchy/openclaw-node/pull/25).

2. **This PR**: bump to \`openclaw-node@0.9.0\` and split \`agent.model\` on the FIRST \`/\` in \`client-router.ts\` so the provider/model pair lands in \`chatOptions\`. Forward-compatible with a future Gateway-side fix that honours \`agentId\` — passing the override is always safe.

## Edge cases covered by tests
- Standard \`provider/model\` shape (e.g. \`ollama-cloud/gemini-3-flash-preview\`)
- Model id that itself contains slashes (e.g. \`huggingface/microsoft/phi-3:mini\`) — split on first \`/\` only
- Missing \`agent.model\` (null) → no override forwarded (preserves existing behavior)
- Unprefixed legacy model id without \`/\` → no override forwarded (defensive against legacy rows / hand-edits)

## Test plan
- [x] \`pnpm -C packages/web test:unit\` — 4016 passed, 12 skipped.
- [x] TypeScript strict + ESLint clean.
- [ ] After merge: staging \`:next\` refresh, drag-and-drop a PNG to Smithers with \`gemini-3-flash-preview\`, observe a successful reply that references the image.