### PR TITLE
fix(e2e/web): drain OC config.apply rate-limit before dispatch probe

### DIFF
--- a/packages/web/e2e/web/web-search.spec.ts
+++ b/packages/web/e2e/web/web-search.spec.ts
@@ -136,12 +136,25 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
     // 1. Start fake-Ollama on the host (port 11435).
     await startFakeOllama();
 
-    // 2. Swap default_provider to ollama-local and seed ollama_local_url.
+    // 2. Drain OC's config.apply rate-limit window. Same race the Odoo
+    //    dispatch probe hit (see odoo-agent-chat.spec.ts step 2): OC 5.3 allows
+    //    ~3 calls per 45 s per (device,IP); tests 1–2 of this suite each
+    //    trigger one or two regens, and this probe's POST agent + PATCH
+    //    allowedTools would push us past the cap. The rejected config.apply
+    //    falls through to the inotify file-watcher fallback, but an earlier
+    //    still-in-flight config.apply succeeds later and overwrites OC's
+    //    in-memory state with stale content — agents.list silently loses the
+    //    dispatch agent and the chat fires INVALID_REQUEST "unknown agent id".
+    //    Run 25936887310 reproduced this exact failure mode at 19:26:54
+    //    (rate-limited) → 19:27:27 (unknown agent id) for pinchy_web_search.
+    await new Promise((r) => setTimeout(r, 45_000));
+
+    // 3. Swap default_provider to ollama-local and seed ollama_local_url.
     const dbUrl =
       process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
     restoreSettings = await seedDefaultProviderToOllama(dbUrl, FAKE_OLLAMA_PORT);
 
-    // 3. Login (API cookie).
+    // 4. Login (API cookie).
     dispatchCookie = await login();
 
     // 4. Reuse the existing web-search connection if a previous test left one


### PR DESCRIPTION
## Summary
Web Search E2E probe is the second dispatch probe to hit the OC 5.3 rate-limit race that Odoo's probe hit pre-#358. Adding the same 45 s drain at the start of the probe's beforeAll closes it.

## Reproduction
Run 25936887310 on commit 4d0d4cbc1 (PR #360, unrelated change in pinchy-odoo):
```
19:26:54.294 [gateway] control-plane write rate-limited method=config.apply retryAfterMs=23075
19:26:54.296 ✗ config.apply UNAVAILABLE — rate limit exceeded
19:26:54.703 [reload] config change detected (file-watcher fallback)
19:26:54.986 ✓ EARLIER config.apply succeeded — likely overwrote OC state with stale content
19:27:27.453 ✗ agent INVALID_REQUEST: unknown agent id "86480b02-..."
```

Identical to the Odoo failure mode fixed in cbd9579ff.

## Fix
45 s `setTimeout` at the start of beforeAll. Matches Odoo's drain step.

## Why now
Per CONTRIBUTING + memory rule "Flaky Tests SOFORT fixen — Ein Rerun ist kein Fix". The flake is reproducible and blocks v0.5.4 release verification.

## Test plan
- [x] Type check passes
- [ ] CI green (this PR's web-e2e shouldn't flake again with the drain)
- [ ] No other dispatch probe regression