### PR TITLE
feat(odoo): add odoo_attach_file tool + fix vision resolver for read-write operators

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -159,11 +159,11 @@ No database migration, no `docker-compose.yml` change, and no env-var changes ar
   new agent templates (Bookkeeper, Project Manager, HR Operator, Warehouse
   Operator, Production Operator, Approval Manager) whose `requiredModels`
   reference Odoo models that previous Pinchy versions didn't probe (e.g.
-  `hr.expense.sheet`, `account.tax`, `project.project`, `mrp.production`).
-  Existing connections still hold the old narrow schema cache, so the new
-  templates' **Create** buttons stay disabled even though your Odoo instance
-  exposes the models. Open **Settings → Integrations → Odoo → ⋯ → Sync now**
-  once after the upgrade to refresh the cache.
+  `hr.expense.sheet`, `account.tax`, `project.project`, `mrp.production`,
+  `ir.attachment`). Existing connections still hold the old narrow schema cache,
+  so the new templates' **Create** buttons stay disabled even though your Odoo
+  instance exposes the models. Open **Settings → Integrations → Odoo → ⋯ → Sync
+  now** once after the upgrade to refresh the cache.
 </Aside>
 
 #### Six new Odoo agent templates
@@ -189,6 +189,14 @@ Every read-write Odoo operator template now declares the `vision` capability in 
 #### Hardened Odoo relation references
 
 When an Odoo tool returns a record, related-record references are now emitted as opaque, encrypted tokens (`pinchy_ref:v1:…`) rather than raw `(id, label)` tuples. The pinchy-odoo plugin transparently resolves these tokens on subsequent calls, so an agent can no longer fabricate or substitute a numeric ID it never saw. Existing agents pick up the new behavior automatically; no configuration change is required.
+
+#### Odoo file attachment (new `odoo_attach_file` tool)
+
+Read-write Odoo operator templates can now attach uploaded files to Odoo records as `ir.attachment`. The Bookkeeper template uses this to link receipt images to the corresponding vendor bill; the Warehouse Operator can attach delivery notes to pickings; the HR Operator can attach medical certificates to leave requests; and so on for the Project Manager, Production Operator, and Approval Manager.
+
+The new `odoo_attach_file` tool is automatically included in the `read-write` permission tier alongside `odoo_create` and `odoo_write`. When you create any read-write Odoo agent, the tool is pre-enabled — no manual permission change is required.
+
+**After upgrading**: existing Odoo connections need a schema re-sync to pick up `ir.attachment`. Open **Settings → Integrations → Odoo → ⋯ → Sync now**. Until you sync, the **Create** buttons for operator templates that reference `ir.attachment` will remain disabled.
 
 #### Chat reliability fixes
 

--- a/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
@@ -35,8 +35,15 @@ describe("integration refs", () => {
       label: "Austria",
     });
 
-    expect(() => decodeRef(ref.replace(/.$/, "x"))).toThrow(
-      /Invalid integration reference/,
-    );
+    // Corrupt a character well before the end to avoid base64url end-padding
+    // effects: in the final 2-char or 3-char group, trailing bits are
+    // zero-padded and changing only those bits leaves the decoded bytes
+    // unchanged, which would make AES-GCM auth pass. Position -10 is safely
+    // inside a full 4-char group where all 6 bits of every character matter.
+    const idx = ref.length - 10;
+    const flipped = ref[idx] === "a" ? "b" : "a";
+    const tampered = ref.slice(0, idx) + flipped + ref.slice(idx + 1);
+
+    expect(() => decodeRef(tampered)).toThrow(/Invalid integration reference/);
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -22,6 +22,11 @@ vi.mock("odoo-node", () => {
   return { OdooClient: MockOdooClient };
 });
 
+// Mock the io wrapper for odoo_attach_file tests
+const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
+vi.mock("../io", () => ({ readFile: mockReadFile }));
+
+
 import { OdooClient } from "odoo-node";
 import { encodeRef } from "../integration-ref";
 import plugin from "../index";
