### PR TITLE
fix(pinchy-odoo): declare inner items for filters tuple so OpenAI accepts schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **Pinchy-Odoo: `odoo_read`, `odoo_count`, `odoo_aggregate` now accepted by OpenAI's strict function-calling validator.** The `filters` parameter schema declared a nested array (`type: "array"` of `type: "array"`) without an inner `items` definition. OpenAI rejected the request with `400 Invalid schema for function 'odoo_aggregate': In context=('properties','filters','items'), array schema missing items.`, surfaced in the UI as `OpenClaw error chunk: LLM request failed: provider rejected the request schema or tool payload`. Anthropic and Ollama accept the looser schema, so the regression was invisible on those providers. A new drift-guard test (`openai-schema-compat`) walks every Pinchy-Odoo tool schema and fails the build if any `type: array` is missing `items`.
+
 ### Breaking Changes
 
 - **Pinchy-Odoo: opaque self-refs on every record.** `odoo_create` now returns `{id, _pinchy_ref}` (was `{id}`), and every record from `odoo_read` gains a `_pinchy_ref` field. Read-write operator templates (Bookkeeper, Warehouse Operator, HR Operator, Project Manager, Production Operator, Approval Manager) can now chain `odoo_create` → `odoo_attach_file` directly: pass the returned `_pinchy_ref` as `targetRef`. The previous behaviour — `odoo_create` returning only a raw integer `id` with no path for the LLM to obtain a valid encrypted ref — made `odoo_attach_file` unreachable in fresh-create flows. The field is named `_pinchy_ref` (not `ref`) to avoid shadowing Odoo's own `ref` field on `account.move` / `account.payment` etc. Old downstream tools that accept raw `ids` (`odoo_write`, `odoo_delete`, etc.) are unchanged.

