### PR TITLE
feat: /api/version + OCI labels, fix Domain Lock verification trap (v0.5.4 pre-release)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -753,9 +753,31 @@ jobs:
           # Missing previous-version images make the upgrade test impossible
           # to run, but they are not a regression in *this* PR — skip with a
           # warning instead of failing.
+          #
+          # Transient GHCR token-endpoint timeouts ("request canceled
+          # (Client.Timeout exceeded while awaiting headers)") are not the
+          # registry being down — they're brief network blips that retry away.
+          # The pull is retried up to 3 times with 10s backoff before any
+          # skip/fail classification kicks in. See #351 for the incident.
           set +e
-          docker compose pull 2>&1 | tee pull.log
-          status=${PIPESTATUS[0]}
+          attempt=1
+          max_attempts=3
+          while [ "$attempt" -le "$max_attempts" ]; do
+            docker compose pull 2>&1 | tee pull.log
+            status=${PIPESTATUS[0]}
+            if [ "$status" -eq 0 ]; then
+              break
+            fi
+            # Don't retry skippable conditions — they won't change on retry.
+            if grep -qE "manifest unknown|not found|toomanyrequests|pull rate limit" pull.log; then
+              break
+            fi
+            if [ "$attempt" -lt "$max_attempts" ]; then
+              echo "::warning::docker compose pull failed (attempt ${attempt}/${max_attempts}). Retrying in 10s..."
+              sleep 10
+            fi
+            attempt=$((attempt + 1))
+          done
           set -e
           if [ "$status" -ne 0 ]; then
             if grep -qE "manifest unknown|not found" pull.log; then
@@ -768,7 +790,7 @@ jobs:
               echo "skip=true" >> "$GITHUB_OUTPUT"
               exit 0
             fi
-            echo "::error::docker compose pull failed for an unexpected reason (not a missing-image or rate-limit condition). See pull.log above."
+            echo "::error::docker compose pull failed ${max_attempts}× for an unexpected reason (not missing-image, not rate-limit). See pull.log above."
             exit 1
           fi
           echo "skip=false" >> "$GITHUB_OUTPUT"

--- a/.github/workflows/pre-release.yml
+++ b/.github/workflows/pre-release.yml
@@ -19,6 +19,12 @@ jobs:
         id: sha
         run: echo "short=$(git rev-parse --short=12 HEAD)" >> "$GITHUB_OUTPUT"
 
+      - name: Read pre-release version (package.json + sha suffix)
+        id: ver
+        run: |
+          PKG_VERSION=$(jq -r .version package.json)
+          echo "version=${PKG_VERSION}+sha.${{ steps.sha.outputs.short }}" >> "$GITHUB_OUTPUT"
+
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
         with:
@@ -45,6 +51,9 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            PINCHY_VERSION=${{ steps.ver.outputs.version }}
+            PINCHY_BUILD_SHA=${{ github.sha }}
 
       - name: Build and push OpenClaw image (:next, :sha-<short>)
         uses: docker/build-push-action@v6