@@ -112,9 +117,9 @@ const agentConfig = {
 };
 
 describe("tool registration", () => {
-  it("registers all 7 tools", () => {
+  it("registers all 8 tools", () => {
     const tools = createApi({ [agentId]: agentConfig });
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(8);
     const names = tools.map((t) => t.name);
     expect(names).toContain("odoo_schema");
     expect(names).toContain("odoo_read");
@@ -123,6 +128,7 @@ describe("tool registration", () => {
     expect(names).toContain("odoo_create");
     expect(names).toContain("odoo_write");
     expect(names).toContain("odoo_delete");
+    expect(names).toContain("odoo_attach_file");
   });
 
   it("returns null for all tools when no agentId", () => {
@@ -928,5 +934,186 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
     // First call fetched, error invalidated cache, second call refetched
     expect(fetchMock).toHaveBeenCalledTimes(2);
     expect(mockSearchRead).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("odoo_attach_file", () => {
+  const attachAgentId = "agent-attach-1";
+  const attachAgentConfig = {
+    connectionId: "conn-test-1",
+    permissions: {
+      "account.move": ["read", "write", "create"],
+      "ir.attachment": ["read", "create"],
+    },
+  };
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    fetchMock.mockResolvedValue({
+      ok: true,
+      status: 200,
+      statusText: "OK",
+      json: async () => ({ type: "odoo", credentials: testCredentials }),
+    });
+  });
+
+  it("attaches a file to a record and returns an encrypted ref", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+
+    const fakeBytes = Buffer.from("fake-image-bytes");
+    mockReadFile.mockResolvedValue(fakeBytes);
+    mockCreate.mockResolvedValue(99);
+
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+    expect(tool).not.toBeNull();
+
+    const result = await tool.execute("call-1", {
+      targetRef,
+      filename: "receipt.jpg",
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.ref).toMatch(/^pinchy_ref:v1:/);
+    expect(data.name).toBe("receipt.jpg");
+    expect(data.mimetype).toBe("image/jpeg");
+
+    expect(mockCreate).toHaveBeenCalledWith("ir.attachment", {
+      res_model: "account.move",
+      res_id: 42,
+      name: "receipt.jpg",
+      datas: fakeBytes.toString("base64"),
+      mimetype: "image/jpeg",
+    });
+
+    expect(mockReadFile).toHaveBeenCalledWith(
+      `/root/.openclaw/workspaces/${attachAgentId}/uploads/receipt.jpg`,
+    );
+  });
+
+  it("returns permission denied when ir.attachment.create is missing", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+
+    const configNoAttach = {
+      connectionId: "conn-test-1",
+      permissions: {
+        "account.move": ["read", "write", "create"],
+        // no ir.attachment entry
+      },
+    };
+
+    const tools = createApi({ [attachAgentId]: configNoAttach });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-1", { targetRef, filename: "receipt.jpg" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns permission denied when targetModel.write is missing", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+
+    const configReadOnly = {
+      connectionId: "conn-test-1",
+      permissions: {
+        "account.move": ["read"],
+        "ir.attachment": ["read", "create"],
+      },
+    };
+
+    const tools = createApi({ [attachAgentId]: configReadOnly });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-1", { targetRef, filename: "receipt.jpg" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("returns an error when the file does not exist", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+
+    const notFound = Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
+    mockReadFile.mockRejectedValue(notFound);
+
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-1", { targetRef, filename: "missing.jpg" });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("missing.jpg");
+  });
+
+  it("returns an error for an invalid targetRef", async () => {
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-1", {
+      targetRef: "not-a-valid-ref",
+      filename: "receipt.jpg",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it.each([
+    ["receipt.jpg", "image/jpeg"],
+    ["scan.jpeg", "image/jpeg"],
+    ["photo.png", "image/png"],
+    ["anim.gif", "image/gif"],
+    ["modern.webp", "image/webp"],
+    ["document.pdf", "application/pdf"],
+    ["unknown.xyz", "application/octet-stream"],
+  ])("detects MIME type for %s as %s", async (filename, expectedMime) => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 1,
+      label: "INV",
+    });
+    mockReadFile.mockResolvedValue(Buffer.from("bytes"));
+    mockCreate.mockResolvedValue(1);
+
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    await tool.execute("call-1", { targetRef, filename });
+
+    expect(mockCreate).toHaveBeenCalledWith(
+      "ir.attachment",
+      expect.objectContaining({ mimetype: expectedMime }),
+    );
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -23,9 +23,11 @@ vi.mock("odoo-node", () => {
 });
 
 // Mock the io wrapper for odoo_attach_file tests
-const { mockReadFile } = vi.hoisted(() => ({ mockReadFile: vi.fn() }));
-vi.mock("../io", () => ({ readFile: mockReadFile }));
-
+const { mockReadFile, mockStat } = vi.hoisted(() => ({
+  mockReadFile: vi.fn(),
+  mockStat: vi.fn(),
+}));
+vi.mock("../io", () => ({ readFile: mockReadFile, stat: mockStat }));
 
 import { OdooClient } from "odoo-node";
 import { encodeRef } from "../integration-ref";
@@ -950,6 +952,8 @@ describe("odoo_attach_file", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    // Default: small file (1 KB). Override per-test for size-limit checks.
+    mockStat.mockResolvedValue({ size: 1024 });
     fetchMock.mockResolvedValue({
       ok: true,
       status: 200,
@@ -1019,7 +1023,10 @@ describe("odoo_attach_file", () => {
     const tools = createApi({ [attachAgentId]: configNoAttach });
     const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
 
-    const result = await tool.execute("call-1", { targetRef, filename: "receipt.jpg" });
+    const result = await tool.execute("call-1", {
+      targetRef,
+      filename: "receipt.jpg",
+    });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Permission denied");
@@ -1046,7 +1053,10 @@ describe("odoo_attach_file", () => {
     const tools = createApi({ [attachAgentId]: configReadOnly });
     const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
 
-    const result = await tool.execute("call-1", { targetRef, filename: "receipt.jpg" });
+    const result = await tool.execute("call-1", {
+      targetRef,
+      filename: "receipt.jpg",
+    });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Permission denied");
@@ -1062,16 +1072,22 @@ describe("odoo_attach_file", () => {
       label: "INV/2025/0001",
     });
 
-    const notFound = Object.assign(new Error("ENOENT: no such file"), { code: "ENOENT" });
-    mockReadFile.mockRejectedValue(notFound);
+    const notFound = Object.assign(new Error("ENOENT: no such file"), {
+      code: "ENOENT",
+    });
+    mockStat.mockRejectedValue(notFound);
 
     const tools = createApi({ [attachAgentId]: attachAgentConfig });
     const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
 
-    const result = await tool.execute("call-1", { targetRef, filename: "missing.jpg" });
+    const result = await tool.execute("call-1", {
+      targetRef,
+      filename: "missing.jpg",
+    });
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("missing.jpg");
+    expect(mockReadFile).not.toHaveBeenCalled();
   });
 
   it("returns an error for an invalid targetRef", async () => {
@@ -1115,5 +1131,113 @@ describe("odoo_attach_file", () => {
       "ir.attachment",
       expect.objectContaining({ mimetype: expectedMime }),
     );
+  });
+
+  // Security: prevents prompt-injection-driven file exfiltration. A
+  // compromised agent could otherwise request `filename: "../../etc/passwd"`
+  // and the plugin would attach arbitrary container files to an Odoo record.
+  describe("filename validation (prevents path traversal)", () => {
+    const validTargetRef = () =>
+      encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "account.move",
+        id: 42,
+        label: "INV/2025/0001",
+      });
+
+    it.each([
+      ["../etc/passwd", "parent directory traversal"],
+      ["../../etc/passwd", "deep parent traversal"],
+      ["/etc/passwd", "absolute path"],
+      ["subdir/file.txt", "subdirectory"],
+      [".env", "hidden file"],
+      ["..", "just dots"],
+      [".", "single dot"],
+      ["..\\windows\\system32", "Windows-style backslash traversal"],
+    ])('rejects filename "%s" (%s)', async (badFilename) => {
+      mockReadFile.mockResolvedValue(Buffer.from("bytes"));
+      mockCreate.mockResolvedValue(1);
+
+      const tools = createApi({ [attachAgentId]: attachAgentConfig });
+      const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+      const result = await tool.execute("call-1", {
+        targetRef: validTargetRef(),
+        filename: badFilename,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/invalid filename/i);
+      expect(mockStat).not.toHaveBeenCalled();
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("accepts a plain filename with spaces, digits, and dashes", async () => {
+      mockReadFile.mockResolvedValue(Buffer.from("bytes"));
+      mockCreate.mockResolvedValue(7);
+
+      const tools = createApi({ [attachAgentId]: attachAgentConfig });
+      const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+      const result = await tool.execute("call-1", {
+        targetRef: validTargetRef(),
+        filename: "Receipt 2026-Q1.pdf",
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mockCreate).toHaveBeenCalled();
+    });
+  });
+
+  // Defense against memory exhaustion: readFile loads the entire file plus a
+  // base64 representation into memory. Without an upper bound a single
+  // upload could OOM the plugin process.
+  describe("file size limit", () => {
+    const validTargetRef = () =>
+      encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "account.move",
+        id: 42,
+        label: "INV/2025/0001",
+      });
+
+    it("rejects files larger than 25 MB", async () => {
+      mockStat.mockResolvedValue({ size: 26 * 1024 * 1024 });
+      mockReadFile.mockResolvedValue(Buffer.from("bytes"));
+      mockCreate.mockResolvedValue(1);
+
+      const tools = createApi({ [attachAgentId]: attachAgentConfig });
+      const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+      const result = await tool.execute("call-1", {
+        targetRef: validTargetRef(),
+        filename: "huge.pdf",
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/too large/i);
+      expect(mockReadFile).not.toHaveBeenCalled();
+      expect(mockCreate).not.toHaveBeenCalled();
+    });
+
+    it("accepts files at exactly 25 MB", async () => {
+      mockStat.mockResolvedValue({ size: 25 * 1024 * 1024 });
+      mockReadFile.mockResolvedValue(Buffer.from("bytes"));
+      mockCreate.mockResolvedValue(1);
+
+      const tools = createApi({ [attachAgentId]: attachAgentConfig });
+      const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+      const result = await tool.execute("call-1", {
+        targetRef: validTargetRef(),
+        filename: "edge.pdf",
+      });
+
+      expect(result.isError).toBeFalsy();
+      expect(mockCreate).toHaveBeenCalled();
+    });
   });
 });

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1,5 +1,5 @@
-import { readFile } from "./io";
-import { extname } from "path";
+import { readFile, stat } from "./io";
+import { basename, extname } from "path";
 import { OdooClient } from "odoo-node";
 import {
   checkPermission,
@@ -10,6 +10,11 @@ import { decodeRef, encodeRef } from "./integration-ref";
 
 const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 
+// 25 MB matches Odoo's default `web.max_file_upload_size` setting. Keeps the
+// plugin process from OOMing on a single attachment (readFile + base64 string
+// roughly triple the file's footprint in memory).
+const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
+
 const MIME_BY_EXT: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -18,7 +23,8 @@ const MIME_BY_EXT: Record<string, string> = {
   ".webp": "image/webp",
   ".pdf": "application/pdf",
   ".doc": "application/msword",
-  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".docx":
+    "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
   ".xls": "application/vnd.ms-excel",
   ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
   ".txt": "text/plain",
@@ -26,7 +32,21 @@ const MIME_BY_EXT: Record<string, string> = {
 };
 
 function mimeForFilename(filename: string): string {
-  return MIME_BY_EXT[extname(filename).toLowerCase()] ?? "application/octet-stream";
+  return (
+    MIME_BY_EXT[extname(filename).toLowerCase()] ?? "application/octet-stream"
+  );
+}
+
+// Reject filenames that could escape the agent's uploads directory.
+// `basename` strips POSIX path components; the extra checks catch
+// Windows-style backslashes, leading-dot hidden files, and ".." / "."
+// segments that survive basename on Linux.
+function isSafeFilename(filename: string): boolean {
+  if (typeof filename !== "string" || filename.length === 0) return false;
+  if (filename !== basename(filename)) return false;
+  if (filename.startsWith(".")) return false;
+  if (filename.includes("\\")) return false;
+  return true;
 }
 
 interface PluginToolContext {
@@ -1161,17 +1181,19 @@ const plugin = {
           name: "odoo_attach_file",
           label: "Odoo Attach File",
           description:
-            "Attach an uploaded file to an existing Odoo record. Pass the opaque ref of the target record and the filename of a file in the agent's uploads directory. Returns the encrypted ref of the new ir.attachment record.",
+            "Attach an uploaded file to an existing Odoo record. Pass the opaque ref of the target record and a plain filename (no path components, no leading dot, max 25 MB) of a file in the agent's uploads directory. Returns the encrypted ref of the new ir.attachment record.",
           parameters: {
             type: "object",
             properties: {
               targetRef: {
                 type: "string",
-                description: "Opaque ref of the Odoo record to attach the file to (e.g. from odoo_read or odoo_create)",
+                description:
+                  "Opaque ref of the Odoo record to attach the file to (e.g. from odoo_read or odoo_create)",
               },
               filename: {
                 type: "string",
-                description: "Filename of an existing upload in the agent's workspace uploads directory",
+                description:
+                  "Plain filename of an existing upload in the agent's workspace uploads directory. Must not contain path separators ('/', '\\') or '..' and must not start with '.'",
               },
             },
             required: ["targetRef", "filename"],
@@ -1180,31 +1202,77 @@ const plugin = {
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             const filename = params.filename as string;
             try {
+              // Filename validation runs first — independent of targetRef
+              // decoding or permission checks — because it defends against
+              // prompt-injection-driven file exfiltration. A compromised
+              // agent could otherwise pass `../../etc/passwd` and have the
+              // plugin attach arbitrary container files to an Odoo record.
+              if (!isSafeFilename(filename)) {
+                return {
+                  isError: true as const,
+                  content: [
+                    {
+                      type: "text",
+                      text: `Invalid filename: "${filename}". Must be a plain file name without path components (no "/", no "\\", no "..", no leading ".").`,
+                    },
+                  ],
+                };
+              }
+
               const targetRef = params.targetRef as string;
               const decoded = decodeRef(targetRef);
 
-              if (!checkPermission(config.permissions, "ir.attachment", "create")) {
+              if (
+                !checkPermission(config.permissions, "ir.attachment", "create")
+              ) {
                 return permissionDenied("create", "ir.attachment");
               }
-              if (!checkPermission(config.permissions, decoded.model, "write")) {
+              if (
+                !checkPermission(config.permissions, decoded.model, "write")
+              ) {
                 return permissionDenied("write", decoded.model);
               }
 
               const filePath = `${WORKSPACE_ROOT}/${agentId}/uploads/${filename}`;
-              let fileBuffer: Buffer;
+
+              let fileSize: number;
               try {
-                fileBuffer = await readFile(filePath) as Buffer;
+                const fileStat = await stat(filePath);
+                fileSize = fileStat.size;
               } catch (err) {
-                const code = err && typeof err === "object" && "code" in err ? String((err as { code: unknown }).code) : "";
+                const code =
+                  err && typeof err === "object" && "code" in err
+                    ? String((err as { code: unknown }).code)
+                    : "";
                 if (code === "ENOENT") {
                   return {
                     isError: true as const,
-                    content: [{ type: "text", text: `File not found: ${filename}. Make sure the file was uploaded before calling odoo_attach_file.` }],
+                    content: [
+                      {
+                        type: "text",
+                        text: `File not found: ${filename}. Make sure the file was uploaded before calling odoo_attach_file.`,
+                      },
+                    ],
                   };
                 }
                 throw err;
               }
 
+              if (fileSize > MAX_ATTACHMENT_BYTES) {
+                const sizeMb = (fileSize / 1024 / 1024).toFixed(1);
+                const maxMb = (MAX_ATTACHMENT_BYTES / 1024 / 1024).toFixed(0);
+                return {
+                  isError: true as const,
+                  content: [
+                    {
+                      type: "text",
+                      text: `File too large: ${filename} is ${sizeMb} MB, max allowed is ${maxMb} MB.`,
+                    },
+                  ],
+                };
+              }
+
+              const fileBuffer = await readFile(filePath);
               const mimetype = mimeForFilename(filename);
               const datas = fileBuffer.toString("base64");
 
@@ -1235,7 +1303,10 @@ const plugin = {
                 ],
               };
             } catch (error) {
-              return errorResult(error, { operation: "attach", model: "ir.attachment" });
+              return errorResult(error, {
+                operation: "attach",
+                model: "ir.attachment",
+              });
             }
           },
         };

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1,3 +1,5 @@
+import { readFile } from "./io";
+import { extname } from "path";
 import { OdooClient } from "odoo-node";
 import {
   checkPermission,
@@ -5,6 +7,27 @@ import {
   type Permissions,
 } from "./permissions";
 import { decodeRef, encodeRef } from "./integration-ref";
+
+const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
+
+const MIME_BY_EXT: Record<string, string> = {
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".png": "image/png",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+  ".pdf": "application/pdf",
+  ".doc": "application/msword",
+  ".docx": "application/vnd.openxmlformats-officedocument.wordprocessingml.document",
+  ".xls": "application/vnd.ms-excel",
+  ".xlsx": "application/vnd.openxmlformats-officedocument.spreadsheetml.sheet",
+  ".txt": "text/plain",
+  ".csv": "text/csv",
+};
+
+function mimeForFilename(filename: string): string {
+  return MIME_BY_EXT[extname(filename).toLowerCase()] ?? "application/octet-stream";
+}
 
 interface PluginToolContext {
   agentId?: string;
@@ -1124,6 +1147,100 @@ const plugin = {
         };
       },
       { name: "odoo_delete" },
+    );
+
+    // 8. odoo_attach_file
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_attach_file",
+          label: "Odoo Attach File",
+          description:
+            "Attach an uploaded file to an existing Odoo record. Pass the opaque ref of the target record and the filename of a file in the agent's uploads directory. Returns the encrypted ref of the new ir.attachment record.",
+          parameters: {
+            type: "object",
+            properties: {
+              targetRef: {
+                type: "string",
+                description: "Opaque ref of the Odoo record to attach the file to (e.g. from odoo_read or odoo_create)",
+              },
+              filename: {
+                type: "string",
+                description: "Filename of an existing upload in the agent's workspace uploads directory",
+              },
+            },
+            required: ["targetRef", "filename"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            const filename = params.filename as string;
+            try {
+              const targetRef = params.targetRef as string;
+              const decoded = decodeRef(targetRef);
+
+              if (!checkPermission(config.permissions, "ir.attachment", "create")) {
+                return permissionDenied("create", "ir.attachment");
+              }
+              if (!checkPermission(config.permissions, decoded.model, "write")) {
+                return permissionDenied("write", decoded.model);
+              }
+
+              const filePath = `${WORKSPACE_ROOT}/${agentId}/uploads/${filename}`;
+              let fileBuffer: Buffer;
+              try {
+                fileBuffer = await readFile(filePath) as Buffer;
+              } catch (err) {
+                const code = err && typeof err === "object" && "code" in err ? String((err as { code: unknown }).code) : "";
+                if (code === "ENOENT") {
+                  return {
+                    isError: true as const,
+                    content: [{ type: "text", text: `File not found: ${filename}. Make sure the file was uploaded before calling odoo_attach_file.` }],
+                  };
+                }
+                throw err;
+              }
+
+              const mimetype = mimeForFilename(filename);
+              const datas = fileBuffer.toString("base64");
+
+              const newId = await withAuthRetry(agentId, config, (client) =>
+                client.create("ir.attachment", {
+                  res_model: decoded.model,
+                  res_id: decoded.id,
+                  name: filename,
+                  datas,
+                  mimetype,
+                }),
+              );
+
+              const ref = encodeRef({
+                integrationType: "odoo",
+                connectionId: config.connectionId,
+                model: "ir.attachment",
+                id: newId as number,
+                label: filename,
+              });
+
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ ref, name: filename, mimetype }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, { operation: "attach", model: "ir.attachment" });
+            }
+          },
+        };
+      },
+      { name: "odoo_attach_file" },
     );
   },
 };

--- a/packages/plugins/pinchy-odoo/io.ts
+++ b/packages/plugins/pinchy-odoo/io.ts
@@ -1,1 +1,1 @@
-export { readFile } from "fs/promises";
+export { readFile, stat } from "fs/promises";

--- a/packages/plugins/pinchy-odoo/io.ts
+++ b/packages/plugins/pinchy-odoo/io.ts
@@ -1,0 +1,1 @@
+export { readFile } from "fs/promises";

--- a/packages/web/src/__tests__/components/new-agent-form.test.tsx
+++ b/packages/web/src/__tests__/components/new-agent-form.test.tsx
@@ -768,6 +768,7 @@ describe("NewAgentForm — optional Odoo models do not block creation", () => {
     { model: "res.partner", name: "Contact", access: readAccess() },
     { model: "mail.activity", name: "Activity", access: fullAccess() },
     { model: "mail.message", name: "Message", access: { ...readAccess(), create: true } },
+    { model: "ir.attachment", name: "Attachments", access: { ...readAccess(), create: true } },
   ];
 
   function readAccess() {

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -36,13 +36,14 @@ describe("TOOL_REGISTRY", () => {
 
   it("contains powerful tools", () => {
     const powerful = TOOL_REGISTRY.filter((t) => t.category === "powerful");
-    expect(powerful.length).toBe(7);
+    expect(powerful.length).toBe(8);
     expect(powerful.map((t) => t.id)).toEqual([
       "pinchy_web_search",
       "pinchy_web_fetch",
       "odoo_create",
       "odoo_write",
       "odoo_delete",
+      "odoo_attach_file",
       "email_draft",
       "email_send",
     ]);
@@ -157,7 +158,7 @@ describe("computeDeniedGroups", () => {
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));
-    expect(odooTools.length).toBe(7);
+    expect(odooTools.length).toBe(8);
     for (const tool of odooTools) {
       expect(tool.integration).toBe("odoo");
     }
@@ -186,7 +187,7 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_schema", "odoo_read", "odoo_count", "odoo_aggregate"]);
   });
 
-  it("getOdooToolsForAccessLevel('read-write') returns 6 tools", () => {
+  it("getOdooToolsForAccessLevel('read-write') returns 7 tools", () => {
     const tools = getOdooToolsForAccessLevel("read-write");
     expect(tools).toEqual([
       "odoo_schema",
@@ -195,10 +196,11 @@ describe("Odoo access level helpers", () => {
       "odoo_aggregate",
       "odoo_create",
       "odoo_write",
+      "odoo_attach_file",
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('full') returns all 7 tools", () => {
+  it("getOdooToolsForAccessLevel('full') returns all 8 tools", () => {
     const tools = getOdooToolsForAccessLevel("full");
     expect(tools).toEqual([
       "odoo_schema",
@@ -207,6 +209,7 @@ describe("Odoo access level helpers", () => {
       "odoo_aggregate",
       "odoo_create",
       "odoo_write",
+      "odoo_attach_file",
       "odoo_delete",
     ]);
   });
@@ -216,9 +219,9 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_schema"]);
   });
 
-  it("getOdooTools() returns exactly 7 tools", () => {
+  it("getOdooTools() returns exactly 8 tools", () => {
     const tools = getOdooTools();
-    expect(tools).toHaveLength(7);
+    expect(tools).toHaveLength(8);
     expect(tools.every((t) => t.integration === "odoo")).toBe(true);
   });
 
@@ -237,6 +240,7 @@ describe("Odoo access level helpers", () => {
         "odoo_aggregate",
         "odoo_create",
         "odoo_write",
+        "odoo_attach_file",
       ])
     ).toBe("read-write");
   });
@@ -250,6 +254,7 @@ describe("Odoo access level helpers", () => {
         "odoo_aggregate",
         "odoo_create",
         "odoo_write",
+        "odoo_attach_file",
         "odoo_delete",
       ])
     ).toBe("full");

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -193,7 +193,10 @@ ${ODOO_OUTPUT_FORMATTING}
 
 ${ODOO_RULES}
 - Never validate a picking without a per-line review — wrong qty becomes wrong stock.
-- Lot/serial products need lot/serial on each move line — never blank.`,
+- Lot/serial products need lot/serial on each move line — never blank.
+
+### Attach documents to a transfer
+If the user sends a delivery note, packing slip, or other shipping document, attach it to the corresponding \`stock.picking\` using \`odoo_attach_file\`. Always confirm the target picking with the user before attaching.`,
     requiredModels: [
       { model: "stock.picking", operations: ["read", "create", "write"] },
       { model: "stock.move", operations: ["read", "create", "write"] },
@@ -205,6 +208,7 @@ ${ODOO_RULES}
       { model: "product.category", operations: ["read"] },
       { model: "res.partner", operations: ["read"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
@@ -344,7 +348,10 @@ ${ODOO_OUTPUT_FORMATTING}
 ${ODOO_RULES}
 - Accounting data is permanent once posted. When in doubt, leave it draft and ask.
 - Never delete a posted record. The proper reversal is a credit note or cancellation (state → cancel via write).
-- VAT and tax_ids matter — always look up the correct \`account.tax\` ID, never guess.`,
+- VAT and tax_ids matter — always look up the correct \`account.tax\` ID, never guess.
+
+### Attach the source document to the bill/invoice
+After creating a draft \`account.move\`, offer to attach the uploaded receipt or invoice image to it. Use \`odoo_attach_file\` with a \`targetRef\` pointing to the \`account.move\` record and the filename of the uploaded file. Source documents attached to accounting records provide the audit trail required by external auditors.`,
     requiredModels: [
       { model: "account.move", operations: ["read", "create", "write"] },
       { model: "account.move.line", operations: ["read", "write"] },
@@ -354,6 +361,7 @@ ${ODOO_RULES}
       { model: "account.journal", operations: ["read"] },
       { model: "account.analytic.line", operations: ["read"] },
       { model: "account.analytic.account", operations: ["read"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: { tier: "reasoning", capabilities: ["vision", "long-context", "tools"] },
   }),
@@ -669,7 +677,10 @@ ${ODOO_OUTPUT_FORMATTING}
 ${ODOO_RULES}
 - HR data is highly confidential — when in doubt, ask the user before exposing details.
 - Prefer aggregates over individual records when the answer is statistical.
-- Never email or message an employee on their behalf — always draft, never send.`,
+- Never email or message an employee on their behalf — always draft, never send.
+
+### Attach supporting documents
+If the user sends a supporting document (e.g., medical certificate for sick leave, signed contract amendment), attach it to the relevant record using \`odoo_attach_file\`. For leave requests, attach to \`hr.leave\`. For employee profile updates, attach to \`hr.employee\`. Always confirm before attaching.`,
     requiredModels: [
       { model: "hr.employee", operations: ["read", "write"] },
       { model: "hr.department", operations: ["read"] },
@@ -681,6 +692,7 @@ ${ODOO_RULES}
       { model: "hr.contract", operations: ["read"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },
       { model: "mail.message", operations: ["read", "create"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
@@ -813,7 +825,10 @@ ${ODOO_OUTPUT_FORMATTING}
 
 ${ODOO_RULES}
 - When you surface at-risk projects, include the project manager's name so the user knows who to escalate to.
-- Don't reassign a task across departments without flagging it — that often crosses a budget boundary.`,
+- Don't reassign a task across departments without flagging it — that often crosses a budget boundary.
+
+### Attach documents to tasks or projects
+If the user sends a file related to a task or project (specification, screenshot, contract, design asset), attach it to the relevant record using \`odoo_attach_file\`. Attach to \`project.task\` for task-level documents or to \`project.project\` for project-wide ones. Confirm the target record with the user first.`,
     requiredModels: [
       { model: "project.project", operations: ["read", "create", "write"] },
       { model: "project.task", operations: ["read", "create", "write"] },
@@ -822,6 +837,7 @@ ${ODOO_RULES}
       { model: "hr.employee", operations: ["read"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },
       { model: "mail.message", operations: ["read", "create"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
@@ -964,7 +980,10 @@ ${ODOO_OUTPUT_FORMATTING}
 
 ${ODOO_RULES}
 - Production is irreversible at scale — when in doubt, ask the user.
-- Never silently round \`qty_producing\`. Always reconcile planned vs. actual with the user.`,
+- Never silently round \`qty_producing\`. Always reconcile planned vs. actual with the user.
+
+### Attach documents to a manufacturing order
+If the user sends a work instruction, quality report, or delivery note related to an MO, attach it to the \`mrp.production\` record using \`odoo_attach_file\`. Confirm the target MO with the user before attaching.`,
     requiredModels: [
       { model: "mrp.production", operations: ["read", "create", "write"] },
       { model: "mrp.workorder", operations: ["read", "write"] },
@@ -976,6 +995,7 @@ ${ODOO_RULES}
       { model: "stock.quant", operations: ["read"] },
       { model: "product.product", operations: ["read"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: { tier: "balanced", capabilities: ["vision", "long-context", "tools"] },
   }),
@@ -1344,7 +1364,10 @@ ${ODOO_OUTPUT_FORMATTING}
 ${ODOO_RULES}
 - Authority limits matter more than convenience — when in doubt, escalate.
 - Always log a rationale (\`mail.message\`) on every approval and every refusal.
-- Aggregate where useful, but approve/refuse one record at a time after individual review.`,
+- Aggregate where useful, but approve/refuse one record at a time after individual review.
+
+### Attach supporting documents to approvals
+If the user sends a receipt, supporting invoice, or policy document related to an approval, attach it to the relevant \`hr.expense.sheet\` or \`hr.expense\` record using \`odoo_attach_file\`. Source documents attached before approval eliminate the most common audit query ("where is the receipt?").`,
     requiredModels: [
       { model: "hr.expense.sheet", operations: ["read", "write"] },
       { model: "hr.expense", operations: ["read"] },
@@ -1356,6 +1379,7 @@ ${ODOO_RULES}
       { model: "res.partner", operations: ["read"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },
       { model: "mail.message", operations: ["read", "create"] },
+      { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: {
       tier: "reasoning",

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -190,6 +190,11 @@ export const MODEL_CATEGORIES: ModelCategory[] = [
     label: "Notes",
     models: [{ model: "note.note", name: "Notes" }],
   },
+  {
+    id: "files",
+    label: "Files & Attachments",
+    models: [{ model: "ir.attachment", name: "Attachments" }],
+  },
 ];
 
 /**

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from "vitest";
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
+import {
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS,
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
+} from "@/lib/ollama-cloud-models";
 import { resolveOllamaCloud } from "../providers/ollama-cloud";
 
 describe("resolveOllamaCloud", () => {
@@ -57,5 +60,62 @@ describe("resolveOllamaCloud — reasoning tier", () => {
     const result = resolveOllamaCloud({ tier: "reasoning", taskType: "general" });
     expect(result.model).toBe("ollama-cloud/deepseek-v4-pro");
     expect(result.fallbackUsed).toBe(false);
+  });
+});
+
+describe("resolveOllamaCloud — vision capability", () => {
+  it("returns a vision-capable model for reasoning tier when vision is in capabilities", () => {
+    const result = resolveOllamaCloud({
+      tier: "reasoning",
+      taskType: "reasoning",
+      capabilities: ["vision"],
+    });
+    const bareId = result.model.replace(/^ollama-cloud\//, "");
+    const entry = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === bareId);
+    expect(entry?.vision, `Expected ${result.model} to have vision:true`).toBe(true);
+  });
+
+  it("returns a vision-capable model for fast tier when vision is in capabilities", () => {
+    const result = resolveOllamaCloud({ tier: "fast", capabilities: ["vision"] });
+    const bareId = result.model.replace(/^ollama-cloud\//, "");
+    const entry = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === bareId);
+    expect(entry?.vision, `Expected ${result.model} to have vision:true`).toBe(true);
+  });
+
+  it("returns a vision-capable model for Bookkeeper hint shape (reasoning+vision+long-context+tools)", () => {
+    const result = resolveOllamaCloud({
+      tier: "reasoning",
+      taskType: "reasoning",
+      capabilities: ["vision", "long-context", "tools"],
+    });
+    const bareId = result.model.replace(/^ollama-cloud\//, "");
+    const entry = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === bareId);
+    expect(entry?.vision, `Expected ${result.model} to have vision:true for Bookkeeper hint`).toBe(
+      true
+    );
+  });
+
+  it("still returns deepseek-v4-pro for reasoning tier when vision is NOT in capabilities", () => {
+    const result = resolveOllamaCloud({ tier: "reasoning", taskType: "reasoning" });
+    expect(result.model).toBe("ollama-cloud/deepseek-v4-pro");
+  });
+
+  it("drift guard: every tier's vision-slot model has vision:true in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS", () => {
+    const tiers = ["fast", "balanced", "reasoning"] as const;
+    const drifts: string[] = [];
+    for (const tier of tiers) {
+      const result = resolveOllamaCloud({ tier, capabilities: ["vision"] });
+      const bareId = result.model.replace(/^ollama-cloud\//, "");
+      const entry = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === bareId);
+      if (!entry?.vision) {
+        drifts.push(`${tier}: ${result.model} has vision:${entry?.vision ?? "not found"}`);
+      }
+    }
+    expect(
+      drifts,
+      drifts.length === 0
+        ? ""
+        : `\n  Vision-slot models without vision:true in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS:\n${drifts.map((d) => `    • ${d}`).join("\n")}\n`
+    ).toEqual([]);
   });
 });

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -10,11 +10,16 @@ type OllamaCloudModelRef = `ollama-cloud/${OllamaCloudModelId}`;
 
 const BY_TIER_FAMILY: Record<
   ModelTier,
-  Partial<Record<ModelTaskType, OllamaCloudModelRef>> & { general: OllamaCloudModelRef }
+  Partial<Record<ModelTaskType, OllamaCloudModelRef>> & {
+    general: OllamaCloudModelRef;
+    vision: OllamaCloudModelRef;
+  }
 > = {
   fast: {
     general: "ollama-cloud/deepseek-v4-flash",
     coder: "ollama-cloud/qwen3-coder-next",
+    // Smallest practical vision model: 8B, vision+tools, 256K context.
+    vision: "ollama-cloud/ministral-3:8b",
   },
   balanced: {
     general: "ollama-cloud/glm-4.7",
@@ -23,11 +28,24 @@ const BY_TIER_FAMILY: Record<
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",
+    // 1M context (matches deepseek-v4-pro), reasoning+vision+tools.
+    // Kimi family avoided: v0.5.3 silent-500 stability incident.
+    vision: "ollama-cloud/gemini-3-flash-preview",
   },
 };
 
 export function resolveOllamaCloud(hint: ModelHint): ResolverResult {
   const tierMap = BY_TIER_FAMILY[hint.tier];
+
+  if (hint.capabilities?.includes("vision")) {
+    const model = tierMap.vision;
+    return {
+      model,
+      reason: `ollama-cloud: tier=${hint.tier}, capabilities=vision → ${model}`,
+      fallbackUsed: false,
+    };
+  }
+
   const taskType = hint.taskType ?? "general";
   const exactMatch = tierMap[taskType];
   const model = exactMatch ?? tierMap.general;

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -95,6 +95,13 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     category: "powerful",
     integration: "odoo",
   },
+  {
+    id: "odoo_attach_file",
+    label: "Odoo: Attach file",
+    description: "Attach an uploaded file to an existing Odoo record as ir.attachment",
+    category: "powerful",
+    integration: "odoo",
+  },
 
   // Email integration tools
   {
@@ -199,7 +206,7 @@ export function detectEmailOperations(allowedToolIds: string[]): string[] {
 export type OdooAccessLevel = "read-only" | "read-write" | "full" | "custom";
 
 const ODOO_READ_TOOLS = ["odoo_schema", "odoo_read", "odoo_count", "odoo_aggregate"] as const;
-const ODOO_WRITE_TOOLS = ["odoo_create", "odoo_write"] as const;
+const ODOO_WRITE_TOOLS = ["odoo_create", "odoo_write", "odoo_attach_file"] as const;
 const ODOO_DELETE_TOOLS = ["odoo_delete"] as const;
 
 /** Returns all Odoo tool definitions from the registry. */


### PR DESCRIPTION
## Summary

- **Issue C — vision resolver fix**: `resolveOllamaCloud` now checks `capabilities: ["vision"]` before `taskType`, so Bookkeeper and other read-write operator templates (which declare `vision` in their capabilities) get a vision-capable model instead of falling through to `deepseek-v4-pro` (text-only). Each tier gets an explicit `vision` slot: `fast → ministral-3:8b`, `balanced → qwen3-vl:235b`, `reasoning → gemini-3-flash-preview`. A drift-guard test enforces that every tier's vision slot is listed as `vision: true` in `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS`.

- **Issue B1 — `odoo_attach_file` tool**: New tool in `pinchy-odoo` reads an uploaded file from the workspace volume, base64-encodes it, and creates an `ir.attachment` linked to the target Odoo record. Permission gate requires both `ir.attachment.create` and `targetModel.write`. `ir.attachment` added to `MODEL_CATEGORIES` so the schema sync probes it. An `io.ts` wrapper enables `vi.mock()` on `readFile` in tests.

- All six read-write Odoo operator templates (Bookkeeper, Warehouse Operator, HR Operator, Project Manager, Production Operator, Approval Manager) gain `ir.attachment` in their `requiredModels` and a file-attachment workflow section in their `defaultAgentsMd`. `odoo_attach_file` is added to `ODOO_WRITE_TOOLS` so `read-write` and `full` access levels include it automatically.

- **Bug fix**: Flaky `integration-ref.test.ts` tamper test — the `/.$/ → "x"` replacement left decoded bytes unchanged when the last base64url character was in a 2-char group with trailing zero-padding bits. Fixed by corrupting a character 10 positions before the end (inside a full 4-char group).

## Test plan

- [ ] `pnpm test` passes (4191 tests, 0 failures)
- [ ] Manually create a Bookkeeper agent after re-syncing an Odoo connection — verify `odoo_attach_file` appears in the allowed tools list
- [ ] Upload a receipt image to a Bookkeeper chat and verify the agent attaches it to the created `account.move` in Odoo
- [ ] Verify that a read-only Odoo template (e.g. Sales Analyst) does NOT include `odoo_attach_file` in its allowed tools
- [ ] On Ollama Cloud provider: verify Bookkeeper agent's model resolves to a vision-capable model (e.g. `gemini-3-flash-preview` for reasoning tier)