### PR TITLE
fix(pinchy-odoo): recurse into nested records when stripping quote-wrapped keys

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -737,6 +737,35 @@ describe("odoo_write", () => {
     expect(mockWrite).not.toHaveBeenCalled();
   });
 
+  // Nested-record variant of the gemini-3-flash-preview regression: Odoo's
+  // x2many command tuples wrap fresh records as `[0, 0, {…}]`, and gemini
+  // applies the same quote-wrapping bug to the inner record's keys too.
+  // Without recursive sanitization the outer field passes but the line never
+  // materialises in Odoo, which causes a write retry loop on staging.
+  it("strips quote-wrapped keys recursively from nested x2many records", async () => {
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+
+    const result = await tool.execute("call-nested-quotes", {
+      model: "res.partner",
+      ids: [42],
+      values: {
+        '"name"': "Tesla",
+        '"child_ids"': [
+          [0, 0, { '"name"': "Contact 1", '"email"': "a@example.com" }],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("res.partner", [42], {
+      name: "Tesla",
+      child_ids: [[0, 0, { name: "Contact 1", email: "a@example.com" }]],
+    });
+  });
+
   // Same regression guard as odoo_create — see comment above the create test.
   it("strips literal JSON-escaped quotes from value keys before write()", async () => {
     mockWrite.mockResolvedValue(true);

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -232,16 +232,26 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 // at the plugin edge we just strip a single surrounding pair of quotes from each
 // key before forwarding to Odoo. Odoo field names never contain quotes, so this
 // rewrite is information-preserving for the well-formed case.
-function unquoteFieldKeys(values: Record<string, unknown>): Record<string, unknown> {
+//
+// Recursion matters: Odoo's many2many/one2many commands nest fresh records,
+// e.g. `{ invoice_line_ids: [[0, 0, { quantity: 1, price_unit: 8.33 }]] }`.
+// Strip quotes at every depth so the inner field names land clean too.
+function unquoteFieldKeysDeep(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(unquoteFieldKeysDeep);
+  if (!isRecord(value)) return value;
   const out: Record<string, unknown> = {};
-  for (const [key, val] of Object.entries(values)) {
+  for (const [key, val] of Object.entries(value)) {
     const stripped =
       key.length >= 2 && key.startsWith('"') && key.endsWith('"')
         ? key.slice(1, -1)
         : key;
-    out[stripped] = val;
+    out[stripped] = unquoteFieldKeysDeep(val);
   }
   return out;
+}
+
+function unquoteFieldKeys(values: Record<string, unknown>): Record<string, unknown> {
+  return unquoteFieldKeysDeep(values) as Record<string, unknown>;
 }
 
 function getSearchReadRecords(result: unknown): OdooRecord[] {


### PR DESCRIPTION
## Summary
Follow-up to [#359](https://github.com/heypinchy/pinchy/pull/359). Staging retest showed the same gemini-3-flash-preview quirk applies to keys of records nested inside Odoo x2many command tuples — `[0, 0, { … }]` — not just the top-level `values` object.

## Symptom
Cosmo (Bookkeeper) entered a write-loop on staging after #359 deployed: 30+ identical `odoo_write` calls in 70 seconds, each trying to add the same line to the same `account.move`:

```json
"values": {
  "invoice_line_ids": [
    [0, 0, { "\"quantity\"": 1, "\"price_unit\"": 8.33 }]
  ]
}
```

#359 cleaned the outer `invoice_line_ids` key but passed the array through as-is. Odoo accepted the outer field, silently failed to materialise the inner line, and returned success — the LLM kept retrying.

## Fix
`unquoteFieldKeys` now recurses through arrays and nested records, stripping a single surrounding pair of quotes from every object key at every depth. Primitive values pass through.

## Test plan
- [x] New regression test pins the x2many shape (`packages/plugins/pinchy-odoo/__tests__/tools.test.ts`)
- [x] 84/84 pinchy-odoo tests pass locally
- [ ] CI green
- [ ] Post-merge: redeploy staging, Cosmo invoice flow completes without a write loop