### PR TITLE
fix(agent-settings): clear Permissions dirty state on save when an integration is configured

### DIFF
--- a/packages/web/e2e/odoo/odoo-permissions.spec.ts
+++ b/packages/web/e2e/odoo/odoo-permissions.spec.ts
@@ -321,6 +321,13 @@ test.describe.serial("Odoo Permission Setup", () => {
       document.querySelector("[title='Disable enterprise']")?.closest(".fixed")?.remove();
     });
 
+    // The cascade is triggered by the post-save refetch of /api/integrations.
+    // Set up the wait BEFORE the click so we don't miss the response.
+    const integrationsRefetch = page.waitForResponse(
+      (resp) => resp.url().endsWith("/api/integrations") && resp.request().method() === "GET",
+      { timeout: 30000 }
+    );
+
     // Save & Restart.
     await page.getByRole("button", { name: /save/i }).last().click();
     const restartDialog = page.getByRole("alertdialog");
@@ -330,11 +337,10 @@ test.describe.serial("Odoo Permission Setup", () => {
     // Save completes — dirty bar reads "All changes saved".
     await expect(page.getByText("All changes saved")).toBeVisible({ timeout: 30000 });
 
-    // The cascade fires within ~100ms of the save returning: fetchData
-    // refetches connections, useOdooPermissions emits a fresh onChange, and
-    // the child component re-evaluates dirty state. Wait long enough for
-    // that to settle, then assert it stayed clean.
-    await page.waitForTimeout(3000);
+    // Wait for the cascade trigger (connections refetch) to complete; from
+    // there React only needs to flush a couple of renders.
+    await integrationsRefetch;
+
     await expect(page.getByText("All changes saved")).toBeVisible();
     await expect(page.getByText("Unsaved changes")).not.toBeVisible();
   });

--- a/packages/web/e2e/odoo/odoo-permissions.spec.ts
+++ b/packages/web/e2e/odoo/odoo-permissions.spec.ts
@@ -297,4 +297,45 @@ test.describe.serial("Odoo Permission Setup", () => {
     // Model should still be in the table
     await expect(page.getByText("res.partner")).toBeVisible();
   });
+
+  // Regression: with an Odoo connection configured, saving any other
+  // Permissions change (here: a KB tool) used to falsely re-mark the tab as
+  // dirty. The parent's post-save fetchData refetches connections with a new
+  // array reference, useOdooPermissions re-runs its load effect, and the
+  // resulting onChange propagates up to AgentSettingsPermissions which
+  // re-evaluated dirty state against stale mount-time refs.
+  test("save clears dirty state and keeps it clear under the Odoo cascade", async ({ page }) => {
+    test.setTimeout(120000);
+    await loginViaUI(page);
+
+    await page.goto(`/chat/${agentId}/settings?tab=permissions`);
+    await expect(page.getByRole("heading", { name: "Odoo" })).toBeVisible({ timeout: 10000 });
+
+    // Toggle a KB tool — its change crosses one of the snapshots that the
+    // child component used to freeze at mount.
+    await page.getByLabel("List approved directories").click();
+    await expect(page.getByText("Unsaved changes")).toBeVisible({ timeout: 10000 });
+
+    // Remove enterprise badge overlay if present (blocks button clicks).
+    await page.evaluate(() => {
+      document.querySelector("[title='Disable enterprise']")?.closest(".fixed")?.remove();
+    });
+
+    // Save & Restart.
+    await page.getByRole("button", { name: /save/i }).last().click();
+    const restartDialog = page.getByRole("alertdialog");
+    await expect(restartDialog).toBeVisible({ timeout: 5000 });
+    await restartDialog.getByRole("button", { name: /save & restart/i }).click();
+
+    // Save completes — dirty bar reads "All changes saved".
+    await expect(page.getByText("All changes saved")).toBeVisible({ timeout: 30000 });
+
+    // The cascade fires within ~100ms of the save returning: fetchData
+    // refetches connections, useOdooPermissions emits a fresh onChange, and
+    // the child component re-evaluates dirty state. Wait long enough for
+    // that to settle, then assert it stayed clean.
+    await page.waitForTimeout(3000);
+    await expect(page.getByText("All changes saved")).toBeVisible();
+    await expect(page.getByText("Unsaved changes")).not.toBeVisible();
+  });
 });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,7 @@
     "iso-639-1": "^3.1.5",
     "jose": "^6.2.3",
     "lucide-react": "^1.11.0",
-    "next": "16.2.5",
+    "next": "16.2.6",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
     "openclaw-node": "0.9.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -47,7 +47,7 @@
     "iso-639-1": "^3.1.5",
     "jose": "^6.2.3",
     "lucide-react": "^1.11.0",
