### PR TITLE
feat(integrations): auth_failed status + Edit credentials (#300, #301)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -134,6 +134,25 @@ jobs:
           git fetch --no-tags --deepen=200 origin || true
           node scripts/check-test-deletions.mjs --base "origin/${{ github.base_ref }}"
 
+      - name: Drizzle snapshot integrity
+        # Catches the PR #334 class of bug: a committed migration .sql whose
+        # _snapshot.json is missing from drizzle/meta/, silently breaking the
+        # snapshot chain. Same script runs in the pre-commit hook locally.
+        run: node scripts/check-drizzle-snapshots.mjs
+
+      - name: Drizzle schema drift check
+        # Catches the inverse: schema.ts diverged from the latest snapshot
+        # without a corresponding migration. `drizzle-kit generate` is a no-op
+        # when in sync; any new files mean someone changed schema.ts and
+        # forgot to commit the migration drizzle would generate.
+        run: |
+          pnpm -C packages/web exec drizzle-kit generate
+          if ! git diff --exit-code -- packages/web/drizzle/; then
+            echo "❌ schema.ts has uncommitted changes that drizzle-kit would generate a migration for."
+            echo "   Run \`pnpm -C packages/web db:generate\` locally and commit the result."
+            exit 1
+          fi
+
       - name: Test
         run: pnpm test
 

--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -17,4 +17,9 @@ if [ ! -w "$HOME" ]; then
   mkdir -p "$PNPM_HOME"
 fi
 
+# Drizzle snapshot integrity: every journal entry must have a snapshot file,
+# and a staged migration .sql must come with its companion _snapshot.json.
+# See scripts/check-drizzle-snapshots.mjs for the rationale (PR #334 incident).
+node scripts/check-drizzle-snapshots.mjs || exit 1
+
 npx lint-staged

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -484,6 +484,9 @@ function handleJsonRpc(body) {
 
     // object/execute_kw
     if (service === "object" && svcMethod === "execute_kw") {
+      if (authMode === "fail") {
+        return { __jsonrpc_error: true, message: "access denied: invalid credentials" };
+      }
       const args = params.args || [];
       // args: [db, uid, apiKey, model, method, positionalArgs, kwArgs]
       const model = args[3];

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -13,6 +13,9 @@ let authConfig = {
   uid: 2,
 };
 
+// Auth failure mode — toggled via /control/auth-mode { mode: "ok" | "fail" }
+let authMode = "ok";
+
 // ---------------------------------------------------------------------------
 // Field schemas per model
 // ---------------------------------------------------------------------------
@@ -465,6 +468,9 @@ function handleJsonRpc(body) {
 
     // common/authenticate
     if (service === "common" && svcMethod === "authenticate") {
+      if (authMode === "fail") {
+        return false;
+      }
       const [db, login, apiKey] = params.args || [];
       if (
         db === authConfig.db &&
@@ -727,6 +733,7 @@ const controlServer = http.createServer(async (req, res) => {
     store = getDefaultRecords();
     resetNextIds();
     accessRights = {};
+    authMode = "ok";
     authConfig = {
       db: "testdb",
       login: "admin",
@@ -798,6 +805,18 @@ const controlServer = http.createServer(async (req, res) => {
       if (body.uid) authConfig.uid = body.uid;
     }
     sendJson(res, 200, { status: "configured", config: authConfig });
+    return;
+  }
+
+  // Toggle auth failure mode: POST /control/auth-mode { mode: "ok" | "fail" }
+  if (req.method === "POST" && path === "/control/auth-mode") {
+    const body = await readBody(req);
+    if (!body || (body.mode !== "ok" && body.mode !== "fail")) {
+      sendJson(res, 400, { error: 'Need { mode: "ok" | "fail" }' });
+      return;
+    }
+    authMode = body.mode;
+    sendJson(res, 200, { status: "ok", authMode });
     return;
   }
 

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -144,19 +144,29 @@ User fields throughout this section (`user.{id}`) carry the user's id only — n
 
 ### Integration management
 
-| Event Type                        | Trigger                                                                         | Detail fields          |
-| --------------------------------- | ------------------------------------------------------------------------------- | ---------------------- |
-| `integration.auth_failed`         | First detection of a permanent auth failure (401/403 from the upstream service) | `id`, `name`, `reason` |
-| `integration.recovered`           | First successful request after an `auth_failed` state                           | `id`, `name`           |
-| `integration.credentials_updated` | Successful PATCH with new credentials or a completed OAuth re-auth              | `id`, `name`, `fields` |
+| Event Type                        | Trigger                                                                         | Detail fields              |
+| --------------------------------- | ------------------------------------------------------------------------------- | -------------------------- |
+| `integration.created`             | A new integration connection was added (Odoo, Web Search, Google, …)            | `type`, `name`             |
+| `integration.updated`             | Name or description of an existing connection changed                           | `id`, `name`, `changes`    |
+| `integration.deleted`             | A connection was removed                                                        | `id`, `name`, `type`       |
+| `integration.credentials_updated` | Successful PATCH with new credentials or a completed OAuth re-auth              | `id`, `name`, `fields`     |
+| `integration.synced`              | Schema was successfully re-synced from the upstream service (Odoo)              | `id`, `name`, `modelCount` |
+| `integration.auth_failed`         | First detection of a permanent auth failure (401/403 from the upstream service) | `id`, `name`, `reason`     |
+| `integration.auth_recovered`      | First successful request after an `auth_failed` state                           | `id`, `name`               |
 
-Only the **first** failure event in a sequence is logged — repeated failures while the integration is already in a failed state do not produce additional entries. Similarly, `integration.recovered` is logged once when the integration returns to a healthy state. This keeps the audit log focused on state transitions rather than every retry attempt.
+Credential changes always emit only `integration.credentials_updated` — even when name or description change in the same PATCH call. The `integration.updated` event covers metadata-only edits. This split lets CISOs filter the trail for "every credential touch" with a single `eventType =` predicate, without having to also union over generic `*.updated` events.
+
+Only the **first** failure event in a sequence is logged — repeated failures while the integration is already in a failed state do not produce additional entries. Similarly, `integration.auth_recovered` is logged once when the integration returns to a healthy state. This keeps the audit log focused on state transitions rather than every retry attempt.
+
+:::note[Pre-0.5.4 history]
+Before Pinchy 0.5.4, integration lifecycle events were logged under `config.changed` with a discriminator field (`detail.action: "integration_created" | "integration_updated" | …`), and `integration.recovered` was named without the `auth_` prefix. Existing audit rows from earlier versions still use the old names — the log is HMAC-signed and immutable. New rows use the names in the table above.
+:::
 
 ### Configuration
 
-| Event Type       | Description                                                         |
-| ---------------- | ------------------------------------------------------------------- |
-| `config.changed` | A system configuration setting was changed (e.g., provider API key) |
+| Event Type       | Description                                                                                                                                        |
+| ---------------- | -------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `config.changed` | A system-level configuration setting was changed — provider keys, OAuth-app secrets, Smithers defaults, plugin toggles. Not used for integrations. |
 
 ### Audit trail access
 

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -142,6 +142,16 @@ User fields throughout this section (`user.{id}`) carry the user's id only — n
 | `channel.created` | An agent was connected to an external channel (e.g. a Telegram bot token was added) |
 | `channel.deleted` | An agent was disconnected from a channel (or all channels of one type were removed) |
 
+### Integration management
+
+| Event Type                        | Trigger                                                                         | Detail fields          |
+| --------------------------------- | ------------------------------------------------------------------------------- | ---------------------- |
+| `integration.auth_failed`         | First detection of a permanent auth failure (401/403 from the upstream service) | `id`, `name`, `reason` |
+| `integration.recovered`           | First successful request after an `auth_failed` state                           | `id`, `name`           |
+| `integration.credentials_updated` | Successful PATCH with new credentials or a completed OAuth re-auth              | `id`, `name`, `fields` |
+
+Only the **first** failure event in a sequence is logged — repeated failures while the integration is already in a failed state do not produce additional entries. Similarly, `integration.recovered` is logged once when the integration returns to a healthy state. This keeps the audit log focused on state transitions rather than every retry attempt.
+
 ### Configuration
 
 | Event Type       | Description                                                         |

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -126,6 +126,19 @@ To re-sync: go to **Settings → Integrations**, select the connection, and clic
 Re-syncing may remove models that are no longer accessible. Agents that were configured to use those models will lose access to them.
 :::
 
+## When credentials expire or get revoked
+
+Pinchy detects permanent authentication failures — an expired API key, a revoked OAuth grant, a changed password — and surfaces them in two places:
+
+- The integration card on **Settings → Integrations** changes from a green checkmark to a red warning, with the failure reason from the upstream service.
+- The **Settings** entry in the sidebar shows a red `!` badge when one or more integrations need attention.
+
+To recover, open the integration's `…` menu and choose **Edit credentials** (or click **Reconnect** on the failed card). Update the affected field — for example, paste in a new API key. Non-secret fields stay pre-filled; secret fields are empty by default and left unchanged if you leave them blank. Pinchy validates the new credentials against the upstream service before saving, and clears the failed state on success. The connection keeps the same ID, so any agent permissions stay attached automatically.
+
+:::note
+Pinchy only marks an integration as failed on **permanent** errors — responses like `401 Unauthorized` or `403 Forbidden`. Transient network errors and rate-limit responses (5xx, 429) are retried and do not surface as a failed state.
+:::
+
 ## Security
 
 All integration credentials are handled with the same rigor as provider API keys:

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -342,6 +342,22 @@ A single SQL query grouped by `detail->>'errorClass'` now aggregates every failu
 
 - **`odoo_schema` tool replaced** — see [Bookkeeper / Odoo schema discovery](#bookkeeper--odoo-schema-discovery-auto-migrated) below. Existing agents are auto-migrated on startup; no manual action is required.
 
+#### Integration audit event names
+
+Integration lifecycle events have moved out of the generic `config.changed` bucket and into their own resource namespace, matching the convention already used for `agent.*`, `group.*`, and `user.*`.
+
+| Before                                                        | After                        |
+| ------------------------------------------------------------- | ---------------------------- |
+| `config.changed` (`detail.action: integration_created`)       | `integration.created`        |
+| `config.changed` (`detail.action: integration_updated`)       | `integration.updated`        |
+| `config.changed` (`detail.action: integration_deleted`)       | `integration.deleted`        |
+| `config.changed` (`detail.action: integration_schema_synced`) | `integration.synced`         |
+| `integration.recovered`                                       | `integration.auth_recovered` |
+
+`integration.auth_failed` and `integration.credentials_updated` are unchanged. Credential changes no longer emit a paired `config.changed` row alongside `integration.credentials_updated` — one mutation now produces one audit row. See [Audit trail → Integration management](/concepts/audit-trail/#integration-management) for the full list and detail-field reference.
+
+Existing audit rows from v0.5.3 and earlier keep their original event names — the log is HMAC-signed and immutable. Any alerting or compliance pipelines that filter on `eventType` need to be updated to match both old and new names during the transition window. A single filter that covers both is `eventType IN ('integration.created', 'integration.updated', 'integration.deleted', 'config.changed') AND resource LIKE 'integration:%'`.
+
 ### Upgrade notes
 
 v0.5.4 extends the Odoo template library with read-write operator agents, hardens how those agents reference Odoo records, and irons out several chat-reliability edges. It also picks up Next.js security patches and OpenClaw 2026.5.7.

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -373,9 +373,53 @@ describe("credential fetching", () => {
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("401");
-    // Two fetches: initial + refetch after first 401
-    expect(mockFetch).toHaveBeenCalledTimes(2);
+    // Two credential fetches: initial + refetch after first 401.
+    // A third fetch goes to report-auth-failure (best-effort).
+    const credentialFetches = mockFetch.mock.calls.filter(
+      (c) => !String(c[0]).includes("report-auth-failure"),
+    );
+    expect(credentialFetches).toHaveLength(2);
     expect(mockList).toHaveBeenCalledTimes(2);
+  });
+
+  it("POSTs report-auth-failure when retry-once also returns an auth error", async () => {
+    mockCredentialResponse();
+    mockList
+      .mockRejectedValueOnce(new Error("HTTP 401: Invalid Credentials"))
+      .mockRejectedValueOnce(new Error("HTTP 401: Invalid Credentials"));
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+    await tool.execute("call-1", {});
+
+    const reportCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("report-auth-failure"),
+    );
+    expect(reportCalls).toHaveLength(1);
+    const [url, opts] = reportCalls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "http://pinchy:7777/api/internal/integrations/conn-1/report-auth-failure",
+    );
+    expect(opts.method).toBe("POST");
+    const headers = opts.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-gateway-token");
+    expect(headers["X-Plugin-Id"]).toBe("pinchy-email");
+    const body = JSON.parse(opts.body as string) as { reason: string };
+    expect(body.reason).toBeTruthy();
+  });
+
+  it("does not POST report-auth-failure on a transient 5xx error", async () => {
+    mockCredentialResponse();
+    mockList.mockRejectedValueOnce(new Error("HTTP 503 Service Unavailable"));
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+    await tool.execute("call-1", {});
+
+    const reportCalls = mockFetch.mock.calls.filter((c) =>
+      String(c[0]).includes("report-auth-failure"),
+    );
+    expect(reportCalls).toHaveLength(0);
   });
 });
 

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -54,6 +54,38 @@ function getAgentConfig(
   return agentConfigs[agentId] ?? null;
 }
 
+/**
+ * Best-effort POST to Pinchy's report-auth-failure endpoint when a
+ * retry-once cycle fails with a permanent auth error. This lets Pinchy
+ * surface a clear "re-authorise" banner to admins rather than requiring
+ * them to trawl through agent error messages.
+ *
+ * Errors are swallowed — never mask the original tool error.
+ */
+async function reportAuthFailure(
+  apiBaseUrl: string,
+  connectionId: string,
+  gatewayToken: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await fetch(
+      `${apiBaseUrl}/api/internal/integrations/${connectionId}/report-auth-failure`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${gatewayToken}`,
+          "Content-Type": "application/json",
+          "X-Plugin-Id": "pinchy-email",
+        },
+        body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      },
+    );
+  } catch {
+    // best-effort — never mask the original tool error
+  }
+}
+
 function permissionDenied(operation: string): {
   content: ContentBlock[];
   isError: true;
@@ -198,7 +230,13 @@ const plugin = {
         if (!isAuthError) throw err;
         invalidate(agentId);
         const fresh = await getOrCreateClient(agentId, config);
-        return fn(fresh);
+        try {
+          return await fn(fresh);
+        } catch (retryErr) {
+          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          await reportAuthFailure(apiBaseUrl, config.connectionId, gatewayToken, retryMsg);
+          throw retryErr;
+        }
       }
     }
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -2142,6 +2142,60 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(mockSearchRead).toHaveBeenCalledTimes(2);
   });
+
+  it("POSTs report-auth-failure when retry-once also returns an auth error", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ type: "odoo", credentials: testCredentials }),
+    } as unknown as Response);
+
+    mockSearchRead
+      .mockRejectedValueOnce(new Error("Access Denied: invalid api key"))
+      .mockRejectedValueOnce(new Error("Access Denied: invalid api key"));
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    const reportCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("report-auth-failure"),
+    );
+    expect(reportCalls).toHaveLength(1);
+    const [url, opts] = reportCalls[0] as [string, RequestInit];
+    expect(url).toBe(
+      "http://pinchy-test:7777/api/internal/integrations/conn-test-1/report-auth-failure",
+    );
+    expect(opts.method).toBe("POST");
+    const headers = opts.headers as Record<string, string>;
+    expect(headers["Authorization"]).toBe("Bearer test-gateway-token");
+    expect(headers["X-Plugin-Id"]).toBe("pinchy-odoo");
+    const body = JSON.parse(opts.body as string) as { reason: string };
+    expect(body.reason).toBeTruthy();
+  });
+
+  it("does not POST report-auth-failure on a transient 5xx error", async () => {
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ type: "odoo", credentials: testCredentials }),
+    } as unknown as Response);
+
+    mockSearchRead.mockRejectedValueOnce(new Error("HTTP 503 Service Unavailable"));
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    await tool.execute("call-1", { model: "sale.order", filters: [] });
+
+    const reportCalls = fetchMock.mock.calls.filter((c) =>
+      String(c[0]).includes("report-auth-failure"),
+    );
+    expect(reportCalls).toHaveLength(0);
+  });
 });
 
 describe("odoo_attach_file", () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1037,6 +1037,30 @@ function wrapReadResult(
   return result;
 }
 
+async function reportAuthFailure(
+  apiBaseUrl: string,
+  connectionId: string,
+  gatewayToken: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await fetch(
+      `${apiBaseUrl}/api/internal/integrations/${connectionId}/report-auth-failure`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${gatewayToken}`,
+          "Content-Type": "application/json",
+          "X-Plugin-Id": "pinchy-odoo",
+        },
+        body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      },
+    );
+  } catch {
+    // best-effort — never mask the original tool error
+  }
+}
+
 function permissionDenied(
   operation: string,
   model: string,
@@ -1155,7 +1179,13 @@ const plugin = {
         if (!isAuthError) throw err;
         invalidate(agentId);
         const fresh = await getOrCreateClient(agentId, config);
-        return fn(fresh);
+        try {
+          return await fn(fresh);
+        } catch (retryErr) {
+          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          await reportAuthFailure(apiBaseUrl, config.connectionId, gatewayToken, retryMsg);
+          throw retryErr;
+        }
       }
     }
 

--- a/packages/plugins/pinchy-odoo/package-lock.json
+++ b/packages/plugins/pinchy-odoo/package-lock.json
@@ -8,453 +8,22 @@
       "name": "@pinchy/pinchy-odoo",
       "version": "0.1.0",
       "dependencies": {
-        "odoo-node": "^0.1.1"
+        "odoo-node": "^0.2.0"
       },
       "devDependencies": {
-        "typescript": "^5.7.0",
-        "vitest": "^3.0.0"
+        "typescript": "^6.0.2",
+        "vitest": "^4.1.4"
       }
     },
-    "node_modules/@esbuild/aix-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.4.tgz",
-      "integrity": "sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==",
-      "cpu": [
-        "ppc64"
-      ],
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.1.tgz",
+      "integrity": "sha512-uTII7OYF+/Mes/MrcIOYp5yOtSMLBWSIoLPpcgwipoiKbli6k322tcoFsxoIIxPDqW01SQGAgko4EzZi2BNv2w==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "aix"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.4.tgz",
-      "integrity": "sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.4.tgz",
-      "integrity": "sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/android-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.4.tgz",
-      "integrity": "sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "android"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.4.tgz",
-      "integrity": "sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/darwin-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.4.tgz",
-      "integrity": "sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "darwin"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.4.tgz",
-      "integrity": "sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.4.tgz",
-      "integrity": "sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==",
-      "cpu": [
-        "arm"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.4.tgz",
-      "integrity": "sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.4.tgz",
-      "integrity": "sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-loong64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.4.tgz",
-      "integrity": "sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.4.tgz",
-      "integrity": "sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==",
-      "cpu": [
-        "mips64el"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.4.tgz",
-      "integrity": "sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==",
-      "cpu": [
-        "ppc64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.4.tgz",
-      "integrity": "sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-s390x": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.4.tgz",
-      "integrity": "sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==",
-      "cpu": [
-        "s390x"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/linux-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.4.tgz",
-      "integrity": "sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "netbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.4.tgz",
-      "integrity": "sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.4.tgz",
-      "integrity": "sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/openharmony-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.4.tgz",
-      "integrity": "sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openharmony"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/sunos-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.4.tgz",
-      "integrity": "sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "sunos"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-arm64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.4.tgz",
-      "integrity": "sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==",
-      "cpu": [
-        "arm64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-ia32": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.4.tgz",
-      "integrity": "sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==",
-      "cpu": [
-        "ia32"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/@esbuild/win32-x64": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.4.tgz",
-      "integrity": "sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==",
-      "cpu": [
-        "x64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ],
-      "engines": {
-        "node": ">=18"
+      "dependencies": {
+        "tslib": "^2.4.0"
       }
     },
     "node_modules/@jridgewell/sourcemap-codec": {
@@ -464,24 +33,39 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/@rollup/rollup-android-arm-eabi": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm-eabi/-/rollup-android-arm-eabi-4.60.0.tgz",
-      "integrity": "sha512-WOhNW9K8bR3kf4zLxbfg6Pxu2ybOUbB2AjMDHSQx86LIF4rH4Ft7vmMwNt0loO0eonglSNy4cpD3MKXXKQu0/A==",
-      "cpu": [
-        "arm"
-      ],
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.1.4.tgz",
+      "integrity": "sha512-3NQNNgA1YSlJb/kMH1ildASP9HW7/7kYnRI2szWJaofaS1hWmbGI4H+d3+22aGzXXN9IJ+n+GiFVcGipJP18ow==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "android"
-      ]
+      "dependencies": {
+        "@tybys/wasm-util": "^0.10.1"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/Brooooooklyn"
+      },
+      "peerDependencies": {
+        "@emnapi/core": "^1.7.1",
+        "@emnapi/runtime": "^1.7.1"
+      }
     },
-    "node_modules/@rollup/rollup-android-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-android-arm64/-/rollup-android-arm64-4.60.0.tgz",
-      "integrity": "sha512-u6JHLll5QKRvjciE78bQXDmqRqNs5M/3GVqZeMwvmjaNODJih/WIrJlFVEihvV0MiYFmd+ZyPr9wxOVbPAG2Iw==",
+    "node_modules/@oxc-project/types": {
+      "version": "0.129.0",
+      "resolved": "https://registry.npmjs.org/@oxc-project/types/-/types-0.129.0.tgz",
+      "integrity": "sha512-3oz8m3FGdr2nDXVqmFUw7jolKliC4MoyXYIG2c7gpjBnzUWQpUGIYcXYKxTdTi+N2jusvt610ckTMkxdwHkYEg==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/Boshen"
+      }
+    },
+    "node_modules/@rolldown/binding-android-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-android-arm64/-/binding-android-arm64-1.0.0.tgz",
+      "integrity": "sha512-TWMZnRLMe63C2Lhyicviu7ZHaU4kxa6PS3rofvc9GmcvptzNN11BcfQ4Sl7MwTOsisQoa2keB/EBdNCAnUo8vA==",
       "cpu": [
         "arm64"
       ],
@@ -490,12 +74,15 @@
       "optional": true,
       "os": [
         "android"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-arm64/-/rollup-darwin-arm64-4.60.0.tgz",
-      "integrity": "sha512-qEF7CsKKzSRc20Ciu2Zw1wRrBz4g56F7r/vRwY430UPp/nt1x21Q/fpJ9N5l47WWvJlkNCPJz3QRVw008fi7yA==",
+    "node_modules/@rolldown/binding-darwin-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-arm64/-/binding-darwin-arm64-1.0.0.tgz",
+      "integrity": "sha512-6XcD+8k0gPVItNagEw78/qqcBDwKcwDYS8V2hRmVsfUSIrd8cWe/CBvRDI5toqFyPfj+FJr6t8U6Xj2P2prEew==",
       "cpu": [
         "arm64"
       ],
@@ -504,12 +91,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-darwin-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-darwin-x64/-/rollup-darwin-x64-4.60.0.tgz",
-      "integrity": "sha512-WADYozJ4QCnXCH4wPB+3FuGmDPoFseVCUrANmA5LWwGmC6FL14BWC7pcq+FstOZv3baGX65tZ378uT6WG8ynTw==",
+    "node_modules/@rolldown/binding-darwin-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-darwin-x64/-/binding-darwin-x64-1.0.0.tgz",
+      "integrity": "sha512-iN/tWVXRQDWvmZlKdceP1Dwug9GDpEymhb9p4xnEe6zvCg5lFmzVljl+1qR1NVx3yfGpr2Na+CuLmv5IU8uzfQ==",
       "cpu": [
         "x64"
       ],
@@ -518,26 +108,15 @@
       "optional": true,
       "os": [
         "darwin"
-      ]
-    },
-    "node_modules/@rollup/rollup-freebsd-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-arm64/-/rollup-freebsd-arm64-4.60.0.tgz",
-      "integrity": "sha512-6b8wGHJlDrGeSE3aH5mGNHBjA0TTkxdoNHik5EkvPHCt351XnigA4pS7Wsj/Eo9Y8RBU6f35cjN9SYmCFBtzxw==",
-      "cpu": [
-        "arm64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "freebsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-freebsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-freebsd-x64/-/rollup-freebsd-x64-4.60.0.tgz",
-      "integrity": "sha512-h25Ga0t4jaylMB8M/JKAyrvvfxGRjnPQIR8lnCayyzEjEOx2EJIlIiMbhpWxDRKGKF8jbNH01NnN663dH638mA==",
+    "node_modules/@rolldown/binding-freebsd-x64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-freebsd-x64/-/binding-freebsd-x64-1.0.0.tgz",
+      "integrity": "sha512-jjQMDvvwSOuhOwMszD/klSOjyWMM3zI64hWTj9KT5x4MxRbZAf+7vLQ6qouRhtsLVFHr3f0ILaJAfgENPiQdAQ==",
       "cpu": [
         "x64"
       ],
@@ -546,12 +125,15 @@
       "optional": true,
       "os": [
         "freebsd"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm-gnueabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-gnueabihf/-/rollup-linux-arm-gnueabihf-4.60.0.tgz",
-      "integrity": "sha512-RzeBwv0B3qtVBWtcuABtSuCzToo2IEAIQrcyB/b2zMvBWVbjo8bZDjACUpnaafaxhTw2W+imQbP2BD1usasK4g==",
+    "node_modules/@rolldown/binding-linux-arm-gnueabihf": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm-gnueabihf/-/binding-linux-arm-gnueabihf-1.0.0.tgz",
+      "integrity": "sha512-d//Dtg2x6/m3mbV64yUGNnDGNZaDGRpDLLNGerHQUVObuNaIQaaDp25yUiqGXtHEXX+NP2d0wAlmKgpYgIAJ2A==",
       "cpu": [
         "arm"
       ],
@@ -560,26 +142,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-arm-musleabihf": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm-musleabihf/-/rollup-linux-arm-musleabihf-4.60.0.tgz",
-      "integrity": "sha512-Sf7zusNI2CIU1HLzuu9Tc5YGAHEZs5Lu7N1ssJG4Tkw6e0MEsN7NdjUDDfGNHy2IU+ENyWT+L2obgWiguWibWQ==",
-      "cpu": [
-        "arm"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-gnu/-/rollup-linux-arm64-gnu-4.60.0.tgz",
-      "integrity": "sha512-DX2x7CMcrJzsE91q7/O02IJQ5/aLkVtYFryqCjduJhUfGKG6yJV8hxaw8pZa93lLEpPTP/ohdN4wFz7yp/ry9A==",
+    "node_modules/@rolldown/binding-linux-arm64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.0.0.tgz",
+      "integrity": "sha512-n7Ofp0mx+aB2cC+Sdy5YtMnXtY9lchnHbY+3Yt0uq9JsWQExf4f5Whu0tK0R8Jdc9S6RchTHjIFY7uc92puOVQ==",
       "cpu": [
         "arm64"
       ],
@@ -588,12 +159,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-arm64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-arm64-musl/-/rollup-linux-arm64-musl-4.60.0.tgz",
-      "integrity": "sha512-09EL+yFVbJZlhcQfShpswwRZ0Rg+z/CsSELFCnPt3iK+iqwGsI4zht3secj5vLEs957QvFFXnzAT0FFPIxSrkQ==",
+    "node_modules/@rolldown/binding-linux-arm64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.0.0.tgz",
+      "integrity": "sha512-EIVjy2cgd7uuMMo94FVkBp7F6DhcZAUwNURkSG3RwUmvAXR6s0ISxM81U+IydcZByPG0pZIHsf1b6kTxoFDgJA==",
       "cpu": [
         "arm64"
       ],
@@ -602,40 +176,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-loong64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-gnu/-/rollup-linux-loong64-gnu-4.60.0.tgz",
-      "integrity": "sha512-i9IcCMPr3EXm8EQg5jnja0Zyc1iFxJjZWlb4wr7U2Wx/GrddOuEafxRdMPRYVaXjgbhvqalp6np07hN1w9kAKw==",
-      "cpu": [
-        "loong64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-loong64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-loong64-musl/-/rollup-linux-loong64-musl-4.60.0.tgz",
-      "integrity": "sha512-DGzdJK9kyJ+B78MCkWeGnpXJ91tK/iKA6HwHxF4TAlPIY7GXEvMe8hBFRgdrR9Ly4qebR/7gfUs9y2IoaVEyog==",
-      "cpu": [
-        "loong64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-gnu/-/rollup-linux-ppc64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RwpnLsqC8qbS8z1H1AxBA1H6qknR4YpPR9w2XX0vo2Sz10miu57PkNcnHVaZkbqyw/kUWfKMI73jhmfi9BRMUQ==",
+    "node_modules/@rolldown/binding-linux-ppc64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-ppc64-gnu/-/binding-linux-ppc64-gnu-1.0.0.tgz",
+      "integrity": "sha512-JEwwOPcwTLAcpDQlqSmjEmfs63xJnSiUNIGvLcDLUHCWK4XowpS/7c7tUsUH6uT/ct6bMUTdXKfI8967FYj6mg==",
       "cpu": [
         "ppc64"
       ],
@@ -644,54 +193,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-ppc64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-ppc64-musl/-/rollup-linux-ppc64-musl-4.60.0.tgz",
-      "integrity": "sha512-Z8pPf54Ly3aqtdWC3G4rFigZgNvd+qJlOE52fmko3KST9SoGfAdSRCwyoyG05q1HrrAblLbk1/PSIV+80/pxLg==",
-      "cpu": [
-        "ppc64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-riscv64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-gnu/-/rollup-linux-riscv64-gnu-4.60.0.tgz",
-      "integrity": "sha512-3a3qQustp3COCGvnP4SvrMHnPQ9d1vzCakQVRTliaz8cIp/wULGjiGpbcqrkv0WrHTEp8bQD/B3HBjzujVWLOA==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-riscv64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-riscv64-musl/-/rollup-linux-riscv64-musl-4.60.0.tgz",
-      "integrity": "sha512-pjZDsVH/1VsghMJ2/kAaxt6dL0psT6ZexQVrijczOf+PeP2BUqTHYejk3l6TlPRydggINOeNRhvpLa0AYpCWSQ==",
-      "cpu": [
-        "riscv64"
-      ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-linux-s390x-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-s390x-gnu/-/rollup-linux-s390x-gnu-4.60.0.tgz",
-      "integrity": "sha512-3ObQs0BhvPgiUVZrN7gqCSvmFuMWvWvsjG5ayJ3Lraqv+2KhOsp+pUbigqbeWqueGIsnn+09HBw27rJ+gYK4VQ==",
+    "node_modules/@rolldown/binding-linux-s390x-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-s390x-gnu/-/binding-linux-s390x-gnu-1.0.0.tgz",
+      "integrity": "sha512-0wjCFhLrihtAubnT9iA0N++0pSV0z5Hg7tNGdNJ4RFaINceHadoF+kiFGyY1qSSNVIAZtLotG8Ju1bgDPkjnFA==",
       "cpu": [
         "s390x"
       ],
@@ -700,12 +210,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-gnu/-/rollup-linux-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-EtylprDtQPdS5rXvAayrNDYoJhIz1/vzN2fEubo3yLE7tfAw+948dO0g4M0vkTVFhKojnF+n6C8bDNe+gDRdTg==",
+    "node_modules/@rolldown/binding-linux-x64-gnu": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.0.0.tgz",
+      "integrity": "sha512-Dfn7iak9BcMMePxcoJfpSbWqnEyrp/dRF63/8qW/eHBdOZov6x5aShLLEYGYdIeSJ6vMLK/XCVB+lGIxm41bQA==",
       "cpu": [
         "x64"
       ],
@@ -714,12 +227,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-linux-x64-musl": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-linux-x64-musl/-/rollup-linux-x64-musl-4.60.0.tgz",
-      "integrity": "sha512-k09oiRCi/bHU9UVFqD17r3eJR9bn03TyKraCrlz5ULFJGdJGi7VOmm9jl44vOJvRJ6P7WuBi/s2A97LxxHGIdw==",
+    "node_modules/@rolldown/binding-linux-x64-musl": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-linux-x64-musl/-/binding-linux-x64-musl-1.0.0.tgz",
+      "integrity": "sha512-5/utzzDmD/pD/bmuaUcbTf/sZYy0aztwIVlfpoW1fTjCZ0BaPOMVWGZL1zvgxyi7ZIVYWlxKONHmSbHuiOh8Jw==",
       "cpu": [
         "x64"
       ],
@@ -728,26 +244,15 @@
       "optional": true,
       "os": [
         "linux"
-      ]
-    },
-    "node_modules/@rollup/rollup-openbsd-x64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openbsd-x64/-/rollup-openbsd-x64-4.60.0.tgz",
-      "integrity": "sha512-1o/0/pIhozoSaDJoDcec+IVLbnRtQmHwPV730+AOD29lHEEo4F5BEUB24H0OBdhbBBDwIOSuf7vgg0Ywxdfiiw==",
-      "cpu": [
-        "x64"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "openbsd"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-openharmony-arm64": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-openharmony-arm64/-/rollup-openharmony-arm64-4.60.0.tgz",
-      "integrity": "sha512-pESDkos/PDzYwtyzB5p/UoNU/8fJo68vcXM9ZW2V0kjYayj1KaaUfi1NmTUTUpMn4UhU4gTuK8gIaFO4UGuMbA==",
+    "node_modules/@rolldown/binding-openharmony-arm64": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-openharmony-arm64/-/binding-openharmony-arm64-1.0.0.tgz",
+      "integrity": "sha512-ouJs8VcUomfLfpbUECqFMRqdV4x6aeAK3MA4m6vTrJJjKyWTV5KnxZx7Jd9G+GlDaQQxubcba00x16OyJ1meig==",
       "cpu": [
         "arm64"
       ],
@@ -756,12 +261,34 @@
       "optional": true,
       "os": [
         "openharmony"
-      ]
+      ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-arm64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-arm64-msvc/-/rollup-win32-arm64-msvc-4.60.0.tgz",
-      "integrity": "sha512-hj1wFStD7B1YBeYmvY+lWXZ7ey73YGPcViMShYikqKT1GtstIKQAtfUI6yrzPjAy/O7pO0VLXGmUVWXQMaYgTQ==",
+    "node_modules/@rolldown/binding-wasm32-wasi": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-wasm32-wasi/-/binding-wasm32-wasi-1.0.0.tgz",
+      "integrity": "sha512-E+oHKGiDA+lsKMmFtffDDw91EryDT7uJocrIuCHqhm6bCTM6xFK+3gaCkYOHfPwQr0cCNarSM2xaELoQDz9jJg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "1.10.0",
+        "@emnapi/runtime": "1.10.0",
+        "@napi-rs/wasm-runtime": "^1.1.4"
+      },
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/binding-win32-arm64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.0.0.tgz",
+      "integrity": "sha512-yYK02n8Rngo+gbm1y6G0+7jk1sJ/2Wt7K0me0Y7k/ErBpyf+LJ2gFpqWVTcRV1rUepBlQRmpgWkTQCiiwrK0Ow==",
       "cpu": [
         "arm64"
       ],
@@ -770,26 +297,15 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-ia32-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-ia32-msvc/-/rollup-win32-ia32-msvc-4.60.0.tgz",
-      "integrity": "sha512-SyaIPFoxmUPlNDq5EHkTbiKzmSEmq/gOYFI/3HHJ8iS/v1mbugVa7dXUzcJGQfoytp9DJFLhHH4U3/eTy2Bq4w==",
-      "cpu": [
-        "ia32"
       ],
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "os": [
-        "win32"
-      ]
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
     },
-    "node_modules/@rollup/rollup-win32-x64-gnu": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-gnu/-/rollup-win32-x64-gnu-4.60.0.tgz",
-      "integrity": "sha512-RdcryEfzZr+lAr5kRm2ucN9aVlCCa2QNq4hXelZxb8GG0NJSazq44Z3PCCc8wISRuCVnGs0lQJVX5Vp6fKA+IA==",
+    "node_modules/@rolldown/binding-win32-x64-msvc": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.0.0.tgz",
+      "integrity": "sha512-14bpChMahXRRXiTwahSl+zzHPW6qQTXtkMuJBFlbo+pqSAews2d4BdCSHfrJ/MBsCZtpmTafsY+1QhBzitcmdg==",
       "cpu": [
         "x64"
       ],
@@ -798,21 +314,35 @@
       "optional": true,
       "os": [
         "win32"
-      ]
-    },
-    "node_modules/@rollup/rollup-win32-x64-msvc": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/@rollup/rollup-win32-x64-msvc/-/rollup-win32-x64-msvc-4.60.0.tgz",
-      "integrity": "sha512-PrsWNQ8BuE00O3Xsx3ALh2Df8fAj9+cvvX9AIA6o4KpATR98c9mud4XtDWVvsEuyia5U4tVSTKygawyJkjm60w==",
-      "cpu": [
-        "x64"
       ],
+      "engines": {
+        "node": "^20.19.0 || >=22.12.0"
+      }
+    },
+    "node_modules/@rolldown/pluginutils": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/@rolldown/pluginutils/-/pluginutils-1.0.0.tgz",
+      "integrity": "sha512-aKs/3GSWyV0mrhNmt/96/Z3yczC3yvrzYATCiCXQebBsGyYzjNdUphRVLeJQ67ySKVXRfMxt2lm12pmXvbPFQQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@standard-schema/spec": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.1.0.tgz",
+      "integrity": "sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.2",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.2.tgz",
+      "integrity": "sha512-RoBvJ2X0wuKlWFIjrwffGw1IqZHKQqzIchKaadZZfnNpsAYp2mM0h36JtPCjNDAHGgYez/15uMBpfGwchhiMgg==",
       "dev": true,
       "license": "MIT",
       "optional": true,
-      "os": [
-        "win32"
-      ]
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
     },
     "node_modules/@types/chai": {
       "version": "5.2.3",
@@ -833,46 +363,47 @@
       "license": "MIT"
     },
     "node_modules/@types/estree": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
-      "integrity": "sha512-dWHzHa2WqEXI/O1E9OjrocMTKJl2mSrEolh1Iomrv6U+JuNwaHXsXx9bLu5gG7BUWFIN0skIQJQ/L1rIex4X6w==",
+      "version": "1.0.9",
+      "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.9.tgz",
+      "integrity": "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@vitest/expect": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.4.tgz",
-      "integrity": "sha512-Io0yyORnB6sikFlt8QW5K7slY4OjqNX9jmJQ02QDda8lyM6B5oNgVWoSoKPac8/kgnCUzuHQKrSLtu/uOqqrig==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-4.1.6.tgz",
+      "integrity": "sha512-7EHDquPthALSV0jhhjgEW8FXaviMx7rSqu8W6oqCoAuOhKov814P99QDV1pxMA3QPv21YudvJngIhjrNI4opLg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
+        "@standard-schema/spec": "^1.1.0",
         "@types/chai": "^5.2.2",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "chai": "^6.2.2",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/mocker": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.4.tgz",
-      "integrity": "sha512-46ryTE9RZO/rfDd7pEqFl7etuyzekzEhUbTW3BvmeO/BcCMEgq59BKhek3dXDWgAj4oMK6OZi+vRr1wPW6qjEQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-4.1.6.tgz",
+      "integrity": "sha512-MCFc63czMjEInOlcY2cpQCvCN+KgbAn+60xu9cMgP4sKaLC5JNAKw7JH8QdAnoAC88hW1IiSNZ+GgVXlN1UcMQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/spy": "3.2.4",
+        "@vitest/spy": "4.1.6",
         "estree-walker": "^3.0.3",
-        "magic-string": "^0.30.17"
+        "magic-string": "^0.30.21"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "msw": "^2.4.9",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "msw": {
@@ -884,42 +415,42 @@
       }
     },
     "node_modules/@vitest/pretty-format": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.4.tgz",
-      "integrity": "sha512-IVNZik8IVRJRTr9fxlitMKeJeXFFFN0JaB9PHPGQ8NKQbGpfjlTx9zO4RefN8gp7eqjNy8nyK3NZmBzOPeIxtA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-4.1.6.tgz",
+      "integrity": "sha512-h5SxD/IzNhZYnrSZRsUZQIC+vD0GY8cUvq0iwsmkFKixRCKLLWqCXa/FIQ4S1R+sI+PGoojkHsdNrbZiM9Qpgw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "tinyrainbow": "^2.0.0"
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/runner": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.4.tgz",
-      "integrity": "sha512-oukfKT9Mk41LreEW09vt45f8wx7DordoWUZMYdY/cyAk7w5TWkTRCNZYF7sX7n2wB7jyGAl74OxgwhPgKaqDMQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-4.1.6.tgz",
+      "integrity": "sha512-nOPCmn2+yD0ZNmKdsXGv/UxMMWbMuKeD6GyYncNwdkYDxpQvrPSKYj2rWuDjC2Y4b6w6hjip5dBKFzEUuZe3vA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/utils": "3.2.4",
-        "pathe": "^2.0.3",
-        "strip-literal": "^3.0.0"
+        "@vitest/utils": "4.1.6",
+        "pathe": "^2.0.3"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/snapshot": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.4.tgz",
-      "integrity": "sha512-dEYtS7qQP2CjU27QBC5oUOxLE/v5eLkGqPE0ZKEIDGMs4vKWe7IjgLOeauHsR0D5YuuycGRO5oSRXnwnmA78fQ==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-4.1.6.tgz",
+      "integrity": "sha512-YhsdE6xAVfTDmzjxL2ZDUvjj+ZsgyOKe+TdQzqkD72wIOmHka8NuGQ6NpTNZv9D2Z63fbwWKJPeVpEw4EQgYxw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "magic-string": "^0.30.17",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "magic-string": "^0.30.21",
         "pathe": "^2.0.3"
       },
       "funding": {
@@ -927,28 +458,25 @@
       }
     },
     "node_modules/@vitest/spy": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.4.tgz",
-      "integrity": "sha512-vAfasCOe6AIK70iP5UD11Ac4siNUNJ9i/9PZ3NKx07sG6sUxeag1LWdNrMWeKKYBLlzuK+Gn65Yd5nyL6ds+nw==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-4.1.6.tgz",
+      "integrity": "sha512-JFKxMx6udhwKh/Ldo270e17QX710vgunMkuPAvXjHSvC6oqLWAHhVhjg/I71q0u0CBSErIODV1Kjv0FQNSWjdg==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "tinyspy": "^4.0.3"
-      },
       "funding": {
         "url": "https://opencollective.com/vitest"
       }
     },
     "node_modules/@vitest/utils": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.4.tgz",
-      "integrity": "sha512-fB2V0JFrQSMsCo9HiSq3Ezpdv4iYaXRG1Sx8edX3MwxfyNn83mKiGzOcH+Fkxt4MHxr3y42fQi1oeAInqgX2QA==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-4.1.6.tgz",
+      "integrity": "sha512-FxIY+U81R3LGKCxaHHFRQ5+g6/iRgGLmeHWdp2Amj4ljQRrEIWHmZyDfDYBRZlpyqA7qKxtS9DD1dhk8RnRIVQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@vitest/pretty-format": "3.2.4",
-        "loupe": "^3.1.4",
-        "tinyrainbow": "^2.0.0"
+        "@vitest/pretty-format": "4.1.6",
+        "convert-source-map": "^2.0.0",
+        "tinyrainbow": "^3.1.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
@@ -964,119 +492,39 @@
         "node": ">=12"
       }
     },
-    "node_modules/cac": {
-      "version": "6.7.14",
-      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
-      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+    "node_modules/chai": {
+      "version": "6.2.2",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-6.2.2.tgz",
+      "integrity": "sha512-NUPRluOfOiTKBKvWPtSD4PhFvWCqOi0BGStNWs57X9js7XGTprSmFoz5F0tWhR4WPjNeR9jXqdC7/UpSJTnlRg==",
       "dev": true,
       "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/convert-source-map": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-2.0.0.tgz",
+      "integrity": "sha512-Kvp459HrV2FEJ1CAsi1Ku+MY3kasH19TFykTz2xWmMeq6bk2NU3XXvfJ+Q61m0xktWwt+1HSYf3JZsTms3aRJg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "dev": true,
+      "license": "Apache-2.0",
       "engines": {
         "node": ">=8"
       }
     },
-    "node_modules/chai": {
-      "version": "5.3.3",
-      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
-      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "assertion-error": "^2.0.1",
-        "check-error": "^2.1.1",
-        "deep-eql": "^5.0.1",
-        "loupe": "^3.1.0",
-        "pathval": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=18"
-      }
-    },
-    "node_modules/check-error": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
-      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 16"
-      }
-    },
-    "node_modules/debug": {
-      "version": "4.4.3",
-      "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
-      "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "ms": "^2.1.3"
-      },
-      "engines": {
-        "node": ">=6.0"
-      },
-      "peerDependenciesMeta": {
-        "supports-color": {
-          "optional": true
-        }
-      }
-    },
-    "node_modules/deep-eql": {
-      "version": "5.0.2",
-      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
-      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      }
-    },
     "node_modules/es-module-lexer": {
-      "version": "1.7.0",
-      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
-      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-2.1.0.tgz",
+      "integrity": "sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/esbuild": {
-      "version": "0.27.4",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.4.tgz",
-      "integrity": "sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==",
-      "dev": true,
-      "hasInstallScript": true,
-      "license": "MIT",
-      "bin": {
-        "esbuild": "bin/esbuild"
-      },
-      "engines": {
-        "node": ">=18"
-      },
-      "optionalDependencies": {
-        "@esbuild/aix-ppc64": "0.27.4",
-        "@esbuild/android-arm": "0.27.4",
-        "@esbuild/android-arm64": "0.27.4",
-        "@esbuild/android-x64": "0.27.4",
-        "@esbuild/darwin-arm64": "0.27.4",
-        "@esbuild/darwin-x64": "0.27.4",
-        "@esbuild/freebsd-arm64": "0.27.4",
-        "@esbuild/freebsd-x64": "0.27.4",
-        "@esbuild/linux-arm": "0.27.4",
-        "@esbuild/linux-arm64": "0.27.4",
-        "@esbuild/linux-ia32": "0.27.4",
-        "@esbuild/linux-loong64": "0.27.4",
-        "@esbuild/linux-mips64el": "0.27.4",
-        "@esbuild/linux-ppc64": "0.27.4",
-        "@esbuild/linux-riscv64": "0.27.4",
-        "@esbuild/linux-s390x": "0.27.4",
-        "@esbuild/linux-x64": "0.27.4",
-        "@esbuild/netbsd-arm64": "0.27.4",
-        "@esbuild/netbsd-x64": "0.27.4",
-        "@esbuild/openbsd-arm64": "0.27.4",
-        "@esbuild/openbsd-x64": "0.27.4",
-        "@esbuild/openharmony-arm64": "0.27.4",
-        "@esbuild/sunos-x64": "0.27.4",
-        "@esbuild/win32-arm64": "0.27.4",
-        "@esbuild/win32-ia32": "0.27.4",
-        "@esbuild/win32-x64": "0.27.4"
-      }
     },
     "node_modules/estree-walker": {
       "version": "3.0.3",
@@ -1131,19 +579,266 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/js-tokens": {
-      "version": "9.0.1",
-      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
-      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
       "dev": true,
-      "license": "MIT"
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
     },
-    "node_modules/loupe": {
-      "version": "3.2.1",
-      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
-      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
       "dev": true,
-      "license": "MIT"
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
     },
     "node_modules/magic-string": {
       "version": "0.30.21",
@@ -1155,17 +850,10 @@
         "@jridgewell/sourcemap-codec": "^1.5.5"
       }
     },
