### PR TITLE
feat(providers): reject non-allowlist Ollama URLs at save time (#296)

### DIFF
--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -353,6 +353,51 @@ describe("POST /api/setup/provider", () => {
     expect(response.status).toBe(400);
   });
 
+  // #296 — Save-time rejection of hosts that won't pass OpenClaw's
+  // isLocalBaseUrl allowlist. The unit test in providers.test.ts covers the
+  // detection; here we just pin the route's surface contract so the UI can
+  // render a helpful hint instead of silent runtime failure at chat time.
+  it("returns 422 with a docs-link hint when ollama-local URL host is not on OpenClaw's allowlist (#296)", async () => {
+    vi.mocked(validateProviderUrl).mockResolvedValueOnce({
+      valid: false,
+      error: "unsupported_local_host",
+      host: "ollama",
+    });
+
+    const response = await POST(
+      makeRequest({
+        provider: "ollama-local",
+        url: "http://ollama:11434",
+      }) as any
+    );
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    // The error must name the offending host so the user can find their
+    // typo, and link to the option-B section of the Ollama setup guide so
+    // they have an actionable fix (the docs change in #295 explains why).
+    expect(data.error).toContain("ollama");
+    expect(data.error).toMatch(/ollama-setup/);
+    expect(data.error).toMatch(/b-ollama-as-a-docker-service/);
+  });
+
+  it("does not save the provider when ollama-local URL host is unsupported (#296)", async () => {
+    vi.mocked(validateProviderUrl).mockResolvedValueOnce({
+      valid: false,
+      error: "unsupported_local_host",
+      host: "ollama",
+    });
+
+    await POST(
+      makeRequest({
+        provider: "ollama-local",
+        url: "http://ollama:11434",
+      }) as any
+    );
+    // No setSetting calls at all — the URL must not land in the DB.
+    expect(setSetting).not.toHaveBeenCalled();
+    expect(regenerateOpenClawConfig).not.toHaveBeenCalled();
+  });
+
   it("should return 502 when ollama-local URL is unreachable", async () => {
     vi.mocked(validateProviderUrl).mockResolvedValueOnce({
       valid: false,

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { isOpenClawLocalBaseUrl } from "@/lib/openclaw-local-url";
 
 vi.mock("fs", async (importOriginal) => {
   const actual = await importOriginal<typeof import("fs")>();
@@ -187,47 +188,12 @@ beforeEach(() => {
   });
 });
 
-/**
- * Mirror of OpenClaw's `isLocalBaseUrl` predicate
- * (model-auth-CsyLGY9m.js:111-118 + isPrivateIpv4Host:120-126). The function
- * isn't exported through any of openclaw's public subpath exports, so the
- * tests below re-implement it as a drift guard: if upstream changes the
- * allowlist, this mirror won't auto-detect that — but anyone bumping the
- * `openclaw` version pin should grep for `OPENCLAW_ISLOCAL_PIN` and
- * re-verify the predicate, then update the docs in ollama-setup.mdx if
- * the allowlist semantics changed.
- *
- * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump; see PR #279)
- */
-function mirrorOpenClawIsLocalBaseUrl(baseUrl: string): boolean {
-  try {
-    let host = new URL(baseUrl).hostname.toLowerCase();
-    // Defensive parity with upstream — on Node/V8 `URL.hostname` already
-    // returns IPv6 literals without brackets, so this branch is currently
-    // dead. Keep it so the mirror stays a 1:1 port of the upstream source
-    // and a future Node engine change can't silently diverge us.
-    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
-    return (
-      host === "localhost" ||
-      host === "127.0.0.1" ||
-      host === "0.0.0.0" ||
-      host === "::1" ||
-      host === "::ffff:7f00:1" ||
-      host === "::ffff:127.0.0.1" ||
-      host.endsWith(".local") ||
-      mirrorIsPrivateIpv4Host(host)
-    );
-  } catch {
-    return false;
-  }
-}
-function mirrorIsPrivateIpv4Host(host: string): boolean {
-  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) return false;
-  const octets = host.split(".").map((o) => Number.parseInt(o, 10));
-  if (octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return false;
-  const [a, b] = octets;
-  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
-}
+// Drift guard: re-export the shared `isOpenClawLocalBaseUrl` (see
+// @/lib/openclaw-local-url) under the local name used by the assertions in
+// this file. The shared module is a 1:1 port of OpenClaw's `isLocalBaseUrl`
+// predicate and now also backs save-time rejection in `validateProviderUrl`
+// (#296), so this file no longer ships a private duplicate.
+const mirrorOpenClawIsLocalBaseUrl = isOpenClawLocalBaseUrl;
 
 describe("regenerateOpenClawConfig", () => {
   beforeEach(() => {

--- a/packages/web/src/__tests__/lib/providers.test.ts
+++ b/packages/web/src/__tests__/lib/providers.test.ts
@@ -188,4 +188,53 @@ describe("validateProviderUrl", () => {
     const result = await validateProviderUrl("http://localhost:11434");
     expect(result).toEqual({ valid: false, error: "provider_error", status: 500 });
   });
+
+  // #296 — Reject hosts that won't pass OpenClaw's isLocalBaseUrl predicate at
+  // save time, instead of letting them sail through and fail silently at chat
+  // time with "No API key found for provider 'ollama'". A bare Docker service
+  // name like `http://ollama:11434` reaches Ollama (so the network probe
+  // passes) but the emitted baseUrl will be rejected by OpenClaw at request
+  // time — see __tests__/lib/openclaw-config.test.ts:1862 for the dual.
+  describe("unsupported_local_host (#296)", () => {
+    it("returns unsupported_local_host for a bare Docker service hostname like http://ollama:11434", async () => {
+      // Network check must NOT run for unsupported hosts — we short-circuit
+      // before the fetch to surface the structured error.
+      const result = await validateProviderUrl("http://ollama:11434");
+      expect(result).toEqual({ valid: false, error: "unsupported_local_host", host: "ollama" });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+
+    it("accepts http://ollama.docker.local:11434 (option B alias, ends in .local)", async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(JSON.stringify({ models: [] }), { status: 200 })
+      );
+      const result = await validateProviderUrl("http://ollama.docker.local:11434");
+      expect(result).toEqual({ valid: true });
+      expect(fetch).toHaveBeenCalledWith("http://ollama.docker.local:11434/api/tags");
+    });
+
+    it("accepts http://host.docker.internal:11434 (Docker host alias, rewritten to ollama.local at config-emit time)", async () => {
+      vi.mocked(fetch).mockResolvedValue(
+        new Response(JSON.stringify({ models: [] }), { status: 200 })
+      );
+      const result = await validateProviderUrl("http://host.docker.internal:11434");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("accepts private-IPv4 hostnames (e.g. 192.168.1.50) that already pass isLocalBaseUrl", async () => {
+      vi.mocked(fetch).mockResolvedValue(new Response("{}", { status: 200 }));
+      const result = await validateProviderUrl("http://192.168.1.50:11434");
+      expect(result).toEqual({ valid: true });
+    });
+
+    it("rejects public hostnames (e.g. example.com) at save time", async () => {
+      const result = await validateProviderUrl("http://example.com:11434");
+      expect(result).toEqual({
+        valid: false,
+        error: "unsupported_local_host",
+        host: "example.com",
+      });
+      expect(fetch).not.toHaveBeenCalled();
+    });
+  });
 });

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -18,6 +18,7 @@ import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
+import { docsUrl } from "@/components/docs-link";
 
 const VALID_PROVIDERS = Object.keys(PROVIDERS) as ProviderName[];
 
@@ -54,6 +55,24 @@ export async function POST(request: NextRequest) {
               "Could not connect to Ollama at this URL. Ensure Ollama is running and accessible.",
           },
           { status: 502 }
+        );
+      }
+      // #296 — Host won't pass OpenClaw's isLocalBaseUrl allowlist. Saving it
+      // would let the URL sail through and fail silently at chat time with
+      // "No API key found for provider 'ollama'". Surface a one-line hint
+      // pointing at option B of the Ollama setup guide so the user can fix
+      // the hostname (e.g. ollama → ollama.docker.local) without reading the
+      // full troubleshooting section.
+      if (validation.error === "unsupported_local_host") {
+        const setupUrl = docsUrl("guides/ollama-setup", "b-ollama-as-a-docker-service");
+        return NextResponse.json(
+          {
+            error:
+              `Host "${validation.host}" is not an allowed local Ollama host. ` +
+              `Use localhost, a *.local alias, or a private IP. ` +
+              `See ${setupUrl} for the recommended Docker setup.`,
+          },
+          { status: 422 }
         );
       }
       return NextResponse.json(

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -28,6 +28,9 @@ import {
   readGatewayTokenFromConfig,
 } from "./secrets-bundle";
 import { writeAgentAuthProfiles, type AuthProfilesProvider } from "./agent-auth-profiles";
+// Docker host aliases live in @/lib/openclaw-local-url so they can be shared
+// with `validateProviderUrl`'s save-time allowlist check (#296).
+import { DOCKER_HOST_ALIASES } from "@/lib/openclaw-local-url";
 import { validateBuiltConfig } from "./validate-built-config";
 
 // OC 2026.4.27+ requires `baseUrl` in `models.providers.<name>` for every configured
@@ -45,30 +48,6 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
   openai: "OPENAI_BASE_URL",
   google: "GOOGLE_BASE_URL",
 };
-
-/**
- * Hostnames that all resolve to "the Docker host machine" — none of them are
- * in OpenClaw's `isLocalBaseUrl` allowlist, so all need to be rewritten to
- * `ollama.local` (which `*.local` matches). docker-compose maps `ollama.local`
- * to `host-gateway`, preserving connectivity.
- *
- * Sourced from Docker docs:
- * - `host.docker.internal` — Docker Desktop 18.03+ and modern Docker on Linux
- *   (with `--add-host=host.docker.internal:host-gateway`)
- * - `gateway.docker.internal` — Docker Desktop's bridge gateway alias
- * - `docker.for.mac.host.internal` / `docker.for.win.host.internal` — legacy
- *   aliases still emitted on older Docker Desktop installs
- *
- * Anything not in this set is left as-is. Public IPs and bare hostnames may
- * still fail OpenClaw's allowlist, but rewriting them to `ollama.local`
- * would silently misroute traffic — the user picked that host on purpose.
- */
-const DOCKER_HOST_ALIASES: ReadonlySet<string> = new Set([
-  "host.docker.internal",
-  "gateway.docker.internal",
-  "docker.for.mac.host.internal",
-  "docker.for.win.host.internal",
-]);
 
 /**
  * Rewrites the user-supplied Ollama URL so OpenClaw's `isLocalBaseUrl` check

--- a/packages/web/src/lib/openclaw-local-url.ts
+++ b/packages/web/src/lib/openclaw-local-url.ts
@@ -1,0 +1,88 @@
+/**
+ * Mirror of OpenClaw's `isLocalBaseUrl` predicate
+ * (model-auth-CsyLGY9m.js:111-118 + isPrivateIpv4Host:120-126). OpenClaw
+ * does not export the function through any of its public subpath exports,
+ * so we re-implement it here as a 1:1 port and use it both at save time
+ * (providers.ts → reject unsupported hosts before they hit the DB) and as
+ * a drift guard in openclaw-config.test.ts.
+ *
+ * If upstream changes the allowlist, this mirror won't auto-detect it —
+ * anyone bumping the `openclaw` version pin should grep for
+ * `OPENCLAW_ISLOCAL_PIN` and re-verify the predicate, then update the
+ * docs in ollama-setup.mdx if the allowlist semantics changed.
+ *
+ * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump; see PR #279)
+ */
+
+/**
+ * Docker host aliases that all resolve to "the host machine running
+ * Docker". None of them pass OpenClaw's `isLocalBaseUrl` allowlist
+ * directly, but `build.ts#rewriteOllamaHostForOpenClaw` rewrites every
+ * one of them to `ollama.local` before the URL ever lands in the
+ * emitted `openclaw.json`. The save-time validator accepts these as
+ * "would pass after rewrite" so users can paste the placeholder URL
+ * (`host.docker.internal:11434`) without seeing a spurious rejection.
+ *
+ * Kept in sync with `DOCKER_HOST_ALIASES` in openclaw-config/build.ts.
+ */
+export const DOCKER_HOST_ALIASES: ReadonlySet<string> = new Set([
+  "host.docker.internal",
+  "gateway.docker.internal",
+  "docker.for.mac.host.internal",
+  "docker.for.win.host.internal",
+]);
+
+function isPrivateIpv4Host(host: string): boolean {
+  if (!/^\d+\.\d+\.\d+\.\d+$/.test(host)) return false;
+  const octets = host.split(".").map((o) => Number.parseInt(o, 10));
+  if (octets.some((p) => !Number.isInteger(p) || p < 0 || p > 255)) return false;
+  const [a, b] = octets;
+  return a === 10 || (a === 172 && b >= 16 && b <= 31) || (a === 192 && b === 168);
+}
+
+/**
+ * 1:1 port of OpenClaw's `isLocalBaseUrl` predicate. Returns true iff
+ * the URL's hostname is on OpenClaw's local-provider allowlist.
+ */
+export function isOpenClawLocalBaseUrl(baseUrl: string): boolean {
+  try {
+    let host = new URL(baseUrl).hostname.toLowerCase();
+    // Defensive parity with upstream — on Node/V8 `URL.hostname` already
+    // returns IPv6 literals without brackets, so this branch is currently
+    // dead. Keep it so the mirror stays a 1:1 port of the upstream source
+    // and a future Node engine change can't silently diverge us.
+    if (host.startsWith("[") && host.endsWith("]")) host = host.slice(1, -1);
+    return (
+      host === "localhost" ||
+      host === "127.0.0.1" ||
+      host === "0.0.0.0" ||
+      host === "::1" ||
+      host === "::ffff:7f00:1" ||
+      host === "::ffff:127.0.0.1" ||
+      host.endsWith(".local") ||
+      isPrivateIpv4Host(host)
+    );
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Returns true if the user-supplied Ollama URL will pass OpenClaw's
+ * `isLocalBaseUrl` allowlist — either directly, or after
+ * `build.ts#rewriteOllamaHostForOpenClaw` rewrites a Docker host alias
+ * to `ollama.local`.
+ *
+ * This is what `validateProviderUrl` enforces at save time: if it
+ * returns false, the URL would be saved successfully and then fail
+ * silently at chat time with "No API key found for provider 'ollama'".
+ */
+export function isOpenClawCompatibleOllamaUrl(rawUrl: string): boolean {
+  try {
+    const host = new URL(rawUrl).hostname.toLowerCase();
+    if (DOCKER_HOST_ALIASES.has(host)) return true;
+    return isOpenClawLocalBaseUrl(rawUrl);
+  } catch {
+    return false;
+  }
+}

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -1,3 +1,5 @@
+import { isOpenClawCompatibleOllamaUrl } from "@/lib/openclaw-local-url";
+
 export type ProviderName = "anthropic" | "openai" | "google" | "ollama-cloud" | "ollama-local";
 
 interface ProviderConfig {
@@ -57,7 +59,8 @@ export type ValidationResult =
   | { valid: false; error: "invalid_key" }
   | { valid: false; error: "network_error" }
   | { valid: false; error: "provider_error"; status: number }
-  | { valid: false; error: "no_compatible_models" };
+  | { valid: false; error: "no_compatible_models" }
+  | { valid: false; error: "unsupported_local_host"; host: string };
 
 function makeValidationRequest(provider: ProviderName, apiKey: string): Promise<Response> {
   switch (provider) {
@@ -95,6 +98,22 @@ function makeValidationRequest(provider: ProviderName, apiKey: string): Promise<
 }
 
 export async function validateProviderUrl(url: string): Promise<ValidationResult> {
+  // Layered guardrail #2 for #280 (#296): reject hosts that won't pass
+  // OpenClaw's isLocalBaseUrl allowlist BEFORE the URL is saved. A bare
+  // Docker service name like `http://ollama:11434` happily answers
+  // /api/tags, so the network probe alone can't catch it — but the
+  // emitted baseUrl is rejected by OpenClaw at chat time and the user
+  // sees the opaque "No API key found for provider 'ollama'" error.
+  let parsedHost: string | null = null;
+  try {
+    parsedHost = new URL(url).hostname;
+  } catch {
+    // Malformed URL — fall through to the network probe so the existing
+    // network_error path handles it.
+  }
+  if (parsedHost && !isOpenClawCompatibleOllamaUrl(url)) {
+    return { valid: false, error: "unsupported_local_host", host: parsedHost };
+  }
   try {
     const response = await fetch(`${url.replace(/\/$/, "")}/api/tags`);
     if (response.ok) return { valid: true };


### PR DESCRIPTION
## Summary
- New shared helper `@/lib/openclaw-local-url` ports OpenClaw's `isLocalBaseUrl` predicate plus the `DOCKER_HOST_ALIASES` set. `build.ts` and the new save-time validator both import from it, eliminating a duplicated mirror that previously lived in `openclaw-config.test.ts`.
- `validateProviderUrl` returns a structured `{ valid: false, error: "unsupported_local_host", host: string }` for URLs whose host won't pass OpenClaw's allowlist (e.g. bare Docker service names like `http://ollama:11434`). The check runs before the `/api/tags` network probe.
- `POST /api/setup/provider` returns 422 with a one-line hint pointing at option B of the Ollama setup guide. Provider is not saved on rejection.

This is layer 3 of the layered guardrail for #280 — docs (#295) and runtime regression test landed earlier. Closes #296.

## Test plan
- [x] `pnpm -C packages/web test` (4377 passed, 12 skipped)
- [x] `pnpm -C packages/web exec tsc --noEmit` (clean)
- [x] `pnpm -C packages/web exec eslint` (clean — only pre-existing warnings)
- [x] New unit coverage in `providers.test.ts`: positive case for `http://ollama.docker.local:11434`, negative for `http://ollama:11434`, plus Docker host alias, private IPv4, and public-host cases
- [x] New route coverage in `setup-provider.test.ts`: 422 with docs-link hint, and "URL is not saved" guard