### PR TITLE
fix(odoo-bookkeeper): document gross-to-net + mandate post-create verification

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1285,8 +1285,7 @@ describe("odoo_create", () => {
   it("description documents price_unit net convention for invoice/order line models", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_create", agentId)!;
-    expect(tool.description).toMatch(/price_unit/);
-    expect(tool.description).toMatch(/tax-exclusive|net/i);
+    expect(tool.description).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
   });
 });
 
@@ -1381,8 +1380,7 @@ describe("odoo_write", () => {
   it("description documents price_unit net convention for invoice/order line models", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_write", agentId)!;
-    expect(tool.description).toMatch(/price_unit/);
-    expect(tool.description).toMatch(/tax-exclusive|net/i);
+    expect(tool.description).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1281,6 +1281,13 @@ describe("odoo_create", () => {
       is_company: true,
     });
   });
+
+  it("description documents price_unit net convention for invoice/order line models", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    expect(tool.description).toMatch(/price_unit/);
+    expect(tool.description).toMatch(/tax-exclusive|net/i);
+  });
 });
 
 describe("odoo_write", () => {
@@ -1369,6 +1376,13 @@ describe("odoo_write", () => {
       email: "updated@example.com",
       city: "Linz",
     });
+  });
+
+  it("description documents price_unit net convention for invoice/order line models", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    expect(tool.description).toMatch(/price_unit/);
+    expect(tool.description).toMatch(/tax-exclusive|net/i);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1355,7 +1355,7 @@ const plugin = {
           name: "odoo_create",
           label: "Odoo Create",
           description:
-            "Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code.",
+            "Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.",
           parameters: {
             type: "object",
             properties: {
@@ -1443,7 +1443,7 @@ const plugin = {
           name: "odoo_write",
           label: "Odoo Write",
           description:
-            "Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code.",
+            "Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.",
           parameters: {
             type: "object",
             properties: {

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
@@ -6,12 +6,11 @@ describe("odoo-bookkeeper template", () => {
   const md = template.defaultAgentsMd;
 
   it("documents that price_unit is tax-exclusive (net)", () => {
-    expect(md).toMatch(/tax-exclusive|net/i);
-    expect(md).toMatch(/price_unit/);
+    expect(md).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
   });
 
   it("mandates post-create verification against amount_total within tolerance", () => {
     expect(md).toMatch(/verify the draft|amount_total.*receipt/i);
-    expect(md).toMatch(/0\.02 EUR|tolerance/);
+    expect(md).toMatch(/0\.02 EUR/);
   });
 });

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
@@ -1,0 +1,17 @@
+import { describe, it, expect } from "vitest";
+import { AGENT_TEMPLATES } from "@/lib/agent-templates";
+
+describe("odoo-bookkeeper template", () => {
+  const template = AGENT_TEMPLATES["odoo-bookkeeper"];
+  const md = template.defaultAgentsMd;
+
+  it("documents that price_unit is tax-exclusive (net)", () => {
+    expect(md).toMatch(/tax-exclusive|net/i);
+    expect(md).toMatch(/price_unit/);
+  });
+
+  it("mandates post-create verification against amount_total within tolerance", () => {
+    expect(md).toMatch(/verify the draft|amount_total.*receipt/i);
+    expect(md).toMatch(/0\.02 EUR|tolerance/);
+  });
+});

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -306,7 +306,7 @@ convert before writing:
 
 For multi-line splits, compute each line's net independently against
 its own tax rate, not against a sum. After computing, the sum of
-\`price_unit × quantity × (1 + tax_rate)\` over all lines must equal the
+\`price_unit * quantity * (1 + tax_rate)\` over all lines must equal the
 receipt's gross total within ±0.02 EUR (rounding tolerance).
 
 If a line has no applicable VAT (e.g. tip, foreign supplier without VAT),
@@ -341,7 +341,7 @@ Lines belong to their move. Always create the move and its lines in a SINGLE \`o
     "invoice_date": "2026-03-22",
     "invoice_line_ids": [
       [0, 0, { "name": "Coffee", "quantity": 2, "price_unit": 4.30, "tax_ids": [[6, 0, [TAX_ID]]] }],
-      [0, 0, { "name": "Tip",    "quantity": 1, "price_unit": 3.10 }]
+      [0, 0, { "name": "Tip",    "quantity": 1, "price_unit": 3.10, "tax_ids": [[6, 0, []]] }]
     ]
   }
 }

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -292,6 +292,26 @@ You book incoming bills and customer invoices into Odoo, reconcile them against 
 
 ${ODOO_QUERY_INSTRUCTIONS}
 
+## Money & Tax Conventions
+
+Odoo treats every \`account.move.line.price_unit\` as a **tax-exclusive
+(net) amount**. The tax recorded in \`tax_ids\` is added on top at posting
+time, and the line's \`account_id\` may inject a default tax if \`tax_ids\`
+is empty. The bill's \`amount_total\` is always gross.
+
+Receipts and invoices the user uploads show **gross** totals. You must
+convert before writing:
+
+> \`price_unit = round(gross_line_total / (1 + tax_rate), 2)\`
+
+For multi-line splits, compute each line's net independently against
+its own tax rate, not against a sum. After computing, the sum of
+\`price_unit × quantity × (1 + tax_rate)\` over all lines must equal the
+receipt's gross total within ±0.02 EUR (rounding tolerance).
+
+If a line has no applicable VAT (e.g. tip, foreign supplier without VAT),
+set \`tax_ids: [[6, 0, []]]\` explicitly to override the account's default.
+
 ## Mandatory Booking Workflow
 
 These rules are not suggestions. Accounting data must be auditable, reversible until posted, and free of duplicates.
@@ -341,8 +361,13 @@ You do not create \`account.payment\` records — those come from bank imports. 
 4. Look up the correct \`account.tax\` ID via \`odoo_search\` on \`account.tax\` filtered by country and \`type_tax_use="purchase"\` and matching rate — never guess tax IDs.
 5. Look up the correct expense \`account.account\` for each line via \`odoo_search\` on \`account.account\` filtered by \`account_type\` (e.g. \`expense\` or \`expense_direct_cost\`) and a meaningful \`code\`/\`name\` for the kind of expense (office supplies, software, travel, …). Never guess account IDs; if the Chart of Accounts has no obvious match, ask the user.
 6. Create the \`account.move\` in draft, with \`move_type="in_invoice"\`, all line items via \`invoice_line_ids\`, and correct \`account_id\` + \`tax_ids\` per line.
-7. Show the user a summary table and ask for posting confirmation.
-8. On confirmation, \`odoo_write\` to change \`state\` to \`"posted"\`.
+7. Verify the draft against the source document: immediately after \`odoo_create\` returns, call \`odoo_read\` on the new move and fetch \`amount_total\`. Compare against the gross total from the receipt.
+   - **Match (difference ≤ 0.02 EUR):** proceed to Step 8.
+   - **Mismatch:** STOP. Do not silently rewrite. Show the user the diff:
+     > "Receipt gross: 90.00 EUR / Odoo draft: 108.00 EUR (delta +18.00 EUR). Likely causes: tax was applied on top of a gross \`price_unit\`, or the account injected an unintended default tax. How would you like to proceed?"
+     Wait for explicit user guidance before any \`odoo_write\`. The original draft stays untouched until the user decides.
+8. Show the user a summary table and ask for posting confirmation.
+9. On confirmation, \`odoo_write\` to change \`state\` to \`"posted"\`.
 
 ### Match a posted bill against an existing bank payment
 1. \`odoo_read\` on \`account.move\` to confirm the bill is posted and \`amount_residual > 0\`.


### PR DESCRIPTION
## Problem

Penny (a customer's Bookkeeper agent) booked two Austrian vendor bills with
inflated totals: gross amounts were written into `price_unit` (which Odoo
treats as net), causing `amount_total` to be inflated by VAT (e.g. 90 EUR
receipt → 108 EUR booked).

Root cause: `defaultAgentsMd` for the Bookkeeper template never explained
that `price_unit` is tax-exclusive, and the workflow had no post-create
verification step to catch the mismatch.

Note: the Platzhalter-Falle (placeholder account injecting unintended tax)
is already fixed in commit `146652f2f` (Step 5 now mandates explicit
`account.account` lookup). This PR fixes only the remaining two gaps.

## Changes

### 1. `odoo_create` + `odoo_write` tool descriptions (defense-in-depth)

Append a one-sentence note that `price_unit` is tax-exclusive in
invoice/order line models. Protects custom Odoo agents that don't use the
Bookkeeper template.

### 2. Bookkeeper `defaultAgentsMd` — new "Money & Tax Conventions" section

Inserted between `ODOO_QUERY_INSTRUCTIONS` and "Mandatory Booking Workflow".
Explains:
- `price_unit` is net; `tax_ids` is added on top; `amount_total` is gross
- Conversion formula: `price_unit = round(gross / (1 + rate), 2)`
- Multi-line reconciliation rule (±0.02 EUR)
- Explicit `tax_ids: [[6,0,[]]]` for zero-VAT lines (and updated the
  inline `invoice_line_ids` example to follow this convention)

### 3. Bookkeeper Workflow — new Step 7 "Verify the draft against source"

After `odoo_create`, immediately call `odoo_read` to fetch `amount_total`
and compare against the receipt gross. On mismatch > 0.02 EUR: hard-stop,
show diff to user, wait for explicit guidance. Never silently rewrite.
Aligns with GoBD/IDW PH 9.860.4 unalterability requirements and OCR-tool
industry patterns (confidence-gated hard-stop).

## Heads-up for existing customers

Customers who already cloned the Bookkeeper template into their org's
`agents.md` will **not** automatically pick up the new Money & Tax section
or Workflow Step 7. They must either:

- re-create the agent from the updated template, or
- manually copy the new sections into their existing `agents.md`.

This needs an explicit callout in the release notes for the version that
ships this PR.

## Limits of this mitigation

Workflow Step 7 is a prompt-based instruction; a non-compliant LLM can skip
it. A runtime guardrail (server-side detection of `odoo_create` on
`account.move` without a subsequent verifying `odoo_read`) is tracked in
#385.

## Test plan

- [x] Layer 1 (plugin unit): `odoo_create` and `odoo_write` descriptions
      bind `price_unit` and `tax-exclusive` within 80 non-period chars
- [x] Layer 2 (template structure): `odoo-bookkeeper` `defaultAgentsMd`
      binds `price_unit` and `tax-exclusive`, and matches `/verify the
      draft|amount_total.*receipt/i` + `/0\.02 EUR/`
- [x] `pnpm test` — all green
- [ ] Manual QA: re-run a vendor bill booking and verify `amount_total`
      matches receipt (Penny / demo.heypinchy.com)