-    "next": "16.2.4",
+    "next": "16.2.5",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
     "openclaw-node": "0.9.0",

--- a/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
@@ -587,12 +587,12 @@ describe("AgentSettingsPermissions", () => {
     });
   });
 
-  // Regression for #XXX: After a successful save the parent updates the
-  // `agent` prop to reflect the persisted state, and refetched `connections`
-  // cause sibling sections (Odoo/Email) to re-emit a fresh onChange. If the
-  // child component's "initial values" snapshot is frozen at first mount,
-  // that downstream onChange triggers a dirty-recheck against stale refs
-  // and falsely marks the Permissions tab as dirty again.
+  // After a successful save the parent updates the `agent` prop to reflect
+  // the persisted state, and refetched `connections` cause sibling sections
+  // (Odoo/Email) to re-emit a fresh onChange. If the child component's
+  // "initial values" snapshot is frozen at first mount, that downstream
+  // onChange triggers a dirty-recheck against stale refs and falsely marks
+  // the Permissions tab as dirty again.
   describe("dirty re-evaluation after agent prop is updated (post-save cascade)", () => {
     const webSearchConnection = { id: "ws-1", name: "Brave Search", type: "web-search" };
 

--- a/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
@@ -1,8 +1,23 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { act, render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentSettingsPermissions } from "@/components/agent-settings-permissions";
+import type { AgentPluginConfig } from "@/db/schema";
+
+// Capture onChange callbacks from child sections so tests can simulate
+// the post-save cascade where a sibling section's onChange fires and
+// causes AgentSettingsPermissions to re-evaluate its dirty state.
+let capturedOdooOnChange:
+  | ((
+      v: {
+        connectionId: string;
+        permissions: Array<{ model: string; operation: string }>;
+      } | null,
+      isDirty: boolean
+    ) => void)
+  | null = null;
+let capturedWebSearchOnChange: ((v: AgentPluginConfig["pinchy-web"]) => void) | null = null;
 
 vi.mock("@/components/odoo-permission-section", () => ({
   OdooPermissionSection: ({
@@ -10,26 +25,36 @@ vi.mock("@/components/odoo-permission-section", () => ({
   }: {
     agentId: string;
     connections: unknown[];
-    onChange: (v: unknown, d: boolean) => void;
+    onChange: (
+      v: {
+        connectionId: string;
+        permissions: Array<{ model: string; operation: string }>;
+      } | null,
+      d: boolean
+    ) => void;
   }) => {
-    void onChange;
+    capturedOdooOnChange = onChange;
     return <div data-testid="odoo-section">Odoo Section</div>;
   },
 }));
 
 vi.mock("@/components/web-search-permission-section", () => ({
   WebSearchPermissionSection: ({
+    onChange,
     showSecurityWarning,
   }: {
     config: unknown;
-    onChange: (v: unknown) => void;
+    onChange: (v: AgentPluginConfig["pinchy-web"]) => void;
     showSecurityWarning: boolean;
-  }) => (
-    <div data-testid="web-search-section">
-      Web Search Config
-      {showSecurityWarning && <span data-testid="security-warning">Security Warning</span>}
-    </div>
-  ),
+  }) => {
+    capturedWebSearchOnChange = onChange;
+    return (
+      <div data-testid="web-search-section">
+        Web Search Config
+        {showSecurityWarning && <span data-testid="security-warning">Security Warning</span>}
+      </div>
+    );
+  },
 }));
 
 vi.mock("@/components/email-permission-section", () => ({
@@ -44,6 +69,11 @@ vi.mock("@/components/email-permission-section", () => ({
     return <div data-testid="email-section">Email Section</div>;
   },
 }));
+
+beforeEach(() => {
+  capturedOdooOnChange = null;
+  capturedWebSearchOnChange = null;
+});
 
 describe("AgentSettingsPermissions", () => {
   const defaultAgent = {
@@ -554,6 +584,188 @@ describe("AgentSettingsPermissions", () => {
         }),
         false
       );
+    });
+  });
+
+  // Regression for #XXX: After a successful save the parent updates the
+  // `agent` prop to reflect the persisted state, and refetched `connections`
+  // cause sibling sections (Odoo/Email) to re-emit a fresh onChange. If the
+  // child component's "initial values" snapshot is frozen at first mount,
+  // that downstream onChange triggers a dirty-recheck against stale refs
+  // and falsely marks the Permissions tab as dirty again.
+  describe("dirty re-evaluation after agent prop is updated (post-save cascade)", () => {
+    const webSearchConnection = { id: "ws-1", name: "Brave Search", type: "web-search" };
+
+    it("clears dirty state for webSearchConfig when agent prop reflects saved value and Odoo cascade fires", async () => {
+      const onChange = vi.fn();
+      const initialAgent = {
+        ...defaultAgent,
+        allowedTools: ["pinchy_web_search"],
+        pluginConfig: null as import("@/db/schema").AgentPluginConfig | null,
+      };
+
+      const { rerender } = render(
+        <AgentSettingsPermissions
+          agent={initialAgent}
+          directories={defaultDirectories}
+          connections={[odooConnection, webSearchConnection]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      // User changes Web Search config (e.g. picks a freshness window).
+      await waitFor(() => expect(capturedWebSearchOnChange).not.toBeNull());
+      act(() => capturedWebSearchOnChange!({ freshness: "pd" }));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ webSearchConfig: { freshness: "pd" } }),
+          true
+        );
+      });
+
+      onChange.mockClear();
+
+      // Save completes: parent re-renders with agent reflecting the saved
+      // pluginConfig and (because fetchData re-fetched) a fresh connections
+      // array reference.
+      rerender(
+        <AgentSettingsPermissions
+          agent={{
+            ...initialAgent,
+            pluginConfig: { "pinchy-web": { freshness: "pd" } },
+          }}
+          directories={defaultDirectories}
+          connections={[{ ...odooConnection }, { ...webSearchConnection }]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      // In production the cascade fires because useOdooPermissions resets
+      // its addedModels to a new Map reference, which propagates a fresh
+      // onChange call up to AgentSettingsPermissions. Simulate that here.
+      await waitFor(() => expect(capturedOdooOnChange).not.toBeNull());
+      act(() => capturedOdooOnChange!({ connectionId: "conn-odoo", permissions: [] }, false));
+
+      // After the cascade, the dirty state must reflect the new (saved)
+      // agent prop — there are no unsaved changes anymore.
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled();
+        const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+        expect(lastCall[1]).toBe(false);
+      });
+    });
+
+    it("clears dirty state for KB tools after the agent prop reflects the saved tools and a sibling onChange fires", async () => {
+      const onChange = vi.fn();
+      const initialAgent = {
+        ...defaultAgent,
+        allowedTools: [] as string[],
+        pluginConfig: null as import("@/db/schema").AgentPluginConfig | null,
+      };
+
+      const { rerender } = render(
+        <AgentSettingsPermissions
+          agent={initialAgent}
+          directories={defaultDirectories}
+          connections={[odooConnection]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      // User checks a KB tool.
+      await userEvent.click(screen.getByLabelText("List approved directories"));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ allowedTools: expect.arrayContaining(["pinchy_ls"]) }),
+          true
+        );
+      });
+
+      onChange.mockClear();
+
+      // Save completes: parent passes new agent prop and a refetched
+      // connections array.
+      rerender(
+        <AgentSettingsPermissions
+          agent={{
+            ...initialAgent,
+            allowedTools: ["pinchy_ls"],
+            pluginConfig: { "pinchy-files": { allowed_paths: [] } },
+          }}
+          directories={defaultDirectories}
+          connections={[{ ...odooConnection }]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      // Sibling Odoo section emits a fresh onChange (simulating the load
+      // effect re-running on the new connections reference).
+      await waitFor(() => expect(capturedOdooOnChange).not.toBeNull());
+      act(() => capturedOdooOnChange!({ connectionId: "conn-odoo", permissions: [] }, false));
+
+      await waitFor(() => {
+        expect(onChange).toHaveBeenCalled();
+        const lastCall = onChange.mock.calls[onChange.mock.calls.length - 1];
+        expect(lastCall[1]).toBe(false);
+      });
+    });
+
+    it("re-marks dirty when the user reverts a saved web search config back to empty", async () => {
+      const onChange = vi.fn();
+      const initialAgent = {
+        ...defaultAgent,
+        allowedTools: ["pinchy_web_search"],
+        pluginConfig: null as import("@/db/schema").AgentPluginConfig | null,
+      };
+
+      const { rerender } = render(
+        <AgentSettingsPermissions
+          agent={initialAgent}
+          directories={defaultDirectories}
+          connections={[webSearchConnection]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      // User picks a freshness value.
+      await waitFor(() => expect(capturedWebSearchOnChange).not.toBeNull());
+      act(() => capturedWebSearchOnChange!({ freshness: "pd" }));
+
+      // Simulate "saved".
+      rerender(
+        <AgentSettingsPermissions
+          agent={{
+            ...initialAgent,
+            pluginConfig: { "pinchy-web": { freshness: "pd" } },
+          }}
+          directories={defaultDirectories}
+          connections={[{ ...webSearchConnection }]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      onChange.mockClear();
+
+      // User reverts the saved value back to empty.
+      act(() => capturedWebSearchOnChange!({}));
+
+      // Compared to the *saved* state ({ freshness: "pd" }), reverting to {}
+      // is dirty again. If we incorrectly compare against the mount-time
+      // snapshot ({}), this would be falsely reported as clean.
+      await waitFor(() => {
+        expect(onChange).toHaveBeenLastCalledWith(
+          expect.objectContaining({ webSearchConfig: {} }),
+          true
+        );
+      });
     });
   });
 });

--- a/packages/web/src/components/agent-settings-permissions.tsx
+++ b/packages/web/src/components/agent-settings-permissions.tsx
@@ -91,6 +91,21 @@ export function AgentSettingsPermissions({
   const initialAllowedPaths = useRef(agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? []);
   const initialWebSearchConfig = useRef(agent.pluginConfig?.["pinchy-web"] ?? {});
 
+  // Re-sync the "initial" snapshot when the agent prop changes (the parent
+  // refetches the agent after a successful save, so the prop now reflects the
+  // persisted state). Without this the dirty comparison would keep using the
+  // mount-time values and falsely report dirty=true the next time a sibling
+  // section emits onChange — e.g. Odoo's load effect re-running on a fresh
+  // connections reference resets `odooIntegration`, which triggers this
+  // component's dirty-recheck against stale refs.
+  useEffect(() => {
+    initialKbToolsRef.current = agent.allowedTools.filter(
+      (id) => !id.startsWith("odoo_") && !id.startsWith("email_")
+    );
+    initialAllowedPaths.current = agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? [];
+    initialWebSearchConfig.current = agent.pluginConfig?.["pinchy-web"] ?? {};
+  }, [agent.allowedTools, agent.pluginConfig]);
+
   const hasKbToolChecked = kbTools.some((tool) => allowedKbTools.includes(tool.id));
   const hasWebToolChecked = webTools.some((tool) => allowedKbTools.includes(tool.id));
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       browser-image-compression:
         specifier: ^2.0.2
         version: 2.0.2
@@ -93,8 +93,8 @@ importers:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.5)
       next:
-        specifier: 16.2.4
-        version: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 16.2.5
+        version: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1442,60 +1442,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.4':
-    resolution: {integrity: sha512-dKkkOzOSwFYe5RX6y26fZgkSpVAlIOJKQHIiydQcrWH6y/97+RceSOAdjZ14Qa3zLduVUy0TXcn+EiM6t4rPgw==}
+  '@next/env@16.2.5':
+    resolution: {integrity: sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==}
 
   '@next/eslint-plugin-next@16.2.4':
     resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
-  '@next/swc-darwin-arm64@16.2.4':
-    resolution: {integrity: sha512-OXTFFox5EKN1Ym08vfrz+OXxmCcEjT4SFMbNRsWZE99dMqt2Kcusl5MqPXcW232RYkMLQTy0hqgAMEsfEd/l2A==}
+  '@next/swc-darwin-arm64@16.2.5':
+    resolution: {integrity: sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.4':
-    resolution: {integrity: sha512-XhpVnUfmYWvD3YrXu55XdcAkQtOnvaI6wtQa8fuF5fGoKoxIUZ0kWPtcOfqJEWngFF/lOS9l3+O9CcownhiQxQ==}
+  '@next/swc-darwin-x64@16.2.5':
+    resolution: {integrity: sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
-    resolution: {integrity: sha512-Mx/tjlNA3G8kg14QvuGAJ4xBwPk1tUHq56JxZ8CXnZwz1Etz714soCEzGQQzVMz4bEnGPowzkV6Xrp6wAkEWOQ==}
+  '@next/swc-linux-arm64-gnu@16.2.5':
+    resolution: {integrity: sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.4':
-    resolution: {integrity: sha512-iVMMp14514u7Nup2umQS03nT/bN9HurK8ufylC3FZNykrwjtx7V1A7+4kvhbDSCeonTVqV3Txnv0Lu+m2oDXNg==}
+  '@next/swc-linux-arm64-musl@16.2.5':
+    resolution: {integrity: sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.4':
-    resolution: {integrity: sha512-EZOvm1aQWgnI/N/xcWOlnS3RQBk0VtVav5Zo7n4p0A7UKyTDx047k8opDbXgBpHl4CulRqRfbw3QrX2w5UOXMQ==}
+  '@next/swc-linux-x64-gnu@16.2.5':
+    resolution: {integrity: sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.4':
-    resolution: {integrity: sha512-h9FxsngCm9cTBf71AR4fGznDEDx1hS7+kSEiIRjq5kO1oXWm07DxVGZjCvk0SGx7TSjlUqhI8oOyz7NfwAdPoA==}
+  '@next/swc-linux-x64-musl@16.2.5':
+    resolution: {integrity: sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
-    resolution: {integrity: sha512-3NdJV5OXMSOeJYijX+bjaLge3mJBlh4ybydbT4GFoB/2hAojWHtMhl3CYlYoMrjPuodp0nzFVi4Tj2+WaMg+Ow==}
+  '@next/swc-win32-arm64-msvc@16.2.5':
+    resolution: {integrity: sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.4':
-    resolution: {integrity: sha512-kMVGgsqhO5YTYODD9IPGGhA6iprWidQckK3LmPeW08PIFENRmgfb4MjXHO+p//d+ts2rpjvK5gXWzXSMrPl9cw==}
+  '@next/swc-win32-x64-msvc@16.2.5':
+    resolution: {integrity: sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5137,8 +5137,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.4:
-    resolution: {integrity: sha512-kPvz56wF5frc+FxlHI5qnklCzbq53HTwORaWBGdT0vNoKh1Aya9XC8aPauH4NJxqtzbWsS5mAbctm4cr+EkQ2Q==}
+  next@16.2.5:
+    resolution: {integrity: sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -7935,34 +7935,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.4': {}
+  '@next/env@16.2.5': {}
 
   '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.4':
+  '@next/swc-darwin-arm64@16.2.5':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.4':
+  '@next/swc-darwin-x64@16.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.4':
+  '@next/swc-linux-arm64-gnu@16.2.5':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.4':
+  '@next/swc-linux-arm64-musl@16.2.5':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.4':
+  '@next/swc-linux-x64-gnu@16.2.5':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.4':
+  '@next/swc-linux-x64-musl@16.2.5':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.4':
+  '@next/swc-win32-arm64-msvc@16.2.5':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.4':
+  '@next/swc-win32-x64-msvc@16.2.5':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -9773,7 +9773,7 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))
@@ -9796,7 +9796,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9)
       mongodb: 7.1.0(socks@2.8.8)
-      next: 16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -11953,9 +11953,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.4(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.2.4
+      '@next/env': 16.2.5
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001770
@@ -11964,14 +11964,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.4
-      '@next/swc-darwin-x64': 16.2.4
-      '@next/swc-linux-arm64-gnu': 16.2.4
-      '@next/swc-linux-arm64-musl': 16.2.4
-      '@next/swc-linux-x64-gnu': 16.2.4
-      '@next/swc-linux-x64-musl': 16.2.4
-      '@next/swc-win32-arm64-msvc': 16.2.4
-      '@next/swc-win32-x64-msvc': 16.2.4
+      '@next/swc-darwin-arm64': 16.2.5
+      '@next/swc-darwin-x64': 16.2.5
+      '@next/swc-linux-arm64-gnu': 16.2.5
+      '@next/swc-linux-arm64-musl': 16.2.5
+      '@next/swc-linux-x64-gnu': 16.2.5
+      '@next/swc-linux-x64-musl': 16.2.5
+      '@next/swc-win32-arm64-msvc': 16.2.5
+      '@next/swc-win32-x64-msvc': 16.2.5
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -61,7 +61,7 @@ importers:
         version: 3.0.3
       better-auth:
         specifier: ^1.6.9
-        version: 1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
+        version: 1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3)))
       browser-image-compression:
         specifier: ^2.0.2
         version: 2.0.2
@@ -93,8 +93,8 @@ importers:
         specifier: ^1.11.0
         version: 1.11.0(react@19.2.5)
       next:
-        specifier: 16.2.5
-        version: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+        specifier: 16.2.6
+        version: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       next-themes:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
@@ -1442,60 +1442,60 @@ packages:
       '@emnapi/core': ^1.7.1
       '@emnapi/runtime': ^1.7.1
 
-  '@next/env@16.2.5':
-    resolution: {integrity: sha512-Lb9ElHD2klcyeVD25vW+siPFqz9QMzDUSgvFZNO+dZEKoMHex4viJhVuzBhrXKqb+UKnih7mVYbt50/7KLsSCA==}
+  '@next/env@16.2.6':
+    resolution: {integrity: sha512-gd8HoHN4ufj73WmR3JmVolrpJR47ILK6LouP5xElPglaVxir6e1a7VzvTvDWkOoPXT9rkkTzyCxBu4yeZfZwcw==}
 
   '@next/eslint-plugin-next@16.2.4':
     resolution: {integrity: sha512-tOX826JJ96gYK/go18sPUgMq9FK1tqxBFfUCEufJb5XIkWFFmpgU7mahJANKGkHs7F41ir3tReJ3Lv5La0RvhA==}
 
-  '@next/swc-darwin-arm64@16.2.5':
-    resolution: {integrity: sha512-BW+8PGVmsruomXHsitD8JG6gny9lEdobctjBwvtPF8AKtxGDR7nR35FOl/oK9UAPXBOBm+vx0k8qtpeHOXQMGQ==}
+  '@next/swc-darwin-arm64@16.2.6':
+    resolution: {integrity: sha512-ZJGkkcNfYgrrMkqOdZ7zoLa1TOy0qpcMfk/z4Mh/FKUz40gVO+HNQWqmLxf67Z5WB64DRp0dhEbyHfel+6sJUg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [darwin]
 
-  '@next/swc-darwin-x64@16.2.5':
-    resolution: {integrity: sha512-ZoCGnCl9LlQJWmqXrZAUlNxvuNmclvE+7zUif+nDydkkehl9FKxHJ+wxSQMj+C37BYFerKiEdX9s9o02ir975Q==}
+  '@next/swc-darwin-x64@16.2.6':
+    resolution: {integrity: sha512-v/YLBHIY132Ced3puBJ7YJKw1lqsCrgcNo2aRJlCEyQrrCeRJlvGlnmxhPxNQI3KE3N1DN5r9TPNPvka3nq5RQ==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [darwin]
 
-  '@next/swc-linux-arm64-gnu@16.2.5':
-    resolution: {integrity: sha512-AwcZzMChaWkOTZt3vu+2ZMIj8g4dYQY+B8VUVhlFSQ2JtvyZpefyYHTe00D6b6L7BysYw7vl3zsvs9jix8tl5Q==}
+  '@next/swc-linux-arm64-gnu@16.2.6':
+    resolution: {integrity: sha512-RPOvqlYBbcQjkz9VQQDZ2T2bARIjXZV1KFlt+V2Mr6SW/e4I9fcKsaA0hdyf2FHoTlsV2xnBd5Y912rP/1Ce6w==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-arm64-musl@16.2.5':
-    resolution: {integrity: sha512-QqMgqWbCBFsfiQ7BF3dUlW8HJy1LWhpcqbTpoHMWA9IV+TnWwDKozQJA5NdIAHjQ00yX2Q7AUkLr/XK4n77q8A==}
+  '@next/swc-linux-arm64-musl@16.2.6':
+    resolution: {integrity: sha512-URUTu1+dMkxJsPFgm+OeEvq9wf5sujw0EvgYy80TDGHTSLTnIHeqb0Eu8A3sC95IRgjejQL+kC4mw+4yPxiAXA==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-linux-x64-gnu@16.2.5':
-    resolution: {integrity: sha512-3hzeiFGZtyATVx9pCeuzTshXmh50vHZitqaeZiyJZaUmjQyrfjsVUgS8apOj1vEJCIpKJM/55F45yPAV2kpjsA==}
+  '@next/swc-linux-x64-gnu@16.2.6':
+    resolution: {integrity: sha512-DOj182mPV8G3UkrayLoREM5YEYI+Dk5wv7Ox9xl1fFibAELEsFD0lDPfHIeILlutMMfdyhlzYPELG3peuKaurw==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [glibc]
 
-  '@next/swc-linux-x64-musl@16.2.5':
-    resolution: {integrity: sha512-0mzZV/mAt7Qj2tYNdTB6AqrS8dwng/AQLSYC5Z1YLpZdi2wxqKDPK7RY2RvjB1fXyJfOfdA3l/yTF5yLi+WfuQ==}
+  '@next/swc-linux-x64-musl@16.2.6':
+    resolution: {integrity: sha512-HKQ5SP/V/ub73UvF7n/zeJlxk2kLmtL7Wzrg4WfmkjmNos5onJ2tKu7yZOPdL18A6Svfn3max29ym+ry7NkK4g==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [linux]
     libc: [musl]
 
-  '@next/swc-win32-arm64-msvc@16.2.5':
-    resolution: {integrity: sha512-f/H4nZ2zJBvA8/+HpsB9mNonF9zfQoAU6D0WxJrfzhJDvJLfngVN85oqxUyrDVK99DIFfFYhLpGa5K+c5uotSw==}
+  '@next/swc-win32-arm64-msvc@16.2.6':
+    resolution: {integrity: sha512-LZXpTlPyS5v7HhSmnvsLGP3iIYgYOBnc8r8ArlT55sGHV89bR2HlDdBjWQ+PY6SJMmk8TuVGFuxalnP3k/0Dwg==}
     engines: {node: '>= 10'}
     cpu: [arm64]
     os: [win32]
 
-  '@next/swc-win32-x64-msvc@16.2.5':
-    resolution: {integrity: sha512-nuP7DHs4koAojsIxVPkihNgKiRUKtCU65j5X6DAbSy8VBrfT/o90bCLLHPf51JEdOZwZMFzM6e0NiGWfIWjVAg==}
+  '@next/swc-win32-x64-msvc@16.2.6':
+    resolution: {integrity: sha512-F0+4i0h9J6C4eE3EAPWsoCk7UW/dbzOjyzxY0qnDUOYFu6FFmdZ6l97/XdV3/Nz3VYyO7UWjyEJUXkGqcoXfMA==}
     engines: {node: '>= 10'}
     cpu: [x64]
     os: [win32]
@@ -5137,8 +5137,8 @@ packages:
       react: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
       react-dom: ^16.8 || ^17 || ^18 || ^19 || ^19.0.0-rc
 
-  next@16.2.5:
-    resolution: {integrity: sha512-TkVTm9F2WEulkgGljm4wPwNgvCCWCVw6StUHsZb8WZpHFRjepoUWg3d7L4IMg7IyjcJ4Co9eVhpro8e8O+KarQ==}
+  next@16.2.6:
+    resolution: {integrity: sha512-qOVgKJg1+At15NpeUP+eJgCHvTCgXsogweq87Ri/Ix7PkqQHg4sdaXmSFqKlgaIXE4kW0g25LE68W87UANlHtw==}
     engines: {node: '>=20.9.0'}
     hasBin: true
     peerDependencies:
@@ -7935,34 +7935,34 @@ snapshots:
       '@tybys/wasm-util': 0.10.1
     optional: true
 
-  '@next/env@16.2.5': {}
+  '@next/env@16.2.6': {}
 
   '@next/eslint-plugin-next@16.2.4':
     dependencies:
       fast-glob: 3.3.1
 
-  '@next/swc-darwin-arm64@16.2.5':
+  '@next/swc-darwin-arm64@16.2.6':
     optional: true
 
-  '@next/swc-darwin-x64@16.2.5':
+  '@next/swc-darwin-x64@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-gnu@16.2.5':
+  '@next/swc-linux-arm64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-arm64-musl@16.2.5':
+  '@next/swc-linux-arm64-musl@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-gnu@16.2.5':
+  '@next/swc-linux-x64-gnu@16.2.6':
     optional: true
 
-  '@next/swc-linux-x64-musl@16.2.5':
+  '@next/swc-linux-x64-musl@16.2.6':
     optional: true
 
-  '@next/swc-win32-arm64-msvc@16.2.5':
+  '@next/swc-win32-arm64-msvc@16.2.6':
     optional: true
 
-  '@next/swc-win32-x64-msvc@16.2.5':
+  '@next/swc-win32-x64-msvc@16.2.6':
     optional: true
 
   '@noble/ciphers@1.3.0': {}
@@ -9773,7 +9773,7 @@ snapshots:
 
   bcryptjs@3.0.3: {}
 
-  better-auth@1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
+  better-auth@1.6.9(@opentelemetry/api@1.9.1)(drizzle-kit@0.31.10)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))(mongodb@7.1.0(socks@2.8.8))(next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5))(react-dom@19.2.5(react@19.2.5))(react@19.2.5)(vitest@4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))):
     dependencies:
       '@better-auth/core': 1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1)
       '@better-auth/drizzle-adapter': 1.6.9(@better-auth/core@1.6.9(@better-auth/utils@0.4.0)(@better-fetch/fetch@1.1.21)(@opentelemetry/api@1.9.1)(better-call@1.3.5(zod@4.3.6))(jose@6.2.3)(kysely@0.28.14)(nanostores@1.1.1))(@better-auth/utils@0.4.0)(drizzle-orm@0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9))
@@ -9796,7 +9796,7 @@ snapshots:
       drizzle-kit: 0.31.10
       drizzle-orm: 0.45.2(@opentelemetry/api@1.9.1)(kysely@0.28.14)(postgres@3.4.9)
       mongodb: 7.1.0(socks@2.8.8)
-      next: 16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
+      next: 16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5)
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
       vitest: 4.1.5(@opentelemetry/api@1.9.1)(@types/node@25.6.0)(jsdom@29.1.0(@noble/hashes@2.0.1))(vite@8.0.10(@types/node@25.6.0)(esbuild@0.27.3)(jiti@2.6.1)(tsx@4.21.0)(yaml@2.8.3))
@@ -11953,9 +11953,9 @@ snapshots:
       react: 19.2.5
       react-dom: 19.2.5(react@19.2.5)
 
-  next@16.2.5(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
+  next@16.2.6(@babel/core@7.29.0)(@opentelemetry/api@1.9.1)(@playwright/test@1.59.1)(react-dom@19.2.5(react@19.2.5))(react@19.2.5):
     dependencies:
-      '@next/env': 16.2.5
+      '@next/env': 16.2.6
       '@swc/helpers': 0.5.15
       baseline-browser-mapping: 2.9.19
       caniuse-lite: 1.0.30001770
@@ -11964,14 +11964,14 @@ snapshots:
       react-dom: 19.2.5(react@19.2.5)
       styled-jsx: 5.1.6(@babel/core@7.29.0)(react@19.2.5)
     optionalDependencies:
-      '@next/swc-darwin-arm64': 16.2.5
-      '@next/swc-darwin-x64': 16.2.5
-      '@next/swc-linux-arm64-gnu': 16.2.5
-      '@next/swc-linux-arm64-musl': 16.2.5
-      '@next/swc-linux-x64-gnu': 16.2.5
-      '@next/swc-linux-x64-musl': 16.2.5
-      '@next/swc-win32-arm64-msvc': 16.2.5
-      '@next/swc-win32-x64-msvc': 16.2.5
+      '@next/swc-darwin-arm64': 16.2.6
+      '@next/swc-darwin-x64': 16.2.6
+      '@next/swc-linux-arm64-gnu': 16.2.6
+      '@next/swc-linux-arm64-musl': 16.2.6
+      '@next/swc-linux-x64-gnu': 16.2.6
+      '@next/swc-linux-x64-musl': 16.2.6
+      '@next/swc-win32-arm64-msvc': 16.2.6
+      '@next/swc-win32-x64-msvc': 16.2.6
       '@opentelemetry/api': 1.9.1
       '@playwright/test': 1.59.1
       sharp: 0.34.5


### PR DESCRIPTION
## Summary

- The Permissions tab's "Unsaved changes" bar and "Save & Restart" button stayed visible after a successful save whenever an Odoo (or Email) connection was configured, even though the save itself succeeded and the agent restarted.
- Root cause: `AgentSettingsPermissions` froze three "initial value" `useRef`s (`initialKbToolsRef`, `initialAllowedPaths`, `initialWebSearchConfig`) at mount and never updated them. The post-save `fetchData()` refetches `connections` with a new array reference, which makes `useOdooPermissions` re-run its load effect and emit a fresh `onChange` with a new `{connectionId, permissions}` object. That re-triggers the dirty-recheck `useEffect`, which compares current state against the stale mount-time refs and falsely reports `isDirty=true`, re-adding `"permissions"` to `dirtyTabs`.
- Fix: a new `useEffect` re-syncs the three refs whenever `agent.allowedTools` or `agent.pluginConfig` changes. By the time the cascade fires, the refs reflect the persisted state and dirty is computed correctly.

## Why this matters

- The bug also broke the "revert after save" UX: re-typing the previously-saved value as empty was incorrectly reported as clean, because the comparison was against the mount-time snapshot, not the saved state.
- Reproducible from the screenshot the user reported: save Web Search settings (or any KB-tools / allowed-paths change) on an agent that has an Odoo connection configured.

## Tests

- **Component tests (3 new):** simulate the cascade via captured `onChange` callbacks — Web Search config, KB tools, and revert-after-save. All 3 fail without the fix and pass with it. Existing 27 tests still pass.
- **E2E regression test (1 new):** in `odoo-permissions.spec.ts`, toggles a KB tool with an Odoo connection present, saves, waits deterministically for the `/api/integrations` refetch (the actual cascade trigger), and asserts the dirty bar stayed clean.

## Bundled dependency bump

- `next` 16.2.4 → 16.2.6 to clear the osv-scan CI gate (GHSA-wfc6-r584-vfw7 medium, GHSA-26hh-7cqf-hhc6 high). The bump is also part of #335; whichever lands second will be a no-op rebase on the Next.js side.

## Test plan

- [x] `pnpm -C packages/web test` — 4058 passed, 12 skipped (same as before)
- [x] `pnpm -C packages/web exec tsc --noEmit` — clean
- [x] `pnpm -C packages/web lint` — 0 errors (warnings unchanged)
- [x] Playwright list confirms the new E2E test is registered in the `odoo-e2e` job
- [ ] CI runs `odoo-e2e` against the production `Dockerfile.pinchy` image