-    "node_modules/ms": {
-      "version": "2.1.3",
-      "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
-      "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/nanoid": {
-      "version": "3.3.11",
-      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.11.tgz",
-      "integrity": "sha512-N8SpfPUnUp1bK+PMYW8qSWdl9U+wwNWI4QKxOYDy9JAro3WMX7p2OeVRF9v+347pnakNevPmiHhNmZ2HbFA76w==",
+      "version": "3.3.12",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.12.tgz",
+      "integrity": "sha512-ZB9RH/39qpq5Vu6Y+NmUaFhQR6pp+M2Xt76XBnEwDaGcVAqhlvxrl3B2bKS5D3NH3QR76v3aSrKaF/Kiy7lEtQ==",
       "dev": true,
       "funding": [
         {
@@ -1181,10 +869,21 @@
         "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
       }
     },
+    "node_modules/obug": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/obug/-/obug-2.1.1.tgz",
+      "integrity": "sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==",
+      "dev": true,
+      "funding": [
+        "https://github.com/sponsors/sxzz",
+        "https://opencollective.com/debug"
+      ],
+      "license": "MIT"
+    },
     "node_modules/odoo-node": {
-      "version": "0.1.1",
-      "resolved": "https://registry.npmjs.org/odoo-node/-/odoo-node-0.1.1.tgz",
-      "integrity": "sha512-EMO/Ln+w1TXR2ySXXWRiDdPl0FEB7tycF4zDqpiXxMuLaRo9aQKz4iI8RnqAP/m3srMGhmyGqkONmuWIRdySDw==",
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/odoo-node/-/odoo-node-0.2.0.tgz",
+      "integrity": "sha512-ov7PNKyyR3YUqU0nrubjA+CuRO5ehzKMky3+WCtGanRxqMQAUOODFX/4kY+UTE1ygJlY+sF+IhZwc1Uf5Suu3w==",
       "license": "MIT",
       "engines": {
         "node": ">=20.0.0"
@@ -1199,16 +898,6 @@
       "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/pathval": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
-      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">= 14.16"
-      }
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -1232,9 +921,9 @@
       }
     },
     "node_modules/postcss": {
-      "version": "8.5.8",
-      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.8.tgz",
-      "integrity": "sha512-OW/rX8O/jXnm82Ey1k44pObPtdblfiuWnrd8X7GJ7emImCOstunGbXUpp7HdBrFQX6rJzn3sPT397Wp5aCwCHg==",
+      "version": "8.5.14",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.14.tgz",
+      "integrity": "sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==",
       "dev": true,
       "funding": [
         {
@@ -1260,49 +949,38 @@
         "node": "^10 || ^12 || >=14"
       }
     },
-    "node_modules/rollup": {
-      "version": "4.60.0",
-      "resolved": "https://registry.npmjs.org/rollup/-/rollup-4.60.0.tgz",
-      "integrity": "sha512-yqjxruMGBQJ2gG4HtjZtAfXArHomazDHoFwFFmZZl0r7Pdo7qCIXKqKHZc8yeoMgzJJ+pO6pEEHa+V7uzWlrAQ==",
+    "node_modules/rolldown": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/rolldown/-/rolldown-1.0.0.tgz",
+      "integrity": "sha512-yD986aXDESFGS95spT1LAv0jssywP4npMEjmMHyN2/5+eE8qQJUype2AaKkRiLgBgyD0LFlubwAht7VmY8rGoA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "1.0.8"
+        "@oxc-project/types": "=0.129.0",
+        "@rolldown/pluginutils": "1.0.0"
       },
       "bin": {
-        "rollup": "dist/bin/rollup"
+        "rolldown": "bin/cli.mjs"
       },
       "engines": {
-        "node": ">=18.0.0",
-        "npm": ">=8.0.0"
+        "node": "^20.19.0 || >=22.12.0"
       },
       "optionalDependencies": {
-        "@rollup/rollup-android-arm-eabi": "4.60.0",
-        "@rollup/rollup-android-arm64": "4.60.0",
-        "@rollup/rollup-darwin-arm64": "4.60.0",
-        "@rollup/rollup-darwin-x64": "4.60.0",
-        "@rollup/rollup-freebsd-arm64": "4.60.0",
-        "@rollup/rollup-freebsd-x64": "4.60.0",
-        "@rollup/rollup-linux-arm-gnueabihf": "4.60.0",
-        "@rollup/rollup-linux-arm-musleabihf": "4.60.0",
-        "@rollup/rollup-linux-arm64-gnu": "4.60.0",
-        "@rollup/rollup-linux-arm64-musl": "4.60.0",
-        "@rollup/rollup-linux-loong64-gnu": "4.60.0",
-        "@rollup/rollup-linux-loong64-musl": "4.60.0",
-        "@rollup/rollup-linux-ppc64-gnu": "4.60.0",
-        "@rollup/rollup-linux-ppc64-musl": "4.60.0",
-        "@rollup/rollup-linux-riscv64-gnu": "4.60.0",
-        "@rollup/rollup-linux-riscv64-musl": "4.60.0",
-        "@rollup/rollup-linux-s390x-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-gnu": "4.60.0",
-        "@rollup/rollup-linux-x64-musl": "4.60.0",
-        "@rollup/rollup-openbsd-x64": "4.60.0",
-        "@rollup/rollup-openharmony-arm64": "4.60.0",
-        "@rollup/rollup-win32-arm64-msvc": "4.60.0",
-        "@rollup/rollup-win32-ia32-msvc": "4.60.0",
-        "@rollup/rollup-win32-x64-gnu": "4.60.0",
-        "@rollup/rollup-win32-x64-msvc": "4.60.0",
-        "fsevents": "~2.3.2"
+        "@rolldown/binding-android-arm64": "1.0.0",
+        "@rolldown/binding-darwin-arm64": "1.0.0",
+        "@rolldown/binding-darwin-x64": "1.0.0",
+        "@rolldown/binding-freebsd-x64": "1.0.0",
+        "@rolldown/binding-linux-arm-gnueabihf": "1.0.0",
+        "@rolldown/binding-linux-arm64-gnu": "1.0.0",
+        "@rolldown/binding-linux-arm64-musl": "1.0.0",
+        "@rolldown/binding-linux-ppc64-gnu": "1.0.0",
+        "@rolldown/binding-linux-s390x-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-gnu": "1.0.0",
+        "@rolldown/binding-linux-x64-musl": "1.0.0",
+        "@rolldown/binding-openharmony-arm64": "1.0.0",
+        "@rolldown/binding-wasm32-wasi": "1.0.0",
+        "@rolldown/binding-win32-arm64-msvc": "1.0.0",
+        "@rolldown/binding-win32-x64-msvc": "1.0.0"
       }
     },
     "node_modules/siginfo": {
@@ -1330,24 +1008,11 @@
       "license": "MIT"
     },
     "node_modules/std-env": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
-      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "version": "4.1.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-4.1.0.tgz",
+      "integrity": "sha512-Rq7ybcX2RuC55r9oaPVEW7/xu3tj8u4GeBYHBWCychFtzMIr86A7e3PPEBPT37sHStKX3+TiX/Fr/ACmJLVlLQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/strip-literal": {
-      "version": "3.1.0",
-      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
-      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "js-tokens": "^9.0.1"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/antfu"
-      }
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -1357,21 +1022,24 @@
       "license": "MIT"
     },
     "node_modules/tinyexec": {
-      "version": "0.3.2",
-      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
-      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-1.1.2.tgz",
+      "integrity": "sha512-dAqSqE/RabpBKI8+h26GfLq6Vb3JVXs30XYQjdMjaj/c2tS8IYYMbIzP599KtRj7c57/wYApb3QjgRgXmrCukA==",
       "dev": true,
-      "license": "MIT"
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/tinyglobby": {
-      "version": "0.2.15",
-      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
-      "integrity": "sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==",
+      "version": "0.2.16",
+      "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.16.tgz",
+      "integrity": "sha512-pn99VhoACYR8nFHhxqix+uvsbXineAasWm5ojXoN8xEwK5Kd3/TrhNn1wByuD52UxWRLy8pu+kRMniEi6Eq9Zg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "fdir": "^6.5.0",
-        "picomatch": "^4.0.3"
+        "picomatch": "^4.0.4"
       },
       "engines": {
         "node": ">=12.0.0"
@@ -1380,40 +1048,28 @@
         "url": "https://github.com/sponsors/SuperchupuDev"
       }
     },
-    "node_modules/tinypool": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
-      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": "^18.0.0 || >=20.0.0"
-      }
-    },
     "node_modules/tinyrainbow": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
-      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-3.1.0.tgz",
+      "integrity": "sha512-Bf+ILmBgretUrdJxzXM0SgXLZ3XfiaUuOj/IKQHuTXip+05Xn+uyEYdVg0kYDipTBcLrCVyUzAPz7QmArb0mmw==",
       "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=14.0.0"
       }
     },
-    "node_modules/tinyspy": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
-      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=14.0.0"
-      }
+      "license": "0BSD",
+      "optional": true
     },
     "node_modules/typescript": {
-      "version": "5.9.3",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-5.9.3.tgz",
-      "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
       "dev": true,
       "license": "Apache-2.0",
       "bin": {
@@ -1425,19 +1081,18 @@
       }
     },
     "node_modules/vite": {
-      "version": "7.3.1",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
-      "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
+      "version": "8.0.12",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-8.0.12.tgz",
+      "integrity": "sha512-w2dDofOWv2QB09ZITZBsvKTVAlYvPR4IAmrY/v0ir9KvLs0xybR7i48wxhM1/oyBWO34wPns+bPGw5ZrZqDpZg==",
       "dev": true,
       "license": "MIT",
       "peer": true,
       "dependencies": {
-        "esbuild": "^0.27.0",
-        "fdir": "^6.5.0",
-        "picomatch": "^4.0.3",
-        "postcss": "^8.5.6",
-        "rollup": "^4.43.0",
-        "tinyglobby": "^0.2.15"
+        "lightningcss": "^1.32.0",
+        "picomatch": "^4.0.4",
+        "postcss": "^8.5.14",
+        "rolldown": "1.0.0",
+        "tinyglobby": "^0.2.16"
       },
       "bin": {
         "vite": "bin/vite.js"
@@ -1453,9 +1108,10 @@
       },
       "peerDependencies": {
         "@types/node": "^20.19.0 || >=22.12.0",
+        "@vitejs/devtools": "^0.1.18",
+        "esbuild": "^0.27.0 || ^0.28.0",
         "jiti": ">=1.21.0",
         "less": "^4.0.0",
-        "lightningcss": "^1.21.0",
         "sass": "^1.70.0",
         "sass-embedded": "^1.70.0",
         "stylus": ">=0.54.8",
@@ -1468,13 +1124,16 @@
         "@types/node": {
           "optional": true
         },
+        "@vitejs/devtools": {
+          "optional": true
+        },
+        "esbuild": {
+          "optional": true
+        },
         "jiti": {
           "optional": true
         },
         "less": {
-          "optional": true
-        },
-        "lightningcss": {
           "optional": true
         },
         "sass": {
@@ -1500,89 +1159,80 @@
         }
       }
     },
