### PR TITLE
docs(upgrading): prune dangling images after every upgrade (#370)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -231,8 +231,10 @@ The staging instance is set up once (see [Staging instance setup](#staging-insta
 **Before each release**, refresh staging to pick up the latest `:next` build, then click through the key flows: Smithers chat, one live integration, one custom agent with chat history.
 
 ```bash
-ssh root@<staging-host> "cd /opt/pinchy && docker compose pull && docker compose up -d"
+ssh root@<staging-host> "cd /opt/pinchy && docker compose pull && docker compose up -d && docker image prune -f"
 ```
+
+The `docker image prune -f` step removes the previous `:next` image that `pull` left dangling. Staging cycles `:next` many times per day, so without it the root volume fills up within a release window (see [#370](https://github.com/heypinchy/pinchy/issues/370)).
 
 Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.6.0.
 
@@ -259,7 +261,7 @@ The release script and CI enforce image builds, GHCR visibility, end-user instal
 
 **Staging**
 
-- [ ] Staging instance on `:next` was clicked through today: Smithers chat, one live integration, one custom agent. See [Staging instance setup](#staging-instance-setup) for the one-time setup and the refresh command (`docker compose pull && up -d`) you run before each click-through.
+- [ ] Staging instance on `:next` was clicked through today: Smithers chat, one live integration, one custom agent. See [Staging instance setup](#staging-instance-setup) for the one-time setup and the refresh command (`docker compose pull && up -d && docker image prune -f`) you run before each click-through.
 
 ### Release steps
 
@@ -315,7 +317,7 @@ This is intentionally an internal/contributor workflow — the public docs at [d
 Every push to `main` triggers the **Pre-release** workflow, which builds and publishes new `:next` images. Pull them onto your staging instance:
 
 ```bash
-ssh root@<staging-ip> "cd /opt/pinchy && docker compose pull && docker compose up -d"
+ssh root@<staging-ip> "cd /opt/pinchy && docker compose pull && docker compose up -d && docker image prune -f"
 ```
 
 Run this manually before each pre-release click-through. Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.6.0.

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -414,9 +414,10 @@ Check for new Pinchy releases and update:
 ```bash
 docker compose pull
 docker compose up -d
+docker image prune -f
 ```
 
-Always read the release notes before updating. Back up the database first.
+Always read the release notes before updating. Back up the database first. The final `docker image prune -f` removes the previous image layer that `pull` left dangling — skip it and `pinchy`/`pinchy-openclaw` `<none>:<none>` layers slowly fill the root volume across upgrades. For a deeper sweep that also drops older pinned versions you no longer need for rollback, run `docker image prune -a -f` between upgrades (not as part of one).
 
 ### Dependency scanning
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -54,12 +54,17 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
    `up -d` applies any pending database migrations, regenerates the OpenClaw configuration, and restarts all services. `docker image prune -f` then removes the previous image layer for each Pinchy service that `pull` left dangling — without this, every upgrade keeps the prior `pinchy` and `pinchy-openclaw` layers on disk and a long-running deployment eventually fills its root volume.
 
    <Aside type="tip">
-     `prune -f` only touches dangling layers (the old digest of the tag you just
-     replaced) and is safe to run on a live deployment. If you've been upgrading
-     for a while and want to reclaim space from **older pinned versions** as
-     well (e.g. `v0.5.0` you no longer plan to roll back to), run `docker image
-     prune -a -f` instead. This removes every image not currently associated
-     with a container, so you lose the ability to instantly roll back without
+     `prune -f` removes layers that no tag and no container references —
+     typically the prior digest of the tag you just replaced, plus any older
+     dangling layers left over from previous upgrades. It's safe to run on a
+     live deployment because the running container still references the new
+     image. On a host that runs other Docker workloads alongside Pinchy, this
+     also clears their dangling layers — that's almost always what you want, but
+     worth knowing if you share the daemon. If you've been upgrading for a while
+     and want to reclaim space from **older pinned versions** as well (e.g.
+     `v0.5.0` you no longer plan to roll back to), run `docker image prune -a
+     -f` instead. This removes every image not currently associated with a
+     container, so you lose the ability to instantly roll back without
      re-pulling — schedule it between upgrades, not as part of one.
    </Aside>
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -45,13 +45,23 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
      which is rare.
    </Aside>
 
-3. **Restart**
+3. **Restart and prune the old image layer**
 
    ```bash
-   docker compose up -d
+   docker compose up -d && docker image prune -f
    ```
 
-   This applies any pending database migrations, regenerates the OpenClaw configuration, and restarts all services.
+   `up -d` applies any pending database migrations, regenerates the OpenClaw configuration, and restarts all services. `docker image prune -f` then removes the previous image layer for each Pinchy service that `pull` left dangling — without this, every upgrade keeps the prior `pinchy` and `pinchy-openclaw` layers on disk and a long-running deployment eventually fills its root volume.
+
+   <Aside type="tip">
+     `prune -f` only touches dangling layers (the old digest of the tag you just
+     replaced) and is safe to run on a live deployment. If you've been upgrading
+     for a while and want to reclaim space from **older pinned versions** as
+     well (e.g. `v0.5.0` you no longer plan to roll back to), run `docker image
+     prune -a -f` instead. This removes every image not currently associated
+     with a container, so you lose the ability to instantly roll back without
+     re-pulling — schedule it between upgrades, not as part of one.
+   </Aside>
 
 4. **Verify**
 
@@ -149,7 +159,7 @@ Upgrade with the standard flow:
 ```bash
 cd /opt/pinchy
 sed -i 's/PINCHY_VERSION=v0.5.3/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
-docker compose pull && docker compose up -d
+docker compose pull && docker compose up -d && docker image prune -f
 ```
 
 No database migration, no `docker-compose.yml` change, and no env-var changes are required.

--- a/docs/src/content/docs/guides/vps-deployment.mdx
+++ b/docs/src/content/docs/guides/vps-deployment.mdx
@@ -306,9 +306,10 @@ docker compose exec db pg_dump -U pinchy pinchy > backup-$(date +%Y%m%d).sql
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
 docker compose pull
 docker compose up -d
+docker image prune -f
 ```
 
-Pinchy runs database migrations automatically on startup — no manual steps needed. See the [Upgrade Guide](/guides/upgrading/) for version-specific notes, rollback instructions, and how to set up automated backups.
+Pinchy runs database migrations automatically on startup — no manual steps needed. `docker image prune -f` after `up -d` removes the previous image layer left dangling by `pull`; without it, a long-running deployment slowly fills its root volume with `<none>:<none>` layers from prior upgrades. See the [Upgrade Guide](/guides/upgrading/) for version-specific notes, rollback instructions, when to escalate to `docker image prune -a -f`, and how to set up automated backups.
 
 ## Troubleshooting
 

--- a/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
+++ b/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
@@ -1,0 +1,92 @@
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { describe, it, expect } from "vitest";
+
+const repoRoot = resolve(__dirname, "../../../../..");
+const upgradingPath = resolve(repoRoot, "docs/src/content/docs/guides/upgrading.mdx");
+const vpsDeploymentPath = resolve(repoRoot, "docs/src/content/docs/guides/vps-deployment.mdx");
+const hardeningPath = resolve(repoRoot, "docs/src/content/docs/guides/hardening.mdx");
+
+const upgrading = readFileSync(upgradingPath, "utf-8");
+const vpsDeployment = readFileSync(vpsDeploymentPath, "utf-8");
+const hardening = readFileSync(hardeningPath, "utf-8");
+
+function sectionBetween(source: string, startRegex: RegExp, endRegex: RegExp): string | undefined {
+  const start = source.split(startRegex)[1];
+  if (!start) return undefined;
+  return start.split(endRegex)[0];
+}
+
+describe("upgrade flow includes Docker image disk-hygiene step (#370)", () => {
+  it("Standard upgrade section in upgrading.mdx references `docker image prune`", () => {
+    // Regression guard for #370: a long-running deployment that follows the
+    // documented upgrade flow must not accumulate dangling <none>:<none>
+    // layers across version bumps. The Standard upgrade section is the
+    // canonical reference; if prune drops out of here, staging fills up again.
+    const standardUpgrade = sectionBetween(upgrading, /^##\s+Standard upgrade\s*$/m, /^##\s+/m);
+    expect(standardUpgrade, "Standard upgrade section not found").toBeDefined();
+    expect(standardUpgrade!).toMatch(/docker image prune\b/);
+  });
+
+  it("Standard upgrade's fenced code blocks use dangling-only prune (`-f`), not aggressive `-a -f`", () => {
+    // The default flow runs on a deployment that may have other tagged
+    // images in use (e.g. user-pulled debug images). `-a -f` would remove
+    // any image not associated with a running container, which is too
+    // invasive for a documented happy path. The aggressive variant is
+    // covered in its own opt-in prose note (which DOES mention `-a -f`
+    // — that's fine; we only check the runnable code).
+    const standardUpgrade = sectionBetween(upgrading, /^##\s+Standard upgrade\s*$/m, /^##\s+/m);
+    expect(standardUpgrade, "Standard upgrade section not found").toBeDefined();
+    const fencedBlocks = [...standardUpgrade!.matchAll(/```(?:bash|sh)?[\s\S]*?```/g)].map(
+      (m) => m[0]
+    );
+    const pruneInvocations = fencedBlocks.flatMap(
+      (block) => block.match(/docker image prune[^\n]*/g) ?? []
+    );
+    expect(pruneInvocations.length).toBeGreaterThan(0);
+    for (const invocation of pruneInvocations) {
+      expect(invocation).not.toMatch(/-a\b/);
+    }
+  });
+
+  it("Upgrading guide documents when to escalate to `docker image prune -a -f`", () => {
+    // Acceptance criterion: "Upgrading guide covers when manual `prune -a`
+    // is appropriate vs. the default `prune`." This catches a refactor that
+    // adds the snippet but drops the rationale for the aggressive variant.
+    expect(upgrading).toMatch(/docker image prune -a -f\b/);
+    expect(upgrading.toLowerCase()).toMatch(/\b(tagged|pinned|version|release)\b/);
+  });
+
+  it("latest version-specific upgrade one-liner pipes through prune", () => {
+    // The %%PINCHY_VERSION%% section ships in the active release notes.
+    // It must show the same hygiene step as the Standard upgrade flow so
+    // copy-paste deployments stay consistent.
+    const currentSection = sectionBetween(
+      upgrading,
+      /^##\s+Upgrading from v0\.5\.3 to %%PINCHY_VERSION%%\s*$/m,
+      /^##\s+Upgrading from /m
+    );
+    expect(currentSection, "current-version upgrade section not found").toBeDefined();
+    expect(currentSection!).toMatch(/docker image prune\b/);
+  });
+
+  it("VPS deployment guide's Updating section runs prune after `up -d`", () => {
+    // vps-deployment.mdx duplicates the canonical upgrade snippet for users
+    // who never click through to the upgrading guide. Same hygiene must apply.
+    const updating = sectionBetween(vpsDeployment, /^##\s+Updating Pinchy\s*$/m, /^##\s+/m);
+    expect(updating, "Updating Pinchy section not found").toBeDefined();
+    expect(updating!).toMatch(/docker image prune\b/);
+  });
+
+  it("hardening guide's Docker image updates section runs prune", () => {
+    // The hardening guide's "Update strategy" snippet is the one ops teams
+    // crib from. Without prune here, hardened deployments still bloat.
+    const updateStrategy = sectionBetween(
+      hardening,
+      /^###\s+Docker image updates\s*$/m,
+      /^###\s+/m
+    );
+    expect(updateStrategy, "Docker image updates section not found").toBeDefined();
+    expect(updateStrategy!).toMatch(/docker image prune\b/);
+  });
+});

--- a/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
+++ b/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
@@ -51,19 +51,39 @@ describe("upgrade flow includes Docker image disk-hygiene step (#370)", () => {
 
   it("Upgrading guide documents when to escalate to `docker image prune -a -f`", () => {
     // Acceptance criterion: "Upgrading guide covers when manual `prune -a`
-    // is appropriate vs. the default `prune`." This catches a refactor that
-    // adds the snippet but drops the rationale for the aggressive variant.
-    expect(upgrading).toMatch(/docker image prune -a -f\b/);
-    expect(upgrading.toLowerCase()).toMatch(/\b(tagged|pinned|version|release)\b/);
+    // is appropriate vs. the default `prune`." We scope the rationale check
+    // to the `<Aside>` block that actually contains the `-a -f` invocation,
+    // so a refactor that empties the aside but leaves the keyword "version"
+    // sitting in some unrelated section heading can't trick the test into
+    // passing.
+    //
+    // We collapse whitespace before matching because prettier wraps long
+    // prose lines — `docker image prune -a -f` typically gets broken as
+    // `docker image\n     prune -a -f` across two lines, which a literal-
+    // space regex misses. Normalizing keeps the assertion stable across
+    // prettier re-flows.
+    const collapse = (s: string) => s.replace(/\s+/g, " ");
+    expect(collapse(upgrading)).toMatch(/docker image prune -a -f\b/);
+    const asides = [...upgrading.matchAll(/<Aside\b[\s\S]*?<\/Aside>/g)].map((m) => m[0]);
+    const escalationAside = asides.find((block) =>
+      /docker image prune -a -f\b/.test(collapse(block))
+    );
+    expect(escalationAside, "escalation Aside block not found").toBeDefined();
+    expect(collapse(escalationAside!).toLowerCase()).toMatch(
+      /\b(tagged|pinned|rollback|roll back)\b/
+    );
   });
 
   it("latest version-specific upgrade one-liner pipes through prune", () => {
     // The %%PINCHY_VERSION%% section ships in the active release notes.
     // It must show the same hygiene step as the Standard upgrade flow so
-    // copy-paste deployments stay consistent.
+    // copy-paste deployments stay consistent. We match the heading version
+    // pattern agnostically so this test survives each release bump without
+    // hand-editing — the `%%PINCHY_VERSION%%` placeholder is the stable
+    // anchor that identifies the current section.
     const currentSection = sectionBetween(
       upgrading,
-      /^##\s+Upgrading from v0\.5\.3 to %%PINCHY_VERSION%%\s*$/m,
+      /^##\s+Upgrading from v[\d.]+ to %%PINCHY_VERSION%%\s*$/m,
       /^##\s+Upgrading from /m
     );
     expect(currentSection, "current-version upgrade section not found").toBeDefined();


### PR DESCRIPTION
## Summary

- Adds `docker image prune -f` to every documented upgrade snippet — Standard upgrade, latest version-specific one-liner, VPS deployment Updating section, hardening guide's update strategy, and the two contributor staging-refresh commands.
- Documents when to escalate to `docker image prune -a -f` (between upgrades only, to drop older pinned versions you no longer need for rollback).
- Adds a drift-guard test that enforces the prune step stays in all five canonical snippets and that runnable code keeps `-f` (not the more invasive `-a`).

Resolves [#370](https://github.com/heypinchy/pinchy/issues/370).

### Why `pull → up -d → prune`, not `pull → prune → up -d`

The issue suggested running prune **before** `up -d`, but at that point the old image is still referenced by the running container — `prune -f` would skip it. After `up -d`, Compose replaces the container and the old layer becomes unreferenced, so prune actually reclaims the space.

### Acceptance criteria

- [x] Customers following the documented upgrade flow get dangling layers pruned on every upgrade.
- [x] The hygiene step is idempotent and safe to run on a running deployment (`prune -f` only touches unreferenced, untagged layers).
- [x] Upgrading guide covers when manual `prune -a` is appropriate vs. the default `prune`.

## Test plan

- [x] `pnpm -C packages/web exec vitest run src/__tests__/docs/` — 10/10 passing (including the new 6-assertion drift guard).
- [x] `cd docs && pnpm build` — 41 pages built clean, MDX valid.
- [ ] Manual click-through on staging: bump `:next`, run the new refresh command, confirm `<none>:<none>` layers from prior pulls are gone (`docker images --filter dangling=true`).