### PR TITLE
[codex] Fix dead-key composer input freeze

### DIFF
--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -487,6 +487,23 @@ describe("Composer input vs send disabled state", () => {
     expect(screen.getByRole("textbox")).not.toBeDisabled();
     expect(screen.getByRole("button", { name: /send message/i })).toBeDisabled();
   });
+
+  it("keeps syncing text after a dead-key composition start does not emit compositionend", async () => {
+    const { useComposerRuntime } = await import("@assistant-ui/react");
+    const setText = vi.fn();
+    vi.mocked(useComposerRuntime).mockReturnValue({
+      getState: () => ({ isEditing: true }),
+      setText,
+    } as never);
+
+    await renderComposerWith({ kind: "ready" });
+
+    const input = screen.getByRole("textbox");
+    fireEvent.compositionStart(input);
+    fireEvent.change(input, { target: { value: "é" } });
+
+    expect(setText).toHaveBeenCalledWith("é");
+  });
 });
 
 describe("ComposerAction Send/Stop mutual exclusion (#207)", () => {

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -30,7 +30,7 @@ import {
   MoreHorizontalIcon,
   SquareIcon,
 } from "lucide-react";
-import { type FC, useState, useEffect, useRef, useContext } from "react";
+import { type ChangeEvent, type FC, useState, useEffect, useRef, useContext } from "react";
 import {
   AgentIdContext,
   RetryResendContext,
@@ -262,16 +262,31 @@ export const Composer: FC = () => {
       <DraftPersistence />
       <ComposerPrimitive.AttachmentDropzone className="aui-composer-attachment-dropzone flex w-full flex-col rounded-2xl border border-input bg-background px-1 pt-2 outline-none transition-shadow has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-ring/20 data-[dragging=true]:border-ring data-[dragging=true]:border-dashed data-[dragging=true]:bg-accent/50">
         <ComposerAttachments />
-        <ComposerPrimitive.Input
-          placeholder="Send a message..."
-          className="aui-composer-input mb-0.5 md:mb-1 max-h-32 min-h-10 md:min-h-14 w-full resize-none bg-transparent px-4 pt-2 pb-1 md:pb-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
-          rows={1}
-          autoFocus
-          aria-label="Message input"
-        />
+        <ComposerTextInput />
         <ComposerAction />
       </ComposerPrimitive.AttachmentDropzone>
     </ComposerPrimitive.Root>
+  );
+};
+
+const ComposerTextInput: FC = () => {
+  const composerRuntime = useComposerRuntime({ optional: true });
+
+  const syncNonComposingChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
+    const isComposing = (event.nativeEvent as { isComposing?: boolean }).isComposing === true;
+    if (isComposing || !composerRuntime?.getState().isEditing) return;
+    composerRuntime.setText(event.currentTarget.value);
+  };
+
+  return (
+    <ComposerPrimitive.Input
+      placeholder="Send a message..."
+      className="aui-composer-input mb-0.5 md:mb-1 max-h-32 min-h-10 md:min-h-14 w-full resize-none bg-transparent px-4 pt-2 pb-1 md:pb-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
+      rows={1}
+      autoFocus
+      aria-label="Message input"
+      onChange={syncNonComposingChange}
+    />
   );
 };
 


### PR DESCRIPTION
## Summary

Fixes the agent chat composer freezing after dead-key input, such as Neo layout accent composition for `é`.

## Root cause

`@assistant-ui/react` suppresses `onChange` updates while its internal composition flag is set. With dead-key keyboard layouts, a composition can start without the matching `compositionend` path the primitive expects. The DOM value changes, but the assistant-ui composer store stays stale, so React re-renders the old controlled value and the textarea appears frozen.

## Changes

- Wrap the composer input in `ComposerTextInput` and sync non-composing `onChange` values directly into the composer runtime.
- Preserve the existing Assistant UI primitive for autosize, Enter submit behavior, paste attachments, and focus behavior.
- Add a regression test for a dead-key composition start followed by a text change without `compositionend`.

## Validation

- `pnpm -C packages/web test src/components/assistant-ui/__tests__/thread.test.tsx` passed: 35 tests.
- Pre-commit lint-staged ran ESLint and Prettier on the changed files.
- Pre-push `pnpm --filter @pinchy/web build` completed successfully. It emitted existing Better Auth environment warnings/default-secret errors during static collection and an NFT tracing warning, but exited successfully.
