### PR TITLE
fix(markdown-editor): align caret with click on inline-code and heading-heavy content

### DIFF
--- a/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
+++ b/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
@@ -54,8 +54,6 @@ test.describe("Markdown editor caret alignment", () => {
 
     const textarea = editor.locator("textarea").first();
     await textarea.click();
-    await page.keyboard.press("ControlOrMeta+A");
-    await page.keyboard.press("Backspace");
 
     // Build a realistic AGENTS.md-style content:
     //   - 20 headings interleaved with paragraphs and short list items
@@ -77,8 +75,21 @@ test.describe("Markdown editor caret alignment", () => {
     sections.push("- trailing line 1");
     sections.push("- trailing line 2");
     const CONTENT = sections.join("\n");
-    // delay:0 is fast enough; we're testing layout, not key event timing.
-    await page.keyboard.type(CONTENT, { delay: 1 });
+
+    // Set the textarea value via React's controlled-input pattern: use the
+    // native value setter so React's input event listener picks up the
+    // change, then dispatch a synthetic input event. Typing character by
+    // character via page.keyboard.type would take 30+ seconds for this
+    // payload on CI and trip the test timeout.
+    await editor.evaluate((root, value) => {
+      const ta = root.querySelector("textarea") as HTMLTextAreaElement;
+      const setter = Object.getOwnPropertyDescriptor(
+        window.HTMLTextAreaElement.prototype,
+        "value"
+      )!.set!;
+      setter.call(ta, value);
+      ta.dispatchEvent(new Event("input", { bubbles: true }));
+    }, CONTENT);
 
     await expect(editor.locator("pre .token.code-snippet").first()).toBeVisible();
     await expect(editor.locator("pre .token.title.important").first()).toBeVisible();

--- a/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
+++ b/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
@@ -45,9 +45,10 @@ test.describe("Markdown editor caret alignment", () => {
     const agentId = href!.match(/\/chat\/([0-9a-f-]+)/)![1];
 
     // Open the Instructions tab (AGENTS.md) — the exact URL from the bug
-    // report.
+    // report. Wait on the editor element directly rather than
+    // `networkidle`: the latter is flaky under streaming/long-lived
+    // connections and is no longer Playwright-recommended.
     await page.goto(`/chat/${agentId}/settings?tab=instructions`);
-    await page.waitForLoadState("networkidle");
 
     const editor = page.locator(".markdown-editor").first();
     await editor.waitFor({ timeout: 10000 });

--- a/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
+++ b/packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts
@@ -1,0 +1,160 @@
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig, loginAsAdmin } from "./helpers";
+
+/**
+ * Regression test for issue #336.
+ *
+ * In the markdown editor (react-simple-code-editor + Prism), the visual
+ * caret drifts away from the logical cursor when token-level styling
+ * changes glyph metrics relative to the underlying <textarea>. The bug
+ * has two known flavours, both caused by layout-affecting properties on
+ * Prism token spans:
+ *
+ *   - Horizontal (per-token width inflation): `padding`/`margin`/etc. on
+ *     inline-code spans makes the highlight <pre> wider than the
+ *     <textarea> by ~1 char per span, so clicks land several columns off.
+ *
+ *   - Vertical (per-token line-box inflation): `font-size`/`font-weight`/
+ *     `font-style` on headings/bold/italic tokens makes those lines taller
+ *     in the <pre> than in the <textarea>. The offset accumulates over a
+ *     long file with many such lines and lands clicks on a different line.
+ *
+ * This test exercises both at once: content with many headings interleaved
+ * with normal lines (vertical accumulator), and a marker line whose ▲ sits
+ * after several inline-code spans (horizontal accumulator). The marker's
+ * <pre> rect captures both offsets, so a single click→selectionStart
+ * comparison catches either flavour.
+ */
+
+test.describe("Markdown editor caret alignment", () => {
+  test.beforeEach(async ({ page }) => {
+    // Tall viewport — the editor expands to its intrinsic content height
+    // and we need ~50 lines of content fully on-screen for the click test.
+    await page.setViewportSize({ width: 1280, height: 1600 });
+    await seedProviderConfig();
+    await loginAsAdmin(page);
+  });
+
+  test("click position in long content with headings and inline-code spans matches the typed character", async ({
+    page,
+  }) => {
+    const smithersLink = page.getByRole("link", { name: /smithers/i }).first();
+    await smithersLink.waitFor({ timeout: 10000 });
+    const href = await smithersLink.getAttribute("href");
+    expect(href).toMatch(/\/chat\/[0-9a-f-]+/);
+    const agentId = href!.match(/\/chat\/([0-9a-f-]+)/)![1];
+
+    // Open the Instructions tab (AGENTS.md) — the exact URL from the bug
+    // report.
+    await page.goto(`/chat/${agentId}/settings?tab=instructions`);
+    await page.waitForLoadState("networkidle");
+
+    const editor = page.locator(".markdown-editor").first();
+    await editor.waitFor({ timeout: 10000 });
+
+    const textarea = editor.locator("textarea").first();
+    await textarea.click();
+    await page.keyboard.press("ControlOrMeta+A");
+    await page.keyboard.press("Backspace");
+
+    // Build a realistic AGENTS.md-style content:
+    //   - 20 headings interleaved with paragraphs and short list items
+    //     (vertical accumulator: each heading is 2px taller in the <pre>
+    //     if the heading rule uses font-size: 1.1em, so 20 headings → 40px
+    //     drift → 2 visual lines off);
+    //   - the marker line near the end has five inline-code spans before
+    //     the ▲ (horizontal accumulator: each span inflates the <pre>
+    //     width if the inline-code rule uses padding, drifting the click
+    //     position by ~1 char per span).
+    const sections: string[] = [];
+    for (let i = 1; i <= 20; i++) {
+      sections.push(`## Section ${i}`);
+      sections.push(`Paragraph text describing section ${i} briefly.`);
+      sections.push(`- bullet point for section ${i}`);
+    }
+    sections.push("");
+    sections.push("Marker line: `a`, `b`, `c`, `d`, `e`▲END");
+    sections.push("- trailing line 1");
+    sections.push("- trailing line 2");
+    const CONTENT = sections.join("\n");
+    // delay:0 is fast enough; we're testing layout, not key event timing.
+    await page.keyboard.type(CONTENT, { delay: 1 });
+
+    await expect(editor.locator("pre .token.code-snippet").first()).toBeVisible();
+    await expect(editor.locator("pre .token.title.important").first()).toBeVisible();
+
+    // Find the rect of "▲" in the <pre> by walking text nodes.
+    const target = await editor.evaluate((root) => {
+      const pre = root.querySelector("pre") as HTMLElement;
+      const ta = root.querySelector("textarea") as HTMLTextAreaElement;
+      const markerIndex = ta.value.indexOf("▲");
+      if (markerIndex < 0) return null;
+
+      let charsSeen = 0;
+      const findRect = (node: Node): DOMRect | null => {
+        if (node.nodeType === Node.TEXT_NODE) {
+          const t = node.textContent ?? "";
+          const localIdx = markerIndex - charsSeen;
+          if (localIdx >= 0 && localIdx < t.length) {
+            const range = document.createRange();
+            range.setStart(node, localIdx);
+            range.setEnd(node, localIdx + 1);
+            return range.getBoundingClientRect();
+          }
+          charsSeen += t.length;
+          return null;
+        }
+        for (const child of Array.from(node.childNodes)) {
+          const r = findRect(child);
+          if (r) return r;
+        }
+        return null;
+      };
+      const rect = findRect(pre);
+      return rect
+        ? {
+            markerIndex,
+            x: rect.left,
+            y: (rect.top + rect.bottom) / 2,
+          }
+        : null;
+    });
+    expect(target, "could not locate '▲' in the highlight <pre>").not.toBeNull();
+
+    // Click on the LEFT edge of the marker glyph in the <pre>. The
+    // <textarea> must resolve that pixel to position `markerIndex`. On
+    // main, both vertical (heading-induced) and horizontal (padding-
+    // induced) drift land selectionStart on a different character.
+    await page.mouse.click(target!.x, target!.y);
+
+    const state = await textarea.evaluate((el) => {
+      const ta = el as HTMLTextAreaElement;
+      const toLineCol = (pos: number) => {
+        const before = ta.value.slice(0, pos);
+        const line = (before.match(/\n/g) ?? []).length;
+        const col = pos - (before.lastIndexOf("\n") + 1);
+        return { line, col };
+      };
+      return {
+        selectionStart: ta.selectionStart,
+        actualLC: toLineCol(ta.selectionStart),
+      };
+    });
+
+    const expectedLC = (() => {
+      const before = CONTENT.slice(0, target!.markerIndex);
+      const line = (before.match(/\n/g) ?? []).length;
+      const col = target!.markerIndex - (before.lastIndexOf("\n") + 1);
+      return { line, col };
+    })();
+
+    // ±1 char tolerance for sub-pixel rounding on the left/right side of
+    // the glyph. Real drift on main is at least several characters and
+    // often a whole line of vertical offset.
+    const drift = Math.abs(state.selectionStart - target!.markerIndex);
+    expect(
+      drift,
+      `caret drift: clicked <pre>'s '▲' at (line ${expectedLC.line}, col ${expectedLC.col}, index ${target!.markerIndex}); textarea selectionStart=${state.selectionStart} → (line ${state.actualLC.line}, col ${state.actualLC.col})`
+    ).toBeLessThanOrEqual(1);
+  });
+});

--- a/packages/web/src/components/markdown-editor.css
+++ b/packages/web/src/components/markdown-editor.css
@@ -1,64 +1,77 @@
-/* Markdown syntax highlighting for PrismJS tokens */
+/* Markdown syntax highlighting for PrismJS tokens.
+ *
+ * IMPORTANT — read before adding any rule here:
+ * react-simple-code-editor renders the highlight <pre> as an overlay above
+ * an invisible <textarea>. The two layers MUST have identical text metrics
+ * for the visual caret to align with the logical cursor. Any per-token
+ * styling that changes glyph width or line-box height — `font-size`,
+ * `font-weight`, `font-style`, `letter-spacing`, `padding`, `margin`,
+ * `border`, `transform`, etc. — desynchronises the layers and lands clicks
+ * on the wrong character (issue #336). The drift can be horizontal
+ * (per-token width inflation) or vertical (per-token taller line boxes
+ * accumulating over a long file with headings/bold/italic spans).
+ *
+ * Safe properties: `color`, `background`, `border-radius`, `box-shadow`,
+ * `text-decoration` (line-through, underline). These paint inside the
+ * existing layout box without changing it.
+ */
 
-/* Headings: # ## ### etc. — title and important are on the SAME element */
+/* Headings: # ## ### etc. — title and important are on the SAME element. */
 .markdown-editor .token.title.important {
   color: var(--color-primary);
-  font-weight: bold;
-  font-size: 1.1em;
 }
 
-/* Heading punctuation (the # characters) */
+/* Heading punctuation (the # characters). */
 .markdown-editor .token.title .token.punctuation {
   color: oklch(0.65 0.1 60);
 }
 
-.markdown-editor .token.bold {
-  font-weight: bold;
-}
-
+/* Bold/italic — emphasise via colour only (font-weight/-style would change
+ * glyph metrics; see header comment). */
+.markdown-editor .token.bold,
 .markdown-editor .token.italic {
-  font-style: italic;
+  color: oklch(0.45 0 0);
 }
 
-/* Strikethrough: ~~text~~ — content is nested inside strike */
+/* Strikethrough: ~~text~~ — content is nested inside strike. line-through
+ * is a paint-only decoration and does not affect layout. */
 .markdown-editor .token.strike .token.content {
   text-decoration: line-through;
 }
 
-/* Links and URLs */
+/* Links and URLs. */
 .markdown-editor .token.url,
 .markdown-editor .token.url-reference .token.string {
   color: oklch(0.5 0.15 250);
 }
 
-/* List markers (-, *, 1.) */
+/* List markers (-, *, 1.). */
 .markdown-editor .token.list.punctuation {
   color: oklch(0.5 0.15 150);
-  font-weight: bold;
 }
 
-/* Blockquotes */
+/* Blockquotes. */
 .markdown-editor .token.blockquote.punctuation,
 .markdown-editor .token.blockquote {
   color: oklch(0.55 0 0);
-  font-style: italic;
 }
 
-/* Horizontal rules */
+/* Horizontal rules. */
 .markdown-editor .token.hr.punctuation {
   color: oklch(0.55 0 0);
 }
 
-/* Inline code */
+/* Inline code — see header comment: `box-shadow` extends the tint visually
+ * without affecting layout, unlike `padding`. */
 .markdown-editor .token.code-snippet,
 .markdown-editor .token.code.keyword {
   color: oklch(0.5 0.12 20);
   background: oklch(0.95 0 0);
   border-radius: 3px;
-  padding: 1px 4px;
+  box-shadow: 0 0 0 2px oklch(0.95 0 0);
 }
 
-/* HTML comments */
+/* HTML comments. */
 .markdown-editor .token.comment {
   color: oklch(0.6 0 0);
 }


### PR DESCRIPTION
## Summary

Felix reported that the cursor visibly drifts when editing Agent Instructions (`/chat/<agentId>/settings?tab=instructions`). Two flavours of the same root cause:

- **Horizontal** (the reported "Cursor verrutscht in der Zeile"): clicks on a line with multiple inline-code spans land several columns to the left of where the user clicked.
- **Vertical** (surfaced while testing): in a long file with many headings, a click on a line near the end inserts text two or three lines lower than where the click hit.

Both are caused by per-token CSS that changes glyph metrics. `react-simple-code-editor` renders a syntax-highlighted `<pre>` as an overlay on top of an invisible `<textarea>`; the layers' text geometry must match exactly. Any rule that changes width or line-box height desyncs them and lands clicks on the wrong character.

Concretely, the previous rules used:

- `padding: 1px 4px` on `.token.code-snippet` → each inline-code span ~8px wider in the `<pre>` than in the `<textarea>` (horizontal drift, ~1 char/span).
- `font-size: 1.1em` and `font-weight: bold` on `.token.title.important` → heading lines 2px taller in the `<pre>` (vertical drift, accumulating to whole lines over a long file with many `## ...` headings).
- `font-weight: bold` / `font-style: italic` on bold/italic/list/blockquote tokens — same class of issue.

This PR strips all layout-affecting properties from token rules and emphasises markdown structure via colour only. Inline-code keeps its tint via `box-shadow` (paint-only) instead of `padding`. A header comment in the CSS file documents the safe-vs-forbidden property list so future style tweaks don't silently reintroduce the bug.

The visible cost is that headings, bold, and italic spans in the editor are no longer rendered taller/bold/italic — just tinted. The proper long-term fix is option C from the issue (move to a real editor like CodeMirror 6 that owns its own caret rendering), but that's a much larger change.

## Verification

Live-tested in dev against a customer-like 220-line AGENTS.md with 22 headings: clicking line 215 col 5 inserted exactly at line 215 col 5 (drift = 0). Without the fix the same click inserted at line 217 col 5 — matching the user's report.

E2E coverage in `packages/web/e2e/17-markdown-editor-cursor-drift.spec.ts`:

- Types a long AGENTS.md-style content with 20 headings and a marker line with five inline-code spans before `▲`.
- Clicks the `▲`'s `<pre>` rect.
- Asserts `textarea.selectionStart` matches the typed character (±1 char for sub-pixel rounding).
- Without the fix: clicked line 61 col 36 → landed line 63 col 17 (2 lines + 19 cols drift).
- With the fix: drift = 0.

Closes #336

## Test plan

- [x] E2E test passes with fix; fails on the original CSS in the same way as the reported bug.
- [x] Existing `markdown-editor.test.tsx` unit tests still pass.
- [x] `pnpm lint` and `pnpm format:check` clean for the touched files.
- [x] Manual smoke against the real 220-line agent: click any line, insert at that exact line.