--- a/packages/plugins/pinchy-odoo/__tests__/openai-schema-compat.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/openai-schema-compat.test.ts
@@ -1,0 +1,115 @@
+import { describe, it, expect, vi } from "vitest";
+
+// odoo-node is mocked the same way as in tools.test.ts so the plugin can
+// register without contacting a real Odoo instance.
+vi.mock("odoo-node", () => {
+  const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {});
+  return { OdooClient: MockOdooClient };
+});
+
+import plugin from "../index";
+
+interface AgentTool {
+  name: string;
+  parameters: Record<string, unknown>;
+}
+
+const testPermissions = {
+  "sale.order": ["read"],
+};
+
+const agentId = "agent-1";
+const agentConfig = {
+  connectionId: "conn-test-1",
+  permissions: testPermissions,
+  modelNames: {},
+};
+
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({
+    type: "odoo",
+    credentials: {
+      url: "https://example.com",
+      db: "x",
+      uid: 1,
+      apiKey: "k",
+    },
+  }),
+}));
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+function collectAllTools(): AgentTool[] {
+  const tools: AgentTool[] = [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: { [agentId]: agentConfig },
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+    ) => {
+      const t = factory({ agentId });
+      if (t) tools.push(t);
+    },
+  };
+  plugin.register(api);
+  return tools;
+}
+
+// Walks a JSON-schema-ish tree and yields every node that declares
+// `type: "array"`. Descends into `properties`, `items`, and `oneOf|anyOf|allOf`
+// so deeply nested arrays (e.g. arrays of arrays) are caught.
+function* walkArraySchemas(
+  node: unknown,
+  path: string[] = [],
+): Generator<{ node: Record<string, unknown>; path: string[] }> {
+  if (!node || typeof node !== "object") return;
+  const obj = node as Record<string, unknown>;
+
+  if (obj.type === "array") {
+    yield { node: obj, path };
+  }
+
+  if (obj.properties && typeof obj.properties === "object") {
+    for (const [key, value] of Object.entries(
+      obj.properties as Record<string, unknown>,
+    )) {
+      yield* walkArraySchemas(value, [...path, "properties", key]);
+    }
+  }
+  if (obj.items !== undefined) {
+    yield* walkArraySchemas(obj.items, [...path, "items"]);
+  }
+  for (const combinator of ["oneOf", "anyOf", "allOf"] as const) {
+    const list = obj[combinator];
+    if (Array.isArray(list)) {
+      for (let i = 0; i < list.length; i++) {
+        yield* walkArraySchemas(list[i], [...path, combinator, String(i)]);
+      }
+    }
+  }
+}
+
+describe("OpenAI strict-schema compatibility", () => {
+  it("every `type: array` in every tool's parameters declares `items`", () => {
+    const tools = collectAllTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    const offenders: string[] = [];
+    for (const tool of tools) {
+      for (const { node, path } of walkArraySchemas(tool.parameters)) {
+        if (!("items" in node)) {
+          offenders.push(
+            `${tool.name}: ${path.join(".") || "<root>"} is type:array without \`items\` — OpenAI will reject it with "array schema missing items"`,
+          );
+        }
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+});

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1130,6 +1130,7 @@ const plugin = {
                 type: "array",
                 items: {
                   type: "array",
+                  items: {},
                   description:
                     "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
                 },
@@ -1225,6 +1226,7 @@ const plugin = {
                 type: "array",
                 items: {
                   type: "array",
+                  items: {},
                   description: "A [field, operator, value] tuple",
                 },
                 description: "Odoo domain filter. Use [] for no filter.",
@@ -1279,6 +1281,7 @@ const plugin = {
                 type: "array",
                 items: {
                   type: "array",
+                  items: {},
                   description: "A [field, operator, value] tuple",
                 },
                 description: "Odoo domain filter. Use [] for no filter.",


### PR DESCRIPTION
## Summary

Customer report: connecting Pinchy v0.5.3 to OpenAI produces `OpenClaw error chunk: LLM request failed: provider rejected the request schema or tool payload`. The underlying error is `400 Invalid schema for function 'odoo_aggregate': In context=('properties', 'filters', 'items'), array schema missing items.` Same defect affects `odoo_read` and `odoo_count`.

## Root cause

In `packages/plugins/pinchy-odoo/index.ts`, the three tools declared their `filters` parameter as a nested array but the **inner** array had no `items` definition:

```ts
filters: {
  type: "array",
  items: {
    type: "array",                  // ← missing `items`
    description: "A [field, operator, value] tuple",
  },
}
```

JSON Schema treats `type: "array"` without `items` as "any value" (spec-valid), but OpenAI's function-calling validator enforces a stricter subset and rejects it. Anthropic and Ollama accept the looser form, so the bug was invisible until a customer used OpenAI.

## Fix

- Add `items: {}` to the inner array in all three tools — preserves the semantic "filter tuple is `[string, string, any]`".
- New drift-guard `openai-schema-compat.test.ts` walks every Pinchy-Odoo tool schema and fails if any `type: "array"` is missing `items` — prevents the same class of regression for future tools.
- `CHANGELOG.md` entry under `[Unreleased] → Fixed`.

## End-to-end verification against real OpenAI

Sent the v0.5.3 schemas and the patched schemas to `gpt-4o-mini`:

| Schema | Tool | HTTP | OpenAI response |
|---|---|---|---|
| v0.5.3 (broken) | `odoo_aggregate` | 400 | `In context=('properties', 'filters', 'items'), array schema missing items` |
| v0.5.3 (broken) | `odoo_read` | 400 | same path, same error |
| v0.5.3 (broken) | `odoo_count` | 400 | same path, same error |
| v0.5.4 (fixed, all three together) | — | 200 | accepted, request flows through |

Error message and JSON path match the bug report exactly.

## Test plan

- [x] `pnpm -C packages/web test` — 4275 passed, 0 failed
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] Drift-guard test fails on the v0.5.3 schemas and passes on the fixed schemas
- [x] Real OpenAI request rejects v0.5.3 (400) and accepts v0.5.4 (200)
- [ ] Smoke test on staging with an OpenAI-configured agent after release