### PR TITLE
fix(openclaw-config): surface persistent EACCES on openclaw.json read (#314)

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4914,6 +4914,32 @@ describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support Se
     const config = JSON.parse(written);
     expect(config.channels.telegram.accounts["agent-99"].botToken).toBe("tg-secret-token");
   });
+
+  it("updateTelegramChannelConfig throws if existing config is unreadable (avoids clobber from EACCES, #314)", () => {
+    // Parallel to the updateIdentityLinks EACCES regression test. The
+    // original telegram-e2e cascade hit this exact path: bot connect →
+    // updateTelegramChannelConfig → readExistingConfig EACCES → previously
+    // returned {} → channels/bindings written without gateway → OC refuses
+    // to start. Two layers of defence apply (same as updateIdentityLinks):
+    //   1. readExistingConfig propagates persistent EACCES (#314).
+    //   2. updateTelegramChannelConfig independently guards on missing
+    //      gateway.mode (covers ENOENT / parse-error empty objects).
+    // Throwing surfaces a 5xx so the bot-connect API route lets the user
+    // retry rather than silently dropping the channel update.
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation(() => {
+      const err = new Error("EACCES: permission denied") as Error & { code: string };
+      err.code = "EACCES";
+      throw err;
+    });
+
+    expect(() =>
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null)
+    ).toThrow(/EACCES|gateway\.mode/);
+    expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    warnSpy.mockRestore();
+  });
 });
 
 describe("regenerateOpenClawConfig validation guard", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2200,6 +2200,57 @@ describe("regenerateOpenClawConfig", () => {
     }
   });
 