@@ -58,3 +67,6 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            PINCHY_VERSION=${{ steps.ver.outputs.version }}
+            PINCHY_BUILD_SHA=${{ github.sha }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -44,6 +44,15 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      - name: Resolve release tag (drops leading 'v' for image labels)
+        id: release-tag
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        run: |
+          VERSION=${RELEASE_TAG#v}
+          echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+
       - name: Extract metadata (tags, labels)
         id: meta-pinchy
         uses: docker/metadata-action@v5
@@ -68,6 +77,9 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            PINCHY_VERSION=${{ steps.release-tag.outputs.version }}
+            PINCHY_BUILD_SHA=${{ github.sha }}
 
       - name: Extract metadata for OpenClaw image
         id: meta-openclaw
@@ -93,6 +105,9 @@ jobs:
           platforms: linux/amd64
           cache-from: type=gha
           cache-to: type=gha,mode=max
+          build-args: |
+            PINCHY_VERSION=${{ steps.release-tag.outputs.version }}
+            PINCHY_BUILD_SHA=${{ github.sha }}
 
   end-user-install-published:
     name: End-user install (published images)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -226,44 +226,15 @@ Before cutting a tag, the maintainer runs the pre-release build on a dedicated s
 
 Same for `pinchy-openclaw`.
 
-**One-time staging setup** on your staging host:
+The staging instance is set up once (see [Staging instance setup](#staging-instance-setup) below for the one-time bootstrap) and pins `PINCHY_VERSION=next`.
 
-1. Deploy Pinchy normally, but pin `:next` in your `.env`:
+**Before each release**, refresh staging to pick up the latest `:next` build, then click through the key flows: Smithers chat, one live integration, one custom agent with chat history.
 
-   ```env
-   PINCHY_VERSION=next
-   ```
+```bash
+ssh root@<staging-host> "cd /opt/pinchy && docker compose pull && docker compose up -d"
+```
 
-2. Install `/usr/local/bin/update-pinchy`:
-
-   ```bash
-   #!/usr/bin/env bash
-   set -euo pipefail
-   cd /srv/pinchy
-   LOG=/var/log/pinchy-update.log
-   echo "[$(date -Iseconds)] pulling" | tee -a "$LOG"
-   docker compose pull 2>&1 | tee -a "$LOG"
-   echo "[$(date -Iseconds)] restarting" | tee -a "$LOG"
-   docker compose up -d 2>&1 | tee -a "$LOG"
-   echo "[$(date -Iseconds)] waiting for health" | tee -a "$LOG"
-   for i in $(seq 1 30); do
-     curl -sf http://localhost:7777/api/health \
-       && { echo "healthy" | tee -a "$LOG"; exit 0; }
-     sleep 2
-   done
-   echo "health check failed" | tee -a "$LOG"
-   docker compose ps | tee -a "$LOG"
-   exit 1
-   ```
-
-   Make it executable: `chmod +x /usr/local/bin/update-pinchy`.
-
-3. Schedule nightly updates via cron or systemd timer:
-   ```cron
-   0 4 * * *  root  /usr/local/bin/update-pinchy
-   ```
-
-**Before each release**, run `sudo update-pinchy` manually during business hours to pull the latest `:next` build, then click through the key flows on staging: Smithers chat, one live integration, one custom agent with chat history.
+Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.6.0.
 
 **Use synthetic data in staging.** Do not restore prod dumps — unnecessary privacy surface.
 

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -3,6 +3,19 @@
 # pull-through cache for `library/*` images on Docker Hub.
 FROM mirror.gcr.io/library/node:22-slim
 
+# Build-time metadata. CI passes --build-arg PINCHY_VERSION + PINCHY_BUILD_SHA;
+# local builds without --build-arg get "dev". OpenClaw's own version is the
+# `openclaw@…` pin below and surfaces via Pinchy's /api/version response.
+ARG PINCHY_VERSION=dev
+ARG PINCHY_BUILD_SHA=dev
+
+LABEL org.opencontainers.image.source="https://github.com/heypinchy/pinchy" \
+      org.opencontainers.image.title="Pinchy OpenClaw runtime" \
+      org.opencontainers.image.description="OpenClaw agent runtime + Pinchy plugin dependencies" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.version="$PINCHY_VERSION" \
+      org.opencontainers.image.revision="$PINCHY_BUILD_SHA"
+
 # python3 + build-essential are needed for native npm modules (better-sqlite3
 # in pinchy-files) to compile from source when the prebuilt binary doesn't
 # match the current node:22-slim point release. Without them the image build

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -3,6 +3,20 @@
 # pull-through cache for `library/*` images on Docker Hub.
 FROM mirror.gcr.io/library/node:22-slim
 
+# Build-time metadata. CI passes --build-arg PINCHY_VERSION + PINCHY_BUILD_SHA;
+# local builds without --build-arg get "dev" so `/api/version` makes that obvious.
+ARG PINCHY_VERSION=dev
+ARG PINCHY_BUILD_SHA=dev
+# PINCHY_BUILD_SHA also reaches runtime so /api/version can surface it.
+ENV PINCHY_BUILD_SHA=$PINCHY_BUILD_SHA
+
+LABEL org.opencontainers.image.source="https://github.com/heypinchy/pinchy" \
+      org.opencontainers.image.title="Pinchy" \
+      org.opencontainers.image.description="Enterprise AI Agent Platform" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.version="$PINCHY_VERSION" \
+      org.opencontainers.image.revision="$PINCHY_BUILD_SHA"
+
 # Cache pnpm in a shared location so the non-root pinchy user can use it
 # without re-downloading on every container start.
 ENV COREPACK_HOME=/app/.cache/corepack

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -24,8 +24,11 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
    Before any upgrade, create a database backup. This lets you roll back if anything goes wrong.
 
    ```bash
-   docker compose exec db pg_dump -U pinchy pinchy > backup-$(date +%Y%m%d).sql
+   mkdir -p backups
+   docker compose exec -T db pg_dump -U pinchy pinchy > backups/pinchy-$(date +%Y%m%d-%H%M%S).sql
    ```
+
+   The `backups/` directory keeps backups out of `/opt/pinchy/` itself so they don't get mistaken for compose files, and is easy to add to your own off-host backup rotation.
 
 2. **Bump the version pin**
 
@@ -52,11 +55,24 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
 
 4. **Verify**
 
-   Open [http://localhost:7777](http://localhost:7777) and confirm everything works. Check the logs for any warnings:
+   Confirm the new version is running by hitting `/api/version` — this endpoint is public and ignores Domain Lock, so it works from inside the server even when external access is locked to a specific domain:
+
+   ```bash
+   curl -s http://localhost:7777/api/version
+   # {"pinchyVersion":"0.5.4","openclawVersion":"2026.5.7","build":"<git sha>","nodeEnv":"production"}
+   ```
+
+   Then open Pinchy in your browser at the URL you normally use (e.g. `https://your-domain.example`) and check the logs for any warnings:
 
    ```bash
    docker compose logs pinchy --tail 50
    ```
+
+   <Aside type="tip">
+     If you have Domain Lock configured, `http://localhost:7777` (the legacy
+     verification URL) will return **403 Forbidden** for any page other than
+     `/api/health` and `/api/version` — use your locked domain instead.
+   </Aside>
 
 </Steps>
 
@@ -169,6 +185,12 @@ When an Odoo tool returns a record, related-record references are now emitted as
 #### Permissions tab no longer reports false-positive dirty state
 
 If an Odoo or Email connection was configured on an agent, the **Settings → Agent → Permissions** tab kept showing "Unsaved changes" and a **Save & Restart** button after a successful save. The dirty-state check now re-syncs against the persisted state once the post-save refetch lands, so a clean save shows as clean.
+
+#### New `/api/version` endpoint + OCI image labels
+
+You can now confirm which Pinchy and OpenClaw versions are actually running without opening the UI. `GET /api/version` returns `{ pinchyVersion, openclawVersion, build, nodeEnv }` and is exempt from Domain Lock so it works from monitoring tools and the host shell. Docker images now also carry standard OCI labels (`org.opencontainers.image.version`, `org.opencontainers.image.revision`, …), so `docker inspect ghcr.io/heypinchy/pinchy:%%PINCHY_VERSION%%` reports the version and git SHA the image was built from.
+
+The upgrading guide's "Verify" step is updated to use `/api/version` instead of opening `http://localhost:7777` directly — the old instruction returned 403 on Domain-Lock-enabled deployments.
 
 #### Runtime and dependency updates
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -28,7 +28,7 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
    docker compose exec -T db pg_dump -U pinchy pinchy > backups/pinchy-$(date +%Y%m%d-%H%M%S).sql
    ```
 
-   The `backups/` directory keeps backups out of `/opt/pinchy/` itself so they don't get mistaken for compose files, and is easy to add to your own off-host backup rotation.
+   Keeping backups under `backups/` instead of loose in `/opt/pinchy/` means they don't sit next to your `docker-compose.yml` / `.env`, and the directory is easy to target with your off-host backup rotation.
 
 2. **Bump the version pin**
 
@@ -103,9 +103,12 @@ If you need to roll back after an upgrade:
 
 2. **Restore the database**
 
+   Pick the backup you want from `backups/` (the most recent one is usually what you want):
+
    ```bash
    docker compose up db -d
-   docker compose exec -T db psql -U pinchy pinchy < backup-YYYYMMDD.sql
+   ls -lt backups/             # newest first
+   docker compose exec -T db psql -U pinchy pinchy < backups/pinchy-YYYYMMDD-HHMMSS.sql
    ```
 
 3. **Pull the previous version**

--- a/packages/web/next.config.ts
+++ b/packages/web/next.config.ts
@@ -3,12 +3,15 @@ import { readFileSync } from "fs";
 import { join } from "path";
 
 const pkg = JSON.parse(readFileSync(join(__dirname, "package.json"), "utf-8"));
+const openclawVersion: string =
+  pkg.devDependencies?.openclaw ?? pkg.dependencies?.openclaw ?? "unknown";
 
 const nextConfig: NextConfig = {
   devIndicators: false,
   allowedDevOrigins: ["local.heypinchy.com", "https://local.heypinchy.com:8443"],
   env: {
     NEXT_PUBLIC_PINCHY_VERSION: pkg.version,
+    NEXT_PUBLIC_OPENCLAW_VERSION: openclawVersion,
   },
   async headers() {
     return [

--- a/packages/web/src/__tests__/api/version.test.ts
+++ b/packages/web/src/__tests__/api/version.test.ts
@@ -1,0 +1,91 @@
+import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { GET } from "@/app/api/version/route";
+
+describe("GET /api/version", () => {
+  const original = {
+    pinchyVersion: process.env.NEXT_PUBLIC_PINCHY_VERSION,
+    openclawVersion: process.env.NEXT_PUBLIC_OPENCLAW_VERSION,
+    buildSha: process.env.PINCHY_BUILD_SHA,
+    nodeEnv: process.env.NODE_ENV,
+  };
+
+  beforeEach(() => {
+    delete process.env.NEXT_PUBLIC_PINCHY_VERSION;
+    delete process.env.NEXT_PUBLIC_OPENCLAW_VERSION;
+    delete process.env.PINCHY_BUILD_SHA;
+  });
+
+  afterEach(() => {
+    if (original.pinchyVersion !== undefined)
+      process.env.NEXT_PUBLIC_PINCHY_VERSION = original.pinchyVersion;
+    if (original.openclawVersion !== undefined)
+      process.env.NEXT_PUBLIC_OPENCLAW_VERSION = original.openclawVersion;
+    if (original.buildSha !== undefined) process.env.PINCHY_BUILD_SHA = original.buildSha;
+    if (original.nodeEnv !== undefined) process.env.NODE_ENV = original.nodeEnv;
+  });
+
+  it("returns 200 with JSON", async () => {
+    const response = await GET();
+    expect(response.status).toBe(200);
+    expect(response.headers.get("content-type")).toContain("application/json");
+  });
+
+  it("returns pinchyVersion from NEXT_PUBLIC_PINCHY_VERSION", async () => {
+    process.env.NEXT_PUBLIC_PINCHY_VERSION = "0.5.4";
+    const response = await GET();
+    const data = await response.json();
+    expect(data.pinchyVersion).toBe("0.5.4");
+  });
+
+  it("falls back to 'unknown' when NEXT_PUBLIC_PINCHY_VERSION is unset", async () => {
+    const response = await GET();
+    const data = await response.json();
+    expect(data.pinchyVersion).toBe("unknown");
+  });
+
+  it("returns openclawVersion from NEXT_PUBLIC_OPENCLAW_VERSION", async () => {
+    process.env.NEXT_PUBLIC_OPENCLAW_VERSION = "2026.5.7";
+    const response = await GET();
+    const data = await response.json();
+    expect(data.openclawVersion).toBe("2026.5.7");
+  });
+
+  it("falls back to 'unknown' when NEXT_PUBLIC_OPENCLAW_VERSION is unset", async () => {
+    const response = await GET();
+    const data = await response.json();
+    expect(data.openclawVersion).toBe("unknown");
+  });
+
+  it("returns build SHA from PINCHY_BUILD_SHA, truncated to 12 chars", async () => {
+    process.env.PINCHY_BUILD_SHA = "2a5e9d41d789940778ed8521f54f7cc60a4c9627";
+    const response = await GET();
+    const data = await response.json();
+    expect(data.build).toBe("2a5e9d41d789");
+  });
+
+  it("returns build='dev' when PINCHY_BUILD_SHA is unset", async () => {
+    const response = await GET();
+    const data = await response.json();
+    expect(data.build).toBe("dev");
+  });
+
+  it("returns nodeEnv from NODE_ENV", async () => {
+    process.env.NODE_ENV = "production";
+    const response = await GET();
+    const data = await response.json();
+    expect(data.nodeEnv).toBe("production");
+  });
+
+  it("emits Cache-Control: no-store so probes always get fresh data", async () => {
+    const response = await GET();
+    expect(response.headers.get("cache-control")).toBe("no-store");
+  });
+
+  it("does not include sensitive fields", async () => {
+    process.env.NEXT_PUBLIC_PINCHY_VERSION = "0.5.4";
+    const response = await GET();
+    const data = await response.json();
+    const keys = Object.keys(data).sort();
+    expect(keys).toEqual(["build", "nodeEnv", "openclawVersion", "pinchyVersion"]);
+  });
+});

--- a/packages/web/src/__tests__/api/version.test.ts
+++ b/packages/web/src/__tests__/api/version.test.ts
@@ -1,28 +1,38 @@
 import { afterEach, beforeEach, describe, expect, it } from "vitest";
 import { GET } from "@/app/api/version/route";
 
+const ENV_KEYS = [
+  "NEXT_PUBLIC_PINCHY_VERSION",
+  "NEXT_PUBLIC_OPENCLAW_VERSION",
+  "PINCHY_BUILD_SHA",
+  "NODE_ENV",
+] as const;
+
 describe("GET /api/version", () => {
-  const original = {
-    pinchyVersion: process.env.NEXT_PUBLIC_PINCHY_VERSION,
-    openclawVersion: process.env.NEXT_PUBLIC_OPENCLAW_VERSION,
-    buildSha: process.env.PINCHY_BUILD_SHA,
-    nodeEnv: process.env.NODE_ENV,
-  };
+  // Snapshot includes `undefined` for keys that weren't set, so restoreEnv()
+  // can `delete` them instead of restoring them as the literal string "undefined".
+  // Without this, tests that set NODE_ENV (originally unset) would leak it into
+  // sibling test files and cause hard-to-debug ordering flakes.
+  const snapshot: Record<string, string | undefined> = {};
+  for (const key of ENV_KEYS) snapshot[key] = process.env[key];
 
-  beforeEach(() => {
-    delete process.env.NEXT_PUBLIC_PINCHY_VERSION;
-    delete process.env.NEXT_PUBLIC_OPENCLAW_VERSION;
-    delete process.env.PINCHY_BUILD_SHA;
-  });
+  function resetEnv() {
+    for (const key of ENV_KEYS) delete process.env[key];
+  }
 
-  afterEach(() => {
-    if (original.pinchyVersion !== undefined)
-      process.env.NEXT_PUBLIC_PINCHY_VERSION = original.pinchyVersion;
-    if (original.openclawVersion !== undefined)
-      process.env.NEXT_PUBLIC_OPENCLAW_VERSION = original.openclawVersion;
-    if (original.buildSha !== undefined) process.env.PINCHY_BUILD_SHA = original.buildSha;
-    if (original.nodeEnv !== undefined) process.env.NODE_ENV = original.nodeEnv;
-  });
+  function restoreEnv() {
+    for (const key of ENV_KEYS) {
+      const value = snapshot[key];
+      if (value === undefined) {
+        delete process.env[key];
+      } else {
+        process.env[key] = value;
+      }
+    }
+  }
+
+  beforeEach(resetEnv);
+  afterEach(restoreEnv);
 
   it("returns 200 with JSON", async () => {
     const response = await GET();

--- a/packages/web/src/__tests__/lib/auth-env-warning.test.ts
+++ b/packages/web/src/__tests__/lib/auth-env-warning.test.ts
@@ -7,13 +7,16 @@ describe("getBetterAuthUrlStartupWarning", () => {
     expect(getBetterAuthUrlStartupWarning({ BETTER_AUTH_URL: "" })).toBeNull();
   });
 
-  it("explains that BETTER_AUTH_URL still controls callback URLs", () => {
+  it("explains what BETTER_AUTH_URL controls when set", () => {
     const warning = getBetterAuthUrlStartupWarning({
       BETTER_AUTH_URL: "https://pinchy.example.com",
     });
 
-    expect(warning).toContain("Domain Lock is configured via Settings");
-    expect(warning).toContain("still controls Better Auth callback URLs");
+    expect(warning).toContain("Domain Lock");
+    // Must name the concrete things BETTER_AUTH_URL still controls, not the
+    // generic "callback URLs" phrase — admins shouldn't have to guess whether
+    // that affects them.
+    expect(warning).toMatch(/email verification|password reset/i);
   });
 
   it("does not say BETTER_AUTH_URL is unused", () => {

--- a/packages/web/src/__tests__/middleware/domain-restriction.test.ts
+++ b/packages/web/src/__tests__/middleware/domain-restriction.test.ts
@@ -46,6 +46,12 @@ describe("domain restriction host check", () => {
     expect(isHostAllowed("evil.example.com", "/api/setup/status")).toBe(true);
   });
 
+  it("always allows /api/version regardless of host", () => {
+    vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
+    expect(isHostAllowed("evil.example.com", "/api/version")).toBe(true);
+    expect(isHostAllowed("localhost:7777", "/api/version")).toBe(true);
+  });
+
   it("allows pinchy-audit hook calls from Docker-internal hostnames", () => {
     vi.mocked(getCachedDomain).mockReturnValue("pinchy.example.com");
     expect(isHostAllowed("pinchy:7777", "/api/internal/audit/tool-use")).toBe(true);

--- a/packages/web/src/__tests__/security/api-auth-check.test.ts
+++ b/packages/web/src/__tests__/security/api-auth-check.test.ts
@@ -34,6 +34,7 @@ const PUBLIC_ROUTES = [
   "api/health/route.ts",
   "api/health/openclaw/route.ts",
   "api/diagnostics/route.ts",
+  "api/version/route.ts",
   "api/internal/openclaw-config-ready/route.ts",
 ];
 

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -85,12 +85,14 @@ describe("auth config consistency", () => {
     );
   });
 
-  it("startup warning should explain BETTER_AUTH_URL still controls Better Auth callbacks", () => {
+  it("startup warning should name what BETTER_AUTH_URL still controls (not the vague 'callback URLs')", () => {
     const content = readFileSync(
       resolve(PROJECT_ROOT, "packages/web/src/lib/auth-env-warning.ts"),
       "utf-8"
     );
-    expect(content).toContain("still controls Better Auth callback URLs");
+    // Must call out the concrete user-visible thing — email/password-reset
+    // links — so admins can decide if the var is still needed for their setup.
+    expect(content).toMatch(/email verification|password reset/i);
     expect(content).not.toContain("BETTER_AUTH_URL is set but no longer used");
   });
 

--- a/packages/web/src/app/api/version/route.ts
+++ b/packages/web/src/app/api/version/route.ts
@@ -1,0 +1,17 @@
+// auth-direct: public version endpoint — no auth, no PII. Mirrors /api/health's
+// exemption from Domain Lock so monitoring tools and upgrade verification work
+// from any host (see server/host-check.ts EXEMPT_PATHS).
+import { NextResponse } from "next/server";
+
+export async function GET() {
+  const sha = process.env.PINCHY_BUILD_SHA;
+  const body = {
+    pinchyVersion: process.env.NEXT_PUBLIC_PINCHY_VERSION ?? "unknown",
+    openclawVersion: process.env.NEXT_PUBLIC_OPENCLAW_VERSION ?? "unknown",
+    build: sha ? sha.slice(0, 12) : "dev",
+    nodeEnv: process.env.NODE_ENV ?? "unknown",
+  };
+  return NextResponse.json(body, {
+    headers: { "Cache-Control": "no-store" },
+  });
+}

--- a/packages/web/src/lib/auth-env-warning.ts
+++ b/packages/web/src/lib/auth-env-warning.ts
@@ -4,7 +4,9 @@ export function getBetterAuthUrlStartupWarning(
   if (!env.BETTER_AUTH_URL) return null;
 
   return (
-    "⚠ BETTER_AUTH_URL is set. Domain Lock is configured via Settings → Security; " +
-    "BETTER_AUTH_URL still controls Better Auth callback URLs."
+    "⚠ BETTER_AUTH_URL is set. Request-host trust is now configured via Domain Lock " +
+    "(Settings → Security). BETTER_AUTH_URL only controls outbound URLs Better Auth " +
+    "writes into email verification and password reset links — make sure it matches " +
+    "the hostname your users actually open Pinchy at."
   );
 }

--- a/packages/web/src/server/host-check.ts
+++ b/packages/web/src/server/host-check.ts
@@ -5,7 +5,7 @@ import { getCachedDomain, normalizeHost } from "@/lib/domain-cache";
 // plugin endpoints are called through Docker-internal hostnames, so they also
 // bypass host matching. The unauthenticated OpenClaw readiness endpoint is
 // only exempt for same-container loopback healthchecks.
-const EXEMPT_PATHS = ["/api/health", "/api/setup/status"];
+const EXEMPT_PATHS = ["/api/health", "/api/setup/status", "/api/version"];
 const LOOPBACK_ONLY_EXEMPT_PATHS = ["/api/internal/openclaw-config-ready"];
 
 function isLoopbackHost(host: string | undefined): boolean {


### PR DESCRIPTION
## Summary

End-of-staging-deviation-review changes ahead of the v0.5.4 release. Four logical commits:

1. **feat(api): `/api/version` endpoint + OCI image labels** — End users couldn't verify which version was running after an upgrade. `/api/health` returns only `{status:"ok"}`; `/api/diagnostics` returns version but is Domain-Lock-gated; `docker inspect` returned an empty `org.opencontainers.image.version`. New `GET /api/version` (public, Cache-Control: no-store) returns `{pinchyVersion, openclawVersion, build, nodeEnv}` and is exempt from Domain Lock. `Dockerfile.pinchy` + `Dockerfile.openclaw` get OCI labels populated from build args; `pre-release.yml` + `release.yml` pass `PINCHY_VERSION` and `PINCHY_BUILD_SHA`. TDD: 10 new endpoint tests, 1 host-check test, 1 entry in `PUBLIC_ROUTES`.

2. **docs(upgrading)**: Step 4 "Verify" no longer tells users to open `http://localhost:7777` (which returns 403 on Domain-Lock-enabled deployments) — uses `curl /api/version` instead, plus the user-facing URL. Step 1 backup convention aligned to `backups/pinchy-<ts>.sql` (matches the internal release-day playbook). v0.5.4 upgrade notes mention the new operational-visibility surface.

3. **docs(contributing)**: Dropped the duplicate `update-pinchy` cron block in the "Testing a release candidate" section — the lower "Staging instance setup" section already documents the simple manual-refresh flow, and the duplication mildly contradicted itself. Auto-deploy still tracked in [#184](https://github.com/heypinchy/pinchy/issues/184).

4. **fix(auth-warning)**: `BETTER_AUTH_URL` startup warning previously said "still controls Better Auth callback URLs" (vague). New wording names email verification + password reset links as the concrete things it affects, so admins can decide whether to keep setting it. (Follow-up: is `BETTER_AUTH_URL` still needed at all when Domain Lock is configured? Tracked as a separate investigation post-v0.5.4 — code-level analysis suggests it's only used for outbound link URLs, but verifying against actual email/reset flows requires more than a staging click-through.)

## Context

While preparing the v0.5.4 staging click-through I noticed several gaps between the docs and what the staging server actually needs/exposes. Rather than write down "watch out for X" and ship, this PR fixes the gaps where they belong (in code or docs).

## Test plan

- [x] `pnpm test` — 4171 passed, 12 skipped, 0 failed
- [x] `pnpm exec tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors (373 pre-existing warnings)
- [ ] CI green on this PR (Docker build will exercise the new ARG/LABEL plumbing)
- [ ] After merge, `:next` build picks up the new build-args and `curl https://staging.heypinchy.com/api/version` returns a populated `build` field
- [ ] Manual: `docker inspect ghcr.io/heypinchy/pinchy:next | jq '.[0].Config.Labels'` shows `org.opencontainers.image.version` populated