### PR TITLE
feat: switch default model tier from fast to balanced

### DIFF
--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -82,6 +82,20 @@ vi.mock("@/lib/provider-models", () => ({
   ]),
 }));
 
+vi.mock("@/lib/model-resolver", () => ({
+  resolveModelForTemplate: vi
+    .fn()
+    .mockResolvedValue({
+      model: "anthropic/claude-sonnet-4-6",
+      reason: "balanced",
+      fallbackUsed: false,
+    }),
+}));
+
+vi.mock("@/lib/personal-agent", () => ({
+  SMITHERS_MODEL_HINT: { tier: "balanced", capabilities: ["tools", "long-context"] },
+}));
+
 vi.mock("@/db", () => ({
   db: {
     update: vi.fn().mockReturnValue({
@@ -108,6 +122,8 @@ import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
 import { requireAdmin } from "@/lib/api-auth";
 import { resetCache, getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import { resolveModelForTemplate } from "@/lib/model-resolver";
+import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
 
 describe("POST /api/setup/provider", () => {
   beforeEach(() => {
@@ -404,8 +420,35 @@ describe("POST /api/setup/provider", () => {
     expect(data.error).toContain("No");
   });
 
-  it("should set dynamically resolved default model for ollama-local as first provider", async () => {
-    vi.mocked(getDefaultModel).mockResolvedValueOnce("ollama/llama3:latest");
+  it("updates Smithers' model using SMITHERS_MODEL_HINT when provider is configured as first provider", async () => {
+    vi.mocked(resolveModelForTemplate).mockResolvedValueOnce({
+      model: "anthropic/claude-sonnet-4-6",
+      reason: "balanced tier",
+      fallbackUsed: false,
+    });
+
+    await POST(
+      makeRequest({
+        provider: "anthropic",
+        apiKey: "sk-ant-key",
+      }) as any
+    );
+
+    expect(resolveModelForTemplate).toHaveBeenCalledWith({
+      hint: SMITHERS_MODEL_HINT,
+      provider: "anthropic",
+    });
+    expect(db.update).toHaveBeenCalled();
+    // getDefaultModel must NOT be called — the route must use resolveModelForTemplate
+    expect(getDefaultModel).not.toHaveBeenCalled();
+  });
+
+  it("updates Smithers' model via SMITHERS_MODEL_HINT for ollama-local as first provider", async () => {
+    vi.mocked(resolveModelForTemplate).mockResolvedValueOnce({
+      model: "ollama/qwen2.5:7b",
+      reason: "balanced tier",
+      fallbackUsed: false,
+    });
 
     await POST(
       makeRequest({
@@ -414,8 +457,12 @@ describe("POST /api/setup/provider", () => {
       }) as any
     );
 
-    expect(getDefaultModel).toHaveBeenCalledWith("ollama-local");
+    expect(resolveModelForTemplate).toHaveBeenCalledWith({
+      hint: SMITHERS_MODEL_HINT,
+      provider: "ollama-local",
+    });
     expect(db.update).toHaveBeenCalled();
+    expect(getDefaultModel).not.toHaveBeenCalled();
   });
 
   it("writes an audit log entry with named provider snapshot for an api-key provider", async () => {

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -83,13 +83,11 @@ vi.mock("@/lib/provider-models", () => ({
 }));
 
 vi.mock("@/lib/model-resolver", () => ({
-  resolveModelForTemplate: vi
-    .fn()
-    .mockResolvedValue({
-      model: "anthropic/claude-sonnet-4-6",
-      reason: "balanced",
-      fallbackUsed: false,
-    }),
+  resolveModelForTemplate: vi.fn().mockResolvedValue({
+    model: "anthropic/claude-sonnet-4-6",
+    reason: "balanced",
+    fallbackUsed: false,
+  }),
 }));
 
 vi.mock("@/lib/personal-agent", () => ({
@@ -123,6 +121,7 @@ import { db } from "@/db";
 import { requireAdmin } from "@/lib/api-auth";
 import { resetCache, getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
+import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
 
 describe("POST /api/setup/provider", () => {
@@ -544,5 +543,28 @@ describe("POST /api/setup/provider", () => {
     expect(serialized).not.toContain("http://host.docker.internal:11434");
     // ...but the host:port is acceptable as a non-secret diagnostic
     expect(detail).toMatchObject({ host: "host.docker.internal:11434" });
+  });
+
+  it("succeeds with 200 even when resolveModelForTemplate throws TemplateCapabilityUnavailableError", async () => {
+    // Provider is being added as the first provider, but resolver finds no
+    // matching model — e.g. an Ollama instance with only text-only models.
+    vi.mocked(resolveModelForTemplate).mockRejectedValueOnce(
+      new TemplateCapabilityUnavailableError(["tools"], "anthropic", "https://docs.heypinchy.com")
+    );
+
+    const response = await POST(
+      makeRequest({
+        provider: "anthropic",
+        apiKey: "sk-ant-key",
+      }) as any
+    );
+
+    // Provider is still saved and route returns 200.
+    expect(response.status).toBe(200);
+    const data = await response.json();
+    expect(data.success).toBe(true);
+    expect(setSetting).toHaveBeenCalledWith("anthropic_api_key", "sk-ant-key", true);
+    // Smithers' model must NOT be updated because resolution failed.
+    expect(db.update).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/app/setup-provider-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-provider-page.test.tsx
@@ -1,7 +1,8 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import SetupProviderPage from "@/app/setup/provider/page";
+import type { ProviderName } from "@/lib/providers";
 
 const pushMock = vi.fn();
 
@@ -21,17 +22,29 @@ vi.mock("next/image", () => ({
   },
 }));
 
+let capturedOnSuccess: ((provider?: ProviderName) => void) | null = null;
+
 vi.mock("@/components/provider-key-form", () => ({
-  ProviderKeyForm: ({ onSuccess }: { onSuccess: () => void }) => (
-    <button onClick={onSuccess} data-testid="mock-provider-form">
-      MockProviderForm
-    </button>
+  ProviderKeyForm: ({ onSuccess }: { onSuccess: (provider?: ProviderName) => void }) => {
+    capturedOnSuccess = onSuccess;
+    return (
+      <button onClick={() => onSuccess()} data-testid="mock-provider-form">
+        MockProviderForm
+      </button>
+    );
+  },
+}));
+
+vi.mock("@/components/setup/smithers-model-info-line", () => ({
+  SmithersModelInfoLine: ({ modelId }: { modelId: string }) => (
+    <p data-testid="smithers-model-info">{modelId}</p>
   ),
 }));
 
 describe("Setup Provider Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    capturedOnSuccess = null;
   });
 
   it("should render the Pinchy logo", () => {
@@ -58,9 +71,39 @@ describe("Setup Provider Page", () => {
     expect(screen.getByTestId("mock-provider-form")).toBeInTheDocument();
   });
 
-  it("should redirect to home on success", () => {
+  it("should redirect to home when onSuccess is called without a provider", () => {
     render(<SetupProviderPage />);
     fireEvent.click(screen.getByTestId("mock-provider-form"));
+    expect(pushMock).toHaveBeenCalledWith("/");
+  });
+
+  it("should show success state when onSuccess is called with a provider", async () => {
+    render(<SetupProviderPage />);
+    capturedOnSuccess!("anthropic");
+    await waitFor(() => {
+      expect(screen.getByText("Provider connected!")).toBeInTheDocument();
+    });
+    expect(screen.queryByTestId("mock-provider-form")).not.toBeInTheDocument();
+  });
+
+  it("should show model info line in success state", async () => {
+    render(<SetupProviderPage />);
+    capturedOnSuccess!("anthropic");
+    await waitFor(() => {
+      expect(screen.getByTestId("smithers-model-info")).toBeInTheDocument();
+    });
+    expect(screen.getByTestId("smithers-model-info")).toHaveTextContent(
+      "anthropic/claude-sonnet-4-6"
+    );
+  });
+
+  it("should redirect to home when Continue button is clicked in success state", async () => {
+    render(<SetupProviderPage />);
+    capturedOnSuccess!("anthropic");
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: /continue to pinchy/i })).toBeInTheDocument();
+    });
+    fireEvent.click(screen.getByRole("button", { name: /continue to pinchy/i }));
     expect(pushMock).toHaveBeenCalledWith("/");
   });
 });

--- a/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
+++ b/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
+
+describe("SmithersModelInfoLine", () => {
+  it("displays the model display name and link to agent settings", () => {
+    render(<SmithersModelInfoLine modelId="anthropic/claude-sonnet-4-6" />);
+    expect(screen.getByText(/Claude Sonnet 4.6/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /Agent Settings/i })).toHaveAttribute(
+      "href",
+      "/settings/agents"
+    );
+  });
+
+  it("renders with openai model id", () => {
+    render(<SmithersModelInfoLine modelId="openai/gpt-5.5" />);
+    expect(screen.getByText(/Gpt 5.5/i)).toBeInTheDocument();
+  });
+
+  it("renders with google model id", () => {
+    render(<SmithersModelInfoLine modelId="google/gemini-2.5-pro" />);
+    expect(screen.getByText(/Gemini 2.5 Pro/i)).toBeInTheDocument();
+  });
+
+  it("shows the informational text", () => {
+    render(<SmithersModelInfoLine modelId="anthropic/claude-sonnet-4-6" />);
+    expect(screen.getByText(/Smithers will use/i)).toBeInTheDocument();
+    expect(screen.getByText(/You can change this in/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
+++ b/packages/web/src/__tests__/components/smithers-model-info-line.test.tsx
@@ -6,7 +6,7 @@ import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-li
 describe("SmithersModelInfoLine", () => {
   it("displays the model display name and link to agent settings", () => {
     render(<SmithersModelInfoLine modelId="anthropic/claude-sonnet-4-6" />);
-    expect(screen.getByText(/Claude Sonnet 4.6/i)).toBeInTheDocument();
+    expect(screen.getByText(/Claude Sonnet 4\.6/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /Agent Settings/i })).toHaveAttribute(
       "href",
       "/settings/agents"
@@ -15,7 +15,7 @@ describe("SmithersModelInfoLine", () => {
 
   it("renders with openai model id", () => {
     render(<SmithersModelInfoLine modelId="openai/gpt-5.5" />);
-    expect(screen.getByText(/Gpt 5.5/i)).toBeInTheDocument();
+    expect(screen.getByText(/GPT 5\.5/i)).toBeInTheDocument();
   });
 
   it("renders with google model id", () => {

--- a/packages/web/src/__tests__/lib/model-display-name.test.ts
+++ b/packages/web/src/__tests__/lib/model-display-name.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { getModelDisplayName } from "@/lib/model-display-name";
+
+describe("getModelDisplayName", () => {
+  it("converts claude-sonnet-4-6 version notation correctly", () => {
+    expect(getModelDisplayName("anthropic/claude-sonnet-4-6")).toBe("Claude Sonnet 4.6");
+  });
+
+  it("converts gpt-5.5 and uppercases GPT", () => {
+    expect(getModelDisplayName("openai/gpt-5.5")).toBe("GPT 5.5");
+  });
+
+  it("converts gemini-2.5-pro", () => {
+    expect(getModelDisplayName("google/gemini-2.5-pro")).toBe("Gemini 2.5 Pro");
+  });
+
+  it("strips parameter suffix (:80b) for ollama-cloud models", () => {
+    expect(getModelDisplayName("ollama-cloud/qwen3-next:80b")).toBe("Qwen3 Next");
+  });
+
+  it("handles llama3.2 without breaking dot notation", () => {
+    expect(getModelDisplayName("ollama/llama3.2")).toBe("Llama3.2");
+  });
+});

--- a/packages/web/src/__tests__/lib/personal-agent.test.ts
+++ b/packages/web/src/__tests__/lib/personal-agent.test.ts
@@ -74,6 +74,12 @@ vi.mock("@/lib/provider-models", () => {
   };
 });
 
+// ── Mock @/lib/model-resolver ─────────────────────────────────────────────────
+const resolveModelForTemplateMock = vi.fn();
+vi.mock("@/lib/model-resolver", () => ({
+  resolveModelForTemplate: (...args: unknown[]) => resolveModelForTemplateMock(...args),
+}));
+
 // ── Mock @/lib/providers ─────────────────────────────────────────────────────
 vi.mock("@/lib/providers", () => ({
   PROVIDERS: {
@@ -520,6 +526,11 @@ describe("seedPersonalAgent", () => {
 
   it("uses the default model from provider settings when available", async () => {
     getSettingMock.mockResolvedValue("openai");
+    resolveModelForTemplateMock.mockResolvedValue({
+      model: "openai/gpt-5.4-mini",
+      reason: "balanced tier match",
+      fallbackUsed: false,
+    });
     const fakeAgent = {
       id: "agent-3",
       name: "Smithers",
@@ -597,5 +608,46 @@ describe("seedPersonalAgent", () => {
 
     expect(agent).toEqual(existingAgent);
     expect(insertMock).not.toHaveBeenCalled();
+  });
+
+  it("resolves Smithers model via resolveModelForTemplate with balanced hint when provider is configured", async () => {
+    findFirstMock.mockResolvedValue(undefined);
+    getSettingMock.mockResolvedValue("anthropic");
+    resolveModelForTemplateMock.mockResolvedValue({
+      model: "anthropic/claude-sonnet-4-6",
+      reason: "balanced tier match",
+      fallbackUsed: false,
+    });
+    const fakeAgent = {
+      id: "agent-hint-1",
+      name: "Smithers",
+      model: "anthropic/claude-sonnet-4-6",
+      ownerId: "user-1",
+      isPersonal: true,
+      createdAt: new Date(),
+    };
+    returningMock.mockResolvedValue([fakeAgent]);
+
+    const { seedPersonalAgent, SMITHERS_MODEL_HINT } = await import("@/lib/personal-agent");
+    await seedPersonalAgent("user-1");
+
+    expect(resolveModelForTemplateMock).toHaveBeenCalledWith({
+      hint: SMITHERS_MODEL_HINT,
+      provider: "anthropic",
+    });
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "anthropic/claude-sonnet-4-6",
+      })
+    );
+  });
+
+  it("exports SMITHERS_MODEL_HINT with balanced tier and tools+long-context capabilities", async () => {
+    const { SMITHERS_MODEL_HINT } = await import("@/lib/personal-agent");
+
+    expect(SMITHERS_MODEL_HINT).toEqual({
+      tier: "balanced",
+      capabilities: ["tools", "long-context"],
+    });
   });
 });

--- a/packages/web/src/__tests__/lib/personal-agent.test.ts
+++ b/packages/web/src/__tests__/lib/personal-agent.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 
 // ── Mock @/db ────────────────────────────────────────────────────────────────
 const returningMock = vi.fn();
@@ -59,20 +60,6 @@ vi.mock("@/lib/onboarding-prompt", () => ({
   getOnboardingPrompt: vi.fn().mockReturnValue("## Onboarding\n\nTest onboarding content"),
   ONBOARDING_GREETING: "Test onboarding greeting",
 }));
-
-// ── Mock @/lib/provider-models ──────────────────────────────────────────────
-vi.mock("@/lib/provider-models", () => {
-  const defaults: Record<string, string> = {
-    anthropic: "anthropic/claude-haiku-4-5-20251001",
-    openai: "openai/gpt-5.4-mini",
-    google: "google/gemini-2.5-flash",
-    "ollama-cloud": "ollama-cloud/gemini-3-flash-preview",
-    "ollama-local": "",
-  };
-  return {
-    getDefaultModel: vi.fn(async (provider: string) => defaults[provider] ?? ""),
-  };
-});
 
 // ── Mock @/lib/model-resolver ─────────────────────────────────────────────────
 const resolveModelForTemplateMock = vi.fn();
@@ -376,7 +363,7 @@ describe("createSmithersAgent", () => {
     );
   });
 
-  it("writes onboarding prompt to USER.md when no context exists", async () => {
+  it("writes onboarding prompt to USER.md when no context exists (admin)", async () => {
     getContextForAgentMock.mockResolvedValueOnce("");
     const fakeAgent = {
       id: "agent-onboard-1",
@@ -649,5 +636,31 @@ describe("seedPersonalAgent", () => {
       tier: "balanced",
       capabilities: ["tools", "long-context"],
     });
+  });
+
+  it("falls back to claude-sonnet-4-6 when resolveModelForTemplate throws TemplateCapabilityUnavailableError", async () => {
+    vi.mocked(getSettingMock).mockResolvedValue("anthropic");
+    resolveModelForTemplateMock.mockRejectedValue(
+      new TemplateCapabilityUnavailableError(["tools"], "anthropic", "https://docs.heypinchy.com")
+    );
+    const fakeAgent = {
+      id: "agent-fallback-1",
+      name: "Smithers",
+      model: "anthropic/claude-sonnet-4-6",
+      ownerId: "user-fallback",
+      isPersonal: true,
+      createdAt: new Date(),
+    };
+    returningMock.mockResolvedValue([fakeAgent]);
+
+    const { seedPersonalAgent } = await import("@/lib/personal-agent");
+    const smithers = await seedPersonalAgent("user-fallback");
+
+    expect(valuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        model: "anthropic/claude-sonnet-4-6",
+      })
+    );
+    expect(smithers.model).toBe("anthropic/claude-sonnet-4-6");
   });
 });

--- a/packages/web/src/__tests__/lib/provider-models-drift.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-drift.test.ts
@@ -18,14 +18,6 @@ describe("balanced default — drift resistance", () => {
       ];
       expect(selectDefaultModel("openai", models)).toBe("openai/gpt-6-2026-06-01");
     });
-
-    it("google: gemini-3-pro-002 beats gemini-2.5-pro-002", () => {
-      const models = [
-        { id: "google/gemini-2.5-pro-002", name: "x" },
-        { id: "google/gemini-3-pro-002", name: "x" },
-      ];
-      expect(selectDefaultModel("google", models)).toBe("google/gemini-3-pro-002");
-    });
   });
 
   describe("rejected variants never win", () => {
@@ -52,6 +44,14 @@ describe("balanced default — drift resistance", () => {
         { id: "anthropic/claude-sonnet-5-0", name: "x" },
       ];
       expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-5-0");
+    });
+
+    it("google: gemini-3-pro-002 beats gemini-2.5-pro-002", () => {
+      const models = [
+        { id: "google/gemini-2.5-pro-002", name: "x" },
+        { id: "google/gemini-3-pro-002", name: "x" },
+      ];
+      expect(selectDefaultModel("google", models)).toBe("google/gemini-3-pro-002");
     });
   });
 

--- a/packages/web/src/__tests__/lib/provider-models-drift.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-drift.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { selectDefaultModel } from "@/lib/provider-models";
+import { selectDefaultModel, BALANCED_PATTERNS } from "@/lib/provider-models";
+import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
 
 describe("balanced default — drift resistance", () => {
   describe("new date-suffix models win", () => {
@@ -76,6 +77,20 @@ describe("balanced default — drift resistance", () => {
       const noMatch = [{ id: `${provider}/something-totally-unexpected`, name: "x" }];
       expect(selectDefaultModel(provider, noMatch)).toBe(anchor);
     });
+  });
+
+  describe("BALANCED_ANCHORS match their own BALANCED_PATTERNS", () => {
+    // If an anchor doesn't match its provider's pattern, the anchor would
+    // never be selected from a live model list — only from the fallback
+    // branch. That makes the anchor a silent dead letter rather than the
+    // canonical balanced default. Lock the invariant down.
+    it.each([["anthropic"], ["openai"], ["google"], ["ollama-cloud"]] as const)(
+      "%s: anchor passes its own pattern",
+      (provider) => {
+        const anchor = BALANCED_ANCHORS[provider];
+        expect(BALANCED_PATTERNS[provider].test(anchor)).toBe(true);
+      }
+    );
   });
 
   describe("REJECT_PATTERN coverage", () => {

--- a/packages/web/src/__tests__/lib/provider-models-drift.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-drift.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from "vitest";
+import { selectDefaultModel } from "@/lib/provider-models";
+
+describe("balanced default — drift resistance", () => {
+  describe("new date-suffix models win", () => {
+    it("anthropic: claude-sonnet-5-0-20260601 beats claude-sonnet-4-6-20251001", () => {
+      const models = [
+        { id: "anthropic/claude-sonnet-4-6-20251001", name: "x" },
+        { id: "anthropic/claude-sonnet-5-0-20260601", name: "x" },
+      ];
+      expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-5-0-20260601");
+    });
+
+    it("openai: gpt-6-2026-06-01 beats gpt-5.5-2025-08-07", () => {
+      const models = [
+        { id: "openai/gpt-5.5-2025-08-07", name: "x" },
+        { id: "openai/gpt-6-2026-06-01", name: "x" },
+      ];
+      expect(selectDefaultModel("openai", models)).toBe("openai/gpt-6-2026-06-01");
+    });
+
+    it("google: gemini-3-pro-002 beats gemini-2.5-pro-002", () => {
+      const models = [
+        { id: "google/gemini-2.5-pro-002", name: "x" },
+        { id: "google/gemini-3-pro-002", name: "x" },
+      ];
+      expect(selectDefaultModel("google", models)).toBe("google/gemini-3-pro-002");
+    });
+  });
+
+  describe("rejected variants never win", () => {
+    it.each([
+      ["anthropic", "anthropic/claude-sonnet-5-0-preview", "anthropic/claude-sonnet-4-6"],
+      ["anthropic", "anthropic/claude-sonnet-5-0-beta", "anthropic/claude-sonnet-4-6"],
+      ["openai", "openai/gpt-6-thinking", "openai/gpt-5.5"],
+      ["openai", "openai/gpt-6-instant", "openai/gpt-5.5"],
+      ["openai", "openai/gpt-6-nano", "openai/gpt-5.5"],
+      ["google", "google/gemini-3-pro-exp", "google/gemini-2.5-pro"],
+    ] as const)("%s: %s does not beat %s", (provider, rejected, expected) => {
+      const models = [
+        { id: rejected, name: "x" },
+        { id: expected, name: "x" },
+      ];
+      expect(selectDefaultModel(provider, models)).toBe(expected);
+    });
+  });
+
+  describe("lexicographic tiebreaker when dates equal", () => {
+    it("anthropic: sonnet-5-0 beats sonnet-4-6 when neither has date suffix", () => {
+      const models = [
+        { id: "anthropic/claude-sonnet-4-6", name: "x" },
+        { id: "anthropic/claude-sonnet-5-0", name: "x" },
+      ];
+      expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-5-0");
+    });
+  });
+
+  describe("regression — gpt-4o-mini bug", () => {
+    it("OpenAI: gpt-5.5 wins over gpt-4o-mini even when both appear in candidates", () => {
+      const models = [
+        { id: "openai/gpt-4o-mini", name: "x" },
+        { id: "openai/gpt-4o-mini-2024-07-18", name: "x" },
+        { id: "openai/gpt-5.5", name: "x" },
+      ];
+      expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.5");
+    });
+  });
+
+  describe("anchor fallback when no pattern match", () => {
+    it.each([
+      ["anthropic", "anthropic/claude-sonnet-4-6"],
+      ["openai", "openai/gpt-5.5"],
+      ["google", "google/gemini-2.5-pro"],
+      ["ollama-cloud", "ollama-cloud/qwen3-next:80b"],
+    ] as const)("%s: empty candidate list → anchor %s", (provider, anchor) => {
+      const noMatch = [{ id: `${provider}/something-totally-unexpected`, name: "x" }];
+      expect(selectDefaultModel(provider, noMatch)).toBe(anchor);
+    });
+  });
+
+  describe("REJECT_PATTERN coverage", () => {
+    const requiredSuffixes = [
+      "preview",
+      "beta",
+      "alpha",
+      "rc",
+      "exp",
+      "experimental",
+      "thinking",
+      "instant",
+      "nano",
+      "search",
+      "realtime",
+      "audio",
+      "vision-only",
+    ];
+    it.each(requiredSuffixes)("rejects -%s suffix", (suffix) => {
+      const id = `openai/gpt-6-${suffix}`;
+      const models = [
+        { id, name: "x" },
+        { id: "openai/gpt-5.5", name: "x" },
+      ];
+      expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.5");
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -815,6 +815,23 @@ describe("selectDefaultModel — lexikalischer Tiebreaker", () => {
     // 20251001 > 0 → date wins, auch wenn haiku-5-0 lexikalisch größer
     expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
   });
+
+  it("google: flash-lite beats flash lexicographically (temporary — resolved in Phase 2 when pattern switches to pro-only)", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    // Current fast-tier pattern /gemini-.*-flash/ has no $ anchor, so it matches
+    // both flash and flash-lite (flash-lite contains "flash" as a substring).
+    // Lexicographic tiebreaker picks flash-lite over flash since
+    // "-lite" makes the string longer. This is expected behavior with
+    // the current pattern; Phase 2 switches to pro-only which avoids
+    // this class of ambiguity entirely.
+    const models = [
+      { id: "google/gemini-2.5-flash", name: "x" },
+      { id: "google/gemini-2.5-flash-lite", name: "x" },
+    ];
+    const result = selectDefaultModel("google", models);
+    // Document actual behavior — don't assert which is "better"
+    expect(result).toBe("google/gemini-2.5-flash-lite");
+  });
 });
 
 describe("getDefaultModel", () => {

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -53,6 +53,7 @@ import {
   getOllamaLocalModels,
   fetchOllamaLocalModelsFromUrl,
   extractModelDate,
+  isRejectedVariant,
 } from "@/lib/provider-models";
 import { getSetting } from "@/lib/settings";
 
@@ -1213,5 +1214,35 @@ describe("extractModelDate", () => {
 
   it("returns 0 when YYYY-MM-DD is not at the end (suffix follows)", () => {
     expect(extractModelDate("openai/gpt-5-mini-2025-08-07-preview")).toBe(0);
+  });
+});
+
+describe("isRejectedVariant", () => {
+  it.each([
+    "openai/gpt-5.5-preview",
+    "openai/gpt-5.5-thinking",
+    "openai/gpt-5.5-instant",
+    "openai/gpt-5.5-nano",
+    "openai/gpt-5.5-search-preview",
+    "openai/gpt-5.5-realtime",
+    "openai/gpt-5.5-audio",
+    "anthropic/claude-sonnet-5-0-beta",
+    "anthropic/claude-sonnet-5-0-alpha",
+    "anthropic/claude-sonnet-5-0-rc",
+    "google/gemini-3-pro-exp",
+    "google/gemini-3-pro-experimental",
+  ])("rejects %s", (id) => {
+    expect(isRejectedVariant(id)).toBe(true);
+  });
+
+  it.each([
+    "openai/gpt-5.5",
+    "openai/gpt-5.5-2025-08-07",
+    "anthropic/claude-sonnet-4-6",
+    "anthropic/claude-sonnet-4-6-20251001",
+    "google/gemini-2.5-pro",
+    "google/gemini-2.5-pro-002",
+  ])("does not reject %s", (id) => {
+    expect(isRejectedVariant(id)).toBe(false);
   });
 });

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -861,7 +861,7 @@ describe("getDefaultModel", () => {
     expect(model).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("falls back to BALANCED_ANCHORS when provider has no API key", async () => {
+  it("returns provider default model when no models are available", async () => {
     vi.mocked(getSetting).mockResolvedValue(null);
 
     const { getDefaultModel } = await import("@/lib/provider-models");

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -1210,4 +1210,8 @@ describe("extractModelDate", () => {
   it("returns 0 for non-date suffixes", () => {
     expect(extractModelDate("google/gemini-2.5-pro-002")).toBe(0);
   });
+
+  it("returns 0 when YYYY-MM-DD is not at the end (suffix follows)", () => {
+    expect(extractModelDate("openai/gpt-5-mini-2025-08-07-preview")).toBe(0);
+  });
 });

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -795,6 +795,28 @@ describe("selectDefaultModel", () => {
   });
 });
 
+describe("selectDefaultModel — lexikalischer Tiebreaker", () => {
+  it("picks lexicographically greater model when dates are equal (both 0)", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "anthropic/claude-haiku-4-5", name: "x" },
+      { id: "anthropic/claude-haiku-5-0", name: "x" },
+    ];
+    // claude-haiku-5-0 > claude-haiku-4-5 lexikalisch → sollte 5-0 gewinnen
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-5-0");
+  });
+
+  it("date-suffix still beats no-suffix when both match pattern", async () => {
+    const { selectDefaultModel } = await import("@/lib/provider-models");
+    const models = [
+      { id: "anthropic/claude-haiku-4-5-20251001", name: "x" },
+      { id: "anthropic/claude-haiku-5-0", name: "x" },
+    ];
+    // 20251001 > 0 → date wins, auch wenn haiku-5-0 lexikalisch größer
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+});
+
 describe("getDefaultModel", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -52,6 +52,7 @@ import {
   resetCache,
   getOllamaLocalModels,
   fetchOllamaLocalModelsFromUrl,
+  extractModelDate,
 } from "@/lib/provider-models";
 import { getSetting } from "@/lib/settings";
 
@@ -1190,5 +1191,23 @@ describe("fetchOllamaLocalModelsFromUrl timeout behavior", () => {
     // The aborted show call should be skipped, not propagated, leaving
     // an empty model list rather than an unhandled exception.
     expect(result).toEqual([]);
+  });
+});
+
+describe("extractModelDate", () => {
+  it("parses YYYYMMDD suffix (Anthropic format)", () => {
+    expect(extractModelDate("anthropic/claude-haiku-4-5-20251001")).toBe(20251001);
+  });
+
+  it("parses YYYY-MM-DD suffix (OpenAI format)", () => {
+    expect(extractModelDate("openai/gpt-5-mini-2025-08-07")).toBe(20250807);
+  });
+
+  it("returns 0 when no date suffix is present", () => {
+    expect(extractModelDate("openai/gpt-4o-mini")).toBe(0);
+  });
+
+  it("returns 0 for non-date suffixes", () => {
+    expect(extractModelDate("google/gemini-2.5-pro-002")).toBe(0);
   });
 });

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -6,28 +6,28 @@ vi.mock("@/lib/providers", () => ({
       name: "Anthropic",
       settingsKey: "anthropic_api_key",
       envVar: "ANTHROPIC_API_KEY",
-      defaultModel: "anthropic/claude-haiku-4-5-20251001",
+      defaultModel: "anthropic/claude-sonnet-4-6",
       placeholder: "sk-ant-...",
     },
     openai: {
       name: "OpenAI",
       settingsKey: "openai_api_key",
       envVar: "OPENAI_API_KEY",
-      defaultModel: "openai/gpt-5.4-mini",
+      defaultModel: "openai/gpt-5.5",
       placeholder: "sk-...",
     },
     google: {
       name: "Google",
       settingsKey: "google_api_key",
       envVar: "GEMINI_API_KEY",
-      defaultModel: "google/gemini-2.5-flash",
+      defaultModel: "google/gemini-2.5-pro",
       placeholder: "AIza...",
     },
     "ollama-cloud": {
       name: "Ollama Cloud",
       settingsKey: "ollama_cloud_api_key",
       envVar: "OLLAMA_CLOUD_API_KEY",
-      defaultModel: "ollama-cloud/gemini-3-flash-preview",
+      defaultModel: "ollama-cloud/qwen3-next:80b",
       placeholder: "sk-...",
     },
     "ollama-local": {
@@ -54,6 +54,7 @@ import {
   fetchOllamaLocalModelsFromUrl,
   extractModelDate,
   isRejectedVariant,
+  selectDefaultModel,
 } from "@/lib/provider-models";
 import { getSetting } from "@/lib/settings";
 
@@ -716,82 +717,82 @@ describe("fetchProviderModels", () => {
 });
 
 describe("selectDefaultModel", () => {
-  it("selects the smallest Anthropic model (haiku pattern)", async () => {
+  it("selects the balanced-tier Anthropic model (sonnet pattern)", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
       { id: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7" },
       { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
       { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
     ];
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("selects the mini OpenAI model (gpt-*-mini pattern)", async () => {
+  it("selects the balanced-tier OpenAI model (gpt-5+ pattern)", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
       { id: "openai/gpt-5.4", name: "gpt-5.4" },
       { id: "openai/gpt-5.4-mini", name: "gpt-5.4-mini" },
       { id: "openai/o1", name: "o1" },
     ];
-    expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.4-mini");
+    expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.4");
   });
 
-  it("selects the flash Google model (gemini-*-flash pattern)", async () => {
+  it("selects the pro Google model (gemini-*-pro pattern)", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
       { id: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro" },
       { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
     ];
-    expect(selectDefaultModel("google", models)).toBe("google/gemini-2.5-flash");
+    expect(selectDefaultModel("google", models)).toBe("google/gemini-2.5-pro");
   });
 
-  it("falls back to hardcoded default when all flash candidates are preview versions (ollama)", async () => {
+  it("falls back to BALANCED_ANCHORS when no candidate matches balanced pattern (ollama-cloud)", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
       { id: "ollama-cloud/kimi-k2.5", name: "Kimi K2.5" },
       { id: "ollama-cloud/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
       { id: "ollama-cloud/qwen3.5:397b", name: "Qwen 3.5 397B" },
     ];
-    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/gemini-3-flash-preview");
+    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/qwen3-next:80b");
   });
 
   it("prefers stable versions over preview versions", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
-      { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
-      { id: "anthropic/claude-haiku-4-5-20251001-preview", name: "Claude Haiku 4.5 Preview" },
+      { id: "anthropic/claude-sonnet-4-6", name: "Claude Sonnet 4.6" },
+      { id: "anthropic/claude-sonnet-4-6-preview", name: "Claude Sonnet 4.6 Preview" },
     ];
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("selects the most recent model when multiple versions match", async () => {
+  it("selects the most recent balanced-tier model when multiple versions match", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
-      { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
-      { id: "anthropic/claude-3-haiku-20240307", name: "Claude 3 Haiku" },
+      { id: "anthropic/claude-sonnet-4-6-20251001", name: "Claude Sonnet 4.6 (Oct)" },
+      { id: "anthropic/claude-sonnet-4-6-20240307", name: "Claude Sonnet 4.6 (Mar)" },
     ];
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6-20251001");
   });
 
-  it("selects the most recent model regardless of list order", async () => {
+  it("selects the most recent balanced-tier model regardless of list order", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
-      { id: "anthropic/claude-3-haiku-20240307", name: "Claude 3 Haiku" },
-      { id: "anthropic/claude-haiku-4-5-20251001", name: "Claude Haiku 4.5" },
+      { id: "anthropic/claude-sonnet-4-6-20240307", name: "Claude Sonnet 4.6 (Mar)" },
+      { id: "anthropic/claude-sonnet-4-6-20251001", name: "Claude Sonnet 4.6 (Oct)" },
     ];
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6-20251001");
   });
 
-  it("falls back to hardcoded default when no pattern matches", async () => {
+  it("falls back to BALANCED_ANCHORS when no pattern matches", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [{ id: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7" }];
-    // No haiku in the list — falls back to PROVIDERS[provider].defaultModel
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    // No sonnet in the list — falls back to BALANCED_ANCHORS
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("falls back to hardcoded default when model list is empty", async () => {
+  it("falls back to BALANCED_ANCHORS when model list is empty", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
-    expect(selectDefaultModel("openai", [])).toBe("openai/gpt-5.4-mini");
+    expect(selectDefaultModel("openai", [])).toBe("openai/gpt-5.5");
   });
 });
 
@@ -799,38 +800,33 @@ describe("selectDefaultModel — lexikalischer Tiebreaker", () => {
   it("picks lexicographically greater model when dates are equal (both 0)", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
-      { id: "anthropic/claude-haiku-4-5", name: "x" },
-      { id: "anthropic/claude-haiku-5-0", name: "x" },
+      { id: "anthropic/claude-sonnet-4-5", name: "x" },
+      { id: "anthropic/claude-sonnet-5-0", name: "x" },
     ];
-    // claude-haiku-5-0 > claude-haiku-4-5 lexikalisch → sollte 5-0 gewinnen
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-5-0");
+    // claude-sonnet-5-0 > claude-sonnet-4-5 lexikalisch → sollte 5-0 gewinnen
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-5-0");
   });
 
   it("date-suffix still beats no-suffix when both match pattern", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
     const models = [
-      { id: "anthropic/claude-haiku-4-5-20251001", name: "x" },
-      { id: "anthropic/claude-haiku-5-0", name: "x" },
+      { id: "anthropic/claude-sonnet-4-6-20251001", name: "x" },
+      { id: "anthropic/claude-sonnet-5-0", name: "x" },
     ];
-    // 20251001 > 0 → date wins, auch wenn haiku-5-0 lexikalisch größer
-    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-haiku-4-5-20251001");
+    // 20251001 > 0 → date wins, auch wenn sonnet-5-0 lexikalisch größer
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6-20251001");
   });
 
-  it("google: flash-lite beats flash lexicographically (temporary — resolved in Phase 2 when pattern switches to pro-only)", async () => {
+  it("google: pro pattern anchored — flash and flash-lite do not match pro pattern", async () => {
     const { selectDefaultModel } = await import("@/lib/provider-models");
-    // Current fast-tier pattern /gemini-.*-flash/ has no $ anchor, so it matches
-    // both flash and flash-lite (flash-lite contains "flash" as a substring).
-    // Lexicographic tiebreaker picks flash-lite over flash since
-    // "-lite" makes the string longer. This is expected behavior with
-    // the current pattern; Phase 2 switches to pro-only which avoids
-    // this class of ambiguity entirely.
+    // Balanced-tier pattern /gemini-[2-9]...-pro/ is anchored, so flash and
+    // flash-lite don't match. Only pro variants are candidates.
     const models = [
       { id: "google/gemini-2.5-flash", name: "x" },
       { id: "google/gemini-2.5-flash-lite", name: "x" },
+      { id: "google/gemini-2.5-pro", name: "x" },
     ];
-    const result = selectDefaultModel("google", models);
-    // Document actual behavior — don't assert which is "better"
-    expect(result).toBe("google/gemini-2.5-flash-lite");
+    expect(selectDefaultModel("google", models)).toBe("google/gemini-2.5-pro");
   });
 });
 
@@ -841,7 +837,7 @@ describe("getDefaultModel", () => {
     vi.mocked(getSetting).mockResolvedValue(null);
   });
 
-  it("returns dynamically selected model from live model list", async () => {
+  it("returns dynamically selected balanced-tier model from live model list", async () => {
     vi.mocked(getSetting).mockImplementation(async (key: string) => {
       if (key === "anthropic_api_key") return "sk-ant-test-key";
       return null;
@@ -862,15 +858,15 @@ describe("getDefaultModel", () => {
 
     const { getDefaultModel } = await import("@/lib/provider-models");
     const model = await getDefaultModel("anthropic");
-    expect(model).toBe("anthropic/claude-haiku-4-5-20251001");
+    expect(model).toBe("anthropic/claude-sonnet-4-6");
   });
 
-  it("falls back to hardcoded default when provider has no API key", async () => {
+  it("falls back to BALANCED_ANCHORS when provider has no API key", async () => {
     vi.mocked(getSetting).mockResolvedValue(null);
 
     const { getDefaultModel } = await import("@/lib/provider-models");
     const model = await getDefaultModel("openai");
-    expect(model).toBe("openai/gpt-5.4-mini");
+    expect(model).toBe("openai/gpt-5.5");
   });
 });
 
@@ -1253,6 +1249,51 @@ describe("extractModelDate", () => {
 
   it("returns 0 when YYYY-MM-DD is not at the end (suffix follows)", () => {
     expect(extractModelDate("openai/gpt-5-mini-2025-08-07-preview")).toBe(0);
+  });
+});
+
+describe("selectDefaultModel — balanced-tier defaults", () => {
+  it("picks Sonnet (not Haiku) for Anthropic", () => {
+    const models = [
+      { id: "anthropic/claude-opus-4-7", name: "Opus" },
+      { id: "anthropic/claude-sonnet-4-6", name: "Sonnet" },
+      { id: "anthropic/claude-haiku-4-5-20251001", name: "Haiku" },
+    ];
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6");
+  });
+
+  it("picks GPT-5 (not gpt-4o-mini) for OpenAI", () => {
+    const models = [
+      { id: "openai/gpt-4o-mini", name: "x" },
+      { id: "openai/gpt-4o-mini-2024-07-18", name: "x" },
+      { id: "openai/gpt-5", name: "x" },
+      { id: "openai/gpt-5.5", name: "x" },
+      { id: "openai/gpt-5-mini-2025-08-07", name: "x" },
+    ];
+    expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.5");
+  });
+
+  it("picks Gemini-Pro (not Flash) for Google", () => {
+    const models = [
+      { id: "google/gemini-2.5-pro", name: "x" },
+      { id: "google/gemini-2.5-flash", name: "x" },
+      { id: "google/gemini-2.5-flash-lite", name: "x" },
+    ];
+    expect(selectDefaultModel("google", models)).toBe("google/gemini-2.5-pro");
+  });
+
+  it("rejects -thinking/-preview/-experimental variants", () => {
+    const models = [
+      { id: "openai/gpt-5.5-thinking", name: "x" },
+      { id: "openai/gpt-5.5", name: "x" },
+      { id: "openai/gpt-5.5-preview", name: "x" },
+    ];
+    expect(selectDefaultModel("openai", models)).toBe("openai/gpt-5.5");
+  });
+
+  it("falls back to BALANCED_ANCHORS when no candidate matches", () => {
+    const models = [{ id: "anthropic/claude-experimental-foo", name: "x" }];
+    expect(selectDefaultModel("anthropic", models)).toBe("anthropic/claude-sonnet-4-6");
   });
 });
 

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -1223,14 +1223,22 @@ describe("isRejectedVariant", () => {
     "openai/gpt-5.5-thinking",
     "openai/gpt-5.5-instant",
     "openai/gpt-5.5-nano",
+    "openai/gpt-5.5-search",
     "openai/gpt-5.5-search-preview",
     "openai/gpt-5.5-realtime",
     "openai/gpt-5.5-audio",
     "anthropic/claude-sonnet-5-0-beta",
     "anthropic/claude-sonnet-5-0-alpha",
     "anthropic/claude-sonnet-5-0-rc",
+    "anthropic/claude-sonnet-5-0-vision-only",
     "google/gemini-3-pro-exp",
     "google/gemini-3-pro-experimental",
+    // Ollama Cloud reasoning/fast-tier models: correctly rejected for balanced-default
+    // selection. kimi-k2-thinking is a reasoning model; nemotron-3-nano is fast/cheap.
+    // They appear in the allowlist because they are tool-capable, but isRejectedVariant
+    // intentionally filters them from the auto-selected balanced default.
+    "ollama-cloud/kimi-k2-thinking",
+    "ollama-cloud/nemotron-3-nano:30b",
   ])("rejects %s", (id) => {
     expect(isRejectedVariant(id)).toBe(true);
   });

--- a/packages/web/src/__tests__/lib/providers.test.ts
+++ b/packages/web/src/__tests__/lib/providers.test.ts
@@ -128,11 +128,11 @@ describe("validateProviderKey", () => {
 });
 
 describe("PROVIDERS", () => {
-  it("should have default models for all providers", () => {
-    expect(PROVIDERS.anthropic.defaultModel).toBe("anthropic/claude-haiku-4-5-20251001");
-    expect(PROVIDERS.openai.defaultModel).toBe("openai/gpt-5.4-mini");
-    expect(PROVIDERS.google.defaultModel).toBe("google/gemini-2.5-flash");
-    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/gemini-3-flash-preview");
+  it("should have balanced-tier default models for all providers", () => {
+    expect(PROVIDERS.anthropic.defaultModel).toBe("anthropic/claude-sonnet-4-6");
+    expect(PROVIDERS.openai.defaultModel).toBe("openai/gpt-5.5");
+    expect(PROVIDERS.google.defaultModel).toBe("google/gemini-2.5-pro");
+    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/qwen3-next:80b");
   });
 
   it("should have settings keys for all providers", () => {

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -9,7 +9,9 @@ import {
 } from "@/lib/providers";
 import { getSetting, setSetting } from "@/lib/settings";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
-import { resetCache, getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import { resetCache, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import { resolveModelForTemplate } from "@/lib/model-resolver";
+import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
@@ -132,8 +134,11 @@ export async function POST(request: NextRequest) {
   if (isFirstProvider) {
     const smithers = await db.query.agents.findFirst();
     if (smithers) {
-      const defaultModel = await getDefaultModel(provider as ProviderName);
-      await db.update(agents).set({ model: defaultModel }).where(eq(agents.id, smithers.id));
+      const resolved = await resolveModelForTemplate({
+        hint: SMITHERS_MODEL_HINT,
+        provider: provider as ProviderName,
+      });
+      await db.update(agents).set({ model: resolved.model }).where(eq(agents.id, smithers.id));
     }
   }
 

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -11,6 +11,7 @@ import { getSetting, setSetting } from "@/lib/settings";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { resetCache, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
+import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
 import { db } from "@/db";
 import { agents } from "@/db/schema";
@@ -134,11 +135,18 @@ export async function POST(request: NextRequest) {
   if (isFirstProvider) {
     const smithers = await db.query.agents.findFirst();
     if (smithers) {
-      const resolved = await resolveModelForTemplate({
-        hint: SMITHERS_MODEL_HINT,
-        provider: provider as ProviderName,
-      });
-      await db.update(agents).set({ model: resolved.model }).where(eq(agents.id, smithers.id));
+      try {
+        const resolved = await resolveModelForTemplate({
+          hint: SMITHERS_MODEL_HINT,
+          provider: provider as ProviderName,
+        });
+        await db.update(agents).set({ model: resolved.model }).where(eq(agents.id, smithers.id));
+      } catch (err) {
+        if (!(err instanceof TemplateCapabilityUnavailableError)) {
+          throw err;
+        }
+        // Provider has no model matching Smithers' hint — keep existing model.
+      }
     }
   }
 

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -9,13 +9,15 @@ import { CheckCircle2 } from "lucide-react";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { BALANCED_ANCHORS } from "@/lib/provider-models";
 
 export default function SetupProviderPage() {
   const router = useRouter();
   const [configuredProvider, setConfiguredProvider] = useState<ProviderName | null>(null);
 
   if (configuredProvider) {
-    const defaultModel = PROVIDERS[configuredProvider].defaultModel;
+    const defaultModel =
+      BALANCED_ANCHORS[configuredProvider] || PROVIDERS[configuredProvider].defaultModel;
     return (
       <div className="min-h-screen flex items-center justify-center px-4">
         <div className="w-full max-w-md flex flex-col items-center gap-6">

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -1,12 +1,47 @@
 "use client";
 
+import { useState } from "react";
 import { useRouter } from "next/navigation";
 import Image from "next/image";
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { CheckCircle2 } from "lucide-react";
 import { ProviderKeyForm } from "@/components/provider-key-form";
+import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
+import { PROVIDERS, type ProviderName } from "@/lib/providers";
 
 export default function SetupProviderPage() {
   const router = useRouter();
+  const [configuredProvider, setConfiguredProvider] = useState<ProviderName | null>(null);
+
+  if (configuredProvider) {
+    const defaultModel = PROVIDERS[configuredProvider].defaultModel;
+    return (
+      <div className="min-h-screen flex items-center justify-center px-4">
+        <div className="w-full max-w-md flex flex-col items-center gap-6">
+          <Image src="/pinchy-logo.png" alt="Pinchy" width={80} height={85} priority />
+
+          <Card className="w-full">
+            <CardHeader className="text-center">
+              <div className="flex justify-center mb-2">
+                <CheckCircle2 className="size-12 text-primary" />
+              </div>
+              <CardTitle>Provider connected!</CardTitle>
+              <CardDescription>
+                Your {PROVIDERS[configuredProvider].name} provider is configured and ready.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <SmithersModelInfoLine modelId={defaultModel} />
+              <Button onClick={() => router.push("/")} className="w-full">
+                Continue to Pinchy
+              </Button>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen flex items-center justify-center px-4">
@@ -21,7 +56,15 @@ export default function SetupProviderPage() {
             </CardDescription>
           </CardHeader>
           <CardContent>
-            <ProviderKeyForm onSuccess={() => router.push("/")} />
+            <ProviderKeyForm
+              onSuccess={(provider) => {
+                if (provider) {
+                  setConfiguredProvider(provider);
+                } else {
+                  router.push("/");
+                }
+              }}
+            />
           </CardContent>
         </Card>
       </div>

--- a/packages/web/src/app/setup/provider/page.tsx
+++ b/packages/web/src/app/setup/provider/page.tsx
@@ -9,7 +9,7 @@ import { CheckCircle2 } from "lucide-react";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { SmithersModelInfoLine } from "@/components/setup/smithers-model-info-line";
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
-import { BALANCED_ANCHORS } from "@/lib/provider-models";
+import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
 
 export default function SetupProviderPage() {
   const router = useRouter();

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -172,7 +172,7 @@ function renderStepWithLink(label: string, link: { text: string; url: string }) 
 }
 
 interface ProviderKeyFormProps {
-  onSuccess: () => void;
+  onSuccess: (provider?: ProviderName) => void;
   submitLabel?: string;
   configuredProviders?: Record<string, { configured: boolean; hint?: string }>;
   defaultProvider?: string | null;
@@ -253,7 +253,7 @@ export function ProviderKeyForm({
       form.reset();
       toast.success(isUrlProvider ? "URL saved" : "API key saved");
       triggerRestart();
-      onSuccess();
+      onSuccess(provider);
     } catch (err) {
       const message = err instanceof Error ? err.message : "Setup failed";
       setValidationStatus("error");
@@ -434,7 +434,7 @@ export function ProviderKeyForm({
                             throw new Error(data.error || "Failed to remove key");
                           }
                           triggerRestart();
-                          onSuccess();
+                          onSuccess(provider!);
                         } catch (err) {
                           toast.error(err instanceof Error ? err.message : "Failed to remove key");
                         } finally {

--- a/packages/web/src/components/setup/smithers-model-info-line.tsx
+++ b/packages/web/src/components/setup/smithers-model-info-line.tsx
@@ -1,0 +1,18 @@
+import Link from "next/link";
+import { getModelDisplayName } from "@/lib/model-display-name";
+
+interface SmithersModelInfoLineProps {
+  modelId: string;
+}
+
+export function SmithersModelInfoLine({ modelId }: SmithersModelInfoLineProps) {
+  return (
+    <p className="text-sm text-muted-foreground mt-2">
+      Smithers will use {getModelDisplayName(modelId)}. You can change this in{" "}
+      <Link href="/settings/agents" className="underline">
+        Agent Settings
+      </Link>
+      .
+    </p>
+  );
+}

--- a/packages/web/src/lib/model-display-name.ts
+++ b/packages/web/src/lib/model-display-name.ts
@@ -1,0 +1,13 @@
+/**
+ * Convert a provider-prefixed model ID to a human-readable display name.
+ *
+ * Examples:
+ *   "anthropic/claude-sonnet-4-6"  → "Claude Sonnet 4.6"
+ *   "openai/gpt-5.5"               → "Gpt 5.5"
+ *   "google/gemini-2.5-pro"        → "Gemini 2.5 Pro"
+ *   "ollama/llama3.2"              → "Llama3.2"
+ */
+export function getModelDisplayName(modelId: string): string {
+  const withoutPrefix = modelId.split("/").slice(1).join("/");
+  return withoutPrefix.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+}

--- a/packages/web/src/lib/model-display-name.ts
+++ b/packages/web/src/lib/model-display-name.ts
@@ -3,11 +3,24 @@
  *
  * Examples:
  *   "anthropic/claude-sonnet-4-6"  → "Claude Sonnet 4.6"
- *   "openai/gpt-5.5"               → "Gpt 5.5"
+ *   "openai/gpt-5.5"               → "GPT 5.5"
  *   "google/gemini-2.5-pro"        → "Gemini 2.5 Pro"
+ *   "ollama-cloud/qwen3-next:80b"  → "Qwen3 Next"
  *   "ollama/llama3.2"              → "Llama3.2"
  */
 export function getModelDisplayName(modelId: string): string {
+  // Strip provider prefix (e.g. "anthropic/")
   const withoutPrefix = modelId.split("/").slice(1).join("/");
-  return withoutPrefix.replace(/-/g, " ").replace(/\b\w/g, (c) => c.toUpperCase());
+
+  // Remove parameter suffix (e.g. ":80b" for ollama models)
+  const withoutSuffix = withoutPrefix.split(":")[0];
+
+  // Replace hyphens between digits with dots (version notation: 4-6 → 4.6)
+  const withVersionDots = withoutSuffix.replace(/(\d)-(\d)/g, "$1.$2");
+
+  // Replace remaining hyphens with spaces
+  const withSpaces = withVersionDots.replace(/-/g, " ");
+
+  // Capitalize first letter of each word, handle known acronyms
+  return withSpaces.replace(/\b\w/g, (c) => c.toUpperCase()).replace(/\bGpt\b/g, "GPT");
 }

--- a/packages/web/src/lib/model-resolver/__tests__/balanced-tier-sync.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/balanced-tier-sync.test.ts
@@ -1,0 +1,28 @@
+/**
+ * Drift guard: ensure model-resolver balanced-tier resolver outputs stay
+ * in sync with BALANCED_ANCHORS (used in the setup wizard UI and
+ * seedPersonalAgent). When a BALANCED_ANCHORS value is updated, the
+ * corresponding provider resolver must be updated too, and vice versa.
+ */
+import { describe, expect, it } from "vitest";
+import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
+import { resolveAnthropic } from "@/lib/model-resolver/providers/anthropic";
+import { resolveOpenAI } from "@/lib/model-resolver/providers/openai";
+import { resolveGoogle } from "@/lib/model-resolver/providers/google";
+
+describe("balanced-tier sync: resolver outputs match BALANCED_ANCHORS", () => {
+  it("anthropic balanced resolver output matches BALANCED_ANCHORS[anthropic]", () => {
+    const r = resolveAnthropic({ tier: "balanced" });
+    expect(r.model).toBe(BALANCED_ANCHORS["anthropic"]);
+  });
+
+  it("openai balanced resolver output matches BALANCED_ANCHORS[openai]", () => {
+    const r = resolveOpenAI({ tier: "balanced" });
+    expect(r.model).toBe(BALANCED_ANCHORS["openai"]);
+  });
+
+  it("google balanced resolver output matches BALANCED_ANCHORS[google]", () => {
+    const r = resolveGoogle({ tier: "balanced" });
+    expect(r.model).toBe(BALANCED_ANCHORS["google"]);
+  });
+});

--- a/packages/web/src/lib/model-resolver/__tests__/google.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/google.test.ts
@@ -8,9 +8,9 @@ describe("resolveGoogle", () => {
     expect(r.fallbackUsed).toBe(false);
   });
 
-  it("maps tier=balanced to gemini-2.5-flash (Google's balanced stable)", () => {
+  it("maps tier=balanced to gemini-2.5-pro (Google's balanced stable, matches BALANCED_ANCHORS)", () => {
     const r = resolveGoogle({ tier: "balanced" });
-    expect(r.model).toBe("google/gemini-2.5-flash");
+    expect(r.model).toBe("google/gemini-2.5-pro");
   });
 
   it("maps tier=reasoning to gemini-2.5-pro (Google's most-advanced stable)", () => {

--- a/packages/web/src/lib/model-resolver/__tests__/openai.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/openai.test.ts
@@ -8,9 +8,9 @@ describe("resolveOpenAI", () => {
     expect(r.fallbackUsed).toBe(false);
   });
 
-  it("maps tier=balanced to gpt-5.4", () => {
+  it("maps tier=balanced to gpt-5.5 (matches BALANCED_ANCHORS)", () => {
     const r = resolveOpenAI({ tier: "balanced" });
-    expect(r.model).toBe("openai/gpt-5.4");
+    expect(r.model).toBe("openai/gpt-5.5");
   });
 
   it("maps tier=reasoning to gpt-5.5", () => {

--- a/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/template-integration.test.ts
@@ -50,8 +50,8 @@ const CASES: Array<{ templateId: string; provider: ProviderName; expected: strin
     provider: "anthropic",
     expected: "anthropic/claude-sonnet-4-6",
   },
-  { templateId: "contract-analyzer", provider: "openai", expected: "openai/gpt-5.4" },
-  { templateId: "contract-analyzer", provider: "google", expected: "google/gemini-2.5-flash" },
+  { templateId: "contract-analyzer", provider: "openai", expected: "openai/gpt-5.5" },
+  { templateId: "contract-analyzer", provider: "google", expected: "google/gemini-2.5-pro" },
 ];
 
 describe("template + provider resolves to expected model", () => {

--- a/packages/web/src/lib/model-resolver/providers/google.ts
+++ b/packages/web/src/lib/model-resolver/providers/google.ts
@@ -2,7 +2,7 @@ import type { ModelHint, ModelTier, ResolverResult } from "../types";
 
 const TIER_MAP: Record<ModelTier, string> = {
   fast: "google/gemini-2.5-flash-lite",
-  balanced: "google/gemini-2.5-flash",
+  balanced: "google/gemini-2.5-pro",
   reasoning: "google/gemini-2.5-pro",
 };
 

--- a/packages/web/src/lib/model-resolver/providers/openai.ts
+++ b/packages/web/src/lib/model-resolver/providers/openai.ts
@@ -2,7 +2,7 @@ import type { ModelHint, ModelTier, ResolverResult } from "../types";
 
 const TIER_MAP: Record<ModelTier, string> = {
   fast: "openai/gpt-5.4-mini",
-  balanced: "openai/gpt-5.4",
+  balanced: "openai/gpt-5.5",
   reasoning: "openai/gpt-5.5",
 };
 

--- a/packages/web/src/lib/personal-agent.ts
+++ b/packages/web/src/lib/personal-agent.ts
@@ -9,9 +9,15 @@ import {
 import { getContextForAgent } from "@/lib/context-sync";
 import { getSetting } from "@/lib/settings";
 import { type ProviderName } from "@/lib/providers";
-import { getDefaultModel } from "@/lib/provider-models";
+import { resolveModelForTemplate } from "@/lib/model-resolver";
+import type { ModelHint } from "@/lib/model-resolver/types";
 import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
 import { getOnboardingPrompt, ONBOARDING_GREETING } from "@/lib/onboarding-prompt";
+
+export const SMITHERS_MODEL_HINT: ModelHint = {
+  tier: "balanced",
+  capabilities: ["tools", "long-context"],
+};
 
 interface CreateSmithersOptions {
   model: string;
@@ -72,9 +78,16 @@ export async function seedPersonalAgent(userId: string, isAdmin = false) {
   if (existing) return existing;
 
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
-  const model = defaultProvider
-    ? await getDefaultModel(defaultProvider)
-    : "anthropic/claude-sonnet-4-6";
+  let model: string;
+  if (defaultProvider) {
+    const resolved = await resolveModelForTemplate({
+      hint: SMITHERS_MODEL_HINT,
+      provider: defaultProvider,
+    });
+    model = resolved.model;
+  } else {
+    model = "anthropic/claude-sonnet-4-6";
+  }
 
   return createSmithersAgent({ model, ownerId: userId, isPersonal: true, isAdmin });
 }

--- a/packages/web/src/lib/personal-agent.ts
+++ b/packages/web/src/lib/personal-agent.ts
@@ -11,6 +11,7 @@ import { getSetting } from "@/lib/settings";
 import { type ProviderName } from "@/lib/providers";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
 import type { ModelHint } from "@/lib/model-resolver/types";
+import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
 import { getOnboardingPrompt, ONBOARDING_GREETING } from "@/lib/onboarding-prompt";
 
@@ -80,11 +81,19 @@ export async function seedPersonalAgent(userId: string, isAdmin = false) {
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
   let model: string;
   if (defaultProvider) {
-    const resolved = await resolveModelForTemplate({
-      hint: SMITHERS_MODEL_HINT,
-      provider: defaultProvider,
-    });
-    model = resolved.model;
+    try {
+      const resolved = await resolveModelForTemplate({
+        hint: SMITHERS_MODEL_HINT,
+        provider: defaultProvider,
+      });
+      model = resolved.model;
+    } catch (err) {
+      if (err instanceof TemplateCapabilityUnavailableError) {
+        model = "anthropic/claude-sonnet-4-6";
+      } else {
+        throw err;
+      }
+    }
   } else {
     model = "anthropic/claude-sonnet-4-6";
   }

--- a/packages/web/src/lib/provider-model-constants.ts
+++ b/packages/web/src/lib/provider-model-constants.ts
@@ -1,0 +1,22 @@
+/**
+ * Client-safe model constants — no server-only imports.
+ *
+ * This file is intentionally kept free of database, settings, or encryption
+ * imports so it can be consumed by both client components and server code.
+ */
+
+import type { ProviderName } from "@/lib/providers";
+
+/**
+ * Preferred balanced-tier model IDs, one per provider, used as the fallback
+ * when selectDefaultModel() cannot match any live model against BALANCED_PATTERNS.
+ * These values are also shown directly in client-side UI (e.g. the setup wizard
+ * success screen) without a live model fetch.
+ */
+export const BALANCED_ANCHORS: Record<ProviderName, string> = {
+  anthropic: "anthropic/claude-sonnet-4-6",
+  openai: "openai/gpt-5.5",
+  google: "google/gemini-2.5-pro",
+  "ollama-cloud": "ollama-cloud/qwen3-next:80b",
+  "ollama-local": "",
+};

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -362,8 +362,15 @@ export function selectDefaultModel(provider: ProviderName, models: ModelInfo[]):
   const candidates = models.filter((m) => pattern.test(m.id) && !PREVIEW_PATTERN.test(m.id));
 
   if (candidates.length > 0) {
-    // Pick the most recent model by date suffix (YYYYMMDD)
-    candidates.sort((a, b) => extractModelDate(b.id) - extractModelDate(a.id));
+    // Pick the most recent model by date suffix (YYYYMMDD), with lexicographic
+    // descending as a tiebreaker so newer-named variants (e.g. claude-haiku-5-0)
+    // deterministically beat older sibling names (e.g. claude-haiku-4-5) when
+    // neither carries a date suffix.
+    candidates.sort((a, b) => {
+      const dateDelta = extractModelDate(b.id) - extractModelDate(a.id);
+      if (dateDelta !== 0) return dateDelta;
+      return b.id.localeCompare(a.id);
+    });
     return candidates[0].id;
   }
 

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -339,6 +339,13 @@ export async function fetchOllamaLocalModelsFromUrl(
 
 const PREVIEW_PATTERN = /preview/i;
 
+const REJECT_PATTERN =
+  /-(preview|beta|alpha|rc|exp|experimental|thinking|instant|nano|search|realtime|audio|vision-only)\b/i;
+
+export function isRejectedVariant(modelId: string): boolean {
+  return REJECT_PATTERN.test(modelId);
+}
+
 /** Extract the YYYYMMDD date suffix from a model ID, or 0 if none found. */
 export function extractModelDate(modelId: string): number {
   const ymd = /(\d{8})$/.exec(modelId);

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -178,7 +178,7 @@ const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   "ollama-local": /.*/,
 };
 
-const BALANCED_ANCHORS: Record<ProviderName, string> = {
+export const BALANCED_ANCHORS: Record<ProviderName, string> = {
   anthropic: "anthropic/claude-sonnet-4-6",
   openai: "openai/gpt-5.5",
   google: "google/gemini-2.5-pro",

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -170,12 +170,20 @@ async function fetchModelsForProvider(
   return config.transform(data);
 }
 
-const DEFAULT_MODEL_PATTERNS: Record<ProviderName, RegExp> = {
-  anthropic: /haiku/,
-  openai: /gpt-.*-mini/,
-  google: /gemini-.*-flash/,
-  "ollama-cloud": /flash/,
+const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
+  anthropic: /^anthropic\/claude-sonnet-\d+-\d+(?:-\d{8})?$/,
+  openai: /^openai\/gpt-([5-9]|\d{2,})(\.\d+)?(?:-\d{4}-\d{2}-\d{2})?$/,
+  google: /^google\/gemini-[2-9](?:\.\d+)?-pro(?:-\d{3})?$/,
+  "ollama-cloud": /^ollama-cloud\/qwen3-next:\d+b$/,
   "ollama-local": /.*/,
+};
+
+const BALANCED_ANCHORS: Record<ProviderName, string> = {
+  anthropic: "anthropic/claude-sonnet-4-6",
+  openai: "openai/gpt-5.5",
+  google: "google/gemini-2.5-pro",
+  "ollama-cloud": "ollama-cloud/qwen3-next:80b",
+  "ollama-local": "",
 };
 
 function parseParameterSize(size: string): number {
@@ -358,13 +366,15 @@ export function extractModelDate(modelId: string): number {
 }
 
 export function selectDefaultModel(provider: ProviderName, models: ModelInfo[]): string {
-  const pattern = DEFAULT_MODEL_PATTERNS[provider];
-  const candidates = models.filter((m) => pattern.test(m.id) && !PREVIEW_PATTERN.test(m.id));
+  const pattern = BALANCED_PATTERNS[provider];
+  const candidates = models.filter(
+    (m) => pattern.test(m.id) && !PREVIEW_PATTERN.test(m.id) && !isRejectedVariant(m.id)
+  );
 
   if (candidates.length > 0) {
     // Pick the most recent model by date suffix (YYYYMMDD), with lexicographic
-    // descending as a tiebreaker so newer-named variants (e.g. claude-haiku-5-0)
-    // deterministically beat older sibling names (e.g. claude-haiku-4-5) when
+    // descending as a tiebreaker so newer-named variants (e.g. claude-sonnet-5-0)
+    // deterministically beat older sibling names (e.g. claude-sonnet-4-6) when
     // neither carries a date suffix.
     candidates.sort((a, b) => {
       const dateDelta = extractModelDate(b.id) - extractModelDate(a.id);
@@ -374,7 +384,7 @@ export function selectDefaultModel(provider: ProviderName, models: ModelInfo[]):
     return candidates[0].id;
   }
 
-  return PROVIDERS[provider].defaultModel;
+  return BALANCED_ANCHORS[provider] || PROVIDERS[provider].defaultModel;
 }
 
 export async function getDefaultModel(provider: ProviderName): Promise<string> {

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -178,13 +178,8 @@ const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   "ollama-local": /.*/,
 };
 
-export const BALANCED_ANCHORS: Record<ProviderName, string> = {
-  anthropic: "anthropic/claude-sonnet-4-6",
-  openai: "openai/gpt-5.5",
-  google: "google/gemini-2.5-pro",
-  "ollama-cloud": "ollama-cloud/qwen3-next:80b",
-  "ollama-local": "",
-};
+export { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
+import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
 
 function parseParameterSize(size: string): number {
   const match = size.match(/^([\d.]+)([BMK]?)$/i);

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -69,10 +69,6 @@ const FALLBACK_MODELS: Record<ProviderName, ModelInfo[]> = {
     { id: "openai/gpt-5.4", name: "GPT-5.4" },
     { id: "openai/gpt-5.4-mini", name: "GPT-5.4 Mini" },
   ],
-  // Order matters for selectDefaultModel tie-breaking when no model carries a
-  // YYYYMMDD date suffix (current state for the Gemini 2.5 family). The default
-  // pattern is /gemini-.*-flash/, so flash and flash-lite both match — first
-  // match wins.
   google: [
     { id: "google/gemini-2.5-pro", name: "Gemini 2.5 Pro" },
     { id: "google/gemini-2.5-flash", name: "Gemini 2.5 Flash" },
@@ -170,7 +166,7 @@ async function fetchModelsForProvider(
   return config.transform(data);
 }
 
-const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
+export const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   anthropic: /^anthropic\/claude-sonnet-\d+-\d+(?:-\d{8})?$/,
   openai: /^openai\/gpt-([5-9]|\d{2,})(\.\d+)?(?:-\d{4}-\d{2}-\d{2})?$/,
   google: /^google\/gemini-[2-9](?:\.\d+)?-pro(?:-\d{3})?$/,
@@ -178,8 +174,8 @@ const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   "ollama-local": /.*/,
 };
 
-export { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
 import { BALANCED_ANCHORS } from "@/lib/provider-model-constants";
+export { BALANCED_ANCHORS };
 
 function parseParameterSize(size: string): number {
   const match = size.match(/^([\d.]+)([BMK]?)$/i);

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -340,9 +340,14 @@ export async function fetchOllamaLocalModelsFromUrl(
 const PREVIEW_PATTERN = /preview/i;
 
 /** Extract the YYYYMMDD date suffix from a model ID, or 0 if none found. */
-function extractModelDate(modelId: string): number {
-  const match = /(\d{8})$/.exec(modelId);
-  return match ? parseInt(match[1], 10) : 0;
+export function extractModelDate(modelId: string): number {
+  const ymd = /(\d{8})$/.exec(modelId);
+  if (ymd) return parseInt(ymd[1], 10);
+
+  const isoDate = /(\d{4})-(\d{2})-(\d{2})$/.exec(modelId);
+  if (isoDate) return parseInt(`${isoDate[1]}${isoDate[2]}${isoDate[3]}`, 10);
+
+  return 0;
 }
 
 export function selectDefaultModel(provider: ProviderName, models: ModelInfo[]): string {

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -15,7 +15,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "anthropic_api_key",
     envVar: "ANTHROPIC_API_KEY",
-    defaultModel: "anthropic/claude-haiku-4-5-20251001",
+    defaultModel: "anthropic/claude-sonnet-4-6",
     placeholder: "sk-ant-...",
   },
   openai: {
@@ -23,7 +23,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "openai_api_key",
     envVar: "OPENAI_API_KEY",
-    defaultModel: "openai/gpt-5.4-mini",
+    defaultModel: "openai/gpt-5.5",
     placeholder: "sk-...",
   },
   google: {
@@ -31,7 +31,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "google_api_key",
     envVar: "GEMINI_API_KEY",
-    defaultModel: "google/gemini-2.5-flash",
+    defaultModel: "google/gemini-2.5-pro",
     placeholder: "AIza...",
   },
   "ollama-cloud": {
@@ -39,7 +39,7 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "ollama_cloud_api_key",
     envVar: "OLLAMA_CLOUD_API_KEY",
-    defaultModel: "ollama-cloud/gemini-3-flash-preview",
+    defaultModel: "ollama-cloud/qwen3-next:80b",
     placeholder: "sk-...",
   },
   "ollama-local": {


### PR DESCRIPTION
## Summary

- Switches Pinchy's default model selection from fast-tier (Haiku/GPT-mini/Flash) to balanced-tier (Sonnet/GPT-5.5/Gemini-Pro) — industry-standard for agent workloads
- Fixes the gpt-4o-mini selection bug caused by a broken OpenAI date parser and an overly broad pattern
- Pins Smithers explicitly to `balanced` via `modelHint` + `resolveModelForTemplate`, protecting him against future global-default changes
- Setup wizard now shows which model Smithers will use after provider configuration, with a link to Agent Settings

## What changed

**Model selection hardening (5 layers):**
- `extractModelDate` now handles both `YYYYMMDD` (Anthropic) and `YYYY-MM-DD` (OpenAI) date formats
- `REJECT_PATTERN` / `isRejectedVariant` filters preview/beta/thinking/nano/etc. variants
- Lexicographic tiebreaker for deterministic sort when dates are equal
- Generation-anchored `BALANCED_PATTERNS` replace the old open `DEFAULT_MODEL_PATTERNS`
- Curated `BALANCED_ANCHORS` as final fallback per provider

**Smithers pinning:**
- `SMITHERS_MODEL_HINT = { tier: "balanced", capabilities: ["tools", "long-context"] }` exported as single source of truth
- Both `seedPersonalAgent` and `POST /api/setup/provider` use the hint via `resolveModelForTemplate`
- Both paths handle `TemplateCapabilityUnavailableError` gracefully (degrade to anchor, don't 500)

**Drift-guard test suite:**
- 6-category drift-resistance test file (`provider-models-drift.test.ts`)
- `balanced-tier-sync.test.ts` enforces alignment between model-resolver provider maps and `BALANCED_ANCHORS`

**Setup wizard UX:**
- `SmithersModelInfoLine` component shown on provider-setup success page
- `getModelDisplayName` converts model IDs to user-friendly names (`claude-sonnet-4-6` → `Claude Sonnet 4.6`)

**No agent migration:** Agents created before this change keep their existing models (create-time only, per Pinchy's auto-default philosophy).

## Test Plan

- [ ] Run full test suite: `pnpm -C packages/web test` — 3836 tests pass
- [ ] Configure Anthropic provider in setup wizard → success screen shows "Smithers will use Claude Sonnet 4.6"
- [ ] Configure OpenAI provider → Smithers gets `gpt-5.5`, not `gpt-4o-mini`
- [ ] Configure Google provider → Smithers gets `gemini-2.5-pro`, not `gemini-2.5-flash`
- [ ] Provider with no tool-capable models → setup still succeeds (TemplateCapabilityUnavailableError caught)