-    "node_modules/vite-node": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
-      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "cac": "^6.7.14",
-        "debug": "^4.4.1",
-        "es-module-lexer": "^1.7.0",
-        "pathe": "^2.0.3",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
-      },
-      "bin": {
-        "vite-node": "vite-node.mjs"
-      },
-      "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
-      },
-      "funding": {
-        "url": "https://opencollective.com/vitest"
-      }
-    },
     "node_modules/vitest": {
-      "version": "3.2.4",
-      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.4.tgz",
-      "integrity": "sha512-LUCP5ev3GURDysTWiP47wRRUpLKMOfPh+yKTx3kVIEiu5KOMeqzpnYNsKyOoVrULivR8tLcks4+lga33Whn90A==",
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-4.1.6.tgz",
+      "integrity": "sha512-6lvjbS3p9b4CrdCmguzbh2/4uoXhGE2q71R4OX5sqF9R1bo9Xd6fGrMAfvp5wnCzlBnFVdCOp6onuTQVbo8iUQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "@types/chai": "^5.2.2",
-        "@vitest/expect": "3.2.4",
-        "@vitest/mocker": "3.2.4",
-        "@vitest/pretty-format": "^3.2.4",
-        "@vitest/runner": "3.2.4",
-        "@vitest/snapshot": "3.2.4",
-        "@vitest/spy": "3.2.4",
-        "@vitest/utils": "3.2.4",
-        "chai": "^5.2.0",
-        "debug": "^4.4.1",
-        "expect-type": "^1.2.1",
-        "magic-string": "^0.30.17",
+        "@vitest/expect": "4.1.6",
+        "@vitest/mocker": "4.1.6",
+        "@vitest/pretty-format": "4.1.6",
+        "@vitest/runner": "4.1.6",
+        "@vitest/snapshot": "4.1.6",
+        "@vitest/spy": "4.1.6",
+        "@vitest/utils": "4.1.6",
+        "es-module-lexer": "^2.0.0",
+        "expect-type": "^1.3.0",
+        "magic-string": "^0.30.21",
+        "obug": "^2.1.1",
         "pathe": "^2.0.3",
-        "picomatch": "^4.0.2",
-        "std-env": "^3.9.0",
+        "picomatch": "^4.0.3",
+        "std-env": "^4.0.0-rc.1",
         "tinybench": "^2.9.0",
-        "tinyexec": "^0.3.2",
-        "tinyglobby": "^0.2.14",
-        "tinypool": "^1.1.1",
-        "tinyrainbow": "^2.0.0",
-        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
-        "vite-node": "3.2.4",
+        "tinyexec": "^1.0.2",
+        "tinyglobby": "^0.2.15",
+        "tinyrainbow": "^3.1.0",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0",
         "why-is-node-running": "^2.3.0"
       },
       "bin": {
         "vitest": "vitest.mjs"
       },
       "engines": {
-        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+        "node": "^20.0.0 || ^22.0.0 || >=24.0.0"
       },
       "funding": {
         "url": "https://opencollective.com/vitest"
       },
       "peerDependencies": {
         "@edge-runtime/vm": "*",
-        "@types/debug": "^4.1.12",
-        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
-        "@vitest/browser": "3.2.4",
-        "@vitest/ui": "3.2.4",
+        "@opentelemetry/api": "^1.9.0",
+        "@types/node": "^20.0.0 || ^22.0.0 || >=24.0.0",
+        "@vitest/browser-playwright": "4.1.6",
+        "@vitest/browser-preview": "4.1.6",
+        "@vitest/browser-webdriverio": "4.1.6",
+        "@vitest/coverage-istanbul": "4.1.6",
+        "@vitest/coverage-v8": "4.1.6",
+        "@vitest/ui": "4.1.6",
         "happy-dom": "*",
-        "jsdom": "*"
+        "jsdom": "*",
+        "vite": "^6.0.0 || ^7.0.0 || ^8.0.0"
       },
       "peerDependenciesMeta": {
         "@edge-runtime/vm": {
           "optional": true
         },
-        "@types/debug": {
+        "@opentelemetry/api": {
           "optional": true
         },
         "@types/node": {
           "optional": true
         },
-        "@vitest/browser": {
+        "@vitest/browser-playwright": {
+          "optional": true
+        },
+        "@vitest/browser-preview": {
+          "optional": true
+        },
+        "@vitest/browser-webdriverio": {
+          "optional": true
+        },
+        "@vitest/coverage-istanbul": {
+          "optional": true
+        },
+        "@vitest/coverage-v8": {
           "optional": true
         },
         "@vitest/ui": {
@@ -1593,6 +1243,9 @@
         },
         "jsdom": {
           "optional": true
+        },
+        "vite": {
+          "optional": false
         }
       }
     },

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -283,6 +283,64 @@ describe("pinchy-web plugin", () => {
       expect(result.content[0].text).toContain("API rate limit");
     });
 
+    it("POSTs report-auth-failure when retry-once also returns a 401 from Brave", async () => {
+      braveSearchMock
+        .mockRejectedValueOnce(new Error("401 Unauthorized"))
+        .mockRejectedValueOnce(new Error("401 Unauthorized"));
+
+      const fetchMock = vi.fn(async () => ({
+        ok: true,
+        status: 200,
+        statusText: "OK",
+        json: async () => ({ credentials: { apiKey: "brave-key-123" } }),
+      }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"] },
+        }),
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      await tool.execute("call-1", { query: "test" });
+
+      const reportCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("report-auth-failure"),
+      );
+      expect(reportCalls).toHaveLength(1);
+      const [url, opts] = reportCalls[0] as [string, RequestInit];
+      expect(url).toBe(
+        "https://pinchy.test/api/internal/integrations/conn-1/report-auth-failure",
+      );
+      expect(opts.method).toBe("POST");
+      const headers = opts.headers as Record<string, string>;
+      expect(headers["Authorization"]).toBe("Bearer gw-token");
+      expect(headers["X-Plugin-Id"]).toBe("pinchy-web");
+      const body = JSON.parse(opts.body as string) as { reason: string };
+      expect(body.reason).toBeTruthy();
+    });
+
+    it("does not POST report-auth-failure on a transient 5xx error from Brave", async () => {
+      braveSearchMock.mockRejectedValueOnce(new Error("503 Service Unavailable"));
+
+      const fetchMock = stubCredentialsFetch("brave-key-123");
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"] },
+        }),
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      await tool.execute("call-1", { query: "test" });
+
+      const reportCalls = fetchMock.mock.calls.filter((c) =>
+        String(c[0]).includes("report-auth-failure"),
+      );
+      expect(reportCalls).toHaveLength(0);
+    });
+
     it("handles non-Error throws from braveSearch", async () => {
       braveSearchMock.mockRejectedValue("string error");
       stubCredentialsFetch("brave-key-123");

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -87,6 +87,38 @@ async function fetchBraveCredentials(
   return data.credentials;
 }
 
+/**
+ * Best-effort POST to Pinchy's report-auth-failure endpoint when a
+ * retry-once cycle fails with a permanent auth error. This lets Pinchy
+ * surface a clear "re-authorise" banner to admins rather than requiring
+ * them to trawl through agent error messages.
+ *
+ * Errors are swallowed — never mask the original tool error.
+ */
+async function reportAuthFailure(
+  apiBaseUrl: string,
+  connectionId: string,
+  gatewayToken: string,
+  reason: string,
+): Promise<void> {
+  try {
+    await fetch(
+      `${apiBaseUrl}/api/internal/integrations/${connectionId}/report-auth-failure`,
+      {
+        method: "POST",
+        headers: {
+          Authorization: `Bearer ${gatewayToken}`,
+          "Content-Type": "application/json",
+          "X-Plugin-Id": "pinchy-web",
+        },
+        body: JSON.stringify({ reason: reason.slice(0, 500) }),
+      },
+    );
+  } catch {
+    // best-effort — never mask the original tool error
+  }
+}
+
 const plugin = {
   id: "pinchy-web",
   name: "Pinchy Web",
@@ -133,7 +165,13 @@ const plugin = {
         }
         invalidateCache();
         const fresh = await getBraveApiKey();
-        return fn(fresh);
+        try {
+          return await fn(fresh);
+        } catch (retryErr) {
+          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
+          await reportAuthFailure(apiBaseUrl, connectionId, gatewayToken, retryMsg);
+          throw retryErr;
+        }
       }
     }
 

--- a/packages/web/drizzle/0034_auth_failed_integration_columns.sql
+++ b/packages/web/drizzle/0034_auth_failed_integration_columns.sql
@@ -1,0 +1,2 @@
+ALTER TABLE "integration_connections" ADD COLUMN "last_error" text;
+ALTER TABLE "integration_connections" ADD COLUMN "last_error_at" timestamp;

--- a/packages/web/drizzle/meta/0034_snapshot.json
+++ b/packages/web/drizzle/meta/0034_snapshot.json
@@ -1,0 +1,1536 @@
+{
+  "id": "3889c468-81ac-4fd9-bc54-e13493bef106",
+  "prevId": "63c5ef0b-d550-4a39-915b-a97b842046d3",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -239,6 +239,13 @@
       "when": 1779412800000,
       "tag": "0033_remove_implicit_filesystem_tools",
       "breakpoints": true
+    },
+    {
+      "idx": 34,
+      "version": "7",
+      "when": 1779412860000,
+      "tag": "0034_auth_failed_integration_columns",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/e2e/odoo/helpers.ts
+++ b/packages/web/e2e/odoo/helpers.ts
@@ -75,6 +75,20 @@ export async function resetOdooMock(): Promise<void> {
   if (!res.ok) throw new Error(`Failed to reset Odoo mock: ${res.status}`);
 }
 
+/**
+ * Toggle auth failure mode on the Odoo mock.
+ * In "fail" mode the mock returns uid=false (auth rejected) for all authenticate calls.
+ * Call setOdooAuthMode("ok") to restore normal behavior.
+ */
+export async function setOdooAuthMode(mode: "ok" | "fail"): Promise<void> {
+  const res = await fetch(`${MOCK_ODOO_URL}/control/auth-mode`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ mode }),
+  });
+  if (!res.ok) throw new Error(`Failed to set Odoo auth mode: ${res.status}`);
+}
+
 export async function seedOdooRecords(
   model: string,
   records: Record<string, unknown>[]

--- a/packages/web/e2e/odoo/odoo-auth-failed.spec.ts
+++ b/packages/web/e2e/odoo/odoo-auth-failed.spec.ts
@@ -1,0 +1,153 @@
+import { test, expect, type Page } from "@playwright/test";
+import {
+  seedSetup,
+  waitForPinchy,
+  waitForOdooMock,
+  resetOdooMock,
+  setOdooAuthMode,
+  login,
+  createOdooConnection,
+  pinchyGet,
+  pinchyDelete,
+  getAdminEmail,
+  getAdminPassword,
+} from "./helpers";
+
+const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
+
+async function loginViaUI(page: Page) {
+  await page.goto("/login");
+  await page.getByLabel(/email/i).fill(getAdminEmail());
+  await page.getByLabel("Password", { exact: true }).fill(getAdminPassword());
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page).not.toHaveURL(/\/login/, { timeout: 15000 });
+}
+
+async function deleteAllConnections(cookie: string) {
+  const res = await pinchyGet("/api/integrations", cookie);
+  if (!res.ok) return;
+  const connections = await res.json();
+  for (const conn of connections) {
+    await pinchyDelete(`/api/integrations/${conn.id}`, cookie);
+  }
+}
+
+test.describe.serial("Odoo auth_failed flow", () => {
+  let cookie: string;
+  let connectionId: string;
+
+  test.beforeAll(async () => {
+    await seedSetup();
+    await waitForPinchy();
+    await waitForOdooMock();
+    await resetOdooMock();
+    cookie = await login();
+    // Clean slate
+    await deleteAllConnections(cookie);
+
+    // Create a fresh Odoo connection (auth is OK at this point)
+    const connRes = await createOdooConnection(cookie, "Auth-Failed Test Odoo");
+    if (connRes.status !== 201) {
+      throw new Error(`Failed to create Odoo connection: ${connRes.status}`);
+    }
+    const conn = await connRes.json();
+    connectionId = conn.id;
+
+    // Trigger an initial sync so the card shows "Connected"
+    await fetch(`${PINCHY_URL}/api/integrations/${connectionId}/sync`, {
+      method: "POST",
+      headers: { Cookie: cookie, Origin: PINCHY_URL },
+    });
+    await new Promise((r) => setTimeout(r, 2000));
+  });
+
+  test.afterAll(async () => {
+    // Always restore auth mode so other test suites are not affected
+    await setOdooAuthMode("ok").catch(() => {});
+    await deleteAllConnections(cookie).catch(() => {});
+  });
+
+  test("auth_failed: sync failure updates card status and sidebar badge appears", async ({
+    page,
+  }) => {
+    await loginViaUI(page);
+
+    // Navigate to integrations settings
+    await page.goto("/settings?tab=integrations");
+
+    // Verify the card is initially Connected
+    const integrationsPanel = page.getByRole("tabpanel");
+    await expect(integrationsPanel.getByText("Connected")).toBeVisible({ timeout: 10000 });
+
+    // Switch mock to fail mode so the next sync returns auth rejected
+    await setOdooAuthMode("fail");
+
+    // Open the card's dropdown and trigger Sync Schema
+    const connectionCard = integrationsPanel.locator(".rounded-lg.border.p-4").first();
+    await connectionCard.locator("[data-slot='dropdown-menu-trigger']").click();
+    await page.getByRole("menuitem", { name: /sync schema/i }).click();
+
+    // The sync hook shows a toast.error on failure
+    // Wait for the card status to update to "Authentication failed"
+    await expect(integrationsPanel.getByText("Authentication failed")).toBeVisible({
+      timeout: 20000,
+    });
+
+    // The sidebar "!" badge should appear on the Settings link
+    // (useIntegrationHealth polls /api/integrations/health)
+    // Force a page reload so the sidebar health badge re-fetches
+    await page.reload();
+    await page.goto("/settings?tab=integrations");
+
+    const settingsLink = page.getByRole("link", { name: /settings/i });
+    const badge = settingsLink.locator('[aria-label^="1 integration"]');
+    await expect(badge).toBeVisible({ timeout: 15000 });
+
+    // Restore auth mode so the reconnect can succeed
+    await setOdooAuthMode("ok");
+
+    // Open the card dropdown and click "Reconnect"
+    const cardAfterFail = integrationsPanel.locator(".rounded-lg.border.p-4").first();
+    await cardAfterFail.locator("[data-slot='dropdown-menu-trigger']").click();
+    await page.getByRole("menuitem", { name: /reconnect/i }).click();
+
+    // Edit credentials dialog opens
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible({ timeout: 5000 });
+
+    // The auth_failed alert hint should be visible in the dialog
+    await expect(dialog.getByText(/current credentials failed authentication/i)).toBeVisible({
+      timeout: 5000,
+    });
+
+    // Fill in the (valid) API key and submit
+    await dialog.getByLabel("API Key").fill("test-api-key");
+    await dialog.getByRole("button", { name: /^save$/i }).click();
+
+    // Success toast appears
+    await expect(page.getByText("Credentials updated")).toBeVisible({ timeout: 10000 });
+
+    // Dialog closes
+    await expect(dialog).not.toBeVisible({ timeout: 5000 });
+
+    // Trigger a sync to clear auth_failed status in DB and on the card
+    await fetch(`${PINCHY_URL}/api/integrations/${connectionId}/sync`, {
+      method: "POST",
+      headers: { Cookie: cookie, Origin: PINCHY_URL },
+    });
+    await new Promise((r) => setTimeout(r, 2000));
+
+    // Reload to pick up fresh state
+    await page.reload();
+    await page.goto("/settings?tab=integrations");
+
+    // Card should show "Connected" again (no auth_failed)
+    await expect(integrationsPanel.getByText("Connected")).toBeVisible({ timeout: 15000 });
+    await expect(integrationsPanel.getByText("Authentication failed")).not.toBeVisible();
+
+    // Sidebar badge should be gone
+    await expect(
+      page.getByRole("link", { name: /settings/i }).locator('[aria-label^="1 integration"]')
+    ).not.toBeVisible();
+  });
+});

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -82,6 +82,7 @@ vi.mock("@/db/schema", () => ({
 
 vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+  and: vi.fn((...args: unknown[]) => ({ and: args })),
 }));
 
 vi.mock("@/lib/integrations/odoo-schema", () => {
@@ -263,5 +264,30 @@ describe("PATCH /api/integrations/[connectionId] — credential probe", () => {
     expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
       expect.objectContaining({ eventType: "integration.credentials_updated" })
     );
+  });
+
+  it("returns 409 when credentials were updated concurrently (optimistic lock)", async () => {
+    // Simulate concurrent update: db.update returns 0 rows
+    mockUpdateSet.mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([]),
+      }),
+    });
+
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    const response = await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({ credentials: validOdooCredentials }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(409);
+    expect(body.error).toMatch(/concurrent/i);
+    // Probe still ran before the write
+    expect(mockProbeIntegrationCredentials).toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -192,6 +192,51 @@ describe("PATCH /api/integrations/[connectionId] — credential probe", () => {
         outcome: "success",
       })
     );