+  it("skips the write when openclaw.json is persistently unreadable via EACCES (#314)", async () => {
+    // Scenario from issue #314: OC's SIGUSR1 restart toggles openclaw.json to
+    // root:0600 longer than `readExistingConfig`'s retry budget (5×100ms +
+    // 300ms async retry + 5×100ms = 1.3s). With persistent EACCES the file
+    // looks empty to `readExistingConfig`, the spread of every
+    // `...existing.<field>` collapses to {}, and the regenerate emits a thin
+    // payload that:
+    //   - strips `meta` → OC's "missing-meta-before-write" anomaly
+    //   - strips `gateway.controlUi.*` OC enrichments
+    //   - strips non-pinchy `plugins.entries.*` (telegram, providers)
+    //   - drops models.providers when settings reads also race
+    //   - drops channels.telegram/bindings/session when DB-derived state
+    //     races with the unreadable file
+    // → inotify diff cascade (4874 → 2351 size-drop) → full gateway restart.
+    //
+    // The contract: when the existing file is provably unreadable (EACCES,
+    // not ENOENT), regenerate must NOT write a thin payload. Skip the write
+    // and rely on the next regenerate (or boot-inits) to heal once the
+    // chmod loop restores 0666.
+    //
+    // We do NOT use fake timers here — `readExistingConfig`'s synchronous
+    // busy-wait uses real Date.now() and would hang under fake clocks.
+    // The total real-time budget is bounded: 5×100ms busy-wait + 300ms
+    // async retry + 5×100ms busy-wait + any extra fix-side budget ≈ ≤ 2s.
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    try {
+      mockedExistsSync.mockReturnValue(true);
+      mockedReadFileSync.mockImplementation((path) => {
+        if (typeof path === "string" && path.includes("openclaw.json")) {
+          throw Object.assign(new Error("EACCES: permission denied"), { code: "EACCES" });
+        }
+        throw Object.assign(new Error("ENOENT"), { code: "ENOENT" });
+      });
+
+      await regenerateOpenClawConfig();
+
+      // No write to openclaw.json — proceeding with `existing = {}` would
+      // have produced the bad thin payload from #314.
+      const openclawWrites = mockedWriteFileSync.mock.calls.filter(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+      );
+      expect(openclawWrites).toEqual([]);
+      // The skip must be loud — silent skips hide the underlying race.
+      expect(errorSpy).toHaveBeenCalled();
+      const message = errorSpy.mock.calls.map((c) => c.join(" ")).join("\n");
+      expect(message).toMatch(/EACCES|unreadable|#314/);
+    } finally {
+      errorSpy.mockRestore();
+    }
+  }, 10000);
+
   describe("config propagation to OpenClaw runtime (#200)", () => {
     // Pinchy must push config changes to OpenClaw's *runtime*, not just
     // disk. The original bug: writing openclaw.json relied on OpenClaw's
@@ -4771,14 +4822,20 @@ describe("updateIdentityLinks", () => {
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
   });
 
-  it("regression: throws if existing config has no gateway.mode (avoids clobber from EACCES)", async () => {
+  it("regression: throws if existing config is unreadable (avoids clobber from EACCES, #314)", async () => {
     // This reproduces the production-image telegram-e2e cascade: while
     // OpenClaw is mid-SIGUSR1-restart, openclaw.json is briefly root:0600.
-    // readExistingConfig hits EACCES, returns {} after retries. Without
-    // the safety check below, updateIdentityLinks would write a config
-    // with ONLY a session block — no gateway, no agents, nothing — and
-    // OpenClaw's next start refuses with "missing gateway.mode" then
-    // crash-loops.
+    //
+    // Two layers of defence:
+    //   1. `readExistingConfig` propagates persistent EACCES rather than
+    //      returning {} (#314 — returning {} let `regenerateOpenClawConfig`
+    //      emit a thin payload that triggered the inotify cascade).
+    //   2. `updateIdentityLinks` independently guards on missing gateway.mode
+    //      so non-EACCES paths (ENOENT, parse error) also can't clobber the
+    //      gateway block.
+    //
+    // Under EACCES the throw now comes from layer 1; either error message is
+    // acceptable as long as no file write happens.
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     mockedExistsSync.mockReturnValue(true);
     mockedReadFileSync.mockImplementation(() => {
@@ -4792,7 +4849,9 @@ describe("updateIdentityLinks", () => {
     // Throwing (rather than silently returning) lets the API route surface
     // the failure as a 5xx so the user can retry, instead of dropping the
     // identity-link update on the floor.
-    expect(() => updateIdentityLinks({ "user-1": ["telegram:123"] })).toThrow(/gateway\.mode/);
+    expect(() => updateIdentityLinks({ "user-1": ["telegram:123"] })).toThrow(
+      /EACCES|gateway\.mode/
+    );
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -191,18 +191,54 @@ async function resolveDefaultPdfModel(): Promise<string | null> {
 }
 
 export async function regenerateOpenClawConfig() {
-  let existing = readExistingConfig();
+  // `readExistingConfig` distinguishes two recoverable failure modes:
+  //   - ENOENT / parse error → returns {} (cold start; we build the first config from scratch).
+  //   - Persistent EACCES → throws (file exists but unreadable; race with OC's
+  //     SIGUSR1-driven 0600/0666 chmod loop). We MUST NOT proceed with an
+  //     empty `existing` in that case: every `...existing.<field>` spread
+  //     collapses, OC enrichments (meta, gateway.controlUi.*, non-pinchy
+  //     plugins.entries, channels.telegram OC fields) get stripped, and the
+  //     resulting thin payload triggers the inotify cascade documented in #314.
+  //   On EACCES, wait one chmod-loop tick and try once more; if still
+  //   unreadable, skip the regenerate entirely — the next API-triggered
+  //   regenerate (or boot-inits) will heal once 0666 is restored.
+  let existing: Record<string, unknown>;
+  try {
+    existing = readExistingConfig();
+  } catch (err) {
+    if ((err as NodeJS.ErrnoException)?.code !== "EACCES") throw err;
+    await new Promise((r) => setTimeout(r, 300));
+    try {
+      existing = readExistingConfig();
+    } catch (err2) {
+      if ((err2 as NodeJS.ErrnoException)?.code !== "EACCES") throw err2;
+      console.error(
+        "[openclaw-config] regenerate skipped: openclaw.json is persistently " +
+          "unreadable (EACCES) after one chmod-loop retry. This is the " +
+          "OC-restart race documented in #314 — the next regenerate (or " +
+          "boot-inits) will heal once 0666 is restored. No write performed."
+      );
+      return;
+    }
+  }
 
-  // If readExistingConfig returned empty it may be a transient EACCES hit:
-  // OpenClaw's in-process SIGUSR1 restart rewrites openclaw.json as root:0600
-  // before start-openclaw.sh's chmod loop restores 0666. Under CI load the
-  // chmod may not run within readExistingConfig()'s 5×100ms budget → returns
-  // {} → meta absent → config.apply sends meta-less payload → OpenClaw 4.27
-  // "missing-meta-before-write" anomaly → sentinel restoration broken →
-  // spurious full gateway restart. 300ms covers one chmod-loop tick worst case.
+  // If readExistingConfig returned empty (ENOENT / parse failure, NOT EACCES —
+  // EACCES is handled above) it may be a transient cold-start hit. 300ms
+  // covers one chmod-loop tick worst case for parse-during-write races.
   if (Object.keys(existing).length === 0) {
     await new Promise((r) => setTimeout(r, 300));
-    existing = readExistingConfig();
+    try {
+      existing = readExistingConfig();
+    } catch (err) {
+      if ((err as NodeJS.ErrnoException)?.code !== "EACCES") throw err;
+      // File appeared during the wait and is now locked — same recovery path
+      // as the first-read EACCES branch above.
+      console.error(
+        "[openclaw-config] regenerate skipped: openclaw.json became " +
+          "unreadable (EACCES) during the cold-start retry. See #314."
+      );
+      return;
+    }
   }
 
   // Build the gateway block. mode and bind are always set. auth.token is written

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -218,6 +218,15 @@ export async function regenerateOpenClawConfig() {
           "OC-restart race documented in #314 — the next regenerate (or " +
           "boot-inits) will heal once 0666 is restored. No write performed."
       );
+      // Silent return: callers (POST /api/agents, POST /api/settings/*) treat this
+      // as success because the file on disk is intentionally left untouched and
+      // still represents the previous good state. This assumes another regenerate
+      // *will* run later — true for change-on-change flows (subsequent setting
+      // edits, channel pair/unpair, agent CRUD), and boot-inits re-regenerate
+      // unconditionally. One-shot actions with no follow-up mutation are the
+      // only blind spot; targeted writes (updateTelegramChannelConfig,
+      // updateIdentityLinks) still throw under EACCES so those callers surface
+      // 5xx and the user can retry.
       return;
     }
   }

--- a/packages/web/src/lib/openclaw-config/normalize.ts
+++ b/packages/web/src/lib/openclaw-config/normalize.ts
@@ -40,7 +40,8 @@ const isPinchyPlugin = (id: string) => id.startsWith("pinchy-");
  * OC in-memory config returned by `config.get()`.
  *
  * Fields supplemented (source wins only for keys absent from payload):
- *   - `meta`: entire block (absent when readExistingConfig returns {} on EACCES)
+ *   - `meta`: entire block (absent when readExistingConfig returned {} during a cold start
+ *     — ENOENT or parse error; EACCES is no longer a {}-return path, it throws since #314)
  *   - `plugins.allow`: non-pinchy-* entries appended at end
  *   - `plugins.entries.*`: non-pinchy-* entries not already in payload
  *   - `gateway.controlUi.*`: fields not already in payload gateway.controlUi

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -31,11 +31,20 @@ export function readExistingConfig(): Record<string, unknown> {
   // Retry briefly on EACCES. OpenClaw rewrites openclaw.json as root:0600 on
   // every internal SIGUSR1 restart; start-openclaw.sh's 3s chmod loop opens
   // it back up to 0666, but Pinchy (uid 999) can hit a small window where
-  // the file is unreadable. Without retry, readFileSync throws → catch
-  // returns {} → targeted writes (updateTelegramChannelConfig etc.) would
-  // produce a config WITHOUT the gateway block, and OpenClaw's next start
-  // refuses with "Gateway start blocked: existing config is missing
-  // gateway.mode". 5 × 100ms covers two chmod-loop ticks worst case.
+  // the file is unreadable.
+  //
+  // Two outcomes after this loop:
+  //   - ENOENT or parse error: returns {} (file genuinely missing or invalid
+  //     — callers treat as cold-start).
+  //   - Persistent EACCES: THROWS so callers can distinguish "file doesn't
+  //     exist" from "file exists but unreadable". Returning {} here would
+  //     conflate the two and let `regenerateOpenClawConfig` proceed with
+  //     empty `existing`, stripping every OC-enriched field (meta,
+  //     gateway.controlUi.*, non-pinchy plugins.entries, channels.telegram
+  //     OC fields) and emitting a thin payload that triggers the inotify
+  //     cascade documented in #314. Targeted writes already throw on
+  //     empty `existing.gateway.mode`; this just surfaces the same race
+  //     loudly one layer up. 5 × 100ms covers two chmod-loop ticks worst case.
   for (let attempt = 0; attempt < 5; attempt++) {
     try {
       return JSON.parse(readFileSync(CONFIG_PATH, "utf-8"));
@@ -50,9 +59,9 @@ export function readExistingConfig(): Record<string, unknown> {
         console.warn(
           "[openclaw-config] readExistingConfig: persistent EACCES on",
           CONFIG_PATH,
-          "— returning empty (callers must guard against partial writes)"
+          "— propagating to caller (must skip-and-retry the regenerate)"
         );
-        return {};
+        throw err;
       }
       // Synchronous busy-wait. Async would change all caller signatures.
       const start = Date.now();
@@ -61,7 +70,8 @@ export function readExistingConfig(): Record<string, unknown> {
       }
     }
   }
-  return {};
+  // Unreachable — every branch of the loop either returns or throws.
+  throw new Error("[openclaw-config] readExistingConfig: unreachable");
 }
 
 // Monotonically-increasing counter that lets each pushConfigInBackground call


### PR DESCRIPTION
## What does this PR do?

Closes #314.

Removes the silent-corruption path that produced #314's thin-payload write. When OC's SIGUSR1 restart toggled `openclaw.json` to `root:0600` longer than `readExistingConfig`'s 5×100 ms + 300 ms-async-retry budget, the read returned `{}` and `regenerateOpenClawConfig` proceeded with empty `existing` — every `...existing.<field>` spread collapsed, `meta` was dropped, and the resulting ~50 %-smaller payload (4874 → 2351 B in the cited CI run) triggered OC's inotify cascade with the `missing-meta-before-write` anomaly and a full gateway restart.

### Root cause

`readExistingConfig` conflated two distinct failure modes:

- **ENOENT / parse error** — file genuinely missing or invalid (legitimate cold-start).
- **Persistent EACCES** — file exists but unreadable (race with the 0600/0666 chmod loop in `start-openclaw.sh`).

Both returned `{}`, so the caller couldn't tell them apart and treated EACCES as "build the first config from scratch" — overwriting a healthy on-disk file with a stripped payload.

### Fix

- [`readExistingConfig`](https://github.com/heypinchy/pinchy/blob/claude/interesting-hermann-de2ef5/packages/web/src/lib/openclaw-config/write.ts) now **throws** after exhausting EACCES retries instead of returning `{}`. ENOENT / parse failures still return `{}` (cold-start path unchanged).
- [`regenerateOpenClawConfig`](https://github.com/heypinchy/pinchy/blob/claude/interesting-hermann-de2ef5/packages/web/src/lib/openclaw-config/build.ts) catches the throw, waits one chmod-loop tick (300 ms), retries once, and **skips the write entirely** (loud `console.error`) if EACCES still persists. The next regenerate (or boot-inits) heals once 0666 is restored. No thin payload ever lands on disk.
- The existing `gateway.mode` guard in the targeted writes (`updateIdentityLinks`, `updateTelegramChannelConfig`) remains as a second layer of defence for non-EACCES empties (ENOENT, parse error).

### TDD

- New failing test reproduces the issue: under persistent `EACCES`, `regenerateOpenClawConfig` previously wrote a thin payload missing `channels.telegram`, `bindings`, `session`, `meta`, and non-pinchy `plugins.entries`. After the fix it skips the write and logs to `console.error`.
- The existing `updateIdentityLinks` EACCES regression test was updated to accept either `EACCES` (now thrown by layer 1) or `gateway.mode` (still thrown by layer 2 for non-EACCES empties).

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [ ] I've updated the documentation (N/A — no product-visible behavior change)
- [x] All existing tests pass (4013 passed, 0 failed, lint clean)

## Reviewer notes

- This is the root-cause fix for the flake guarded by the defence-in-depth size-drop guard in #311. The #311 guard remains useful as a belt-and-suspenders catch for any future code path that produces a >50 %-smaller payload.
- API observable behaviour: when EACCES persists across both retries, the regenerate skips silently (logs to stderr). Callers (POST `/api/agents`, POST `/api/settings/providers`, etc.) return success because the file on disk is left untouched and still represents the previous good state. The user's intended change reaches OC on the next regenerate.
- Targeted writes still throw under EACCES — the API route surfaces a 5xx and the user can retry, matching the existing contract.