### PR TITLE
fix(pinchy-odoo): strip quote-wrapped keys from create/write values

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -663,6 +663,39 @@ describe("odoo_create", () => {
     expect(result.isError).toBe(true);
     expect(mockCreate).not.toHaveBeenCalled();
   });
+
+  // Regression guard: some LLMs (observed with ollama-cloud/gemini-3-flash-preview
+  // on the v0.5.4 staging click-through) emit tool_call arguments where the keys
+  // of object-valued args contain literal JSON-escaped quotes — e.g.
+  //   values: { "\"name\"": "Tesla", "\"city\"": "Wien" }
+  // instead of
+  //   values: { "name": "Tesla", "city": "Wien" }
+  // Without sanitization those quotes reach Odoo verbatim and create() rejects
+  // every record because no field "\"name\"" exists.
+  it("strips literal JSON-escaped quotes from value keys before create()", async () => {
+    mockCreate.mockResolvedValue(99);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const result = await tool.execute("call-quoted-keys", {
+      model: "res.partner",
+      values: {
+        '"name"': "Tesla Motors Austria GmbH",
+        '"vat"': "ATU67878139",
+        '"city"': "Wien",
+        '"is_company"': true,
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("res.partner", {
+      name: "Tesla Motors Austria GmbH",
+      vat: "ATU67878139",
+      city: "Wien",
+      is_company: true,
+    });
+  });
 });
 
 describe("odoo_write", () => {
@@ -702,6 +735,26 @@ describe("odoo_write", () => {
     expect(result.content[0].text).toContain("Permission denied");
     expect(result.isError).toBe(true);
     expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  // Same regression guard as odoo_create — see comment above the create test.
+  it("strips literal JSON-escaped quotes from value keys before write()", async () => {
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+
+    const result = await tool.execute("call-quoted-keys", {
+      model: "res.partner",
+      ids: [42],
+      values: { '"email"': "updated@example.com", '"city"': "Linz" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("res.partner", [42], {
+      email: "updated@example.com",
+      city: "Linz",
+    });
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -224,6 +224,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+// Some LLMs (observed: ollama-cloud/gemini-3-flash-preview during v0.5.4 staging
+// click-through) emit tool_call arguments where the keys of object-valued args
+// are wrapped in literal JSON-quoted strings — e.g. `{"\"name\"": "Tesla"}`
+// instead of `{"name": "Tesla"}`. Whether this is the model's tokenizer leaking
+// raw JSON into the arguments string or a pi-ai parsing quirk is upstream of us;
+// at the plugin edge we just strip a single surrounding pair of quotes from each
+// key before forwarding to Odoo. Odoo field names never contain quotes, so this
+// rewrite is information-preserving for the well-formed case.
+function unquoteFieldKeys(values: Record<string, unknown>): Record<string, unknown> {
+  const out: Record<string, unknown> = {};
+  for (const [key, val] of Object.entries(values)) {
+    const stripped =
+      key.length >= 2 && key.startsWith('"') && key.endsWith('"')
+        ? key.slice(1, -1)
+        : key;
+    out[stripped] = val;
+  }
+  return out;
+}
+
 function getSearchReadRecords(result: unknown): OdooRecord[] {
   if (Array.isArray(result)) return result.filter(isRecord);
   if (isRecord(result) && Array.isArray(result.records)) {
@@ -1029,7 +1049,7 @@ const plugin = {
                         client,
                         config.connectionId,
                         model,
-                        params.values,
+                        unquoteFieldKeys(params.values),
                       )
                     : (params.values as Record<string, unknown>);
                   return client.create(model, values);
@@ -1097,7 +1117,7 @@ const plugin = {
                         client,
                         config.connectionId,
                         model,
-                        params.values,
+                        unquoteFieldKeys(params.values),
                       )
                     : (params.values as Record<string, unknown>);
                   return client.write(model, params.ids as number[], values);


### PR DESCRIPTION
## Summary
- v0.5.4 release blocker found during staging click-through after [#358](https://github.com/heypinchy/pinchy/pull/358) merged
- `ollama-cloud/gemini-3-flash-preview` (the model auto-picked for the new Bookkeeper template's vision+tools+reasoning hint) emits tool_call arguments where the keys of object-valued args are wrapped in literal JSON quotes — `\"name\"` instead of `name` etc. Odoo rejects every create.
- Defensive sanitization at the pinchy-odoo edge: strip a single surrounding pair of quotes from each key in `odoo_create` / `odoo_write` values. Odoo field names never legitimately contain quotes, so it's information-preserving for well-formed calls.
- Two regression tests pin the exact gemini-3-flash-preview payload shape.

## Why now (vs. waiting)
Per CONTRIBUTING.md `Pre-release checklist`: "no known bugs in releases". v0.5.4 prep surfaced this; fixing inline keeps the release moving.

## Test plan
- [x] `pnpm -C packages/web exec vitest run ../plugins/pinchy-odoo` — 83/83 passes (was 81 + 2 new regression tests)
- [x] `pnpm -C packages/web test` — 4222/4222 unit tests pass
- [ ] CI green
- [ ] Post-merge: redeploy staging, click through Tesla invoice → Cosmo Bookkeeper → odoo_create now succeeds