### PR TITLE
Harden Odoo relation references for agent writes

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -92,6 +92,28 @@ const MODEL_FIELDS = {
       readonly: false,
       relation: "res.country.state",
     },
+    country_id: {
+      string: "Country",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.country",
+    },
+  },
+  "res.country": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: {
+      string: "Country Name",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    code: {
+      string: "Country Code",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
   },
   "product.product": {
     id: { string: "ID", type: "integer", required: false, readonly: true },
@@ -194,6 +216,7 @@ function getDefaultRecords() {
         is_company: true,
         zip: "1010",
         state_id: [1, "Wien"],
+        country_id: [14, "Austria"],
       },
       {
         id: 2,
@@ -203,6 +226,7 @@ function getDefaultRecords() {
         is_company: true,
         zip: "8010",
         state_id: [2, "Steiermark"],
+        country_id: [14, "Austria"],
       },
       {
         id: 3,
@@ -212,6 +236,7 @@ function getDefaultRecords() {
         is_company: true,
         zip: "4020",
         state_id: [3, "Oberösterreich"],
+        country_id: [14, "Austria"],
       },
       {
         id: 4,
@@ -221,7 +246,15 @@ function getDefaultRecords() {
         is_company: true,
         zip: "5020",
         state_id: [4, "Salzburg"],
+        country_id: [14, "Austria"],
       },
+    ],
+    "res.country": [
+      { id: 1, name: "Aruba", code: "AW" },
+      { id: 14, name: "Austria", code: "AT" },
+      { id: 220, name: "Uganda", code: "UG" },
+      { id: 230, name: "Uzbekistan", code: "UZ" },
+      { id: 233, name: "United States", code: "US" },
     ],
     "product.product": [
       {
@@ -250,6 +283,7 @@ function getDefaultRecords() {
       { id: 1, model: "sale.order", name: "Sales Order" },
       { id: 2, model: "res.partner", name: "Contact" },
       { id: 3, model: "product.product", name: "Product" },
+      { id: 4, model: "res.country", name: "Country" },
     ],
   };
 }
@@ -328,10 +362,7 @@ function evaluateLeaf(record, leaf) {
     case "not in":
       return !Array.isArray(value) || !value.includes(recordValue);
     case "like":
-      return (
-        typeof recordValue === "string" &&
-        recordValue.includes(value)
-      );
+      return typeof recordValue === "string" && recordValue.includes(value);
     case "ilike":
       return (
         typeof recordValue === "string" &&
@@ -393,7 +424,10 @@ function sortRecords(records, orderStr) {
   if (!orderStr) return records;
   const parts = orderStr.split(",").map((s) => {
     const tokens = s.trim().split(/\s+/);
-    return { field: tokens[0], desc: (tokens[1] || "asc").toLowerCase() === "desc" };
+    return {
+      field: tokens[0],
+      desc: (tokens[1] || "asc").toLowerCase() === "desc",
+    };
   });
   return [...records].sort((a, b) => {
     for (const { field, desc } of parts) {
@@ -492,36 +526,38 @@ function handleJsonRpc(body) {
           groups[groupKey].records.push(record);
         }
 
-        let results = Object.entries(groups).map(([key, { records, rawKey }]) => {
-          const result = {};
-          result[groupByField] = rawKey;
-          result[groupByField + "_count"] = records.length;
-          result["__count"] = records.length;
+        let results = Object.entries(groups).map(
+          ([key, { records, rawKey }]) => {
+            const result = {};
+            result[groupByField] = rawKey;
+            result[groupByField + "_count"] = records.length;
+            result["__count"] = records.length;
 
-          // Sum numeric fields if requested
-          if (groupFields) {
-            for (const f of groupFields) {
-              const fieldName = f.includes(":") ? f.split(":")[0] : f;
-              if (fieldName === groupByField) continue;
-              const fieldSchema =
-                MODEL_FIELDS[model] && MODEL_FIELDS[model][fieldName];
-              if (
-                fieldSchema &&
-                (fieldSchema.type === "float" ||
-                  fieldSchema.type === "monetary" ||
-                  fieldSchema.type === "integer")
-              ) {
-                result[fieldName] = records.reduce(
-                  (sum, r) => sum + (r[fieldName] || 0),
-                  0
-                );
+            // Sum numeric fields if requested
+            if (groupFields) {
+              for (const f of groupFields) {
+                const fieldName = f.includes(":") ? f.split(":")[0] : f;
+                if (fieldName === groupByField) continue;
+                const fieldSchema =
+                  MODEL_FIELDS[model] && MODEL_FIELDS[model][fieldName];
+                if (
+                  fieldSchema &&
+                  (fieldSchema.type === "float" ||
+                    fieldSchema.type === "monetary" ||
+                    fieldSchema.type === "integer")
+                ) {
+                  result[fieldName] = records.reduce(
+                    (sum, r) => sum + (r[fieldName] || 0),
+                    0,
+                  );
+                }
               }
             }
-          }
 
-          result["__domain"] = [[groupByField, "=", rawKey]];
-          return result;
-        });
+            result["__domain"] = [[groupByField, "=", rawKey]];
+            return result;
+          },
+        );
 
         const start = offset || 0;
         const end = limit ? start + limit : results.length;
@@ -574,7 +610,10 @@ function handleJsonRpc(body) {
         const modelRights = accessRights[model];
         const hasAccess = modelRights ? (modelRights[operation] ?? true) : true;
         if (!hasAccess && raiseException) {
-          return { __jsonrpc_error: true, message: "AccessError: permission denied" };
+          return {
+            __jsonrpc_error: true,
+            message: "AccessError: permission denied",
+          };
         }
         return hasAccess;
       }
@@ -652,7 +691,11 @@ const jsonRpcServer = http.createServer(async (req, res) => {
       sendJson(res, 200, {
         jsonrpc: "2.0",
         id: body.id || null,
-        error: { message: result.message, code: 200, data: { message: result.message } },
+        error: {
+          message: result.message,
+          code: 200,
+          data: { message: result.message },
+        },
       });
     } else {
       sendJson(res, 200, {
@@ -705,9 +748,7 @@ const controlServer = http.createServer(async (req, res) => {
     for (const record of body.records) {
       if (record.id) {
         // Remove existing record with same id
-        store[body.model] = store[body.model].filter(
-          (r) => r.id !== record.id
-        );
+        store[body.model] = store[body.model].filter((r) => r.id !== record.id);
         store[body.model].push(record);
         if (record.id >= (nextIds[body.model] || 1)) {
           nextIds[body.model] = record.id + 1;
@@ -773,9 +814,13 @@ const controlServer = http.createServer(async (req, res) => {
 // ---------------------------------------------------------------------------
 resetNextIds();
 
-async function start({ jsonRpcPort = 8069, controlPort = 9002 } = {}) {
-  await new Promise((resolve) => jsonRpcServer.listen(jsonRpcPort, resolve));
-  await new Promise((resolve) => controlServer.listen(controlPort, resolve));
+async function start({ jsonRpcPort = 8069, controlPort = 9002, host } = {}) {
+  await new Promise((resolve) =>
+    jsonRpcServer.listen(jsonRpcPort, host, resolve),
+  );
+  await new Promise((resolve) =>
+    controlServer.listen(controlPort, host, resolve),
+  );
   return {
     jsonRpcPort: jsonRpcServer.address().port,
     controlPort: controlServer.address().port,

--- a/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it, vi } from "vitest";
+import { decodeRef, encodeRef } from "../integration-ref";
+
+describe("integration refs", () => {
+  it("roundtrips an opaque Odoo reference", () => {
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+
+    const ref = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.country",
+      id: 14,
+      label: "Austria",
+    });
+
+    expect(ref).toMatch(/^pinchy_ref:v1:/);
+    expect(ref).not.toContain("Austria");
+    expect(ref).not.toContain("res.country");
+    expect(decodeRef(ref)).toEqual({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.country",
+      id: 14,
+      label: "Austria",
+    });
+  });
+
+  it("rejects tampered references", () => {
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    const ref = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.country",
+      id: 14,
+      label: "Austria",
+    });
+
+    expect(() => decodeRef(ref.replace(/.$/, "x"))).toThrow(
+      /Invalid integration reference/,
+    );
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -32,8 +32,11 @@ interface AgentTool {
   name: string;
   execute: (
     toolCallId: string,
-    params: Record<string, unknown>
-  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean }>;
+    params: Record<string, unknown>,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
 }
 
 let mockOdoo: MockOdooHandle;
@@ -46,11 +49,20 @@ const PINCHY_GATEWAY_TOKEN = "test-gateway-token-integration";
 const credentialsByConnectionId = new Map<string, unknown>();
 
 beforeAll(async () => {
+  process.env.PINCHY_REF_TOKEN_KEY = "a".repeat(64);
   // Mock Odoo on an OS-picked port (no collision with the docker-compose service)
   const mockServer = require("../../../../config/odoo-mock/server.js") as {
-    start: (opts: { jsonRpcPort: number; controlPort: number }) => Promise<MockOdooHandle>;
+    start: (opts: {
+      jsonRpcPort: number;
+      controlPort: number;
+      host?: string;
+    }) => Promise<MockOdooHandle>;
   };
-  mockOdoo = await mockServer.start({ jsonRpcPort: 0, controlPort: 0 });
+  mockOdoo = await mockServer.start({
+    jsonRpcPort: 0,
+    controlPort: 0,
+    host: "127.0.0.1",
+  });
 
   // Mock Pinchy: implements just the credentials endpoint with the same
   // auth contract Pinchy itself uses (Bearer gateway token).
@@ -61,7 +73,9 @@ beforeAll(async () => {
       res.end(JSON.stringify({ error: "Unauthorized" }));
       return;
     }
-    const match = req.url?.match(/^\/api\/internal\/integrations\/([^/]+)\/credentials$/);
+    const match = req.url?.match(
+      /^\/api\/internal\/integrations\/([^/]+)\/credentials$/,
+    );
     if (!match) {
       res.writeHead(404);
       res.end();
@@ -77,7 +91,9 @@ beforeAll(async () => {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(JSON.stringify({ type: "odoo", credentials }));
   });
-  await new Promise<void>((resolve) => mockPinchy.listen(0, resolve));
+  await new Promise<void>((resolve) =>
+    mockPinchy.listen(0, "127.0.0.1", resolve),
+  );
   mockPinchyPort = (mockPinchy.address() as AddressInfo).port;
 });
 
@@ -85,14 +101,16 @@ afterAll(async () => {
   await mockOdoo?.stop();
   if (mockPinchy) {
     await new Promise<void>((resolve, reject) =>
-      mockPinchy.close((err) => (err ? reject(err) : resolve()))
+      mockPinchy.close((err) => (err ? reject(err) : resolve())),
     );
   }
 });
 
 function createApi(agentConfigs: Record<string, unknown> = {}) {
-  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> =
-    [];
+  const tools: Array<{
+    factory: (ctx: { agentId?: string }) => AgentTool | null;
+    name: string;
+  }> = [];
   const api = {
     pluginConfig: {
       apiBaseUrl: `http://127.0.0.1:${mockPinchyPort}`,
@@ -101,7 +119,7 @@ function createApi(agentConfigs: Record<string, unknown> = {}) {
     },
     registerTool: (
       factory: (ctx: { agentId?: string }) => AgentTool | null,
-      opts?: { name?: string }
+      opts?: { name?: string },
     ) => {
       tools.push({ factory, name: opts?.name ?? "" });
     },
@@ -111,18 +129,26 @@ function createApi(agentConfigs: Record<string, unknown> = {}) {
   return tools;
 }
 
-function findTool(tools: ReturnType<typeof createApi>, name: string, agentId: string): AgentTool {
+function findTool(
+  tools: ReturnType<typeof createApi>,
+  name: string,
+  agentId: string,
+): AgentTool {
   const entry = tools.find((t) => t.name === name);
   if (!entry) throw new Error(`Tool ${name} not registered`);
   const tool = entry.factory({ agentId });
-  if (!tool) throw new Error(`Tool ${name} factory returned null for agent ${agentId}`);
+  if (!tool)
+    throw new Error(`Tool ${name} factory returned null for agent ${agentId}`);
   return tool;
 }
 
 const agentId = "agent-integration";
 const agentConfig = {
   connectionId: "conn-integration",
-  permissions: { "sale.order": ["read"], "res.partner": ["read"] },
+  permissions: {
+    "sale.order": ["read"],
+    "res.partner": ["read", "create", "write"],
+  },
   modelNames: { "sale.order": "Sales Order", "res.partner": "Contact" },
 };
 
@@ -147,14 +173,19 @@ describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () =
     const data = JSON.parse(result.content[0].text);
     expect(data.name).toBe("Sales Order");
     expect(data.fields.length).toBeGreaterThan(0);
-    expect(data.fields.some((f: { name: string }) => f.name === "name")).toBe(true);
+    expect(data.fields.some((f: { name: string }) => f.name === "name")).toBe(
+      true,
+    );
   });
 
   it("odoo_count returns { count: number } for an empty filter", async () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_count", agentId);
 
-    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
 
     expect(result.isError).toBeFalsy();
     const data = JSON.parse(result.content[0].text);
@@ -165,12 +196,93 @@ describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () =
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId);
 
-    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
 
     expect(result.isError).toBeFalsy();
     const data = JSON.parse(result.content[0].text);
     expect(Array.isArray(data.records)).toBe(true);
     expect(typeof data.total).toBe("number");
+  });
+
+  it("creates a partner with a country code lookup after a real Odoo round-trip", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId);
+
+    const result = await tool.execute("call-create-country-lookup", {
+      model: "res.partner",
+      values: {
+        name: "Lookup Partner",
+        country_id: { lookup: { code: "AT" } },
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const { id } = JSON.parse(result.content[0].text) as { id: number };
+    const records = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=res.partner`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(records.find((record) => record.id === id)).toMatchObject({
+      name: "Lookup Partner",
+      country_id: 14,
+    });
+  });
+
+  it("reuses an emitted country ref in a subsequent write", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const readTool = findTool(tools, "odoo_read", agentId);
+    const writeTool = findTool(tools, "odoo_write", agentId);
+
+    const readResult = await readTool.execute("call-read-country-ref", {
+      model: "res.partner",
+      filters: [["id", "=", 1]],
+      fields: ["name", "country_id"],
+    });
+    expect(readResult.isError).toBeFalsy();
+    const readData = JSON.parse(readResult.content[0].text);
+    const country = readData.records[0].country_id;
+    expect(country).toMatchObject({
+      ref: expect.stringMatching(/^pinchy_ref:v1:/),
+      label: "Austria",
+      model: "res.country",
+    });
+
+    const writeResult = await writeTool.execute("call-write-country-ref", {
+      model: "res.partner",
+      ids: [2],
+      values: { country_id: { ref: country.ref } },
+    });
+
+    expect(writeResult.isError).toBeFalsy();
+    const records = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=res.partner`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(records.find((record) => record.id === 2)).toMatchObject({
+      country_id: 14,
+    });
+  });
+
+  it("rejects raw numeric relation IDs before creating a record in Odoo", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId);
+
+    const result = await tool.execute("call-create-raw-country", {
+      model: "res.partner",
+      values: { name: "Raw Numeric Partner", country_id: 14 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Raw numeric IDs are not accepted",
+    );
+    const records = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=res.partner`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(
+      records.some((record) => record.name === "Raw Numeric Partner"),
+    ).toBe(false);
   });
 
   it("REGRESSION (#209): if Pinchy returns the SecretRef-shaped dict instead of credentials, the plugin fails fast WITHOUT producing a Python crash", async () => {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -23,6 +23,7 @@ vi.mock("odoo-node", () => {
 });
 
 import { OdooClient } from "odoo-node";
+import { encodeRef } from "../integration-ref";
 import plugin from "../index";
 
 interface AgentTool {
@@ -34,7 +35,11 @@ interface AgentTool {
     toolCallId: string,
     params: Record<string, unknown>,
     signal?: AbortSignal,
-  ) => Promise<{ content: Array<{ type: string; text: string }>; isError?: boolean; details?: unknown }>;
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+    details?: unknown;
+  }>;
 }
 
 // The plugin no longer takes credentials in its config — it fetches them
@@ -62,7 +67,10 @@ const fetchMock = vi.fn(async () => ({
 globalThis.fetch = fetchMock as unknown as typeof fetch;
 
 function createApi(agentConfigs: Record<string, unknown> = {}) {
-  const tools: Array<{ factory: (ctx: { agentId?: string }) => AgentTool | null; name: string }> = [];
+  const tools: Array<{
+    factory: (ctx: { agentId?: string }) => AgentTool | null;
+    name: string;
+  }> = [];
 
   const api = {
     pluginConfig: {
@@ -70,7 +78,10 @@ function createApi(agentConfigs: Record<string, unknown> = {}) {
       gatewayToken: "test-gateway-token",
       agents: agentConfigs,
     },
-    registerTool: (factory: (ctx: { agentId?: string }) => AgentTool | null, opts?: { name?: string }) => {
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string },
+    ) => {
       tools.push({ factory, name: opts?.name ?? "" });
     },
   };
@@ -79,7 +90,11 @@ function createApi(agentConfigs: Record<string, unknown> = {}) {
   return tools;
 }
 
-function findTool(tools: ReturnType<typeof createApi>, name: string, agentId?: string): AgentTool | null {
+function findTool(
+  tools: ReturnType<typeof createApi>,
+  name: string,
+  agentId?: string,
+): AgentTool | null {
   const entry = tools.find((t) => t.name === name);
   if (!entry) return null;
   return entry.factory({ agentId });
@@ -141,9 +156,28 @@ describe("odoo_schema", () => {
 
   it("returns fields for a specific permitted model", async () => {
     const expectedFields = [
-      { name: "name", string: "Order Reference", type: "char", required: true, readonly: true },
-      { name: "partner_id", string: "Customer", type: "many2one", required: true, readonly: false, relation: "res.partner" },
-      { name: "amount_total", string: "Total", type: "monetary", required: false, readonly: true },
+      {
+        name: "name",
+        string: "Order Reference",
+        type: "char",
+        required: true,
+        readonly: true,
+      },
+      {
+        name: "partner_id",
+        string: "Customer",
+        type: "many2one",
+        required: true,
+        readonly: false,
+        relation: "res.partner",
+      },
+      {
+        name: "amount_total",
+        string: "Total",
+        type: "monetary",
+        required: false,
+        readonly: true,
+      },
     ];
     mockFields.mockResolvedValue(expectedFields);
 
@@ -171,6 +205,7 @@ describe("odoo_schema", () => {
 describe("odoo_read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
   });
 
   it("reads records with correct parameters", async () => {
@@ -200,7 +235,12 @@ describe("odoo_read", () => {
     expect(mockSearchRead).toHaveBeenCalledWith(
       "sale.order",
       [["state", "=", "sale"]],
-      { fields: ["name", "amount_total"], limit: 10, offset: 0, order: "date_order desc" },
+      {
+        fields: ["name", "amount_total"],
+        limit: 10,
+        offset: 0,
+        order: "date_order desc",
+      },
     );
   });
 
@@ -217,6 +257,43 @@ describe("odoo_read", () => {
     expect(result.content[0].text).toContain("account.move");
     expect(result.isError).toBe(true);
     expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("returns many2one values as opaque refs with labels", async () => {
+    mockFields.mockResolvedValue([
+      { name: "id", string: "ID", type: "integer" },
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 7, name: "Wien Partner", country_id: [14, "Austria"] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-ref-read", {
+      model: "res.partner",
+      filters: [],
+      fields: ["name", "country_id"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.records[0].country_id).toEqual({
+      ref: expect.stringMatching(/^pinchy_ref:v1:/),
+      label: "Austria",
+      model: "res.country",
+    });
+    expect(data.records[0].country_id.ref).not.toContain("14");
   });
 });
 
@@ -238,7 +315,9 @@ describe("odoo_count", () => {
 
     const data = JSON.parse(result.content[0].text);
     expect(data.count).toBe(42);
-    expect(mockSearchCount).toHaveBeenCalledWith("sale.order", [["state", "=", "sale"]]);
+    expect(mockSearchCount).toHaveBeenCalledWith("sale.order", [
+      ["state", "=", "sale"],
+    ]);
   });
 
   it("denies count on unpermitted model", async () => {
@@ -262,7 +341,9 @@ describe("odoo_aggregate", () => {
 
   it("aggregates data for a permitted model", async () => {
     mockReadGroup.mockResolvedValue({
-      groups: [{ partner_id: [1, "Customer A"], amount_total: 1500, __count: 3 }],
+      groups: [
+        { partner_id: [1, "Customer A"], amount_total: 1500, __count: 3 },
+      ],
     });
 
     const tools = createApi({ [agentId]: agentConfig });
@@ -305,6 +386,7 @@ describe("odoo_aggregate", () => {
 describe("odoo_create", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
   });
 
   it("creates a record on a permitted model", async () => {
@@ -320,7 +402,244 @@ describe("odoo_create", () => {
 
     const data = JSON.parse(result.content[0].text);
     expect(data.id).toBe(42);
-    expect(mockCreate).toHaveBeenCalledWith("res.partner", { name: "New Partner", email: "new@example.com" });
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "New Partner",
+      email: "new@example.com",
+    });
+  });
+
+  it("resolves country_id by exact country name instead of using the first same-letter country", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [
+        { id: 1, name: "Aruba", code: "AW" },
+        { id: 14, name: "Austria", code: "AT" },
+      ],
+      total: 2,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(42);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-name", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: "Austria" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Wien Partner",
+      country_id: 14,
+    });
+  });
+
+  it("rejects raw numeric country_id values", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-raw-id", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: 14 },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "Raw numeric IDs are not accepted",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("resolves country_id from an explicit code lookup", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [
+        { id: 1, name: "Aruba", code: "AW" },
+        { id: 14, name: "Austria", code: "AT" },
+      ],
+      total: 2,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(44);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-code-lookup", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: { lookup: { code: "AT" } } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Wien Partner",
+      country_id: 14,
+    });
+  });
+
+  it("resolves country_id from an opaque ref", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockCreate.mockResolvedValue(45);
+    const ref = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.country",
+      id: 14,
+      label: "Austria",
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-ref", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: { ref } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Wien Partner",
+      country_id: 14,
+    });
+  });
+
+  it("rejects an opaque ref for the wrong relation model", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    const ref = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.partner",
+      id: 7,
+      label: "Wien Partner",
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-wrong-ref", {
+      model: "res.partner",
+      values: { name: "Wien Partner", country_id: { ref } },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("expected res.country");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("resolves USA as the United States country code instead of the first U country", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [
+        { id: 230, name: "Uzbekistan", code: "UZ" },
+        { id: 233, name: "United States", code: "US" },
+      ],
+      total: 2,
+      limit: 1000,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(43);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-usa", {
+      model: "res.partner",
+      values: { name: "US Partner", country_id: "USA" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "US Partner",
+      country_id: 233,
+    });
+  });
+
+  it("rejects ambiguous country text instead of creating with an arbitrary match", async () => {
+    mockFields.mockResolvedValue([
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "country_id",
+        string: "Country",
+        type: "many2one",
+        relation: "res.country",
+      },
+    ]);
+    mockSearchRead.mockResolvedValue({
+      records: [
+        { id: 220, name: "Uganda", code: "UG" },
+        { id: 230, name: "Uzbekistan", code: "UZ" },
+      ],
+      total: 2,
+      limit: 1000,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-country-ambiguous", {
+      model: "res.partner",
+      values: { name: "Unknown Partner", country_id: "U" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Could not resolve country_id");
+    expect(result.content[0].text).toContain("Uganda");
+    expect(result.content[0].text).toContain("Uzbekistan");
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 
   it("denies create on model without create permission", async () => {
@@ -358,7 +677,9 @@ describe("odoo_write", () => {
 
     const data = JSON.parse(result.content[0].text);
     expect(data.success).toBe(true);
-    expect(mockWrite).toHaveBeenCalledWith("res.partner", [1, 2], { email: "updated@example.com" });
+    expect(mockWrite).toHaveBeenCalledWith("res.partner", [1, 2], {
+      email: "updated@example.com",
+    });
   });
 
   it("denies write on model without write permission", async () => {
@@ -388,7 +709,10 @@ describe("odoo_delete", () => {
     // Add delete permission for this test
     const configWithDelete = {
       ...agentConfig,
-      permissions: { ...testPermissions, "res.partner": ["read", "write", "create", "delete"] },
+      permissions: {
+        ...testPermissions,
+        "res.partner": ["read", "write", "create", "delete"],
+      },
     };
     const tools = createApi({ [agentId]: configWithDelete });
     const tool = findTool(tools, "odoo_delete", agentId)!;
@@ -439,7 +763,9 @@ describe("error handling", () => {
   });
 
   it("returns permission message for Odoo access errors", async () => {
-    mockSearchRead.mockRejectedValue(new Error("AccessError: no read access on sale.order"));
+    mockSearchRead.mockRejectedValue(
+      new Error("AccessError: no read access on sale.order"),
+    );
 
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId)!;
@@ -497,7 +823,12 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
   });
 
   it("fetches credentials once and reuses the OdooClient across multiple tool calls for the same agent", async () => {
-    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
+    mockSearchRead.mockResolvedValue({
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
     mockSearchCount.mockResolvedValue(0);
 
     const tools = createApi({ [agentId]: agentConfig });
@@ -515,13 +846,21 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
   });
 
   it("fetches credentials separately for different agents (no cross-agent leakage)", async () => {
-    mockSearchRead.mockResolvedValue({ records: [], total: 0, limit: 100, offset: 0 });
+    mockSearchRead.mockResolvedValue({
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
 
     const agent2Config = {
       connectionId: "conn-test-2",
       permissions: testPermissions,
     };
-    const tools = createApi({ [agentId]: agentConfig, "agent-2": agent2Config });
+    const tools = createApi({
+      [agentId]: agentConfig,
+      "agent-2": agent2Config,
+    });
 
     const tool1 = findTool(tools, "odoo_read", agentId)!;
     const tool2 = findTool(tools, "odoo_read", "agent-2")!;
@@ -545,14 +884,21 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
       json: async () => ({
         type: "odoo",
         // Exactly the broken shape from staging: an unresolved SecretRef.
-        credentials: { source: "file", provider: "pinchy", id: "/integrations/x/odooApiKey" },
+        credentials: {
+          source: "file",
+          provider: "pinchy",
+          id: "/integrations/x/odooApiKey",
+        },
       }),
     } as unknown as Response);
 
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_count", agentId)!;
 
-    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
 
     expect(result.isError).toBe(true);
     const text = result.content[0].text;
@@ -561,13 +907,23 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
   });
 
   it("invalidates the cache and refetches credentials on auth error", async () => {
-    mockSearchRead.mockRejectedValueOnce(new Error("Access Denied: invalid api key"));
-    mockSearchRead.mockResolvedValueOnce({ records: [], total: 0, limit: 100, offset: 0 });
+    mockSearchRead.mockRejectedValueOnce(
+      new Error("Access Denied: invalid api key"),
+    );
+    mockSearchRead.mockResolvedValueOnce({
+      records: [],
+      total: 0,
+      limit: 100,
+      offset: 0,
+    });
 
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId)!;
 
-    const result = await tool.execute("call-1", { model: "sale.order", filters: [] });
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
 
     expect(result.isError).toBeFalsy();
     // First call fetched, error invalidated cache, second call refetched

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -293,7 +293,6 @@ describe("odoo_read", () => {
       label: "Austria",
       model: "res.country",
     });
-    expect(data.records[0].country_id.ref).not.toContain("14");
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1,5 +1,10 @@
 import { OdooClient } from "odoo-node";
-import { checkPermission, getPermittedModels, type Permissions } from "./permissions";
+import {
+  checkPermission,
+  getPermittedModels,
+  type Permissions,
+} from "./permissions";
+import { decodeRef, encodeRef } from "./integration-ref";
 
 interface PluginToolContext {
   agentId?: string;
@@ -27,7 +32,11 @@ interface AgentTool {
     toolCallId: string,
     params: Record<string, unknown>,
     signal?: AbortSignal,
-  ) => Promise<{ content: ContentBlock[]; isError?: boolean; details?: unknown }>;
+  ) => Promise<{
+    content: ContentBlock[];
+    isError?: boolean;
+    details?: unknown;
+  }>;
 }
 
 interface PluginConfig {
@@ -49,6 +58,34 @@ interface OdooCredentials {
   apiKey: string;
 }
 
+interface OdooField {
+  name: string;
+  string?: string;
+  type?: string;
+  relation?: string;
+}
+
+type OdooRecord = Record<string, unknown>;
+
+interface OdooRefValue {
+  ref: string;
+  label: string;
+  model: string;
+}
+
+interface RelationLookup {
+  name?: string;
+  code?: string;
+}
+
+const COUNTRY_ALIASES_TO_CODE: Record<string, string> = {
+  america: "US",
+  usa: "US",
+  us: "US",
+  unitedstates: "US",
+  unitedstatesofamerica: "US",
+};
+
 function getAgentConfig(
   agentConfigs: Record<string, AgentOdooConfig>,
   agentId: string,
@@ -63,16 +100,22 @@ function getAgentConfig(
  * `unhashable type: 'dict'`, see issue #209). Without this assertion a
  * malformed payload would propagate all the way to Odoo before erroring.
  */
-function assertCredentialsShape(creds: unknown): asserts creds is OdooCredentials {
+function assertCredentialsShape(
+  creds: unknown,
+): asserts creds is OdooCredentials {
   if (!creds || typeof creds !== "object") {
-    throw new Error(`pinchy-odoo: credentials must be an object, got ${typeof creds}`);
+    throw new Error(
+      `pinchy-odoo: credentials must be an object, got ${typeof creds}`,
+    );
   }
   const obj = creds as Record<string, unknown>;
   // Detect the SecretRef-shaped payload (#209) up front so the error
   // message points at the actual root cause instead of a "field missing"
   // symptom that's harder to debug.
   const looksLikeSecretRef =
-    typeof obj.source === "string" && typeof obj.provider === "string" && typeof obj.id === "string";
+    typeof obj.source === "string" &&
+    typeof obj.provider === "string" &&
+    typeof obj.id === "string";
   const expected: Array<[keyof OdooCredentials, "string" | "number"]> = [
     ["url", "string"],
     ["db", "string"],
@@ -134,7 +177,341 @@ function createClient(creds: OdooCredentials): OdooClient {
   });
 }
 
-function permissionDenied(operation: string, model: string): { content: ContentBlock[]; isError: true } {
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function getSearchReadRecords(result: unknown): OdooRecord[] {
+  if (Array.isArray(result)) return result.filter(isRecord);
+  if (isRecord(result) && Array.isArray(result.records)) {
+    return result.records.filter(isRecord);
+  }
+  return [];
+}
+
+function normalizeFields(fields: unknown): OdooField[] {
+  if (Array.isArray(fields)) {
+    return fields.filter(isRecord).flatMap((field) => {
+      if (typeof field.name !== "string") return [];
+      return [
+        {
+          name: field.name,
+          string: typeof field.string === "string" ? field.string : undefined,
+          type: typeof field.type === "string" ? field.type : undefined,
+          relation:
+            typeof field.relation === "string" ? field.relation : undefined,
+        },
+      ];
+    });
+  }
+
+  if (!isRecord(fields)) return [];
+
+  return Object.entries(fields).flatMap(([name, field]) => {
+    if (!isRecord(field)) return [];
+    return [
+      {
+        name,
+        string: typeof field.string === "string" ? field.string : undefined,
+        type: typeof field.type === "string" ? field.type : undefined,
+        relation:
+          typeof field.relation === "string" ? field.relation : undefined,
+      },
+    ];
+  });
+}
+
+function normalizeLookupText(value: string): string {
+  return value.trim().toLowerCase();
+}
+
+function normalizeCountryAliasKey(value: string): string {
+  return normalizeLookupText(value).replace(/[\s._-]/g, "");
+}
+
+function countryCodeForInput(value: string): string | null {
+  const trimmed = value.trim();
+  if (/^[a-z]{2}$/i.test(trimmed)) return trimmed.toUpperCase();
+  return COUNTRY_ALIASES_TO_CODE[normalizeCountryAliasKey(trimmed)] ?? null;
+}
+
+function recordId(record: OdooRecord): number | null {
+  return typeof record.id === "number" ? record.id : null;
+}
+
+function recordText(record: OdooRecord, field: string): string | null {
+  const value = record[field];
+  return typeof value === "string" ? value : null;
+}
+
+function uniqueIds(records: OdooRecord[]): number[] {
+  return [
+    ...new Set(records.map(recordId).filter((id): id is number => id !== null)),
+  ];
+}
+
+function recordLabel(record: OdooRecord): string {
+  return (
+    recordText(record, "display_name") ??
+    recordText(record, "name") ??
+    String(record.id ?? "")
+  );
+}
+
+function formatSuggestions(records: OdooRecord[]): string {
+  const labels = [
+    ...new Set(records.map(recordLabel).filter((label) => label.length > 0)),
+  ].slice(0, 5);
+  return labels.length > 0 ? ` Suggestions: ${labels.join(", ")}.` : "";
+}
+
+function rankedSuggestions(input: string, records: OdooRecord[]): OdooRecord[] {
+  const requested = normalizeLookupText(input);
+  const startsWith = records.filter((record) => {
+    const name = recordText(record, "name");
+    const displayName = recordText(record, "display_name");
+    return (
+      (name !== null && normalizeLookupText(name).startsWith(requested)) ||
+      (displayName !== null &&
+        normalizeLookupText(displayName).startsWith(requested))
+    );
+  });
+  return startsWith.length > 0 ? startsWith : records;
+}
+
+function parseLookup(field: OdooField, value: unknown): RelationLookup | null {
+  if (typeof value === "string") {
+    const input = value.trim();
+    if (input === "") return { name: "" };
+    const countryCode =
+      field.relation === "res.country" ? countryCodeForInput(input) : null;
+    return countryCode ? { code: countryCode } : { name: input };
+  }
+
+  if (!isRecord(value) || !isRecord(value.lookup)) return null;
+  const lookup = value.lookup;
+  return {
+    name: typeof lookup.name === "string" ? lookup.name.trim() : undefined,
+    code:
+      typeof lookup.code === "string"
+        ? lookup.code.trim().toUpperCase()
+        : undefined,
+  };
+}
+
+function resolveReferenceFromRecords(
+  field: OdooField,
+  lookup: RelationLookup,
+  records: OdooRecord[],
+): number {
+  const label = field.string ?? field.name;
+  const input = lookup.code ?? lookup.name ?? "";
+
+  if (field.relation === "res.country" && lookup.code) {
+    const codeMatches = records.filter(
+      (record) => recordText(record, "code")?.toUpperCase() === lookup.code,
+    );
+    const ids = uniqueIds(codeMatches);
+    if (ids.length === 1) return ids[0];
+    if (ids.length > 1) {
+      throw new Error(
+        `Could not resolve ${field.name}: multiple countries match code "${lookup.code}".`,
+      );
+    }
+  }
+
+  if (!lookup.name) {
+    throw new Error(
+      `Could not resolve ${field.name} from "${input}".${formatSuggestions(records)} Provide an exact ${label} name or ref.`,
+    );
+  }
+
+  const requested = normalizeLookupText(lookup.name);
+  const exactMatches = records.filter((record) => {
+    const name = recordText(record, "name");
+    const displayName = recordText(record, "display_name");
+    return (
+      (name !== null && normalizeLookupText(name) === requested) ||
+      (displayName !== null && normalizeLookupText(displayName) === requested)
+    );
+  });
+  const ids = uniqueIds(exactMatches);
+  if (ids.length === 1) return ids[0];
+  if (ids.length > 1) {
+    throw new Error(
+      `Could not resolve ${field.name}: multiple ${label} records match "${input}".`,
+    );
+  }
+
+  throw new Error(
+    `Could not resolve ${field.name} from "${input}".${formatSuggestions(
+      rankedSuggestions(input, records),
+    )} Provide an exact ${label} name or ref.`,
+  );
+}
+
+function refToId(
+  connectionId: string,
+  field: OdooField,
+  value: Record<string, unknown>,
+): number | null {
+  if (typeof value.ref !== "string") return null;
+  const ref = decodeRef(value.ref);
+  if (ref.integrationType !== "odoo") {
+    throw new Error(`Invalid ref for ${field.name}: expected odoo.`);
+  }
+  if (ref.connectionId !== connectionId) {
+    throw new Error(
+      `Invalid ref for ${field.name}: connection does not match.`,
+    );
+  }
+  if (ref.model !== field.relation) {
+    throw new Error(
+      `Invalid ref for ${field.name}: expected ${field.relation}, got ${ref.model}.`,
+    );
+  }
+  return ref.id;
+}
+
+async function resolveRelationValue(
+  client: OdooClient,
+  connectionId: string,
+  field: OdooField,
+  value: unknown,
+): Promise<unknown> {
+  if (value == null || value === false) return value;
+  if (typeof value === "number") {
+    throw new Error(
+      `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`,
+    );
+  }
+  if (Array.isArray(value) && typeof value[0] === "number") {
+    throw new Error(
+      `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`,
+    );
+  }
+  if (isRecord(value)) {
+    const refId = refToId(connectionId, field, value);
+    if (refId !== null) return refId;
+    if (typeof value.id === "number") {
+      throw new Error(
+        `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`,
+      );
+    }
+  }
+
+  const lookup = parseLookup(field, value);
+  if (!lookup) return value;
+  if (lookup.name === "") return false;
+  if (lookup.name && /^\d+$/.test(lookup.name)) {
+    throw new Error(
+      `Raw numeric IDs are not accepted for ${field.name}. Use an opaque ref or lookup.`,
+    );
+  }
+  if (!field.relation) return value;
+
+  const result =
+    field.relation === "res.country"
+      ? await client.searchRead(field.relation, [], {
+          fields: ["id", "name", "display_name", "code"],
+          limit: 1000,
+        })
+      : await client.searchRead(
+          field.relation,
+          [["name", "ilike", lookup.name ?? ""]],
+          {
+            fields: ["id", "name", "display_name"],
+            limit: 20,
+          },
+        );
+
+  return resolveReferenceFromRecords(
+    field,
+    lookup,
+    getSearchReadRecords(result),
+  );
+}
+
+async function normalizeMany2OneValues(
+  client: OdooClient,
+  connectionId: string,
+  model: string,
+  values: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  const fields = normalizeFields(await client.fields(model));
+  if (fields.length === 0) return values;
+
+  const normalized = { ...values };
+  for (const field of fields) {
+    if (field.type !== "many2one" || !(field.name in normalized)) continue;
+    normalized[field.name] = await resolveRelationValue(
+      client,
+      connectionId,
+      field,
+      normalized[field.name],
+    );
+  }
+  return normalized;
+}
+
+function wrapMany2OneValue(
+  connectionId: string,
+  field: OdooField,
+  value: unknown,
+): unknown {
+  if (
+    field.type !== "many2one" ||
+    !field.relation ||
+    !Array.isArray(value) ||
+    typeof value[0] !== "number"
+  ) {
+    return value;
+  }
+  const label = typeof value[1] === "string" ? value[1] : String(value[0]);
+  return {
+    ref: encodeRef({
+      integrationType: "odoo",
+      connectionId,
+      model: field.relation,
+      id: value[0],
+      label,
+    }),
+    label,
+    model: field.relation,
+  } satisfies OdooRefValue;
+}
+
+function wrapReadResult(
+  connectionId: string,
+  fields: OdooField[],
+  result: unknown,
+): unknown {
+  const byName = new Map(fields.map((field) => [field.name, field]));
+  const wrapRecord = (record: OdooRecord): OdooRecord => {
+    const wrapped = { ...record };
+    for (const [name, value] of Object.entries(wrapped)) {
+      const field = byName.get(name);
+      if (field) {
+        wrapped[name] = wrapMany2OneValue(connectionId, field, value);
+      }
+    }
+    return wrapped;
+  };
+
+  if (Array.isArray(result)) return result.filter(isRecord).map(wrapRecord);
+  if (isRecord(result) && Array.isArray(result.records)) {
+    return {
+      ...result,
+      records: result.records.filter(isRecord).map(wrapRecord),
+    };
+  }
+  return result;
+}
+
+function permissionDenied(
+  operation: string,
+  model: string,
+): { content: ContentBlock[]; isError: true } {
   return {
     isError: true,
     content: [
@@ -157,7 +534,10 @@ function isOdooAccessError(error: unknown): boolean {
   );
 }
 
-function errorResult(error: unknown, context?: { operation?: string; model?: string }): { content: ContentBlock[]; isError: true } {
+function errorResult(
+  error: unknown,
+  context?: { operation?: string; model?: string },
+): { content: ContentBlock[]; isError: true } {
   if (isOdooAccessError(error) && context?.model) {
     const op = context.operation ?? "access";
     return {
@@ -171,7 +551,10 @@ function errorResult(error: unknown, context?: { operation?: string; model?: str
     };
   }
   const message = error instanceof Error ? error.message : "Unknown error";
-  return { isError: true, content: [{ type: "text", text: `Error: ${message}` }] };
+  return {
+    isError: true,
+    content: [{ type: "text", text: `Error: ${message}` }],
+  };
 }
 
 const plugin = {
@@ -205,9 +588,16 @@ const plugin = {
     ): Promise<OdooClient> {
       const hit = cache.get(agentId);
       if (hit && hit.expiresAt > Date.now()) return hit.client;
-      const creds = await fetchCredentials(apiBaseUrl, gatewayToken, config.connectionId);
+      const creds = await fetchCredentials(
+        apiBaseUrl,
+        gatewayToken,
+        config.connectionId,
+      );
       const client = createClient(creds);
-      cache.set(agentId, { client, expiresAt: Date.now() + CREDENTIALS_TTL_MS });
+      cache.set(agentId, {
+        client,
+        expiresAt: Date.now() + CREDENTIALS_TTL_MS,
+      });
       return client;
     }
 
@@ -258,7 +648,8 @@ const plugin = {
             properties: {
               model: {
                 type: "string",
-                description: "Model name to get fields for. Omit to list all available models.",
+                description:
+                  "Model name to get fields for. Omit to list all available models.",
               },
             },
           },
@@ -269,12 +660,17 @@ const plugin = {
 
               if (!model) {
                 // List all permitted models with human-readable names
-                const permittedModels = getPermittedModels(config.permissions, "read");
+                const permittedModels = getPermittedModels(
+                  config.permissions,
+                  "read",
+                );
                 const models = permittedModels.map((m) => ({
                   model: m,
                   name: names[m] ?? m,
                 }));
-                return { content: [{ type: "text", text: JSON.stringify(models) }] };
+                return {
+                  content: [{ type: "text", text: JSON.stringify(models) }],
+                };
               }
 
               // Check if model is in permissions
@@ -282,7 +678,10 @@ const plugin = {
                 return {
                   isError: true,
                   content: [
-                    { type: "text", text: `Model "${model}" is not available for this agent.` },
+                    {
+                      type: "text",
+                      text: `Model "${model}" is not available for this agent.`,
+                    },
                   ],
                 };
               }
@@ -297,7 +696,10 @@ const plugin = {
                 content: [
                   {
                     type: "text",
-                    text: JSON.stringify({ name: names[model] ?? model, fields }),
+                    text: JSON.stringify({
+                      name: names[model] ?? model,
+                      fields,
+                    }),
                   },
                 ],
               };
@@ -326,12 +728,16 @@ const plugin = {
           parameters: {
             type: "object",
             properties: {
-              model: { type: "string", description: "Odoo model name, e.g. 'sale.order'" },
+              model: {
+                type: "string",
+                description: "Odoo model name, e.g. 'sale.order'",
+              },
               filters: {
                 type: "array",
                 items: {
                   type: "array",
-                  description: "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
+                  description:
+                    "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
                 },
                 description:
                   "Odoo domain filter. Array of [field, operator, value] tuples. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Use [] for no filter.",
@@ -341,9 +747,18 @@ const plugin = {
                 items: { type: "string" },
                 description: "Fields to return. Omit for default fields.",
               },
-              limit: { type: "number", description: "Max records (default: 100)" },
-              offset: { type: "number", description: "Skip N records for pagination" },
-              order: { type: "string", description: "Sort order, e.g. 'date_order desc'" },
+              limit: {
+                type: "number",
+                description: "Max records (default: 100)",
+              },
+              offset: {
+                type: "number",
+                description: "Skip N records for pagination",
+              },
+              order: {
+                type: "string",
+                description: "Sort order, e.g. 'date_order desc'",
+              },
             },
             required: ["model", "filters"],
           },
@@ -354,18 +769,39 @@ const plugin = {
                 return permissionDenied("read", model);
               }
 
-              const result = await withAuthRetry(agentId, config, (client) =>
-                client.searchRead(model, params.filters as unknown[], {
-                  fields: params.fields as string[] | undefined,
-                  limit: params.limit as number | undefined,
-                  offset: params.offset as number | undefined,
-                  order: params.order as string | undefined,
-                }),
+              const result = await withAuthRetry(
+                agentId,
+                config,
+                async (client) => {
+                  const modelFields = normalizeFields(
+                    await client.fields(model),
+                  );
+                  const records = await client.searchRead(
+                    model,
+                    params.filters as unknown[],
+                    {
+                      fields: params.fields as string[] | undefined,
+                      limit: params.limit as number | undefined,
+                      offset: params.offset as number | undefined,
+                      order: params.order as string | undefined,
+                    },
+                  );
+                  return wrapReadResult(
+                    config.connectionId,
+                    modelFields,
+                    records,
+                  );
+                },
               );
 
-              return { content: [{ type: "text", text: JSON.stringify(result) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify(result) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "read", model: params.model as string });
+              return errorResult(error, {
+                operation: "read",
+                model: params.model as string,
+              });
             }
           },
         };
@@ -392,7 +828,10 @@ const plugin = {
               model: { type: "string", description: "Odoo model name" },
               filters: {
                 type: "array",
-                items: { type: "array", description: "A [field, operator, value] tuple" },
+                items: {
+                  type: "array",
+                  description: "A [field, operator, value] tuple",
+                },
                 description: "Odoo domain filter. Use [] for no filter.",
               },
             },
@@ -409,9 +848,14 @@ const plugin = {
                 client.searchCount(model, params.filters as unknown[]),
               );
 
-              return { content: [{ type: "text", text: JSON.stringify({ count }) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify({ count }) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "count", model: params.model as string });
+              return errorResult(error, {
+                operation: "count",
+                model: params.model as string,
+              });
             }
           },
         };
@@ -438,7 +882,10 @@ const plugin = {
               model: { type: "string", description: "Odoo model name" },
               filters: {
                 type: "array",
-                items: { type: "array", description: "A [field, operator, value] tuple" },
+                items: {
+                  type: "array",
+                  description: "A [field, operator, value] tuple",
+                },
                 description: "Odoo domain filter. Use [] for no filter.",
               },
               fields: {
@@ -450,10 +897,14 @@ const plugin = {
               groupby: {
                 type: "array",
                 items: { type: "string" },
-                description: "Fields to group by, e.g. ['partner_id'] or ['date_order:month']",
+                description:
+                  "Fields to group by, e.g. ['partner_id'] or ['date_order:month']",
               },
               limit: { type: "number", description: "Max groups to return" },
-              offset: { type: "number", description: "Skip N groups for pagination" },
+              offset: {
+                type: "number",
+                description: "Skip N groups for pagination",
+              },
               orderby: { type: "string", description: "Sort order for groups" },
             },
             required: ["model", "filters", "fields", "groupby"],
@@ -479,9 +930,14 @@ const plugin = {
                 ),
               );
 
-              return { content: [{ type: "text", text: JSON.stringify(result) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify(result) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "aggregate", model: params.model as string });
+              return errorResult(error, {
+                operation: "aggregate",
+                model: params.model as string,
+              });
             }
           },
         };
@@ -500,12 +956,17 @@ const plugin = {
         return {
           name: "odoo_create",
           label: "Odoo Create",
-          description: "Create a new record in Odoo. Returns the ID of the created record.",
+          description:
+            "Create a new record in Odoo. Returns the ID of the created record. For many2one fields, pass numeric IDs only when you already have an exact record ID; otherwise pass an exact display name or country code and the tool will resolve it safely.",
           parameters: {
             type: "object",
             properties: {
               model: { type: "string", description: "Odoo model name" },
-              values: { type: "object", description: "Field values for the new record" },
+              values: {
+                type: "object",
+                description:
+                  "Field values for the new record. Many2one text values must be exact names or supported codes, not partial/fuzzy matches.",
+              },
             },
             required: ["model", "values"],
           },
@@ -516,13 +977,30 @@ const plugin = {
                 return permissionDenied("create", model);
               }
 
-              const id = await withAuthRetry(agentId, config, (client) =>
-                client.create(model, params.values as Record<string, unknown>),
+              const id = await withAuthRetry(
+                agentId,
+                config,
+                async (client) => {
+                  const values = isRecord(params.values)
+                    ? await normalizeMany2OneValues(
+                        client,
+                        config.connectionId,
+                        model,
+                        params.values,
+                      )
+                    : (params.values as Record<string, unknown>);
+                  return client.create(model, values);
+                },
               );
 
-              return { content: [{ type: "text", text: JSON.stringify({ id }) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify({ id }) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "create", model: params.model as string });
+              return errorResult(error, {
+                operation: "create",
+                model: params.model as string,
+              });
             }
           },
         };
@@ -541,7 +1019,8 @@ const plugin = {
         return {
           name: "odoo_write",
           label: "Odoo Write",
-          description: "Update an existing record in Odoo.",
+          description:
+            "Update an existing record in Odoo. For many2one fields, pass numeric IDs only when you already have an exact record ID; otherwise pass an exact display name or country code and the tool will resolve it safely.",
           parameters: {
             type: "object",
             properties: {
@@ -551,7 +1030,11 @@ const plugin = {
                 items: { type: "number" },
                 description: "IDs of records to update",
               },
-              values: { type: "object", description: "Field values to update" },
+              values: {
+                type: "object",
+                description:
+                  "Field values to update. Many2one text values must be exact names or supported codes, not partial/fuzzy matches.",
+              },
             },
             required: ["model", "ids", "values"],
           },
@@ -562,17 +1045,30 @@ const plugin = {
                 return permissionDenied("write", model);
               }
 
-              const success = await withAuthRetry(agentId, config, (client) =>
-                client.write(
-                  model,
-                  params.ids as number[],
-                  params.values as Record<string, unknown>,
-                ),
+              const success = await withAuthRetry(
+                agentId,
+                config,
+                async (client) => {
+                  const values = isRecord(params.values)
+                    ? await normalizeMany2OneValues(
+                        client,
+                        config.connectionId,
+                        model,
+                        params.values,
+                      )
+                    : (params.values as Record<string, unknown>);
+                  return client.write(model, params.ids as number[], values);
+                },
               );
 
-              return { content: [{ type: "text", text: JSON.stringify({ success }) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify({ success }) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "write", model: params.model as string });
+              return errorResult(error, {
+                operation: "write",
+                model: params.model as string,
+              });
             }
           },
         };
@@ -615,9 +1111,14 @@ const plugin = {
                 client.unlink(model, params.ids as number[]),
               );
 
-              return { content: [{ type: "text", text: JSON.stringify({ success }) }] };
+              return {
+                content: [{ type: "text", text: JSON.stringify({ success }) }],
+              };
             } catch (error) {
-              return errorResult(error, { operation: "delete", model: params.model as string });
+              return errorResult(error, {
+                operation: "delete",
+                model: params.model as string,
+              });
             }
           },
         };

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -957,7 +957,7 @@ const plugin = {
           name: "odoo_create",
           label: "Odoo Create",
           description:
-            "Create a new record in Odoo. Returns the ID of the created record. For many2one fields, pass numeric IDs only when you already have an exact record ID; otherwise pass an exact display name or country code and the tool will resolve it safely.",
+            "Create a new record in Odoo. Returns the ID of the created record. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code.",
           parameters: {
             type: "object",
             properties: {
@@ -1020,7 +1020,7 @@ const plugin = {
           name: "odoo_write",
           label: "Odoo Write",
           description:
-            "Update an existing record in Odoo. For many2one fields, pass numeric IDs only when you already have an exact record ID; otherwise pass an exact display name or country code and the tool will resolve it safely.",
+            "Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code.",
           parameters: {
             type: "object",
             properties: {

--- a/packages/plugins/pinchy-odoo/integration-ref.ts
+++ b/packages/plugins/pinchy-odoo/integration-ref.ts
@@ -1,0 +1,113 @@
+import { createCipheriv, createDecipheriv, randomBytes } from "crypto";
+import { existsSync, readFileSync, writeFileSync } from "fs";
+import { join } from "path";
+
+const PREFIX = "pinchy_ref:v1:";
+const ALGORITHM = "aes-256-gcm";
+const IV_LENGTH = 12;
+
+export interface IntegrationRefPayload {
+  integrationType: string;
+  connectionId: string;
+  model: string;
+  id: number;
+  label: string;
+}
+
+function isPayload(value: unknown): value is IntegrationRefPayload {
+  if (!value || typeof value !== "object") return false;
+  const obj = value as Record<string, unknown>;
+  return (
+    obj.integrationType === "odoo" &&
+    typeof obj.connectionId === "string" &&
+    obj.connectionId.length > 0 &&
+    typeof obj.model === "string" &&
+    obj.model.length > 0 &&
+    typeof obj.id === "number" &&
+    Number.isInteger(obj.id) &&
+    obj.id > 0 &&
+    typeof obj.label === "string"
+  );
+}
+
+function getKey(): Buffer {
+  const envKey = process.env.PINCHY_REF_TOKEN_KEY;
+  if (envKey) {
+    if (envKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(envKey)) {
+      throw new Error("PINCHY_REF_TOKEN_KEY must be 64 hex characters");
+    }
+    return Buffer.from(envKey, "hex");
+  }
+
+  const keyDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
+  const keyPath = join(keyDir, ".integration_ref_key");
+  if (existsSync(keyPath)) {
+    const fileKey = readFileSync(keyPath, "utf-8").trim();
+    if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
+      throw new Error(
+        `Invalid secret in ${keyPath}: expected 64 hex characters`,
+      );
+    }
+    return Buffer.from(fileKey, "hex");
+  }
+
+  if (existsSync(keyDir)) {
+    const newKey = randomBytes(32).toString("hex");
+    writeFileSync(keyPath, newKey, { mode: 0o600 });
+    return Buffer.from(newKey, "hex");
+  }
+
+  throw new Error(
+    "PINCHY_REF_TOKEN_KEY environment variable is required (64 hex characters) " +
+      "or ENCRYPTION_KEY_DIR must point to a writable directory",
+  );
+}
+
+export function encodeRef(payload: IntegrationRefPayload): string {
+  if (!isPayload(payload)) {
+    throw new Error("Invalid integration reference payload");
+  }
+
+  const iv = randomBytes(IV_LENGTH);
+  const cipher = createCipheriv(ALGORITHM, getKey(), iv);
+  const ciphertext = Buffer.concat([
+    cipher.update(JSON.stringify(payload), "utf8"),
+    cipher.final(),
+  ]);
+  const tag = cipher.getAuthTag();
+
+  return `${PREFIX}${Buffer.concat([iv, tag, ciphertext]).toString("base64url")}`;
+}
+
+export function decodeRef(ref: string): IntegrationRefPayload {
+  if (!ref.startsWith(PREFIX)) {
+    throw new Error("Invalid integration reference");
+  }
+
+  try {
+    const raw = Buffer.from(ref.slice(PREFIX.length), "base64url");
+    if (raw.length <= IV_LENGTH + 16) {
+      throw new Error("too short");
+    }
+    const iv = raw.subarray(0, IV_LENGTH);
+    const tag = raw.subarray(IV_LENGTH, IV_LENGTH + 16);
+    const ciphertext = raw.subarray(IV_LENGTH + 16);
+    const decipher = createDecipheriv(ALGORITHM, getKey(), iv);
+    decipher.setAuthTag(tag);
+    const plaintext = Buffer.concat([
+      decipher.update(ciphertext),
+      decipher.final(),
+    ]).toString("utf8");
+    const payload = JSON.parse(plaintext) as unknown;
+    if (!isPayload(payload)) {
+      throw new Error("invalid payload");
+    }
+    return payload;
+  } catch {
+    throw new Error("Invalid integration reference");
+  }
+}
+
+export function isIntegrationRef(value: unknown): value is string {
+  return typeof value === "string" && value.startsWith(PREFIX);
+}

--- a/packages/plugins/pinchy-odoo/integration-ref.ts
+++ b/packages/plugins/pinchy-odoo/integration-ref.ts
@@ -7,12 +7,14 @@ const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
 
 export interface IntegrationRefPayload {
-  integrationType: string;
+  integrationType: "odoo";
   connectionId: string;
   model: string;
   id: number;
   label: string;
 }
+
+let cachedKey: Buffer | null = null;
 
 function isPayload(value: unknown): value is IntegrationRefPayload {
   if (!value || typeof value !== "object") return false;
@@ -30,31 +32,47 @@ function isPayload(value: unknown): value is IntegrationRefPayload {
   );
 }
 
+function readKeyFile(keyPath: string): Buffer {
+  const fileKey = readFileSync(keyPath, "utf-8").trim();
+  if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
+    throw new Error(`Invalid secret in ${keyPath}: expected 64 hex characters`);
+  }
+  return Buffer.from(fileKey, "hex");
+}
+
 function getKey(): Buffer {
+  if (cachedKey) return cachedKey;
+
   const envKey = process.env.PINCHY_REF_TOKEN_KEY;
   if (envKey) {
     if (envKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(envKey)) {
       throw new Error("PINCHY_REF_TOKEN_KEY must be 64 hex characters");
     }
-    return Buffer.from(envKey, "hex");
+    cachedKey = Buffer.from(envKey, "hex");
+    return cachedKey;
   }
 
   const keyDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
   const keyPath = join(keyDir, ".integration_ref_key");
   if (existsSync(keyPath)) {
-    const fileKey = readFileSync(keyPath, "utf-8").trim();
-    if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
-      throw new Error(
-        `Invalid secret in ${keyPath}: expected 64 hex characters`,
-      );
-    }
-    return Buffer.from(fileKey, "hex");
+    cachedKey = readKeyFile(keyPath);
+    return cachedKey;
   }
 
   if (existsSync(keyDir)) {
     const newKey = randomBytes(32).toString("hex");
-    writeFileSync(keyPath, newKey, { mode: 0o600 });
-    return Buffer.from(newKey, "hex");
+    try {
+      writeFileSync(keyPath, newKey, { mode: 0o600, flag: "wx" });
+      cachedKey = Buffer.from(newKey, "hex");
+    } catch (error) {
+      const code =
+        error && typeof error === "object" && "code" in error
+          ? String((error as { code: unknown }).code)
+          : "";
+      if (code !== "EEXIST") throw error;
+      cachedKey = readKeyFile(keyPath);
+    }
+    return cachedKey;
   }
 
   throw new Error(


### PR DESCRIPTION
## What does this PR do?

This hardens the Odoo plugin boundary so agents can no longer write hallucinated numeric IDs into `many2one` relation fields.

The production issue this addresses: agents inferred Odoo country IDs from generic model knowledge instead of resolving them in the connected database, causing values like Austria/USA/Luxembourg to be written as the wrong country when local IDs differed from assumed defaults.

Changes:
- Adds opaque `pinchy_ref:v1` integration references for Odoo records.
- Wraps `many2one` values returned by `odoo_read` as `{ ref, label, model }`.
- Makes `odoo_create` and `odoo_write` reject raw numeric relation IDs.
- Allows relation writes through Pinchy-issued refs or exact lookups.
- Returns suggestions for ambiguous/missing relation lookups without writing.
- Extends the Odoo mock and tests.

## Test Plan

- [x] `pnpm -C packages/web test ../plugins/pinchy-odoo`
- [x] `git diff --check`
- [x] Pre-push `pnpm --filter @pinchy/web build` passed
