### PR TITLE
fix(model-resolver): block *-preview models for tools+vision (#344)

### DIFF
--- a/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { isBlocked } from "../blocklist";
+import { getForbiddenCapabilitySets, isBlocked } from "../blocklist";
 
 describe("isBlocked", () => {
   it("blocks deepseek-r1 when tools capability is required", () => {
@@ -35,5 +35,21 @@ describe("isBlocked", () => {
   it("does not block stable gemini models", () => {
     expect(isBlocked("gemini-2.5-pro", ["tools"])).toBe(false);
     expect(isBlocked("gemini-2.5-flash-lite", ["tools"])).toBe(false);
+  });
+});
+
+describe("getForbiddenCapabilitySets", () => {
+  it("returns one entry per rule, each a non-empty capability list", () => {
+    const sets = getForbiddenCapabilitySets();
+    expect(sets.length).toBeGreaterThan(0);
+    for (const set of sets) {
+      expect(set.length).toBeGreaterThan(0);
+    }
+  });
+
+  it("includes the tools capability (current rules all forbid tools)", () => {
+    const sets = getForbiddenCapabilitySets();
+    const flattened = sets.flatMap((s) => [...s]);
+    expect(flattened).toContain("tools");
   });
 });

--- a/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
@@ -13,4 +13,27 @@ describe("isBlocked", () => {
   it("allows generic reliable models", () => {
     expect(isBlocked("qwen3:32b", ["tools"])).toBe(false);
   });
+
+  it("blocks gemini-3-flash-preview when tools capability is required", () => {
+    expect(isBlocked("gemini-3-flash-preview", ["tools"])).toBe(true);
+  });
+
+  it("blocks gemini-3-flash-preview when vision+tools is required", () => {
+    expect(isBlocked("gemini-3-flash-preview", ["vision", "tools"])).toBe(true);
+  });
+
+  it("allows gemini-3-flash-preview without tools requirement", () => {
+    expect(isBlocked("gemini-3-flash-preview", ["vision"])).toBe(false);
+    expect(isBlocked("gemini-3-flash-preview", [])).toBe(false);
+  });
+
+  it("blocks any preview-suffixed model when tools is required", () => {
+    expect(isBlocked("gemini-2.5-flash-preview", ["tools"])).toBe(true);
+    expect(isBlocked("some-new-model-preview", ["tools"])).toBe(true);
+  });
+
+  it("does not block stable gemini models", () => {
+    expect(isBlocked("gemini-2.5-pro", ["tools"])).toBe(false);
+    expect(isBlocked("gemini-2.5-flash-lite", ["tools"])).toBe(false);
+  });
 });

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -3,8 +3,9 @@ import {
   TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS,
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
 } from "@/lib/ollama-cloud-models";
-import { isBlocked } from "../blocklist";
+import { getForbiddenCapabilitySets, isBlocked } from "../blocklist";
 import { resolveOllamaCloud } from "../providers/ollama-cloud";
+import type { ModelCapability } from "../types";
 
 describe("resolveOllamaCloud", () => {
   it("picks a flash model for tier=fast", () => {
@@ -116,6 +117,43 @@ describe("resolveOllamaCloud — vision capability", () => {
       offenders.length === 0
         ? ""
         : `\n  Vision-slot models that are in the tools-blocklist:\n${offenders.map((o) => `    • ${o}`).join("\n")}\n`
+    ).toEqual([]);
+  });
+
+  // Generic drift-guard: covers every `forbiddenWhen` capability-set currently
+  // declared in `blocklist.ts`, exercising both the vision-slot path (vision in
+  // capabilities) and the general/taskType path. When someone adds a new
+  // blocklist rule with a new forbidden capability (e.g. `["long-context"]`),
+  // this test automatically picks it up — no need to nachziehen the test
+  // alongside the rule.
+  it("does NOT return a blocked model for any tier × taskType × known forbidden capability-set", () => {
+    const tiers = ["fast", "balanced", "reasoning"] as const;
+    const taskTypes = ["general", "coder", "vision", "reasoning"] as const;
+    const forbiddenSets = getForbiddenCapabilitySets();
+    const offenders: string[] = [];
+    for (const tier of tiers) {
+      for (const taskType of taskTypes) {
+        for (const forbidden of forbiddenSets) {
+          for (const includeVision of [false, true]) {
+            const capabilities: ModelCapability[] = includeVision
+              ? Array.from(new Set<ModelCapability>([...forbidden, "vision"]))
+              : [...forbidden];
+            const result = resolveOllamaCloud({ tier, taskType, capabilities });
+            const bareId = result.model.replace(/^ollama-cloud\//, "");
+            if (isBlocked(bareId, capabilities)) {
+              offenders.push(
+                `tier=${tier}, taskType=${taskType}, caps=[${capabilities.join(",")}] → ${result.model}`
+              );
+            }
+          }
+        }
+      }
+    }
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ""
+        : `\n  Resolver returned blocked models for these inputs:\n${offenders.map((o) => `    • ${o}`).join("\n")}\n`
     ).toEqual([]);
   });
 

--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -3,6 +3,7 @@ import {
   TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS,
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
 } from "@/lib/ollama-cloud-models";
+import { isBlocked } from "../blocklist";
 import { resolveOllamaCloud } from "../providers/ollama-cloud";
 
 describe("resolveOllamaCloud", () => {
@@ -98,6 +99,24 @@ describe("resolveOllamaCloud — vision capability", () => {
   it("still returns deepseek-v4-pro for reasoning tier when vision is NOT in capabilities", () => {
     const result = resolveOllamaCloud({ tier: "reasoning", taskType: "reasoning" });
     expect(result.model).toBe("ollama-cloud/deepseek-v4-pro");
+  });
+
+  it("does NOT return a blocked model for any tier's vision slot (pinchy#344)", () => {
+    const tiers = ["fast", "balanced", "reasoning"] as const;
+    const offenders: string[] = [];
+    for (const tier of tiers) {
+      const result = resolveOllamaCloud({ tier, capabilities: ["vision", "tools"] });
+      const bareId = result.model.replace(/^ollama-cloud\//, "");
+      if (isBlocked(bareId, ["tools"])) {
+        offenders.push(`${tier}: ${result.model}`);
+      }
+    }
+    expect(
+      offenders,
+      offenders.length === 0
+        ? ""
+        : `\n  Vision-slot models that are in the tools-blocklist:\n${offenders.map((o) => `    • ${o}`).join("\n")}\n`
+    ).toEqual([]);
   });
 
   it("drift guard: every tier's vision-slot model has vision:true in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS", () => {

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -29,3 +29,13 @@ export function isBlocked(modelId: string, requiredCapabilities: ModelCapability
       rule.forbiddenWhen.some((c) => requiredCapabilities.includes(c))
   );
 }
+
+/**
+ * Returns every distinct `forbiddenWhen` capability-set across all blocklist
+ * rules. Exposed so resolver drift-guards can iterate over current rules
+ * instead of hard-coding `["tools"]`. Add a new rule with a new forbidden
+ * capability and the drift-guards automatically cover it.
+ */
+export function getForbiddenCapabilitySets(): ReadonlyArray<readonly ModelCapability[]> {
+  return RULES.map((r) => r.forbiddenWhen);
+}

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -12,6 +12,14 @@ const RULES: BlockRule[] = [
     forbiddenWhen: ["tools"],
     reason: "DeepSeek-R1 tool-calling unreliable without reasoning:false flag",
   },
+  // Remove once pinchy#344 / openclaw#72879 (thought_signature drop) and the
+  // silent-hang variant on the reasoning+vision+tools path are resolved upstream.
+  {
+    modelPattern: /-preview\b/i,
+    forbiddenWhen: ["tools"],
+    reason:
+      "Preview models (e.g. gemini-3-flash-preview) are unstable for tools+vision: silent hangs and schema-rejection errors observed in production (pinchy#344, pinchy#338)",
+  },
 ];
 
 export function isBlocked(modelId: string, requiredCapabilities: ModelCapability[]): boolean {

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -8,6 +8,12 @@ import type { OllamaCloudModelId } from "@/lib/ollama-cloud-models";
 // (`llama3.3:70b → HTTP 404`) would have failed `tsc` here.
 type OllamaCloudModelRef = `ollama-cloud/${OllamaCloudModelId}`;
 
+// NOTE: this resolver hardcodes its picks and does NOT filter through
+// `isBlocked` at runtime (unlike `ollama-local.ts`, which does). The
+// drift-guard test in `__tests__/ollama-cloud.test.ts` ("does NOT return
+// a blocked model for any tier's vision slot") is what enforces the
+// invariant — if you add or change an entry below that lands in the
+// tools-blocklist, that test will fail before the regression ships.
 const BY_TIER_FAMILY: Record<
   ModelTier,
   Partial<Record<ModelTaskType, OllamaCloudModelRef>> & {

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -28,9 +28,13 @@ const BY_TIER_FAMILY: Record<
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",
-    // 1M context (matches deepseek-v4-pro), reasoning+vision+tools.
-    // Kimi family avoided: v0.5.3 silent-500 stability incident.
-    vision: "ollama-cloud/gemini-3-flash-preview",
+    // Largest non-preview reasoning+vision+tools model (262K context).
+    // gemini-3-flash-preview was the previous pick (1M context) but is blocked
+    // by the tools-blocklist as of pinchy#344 (silent hang + schema rejection on
+    // the tools+vision path). Kimi family also avoided: v0.5.3 silent-500 incident.
+    // Restore gemini-3-flash-preview here once upstream openclaw#72879 ships and
+    // the silent-hang variant is fixed (track in pinchy#344).
+    vision: "ollama-cloud/qwen3.5:397b",
   },
 };
 


### PR DESCRIPTION
Closes #344.

## Summary

- Add a blocklist rule in `model-resolver/blocklist.ts` that forbids any `*-preview` model when `tools` is required, mirroring the existing `deepseek-r1` rule shape. Carries an inline comment pointing at #344 / openclaw#72879 so the cleanup path is obvious once the upstream `thought_signature` drop and silent-hang variants are fixed.
- Swap the `ollama-cloud` reasoning + vision slot from `gemini-3-flash-preview` (1M ctx, but blocked) to `qwen3.5:397b` (262K ctx, reasoning + vision + tools, non-preview). Without this swap the auto-default picker would still hand users the broken combination, since the cloud resolver hardcodes its picks and doesn't filter through the blocklist.
- Tests: extend `blocklist.test.ts` with cases covering `gemini-3-flash-preview` + the broader `-preview` family, and add a generic drift guard in `ollama-cloud.test.ts` that fails if any tier x taskType x known forbidden-capability-set ever resolves to a blocked model. Both went red before the fix.
- Document in `ollama-cloud.ts` that the cloud resolver doesn't filter through `isBlocked` at runtime (the drift-guard test is the only enforcement layer). Export `getForbiddenCapabilitySets()` from `blocklist.ts` so the drift-guard automatically covers any new blocklist rule with a new forbidden capability (e.g. `["long-context"]` in the future), no test edits needed.

The `gemini-3-flash-preview` entry stays in `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS`, so advanced users who explicitly know what they're doing can still pick it via override - only the default picker and "compatible models" view stop steering them into the broken combination.

## User-visible behavior change

The default reasoning + vision model on Ollama Cloud drops from `gemini-3-flash-preview` (1,048,576 token context) to `qwen3.5:397b` (262,144 token context) - a 4x reduction. Existing agents pinned to `gemini-3-flash-preview` are unaffected (their override stays); only newly-defaulted agents see the smaller window. Worth flagging in release notes for users running large knowledge-base scans against the reasoning + vision tier.

## Test plan

- [x] `pnpm test src/lib/model-resolver/__tests__/blocklist.test.ts` - 10 / 10 pass
- [x] `pnpm test src/lib/model-resolver/__tests__/ollama-cloud.test.ts` - 15 / 15 pass
- [x] `pnpm test` - 4379 pass / 12 skipped, no regressions
- [x] `pnpm lint` - no new errors (pre-existing security warnings only)
- [x] `tsc --noEmit` - clean
- [x] `pnpm build` - succeeds (via pre-commit hook)