+    // ONLY the credentials_updated audit fires for a credentials-only PATCH.
+    // We deliberately do NOT emit an additional integration.updated event for
+    // the credentials field — that would produce two audit rows per mutation
+    // and force CISO filters to deduplicate.
+    expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "integration.updated" })
+    );
+  });
+
+  it("PATCH with both name AND credentials emits BOTH integration.updated and integration.credentials_updated", async () => {
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({
+          name: "Renamed Odoo",
+          credentials: { ...validOdooCredentials, apiKey: "rotated-key" },
+        }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+
+    // integration.updated for the name change
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "integration.updated",
+        detail: expect.objectContaining({
+          changes: expect.objectContaining({ name: { from: "Test Odoo", to: "Renamed Odoo" } }),
+        }),
+      })
+    );
+    // The integration.updated diff must NOT include credentials — that gets
+    // its own dedicated event so the change types stay separable in the log.
+    const updatedCall = mockAppendAuditLog.mock.calls.find(
+      (c) => (c[0] as { eventType?: string }).eventType === "integration.updated"
+    );
+    const updatedDetail = (updatedCall?.[0] as { detail: { changes: Record<string, unknown> } })
+      .detail;
+    expect(updatedDetail.changes).not.toHaveProperty("credentials");
+
+    // Separate integration.credentials_updated event still fires
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "integration.credentials_updated" })
+    );
   });
 
   it("PATCH with bad new credentials returns 400 with reason and writes nothing", async () => {

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -266,6 +266,36 @@ describe("PATCH /api/integrations/[connectionId] — credential probe", () => {
     );
   });
 
+  it("persists freshCredentials returned by probe (e.g. new uid after login change)", async () => {
+    // When the user changes their Odoo login, the stored uid becomes stale.
+    // The probe re-authenticates and returns the fresh uid; the route must
+    // merge that into the encrypted credentials so future syncs use it.
+    mockProbeIntegrationCredentials.mockResolvedValue({
+      success: true,
+      freshCredentials: { uid: 99 },
+    });
+
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({
+          credentials: { ...validOdooCredentials, login: "new-user", apiKey: "new-key" },
+        }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+
+    // encrypt() must have been called with JSON containing the FRESH uid (99),
+    // not the stale stored uid (2).
+    const encryptedPayload = mockEncrypt.mock.calls[0]?.[0] as string;
+    const persistedCreds = JSON.parse(encryptedPayload);
+    expect(persistedCreds.uid).toBe(99);
+    expect(persistedCreds.login).toBe("new-user");
+    expect(persistedCreds.apiKey).toBe("new-key");
+  });
+
   it("returns 409 when credentials were updated concurrently (optimistic lock)", async () => {
     // Simulate concurrent update: db.update returns 0 rows
     mockUpdateSet.mockReturnValueOnce({

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -1,0 +1,258 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+const mockEncrypt = vi.fn().mockReturnValue("encrypted-creds");
+const mockDecrypt = vi.fn().mockReturnValue(
+  JSON.stringify({
+    url: "https://odoo.example.com",
+    db: "prod",
+    login: "admin",
+    apiKey: "secret-key",
+    uid: 2,
+  })
+);
+vi.mock("@/lib/encryption", () => ({
+  encrypt: (...args: unknown[]) => mockEncrypt(...args),
+  decrypt: (...args: unknown[]) => mockDecrypt(...args),
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+const mockAppendAuditLog = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
+}));
+
+const mockProbeIntegrationCredentials = vi.fn();
+vi.mock("@/lib/integrations/probe", () => ({
+  probeIntegrationCredentials: (...args: unknown[]) => mockProbeIntegrationCredentials(...args),
+}));
+
+const mockClearIntegrationAuthError = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/integrations/auth-state", () => ({
+  clearIntegrationAuthError: (...args: unknown[]) => mockClearIntegrationAuthError(...args),
+  setIntegrationAuthFailed: vi.fn().mockResolvedValue(undefined),
+}));
+
+const { mockUpdateSet, mockSelectWhere } = vi.hoisted(() => ({
+  mockUpdateSet: vi.fn(),
+  mockSelectWhere: vi.fn(),
+}));
+
+const mockOdooConnection = {
+  id: "conn-1",
+  type: "odoo",
+  name: "Test Odoo",
+  description: "Test connection",
+  credentials: "encrypted-creds",
+  data: null,
+  status: "active",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: mockUpdateSet.mockReturnValue({
+        where: vi.fn().mockReturnValue({
+          returning: vi.fn().mockResolvedValue([{ ...mockOdooConnection, name: "Test Odoo" }]),
+        }),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+}));
+
+vi.mock("@/lib/integrations/odoo-schema", () => ({
+  odooCredentialsSchema: {
+    safeParse: (data: unknown) => {
+      const d = data as Record<string, unknown>;
+      if (
+        typeof d.url === "string" &&
+        d.url.startsWith("https://") &&
+        d.db &&
+        d.login &&
+        d.apiKey
+      ) {
+        return { success: true, data: d };
+      }
+      return { success: false, error: { errors: [{ message: "Invalid credentials" }] } };
+    },
+  },
+}));
+
+vi.mock("@/lib/integrations/url-validation", () => ({
+  validateExternalUrl: (url: string) => {
+    if (url.startsWith("https://")) return { valid: true };
+    return { valid: false, error: "URL must use HTTPS" };
+  },
+}));
+
+vi.mock("@/lib/integrations/mask-credentials", () => ({
+  maskConnectionCredentials: (_type: string, _creds: unknown, _decrypt: unknown) => ({
+    url: "https://odoo.example.com",
+    db: "prod",
+    login: "admin",
+  }),
+}));
+
+vi.mock("@/lib/integrations/oauth-settings", () => ({
+  deleteOAuthSettings: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { NextRequest } from "next/server";
+
+function makeRequest(path: string, options?: RequestInit) {
+  return new NextRequest(`http://localhost:7777${path}`, options);
+}
+
+const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
+
+const validOdooCredentials = {
+  url: "https://odoo.example.com",
+  db: "prod",
+  login: "admin",
+  apiKey: "secret-key",
+  uid: 2,
+};
+
+describe("PATCH /api/integrations/[connectionId] — credential probe", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+    mockSelectWhere.mockResolvedValue([mockOdooConnection]);
+    mockProbeIntegrationCredentials.mockResolvedValue({ success: true });
+    mockDecrypt.mockReturnValue(JSON.stringify(validOdooCredentials));
+    mockEncrypt.mockReturnValue("encrypted-creds");
+  });
+
+  it("PATCH with new credentials probes upstream and updates on success", async () => {
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    const newCredentials = { ...validOdooCredentials, apiKey: "new-secret-key" };
+    const response = await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({ credentials: newCredentials }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+
+    expect(response.status).toBe(200);
+    // Probe was called with merged credentials
+    expect(mockProbeIntegrationCredentials).toHaveBeenCalledWith(
+      "odoo",
+      expect.objectContaining({ apiKey: "new-secret-key" })
+    );
+    // DB update was called
+    expect(mockUpdateSet).toHaveBeenCalled();
+    // clearIntegrationAuthError was called
+    expect(mockClearIntegrationAuthError).toHaveBeenCalledWith(
+      expect.objectContaining({ connectionId: "conn-1" })
+    );
+    // Audit log for credentials_updated was written with fields
+    expect(mockAppendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "integration.credentials_updated",
+        resource: "integration:conn-1",
+        detail: expect.objectContaining({
+          fields: expect.arrayContaining(["apiKey"]),
+        }),
+        outcome: "success",
+      })
+    );
+  });
+
+  it("PATCH with bad new credentials returns 400 with reason and writes nothing", async () => {
+    mockProbeIntegrationCredentials.mockResolvedValue({
+      success: false,
+      reason: "Access denied",
+    });
+
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    const response = await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({ credentials: validOdooCredentials }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toContain("Access denied");
+    // db.update should NOT have been called
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it("PATCH on google connection rejects credentials field", async () => {
+    const googleConnection = {
+      ...mockOdooConnection,
+      id: "conn-google-1",
+      type: "google",
+    };
+    mockSelectWhere.mockResolvedValueOnce([googleConnection]);
+
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    const response = await PATCH(
+      makeRequest("/api/integrations/conn-google-1", {
+        method: "PATCH",
+        body: JSON.stringify({ credentials: { accessToken: "x" } }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-google-1" }) }
+    );
+    const body = await response.json();
+
+    expect(response.status).toBe(400);
+    expect(body.error).toMatch(/Google|OAuth|Reconnect/i);
+    // Probe should not have been called
+    expect(mockProbeIntegrationCredentials).not.toHaveBeenCalled();
+    // DB update should not have been called
+    expect(mockUpdateSet).not.toHaveBeenCalled();
+  });
+
+  it("PATCH with only name (no credentials) skips probe and updates normally", async () => {
+    const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
+
+    const response = await PATCH(
+      makeRequest("/api/integrations/conn-1", {
+        method: "PATCH",
+        body: JSON.stringify({ name: "New Name" }),
+      }),
+      { params: Promise.resolve({ connectionId: "conn-1" }) }
+    );
+
+    expect(response.status).toBe(200);
+    // Probe should NOT have been called
+    expect(mockProbeIntegrationCredentials).not.toHaveBeenCalled();
+    // DB update was still called (for name change)
+    expect(mockUpdateSet).toHaveBeenCalled();
+    // No credentials_updated audit log
+    expect(mockAppendAuditLog).not.toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "integration.credentials_updated" })
+    );
+  });
+});

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -84,8 +84,16 @@ vi.mock("drizzle-orm", () => ({
   eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
 }));
 
-vi.mock("@/lib/integrations/odoo-schema", () => ({
-  odooCredentialsSchema: {
+vi.mock("@/lib/integrations/odoo-schema", () => {
+  // The route calls odooCredentialsSchema.partial() to allow partial updates.
+  // The partial schema accepts any subset of odoo fields (no required fields check).
+  const partialSchema = {
+    safeParse: (data: unknown) => {
+      return { success: true, data };
+    },
+  };
+  const odooCredentialsSchema = {
+    partial: () => partialSchema,
     safeParse: (data: unknown) => {
       const d = data as Record<string, unknown>;
       if (
@@ -99,8 +107,9 @@ vi.mock("@/lib/integrations/odoo-schema", () => ({
       }
       return { success: false, error: { errors: [{ message: "Invalid credentials" }] } };
     },
-  },
-}));
+  };
+  return { odooCredentialsSchema };
+});
 
 vi.mock("@/lib/integrations/url-validation", () => ({
   validateExternalUrl: (url: string) => {

--- a/packages/web/src/__tests__/api/integration-sync-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-sync-route.test.ts
@@ -137,10 +137,11 @@ describe("POST /api/integrations/[connectionId]/sync — auth state flipping", (
     expect(mockSetIntegrationAuthFailed).not.toHaveBeenCalled();
   });
 
-  it("calls setIntegrationAuthFailed when fetchOdooSchema returns failure", async () => {
+  it("calls setIntegrationAuthFailed when fetchOdooSchema returns failure with isAuthError: true", async () => {
     mockFetchOdooSchema.mockResolvedValue({
       success: false,
       error: "Could not access any Odoo models.",
+      isAuthError: true,
     });
 
     const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
@@ -160,7 +161,27 @@ describe("POST /api/integrations/[connectionId]/sync — auth state flipping", (
     expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
   });
 
-  it("calls setIntegrationAuthFailed when fetchOdooSchema throws", async () => {
+  it("does NOT call setIntegrationAuthFailed when fetchOdooSchema returns isAuthError: false", async () => {
+    mockFetchOdooSchema.mockResolvedValue({
+      success: false,
+      error: "Could not access any Odoo models.",
+      isAuthError: false,
+    });
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/sync"), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(mockSetIntegrationAuthFailed).not.toHaveBeenCalled();
+    expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
+  });
+
+  it("does NOT call setIntegrationAuthFailed when fetchOdooSchema throws (transient error)", async () => {
     mockFetchOdooSchema.mockRejectedValue(new Error("Network timeout"));
 
     const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
@@ -173,11 +194,7 @@ describe("POST /api/integrations/[connectionId]/sync — auth state flipping", (
     expect(response.status).toBe(200);
     expect(body.success).toBe(false);
     expect(body.error).toBe("Network timeout");
-    expect(mockSetIntegrationAuthFailed).toHaveBeenCalledWith({
-      connectionId: "conn-1",
-      reason: "Network timeout",
-      actor: { type: "user", id: "user-1" },
-    });
+    expect(mockSetIntegrationAuthFailed).not.toHaveBeenCalled();
     expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/api/integration-sync-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-sync-route.test.ts
@@ -1,0 +1,183 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+const mockDecrypt = vi.fn();
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (...args: unknown[]) => mockDecrypt(...args),
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+const mockSelectWhere = vi.fn();
+const mockUpdateWhere = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: mockUpdateWhere,
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+}));
+
+const mockFetchOdooSchema = vi.fn();
+vi.mock("@/lib/integrations/odoo-sync", () => ({
+  fetchOdooSchema: (...args: unknown[]) => mockFetchOdooSchema(...args),
+}));
+
+vi.mock("@/lib/integrations/odoo-schema", () => ({
+  odooCredentialsSchema: {
+    safeParse: vi.fn().mockReturnValue({
+      success: true,
+      data: {
+        url: "https://odoo.example.com",
+        db: "prod",
+        login: "admin",
+        apiKey: "secret-key",
+        uid: 2,
+      },
+    }),
+  },
+}));
+
+vi.mock("@/lib/integrations/url-validation", () => ({
+  validateExternalUrl: vi.fn().mockReturnValue({ valid: true }),
+}));
+
+const mockClearIntegrationAuthError = vi.fn();
+const mockSetIntegrationAuthFailed = vi.fn();
+vi.mock("@/lib/integrations/auth-state", () => ({
+  clearIntegrationAuthError: (...args: unknown[]) => mockClearIntegrationAuthError(...args),
+  setIntegrationAuthFailed: (...args: unknown[]) => mockSetIntegrationAuthFailed(...args),
+}));
+
+vi.mock("@/lib/audit-deferred", () => ({
+  deferAuditLog: vi.fn(),
+}));
+
+import { NextRequest } from "next/server";
+
+const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
+
+const mockConnection = {
+  id: "conn-1",
+  type: "odoo",
+  name: "Test Odoo",
+  credentials: "encrypted-creds",
+  status: "active",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+const decryptedOdooCreds = {
+  url: "https://odoo.example.com",
+  db: "prod",
+  login: "admin",
+  apiKey: "secret-key",
+  uid: 2,
+};
+
+function makeRequest(path: string) {
+  return new NextRequest(`http://localhost:7777${path}`, { method: "POST" });
+}
+
+describe("POST /api/integrations/[connectionId]/sync — auth state flipping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+    mockDecrypt.mockReturnValue(JSON.stringify(decryptedOdooCreds));
+    mockSelectWhere.mockResolvedValue([mockConnection]);
+    mockClearIntegrationAuthError.mockResolvedValue(undefined);
+    mockSetIntegrationAuthFailed.mockResolvedValue(undefined);
+  });
+
+  it("calls clearIntegrationAuthError when fetchOdooSchema returns success", async () => {
+    mockFetchOdooSchema.mockResolvedValue({
+      success: true,
+      models: 5,
+      lastSyncAt: "2026-05-11T00:00:00.000Z",
+      categories: [],
+      data: { models: [], lastSyncAt: "2026-05-11T00:00:00.000Z" },
+    });
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/sync"), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockClearIntegrationAuthError).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      actor: { type: "user", id: "user-1" },
+    });
+    expect(mockSetIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+
+  it("calls setIntegrationAuthFailed when fetchOdooSchema returns failure", async () => {
+    mockFetchOdooSchema.mockResolvedValue({
+      success: false,
+      error: "Could not access any Odoo models.",
+    });
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/sync"), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(mockSetIntegrationAuthFailed).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      reason: "Could not access any Odoo models.",
+      actor: { type: "user", id: "user-1" },
+    });
+    expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
+  });
+
+  it("calls setIntegrationAuthFailed when fetchOdooSchema throws", async () => {
+    mockFetchOdooSchema.mockRejectedValue(new Error("Network timeout"));
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/sync/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/sync"), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Network timeout");
+    expect(mockSetIntegrationAuthFailed).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      reason: "Network timeout",
+      actor: { type: "user", id: "user-1" },
+    });
+    expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/api/integration-test-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-test-route.test.ts
@@ -1,0 +1,158 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+const mockDecrypt = vi.fn();
+const mockEncrypt = vi.fn().mockReturnValue("encrypted-creds");
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (...args: unknown[]) => mockDecrypt(...args),
+  encrypt: (...args: unknown[]) => mockEncrypt(...args),
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+const mockSelectWhere = vi.fn();
+const mockUpdateSet = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+    update: vi.fn().mockReturnValue({
+      set: mockUpdateSet.mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col: unknown, val: unknown) => ({ col, val })),
+}));
+
+const mockProbeIntegrationCredentials = vi.fn();
+vi.mock("@/lib/integrations/probe", () => ({
+  probeIntegrationCredentials: (...args: unknown[]) => mockProbeIntegrationCredentials(...args),
+}));
+
+const mockClearIntegrationAuthError = vi.fn();
+const mockSetIntegrationAuthFailed = vi.fn();
+vi.mock("@/lib/integrations/auth-state", () => ({
+  clearIntegrationAuthError: (...args: unknown[]) => mockClearIntegrationAuthError(...args),
+  setIntegrationAuthFailed: (...args: unknown[]) => mockSetIntegrationAuthFailed(...args),
+}));
+
+// odoo-node mock (needed because route still imports OdooClient for uid self-heal)
+vi.mock("odoo-node", () => {
+  function OdooClient() {}
+  OdooClient.authenticate = vi.fn().mockResolvedValue(2);
+  return { OdooClient };
+});
+
+vi.mock("@/lib/integrations/odoo-schema", () => ({
+  odooCredentialsSchema: {
+    safeParse: vi.fn().mockReturnValue({
+      success: true,
+      data: {
+        url: "https://odoo.example.com",
+        db: "prod",
+        login: "admin",
+        apiKey: "secret-key",
+        uid: 2,
+      },
+    }),
+  },
+}));
+
+import { NextRequest } from "next/server";
+
+const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
+
+const mockConnection = {
+  id: "conn-1",
+  type: "odoo",
+  name: "Test Odoo",
+  credentials: "encrypted-creds",
+  status: "active",
+  createdAt: new Date("2026-01-01"),
+  updatedAt: new Date("2026-01-01"),
+};
+
+const decryptedOdooCreds = {
+  url: "https://odoo.example.com",
+  db: "prod",
+  login: "admin",
+  apiKey: "secret-key",
+  uid: 2,
+};
+
+function makeRequest(path: string, options?: RequestInit) {
+  return new NextRequest(`http://localhost:7777${path}`, options);
+}
+
+describe("POST /api/integrations/[connectionId]/test — auth state flipping", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+    mockDecrypt.mockReturnValue(JSON.stringify(decryptedOdooCreds));
+    mockSelectWhere.mockResolvedValue([mockConnection]);
+    mockClearIntegrationAuthError.mockResolvedValue(undefined);
+    mockSetIntegrationAuthFailed.mockResolvedValue(undefined);
+  });
+
+  it("calls clearIntegrationAuthError with connectionId and actor when probe succeeds", async () => {
+    mockProbeIntegrationCredentials.mockResolvedValue({ success: true });
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/test", { method: "POST" }), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(true);
+    expect(mockClearIntegrationAuthError).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      actor: { type: "user", id: "user-1" },
+    });
+    expect(mockSetIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+
+  it("calls setIntegrationAuthFailed with connectionId, reason, and actor when probe fails", async () => {
+    mockProbeIntegrationCredentials.mockResolvedValue({
+      success: false,
+      reason: "Authentication failed",
+    });
+
+    const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
+
+    const response = await POST(makeRequest("/api/integrations/conn-1/test", { method: "POST" }), {
+      params: Promise.resolve({ connectionId: "conn-1" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.success).toBe(false);
+    expect(body.error).toBe("Authentication failed");
+    expect(mockSetIntegrationAuthFailed).toHaveBeenCalledWith({
+      connectionId: "conn-1",
+      reason: "Authentication failed",
+      actor: { type: "user", id: "user-1" },
+    });
+    expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/api/integrations-health.test.ts
+++ b/packages/web/src/__tests__/api/integrations-health.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: (...args: unknown[]) => mockGetSession(...args) } },
+}));
+
+// Mock db
+const mockSelectWhere = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: mockSelectWhere,
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  integrationConnections: { status: "status" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+  sql: vi.fn().mockReturnValue("count_sql"),
+}));
+
+import { NextRequest } from "next/server";
+
+const adminSession = { user: { id: "u1", email: "admin@test.com", role: "admin" } };
+
+function makeRequest() {
+  return new NextRequest("http://localhost:7777/api/integrations/health");
+}
+
+describe("GET /api/integrations/health", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+  });
+
+  it("returns { authFailedCount: N }", async () => {
+    mockSelectWhere.mockResolvedValue([{ count: 2 }]);
+    const { GET } = await import("@/app/api/integrations/health/route");
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body).toEqual({ authFailedCount: 2 });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns { authFailedCount: 0 } when none failed", async () => {
+    mockSelectWhere.mockResolvedValue([{ count: 0 }]);
+    const { GET } = await import("@/app/api/integrations/health/route");
+    const res = await GET(makeRequest());
+    const body = await res.json();
+    expect(body).toEqual({ authFailedCount: 0 });
+  });
+
+  it("returns 403 for non-admin authenticated user", async () => {
+    mockGetSession.mockResolvedValue({ user: { id: "u2", role: "user" } });
+    const { GET } = await import("@/app/api/integrations/health/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(403);
+  });
+
+  it("returns 401 for unauthenticated request", async () => {
+    mockGetSession.mockResolvedValue(null);
+    const { GET } = await import("@/app/api/integrations/health/route");
+    const res = await GET(makeRequest());
+    expect(res.status).toBe(401);
+  });
+});

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -432,9 +432,8 @@ describe("POST /api/integrations", () => {
       expect.objectContaining({
         actorType: "user",
         actorId: "user-1",
-        eventType: "config.changed",
+        eventType: "integration.created",
         detail: expect.objectContaining({
-          action: "integration_created",
           type: "odoo",
           name: "Prod Odoo",
         }),
@@ -611,9 +610,8 @@ describe("PATCH /api/integrations/[connectionId]", () => {
     expect(mockUpdateSet).toHaveBeenCalledWith(expect.objectContaining({ name: "Updated Odoo" }));
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventType: "config.changed",
+        eventType: "integration.updated",
         detail: expect.objectContaining({
-          action: "integration_updated",
           id: "conn-1",
           changes: expect.objectContaining({
             name: { from: "Test Odoo", to: "Updated Odoo" },
@@ -773,9 +771,9 @@ describe("DELETE /api/integrations/[connectionId]", () => {
     expect(mockDeleteWhere).toHaveBeenCalled();
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventType: "config.changed",
+        eventType: "integration.deleted",
         detail: expect.objectContaining({
-          action: "integration_deleted",
+          id: "conn-1",
           type: "odoo",
           name: "Test Odoo",
         }),
@@ -1349,9 +1347,8 @@ describe("POST /api/integrations (web-search)", () => {
       expect.objectContaining({
         actorType: "user",
         actorId: "user-1",
-        eventType: "config.changed",
+        eventType: "integration.created",
         detail: expect.objectContaining({
-          action: "integration_created",
           type: "web-search",
           name: "Brave Search",
         }),

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -544,6 +544,8 @@ describe("PATCH /api/integrations/[connectionId]", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
+    // Probe succeeds by default so credential-update tests pass without extra setup
+    mockProbeIntegrationCredentials.mockResolvedValue({ success: true });
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -665,6 +667,8 @@ describe("PATCH /api/integrations/[connectionId]", () => {
       result.where = vi.fn().mockResolvedValue([webSearchConnection]);
       return result;
     });
+    // Existing web-search credentials stored in DB
+    mockDecrypt.mockReturnValueOnce(JSON.stringify({ apiKey: "old-brave-key" }));
 
     const { PATCH } = await import("@/app/api/integrations/[connectionId]/route");
 
@@ -677,6 +681,8 @@ describe("PATCH /api/integrations/[connectionId]", () => {
     );
 
     expect(response.status).toBe(200);
+    // After merging existing { apiKey: "old-brave-key" } with new { apiKey: "new-brave-key" }
+    // the merged result is { apiKey: "new-brave-key" }
     expect(mockEncrypt).toHaveBeenCalledWith(JSON.stringify({ apiKey: "new-brave-key" }));
   });
 

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -117,6 +117,18 @@ vi.mock("@/lib/integrations/oauth-settings", () => ({
   deleteOAuthSettings: (...args: unknown[]) => mockDeleteOAuthSettings(...args),
 }));
 
+const mockProbeIntegrationCredentials = vi.fn();
+vi.mock("@/lib/integrations/probe", () => ({
+  probeIntegrationCredentials: (...args: unknown[]) => mockProbeIntegrationCredentials(...args),
+}));
+
+const mockClearIntegrationAuthError = vi.fn().mockResolvedValue(undefined);
+const mockSetIntegrationAuthFailed = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/integrations/auth-state", () => ({
+  clearIntegrationAuthError: (...args: unknown[]) => mockClearIntegrationAuthError(...args),
+  setIntegrationAuthFailed: (...args: unknown[]) => mockSetIntegrationAuthFailed(...args),
+}));
+
 import { NextRequest } from "next/server";
 
 function makeRequest(path: string, options?: RequestInit) {
@@ -838,7 +850,10 @@ describe("POST /api/integrations/[connectionId]/test", () => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
     mockAuthenticate.mockResolvedValue(2);
-    mockVersion.mockResolvedValue({ serverVersion: "17.0" });
+    // Route now delegates probe to probeIntegrationCredentials
+    mockProbeIntegrationCredentials.mockResolvedValue({ success: true });
+    mockClearIntegrationAuthError.mockResolvedValue(undefined);
+    mockSetIntegrationAuthFailed.mockResolvedValue(undefined);
   });
 
   it("should return 401 when not authenticated", async () => {
@@ -877,7 +892,7 @@ describe("POST /api/integrations/[connectionId]/test", () => {
     expect(response.status).toBe(404);
   });
 
-  it("should authenticate and return version on success", async () => {
+  it("should run the Odoo uid self-heal and return success on valid credentials", async () => {
     const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
 
     const response = await POST(makeRequest("/api/integrations/conn-1/test", { method: "POST" }), {
@@ -887,15 +902,16 @@ describe("POST /api/integrations/[connectionId]/test", () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(body.version).toBe("17.0");
-    expect(body.uid).toBe(2);
+    // Uid self-heal still calls OdooClient.authenticate
     expect(mockAuthenticate).toHaveBeenCalledWith({
       url: "https://odoo.example.com",
       db: "prod",
       login: "admin",
       apiKey: "secret-key",
     });
-    expect(mockVersion).toHaveBeenCalled();
+    // Probe is delegated — version/uid are no longer in the response
+    expect(body.version).toBeUndefined();
+    expect(body.uid).toBeUndefined();
   });
 
   it("should return error when authentication fails", async () => {
@@ -912,17 +928,16 @@ describe("POST /api/integrations/[connectionId]/test", () => {
     expect(body.error).toBe("Authentication failed");
   });
 
-  it("should update uid when it changes", async () => {
+  it("should update stored credentials when uid changes (self-heal)", async () => {
     mockAuthenticate.mockResolvedValueOnce(5);
     const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
 
     const response = await POST(makeRequest("/api/integrations/conn-1/test", { method: "POST" }), {
       params: Promise.resolve({ connectionId: "conn-1" }),
     });
-    const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body.uid).toBe(5);
+    // Re-encryption with updated uid still happens
     expect(mockEncrypt).toHaveBeenCalledWith(
       JSON.stringify({
         url: "https://odoo.example.com",
@@ -936,9 +951,6 @@ describe("POST /api/integrations/[connectionId]/test", () => {
 });
 
 describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
-  let mockFetch: ReturnType<typeof vi.fn>;
-  const originalFetch = global.fetch;
-
   const webSearchConnection = {
     ...mockConnection,
     id: "conn-ws-1",
@@ -949,9 +961,9 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
-    mockFetch = vi.fn();
-    global.fetch = mockFetch;
     mockDecrypt.mockReturnValue(JSON.stringify({ apiKey: "BSA-valid-key" }));
+    mockClearIntegrationAuthError.mockResolvedValue(undefined);
+    mockSetIntegrationAuthFailed.mockResolvedValue(undefined);
     mockSelectFrom.mockImplementation(() => {
       const result = Promise.resolve([webSearchConnection]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
@@ -962,7 +974,6 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
   });
 
   afterEach(() => {
-    global.fetch = originalFetch;
     mockDecrypt.mockReturnValue(
       JSON.stringify({
         url: "https://odoo.example.com",
@@ -974,8 +985,8 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
     );
   });
 
-  it("should return success when Brave API key is valid", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: true });
+  it("should return success when probe succeeds for a valid Brave API key", async () => {
+    mockProbeIntegrationCredentials.mockResolvedValueOnce({ success: true });
     const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
 
     const response = await POST(
@@ -986,14 +997,16 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(true);
-    expect(mockFetch).toHaveBeenCalledWith(
-      "https://api.search.brave.com/res/v1/web/search?q=test&count=1",
-      { headers: { "X-Subscription-Token": "BSA-valid-key" } }
-    );
+    expect(mockProbeIntegrationCredentials).toHaveBeenCalledWith("web-search", {
+      apiKey: "BSA-valid-key",
+    });
   });
 
-  it("should return error when Brave API key is invalid", async () => {
-    mockFetch.mockResolvedValueOnce({ ok: false, status: 401 });
+  it("should return error when probe fails for an invalid Brave API key", async () => {
+    mockProbeIntegrationCredentials.mockResolvedValueOnce({
+      success: false,
+      reason: "Authentication failed (HTTP 401)",
+    });
     const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
 
     const response = await POST(
@@ -1004,11 +1017,14 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(false);
-    expect(body.error).toBe("Invalid API key");
+    expect(body.error).toBe("Authentication failed (HTTP 401)");
   });
 
   it("should return error when credentials have no apiKey", async () => {
-    mockDecrypt.mockReturnValueOnce(JSON.stringify({}));
+    mockProbeIntegrationCredentials.mockResolvedValueOnce({
+      success: false,
+      reason: "apiKey is required",
+    });
     const { POST } = await import("@/app/api/integrations/[connectionId]/test/route");
 
     const response = await POST(
@@ -1019,7 +1035,7 @@ describe("POST /api/integrations/[connectionId]/test (web-search)", () => {
 
     expect(response.status).toBe(200);
     expect(body.success).toBe(false);
-    expect(body.error).toBe("Invalid credentials format");
+    expect(body.error).toBe("apiKey is required");
   });
 });
 

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -1376,6 +1376,97 @@ describe("POST /api/integrations (web-search)", () => {
   });
 });
 
+describe("GET /api/integrations (lastError/lastErrorAt)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+  });
+
+  it("returns lastError and lastErrorAt for auth_failed connections", async () => {
+    const lastErrorAt = new Date("2026-05-01T10:00:00Z");
+    const authFailedConnection = {
+      ...mockConnection,
+      id: "conn-failed",
+      status: "auth_failed",
+      lastError: "Access denied",
+      lastErrorAt,
+    };
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Promise.resolve([authFailedConnection]) as Promise<unknown[]> & {
+        where: ReturnType<typeof vi.fn>;
+      };
+      result.where = vi.fn().mockResolvedValue([authFailedConnection]);
+      return result;
+    });
+
+    const { GET } = await import("@/app/api/integrations/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0].status).toBe("auth_failed");
+    expect(body[0].lastError).toBe("Access denied");
+    expect(body[0].lastErrorAt).toBeTruthy();
+  });
+
+  it("returns lastError: null and lastErrorAt: null for active connections", async () => {
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Promise.resolve([
+        { ...mockConnection, lastError: null, lastErrorAt: null },
+      ]) as Promise<unknown[]> & { where: ReturnType<typeof vi.fn> };
+      result.where = vi
+        .fn()
+        .mockResolvedValue([{ ...mockConnection, lastError: null, lastErrorAt: null }]);
+      return result;
+    });
+
+    const { GET } = await import("@/app/api/integrations/route");
+    const response = await GET();
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body[0].status).toBe("active");
+    expect(body[0].lastError).toBeNull();
+    expect(body[0].lastErrorAt).toBeNull();
+  });
+});
+
+describe("GET /api/integrations/[connectionId] (lastError/lastErrorAt)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+  });
+
+  it("returns lastError and lastErrorAt for auth_failed connection", async () => {
+    const lastErrorAt = new Date("2026-05-01T10:00:00Z");
+    const authFailedConnection = {
+      ...mockConnection,
+      id: "conn-failed",
+      status: "auth_failed",
+      lastError: "Access denied",
+      lastErrorAt,
+    };
+    mockSelectFrom.mockImplementationOnce(() => {
+      const result = Promise.resolve([authFailedConnection]) as Promise<unknown[]> & {
+        where: ReturnType<typeof vi.fn>;
+      };
+      result.where = vi.fn().mockResolvedValue([authFailedConnection]);
+      return result;
+    });
+
+    const { GET } = await import("@/app/api/integrations/[connectionId]/route");
+    const response = await GET(makeRequest("/api/integrations/conn-failed"), {
+      params: Promise.resolve({ connectionId: "conn-failed" }),
+    });
+    const body = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(body.status).toBe("auth_failed");
+    expect(body.lastError).toBe("Access denied");
+    expect(body.lastErrorAt).toBeTruthy();
+  });
+});
+
 describe("GET /api/integrations (web-search masking)", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/__tests__/api/internal-report-auth-failure.test.ts
+++ b/packages/web/src/__tests__/api/internal-report-auth-failure.test.ts
@@ -1,0 +1,51 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+vi.mock("@/lib/integrations/auth-state");
+vi.mock("@/lib/gateway-auth", () => ({
+  validateGatewayToken: vi.fn(),
+}));
+
+import { POST } from "@/app/api/internal/integrations/[connectionId]/report-auth-failure/route";
+import { setIntegrationAuthFailed } from "@/lib/integrations/auth-state";
+import { validateGatewayToken } from "@/lib/gateway-auth";
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("POST /api/internal/integrations/[id]/report-auth-failure", () => {
+  it("returns 401 when gateway token is missing/invalid", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(false);
+    const req = new NextRequest("http://x", {
+      method: "POST",
+      body: JSON.stringify({ reason: "401" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+    expect(res.status).toBe(401);
+    expect(setIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+
+  it("calls setIntegrationAuthFailed with actor=system:plugin and provided reason", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    vi.mocked(setIntegrationAuthFailed).mockResolvedValue(undefined);
+    const req = new NextRequest("http://x", {
+      method: "POST",
+      headers: { "X-Plugin-Id": "pinchy-odoo", Authorization: "Bearer token" },
+      body: JSON.stringify({ reason: "Odoo authenticate returned 401" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+    expect(res.status).toBe(204);
+    expect(setIntegrationAuthFailed).toHaveBeenCalledWith({
+      connectionId: "c1",
+      reason: "Odoo authenticate returned 401",
+      actor: { type: "system", id: "plugin:pinchy-odoo" },
+    });
+  });
+
+  it("returns 400 when body is missing required `reason`", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    const req = new NextRequest("http://x", { method: "POST", body: "{}" });
+    const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+    expect(res.status).toBe(400);
+    expect(setIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/api/internal-report-auth-failure.test.ts
+++ b/packages/web/src/__tests__/api/internal-report-auth-failure.test.ts
@@ -48,4 +48,57 @@ describe("POST /api/internal/integrations/[id]/report-auth-failure", () => {
     expect(res.status).toBe(400);
     expect(setIntegrationAuthFailed).not.toHaveBeenCalled();
   });
+
+  it("rejects unknown X-Plugin-Id values rather than recording them as an audit actor", async () => {
+    // All Pinchy plugins share the same bootstrap gateway token, so a plugin
+    // can claim any X-Plugin-Id in its header. Without validation, a buggy
+    // (or malicious) plugin could record auth_failed transitions under
+    // another plugin's name in the audit trail. We allowlist against the
+    // known Pinchy plugin IDs and reject anything else with 400.
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    const req = new NextRequest("http://x", {
+      method: "POST",
+      headers: { "X-Plugin-Id": "../../etc/passwd", Authorization: "Bearer token" },
+      body: JSON.stringify({ reason: "401" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+    expect(res.status).toBe(400);
+    expect(setIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+
+  it("rejects missing X-Plugin-Id header (forces explicit attribution)", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    const req = new NextRequest("http://x", {
+      method: "POST",
+      headers: { Authorization: "Bearer token" },
+      body: JSON.stringify({ reason: "401" }),
+    });
+    const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+    expect(res.status).toBe(400);
+    expect(setIntegrationAuthFailed).not.toHaveBeenCalled();
+  });
+
+  it("accepts every plugin ID in the KNOWN_PINCHY_PLUGINS allowlist", async () => {
+    vi.mocked(validateGatewayToken).mockReturnValue(true);
+    vi.mocked(setIntegrationAuthFailed).mockResolvedValue(undefined);
+    // External-integration plugins are the ones that report auth failures,
+    // but we accept any known Pinchy plugin ID — internal ones may grow into
+    // this responsibility later (e.g. pinchy-files reporting a workspace
+    // mount auth failure).
+    for (const pluginId of ["pinchy-odoo", "pinchy-email", "pinchy-web"]) {
+      vi.clearAllMocks();
+      vi.mocked(validateGatewayToken).mockReturnValue(true);
+      vi.mocked(setIntegrationAuthFailed).mockResolvedValue(undefined);
+      const req = new NextRequest("http://x", {
+        method: "POST",
+        headers: { "X-Plugin-Id": pluginId, Authorization: "Bearer token" },
+        body: JSON.stringify({ reason: "401" }),
+      });
+      const res = await POST(req, { params: Promise.resolve({ connectionId: "c1" }) });
+      expect(res.status, `expected 204 for ${pluginId}`).toBe(204);
+      expect(setIntegrationAuthFailed).toHaveBeenCalledWith(
+        expect.objectContaining({ actor: { type: "system", id: `plugin:${pluginId}` } })
+      );
+    }
+  });
 });

--- a/packages/web/src/__tests__/api/oauth-callback.test.ts
+++ b/packages/web/src/__tests__/api/oauth-callback.test.ts
@@ -7,10 +7,8 @@ const {
   mockAppendAuditLog,
   mockValues,
   mockSelectLimit,
-  mockSelectWhere,
   mockSelectFrom,
   mockUpdateReturning,
-  mockUpdateWhere,
   mockUpdateSet,
   mockDeleteWhere,
 } = vi.hoisted(() => {
@@ -28,10 +26,8 @@ const {
     mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
     mockValues: vi.fn(),
     mockSelectLimit,
-    mockSelectWhere,
     mockSelectFrom,
     mockUpdateReturning,
-    mockUpdateWhere,
     mockUpdateSet,
     mockDeleteWhere,
   };
@@ -63,6 +59,11 @@ vi.mock("@/lib/audit", async (importOriginal) => {
     appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
   };
 });
+
+const mockClearIntegrationAuthError = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/integrations/auth-state", () => ({
+  clearIntegrationAuthError: (...args: unknown[]) => mockClearIntegrationAuthError(...args),
+}));
 
 const mockConnection = {
   id: "conn-new-123",
@@ -567,6 +568,138 @@ describe("GET /api/integrations/oauth/callback", () => {
         })
       );
       expect(mockUpdateSet).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("reconnect flow — state.reconnectConnectionId is set", () => {
+    // Build a state param that encodes reconnectConnectionId (as POST /oauth/start would)
+    function buildReconnectState(reconnectConnectionId: string) {
+      const stateObj = {
+        nonce: "test-nonce-abc123",
+        reconnectConnectionId,
+      };
+      return Buffer.from(JSON.stringify(stateObj)).toString("base64url");
+    }
+
+    const RECONNECT_STATE = buildReconnectState("existing-conn-id");
+
+    beforeEach(() => {
+      mockGetSession.mockResolvedValue(adminSession());
+      mockGetOAuthSettings.mockResolvedValue({
+        clientId: "test-client-id",
+        clientSecret: "test-client-secret",
+      });
+      mockFetch
+        .mockResolvedValueOnce(mockTokenExchange())
+        .mockResolvedValueOnce(mockProfileFetch());
+      mockUpdateReturning.mockResolvedValue([{ ...mockConnection, id: "existing-conn-id" }]);
+    });
+
+    it("updates existing row instead of inserting a new one", async () => {
+      await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      // Should update credentials only — status/lastError/lastErrorAt are
+      // handled by clearIntegrationAuthError so it can write integration.recovered
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.objectContaining({
+          credentials: "encrypted-creds",
+        })
+      );
+      expect(mockUpdateSet).toHaveBeenCalledWith(
+        expect.not.objectContaining({
+          status: expect.anything(),
+          lastError: expect.anything(),
+          lastErrorAt: expect.anything(),
+        })
+      );
+      expect(mockValues).not.toHaveBeenCalled();
+    });
+
+    it("calls clearIntegrationAuthError after updating credentials", async () => {
+      await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      expect(mockClearIntegrationAuthError).toHaveBeenCalledWith(
+        expect.objectContaining({ connectionId: "existing-conn-id" })
+      );
+    });
+
+    it("writes integration.credentials_updated audit log", async () => {
+      vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
+      await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      expect(mockAppendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorId: "admin-1",
+          eventType: "integration.credentials_updated",
+          resource: "integration:existing-conn-id",
+          outcome: "success",
+          detail: expect.objectContaining({ fields: ["oauth_tokens"] }),
+        })
+      );
+    });
+
+    it("does not set oauth_pending_id cookie (no pending row created)", async () => {
+      const response = await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      const setCookies = response.headers.getSetCookie
+        ? response.headers.getSetCookie().join("; ")
+        : (response.headers.get("Set-Cookie") ?? "");
+      // oauth_pending_id should not appear or should be empty/max-age=0
+      expect(setCookies).not.toMatch(/oauth_pending_id=[^;]+(?!Max-Age=0)/);
+    });
+
+    it("redirects to settings with the reconnected connection id", async () => {
+      const response = await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      expect(response.status).toBe(302);
+      const location = new URL(response.headers.get("Location")!);
+      expect(location.searchParams.get("tab")).toBe("integrations");
+      expect(location.searchParams.get("created")).toBe("existing-conn-id");
+    });
+
+    it("redirects with error if the connection was deleted before callback", async () => {
+      // UPDATE returns empty array — connection was deleted between OAuth start and callback
+      mockUpdateReturning.mockResolvedValue([]);
+
+      const response = await GET(
+        makeRequest(
+          { code: "auth-code-123", state: RECONNECT_STATE },
+          `oauth_state=${RECONNECT_STATE}`
+        )
+      );
+
+      expect(response.status).toBe(302);
+      const location = new URL(response.headers.get("Location")!);
+      expect(location.pathname).toBe("/settings");
+      expect(location.searchParams.get("tab")).toBe("integrations");
+      expect(location.searchParams.get("error")).toBe("connection_not_found");
+      // clearIntegrationAuthError must NOT be called when connection is gone
+      expect(mockClearIntegrationAuthError).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/__tests__/api/oauth-callback.test.ts
+++ b/packages/web/src/__tests__/api/oauth-callback.test.ts
@@ -413,10 +413,9 @@ describe("GET /api/integrations/oauth/callback", () => {
       expect(mockAppendAuditLog).toHaveBeenCalledWith({
         actorType: "user",
         actorId: "admin-1",
-        eventType: "config.changed",
+        eventType: "integration.created",
         resource: `integration:${mockConnection.id}`,
         detail: {
-          action: "integration_created",
           type: "google",
           emailHash: expect.stringMatching(/^[0-9a-f]{64}$/),
           emailPreview: "user@gmail.com",
@@ -604,7 +603,7 @@ describe("GET /api/integrations/oauth/callback", () => {
       );
 
       // Should update credentials only — status/lastError/lastErrorAt are
-      // handled by clearIntegrationAuthError so it can write integration.recovered
+      // handled by clearIntegrationAuthError so it can write integration.auth_recovered
       expect(mockUpdateSet).toHaveBeenCalledWith(
         expect.objectContaining({
           credentials: "encrypted-creds",

--- a/packages/web/src/__tests__/api/oauth-start.test.ts
+++ b/packages/web/src/__tests__/api/oauth-start.test.ts
@@ -24,10 +24,17 @@ vi.mock("@/lib/audit", () => ({
   appendAuditLog: (...args: unknown[]) => mockAppendAuditLog(...args),
 }));
 
-const { mockInsertValues, mockDeleteWhere } = vi.hoisted(() => ({
-  mockInsertValues: vi.fn(),
-  mockDeleteWhere: vi.fn(),
-}));
+const { mockInsertValues, mockDeleteWhere, mockSelectLimit, mockSelectFrom } = vi.hoisted(() => {
+  const mockSelectLimit = vi.fn();
+  const mockSelectWhere = vi.fn().mockReturnValue({ limit: mockSelectLimit });
+  const mockSelectFrom = vi.fn().mockReturnValue({ where: mockSelectWhere });
+  return {
+    mockInsertValues: vi.fn(),
+    mockDeleteWhere: vi.fn(),
+    mockSelectLimit,
+    mockSelectFrom,
+  };
+});
 
 vi.mock("@/db", () => ({
   db: {
@@ -39,6 +46,7 @@ vi.mock("@/db", () => ({
     delete: vi.fn().mockReturnValue({
       where: mockDeleteWhere.mockResolvedValue(undefined),
     }),
+    select: vi.fn().mockReturnValue({ from: mockSelectFrom }),
   },
 }));
 
@@ -177,5 +185,113 @@ describe("GET /api/integrations/oauth/start", () => {
     const location = res.headers.get("location") ?? "";
     const redirectUri = new URL(location).searchParams.get("redirect_uri");
     expect(redirectUri).toBe("https://pinchy.example.com/api/integrations/oauth/callback");
+  });
+});
+
+describe("POST /api/integrations/oauth/start (reconnect)", () => {
+  function makePostRequest(
+    body: unknown,
+    url = "https://local.heypinchy.com:8443/api/integrations/oauth/start"
+  ) {
+    return new NextRequest(url, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+  }
+
+  const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
+  const oauthSettings = { clientId: "client-id-123", clientSecret: "secret-abc" };
+
+  const mockGoogleConnection = {
+    id: "c1",
+    type: "google",
+    name: "user@gmail.com",
+    status: "auth_failed",
+  };
+
+  const mockOdooConnection = {
+    id: "c1",
+    type: "odoo",
+    name: "Odoo connection",
+    status: "auth_failed",
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue(adminSession);
+    mockGetOAuthSettings.mockResolvedValue(oauthSettings);
+    // Default: select returns the google connection
+    mockSelectLimit.mockResolvedValue([mockGoogleConnection]);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 401 when not admin", async () => {
+    mockGetSession.mockResolvedValueOnce({ user: { id: "user-2", role: "member" } });
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 400 when reconnectConnectionId is missing", async () => {
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({}));
+    expect(res.status).toBe(400);
+  });
+
+  it("returns 404 when connection does not exist", async () => {
+    mockSelectLimit.mockResolvedValueOnce([]);
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "nonexistent" }));
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 400 when connection is not google type", async () => {
+    mockSelectLimit.mockResolvedValueOnce([mockOdooConnection]);
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toMatch(/google/i);
+  });
+
+  it("encodes reconnectConnectionId into state when connection exists and is google type", async () => {
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    expect(res.status).toBe(200);
+
+    const body = await res.json();
+    expect(body.url).toContain("accounts.google.com");
+
+    // The state param should decode to an object containing reconnectConnectionId
+    const authUrl = new URL(body.url);
+    const stateParam = authUrl.searchParams.get("state");
+    expect(stateParam).toBeTruthy();
+    const decoded = JSON.parse(Buffer.from(stateParam!, "base64url").toString("utf-8"));
+    expect(decoded).toMatchObject({ reconnectConnectionId: "c1" });
+  });
+
+  it("sets oauth_state cookie with the encoded state for CSRF", async () => {
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    const body = await res.json();
+    const authUrl = new URL(body.url);
+    const stateParam = authUrl.searchParams.get("state")!;
+
+    const setCookie = res.headers.get("set-cookie") ?? "";
+    expect(setCookie).toContain(`oauth_state=${stateParam}`);
+  });
+
+  it("returns 400 when OAuth is not configured", async () => {
+    mockGetOAuthSettings.mockResolvedValueOnce(null);
+    const { POST } = await import("@/app/api/integrations/oauth/start/route");
+    const res = await POST(makePostRequest({ reconnectConnectionId: "c1" }));
+    expect(res.status).toBe(400);
   });
 });

--- a/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
@@ -132,8 +132,11 @@ describe("AddIntegrationDialog", () => {
       render(<AddIntegrationDialog {...defaultProps} />);
       await selectOdooType(user);
 
+      // Whitespace in the input means UrlInput's normalizer cannot repair it
+      // (URL constructor rejects whitespace in hostnames), so zod's url()
+      // rejects it and the dependent DB field stays hidden.
       const urlInput = screen.getByLabelText("URL");
-      await user.type(urlInput, "not-a-url");
+      await user.type(urlInput, "not a url");
       await user.tab();
 
       expect(screen.queryByLabelText("Database")).not.toBeInTheDocument();

--- a/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
@@ -1,0 +1,343 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { toast } from "sonner";
+import { ApiError } from "@/lib/api-client";
+import { EditCredentialsDialog } from "@/components/edit-credentials-dialog";
+import type { IntegrationConnection } from "@/lib/integrations/types";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return {
+    ...actual,
+    apiPatch: vi.fn(),
+    apiPost: vi.fn(),
+  };
+});
+
+import { apiPatch, apiPost } from "@/lib/api-client";
+
+const odooConnection: IntegrationConnection = {
+  id: "conn-odoo-1",
+  type: "odoo",
+  name: "Production ERP",
+  description: "",
+  credentials: { url: "https://odoo.example.com", db: "prod", login: "admin" },
+  data: null,
+  status: "active",
+  lastError: null,
+  lastErrorAt: null,
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+};
+
+const authFailedOdooConnection: IntegrationConnection = {
+  ...odooConnection,
+  id: "conn-odoo-2",
+  name: "Staging ERP",
+  status: "auth_failed",
+  lastError: "401 from Odoo",
+};
+
+const webSearchConnection: IntegrationConnection = {
+  id: "conn-ws-1",
+  type: "web-search",
+  name: "Brave Search",
+  description: "",
+  credentials: "configured",
+  data: null,
+  status: "active",
+  lastError: null,
+  lastErrorAt: null,
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+};
+
+const googleConnection: IntegrationConnection = {
+  id: "conn-google-1",
+  type: "google",
+  name: "Google Workspace",
+  description: "",
+  credentials: null,
+  data: { provider: "google" },
+  status: "active",
+  lastError: null,
+  lastErrorAt: null,
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+};
+
+describe("EditCredentialsDialog", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("Odoo integration", () => {
+    it("renders the dialog with fields pre-filled from connection data", async () => {
+      render(
+        <EditCredentialsDialog
+          connection={odooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      expect(screen.getByLabelText("URL")).toHaveValue("https://odoo.example.com");
+      expect(screen.getByLabelText("Database")).toHaveValue("prod");
+      expect(screen.getByLabelText("Login")).toHaveValue("admin");
+      expect(screen.getByLabelText("API Key")).toHaveValue("");
+    });
+
+    it("sends PATCH with only non-empty fields — empty fields are omitted", async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiPatch).mockResolvedValue({ id: "conn-odoo-1" });
+
+      render(
+        <EditCredentialsDialog
+          connection={odooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      // Clear pre-filled db and login so they are empty (user wants to keep them via server merge)
+      await user.clear(screen.getByLabelText("Database"));
+      await user.clear(screen.getByLabelText("Login"));
+      await user.type(screen.getByLabelText("API Key"), "new-api-key");
+
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(apiPatch).toHaveBeenCalled();
+      });
+
+      const callArg = vi.mocked(apiPatch).mock.calls[0][1] as {
+        credentials: Record<string, string>;
+      };
+      // Empty db and login should not be sent — server will keep existing values
+      expect(callArg.credentials).not.toHaveProperty("db");
+      expect(callArg.credentials).not.toHaveProperty("login");
+      expect(callArg.credentials).toHaveProperty("apiKey", "new-api-key");
+    });
+
+    it("shows success toast and calls onSuccess on save", async () => {
+      const user = userEvent.setup();
+      const onSuccess = vi.fn();
+      vi.mocked(apiPatch).mockResolvedValue({ id: "conn-odoo-1" });
+
+      render(
+        <EditCredentialsDialog
+          connection={odooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={onSuccess}
+        />
+      );
+
+      await user.type(screen.getByLabelText("API Key"), "some-key");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(toast.success).toHaveBeenCalledWith("Credentials updated");
+      });
+      expect(onSuccess).toHaveBeenCalled();
+    });
+
+    it("shows inline error from server 400 and keeps dialog open", async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiPatch).mockRejectedValue(new ApiError(400, "Connection refused by Odoo"));
+
+      render(
+        <EditCredentialsDialog
+          connection={odooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByLabelText("API Key"), "bad-key");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Connection refused by Odoo")).toBeInTheDocument();
+      });
+
+      expect(toast.success).not.toHaveBeenCalled();
+    });
+
+    it("shows 'Current credentials failed authentication' hint when status is auth_failed", () => {
+      render(
+        <EditCredentialsDialog
+          connection={authFailedOdooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      expect(screen.getByText(/Current credentials failed authentication/i)).toBeInTheDocument();
+    });
+
+    it("does not show auth_failed hint for active connections", () => {
+      render(
+        <EditCredentialsDialog
+          connection={odooConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      expect(
+        screen.queryByText(/Current credentials failed authentication/i)
+      ).not.toBeInTheDocument();
+    });
+  });
+
+  describe("Web Search integration", () => {
+    it("renders only the API Key field for web-search", () => {
+      render(
+        <EditCredentialsDialog
+          connection={webSearchConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      expect(screen.getByLabelText("API Key")).toBeInTheDocument();
+      expect(screen.queryByLabelText("URL")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("Database")).not.toBeInTheDocument();
+    });
+
+    it("sends PATCH with apiKey when provided", async () => {
+      const user = userEvent.setup();
+      vi.mocked(apiPatch).mockResolvedValue({ id: "conn-ws-1" });
+
+      render(
+        <EditCredentialsDialog
+          connection={webSearchConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.type(screen.getByLabelText("API Key"), "new-brave-key");
+      await user.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(apiPatch).toHaveBeenCalledWith("/api/integrations/conn-ws-1", {
+          credentials: { apiKey: "new-brave-key" },
+        });
+      });
+    });
+  });
+
+  describe("Google integration", () => {
+    it("shows 'Reconnect via Google' button instead of credential fields", () => {
+      render(
+        <EditCredentialsDialog
+          connection={googleConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      expect(screen.getByRole("button", { name: "Reconnect via Google" })).toBeInTheDocument();
+      expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+      expect(screen.queryByLabelText("URL")).not.toBeInTheDocument();
+    });
+
+    it("calls apiPost with reconnectConnectionId when 'Reconnect via Google' is clicked", async () => {
+      const user = userEvent.setup();
+      // Mock location assign
+      const assignMock = vi.fn();
+      Object.defineProperty(window, "location", {
+        value: { ...window.location, assign: assignMock },
+        writable: true,
+      });
+      vi.mocked(apiPost).mockResolvedValue({
+        url: "https://accounts.google.com/oauth?code=xxx",
+      });
+
+      render(
+        <EditCredentialsDialog
+          connection={googleConnection}
+          open={true}
+          onOpenChange={vi.fn()}
+          onSuccess={vi.fn()}
+        />
+      );
+
+      await user.click(screen.getByRole("button", { name: "Reconnect via Google" }));
+
+      await waitFor(() => {
+        expect(apiPost).toHaveBeenCalledWith("/api/integrations/oauth/start", {
+          reconnectConnectionId: "conn-google-1",
+        });
+      });
+
+      await waitFor(() => {
+        expect(assignMock).toHaveBeenCalledWith("https://accounts.google.com/oauth?code=xxx");
+      });
+    });
+  });
+
+  it("does not render form content when connection is null (open=true)", () => {
+    render(
+      <EditCredentialsDialog
+        connection={null}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    // Dialog is open but connection is null — no form fields should appear
+    expect(screen.queryByLabelText("URL")).not.toBeInTheDocument();
+    expect(screen.queryByLabelText("API Key")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: "Reconnect via Google" })).not.toBeInTheDocument();
+  });
+
+  it("sends PATCH with empty credentials object when all Odoo fields are left empty", async () => {
+    const user = userEvent.setup();
+    vi.mocked(apiPatch).mockResolvedValue({ id: "conn-odoo-1" });
+
+    render(
+      <EditCredentialsDialog
+        connection={odooConnection}
+        open={true}
+        onOpenChange={vi.fn()}
+        onSuccess={vi.fn()}
+      />
+    );
+
+    // Clear all pre-filled fields so all are empty
+    await user.clear(screen.getByLabelText("URL"));
+    await user.clear(screen.getByLabelText("Database"));
+    await user.clear(screen.getByLabelText("Login"));
+
+    await user.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(apiPatch).toHaveBeenCalled();
+    });
+
+    const callArg = vi.mocked(apiPatch).mock.calls[0][1] as {
+      credentials: Record<string, string>;
+    };
+    // All empty — no credential fields should be sent; server keeps existing values
+    expect(callArg.credentials).toEqual({});
+  });
+});

--- a/packages/web/src/__tests__/components/settings-integrations.test.tsx
+++ b/packages/web/src/__tests__/components/settings-integrations.test.tsx
@@ -1,0 +1,144 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { SettingsIntegrations } from "@/components/settings-integrations";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+vi.mock("@/lib/integrations/odoo-sync", () => ({
+  getAccessibleCategoryLabels: () => [],
+}));
+
+const activeOdooConnection = {
+  id: "conn-odoo-1",
+  type: "odoo",
+  name: "Production ERP",
+  description: "",
+  credentials: "encrypted",
+  status: "active",
+  lastError: null,
+  lastErrorAt: null,
+  data: { lastSyncAt: "2026-04-13T12:00:00Z", categories: [] },
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-04-13T12:00:00Z",
+  cannotDecrypt: false,
+};
+
+const authFailedOdooConnection = {
+  id: "conn-odoo-2",
+  type: "odoo",
+  name: "Staging ERP",
+  description: "",
+  credentials: "encrypted",
+  status: "auth_failed",
+  lastError: "401 from Odoo",
+  lastErrorAt: "2026-05-10T10:00:00Z",
+  data: null,
+  createdAt: "2026-04-13T12:00:00Z",
+  updatedAt: "2026-05-10T10:00:00Z",
+  cannotDecrypt: false,
+};
+
+function mockFetchConnections(connections: unknown[]) {
+  return vi.spyOn(global, "fetch").mockImplementation(() =>
+    Promise.resolve({
+      ok: true,
+      json: async () => connections,
+    } as Response)
+  );
+}
+
+describe("SettingsIntegrations — auth_failed state", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("renders a warning icon and 'Authentication failed' label when status is auth_failed", async () => {
+    const fetchSpy = mockFetchConnections([authFailedOdooConnection]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Staging ERP")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Authentication failed/i)).toBeInTheDocument();
+
+    const warningIcon = document.querySelector("[aria-label='Authentication failed']");
+    expect(warningIcon).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("renders lastError text when status is auth_failed", async () => {
+    const fetchSpy = mockFetchConnections([authFailedOdooConnection]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Staging ERP")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText("401 from Odoo")).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("renders green check + 'Connected' when status is active", async () => {
+    const fetchSpy = mockFetchConnections([activeOdooConnection]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Production ERP")).toBeInTheDocument();
+    });
+
+    expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+    expect(screen.queryByText(/Authentication failed/i)).not.toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("shows a 'Reconnect' menu item in the dropdown for auth_failed cards", async () => {
+    const user = userEvent.setup();
+    const fetchSpy = mockFetchConnections([authFailedOdooConnection]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Staging ERP")).toBeInTheDocument();
+    });
+
+    const row = screen.getByText("Staging ERP").closest("[class*='rounded-lg']")!;
+    const buttons = row.querySelectorAll("button");
+    const menuButton = buttons[buttons.length - 1];
+    await user.click(menuButton);
+
+    expect(screen.getByText("Reconnect")).toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+
+  it("does not show 'Reconnect' for active connections", async () => {
+    const user = userEvent.setup();
+    const fetchSpy = mockFetchConnections([activeOdooConnection]);
+
+    render(<SettingsIntegrations />);
+
+    await waitFor(() => {
+      expect(screen.getByText("Production ERP")).toBeInTheDocument();
+    });
+
+    const row = screen.getByText("Production ERP").closest("[class*='rounded-lg']")!;
+    const buttons = row.querySelectorAll("button");
+    const menuButton = buttons[buttons.length - 1];
+    await user.click(menuButton);
+
+    expect(screen.queryByText("Reconnect")).not.toBeInTheDocument();
+
+    fetchSpy.mockRestore();
+  });
+});

--- a/packages/web/src/__tests__/components/sidebar.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar.test.tsx
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -18,6 +18,17 @@ const { mockSignOut, mockRouterPush, mockUsePathname, mockAgentsContextValue } =
     getAgent: vi.fn(),
   },
 }));
+
+function mockHealthFetch(authFailedCount: number) {
+  vi.spyOn(globalThis, "fetch").mockResolvedValue({
+    ok: true,
+    json: async () => ({ authFailedCount }),
+  } as Response);
+}
+
+function clearHealthFetch() {
+  vi.restoreAllMocks();
+}
 
 vi.mock("@/components/agents-provider", () => ({
   useAgentsContext: () => mockAgentsContextValue,
@@ -72,6 +83,10 @@ describe("AppSidebar", () => {
     vi.clearAllMocks();
     mockUsePathname.mockReturnValue("/chat/1");
     setAgents([]);
+  });
+
+  afterEach(() => {
+    clearHealthFetch();
   });
 
   it("should render Pinchy branding", () => {
@@ -329,6 +344,40 @@ describe("AppSidebar", () => {
       "noopener,noreferrer"
     );
     openSpy.mockRestore();
+  });
+
+  describe("Settings badge for auth-failed integrations", () => {
+    it("renders a badge on the Settings link when authFailedCount > 0", async () => {
+      mockHealthFetch(1);
+      renderSidebar(true);
+      const badge = await screen.findByLabelText(/integration.*needs attention/i);
+      expect(badge).toBeInTheDocument();
+      expect(badge).toHaveTextContent("!");
+    });
+
+    it("renders badge with correct plural label when authFailedCount > 1", async () => {
+      mockHealthFetch(3);
+      renderSidebar(true);
+      const badge = await screen.findByLabelText(/3 integrations need attention/i);
+      expect(badge).toBeInTheDocument();
+    });
+
+    it("does not render a badge when authFailedCount is 0", async () => {
+      mockHealthFetch(0);
+      renderSidebar(true);
+      await waitFor(() => {
+        expect(screen.queryByLabelText(/integration.*need/i)).not.toBeInTheDocument();
+      });
+    });
+
+    it("does not fetch /api/integrations/health for non-admin users", () => {
+      const fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue({} as Response);
+      renderSidebar(false);
+      expect(fetchSpy).not.toHaveBeenCalledWith(
+        expect.stringContaining("/api/integrations/health"),
+        expect.anything()
+      );
+    });
   });
 
   describe("agent ordering", () => {

--- a/packages/web/src/__tests__/lib/audit-deferred.test.ts
+++ b/packages/web/src/__tests__/lib/audit-deferred.test.ts
@@ -15,9 +15,9 @@ import {
 const validEntry = {
   actorType: "user" as const,
   actorId: "user-1",
-  eventType: "config.changed" as const,
+  eventType: "integration.created" as const,
   resource: "integration:abc",
-  detail: { action: "integration_created", type: "odoo", name: "Test" },
+  detail: { type: "odoo", name: "Test" },
   outcome: "success" as const,
 };
 
@@ -69,7 +69,7 @@ describe("deferAuditLog", () => {
     expect(parsed).toMatchObject({
       level: "error",
       event: "audit_log_write_failed",
-      eventType: "config.changed",
+      eventType: "integration.created",
       actorId: "user-1",
       resource: "integration:abc",
       outcome: "success",
@@ -126,7 +126,7 @@ describe("recordAuditFailure", () => {
     expect(parsed).toMatchObject({
       level: "error",
       event: "audit_log_write_failed",
-      eventType: "config.changed",
+      eventType: "integration.created",
       actorType: "user",
       actorId: "user-1",
       resource: "integration:abc",

--- a/packages/web/src/__tests__/lib/audit.test.ts
+++ b/packages/web/src/__tests__/lib/audit.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { describe, it, expect, beforeEach, afterEach, vi, expectTypeOf } from "vitest";
 import { createHmac } from "crypto";
 import {
   computeRowHmacV1,
@@ -8,6 +8,7 @@ import {
   redactEmail,
   scrubEmails,
 } from "@/lib/audit";
+import type { AuditLogEntry } from "@/lib/audit";
 
 describe("computeRowHmac", () => {
   const secret = Buffer.from("a".repeat(64), "hex");
@@ -340,5 +341,43 @@ describe("scrubEmails", () => {
     expect(out).not.toContain("clemens.helm");
     expect(out).not.toContain("devcraft.academy");
     expect(out).not.toContain("@");
+  });
+});
+
+describe("AuditLogEntry — integration events", () => {
+  it("accepts integration.auth_failed events", () => {
+    const entry: AuditLogEntry = {
+      actorType: "system",
+      actorId: "plugin:pinchy-odoo",
+      eventType: "integration.auth_failed",
+      resource: "integration:abc",
+      detail: { id: "abc", name: "Odoo Sales", reason: "401 from Odoo" },
+      outcome: "success",
+    };
+    expectTypeOf(entry).toMatchTypeOf<AuditLogEntry>();
+  });
+
+  it("accepts integration.recovered events", () => {
+    const entry: AuditLogEntry = {
+      actorType: "user",
+      actorId: "user-1",
+      eventType: "integration.recovered",
+      resource: "integration:abc",
+      detail: { id: "abc", name: "Odoo Sales" },
+      outcome: "success",
+    };
+    expectTypeOf(entry).toMatchTypeOf<AuditLogEntry>();
+  });
+
+  it("accepts integration.credentials_updated events", () => {
+    const entry: AuditLogEntry = {
+      actorType: "user",
+      actorId: "user-1",
+      eventType: "integration.credentials_updated",
+      resource: "integration:abc",
+      detail: { id: "abc", name: "Odoo Sales", fields: ["password"] },
+      outcome: "success",
+    };
+    expectTypeOf(entry).toMatchTypeOf<AuditLogEntry>();
   });
 });

--- a/packages/web/src/__tests__/lib/audit.test.ts
+++ b/packages/web/src/__tests__/lib/audit.test.ts
@@ -357,11 +357,11 @@ describe("AuditLogEntry — integration events", () => {
     expectTypeOf(entry).toMatchTypeOf<AuditLogEntry>();
   });
 
-  it("accepts integration.recovered events", () => {
+  it("accepts integration.auth_recovered events", () => {
     const entry: AuditLogEntry = {
       actorType: "user",
       actorId: "user-1",
-      eventType: "integration.recovered",
+      eventType: "integration.auth_recovered",
       resource: "integration:abc",
       detail: { id: "abc", name: "Odoo Sales" },
       outcome: "success",

--- a/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
@@ -143,4 +143,18 @@ describe("clearIntegrationAuthError", () => {
     expect(mockedDb.update).not.toHaveBeenCalled();
     expect(mockedAppendAudit).not.toHaveBeenCalled();
   });
+
+  it("returns silently when connection does not exist (no throw, no audit)", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([]) }),
+    } as never);
+
+    await clearIntegrationAuthError({
+      connectionId: "ghost",
+      actor: { type: "user", id: "u1" },
+    });
+
+    expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
@@ -68,10 +68,12 @@ describe("setIntegrationAuthFailed", () => {
         where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "auth_failed" }]),
       }),
     } as never);
+    // The conditional UPDATE excludes rows already in auth_failed state, so
+    // RETURNING comes back empty — the idempotent path.
     const fakeUpdate = {
       set: vi.fn().mockReturnThis(),
       where: vi.fn().mockReturnThis(),
-      returning: vi.fn().mockResolvedValue([{ id: "c1", name: "Odoo" }]),
+      returning: vi.fn().mockResolvedValue([]),
     };
     mockedDb.update.mockReturnValue(fakeUpdate as never);
 
@@ -97,6 +99,37 @@ describe("setIntegrationAuthFailed", () => {
     });
 
     expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
+
+  it("does NOT emit a duplicate audit when a concurrent caller already transitioned (conditional UPDATE returns 0 rows)", async () => {
+    // Race scenario: two callers both see status='active' on their SELECT
+    // (e.g. sync route + plugin report-auth-failure firing simultaneously).
+    // Without an atomic conditional UPDATE, both would write the same audit
+    // transition. We guard against this by guarding the UPDATE on the prior
+    // status and emitting audit only when RETURNING confirms WE flipped it.
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "active" }]),
+      }),
+    } as never);
+    // The UPDATE … WHERE status != 'auth_failed' affects zero rows because
+    // the other caller already flipped it between our SELECT and UPDATE.
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([]),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+
+    await setIntegrationAuthFailed({
+      connectionId: "c1",
+      reason: "401 from Odoo",
+      actor: { type: "system", id: "plugin:pinchy-odoo" },
+    });
+
+    expect(fakeUpdate.set).toHaveBeenCalled();
+    // Critical: no audit row for a transition we did not perform.
     expect(mockedAppendAudit).not.toHaveBeenCalled();
   });
 });
@@ -161,6 +194,32 @@ describe("clearIntegrationAuthError", () => {
     expect(mockedDb.update).not.toHaveBeenCalled();
     expect(mockedAppendAudit).not.toHaveBeenCalled();
   });
+
+  it("does NOT emit a duplicate audit when a concurrent caller already recovered (conditional UPDATE returns 0 rows)", async () => {
+    // Same race shape as setIntegrationAuthFailed: two callers see
+    // status='auth_failed' simultaneously (e.g. successful Test + successful
+    // Sync within milliseconds), both want to flip back to 'active'. Audit
+    // must fire exactly once — the caller that wins the conditional UPDATE.
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "auth_failed" }]),
+      }),
+    } as never);
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([]),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+
+    await clearIntegrationAuthError({
+      connectionId: "c1",
+      actor: { type: "user", id: "u1" },
+    });
+
+    expect(fakeUpdate.set).toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
 });
 
 describe("audit failure handling", () => {
@@ -172,7 +231,8 @@ describe("audit failure handling", () => {
     } as never);
     const fakeUpdate = {
       set: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue(undefined),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "c1" }]),
     };
     mockedDb.update.mockReturnValue(fakeUpdate as never);
     mockedAppendAudit.mockRejectedValueOnce(new Error("DB write failed"));
@@ -197,7 +257,8 @@ describe("audit failure handling", () => {
     } as never);
     const fakeUpdate = {
       set: vi.fn().mockReturnThis(),
-      where: vi.fn().mockResolvedValue(undefined),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "c1" }]),
     };
     mockedDb.update.mockReturnValue(fakeUpdate as never);
     mockedAppendAudit.mockRejectedValueOnce(new Error("DB write failed"));

--- a/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
@@ -125,7 +125,7 @@ describe("clearIntegrationAuthError", () => {
     );
     expect(mockedAppendAudit).toHaveBeenCalledWith(
       expect.objectContaining({
-        eventType: "integration.recovered",
+        eventType: "integration.auth_recovered",
         resource: "integration:c1",
         outcome: "success",
       })
@@ -209,7 +209,7 @@ describe("audit failure handling", () => {
 
     expect(mockedRecordAuditFailure).toHaveBeenCalledWith(
       expect.any(Error),
-      expect.objectContaining({ eventType: "integration.recovered" })
+      expect.objectContaining({ eventType: "integration.auth_recovered" })
     );
   });
 });

--- a/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
@@ -8,15 +8,19 @@ vi.mock("@/db", () => ({
 }));
 vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn(),
+}));
+vi.mock("@/lib/audit-deferred", () => ({
   recordAuditFailure: vi.fn(),
 }));
 
 import { db } from "@/db";
 import { appendAuditLog } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
 import { setIntegrationAuthFailed, clearIntegrationAuthError } from "@/lib/integrations/auth-state";
 
 const mockedDb = vi.mocked(db);
 const mockedAppendAudit = vi.mocked(appendAuditLog);
+const mockedRecordAuditFailure = vi.mocked(recordAuditFailure);
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -156,5 +160,56 @@ describe("clearIntegrationAuthError", () => {
 
     expect(mockedDb.update).not.toHaveBeenCalled();
     expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe("audit failure handling", () => {
+  it("calls recordAuditFailure when appendAuditLog throws during auth_failed transition", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "active" }]),
+      }),
+    } as never);
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+    mockedAppendAudit.mockRejectedValueOnce(new Error("DB write failed"));
+
+    await setIntegrationAuthFailed({
+      connectionId: "c1",
+      reason: "401",
+      actor: { type: "system", id: "plugin:x" },
+    });
+
+    expect(mockedRecordAuditFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ eventType: "integration.auth_failed" })
+    );
+  });
+
+  it("calls recordAuditFailure when appendAuditLog throws during recovery", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "auth_failed" }]),
+      }),
+    } as never);
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockResolvedValue(undefined),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+    mockedAppendAudit.mockRejectedValueOnce(new Error("DB write failed"));
+
+    await clearIntegrationAuthError({
+      connectionId: "c1",
+      actor: { type: "user", id: "u1" },
+    });
+
+    expect(mockedRecordAuditFailure).toHaveBeenCalledWith(
+      expect.any(Error),
+      expect.objectContaining({ eventType: "integration.recovered" })
+    );
   });
 });

--- a/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/auth-state.test.ts
@@ -1,0 +1,146 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/db", () => ({
+  db: {
+    update: vi.fn(),
+    select: vi.fn(),
+  },
+}));
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn(),
+  recordAuditFailure: vi.fn(),
+}));
+
+import { db } from "@/db";
+import { appendAuditLog } from "@/lib/audit";
+import { setIntegrationAuthFailed, clearIntegrationAuthError } from "@/lib/integrations/auth-state";
+
+const mockedDb = vi.mocked(db);
+const mockedAppendAudit = vi.mocked(appendAuditLog);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("setIntegrationAuthFailed", () => {
+  it("writes status=auth_failed + lastError + lastErrorAt + audit when status was active", async () => {
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "c1", name: "Odoo", status: "active" }]),
+    };
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "active" }]),
+      }),
+    } as never);
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+
+    await setIntegrationAuthFailed({
+      connectionId: "c1",
+      reason: "401 from Odoo",
+      actor: { type: "system", id: "plugin:pinchy-odoo" },
+    });
+
+    expect(fakeUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: "auth_failed",
+        lastError: "401 from Odoo",
+      })
+    );
+    expect(mockedAppendAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "integration.auth_failed",
+        resource: "integration:c1",
+        outcome: "success",
+        detail: { id: "c1", name: "Odoo", reason: "401 from Odoo" },
+      })
+    );
+  });
+
+  it("is idempotent: does NOT write a second audit entry when status is already auth_failed", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "auth_failed" }]),
+      }),
+    } as never);
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "c1", name: "Odoo" }]),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+
+    await setIntegrationAuthFailed({
+      connectionId: "c1",
+      reason: "401 from Odoo (again)",
+      actor: { type: "system", id: "plugin:pinchy-odoo" },
+    });
+
+    expect(fakeUpdate.set).toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
+
+  it("returns silently when connection does not exist (no throw, no audit)", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({ where: () => Promise.resolve([]) }),
+    } as never);
+
+    await setIntegrationAuthFailed({
+      connectionId: "ghost",
+      reason: "401",
+      actor: { type: "system", id: "plugin:x" },
+    });
+
+    expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
+});
+
+describe("clearIntegrationAuthError", () => {
+  it("only writes audit + clears when prior status was auth_failed", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "auth_failed" }]),
+      }),
+    } as never);
+    const fakeUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnThis(),
+      returning: vi.fn().mockResolvedValue([{ id: "c1", name: "Odoo" }]),
+    };
+    mockedDb.update.mockReturnValue(fakeUpdate as never);
+
+    await clearIntegrationAuthError({
+      connectionId: "c1",
+      actor: { type: "user", id: "u1" },
+    });
+
+    expect(fakeUpdate.set).toHaveBeenCalledWith(
+      expect.objectContaining({ status: "active", lastError: null, lastErrorAt: null })
+    );
+    expect(mockedAppendAudit).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "integration.recovered",
+        resource: "integration:c1",
+        outcome: "success",
+      })
+    );
+  });
+
+  it("does nothing when prior status was already active", async () => {
+    mockedDb.select.mockReturnValue({
+      from: () => ({
+        where: () => Promise.resolve([{ id: "c1", name: "Odoo", status: "active" }]),
+      }),
+    } as never);
+
+    await clearIntegrationAuthError({
+      connectionId: "c1",
+      actor: { type: "user", id: "u1" },
+    });
+
+    expect(mockedDb.update).not.toHaveBeenCalled();
+    expect(mockedAppendAudit).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/integrations/probe.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/probe.test.ts
@@ -1,0 +1,77 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/integrations/odoo-sync", () => ({
+  fetchOdooSchema: vi.fn(),
+}));
+vi.mock("@/lib/integrations/brave-probe", () => ({
+  probeBraveApiKey: vi.fn(),
+}));
+
+import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
+import { probeBraveApiKey } from "@/lib/integrations/brave-probe";
+import { probeIntegrationCredentials } from "@/lib/integrations/probe";
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("probeIntegrationCredentials", () => {
+  const validOdooCreds = {
+    url: "https://odoo.example.com",
+    db: "mydb",
+    login: "admin",
+    apiKey: "sk-xxx",
+    uid: 1,
+  };
+
+  it("odoo: returns success when fetchOdooSchema succeeds", async () => {
+    vi.mocked(fetchOdooSchema).mockResolvedValue({
+      success: true,
+      models: 5,
+      data: {} as never,
+      lastSyncAt: new Date().toISOString(),
+    } as never);
+    const res = await probeIntegrationCredentials("odoo", validOdooCreds);
+    expect(res).toEqual({ success: true });
+  });
+
+  it("odoo: returns failure with reason from fetchOdooSchema", async () => {
+    vi.mocked(fetchOdooSchema).mockResolvedValue({
+      success: false,
+      error: "Access denied",
+    } as never);
+    const res = await probeIntegrationCredentials("odoo", validOdooCreds);
+    expect(res).toEqual({ success: false, reason: "Access denied" });
+  });
+
+  it("odoo: returns failure for invalid credentials shape", async () => {
+    const res = await probeIntegrationCredentials("odoo", {
+      url: "https://o",
+      db: "p",
+      login: "u",
+    });
+    expect(res).toEqual({ success: false, reason: "Invalid credentials format" });
+    expect(fetchOdooSchema).not.toHaveBeenCalled();
+  });
+
+  it("web-search: delegates to probeBraveApiKey", async () => {
+    vi.mocked(probeBraveApiKey).mockResolvedValue({ success: true });
+    const res = await probeIntegrationCredentials("web-search", { apiKey: "k" });
+    expect(res).toEqual({ success: true });
+    expect(probeBraveApiKey).toHaveBeenCalledWith("k");
+  });
+
+  it("web-search: returns failure when apiKey is missing", async () => {
+    const res = await probeIntegrationCredentials("web-search", {});
+    expect(res).toEqual({ success: false, reason: "apiKey is required" });
+    expect(probeBraveApiKey).not.toHaveBeenCalled();
+  });
+
+  it("returns failure with explicit message for unknown type", async () => {
+    const res = await probeIntegrationCredentials("unknown-type" as never, {});
+    expect(res).toEqual({
+      success: false,
+      reason: "Cannot probe credentials for unknown type: unknown-type",
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/integrations/probe.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/probe.test.ts
@@ -1,5 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+const { mockAuthenticate } = vi.hoisted(() => ({ mockAuthenticate: vi.fn() }));
+
+vi.mock("odoo-node", () => ({
+  OdooClient: Object.assign(class {}, { authenticate: mockAuthenticate }),
+}));
 vi.mock("@/lib/integrations/odoo-sync", () => ({
   fetchOdooSchema: vi.fn(),
 }));
@@ -13,6 +18,7 @@ import { probeIntegrationCredentials } from "@/lib/integrations/probe";
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockAuthenticate.mockResolvedValue(2);
 });
 
 describe("probeIntegrationCredentials", () => {
@@ -24,7 +30,7 @@ describe("probeIntegrationCredentials", () => {
     uid: 1,
   };
 
-  it("odoo: returns success when fetchOdooSchema succeeds", async () => {
+  it("odoo: returns success with freshCredentials when fetchOdooSchema succeeds", async () => {
     vi.mocked(fetchOdooSchema).mockResolvedValue({
       success: true,
       models: 5,
@@ -32,7 +38,7 @@ describe("probeIntegrationCredentials", () => {
       lastSyncAt: new Date().toISOString(),
     } as never);
     const res = await probeIntegrationCredentials("odoo", validOdooCreds);
-    expect(res).toEqual({ success: true });
+    expect(res).toEqual({ success: true, freshCredentials: { uid: 2 } });
   });
 
   it("odoo: returns failure with reason from fetchOdooSchema", async () => {
@@ -72,6 +78,56 @@ describe("probeIntegrationCredentials", () => {
     expect(res).toEqual({
       success: false,
       reason: "Cannot probe credentials for unknown type: unknown-type",
+    });
+  });
+
+  describe("odoo authentication", () => {
+    it("returns clear auth-failed message when OdooClient.authenticate throws", async () => {
+      mockAuthenticate.mockRejectedValue(new Error("Invalid credentials"));
+      const res = await probeIntegrationCredentials("odoo", validOdooCreds);
+      expect(res.success).toBe(false);
+      if (res.success) return;
+      expect(res.reason).toMatch(/authentication failed/i);
+      expect(res.reason).toMatch(/login.*api key|api key.*login/i);
+      expect(fetchOdooSchema).not.toHaveBeenCalled();
+    });
+
+    it("re-resolves uid by re-authenticating with login + apiKey, passes fresh uid to fetchOdooSchema", async () => {
+      mockAuthenticate.mockResolvedValue(42); // fresh uid from Odoo
+      vi.mocked(fetchOdooSchema).mockResolvedValue({
+        success: true,
+        models: 5,
+        data: {} as never,
+        lastSyncAt: new Date().toISOString(),
+      } as never);
+
+      await probeIntegrationCredentials("odoo", {
+        ...validOdooCreds,
+        uid: 2, // stale, should be replaced by 42
+      });
+
+      expect(mockAuthenticate).toHaveBeenCalledWith({
+        url: validOdooCreds.url,
+        db: validOdooCreds.db,
+        login: validOdooCreds.login,
+        apiKey: validOdooCreds.apiKey,
+      });
+      expect(fetchOdooSchema).toHaveBeenCalledWith(expect.objectContaining({ uid: 42 }));
+    });
+
+    it("returns the fresh uid on success so caller can persist it (login change)", async () => {
+      mockAuthenticate.mockResolvedValue(42);
+      vi.mocked(fetchOdooSchema).mockResolvedValue({ success: true } as never);
+
+      const res = await probeIntegrationCredentials("odoo", validOdooCreds);
+
+      expect(res).toEqual({ success: true, freshCredentials: { uid: 42 } });
+    });
+
+    it("does NOT call fetchOdooSchema when authentication fails (avoids opaque 'no models' message)", async () => {
+      mockAuthenticate.mockRejectedValue(new Error("AccessDenied"));
+      await probeIntegrationCredentials("odoo", validOdooCreds);
+      expect(fetchOdooSchema).not.toHaveBeenCalled();
     });
   });
 });

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -9,6 +9,8 @@ import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
 import { maskConnectionCredentials } from "@/lib/integrations/mask-credentials";
 import { deleteOAuthSettings } from "@/lib/integrations/oauth-settings";
+import { probeIntegrationCredentials } from "@/lib/integrations/probe";
+import { clearIntegrationAuthError } from "@/lib/integrations/auth-state";
 import { z } from "zod";
 import { parseRequestBody, formatValidationError } from "@/lib/api-validation";
 
@@ -65,6 +67,15 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
   const rawCredentials = body.credentials;
   let parsedCredentials: Record<string, unknown> | undefined;
   if (rawCredentials !== undefined) {
+    if (existing.type === "google") {
+      return NextResponse.json(
+        {
+          error:
+            "Google credentials cannot be edited directly. Use Reconnect to start a new OAuth flow.",
+        },
+        { status: 400 }
+      );
+    }
     const credSchema = credentialSchemas[existing.type];
     if (!credSchema) {
       return NextResponse.json(
@@ -101,7 +112,19 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
         return NextResponse.json({ error: urlCheck.error }, { status: 400 });
       }
     }
-    updateData.credentials = encrypt(JSON.stringify(parsedCredentials));
+
+    // Merge with existing stored credentials so callers can omit unchanged fields
+    // ("leave empty to keep current" pattern).
+    const existingDecoded = JSON.parse(decrypt(existing.credentials)) as Record<string, unknown>;
+    const merged = { ...existingDecoded, ...parsedCredentials };
+
+    // Probe before persisting.
+    const probe = await probeIntegrationCredentials(existing.type, merged);
+    if (!probe.success) {
+      return NextResponse.json({ error: probe.reason }, { status: 400 });
+    }
+
+    updateData.credentials = encrypt(JSON.stringify(merged));
     changes.credentials = { from: "[redacted]", to: "[redacted]" };
   }
 
@@ -118,6 +141,25 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
       eventType: "config.changed",
       resource: `integration:${connectionId}`,
       detail: { action: "integration_updated", id: connectionId, changes },
+      outcome: "success",
+    });
+  }
+
+  if (parsedCredentials !== undefined) {
+    await clearIntegrationAuthError({
+      connectionId,
+      actor: { type: "user", id: session.user.id! },
+    });
+    await appendAuditLog({
+      actorType: "user",
+      actorId: session.user.id!,
+      eventType: "integration.credentials_updated",
+      resource: `integration:${connectionId}`,
+      detail: {
+        id: connectionId,
+        name: updated.name,
+        fields: Object.keys(parsedCredentials),
+      },
       outcome: "success",
     });
   }

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -127,7 +127,12 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
       return NextResponse.json({ error: probe.reason }, { status: 400 });
     }
 
-    updateData.credentials = encrypt(JSON.stringify(merged));
+    // Apply fields the probe resolved (e.g. fresh `uid` after a login change).
+    const finalCredentials = probe.freshCredentials
+      ? { ...merged, ...probe.freshCredentials }
+      : merged;
+
+    updateData.credentials = encrypt(JSON.stringify(finalCredentials));
     changes.credentials = { from: "[redacted]", to: "[redacted]" };
   }
 

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { eq } from "drizzle-orm";
+import { and, eq } from "drizzle-orm";
 import { withAdmin } from "@/lib/api-auth";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
@@ -134,8 +134,27 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
   const [updated] = await db
     .update(integrationConnections)
     .set(updateData)
-    .where(eq(integrationConnections.id, connectionId))
+    .where(
+      parsedCredentials !== undefined
+        ? and(
+            eq(integrationConnections.id, connectionId),
+            eq(integrationConnections.credentials, existing.credentials)
+          )
+        : eq(integrationConnections.id, connectionId)
+    )
     .returning();
+
+  if (!updated) {
+    return NextResponse.json(
+      {
+        error:
+          parsedCredentials !== undefined
+            ? "Credentials were updated concurrently, please try again"
+            : "Connection not found",
+      },
+      { status: parsedCredentials !== undefined ? 409 : 404 }
+    );
+  }
 
   if (Object.keys(changes).length > 0) {
     await appendAuditLog({

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -133,7 +133,11 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
       : merged;
 
     updateData.credentials = encrypt(JSON.stringify(finalCredentials));
-    changes.credentials = { from: "[redacted]", to: "[redacted]" };
+    // NOTE: credential changes intentionally do NOT go into `changes` — they
+    // get their own dedicated `integration.credentials_updated` event below,
+    // which gives CISOs a clean filter for "all credential touches" without
+    // having to also union "config.changed where details.changes.credentials
+    // exists". One mutation → one audit row.
   }
 
   const [updated] = await db
@@ -165,9 +169,9 @@ export const PATCH = withAdmin<RouteContext>(async (request, { params }, session
     await appendAuditLog({
       actorType: "user",
       actorId: session.user.id!,
-      eventType: "config.changed",
+      eventType: "integration.updated",
       resource: `integration:${connectionId}`,
-      detail: { action: "integration_updated", id: connectionId, changes },
+      detail: { id: connectionId, name: updated.name, changes },
       outcome: "success",
     });
   }
@@ -226,9 +230,9 @@ export const DELETE = withAdmin<RouteContext>(async (_req, { params }, session) 
   await appendAuditLog({
     actorType: "user",
     actorId: session.user.id!,
-    eventType: "config.changed",
+    eventType: "integration.deleted",
     resource: `integration:${connectionId}`,
-    detail: { action: "integration_deleted", type: existing.type, name: existing.name },
+    detail: { id: connectionId, name: existing.name, type: existing.type },
     outcome: "success",
   });
 

--- a/packages/web/src/app/api/integrations/[connectionId]/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/route.ts
@@ -23,8 +23,11 @@ const updateConnectionSchema = z
   .passthrough();
 
 const credentialSchemas: Record<string, z.ZodType> = {
-  odoo: odooCredentialsSchema,
-  "web-search": z.object({ apiKey: z.string().min(1) }).strict(),
+  odoo: odooCredentialsSchema.partial(),
+  "web-search": z
+    .object({ apiKey: z.string().min(1) })
+    .strict()
+    .partial(),
 };
 
 type RouteContext = { params: Promise<{ connectionId: string }> };

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -64,10 +64,9 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
     deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
-      eventType: "config.changed",
+      eventType: "integration.synced",
       resource: `integration:${connectionId}`,
       detail: {
-        action: "integration_schema_synced",
         id: connectionId,
         name: connection.name,
         modelCount: result.models,

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -41,11 +41,13 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
 
     const result = await fetchOdooSchema(parsed.data);
     if (!result.success) {
-      await setIntegrationAuthFailed({
-        connectionId,
-        reason: result.error,
-        actor: { type: "user", id: session.user.id! },
-      });
+      if (result.isAuthError) {
+        await setIntegrationAuthFailed({
+          connectionId,
+          reason: result.error,
+          actor: { type: "user", id: session.user.id! },
+        });
+      }
       return NextResponse.json(result);
     }
 
@@ -80,13 +82,6 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Sync failed";
-    await setIntegrationAuthFailed({
-      connectionId,
-      reason: message,
-      actor: { type: "user", id: session.user.id! },
-    }).catch(() => {
-      /* don't mask the original error */
-    });
     return NextResponse.json({ success: false, error: message }, { status: 200 });
   }
 });

--- a/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/sync/route.ts
@@ -8,6 +8,7 @@ import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { validateExternalUrl } from "@/lib/integrations/url-validation";
+import { setIntegrationAuthFailed, clearIntegrationAuthError } from "@/lib/integrations/auth-state";
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
@@ -40,6 +41,11 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
 
     const result = await fetchOdooSchema(parsed.data);
     if (!result.success) {
+      await setIntegrationAuthFailed({
+        connectionId,
+        reason: result.error,
+        actor: { type: "user", id: session.user.id! },
+      });
       return NextResponse.json(result);
     }
 
@@ -47,6 +53,11 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
       .update(integrationConnections)
       .set({ data: result.data, updatedAt: new Date() })
       .where(eq(integrationConnections.id, connectionId));
+
+    await clearIntegrationAuthError({
+      connectionId,
+      actor: { type: "user", id: session.user.id! },
+    });
 
     deferAuditLog({
       actorType: "user",
@@ -69,6 +80,13 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }, session) =>
     });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Sync failed";
+    await setIntegrationAuthFailed({
+      connectionId,
+      reason: message,
+      actor: { type: "user", id: session.user.id! },
+    }).catch(() => {
+      /* don't mask the original error */
+    });
     return NextResponse.json({ success: false, error: message }, { status: 200 });
   }
 });

--- a/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
@@ -1,5 +1,5 @@
 // audit-exempt: audit writes happen indirectly via setIntegrationAuthFailed (integration.auth_failed)
-// and clearIntegrationAuthError (integration.recovered) on status transitions. The Odoo uid
+// and clearIntegrationAuthError (integration.auth_recovered) on status transitions. The Odoo uid
 // self-heal path intentionally writes no audit entry — it is a one-time bootstrap, not a
 // user-initiated change.
 import { NextResponse } from "next/server";

--- a/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
+++ b/packages/web/src/app/api/integrations/[connectionId]/test/route.ts
@@ -1,7 +1,7 @@
-// audit-exempt: read-only for web-search. The Odoo branch may auto-repair a
-// stored uid when the first successful authenticate returns a different value
-// (one-time bootstrap), which is intentional and not user-initiated state
-// change — no separate audit entry is written for that self-heal path.
+// audit-exempt: audit writes happen indirectly via setIntegrationAuthFailed (integration.auth_failed)
+// and clearIntegrationAuthError (integration.recovered) on status transitions. The Odoo uid
+// self-heal path intentionally writes no audit entry — it is a one-time bootstrap, not a
+// user-initiated change.
 import { NextResponse } from "next/server";
 import { eq } from "drizzle-orm";
 import { OdooClient } from "odoo-node";
@@ -10,11 +10,14 @@ import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { decrypt, encrypt } from "@/lib/encryption";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
+import { probeIntegrationCredentials } from "@/lib/integrations/probe";
+import { clearIntegrationAuthError, setIntegrationAuthFailed } from "@/lib/integrations/auth-state";
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
-export const POST = withAdmin<RouteContext>(async (_req, { params }) => {
+export const POST = withAdmin<RouteContext>(async (_req, { params }, session) => {
   const { connectionId } = await params;
+  const actor = { type: "user" as const, id: session.user.id! };
 
   const [connection] = await db
     .select()
@@ -28,65 +31,44 @@ export const POST = withAdmin<RouteContext>(async (_req, { params }) => {
   try {
     const decrypted = JSON.parse(decrypt(connection.credentials));
 
-    // Web-search: validate API key against Brave Search API
-    if (connection.type === "web-search") {
-      const apiKey = decrypted.apiKey as string | undefined;
-      if (!apiKey) {
-        return NextResponse.json(
-          { success: false, error: "Invalid credentials format" },
-          { status: 200 }
-        );
+    // Odoo uid self-heal: if the authenticate call returns a different uid than
+    // what is stored (e.g. first connection with a placeholder), update the stored
+    // credentials. This must happen before the probe so the probe uses the correct uid.
+    if (connection.type === "odoo") {
+      const parsed = odooCredentialsSchema.safeParse(decrypted);
+      if (parsed.success) {
+        const creds = parsed.data;
+        const uid = await OdooClient.authenticate({
+          url: creds.url,
+          db: creds.db,
+          login: creds.login,
+          apiKey: creds.apiKey,
+        });
+        if (uid !== creds.uid) {
+          decrypted.uid = uid;
+          await db
+            .update(integrationConnections)
+            .set({
+              credentials: encrypt(JSON.stringify({ ...creds, uid })),
+              updatedAt: new Date(),
+            })
+            .where(eq(integrationConnections.id, connectionId));
+        }
       }
-      const res = await fetch("https://api.search.brave.com/res/v1/web/search?q=test&count=1", {
-        headers: { "X-Subscription-Token": apiKey },
-      });
-      if (!res.ok) {
-        return NextResponse.json({ success: false, error: "Invalid API key" }, { status: 200 });
-      }
+    }
+
+    const probe = await probeIntegrationCredentials(connection.type, decrypted);
+
+    if (probe.success) {
+      await clearIntegrationAuthError({ connectionId, actor });
       return NextResponse.json({ success: true });
+    } else {
+      await setIntegrationAuthFailed({ connectionId, reason: probe.reason, actor });
+      return NextResponse.json({ success: false, error: probe.reason }, { status: 200 });
     }
-
-    // Odoo: authenticate and verify version
-    const parsed = odooCredentialsSchema.safeParse(decrypted);
-    if (!parsed.success) {
-      return NextResponse.json(
-        { success: false, error: "Invalid credentials format" },
-        { status: 200 }
-      );
-    }
-
-    const creds = parsed.data;
-
-    // Authenticate against the real Odoo instance
-    const uid = await OdooClient.authenticate({
-      url: creds.url,
-      db: creds.db,
-      login: creds.login,
-      apiKey: creds.apiKey,
-    });
-
-    // Verify we can also get the version
-    const client = new OdooClient({ url: creds.url, db: creds.db, uid, apiKey: creds.apiKey });
-    const version = await client.version();
-
-    // If uid changed (e.g. first connection with placeholder uid), update stored credentials
-    if (uid !== creds.uid) {
-      await db
-        .update(integrationConnections)
-        .set({
-          credentials: encrypt(JSON.stringify({ ...creds, uid })),
-          updatedAt: new Date(),
-        })
-        .where(eq(integrationConnections.id, connectionId));
-    }
-
-    return NextResponse.json({
-      success: true,
-      version: version.serverVersion,
-      uid,
-    });
   } catch (error) {
     const message = error instanceof Error ? error.message : "Connection failed";
+    await setIntegrationAuthFailed({ connectionId, reason: message, actor });
     return NextResponse.json({ success: false, error: message }, { status: 200 });
   }
 });

--- a/packages/web/src/app/api/integrations/health/route.ts
+++ b/packages/web/src/app/api/integrations/health/route.ts
@@ -1,0 +1,14 @@
+// audit-exempt: read-only badge endpoint
+import { NextResponse } from "next/server";
+import { eq, sql } from "drizzle-orm";
+import { withAdmin } from "@/lib/api-auth";
+import { db } from "@/db";
+import { integrationConnections } from "@/db/schema";
+
+export const GET = withAdmin(async () => {
+  const [row] = await db
+    .select({ count: sql<number>`count(*)::int` })
+    .from(integrationConnections)
+    .where(eq(integrationConnections.status, "auth_failed"));
+  return NextResponse.json({ authFailedCount: row?.count ?? 0 });
+});

--- a/packages/web/src/app/api/integrations/oauth/callback/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/callback/route.ts
@@ -11,7 +11,26 @@ import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { redactEmail } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
+import { clearIntegrationAuthError } from "@/lib/integrations/auth-state";
 import { eq, and } from "drizzle-orm";
+
+/**
+ * Try to decode the OAuth state as a JSON payload (reconnect flow).
+ * Falls back to null if it's a plain nonce string (existing connect flow).
+ */
+function decodeStatePayload(
+  state: string
+): { nonce?: string; reconnectConnectionId?: string } | null {
+  try {
+    const decoded = Buffer.from(state, "base64url").toString("utf-8");
+    const obj = JSON.parse(decoded);
+    if (typeof obj === "object" && obj !== null)
+      return obj as { nonce?: string; reconnectConnectionId?: string };
+    return null;
+  } catch {
+    return null;
+  }
+}
 
 function errorRedirect(origin: string, error: string) {
   const url = new URL("/settings", origin);
@@ -121,7 +140,7 @@ export async function GET(request: Request) {
   const profileData = await profileResponse.json();
   const { emailAddress } = profileData;
 
-  // 8. Persist integration — UPDATE pending record if possible, otherwise INSERT
+  // 8. Persist integration
   const expiresAt = new Date(Date.now() + expires_in * 1000).toISOString();
   const encryptedCredentials = encrypt(
     JSON.stringify({
@@ -138,30 +157,92 @@ export async function GET(request: Request) {
     connectedAt: new Date().toISOString(),
   };
 
-  const pendingId = cookies["oauth_pending_id"];
   let connection: typeof integrationConnections.$inferSelect;
 
-  if (pendingId) {
-    const rows = await db
-      .select()
-      .from(integrationConnections)
-      .where(
-        and(eq(integrationConnections.id, pendingId), eq(integrationConnections.status, "pending"))
-      )
-      .limit(1);
+  // Check if this is a reconnect (state encodes reconnectConnectionId)
+  const statePayload = decodeStatePayload(state);
+  const reconnectConnectionId = statePayload?.reconnectConnectionId;
 
-    if (rows.length > 0) {
-      [connection] = await db
-        .update(integrationConnections)
-        .set({
-          name: emailAddress,
-          status: "active",
-          credentials: encryptedCredentials,
-          data: connectionData,
-          updatedAt: new Date(),
-        })
-        .where(eq(integrationConnections.id, pendingId))
-        .returning();
+  if (reconnectConnectionId) {
+    // Reconnect path: update the existing connection row so that
+    // agent_connection_permissions referencing it are preserved.
+    // Do NOT set status/lastError/lastErrorAt here — let clearIntegrationAuthError
+    // handle the auth_failed → active transition and write the integration.recovered
+    // audit event. If the connection was already active this is a no-op there.
+    [connection] = await db
+      .update(integrationConnections)
+      .set({
+        name: emailAddress,
+        credentials: encryptedCredentials,
+        data: connectionData,
+        updatedAt: new Date(),
+      })
+      .where(eq(integrationConnections.id, reconnectConnectionId))
+      .returning();
+
+    if (!connection) {
+      return errorRedirect(origin, "connection_not_found");
+    }
+
+    // Clear auth_failed state and write integration.recovered audit if needed
+    // (no-op if the connection was already active)
+    await clearIntegrationAuthError({
+      connectionId: reconnectConnectionId,
+      actor: { type: "user", id: session.user.id! },
+    });
+
+    // 9a. Audit log for reconnect
+    deferAuditLog({
+      actorType: "user",
+      actorId: session.user.id!,
+      eventType: "integration.credentials_updated",
+      resource: `integration:${connection.id}`,
+      detail: {
+        id: connection.id,
+        name: connection.name,
+        fields: ["oauth_tokens"],
+      },
+      outcome: "success",
+    });
+  } else {
+    // Original connect path: UPDATE pending record if possible, otherwise INSERT
+    const pendingId = cookies["oauth_pending_id"];
+
+    if (pendingId) {
+      const rows = await db
+        .select()
+        .from(integrationConnections)
+        .where(
+          and(
+            eq(integrationConnections.id, pendingId),
+            eq(integrationConnections.status, "pending")
+          )
+        )
+        .limit(1);
+
+      if (rows.length > 0) {
+        [connection] = await db
+          .update(integrationConnections)
+          .set({
+            name: emailAddress,
+            status: "active",
+            credentials: encryptedCredentials,
+            data: connectionData,
+            updatedAt: new Date(),
+          })
+          .where(eq(integrationConnections.id, pendingId))
+          .returning();
+      } else {
+        [connection] = await db
+          .insert(integrationConnections)
+          .values({
+            type: "google",
+            name: emailAddress,
+            credentials: encryptedCredentials,
+            data: connectionData,
+          })
+          .returning();
+      }
     } else {
       [connection] = await db
         .insert(integrationConnections)
@@ -173,36 +254,26 @@ export async function GET(request: Request) {
         })
         .returning();
     }
-  } else {
-    [connection] = await db
-      .insert(integrationConnections)
-      .values({
-        type: "google",
-        name: emailAddress,
-        credentials: encryptedCredentials,
-        data: connectionData,
-      })
-      .returning();
-  }
 
-  // 9. Audit log
-  // GDPR Art. 17: never record the plaintext Gmail address. The audit row
-  // is HMAC-signed, so we cannot redact later. redactEmail() gives us a
-  // keyed hash + masked preview; the connectionId in `resource` is enough
-  // to look up the live mailbox name from the integrations table while it
-  // exists.
-  deferAuditLog({
-    actorType: "user",
-    actorId: session.user.id!,
-    eventType: "config.changed",
-    resource: `integration:${connection.id}`,
-    detail: {
-      action: "integration_created",
-      type: "google",
-      ...redactEmail(emailAddress),
-    },
-    outcome: "success",
-  });
+    // 9b. Audit log for new connection
+    // GDPR Art. 17: never record the plaintext Gmail address. The audit row
+    // is HMAC-signed, so we cannot redact later. redactEmail() gives us a
+    // keyed hash + masked preview; the connectionId in `resource` is enough
+    // to look up the live mailbox name from the integrations table while it
+    // exists.
+    deferAuditLog({
+      actorType: "user",
+      actorId: session.user.id!,
+      eventType: "config.changed",
+      resource: `integration:${connection.id}`,
+      detail: {
+        action: "integration_created",
+        type: "google",
+        ...redactEmail(emailAddress),
+      },
+      outcome: "success",
+    });
+  }
 
   // 10. Clean up cookies and redirect
   const successUrl = new URL("/settings", origin);

--- a/packages/web/src/app/api/integrations/oauth/callback/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/callback/route.ts
@@ -101,12 +101,11 @@ export async function GET(request: Request) {
     deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
-      eventType: "config.changed",
+      eventType: "integration.created",
       resource: "integration:google",
       detail: {
-        action: "integration_oauth_failed",
         type: "google",
-        error: { message: "token_exchange_failed" },
+        reason: "token_exchange_failed",
       },
       outcome: "failure",
     });
@@ -125,12 +124,11 @@ export async function GET(request: Request) {
     deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
-      eventType: "config.changed",
+      eventType: "integration.created",
       resource: "integration:google",
       detail: {
-        action: "integration_oauth_failed",
         type: "google",
-        error: { message: "profile_fetch_failed" },
+        reason: "profile_fetch_failed",
       },
       outcome: "failure",
     });
@@ -167,7 +165,7 @@ export async function GET(request: Request) {
     // Reconnect path: update the existing connection row so that
     // agent_connection_permissions referencing it are preserved.
     // Do NOT set status/lastError/lastErrorAt here — let clearIntegrationAuthError
-    // handle the auth_failed → active transition and write the integration.recovered
+    // handle the auth_failed → active transition and write the integration.auth_recovered
     // audit event. If the connection was already active this is a no-op there.
     [connection] = await db
       .update(integrationConnections)
@@ -184,7 +182,7 @@ export async function GET(request: Request) {
       return errorRedirect(origin, "connection_not_found");
     }
 
-    // Clear auth_failed state and write integration.recovered audit if needed
+    // Clear auth_failed state and write integration.auth_recovered audit if needed
     // (no-op if the connection was already active)
     await clearIntegrationAuthError({
       connectionId: reconnectConnectionId,
@@ -264,10 +262,9 @@ export async function GET(request: Request) {
     deferAuditLog({
       actorType: "user",
       actorId: session.user.id!,
-      eventType: "config.changed",
+      eventType: "integration.created",
       resource: `integration:${connection.id}`,
       detail: {
-        action: "integration_created",
         type: "google",
         ...redactEmail(emailAddress),
       },

--- a/packages/web/src/app/api/integrations/oauth/start/route.ts
+++ b/packages/web/src/app/api/integrations/oauth/start/route.ts
@@ -3,11 +3,23 @@
 // failure we must redirect (not return JSON) — symmetric with oauth/callback.
 // The api-auth wrappers always return JSON, so this route uses an inline
 // session check.
-import { NextResponse } from "next/server";
+//
+// POST /oauth/start is the programmatic reconnect entry point. It accepts a
+// JSON body with reconnectConnectionId and returns { url } for the client to
+// navigate to. Failures return JSON errors (not redirects) since the POST is
+// called via fetch, not browser navigation.
+//
+// audit-exempt: Neither handler mutates persistent state — GET creates a pending
+// row (not auditable on its own) and POST only builds a redirect URL. The actual
+// credential mutation and audit entry (integration.credentials_updated) are
+// written by oauth/callback after the token exchange succeeds.
+import { NextRequest, NextResponse } from "next/server";
 import { headers } from "next/headers";
 import { randomBytes } from "crypto";
+import { z } from "zod";
 import { getSession } from "@/lib/auth";
 import { getOAuthSettings } from "@/lib/integrations/oauth-settings";
+import { parseRequestBody } from "@/lib/api-validation";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { encrypt } from "@/lib/encryption";
@@ -99,6 +111,91 @@ export async function GET(request: Request) {
     path: "/",
   });
   response.cookies.set("oauth_pending_id", pending.id, {
+    httpOnly: true,
+    secure: isSecure,
+    sameSite: "lax",
+    maxAge: 600,
+    path: "/",
+  });
+
+  return response;
+}
+
+const reconnectSchema = z.object({
+  reconnectConnectionId: z.string().min(1),
+});
+
+/**
+ * POST /api/integrations/oauth/start
+ *
+ * Programmatic reconnect entry point for google connections that have entered
+ * auth_failed state. Accepts { reconnectConnectionId } and returns { url }
+ * for the client to navigate to. The state parameter is a base64url-encoded
+ * JSON payload containing a CSRF nonce and the connection ID to update.
+ *
+ * audit-exempt: This handler only validates and builds the OAuth redirect URL.
+ * No state is mutated here; the audit entry is written by oauth/callback when
+ * the tokens are actually exchanged and persisted (integration.credentials_updated).
+ */
+export async function POST(request: NextRequest) {
+  const requestUrl = new URL(request.url);
+  const forwardedProto = request.headers.get("x-forwarded-proto")?.split(",")[0].trim();
+  const forwardedHost = request.headers.get("x-forwarded-host") || request.headers.get("host");
+  const origin =
+    forwardedProto && forwardedHost ? `${forwardedProto}://${forwardedHost}` : requestUrl.origin;
+
+  const session = await getSession({ headers: await headers() });
+  if (!session?.user || session.user.role !== "admin") {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await parseRequestBody(reconnectSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const { reconnectConnectionId } = parsed.data;
+
+  // Verify the connection exists and is a google-type connection
+  const [connection] = await db
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, reconnectConnectionId))
+    .limit(1);
+
+  if (!connection) {
+    return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+  }
+
+  if (connection.type !== "google") {
+    return NextResponse.json(
+      { error: "Only google connections support OAuth re-auth" },
+      { status: 400 }
+    );
+  }
+
+  const settings = await getOAuthSettings("google");
+  if (!settings) {
+    return NextResponse.json({ error: "Google OAuth is not configured" }, { status: 400 });
+  }
+
+  // Build the state as base64url-encoded JSON so the callback can extract
+  // both the CSRF nonce and the reconnectConnectionId.
+  const nonce = randomBytes(32).toString("hex");
+  const stateObj = { nonce, reconnectConnectionId };
+  const state = Buffer.from(JSON.stringify(stateObj)).toString("base64url");
+
+  const redirectUri = `${origin}/api/integrations/oauth/callback`;
+
+  const authUrl = new URL("https://accounts.google.com/o/oauth2/v2/auth");
+  authUrl.searchParams.set("client_id", settings.clientId);
+  authUrl.searchParams.set("redirect_uri", redirectUri);
+  authUrl.searchParams.set("response_type", "code");
+  authUrl.searchParams.set("scope", GOOGLE_OAUTH_SCOPES);
+  authUrl.searchParams.set("access_type", "offline");
+  authUrl.searchParams.set("prompt", "consent");
+  authUrl.searchParams.set("state", state);
+
+  const isSecure = (forwardedProto ?? requestUrl.protocol.replace(":", "")) === "https";
+  const response = NextResponse.json({ url: authUrl.toString() }, { status: 200 });
+  response.cookies.set("oauth_state", state, {
     httpOnly: true,
     secure: isSecure,
     sameSite: "lax",

--- a/packages/web/src/app/api/integrations/route.ts
+++ b/packages/web/src/app/api/integrations/route.ts
@@ -108,9 +108,9 @@ export const POST = withAdmin(async (request, _ctx, session) => {
   deferAuditLog({
     actorType: "user",
     actorId: session.user.id!,
-    eventType: "config.changed",
+    eventType: "integration.created",
     resource: `integration:${connection.id}`,
-    detail: { action: "integration_created", type, name },
+    detail: { type, name },
     outcome: "success",
   });
 

--- a/packages/web/src/app/api/internal/integrations/[connectionId]/report-auth-failure/route.ts
+++ b/packages/web/src/app/api/internal/integrations/[connectionId]/report-auth-failure/route.ts
@@ -1,0 +1,32 @@
+// audit-exempt: setIntegrationAuthFailed handles its own audit-on-transition.
+import { NextRequest, NextResponse } from "next/server";
+import { z } from "zod";
+import { validateGatewayToken } from "@/lib/gateway-auth";
+import { setIntegrationAuthFailed } from "@/lib/integrations/auth-state";
+import { parseRequestBody } from "@/lib/api-validation";
+
+const bodySchema = z.object({
+  reason: z.string().min(1).max(500),
+});
+
+type RouteContext = { params: Promise<{ connectionId: string }> };
+
+export async function POST(request: NextRequest, { params }: RouteContext) {
+  if (!validateGatewayToken(request.headers)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await parseRequestBody(bodySchema, request);
+  if ("error" in parsed) return parsed.error;
+
+  const { connectionId } = await params;
+  const pluginId = request.headers.get("X-Plugin-Id") ?? "unknown";
+
+  await setIntegrationAuthFailed({
+    connectionId,
+    reason: parsed.data.reason,
+    actor: { type: "system", id: `plugin:${pluginId}` },
+  });
+
+  return new NextResponse(null, { status: 204 });
+}

--- a/packages/web/src/app/api/internal/integrations/[connectionId]/report-auth-failure/route.ts
+++ b/packages/web/src/app/api/internal/integrations/[connectionId]/report-auth-failure/route.ts
@@ -4,10 +4,18 @@ import { z } from "zod";
 import { validateGatewayToken } from "@/lib/gateway-auth";
 import { setIntegrationAuthFailed } from "@/lib/integrations/auth-state";
 import { parseRequestBody } from "@/lib/api-validation";
+import { KNOWN_PINCHY_PLUGINS } from "@/lib/openclaw-config/plugin-manifest-loader";
 
 const bodySchema = z.object({
   reason: z.string().min(1).max(500),
 });
+
+// All Pinchy plugins share the same bootstrap gateway token (Pattern C in
+// AGENTS.md), so the header alone cannot prove which plugin is calling. We
+// allowlist X-Plugin-Id against the known Pinchy-plugin set so a buggy or
+// impersonating caller cannot record audit transitions under an arbitrary
+// actor name.
+const KNOWN_PLUGIN_IDS: ReadonlySet<string> = new Set(KNOWN_PINCHY_PLUGINS);
 
 type RouteContext = { params: Promise<{ connectionId: string }> };
 
@@ -16,11 +24,15 @@ export async function POST(request: NextRequest, { params }: RouteContext) {
     return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
   }
 
+  const pluginId = request.headers.get("X-Plugin-Id");
+  if (!pluginId || !KNOWN_PLUGIN_IDS.has(pluginId)) {
+    return NextResponse.json({ error: "Missing or unknown X-Plugin-Id header" }, { status: 400 });
+  }
+
   const parsed = await parseRequestBody(bodySchema, request);
   if ("error" in parsed) return parsed.error;
 
   const { connectionId } = await params;
-  const pluginId = request.headers.get("X-Plugin-Id") ?? "unknown";
 
   await setIntegrationAuthFailed({
     connectionId,

--- a/packages/web/src/components/add-integration-dialog.tsx
+++ b/packages/web/src/components/add-integration-dialog.tsx
@@ -20,6 +20,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { UrlInput } from "@/components/ui/url-input";
 import { Label } from "@/components/ui/label";
 import { Button } from "@/components/ui/button";
 import {
@@ -31,11 +32,8 @@ import {
 } from "@/components/ui/select";
 import { toast } from "sonner";
 import { PasswordInput } from "@/components/password-input";
-import {
-  normalizeOdooUrl,
-  parseOdooSubdomainHint,
-  generateConnectionName,
-} from "@/lib/integrations/odoo-url";
+import { parseOdooSubdomainHint, generateConnectionName } from "@/lib/integrations/odoo-url";
+import { normalizeUrl } from "@/lib/url";
 import { Loader2, CheckCircle2, AlertTriangle, Copy, Check } from "lucide-react";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { OdooIcon, GoogleIcon, BraveIcon } from "./integration-icons";
@@ -484,7 +482,7 @@ export function AddIntegrationDialog({
   // --- URL blur: fetch databases ---
 
   async function handleUrlBlur(raw: string) {
-    const url = normalizeOdooUrl(raw);
+    const url = normalizeUrl(raw);
     if (!url) return;
 
     if (url !== raw) {
@@ -841,8 +839,8 @@ export function AddIntegrationDialog({
                     <FormItem>
                       <FormLabel>URL</FormLabel>
                       <FormControl>
-                        <Input
-                          placeholder="https://odoo.example.com"
+                        <UrlInput
+                          placeholder="odoo.example.com"
                           {...field}
                           onBlur={(e) => {
                             field.onBlur();

--- a/packages/web/src/components/edit-credentials-dialog.tsx
+++ b/packages/web/src/components/edit-credentials-dialog.tsx
@@ -1,0 +1,369 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useForm } from "react-hook-form";
+import { zodResolver } from "@hookform/resolvers/zod";
+import { toast } from "sonner";
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+} from "@/components/ui/dialog";
+import {
+  Form,
+  FormField,
+  FormItem,
+  FormLabel,
+  FormControl,
+  FormMessage,
+} from "@/components/ui/form";
+import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { AlertTriangle, Loader2 } from "lucide-react";
+import { apiPatch, apiPost, ApiError } from "@/lib/api-client";
+import { odooEditSchema, webSearchEditSchema } from "@/lib/schemas/integration-edit";
+import type { IntegrationConnection } from "@/lib/integrations/types";
+import type { z } from "zod";
+
+interface EditCredentialsDialogProps {
+  connection: IntegrationConnection | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  onSuccess: () => void;
+}
+
+type OdooFormValues = z.infer<typeof odooEditSchema>;
+type WebSearchFormValues = z.infer<typeof webSearchEditSchema>;
+
+function OdooForm({
+  connection,
+  onSuccess,
+  onOpenChange,
+}: {
+  connection: IntegrationConnection;
+  onSuccess: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [serverError, setServerError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const maskedCreds =
+    connection.credentials && typeof connection.credentials === "object"
+      ? (connection.credentials as { url?: string; db?: string; login?: string })
+      : {};
+
+  const form = useForm<OdooFormValues>({
+    resolver: zodResolver(odooEditSchema),
+    defaultValues: {
+      url: maskedCreds.url ?? "",
+      db: maskedCreds.db ?? "",
+      login: maskedCreds.login ?? "",
+      apiKey: "",
+    },
+  });
+
+  useEffect(() => {
+    form.reset({
+      url: maskedCreds.url ?? "",
+      db: maskedCreds.db ?? "",
+      login: maskedCreds.login ?? "",
+      apiKey: "",
+    });
+    setServerError("");
+  }, [connection.id]);
+
+  async function onSubmit(values: OdooFormValues) {
+    setSaving(true);
+    setServerError("");
+    const credentials: Record<string, string> = {};
+    if (values.url) credentials.url = values.url;
+    if (values.db) credentials.db = values.db;
+    if (values.login) credentials.login = values.login;
+    if (values.apiKey) credentials.apiKey = values.apiKey;
+
+    try {
+      await apiPatch(`/api/integrations/${connection.id}`, { credentials });
+      toast.success("Credentials updated");
+      onSuccess();
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setServerError(err.message);
+      } else {
+        setServerError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {connection.status === "auth_failed" && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              Current credentials failed authentication — please enter new credentials below.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <FormField
+          control={form.control}
+          name="url"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>URL</FormLabel>
+              <FormControl>
+                <Input placeholder="Leave empty to keep current" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="db"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Database</FormLabel>
+              <FormControl>
+                <Input placeholder="Leave empty to keep current" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="login"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>Login</FormLabel>
+              <FormControl>
+                <Input placeholder="Leave empty to keep current" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+        <FormField
+          control={form.control}
+          name="apiKey"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>API Key</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="Leave empty to keep current" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+function WebSearchForm({
+  connection,
+  onSuccess,
+  onOpenChange,
+}: {
+  connection: IntegrationConnection;
+  onSuccess: () => void;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [serverError, setServerError] = useState("");
+  const [saving, setSaving] = useState(false);
+
+  const form = useForm<WebSearchFormValues>({
+    resolver: zodResolver(webSearchEditSchema),
+    defaultValues: { apiKey: "" },
+  });
+
+  useEffect(() => {
+    form.reset({ apiKey: "" });
+    setServerError("");
+  }, [connection.id]);
+
+  async function onSubmit(values: WebSearchFormValues) {
+    setSaving(true);
+    setServerError("");
+    const credentials: Record<string, string> = {};
+    if (values.apiKey) credentials.apiKey = values.apiKey;
+
+    try {
+      await apiPatch(`/api/integrations/${connection.id}`, { credentials });
+      toast.success("Credentials updated");
+      onSuccess();
+      onOpenChange(false);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setServerError(err.message);
+      } else {
+        setServerError("Something went wrong. Please try again.");
+      }
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  return (
+    <Form {...form}>
+      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-4">
+        {connection.status === "auth_failed" && (
+          <Alert variant="destructive">
+            <AlertTriangle className="h-4 w-4" />
+            <AlertDescription>
+              Current credentials failed authentication — please enter new credentials below.
+            </AlertDescription>
+          </Alert>
+        )}
+
+        <FormField
+          control={form.control}
+          name="apiKey"
+          render={({ field }) => (
+            <FormItem>
+              <FormLabel>API Key</FormLabel>
+              <FormControl>
+                <Input type="password" placeholder="Leave empty to keep current" {...field} />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+
+        {serverError && <p className="text-sm text-destructive">{serverError}</p>}
+
+        <div className="flex justify-end gap-2">
+          <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+            Cancel
+          </Button>
+          <Button type="submit" disabled={saving}>
+            {saving ? (
+              <>
+                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+                Saving...
+              </>
+            ) : (
+              "Save"
+            )}
+          </Button>
+        </div>
+      </form>
+    </Form>
+  );
+}
+
+function GoogleReconnect({
+  connection,
+  onOpenChange,
+}: {
+  connection: IntegrationConnection;
+  onOpenChange: (open: boolean) => void;
+}) {
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState("");
+
+  async function handleReconnect() {
+    setLoading(true);
+    setError("");
+    try {
+      const result = await apiPost<{ url: string }>("/api/integrations/oauth/start", {
+        reconnectConnectionId: connection.id,
+      });
+      window.location.assign(result.url);
+    } catch (err) {
+      if (err instanceof ApiError) {
+        setError(err.message);
+      } else {
+        setError("Something went wrong. Please try again.");
+      }
+      setLoading(false);
+    }
+  }
+
+  return (
+    <div className="space-y-4">
+      <p className="text-sm text-muted-foreground">
+        Google credentials are managed via OAuth. Click below to start a new authorization flow.
+      </p>
+
+      {error && <p className="text-sm text-destructive">{error}</p>}
+
+      <div className="flex justify-end gap-2">
+        <Button type="button" variant="outline" onClick={() => onOpenChange(false)}>
+          Cancel
+        </Button>
+        <Button onClick={handleReconnect} disabled={loading}>
+          {loading ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Redirecting...
+            </>
+          ) : (
+            "Reconnect via Google"
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}
+
+export function EditCredentialsDialog({
+  connection,
+  open,
+  onOpenChange,
+  onSuccess,
+}: EditCredentialsDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent className="sm:max-w-md">
+        <DialogHeader>
+          <DialogTitle>Edit Credentials</DialogTitle>
+          <DialogDescription>
+            Update the credentials for{" "}
+            <span className="font-medium">{connection?.name ?? "this integration"}</span>. Leave
+            fields empty to keep their current values.
+          </DialogDescription>
+        </DialogHeader>
+
+        {connection?.type === "google" ? (
+          <GoogleReconnect connection={connection} onOpenChange={onOpenChange} />
+        ) : connection?.type === "odoo" ? (
+          <OdooForm connection={connection} onSuccess={onSuccess} onOpenChange={onOpenChange} />
+        ) : connection?.type === "web-search" ? (
+          <WebSearchForm
+            connection={connection}
+            onSuccess={onSuccess}
+            onOpenChange={onOpenChange}
+          />
+        ) : null}
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/edit-credentials-dialog.tsx
+++ b/packages/web/src/components/edit-credentials-dialog.tsx
@@ -73,7 +73,7 @@ function OdooForm({
       apiKey: "",
     });
     setServerError("");
-  }, [connection.id]);
+  }, [connection.id, maskedCreds.url, maskedCreds.db, maskedCreds.login]);
 
   async function onSubmit(values: OdooFormValues) {
     setSaving(true);

--- a/packages/web/src/components/edit-credentials-dialog.tsx
+++ b/packages/web/src/components/edit-credentials-dialog.tsx
@@ -20,6 +20,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { Input } from "@/components/ui/input";
+import { UrlInput } from "@/components/ui/url-input";
 import { Button } from "@/components/ui/button";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { AlertTriangle, Loader2 } from "lucide-react";
@@ -119,7 +120,7 @@ function OdooForm({
             <FormItem>
               <FormLabel>URL</FormLabel>
               <FormControl>
-                <Input placeholder="Leave empty to keep current" {...field} />
+                <UrlInput placeholder="Leave empty to keep current" {...field} />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -34,6 +34,7 @@ import {
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 // toast is now handled by useIntegrationActions hook
 import { AddIntegrationDialog } from "./add-integration-dialog";
+import { EditCredentialsDialog } from "./edit-credentials-dialog";
 import { EditOAuthDialog } from "./edit-oauth-dialog";
 import { BraveIcon, GoogleIcon, OdooIcon } from "./integration-icons";
 import type { IntegrationConnection } from "@/lib/integrations/types";
@@ -66,6 +67,7 @@ export function SettingsIntegrations() {
   const [renameName, setRenameName] = useState("");
   const [showOAuthEdit, setShowOAuthEdit] = useState(false);
   const [resumeGoogleSetup, setResumeGoogleSetup] = useState(false);
+  const [editCredConn, setEditCredConn] = useState<IntegrationConnection | null>(null);
 
   const fetchConnections = useCallback(async () => {
     try {
@@ -195,11 +197,7 @@ export function SettingsIntegrations() {
                           ) : (
                             <>
                               {conn.status === "auth_failed" && (
-                                <DropdownMenuItem
-                                  onClick={() => {
-                                    // TODO(Task 14): open edit-credentials dialog
-                                  }}
-                                >
+                                <DropdownMenuItem onClick={() => setEditCredConn(conn)}>
                                   Reconnect
                                 </DropdownMenuItem>
                               )}
@@ -217,6 +215,9 @@ export function SettingsIntegrations() {
                                 </DropdownMenuItem>
                               ) : (
                                 <>
+                                  <DropdownMenuItem onClick={() => setEditCredConn(conn)}>
+                                    Edit credentials
+                                  </DropdownMenuItem>
                                   <DropdownMenuItem
                                     onClick={() => testConnection(conn.id)}
                                     disabled={testing === conn.id}
@@ -395,6 +396,16 @@ export function SettingsIntegrations() {
       </AlertDialog>
 
       <EditOAuthDialog open={showOAuthEdit} onOpenChange={setShowOAuthEdit} />
+
+      <EditCredentialsDialog
+        connection={editCredConn}
+        open={editCredConn !== null}
+        onOpenChange={(o) => !o && setEditCredConn(null)}
+        onSuccess={() => {
+          setEditCredConn(null);
+          fetchConnections();
+        }}
+      />
     </div>
   );
 }

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -194,6 +194,15 @@ export function SettingsIntegrations() {
                             </>
                           ) : (
                             <>
+                              {conn.status === "auth_failed" && (
+                                <DropdownMenuItem
+                                  onClick={() => {
+                                    // TODO(Task 14): open edit-credentials dialog
+                                  }}
+                                >
+                                  Reconnect
+                                </DropdownMenuItem>
+                              )}
                               <DropdownMenuItem
                                 onClick={() => {
                                   setRenameTarget(conn);
@@ -246,6 +255,24 @@ export function SettingsIntegrations() {
                           <>
                             <CheckCircle2 className="h-3.5 w-3.5 text-green-600 dark:text-green-400" />
                             <span>Connected</span>
+                          </>
+                        ) : conn.status === "auth_failed" ? (
+                          <>
+                            <AlertTriangle
+                              className="h-3.5 w-3.5 text-destructive"
+                              aria-label="Authentication failed"
+                            />
+                            <span className="text-sm text-destructive font-medium">
+                              Authentication failed
+                            </span>
+                            {conn.lastError && (
+                              <span
+                                className="text-xs text-muted-foreground truncate"
+                                title={conn.lastError}
+                              >
+                                {conn.lastError}
+                              </span>
+                            )}
                           </>
                         ) : testing === conn.id ? (
                           <>

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -21,6 +21,7 @@ import { Button } from "@/components/ui/button";
 import { getAgentAvatarSvg } from "@/lib/avatar";
 import { buildBugReportUrl } from "@/lib/github-issue";
 import { AgentSidebarIndicator } from "@/components/agent-sidebar-indicator";
+import { useIntegrationHealth } from "@/hooks/use-integration-health";
 
 interface AppSidebarProps {
   isAdmin: boolean;
@@ -29,6 +30,7 @@ interface AppSidebarProps {
 export function AppSidebar({ isAdmin }: AppSidebarProps) {
   const pathname = usePathname();
   const { sortedAgents } = useAgentsContext();
+  const { authFailedCount } = useIntegrationHealth(isAdmin);
 
   return (
     <Sidebar>
@@ -108,6 +110,14 @@ export function AppSidebar({ isAdmin }: AppSidebarProps) {
               <Link href="/settings">
                 <Settings className="size-4" />
                 <span>Settings</span>
+                {authFailedCount > 0 && (
+                  <span
+                    aria-label={`${authFailedCount} integration${authFailedCount === 1 ? "" : "s"} need${authFailedCount === 1 ? "s" : ""} attention`}
+                    className="ml-auto flex items-center justify-center size-4 rounded-full bg-destructive text-destructive-foreground text-[10px] font-bold"
+                  >
+                    !
+                  </span>
+                )}
               </Link>
             </SidebarMenuButton>
           </SidebarMenuItem>

--- a/packages/web/src/components/ui/__tests__/url-input.test.tsx
+++ b/packages/web/src/components/ui/__tests__/url-input.test.tsx
@@ -1,0 +1,72 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { UrlInput } from "../url-input";
+
+describe("UrlInput", () => {
+  it("normalizes value onBlur (prepends https:// for bare hostname)", async () => {
+    const handleChange = vi.fn();
+    render(<UrlInput value="odoo-demo.heypinchy.com" onChange={handleChange} />);
+
+    const input = screen.getByRole("textbox");
+    input.focus();
+    await userEvent.tab(); // blur
+
+    // The synthetic change event should fire with the normalized value
+    expect(handleChange).toHaveBeenCalled();
+    const lastCall = handleChange.mock.calls.at(-1);
+    const event = lastCall?.[0];
+    expect(event.target.value).toBe("https://odoo-demo.heypinchy.com");
+  });
+
+  it("normalizes value onBlur (strips path)", async () => {
+    const handleChange = vi.fn();
+    render(<UrlInput value="https://odoo.example.com/web/login" onChange={handleChange} />);
+
+    const input = screen.getByRole("textbox");
+    input.focus();
+    await userEvent.tab();
+
+    const event = handleChange.mock.calls.at(-1)?.[0];
+    expect(event.target.value).toBe("https://odoo.example.com");
+  });
+
+  it("does not fire onChange when value is already normalized", async () => {
+    const handleChange = vi.fn();
+    render(<UrlInput value="https://odoo.example.com" onChange={handleChange} />);
+
+    const input = screen.getByRole("textbox");
+    input.focus();
+    await userEvent.tab();
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("leaves invalid input untouched (zod validation will catch it later)", async () => {
+    const handleChange = vi.fn();
+    render(<UrlInput value="not a url" onChange={handleChange} />);
+
+    const input = screen.getByRole("textbox");
+    input.focus();
+    await userEvent.tab();
+
+    expect(handleChange).not.toHaveBeenCalled();
+  });
+
+  it("still forwards onBlur callback when provided", async () => {
+    const handleBlur = vi.fn();
+    render(<UrlInput value="https://example.com" onBlur={handleBlur} onChange={() => {}} />);
+
+    screen.getByRole("textbox").focus();
+    await userEvent.tab();
+
+    expect(handleBlur).toHaveBeenCalled();
+  });
+
+  it("renders as a plain text input (not type=url) so submission isn't blocked by missing protocol", () => {
+    render(<UrlInput value="" onChange={() => {}} />);
+    const input = screen.getByRole("textbox") as HTMLInputElement;
+    expect(input.type).toBe("text");
+    expect(input.inputMode).toBe("url");
+  });
+});

--- a/packages/web/src/components/ui/url-input.tsx
+++ b/packages/web/src/components/ui/url-input.tsx
@@ -1,0 +1,51 @@
+"use client";
+
+import * as React from "react";
+import { Input } from "./input";
+import { normalizeUrl } from "@/lib/url";
+
+/**
+ * Input variant that auto-normalizes URLs onBlur:
+ *  - prepends `https://` when no protocol is present
+ *  - strips path / query / fragment to the bare origin
+ *
+ * Renders as `type="text"` (not `type="url"`) on purpose. Native URL inputs
+ * block form submission when the value lacks a protocol — which is the
+ * exact UX trap we want to fix (users pasting bare hostnames).
+ *
+ * Pairs with react-hook-form via the standard `{...field}` spread: when
+ * normalization changes the value, we dispatch a synthetic onChange so the
+ * form state stays in sync.
+ */
+export function UrlInput({ onBlur, onChange, ...props }: React.ComponentProps<typeof Input>) {
+  function handleBlur(event: React.FocusEvent<HTMLInputElement>) {
+    const raw = event.target.value;
+    const normalized = normalizeUrl(raw);
+
+    if (normalized && normalized !== raw) {
+      // Mutate the input value, then fire onChange so react-hook-form (and
+      // any other controlled-input consumer) picks up the normalized value.
+      event.target.value = normalized;
+      const syntheticEvent = {
+        ...event,
+        target: event.target,
+        currentTarget: event.currentTarget,
+      } as React.ChangeEvent<HTMLInputElement>;
+      onChange?.(syntheticEvent);
+    }
+
+    onBlur?.(event);
+  }
+
+  return (
+    <Input
+      type="text"
+      inputMode="url"
+      autoComplete="url"
+      spellCheck={false}
+      onBlur={handleBlur}
+      onChange={onChange}
+      {...props}
+    />
+  );
+}

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -304,7 +304,9 @@ export const integrationConnections = pgTable("integration_connections", {
   description: text("description").notNull().default(""),
   credentials: text("credentials").notNull(), // AES-256-GCM encrypted JSON
   data: jsonb("data"), // Type-specific, Zod-validated (schema cache)
-  status: text("status").notNull().default("active"), // 'active' | 'pending'
+  status: text("status").notNull().default("active"), // 'active' | 'pending' | 'auth_failed'
+  lastError: text("last_error"),
+  lastErrorAt: timestamp("last_error_at"),
   createdAt: timestamp("created_at").defaultNow(),
   updatedAt: timestamp("updated_at").defaultNow(),
 });

--- a/packages/web/src/hooks/__tests__/use-integration-actions.test.ts
+++ b/packages/web/src/hooks/__tests__/use-integration-actions.test.ts
@@ -143,7 +143,7 @@ describe("useIntegrationActions", () => {
       });
 
       expect(mockToastError).toHaveBeenCalledWith("Permission denied");
-      expect(mockOnChange).not.toHaveBeenCalled();
+      expect(mockOnChange).toHaveBeenCalled();
     });
   });
 

--- a/packages/web/src/hooks/use-integration-actions.ts
+++ b/packages/web/src/hooks/use-integration-actions.ts
@@ -36,10 +36,10 @@ export function useIntegrationActions(onChange: () => void) {
         const data = await res.json();
         if (data.success) {
           toast.success("Schema synced successfully");
-          onChange();
         } else {
           toast.error(data.error || "Schema sync failed");
         }
+        onChange();
       } catch {
         toast.error("Failed to sync schema");
       } finally {

--- a/packages/web/src/hooks/use-integration-health.ts
+++ b/packages/web/src/hooks/use-integration-health.ts
@@ -1,0 +1,27 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export function useIntegrationHealth(enabled: boolean): { authFailedCount: number } {
+  const [count, setCount] = useState(0);
+  useEffect(() => {
+    if (!enabled) return;
+    let cancelled = false;
+    const fetchHealth = async () => {
+      try {
+        const res = await fetch("/api/integrations/health");
+        if (!res.ok) return;
+        const data = (await res.json()) as { authFailedCount: number };
+        if (!cancelled) setCount(data.authFailedCount);
+      } catch {
+        /* badge is best-effort */
+      }
+    };
+    fetchHealth();
+    const id = setInterval(fetchHealth, 60_000);
+    return () => {
+      cancelled = true;
+      clearInterval(id);
+    };
+  }, [enabled]);
+  return { authFailedCount: count };
+}

--- a/packages/web/src/lib/__tests__/url.test.ts
+++ b/packages/web/src/lib/__tests__/url.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect } from "vitest";
+import { normalizeUrl } from "../url";
+
+describe("normalizeUrl", () => {
+  describe("path / query / fragment stripping", () => {
+    it("strips trailing slash", () => {
+      expect(normalizeUrl("https://odoo.example.com/")).toBe("https://odoo.example.com");
+    });
+
+    it("strips path", () => {
+      expect(normalizeUrl("https://odoo.example.com/odoo")).toBe("https://odoo.example.com");
+    });
+
+    it("strips /web/login path", () => {
+      expect(normalizeUrl("https://odoo.example.com/web/login")).toBe("https://odoo.example.com");
+    });
+
+    it("strips query string", () => {
+      expect(normalizeUrl("https://odoo.example.com/web?db=prod")).toBe("https://odoo.example.com");
+    });
+
+    it("strips fragment", () => {
+      expect(normalizeUrl("https://odoo.example.com/web#section")).toBe("https://odoo.example.com");
+    });
+
+    it("returns origin as-is when already clean", () => {
+      expect(normalizeUrl("https://odoo.example.com")).toBe("https://odoo.example.com");
+    });
+
+    it("preserves port", () => {
+      expect(normalizeUrl("https://odoo.example.com:8069/web")).toBe(
+        "https://odoo.example.com:8069"
+      );
+    });
+  });
+
+  describe("protocol prepending", () => {
+    it("prepends https:// when no protocol given", () => {
+      expect(normalizeUrl("odoo-demo.heypinchy.com")).toBe("https://odoo-demo.heypinchy.com");
+    });
+
+    it("prepends https:// and strips path simultaneously", () => {
+      expect(normalizeUrl("odoo-demo.heypinchy.com/web/login")).toBe(
+        "https://odoo-demo.heypinchy.com"
+      );
+    });
+
+    it("keeps http:// when explicitly given", () => {
+      expect(normalizeUrl("http://localhost:8069/")).toBe("http://localhost:8069");
+    });
+
+    it("keeps https:// when explicitly given", () => {
+      expect(normalizeUrl("https://example.com/")).toBe("https://example.com");
+    });
+
+    it("handles uppercase HTTPS:// (case-insensitive)", () => {
+      expect(normalizeUrl("HTTPS://example.com/path")).toBe("https://example.com");
+    });
+
+    it("trims surrounding whitespace before normalizing", () => {
+      expect(normalizeUrl("  odoo-demo.heypinchy.com  ")).toBe("https://odoo-demo.heypinchy.com");
+    });
+  });
+
+  describe("invalid input", () => {
+    it("returns null for empty string", () => {
+      expect(normalizeUrl("")).toBeNull();
+    });
+
+    it("returns null for whitespace-only string", () => {
+      expect(normalizeUrl("   ")).toBeNull();
+    });
+
+    it("returns null for non-URL-shaped input that even prepending cannot fix", () => {
+      expect(normalizeUrl("not a url at all with spaces")).toBeNull();
+    });
+  });
+});

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -68,8 +68,12 @@ export type AuditEventType =
   | "audit.exported"
   | "attachment.uploaded"
   | "diagnostics.exported"
+  | "integration.created"
+  | "integration.updated"
+  | "integration.deleted"
+  | "integration.synced"
   | "integration.auth_failed"
-  | "integration.recovered"
+  | "integration.auth_recovered"
   | "integration.credentials_updated";
 
 interface HmacFieldsV1 {
@@ -356,13 +360,15 @@ export type AuditLogEntry =
   | (AuditLogBase & {
       eventType:
         | "integration.auth_failed"
-        | "integration.recovered"
-        | "integration.credentials_updated";
+        | "integration.auth_recovered"
+        | "integration.credentials_updated"
+        | "integration.synced";
       detail: {
         id: string;
         name: string;
         reason?: string;
         fields?: string[];
+        modelCount?: number;
       };
     });
 

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -22,7 +22,15 @@ export type MembershipDetail = {
   [key: string]: unknown;
 };
 
-export type AuditResource = "agent" | "group" | "user" | "settings" | "config" | "channel" | "chat";
+export type AuditResource =
+  | "agent"
+  | "group"
+  | "user"
+  | "settings"
+  | "config"
+  | "channel"
+  | "chat"
+  | "integration";
 
 export type AuditEventType =
   | `tool.${string}`
@@ -59,7 +67,10 @@ export type AuditEventType =
   | "agent.upstream_format_error"
   | "audit.exported"
   | "attachment.uploaded"
-  | "diagnostics.exported";
+  | "diagnostics.exported"
+  | "integration.auth_failed"
+  | "integration.recovered"
+  | "integration.credentials_updated";
 
 interface HmacFieldsV1 {
   timestamp: Date;
@@ -340,6 +351,18 @@ export type AuditLogEntry =
         byteSize: number;
         droppedTurns: number;
         truncated: boolean;
+      };
+    })
+  | (AuditLogBase & {
+      eventType:
+        | "integration.auth_failed"
+        | "integration.recovered"
+        | "integration.credentials_updated";
+      detail: {
+        id: string;
+        name: string;
+        reason?: string;
+        fields?: string[];
       };
     });
 

--- a/packages/web/src/lib/integrations/__tests__/brave-probe.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/brave-probe.test.ts
@@ -1,0 +1,68 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { probeBraveApiKey } from "../brave-probe";
+
+const mockFetch = vi.fn();
+vi.stubGlobal("fetch", mockFetch);
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("probeBraveApiKey", () => {
+  it("returns success when Brave responds 2xx", async () => {
+    mockFetch.mockResolvedValue({ ok: true, status: 200 });
+    const res = await probeBraveApiKey("valid-key");
+    expect(res).toEqual({ success: true });
+  });
+
+  it("returns a user-friendly 'key rejected' reason for HTTP 401", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 401 });
+    const res = await probeBraveApiKey("bad-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/api key.*rejected|reject.*api key|invalid.*api key/i);
+    expect(res.reason).not.toMatch(/HTTP 401/);
+  });
+
+  it("returns a user-friendly 'key rejected' reason for HTTP 403", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 403 });
+    const res = await probeBraveApiKey("bad-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/api key.*rejected|reject.*api key|invalid.*api key/i);
+  });
+
+  it("returns a user-friendly 'key rejected' reason for HTTP 422 (Brave's typical bad-key code)", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 422 });
+    const res = await probeBraveApiKey("bad-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/api key.*rejected|reject.*api key|invalid.*api key/i);
+    // Crucially: must NOT just say "HTTP 422" — that's what the user complained about.
+    expect(res.reason).not.toMatch(/HTTP 422/i);
+  });
+
+  it("returns a 'rate limited' message for HTTP 429", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 429 });
+    const res = await probeBraveApiKey("ok-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/rate limit/i);
+  });
+
+  it("returns an 'unreachable' message for 5xx (transient outage)", async () => {
+    mockFetch.mockResolvedValue({ ok: false, status: 503 });
+    const res = await probeBraveApiKey("ok-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/unreachable|temporarily|try again/i);
+  });
+
+  it("returns a 'network error' message when fetch rejects", async () => {
+    mockFetch.mockRejectedValue(new Error("getaddrinfo ENOTFOUND"));
+    const res = await probeBraveApiKey("ok-key");
+    expect(res.success).toBe(false);
+    if (res.success) return;
+    expect(res.reason).toMatch(/could not reach|network/i);
+  });
+});

--- a/packages/web/src/lib/integrations/__tests__/odoo-sync.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/odoo-sync.test.ts
@@ -137,6 +137,32 @@ describe("fetchOdooSchema", () => {
     expect(result.success).toBe(false);
     if (result.success) return;
     expect(result.error).toContain("Could not access any Odoo models");
+    expect(result.isAuthError).toBe(true);
+  });
+
+  it("returns isAuthError: false when all models fail due to transient errors", async () => {
+    vi.useFakeTimers();
+    mockFields.mockRejectedValue(new Error("ETIMEDOUT"));
+
+    const promise = fetchOdooSchema(creds);
+    // Advance past all retry delays (MAX_RETRIES=2: 500ms + 1000ms per model)
+    await vi.runAllTimersAsync();
+    const result = await promise;
+
+    vi.useRealTimers();
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.isAuthError).toBe(false);
+  });
+
+  it("returns isAuthError: true when all models fail due to auth/permission errors", async () => {
+    mockFields.mockRejectedValue(new Error("access denied"));
+
+    const result = await fetchOdooSchema(creds);
+
+    expect(result.success).toBe(false);
+    if (result.success) return;
+    expect(result.isAuthError).toBe(true);
   });
 
   it("retries transient errors instead of treating them as no-access", async () => {

--- a/packages/web/src/lib/integrations/__tests__/odoo-url.test.ts
+++ b/packages/web/src/lib/integrations/__tests__/odoo-url.test.ts
@@ -1,47 +1,5 @@
 import { describe, it, expect } from "vitest";
-import { normalizeOdooUrl, parseOdooSubdomainHint, generateConnectionName } from "../odoo-url";
-
-describe("normalizeOdooUrl", () => {
-  it("strips trailing slash", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com/")).toBe("https://odoo.example.com");
-  });
-
-  it("strips path", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com/odoo")).toBe("https://odoo.example.com");
-  });
-
-  it("strips /web/login path", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com/web/login")).toBe("https://odoo.example.com");
-  });
-
-  it("strips query string", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com/web?db=prod")).toBe(
-      "https://odoo.example.com"
-    );
-  });
-
-  it("returns origin as-is when already clean", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com")).toBe("https://odoo.example.com");
-  });
-
-  it("preserves port", () => {
-    expect(normalizeOdooUrl("https://odoo.example.com:8069/web")).toBe(
-      "https://odoo.example.com:8069"
-    );
-  });
-
-  it("handles http", () => {
-    expect(normalizeOdooUrl("http://localhost:8069/")).toBe("http://localhost:8069");
-  });
-
-  it("returns null for invalid URL", () => {
-    expect(normalizeOdooUrl("not-a-url")).toBeNull();
-  });
-
-  it("returns null for empty string", () => {
-    expect(normalizeOdooUrl("")).toBeNull();
-  });
-});
+import { parseOdooSubdomainHint, generateConnectionName } from "../odoo-url";
 
 describe("parseOdooSubdomainHint", () => {
   it("extracts subdomain from *.odoo.com", () => {

--- a/packages/web/src/lib/integrations/auth-state.ts
+++ b/packages/web/src/lib/integrations/auth-state.ts
@@ -62,7 +62,7 @@ export async function clearIntegrationAuthError(args: {
   const entry = {
     actorType: actor.type,
     actorId: actor.id,
-    eventType: "integration.recovered" as const,
+    eventType: "integration.auth_recovered" as const,
     resource: `integration:${connectionId}`,
     detail: { id: connectionId, name: existing.name },
     outcome: "success" as const,

--- a/packages/web/src/lib/integrations/auth-state.ts
+++ b/packages/web/src/lib/integrations/auth-state.ts
@@ -2,6 +2,7 @@ import { eq } from "drizzle-orm";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
 
 type Actor = { type: "user" | "system"; id: string };
 
@@ -25,14 +26,19 @@ export async function setIntegrationAuthFailed(args: {
 
   // Only audit the *transition* — not every duplicate failure.
   if (existing.status !== "auth_failed") {
-    await appendAuditLog({
+    const entry = {
       actorType: actor.type,
       actorId: actor.id,
-      eventType: "integration.auth_failed",
+      eventType: "integration.auth_failed" as const,
       resource: `integration:${connectionId}`,
       detail: { id: connectionId, name: existing.name, reason },
-      outcome: "success",
-    });
+      outcome: "success" as const,
+    };
+    try {
+      await appendAuditLog(entry);
+    } catch (err) {
+      recordAuditFailure(err, entry);
+    }
   }
 }
 
@@ -53,12 +59,17 @@ export async function clearIntegrationAuthError(args: {
     .set({ status: "active", lastError: null, lastErrorAt: null, updatedAt: new Date() })
     .where(eq(integrationConnections.id, connectionId));
 
-  await appendAuditLog({
+  const entry = {
     actorType: actor.type,
     actorId: actor.id,
-    eventType: "integration.recovered",
+    eventType: "integration.recovered" as const,
     resource: `integration:${connectionId}`,
     detail: { id: connectionId, name: existing.name },
-    outcome: "success",
-  });
+    outcome: "success" as const,
+  };
+  try {
+    await appendAuditLog(entry);
+  } catch (err) {
+    recordAuditFailure(err, entry);
+  }
 }

--- a/packages/web/src/lib/integrations/auth-state.ts
+++ b/packages/web/src/lib/integrations/auth-state.ts
@@ -1,0 +1,64 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { integrationConnections } from "@/db/schema";
+import { appendAuditLog } from "@/lib/audit";
+
+type Actor = { type: "user" | "system"; id: string };
+
+export async function setIntegrationAuthFailed(args: {
+  connectionId: string;
+  reason: string;
+  actor: Actor;
+}): Promise<void> {
+  const { connectionId, reason, actor } = args;
+  const [existing] = await db
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, connectionId));
+  if (!existing) return;
+
+  const now = new Date();
+  await db
+    .update(integrationConnections)
+    .set({ status: "auth_failed", lastError: reason, lastErrorAt: now, updatedAt: now })
+    .where(eq(integrationConnections.id, connectionId));
+
+  // Only audit the *transition* — not every duplicate failure.
+  if (existing.status !== "auth_failed") {
+    await appendAuditLog({
+      actorType: actor.type,
+      actorId: actor.id,
+      eventType: "integration.auth_failed",
+      resource: `integration:${connectionId}`,
+      detail: { id: connectionId, name: existing.name, reason },
+      outcome: "success",
+    });
+  }
+}
+
+export async function clearIntegrationAuthError(args: {
+  connectionId: string;
+  actor: Actor;
+}): Promise<void> {
+  const { connectionId, actor } = args;
+  const [existing] = await db
+    .select()
+    .from(integrationConnections)
+    .where(eq(integrationConnections.id, connectionId));
+  if (!existing) return;
+  if (existing.status !== "auth_failed") return;
+
+  await db
+    .update(integrationConnections)
+    .set({ status: "active", lastError: null, lastErrorAt: null, updatedAt: new Date() })
+    .where(eq(integrationConnections.id, connectionId));
+
+  await appendAuditLog({
+    actorType: actor.type,
+    actorId: actor.id,
+    eventType: "integration.recovered",
+    resource: `integration:${connectionId}`,
+    detail: { id: connectionId, name: existing.name },
+    outcome: "success",
+  });
+}

--- a/packages/web/src/lib/integrations/auth-state.ts
+++ b/packages/web/src/lib/integrations/auth-state.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { and, eq, ne } from "drizzle-orm";
 import { db } from "@/db";
 import { integrationConnections } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
@@ -19,26 +19,37 @@ export async function setIntegrationAuthFailed(args: {
   if (!existing) return;
 
   const now = new Date();
-  await db
+
+  // Atomic transition: the UPDATE only fires when the row is NOT already in
+  // auth_failed state. If a concurrent caller (e.g. sync + plugin-report
+  // racing on the same connection) already flipped the status between our
+  // SELECT and UPDATE, the WHERE excludes our row and `returning()` is empty
+  // — we exit without writing a duplicate transition audit.
+  const transitioned = await db
     .update(integrationConnections)
     .set({ status: "auth_failed", lastError: reason, lastErrorAt: now, updatedAt: now })
-    .where(eq(integrationConnections.id, connectionId));
+    .where(
+      and(
+        eq(integrationConnections.id, connectionId),
+        ne(integrationConnections.status, "auth_failed")
+      )
+    )
+    .returning({ id: integrationConnections.id });
 
-  // Only audit the *transition* — not every duplicate failure.
-  if (existing.status !== "auth_failed") {
-    const entry = {
-      actorType: actor.type,
-      actorId: actor.id,
-      eventType: "integration.auth_failed" as const,
-      resource: `integration:${connectionId}`,
-      detail: { id: connectionId, name: existing.name, reason },
-      outcome: "success" as const,
-    };
-    try {
-      await appendAuditLog(entry);
-    } catch (err) {
-      recordAuditFailure(err, entry);
-    }
+  if (transitioned.length === 0) return;
+
+  const entry = {
+    actorType: actor.type,
+    actorId: actor.id,
+    eventType: "integration.auth_failed" as const,
+    resource: `integration:${connectionId}`,
+    detail: { id: connectionId, name: existing.name, reason },
+    outcome: "success" as const,
+  };
+  try {
+    await appendAuditLog(entry);
+  } catch (err) {
+    recordAuditFailure(err, entry);
   }
 }
 
@@ -54,10 +65,20 @@ export async function clearIntegrationAuthError(args: {
   if (!existing) return;
   if (existing.status !== "auth_failed") return;
 
-  await db
+  // Same atomic-transition guard as setIntegrationAuthFailed: only flip back
+  // and emit the recovery audit when we win the race.
+  const transitioned = await db
     .update(integrationConnections)
     .set({ status: "active", lastError: null, lastErrorAt: null, updatedAt: new Date() })
-    .where(eq(integrationConnections.id, connectionId));
+    .where(
+      and(
+        eq(integrationConnections.id, connectionId),
+        eq(integrationConnections.status, "auth_failed")
+      )
+    )
+    .returning({ id: integrationConnections.id });
+
+  if (transitioned.length === 0) return;
 
   const entry = {
     actorType: actor.type,

--- a/packages/web/src/lib/integrations/brave-probe.ts
+++ b/packages/web/src/lib/integrations/brave-probe.ts
@@ -1,0 +1,16 @@
+export async function probeBraveApiKey(
+  apiKey: string
+): Promise<{ success: true } | { success: false; reason: string }> {
+  try {
+    const res = await fetch("https://api.search.brave.com/res/v1/web/search?q=ping&count=1", {
+      headers: { "X-Subscription-Token": apiKey, Accept: "application/json" },
+    });
+    if (res.ok) return { success: true };
+    if (res.status === 401 || res.status === 403) {
+      return { success: false, reason: `Authentication failed (HTTP ${res.status})` };
+    }
+    return { success: false, reason: `Brave API returned HTTP ${res.status}` };
+  } catch (err) {
+    return { success: false, reason: err instanceof Error ? err.message : "Network error" };
+  }
+}

--- a/packages/web/src/lib/integrations/brave-probe.ts
+++ b/packages/web/src/lib/integrations/brave-probe.ts
@@ -1,3 +1,17 @@
+/**
+ * Probe the Brave Search API with a candidate subscription key.
+ *
+ * Returns user-actionable error messages rather than raw HTTP codes — the
+ * scenarios users actually hit when entering credentials are: wrong key,
+ * rate limit, transient Brave outage, or no network.
+ *
+ * HTTP status mapping (observed in practice):
+ *  - 401 / 403:  missing or invalid subscription key
+ *  - 422:        Brave's typical response for a structurally valid but
+ *                rejected subscription key (e.g. expired plan)
+ *  - 429:        rate limit hit
+ *  - 5xx:        Brave-side outage
+ */
 export async function probeBraveApiKey(
   apiKey: string
 ): Promise<{ success: true } | { success: false; reason: string }> {
@@ -6,11 +20,39 @@ export async function probeBraveApiKey(
       headers: { "X-Subscription-Token": apiKey, Accept: "application/json" },
     });
     if (res.ok) return { success: true };
-    if (res.status === 401 || res.status === 403) {
-      return { success: false, reason: `Authentication failed (HTTP ${res.status})` };
+
+    if (res.status === 401 || res.status === 403 || res.status === 422) {
+      return {
+        success: false,
+        reason:
+          "The API key was rejected by Brave Search. Please verify the key is correct and your subscription is active.",
+      };
     }
-    return { success: false, reason: `Brave API returned HTTP ${res.status}` };
+
+    if (res.status === 429) {
+      return {
+        success: false,
+        reason: "Rate limit reached on Brave Search. Wait a moment and try again.",
+      };
+    }
+
+    if (res.status >= 500) {
+      return {
+        success: false,
+        reason: `Brave Search is temporarily unreachable (HTTP ${res.status}). Please try again in a moment.`,
+      };
+    }
+
+    // Unexpected client-side status — surface the code so a caller can debug.
+    return {
+      success: false,
+      reason: `Unexpected response from Brave Search (HTTP ${res.status}).`,
+    };
   } catch (err) {
-    return { success: false, reason: err instanceof Error ? err.message : "Network error" };
+    const detail = err instanceof Error ? err.message : "unknown";
+    return {
+      success: false,
+      reason: `Could not reach Brave Search — network or DNS error. (${detail})`,
+    };
   }
 }

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -256,6 +256,7 @@ export interface OdooSyncResult {
 export interface OdooSyncError {
   success: false;
   error: string;
+  isAuthError: boolean;
 }
 
 const MAX_CONCURRENCY = 5;
@@ -354,6 +355,7 @@ export async function fetchOdooSchema(credentials: {
     fields: unknown[];
     accessible: boolean;
     access?: AccessRights;
+    hadAccessError?: boolean;
   };
 
   const tasks = ALL_KNOWN_MODELS.map(({ model, name, category }) => {
@@ -389,7 +391,14 @@ export async function fetchOdooSchema(credentials: {
 
           return { model, name, category, fields, accessible: true, access };
         } catch (error) {
-          if (isAccessError(error) || !isTransientOdooProbeError(error)) {
+          if (isAccessError(error)) {
+            // Permanent access denial — flag it so the caller can distinguish
+            // auth-related failures (which should mark the integration as
+            // auth_failed) from transient errors.
+            return { model, name, category, fields: [], accessible: false, hadAccessError: true };
+          }
+          if (!isTransientOdooProbeError(error)) {
+            // Non-transient, non-access error — no point in retrying.
             return { model, name, category, fields: [], accessible: false };
           }
           if (attempt === MAX_RETRIES) {
@@ -407,11 +416,13 @@ export async function fetchOdooSchema(credentials: {
   const accessibleModels = results.filter((r) => r.accessible && r.fields.length > 0);
 
   if (accessibleModels.length === 0) {
+    const anyAccessError = results.some((r) => r.hadAccessError);
     return {
       success: false,
       error:
         "Could not access any Odoo models. Please ensure the API user has at least " +
         "read access to the modules you want to use (e.g. Sales, Inventory, Contacts).",
+      isAuthError: anyAccessError,
     };
   }
 

--- a/packages/web/src/lib/integrations/odoo-url.ts
+++ b/packages/web/src/lib/integrations/odoo-url.ts
@@ -1,24 +1,4 @@
 /**
- * Normalize an Odoo URL to just the origin (protocol + host).
- * Strips paths, trailing slashes, query strings, and fragments.
- *
- * Examples:
- *   "https://odoo.example.com/"              → "https://odoo.example.com"
- *   "https://odoo.example.com/odoo"          → "https://odoo.example.com"
- *   "https://odoo.example.com/web/login?x=1" → "https://odoo.example.com"
- *
- * Returns null for invalid URLs.
- */
-export function normalizeOdooUrl(raw: string): string | null {
-  try {
-    const parsed = new URL(raw);
-    return parsed.origin;
-  } catch {
-    return null;
-  }
-}
-
-/**
  * Try to extract the database name from an Odoo SaaS URL subdomain.
  *
  * Examples:

--- a/packages/web/src/lib/integrations/probe.ts
+++ b/packages/web/src/lib/integrations/probe.ts
@@ -1,17 +1,50 @@
+import { OdooClient } from "odoo-node";
 import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
 import { probeBraveApiKey } from "@/lib/integrations/brave-probe";
 import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
 
+/**
+ * Verify that credentials work for the given integration type.
+ *
+ * On success may return `freshCredentials` — values resolved during the probe
+ * that the caller should persist (e.g. Odoo's `uid` after a `login` change).
+ */
+export type ProbeResult =
+  | { success: true; freshCredentials?: Record<string, unknown> }
+  | { success: false; reason: string };
+
 export async function probeIntegrationCredentials(
   type: string,
   credentials: Record<string, unknown>
-): Promise<{ success: true } | { success: false; reason: string }> {
+): Promise<ProbeResult> {
   if (type === "odoo") {
     const parsed = odooCredentialsSchema.safeParse(credentials);
     if (!parsed.success) return { success: false, reason: "Invalid credentials format" };
-    const result = await fetchOdooSchema(parsed.data);
+
+    // Re-authenticate so we (a) verify the login/apiKey actually work and
+    // (b) refresh the stored uid in case the login changed. Without this
+    // step, a wrong login or apiKey would surface as the opaque "Could not
+    // access any Odoo models" error from the model probe below — because
+    // the probe runs with a stale uid against the new key.
+    let uid: number;
+    try {
+      uid = await OdooClient.authenticate({
+        url: parsed.data.url,
+        db: parsed.data.db,
+        login: parsed.data.login,
+        apiKey: parsed.data.apiKey,
+      });
+    } catch (err) {
+      const detail = err instanceof Error ? err.message : String(err);
+      return {
+        success: false,
+        reason: `Authentication failed. Please verify your login and API key. (${detail})`,
+      };
+    }
+
+    const result = await fetchOdooSchema({ ...parsed.data, uid });
     if (!result.success) return { success: false, reason: result.error };
-    return { success: true };
+    return { success: true, freshCredentials: { uid } };
   }
 
   if (type === "web-search") {

--- a/packages/web/src/lib/integrations/probe.ts
+++ b/packages/web/src/lib/integrations/probe.ts
@@ -1,0 +1,26 @@
+import { fetchOdooSchema } from "@/lib/integrations/odoo-sync";
+import { probeBraveApiKey } from "@/lib/integrations/brave-probe";
+import { odooCredentialsSchema } from "@/lib/integrations/odoo-schema";
+
+export async function probeIntegrationCredentials(
+  type: string,
+  credentials: Record<string, unknown>
+): Promise<{ success: true } | { success: false; reason: string }> {
+  if (type === "odoo") {
+    const parsed = odooCredentialsSchema.safeParse(credentials);
+    if (!parsed.success) return { success: false, reason: "Invalid credentials format" };
+    const result = await fetchOdooSchema(parsed.data);
+    if (!result.success) return { success: false, reason: result.error };
+    return { success: true };
+  }
+
+  if (type === "web-search") {
+    const apiKey = credentials.apiKey;
+    if (typeof apiKey !== "string" || !apiKey) {
+      return { success: false, reason: "apiKey is required" };
+    }
+    return probeBraveApiKey(apiKey);
+  }
+
+  return { success: false, reason: `Cannot probe credentials for unknown type: ${type}` };
+}

--- a/packages/web/src/lib/integrations/types.ts
+++ b/packages/web/src/lib/integrations/types.ts
@@ -19,7 +19,9 @@ export interface IntegrationConnection {
     provider?: string;
     connectedAt?: string;
   } | null;
-  status: "active" | "pending";
+  status: "active" | "pending" | "auth_failed";
+  lastError: string | null;
+  lastErrorAt: string | null;
   createdAt: string;
   updatedAt: string;
   cannotDecrypt: boolean;

--- a/packages/web/src/lib/schemas/integration-edit.ts
+++ b/packages/web/src/lib/schemas/integration-edit.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+// All fields optional — empty string means "leave current value unchanged".
+// The submit handler filters out empty strings before sending the PATCH body.
+export const odooEditSchema = z.object({
+  url: z.string().optional(),
+  db: z.string().optional(),
+  login: z.string().optional(),
+  apiKey: z.string().optional(),
+});
+
+export const webSearchEditSchema = z.object({
+  apiKey: z.string().optional(),
+});

--- a/packages/web/src/lib/uploads.ts
+++ b/packages/web/src/lib/uploads.ts
@@ -1,5 +1,5 @@
-import { createHash } from "crypto";
-import { mkdir, open, readFile } from "fs/promises";
+import { createHash, randomBytes } from "crypto";
+import { link, mkdir, readFile, unlink, writeFile } from "fs/promises";
 import { join, parse as parsePath } from "path";
 import { getWorkspacePath } from "@/lib/workspace";
 
@@ -81,14 +81,18 @@ export async function persistAttachment(
     const candidate = i === 0 ? filename : `${name} (${i})${ext}`;
     const candidatePath = join(uploadsDir, candidate);
 
+    // Write to a unique temp file first, then atomically hard-link it to the
+    // slot. `link(tmp, final)` succeeds only when `final` does not exist —
+    // and crucially, it only runs AFTER the temp file is fully written. This
+    // closes the TOCTOU window where a concurrent caller could `open(slot,
+    // "wx")` first but then race the `EEXIST`-loser's `readFile(slot)` on an
+    // empty file (mis-deduping to a fresh slot instead of joining).
+    const tmpName = `.${candidate}.${process.pid}-${randomBytes(6).toString("hex")}.tmp`;
+    const tmpPath = join(uploadsDir, tmpName);
+    await writeFile(tmpPath, buffer);
+
     try {
-      // O_CREAT | O_EXCL — atomic create-or-fail. Wins the slot or throws EEXIST.
-      const fh = await open(candidatePath, "wx");
-      try {
-        await fh.writeFile(buffer);
-      } finally {
-        await fh.close();
-      }
+      await link(tmpPath, candidatePath);
       return {
         relativePath: `${UPLOADS_SUBDIR}/${candidate}`,
         reused: false,
@@ -96,7 +100,9 @@ export async function persistAttachment(
       };
     } catch (err) {
       if ((err as NodeJS.ErrnoException).code !== "EEXIST") throw err;
-      // Existing file under this name — does it match our content?
+      // Slot taken. Because `link` only succeeds after the winner's temp file
+      // was fully written, `candidatePath` is guaranteed to hold the winner's
+      // complete content — safe to read and compare hashes.
       const existing = await readFile(candidatePath);
       if (createHash("sha256").update(existing).digest("hex") === contentHash) {
         return {
@@ -106,6 +112,11 @@ export async function persistAttachment(
         };
       }
       // Different content occupies this slot — try the next one.
+    } finally {
+      // Clean up the temp file in all paths. On the success branch, the inode
+      // still lives via the hard link at `candidatePath`; we are only removing
+      // the extra name, not the content.
+      await unlink(tmpPath).catch(() => {});
     }
   }
 

--- a/packages/web/src/lib/url.ts
+++ b/packages/web/src/lib/url.ts
@@ -1,0 +1,31 @@
+/**
+ * Normalize a user-entered URL to its origin (protocol + host[:port]).
+ *
+ * - Prepends `https://` if no protocol is given (so users can paste a bare host).
+ * - Strips path, query string, fragment, and trailing slashes.
+ * - Trims surrounding whitespace.
+ *
+ * Examples:
+ *   "odoo-demo.heypinchy.com"           → "https://odoo-demo.heypinchy.com"
+ *   "https://odoo.example.com/web?x=1"  → "https://odoo.example.com"
+ *   "http://localhost:8069/"            → "http://localhost:8069"
+ *
+ * Returns `null` for empty or syntactically unrepairable input — callers
+ * should then fall back to their own validation (e.g. zod's `.url()`).
+ */
+export function normalizeUrl(raw: string): string | null {
+  const trimmed = raw.trim();
+  if (!trimmed) return null;
+
+  const withProtocol = /^https?:\/\//i.test(trimmed) ? trimmed : `https://${trimmed}`;
+  try {
+    const parsed = new URL(withProtocol);
+    // Reject hostnames that look like garbage (e.g. user typed prose).
+    // A bare hostname without a TLD or a port is technically valid per URL spec
+    // but rarely what the user meant — except for `localhost`, which we allow.
+    if (!parsed.hostname || /\s/.test(parsed.hostname)) return null;
+    return parsed.origin;
+  } catch {
+    return null;
+  }
+}

--- a/scripts/check-drizzle-snapshots.mjs
+++ b/scripts/check-drizzle-snapshots.mjs
@@ -1,0 +1,84 @@
+#!/usr/bin/env node
+/**
+ * Pre-commit + CI guard: verify the drizzle migration / snapshot pair stays
+ * consistent.
+ *
+ * Two checks (see `scripts/lib/check-drizzle-snapshots.mjs` for the pure rule
+ * and TDD coverage):
+ *
+ *  1. Every entry in `_journal.json` has a matching `NNNN_snapshot.json`.
+ *  2. If a new migration .sql is staged for THIS commit, its companion
+ *     snapshot must also be staged.
+ *
+ * Run from the repo root. Exits non-zero with a human-readable explanation
+ * when any rule is broken.
+ */
+import { existsSync, readFileSync, readdirSync } from "node:fs";
+import { execSync } from "node:child_process";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+import { findSnapshotIssues } from "./lib/check-drizzle-snapshots.mjs";
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const metaDir = join(repoRoot, "packages/web/drizzle/meta");
+const migrationsDir = join(repoRoot, "packages/web/drizzle");
+const journalPath = join(metaDir, "_journal.json");
+
+if (!existsSync(journalPath)) {
+  // Migration tooling not initialized — nothing to guard. (Happens in early
+  // clones before `pnpm db:generate` has ever run.)
+  process.exit(0);
+}
+
+const journal = JSON.parse(readFileSync(journalPath, "utf8"));
+const journalEntries = journal.entries ?? [];
+const existingSnapshotFilenames = readdirSync(metaDir);
+
+function gitDiffCached(args) {
+  try {
+    const out = execSync(`git diff --cached --name-only ${args}`, {
+      encoding: "utf8",
+      cwd: repoRoot,
+    });
+    return out.split("\n").filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+const stagedNewFiles = gitDiffCached("--diff-filter=A");
+const stagedAnyChange = gitDiffCached("");
+
+const sqlPathPrefix = "packages/web/drizzle/";
+const snapshotPathPrefix = "packages/web/drizzle/meta/";
+
+const stagedSqlBasenames = stagedNewFiles
+  .filter((p) => p.startsWith(sqlPathPrefix) && /\/\d{4}_.*\.sql$/.test(p))
+  .map((p) => p.slice(sqlPathPrefix.length));
+
+const stagedSnapshotBasenames = stagedAnyChange
+  .filter((p) => p.startsWith(snapshotPathPrefix) && /\/\d{4}_snapshot\.json$/.test(p))
+  .map((p) => p.slice(snapshotPathPrefix.length));
+
+const issues = findSnapshotIssues({
+  journalEntries,
+  existingSnapshotFilenames,
+  stagedSqlBasenames,
+  stagedSnapshotBasenames,
+});
+
+if (issues.length === 0) {
+  process.exit(0);
+}
+
+console.error("❌ Drizzle snapshot integrity check failed:\n");
+for (const issue of issues) {
+  console.error(`  • ${issue}\n`);
+}
+console.error(
+  `(See docs at https://docs.heypinchy.com/contribute/drizzle-migrations/ for the snapshot recovery runbook.)\n`
+);
+console.error(
+  `(Migrations dir: ${migrationsDir.replace(repoRoot + "/", "")})`
+);
+process.exit(1);

--- a/scripts/lib/check-drizzle-snapshots.mjs
+++ b/scripts/lib/check-drizzle-snapshots.mjs
@@ -1,0 +1,64 @@
+/**
+ * Pure logic for the drizzle-snapshot integrity check.
+ *
+ * Background: in PR #334 the commit `9a2e8be80` shipped a new migration's
+ * SQL and journal entry but forgot to stage the matching `_snapshot.json`.
+ * The lapse only surfaced days later in CI, when the snapshot-chain test
+ * landed on main. This helper exists so we can catch the same mistake
+ * locally (pre-commit) and in CI (drift check).
+ *
+ * Inputs are plain data so the rule is unit-testable without touching disk;
+ * the wrapper script gathers journal/git/fs state and feeds it in.
+ *
+ * @param {object} input
+ * @param {Array<{idx: number, tag: string}>} input.journalEntries
+ *   Parsed `_journal.json#entries` — what drizzle THINKS exists.
+ * @param {string[]} input.existingSnapshotFilenames
+ *   Basenames of files currently in `drizzle/meta/` — what's ACTUALLY on disk.
+ * @param {string[]} input.stagedSqlBasenames
+ *   Basenames of newly-added `NNNN_*.sql` files staged for THIS commit
+ *   (`git diff --cached --name-only --diff-filter=A`).
+ * @param {string[]} input.stagedSnapshotBasenames
+ *   Basenames of `NNNN_snapshot.json` files staged for THIS commit
+ *   (any change type — created or modified).
+ * @returns {string[]} Human-readable issue messages. Empty array = OK.
+ */
+export function findSnapshotIssues({
+  journalEntries,
+  existingSnapshotFilenames,
+  stagedSqlBasenames,
+  stagedSnapshotBasenames,
+}) {
+  const issues = [];
+  const presentSnapshots = new Set(
+    existingSnapshotFilenames.filter((f) => /^\d{4}_snapshot\.json$/.test(f))
+  );
+  const stagedSnapshots = new Set(stagedSnapshotBasenames);
+
+  // Rule 1: every journal entry must have a snapshot file on disk.
+  for (const entry of journalEntries) {
+    const expected = `${String(entry.idx).padStart(4, "0")}_snapshot.json`;
+    if (!presentSnapshots.has(expected)) {
+      issues.push(
+        `Journal references migration "${entry.tag}" (idx=${entry.idx}) but ${expected} is missing from drizzle/meta/. Run \`pnpm -C packages/web db:generate\` and commit the resulting snapshot.`
+      );
+    }
+  }
+
+  // Rule 2: when a new migration .sql is staged, its snapshot must also be
+  // staged (drizzle generated both in the same step; staging only the .sql
+  // is the typical mistake).
+  for (const sql of stagedSqlBasenames) {
+    const match = sql.match(/^(\d{4})_.*\.sql$/);
+    if (!match) continue;
+    const idx = match[1];
+    const expectedSnapshot = `${idx}_snapshot.json`;
+    if (!stagedSnapshots.has(expectedSnapshot)) {
+      issues.push(
+        `Staged migration ${sql} but its companion ${expectedSnapshot} is not staged for this commit. Did you forget \`git add packages/web/drizzle/meta/${expectedSnapshot}\` after running \`pnpm db:generate\`?`
+      );
+    }
+  }
+
+  return issues;
+}

--- a/scripts/lib/check-drizzle-snapshots.test.mjs
+++ b/scripts/lib/check-drizzle-snapshots.test.mjs
@@ -1,0 +1,118 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { findSnapshotIssues } from "./check-drizzle-snapshots.mjs";
+
+// Pure-function tests for the snapshot-integrity check that the pre-commit
+// hook and CI run. The check guards against two failure modes that bit us in
+// PR #334:
+//
+//   1. A migration .sql is committed without its matching _snapshot.json —
+//      `git add packages/web/drizzle/0031_*.sql` succeeds; `git add
+//      packages/web/drizzle/meta/0031_snapshot.json` is forgotten.
+//
+//   2. The journal lists a migration that has no snapshot file at all in
+//      `drizzle/meta/` — the chain is broken silently until someone runs the
+//      drizzle CLI or `migration-snapshots.test.ts`.
+
+test("happy path: every journal entry has a snapshot, no issues", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [
+      { idx: 0, tag: "0000_init" },
+      { idx: 1, tag: "0001_add_users" },
+    ],
+    existingSnapshotFilenames: ["0000_snapshot.json", "0001_snapshot.json"],
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.deepEqual(issues, []);
+});
+
+test("flags journal entry with missing snapshot file", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [
+      { idx: 0, tag: "0000_init" },
+      { idx: 1, tag: "0001_add_users" },
+    ],
+    existingSnapshotFilenames: ["0000_snapshot.json"], // 0001 missing
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /0001_snapshot\.json/);
+  assert.match(issues[0], /0001_add_users/);
+});
+
+test("flags multiple missing snapshots", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [
+      { idx: 0, tag: "0000_init" },
+      { idx: 1, tag: "0001_users" },
+      { idx: 2, tag: "0002_groups" },
+    ],
+    existingSnapshotFilenames: ["0000_snapshot.json"],
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.equal(issues.length, 2);
+});
+
+test("flags newly-staged SQL without its snapshot also being staged", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [
+      { idx: 0, tag: "0000_init" },
+      { idx: 1, tag: "0001_add_column" },
+    ],
+    existingSnapshotFilenames: ["0000_snapshot.json", "0001_snapshot.json"],
+    stagedSqlBasenames: ["0001_add_column.sql"],
+    stagedSnapshotBasenames: [], // forgot to stage snapshot
+  });
+  // The snapshot exists on disk (drizzle wrote it) but isn't staged for this
+  // commit — exactly the trap from PR #334 where `git add` was selective.
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /0001_snapshot\.json/);
+  assert.match(issues[0], /stage|git add/i);
+});
+
+test("staged SQL with staged snapshot is OK", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [
+      { idx: 0, tag: "0000_init" },
+      { idx: 1, tag: "0001_add_column" },
+    ],
+    existingSnapshotFilenames: ["0000_snapshot.json", "0001_snapshot.json"],
+    stagedSqlBasenames: ["0001_add_column.sql"],
+    stagedSnapshotBasenames: ["0001_snapshot.json"],
+  });
+  assert.deepEqual(issues, []);
+});
+
+test("handles 4-digit zero-padded indexes correctly (e.g. idx 31 → 0031_snapshot.json)", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [{ idx: 31, tag: "0031_auth_failed_integration_columns" }],
+    existingSnapshotFilenames: [],
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.equal(issues.length, 1);
+  assert.match(issues[0], /0031_snapshot\.json/);
+});
+
+test("ignores non-snapshot files in the meta directory", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [{ idx: 0, tag: "0000_init" }],
+    existingSnapshotFilenames: ["0000_snapshot.json", "_journal.json", "README.md"],
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.deepEqual(issues, []);
+});
+
+test("empty journal produces no issues", () => {
+  const issues = findSnapshotIssues({
+    journalEntries: [],
+    existingSnapshotFilenames: [],
+    stagedSqlBasenames: [],
+    stagedSnapshotBasenames: [],
+  });
+  assert.deepEqual(issues, []);
+});


### PR DESCRIPTION
## Summary

- Persists `auth_failed` status + `lastError`/`lastErrorAt` on integration connections (#300).
- Detects permanent auth failures at three points: manual Test/Sync API routes, and Pinchy plugins via a new internal `report-auth-failure` endpoint (called after retry-once also fails).
- Adds a sidebar Settings `!` badge when one or more integrations need attention.
- Shows auth_failed state visually in IntegrationCard (red warning, error message, Reconnect action).
- Adds an Edit-Credentials dialog with "leave empty to keep current" semantics — probes upstream before writing, no cascade on agent permissions (#301).
- Adds a Google OAuth re-auth path that updates tokens on the existing connection (preserving the connectionId so `agent_connection_permissions` stay intact).
- New audit events: `integration.auth_failed`, `integration.recovered`, `integration.credentials_updated`.

## Key design decisions

- `setIntegrationAuthFailed` / `clearIntegrationAuthError` are transition-only (audit only on status change, not on repeated failures — prevents log flooding).
- PATCH credential validation uses `.partial()` schemas so partial updates (e.g., only changing apiKey) work without sending all fields.
- The `report-auth-failure` internal endpoint is callable by plugins with their gateway token + `X-Plugin-Id` header.

## Test plan

- [x] `pnpm test` green (4085 tests pass)
- [x] Plugin tests green (pinchy-odoo: 47, pinchy-email: 58, pinchy-web: 71)
- [x] TypeScript compiles without errors
- [x] Build succeeds
- [x] E2E spec written for the auth_failed Odoo flow (`e2e/odoo/odoo-auth-failed.spec.ts`)
- [ ] `pnpm -C packages/web test:e2e:odoo` — requires Docker Compose with Odoo mock
- [ ] Manually verify full flow in Docker (create integration → break credentials → sync → see badge → reconnect → credentials updated → back to Connected)
- [ ] Verify audit log contains `integration.auth_failed`, `integration.recovered`, `integration.credentials_updated` events
- [ ] Verify agent permissions remain intact after Edit credentials

Closes #300, #301.