### PR TITLE
feat(pinchy-docs): expose public docs URL so agents can cite it

### DIFF
--- a/packages/plugins/pinchy-docs/config-schema.test.ts
+++ b/packages/plugins/pinchy-docs/config-schema.test.ts
@@ -10,6 +10,7 @@ const REPRESENTATIVE_EMITTED_CONFIG = {
   agents: {
     "agent-uuid": {},
   },
+  publicBaseUrl: "https://docs.heypinchy.com",
 };
 
 describe("pinchy-docs manifest contract", () => {
@@ -26,5 +27,24 @@ describe("pinchy-docs manifest contract", () => {
 
   it("uses additionalProperties: false", () => {
     expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+
+  it("treats publicBaseUrl as optional (air-gapped forks ship without it)", () => {
+    const result = validatePluginEntry(manifest, {
+      docsPath: "/pinchy-docs",
+      agents: { "agent-uuid": {} },
+    });
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects non-string publicBaseUrl", () => {
+    expect(
+      validatePluginEntry(manifest, {
+        docsPath: "/pinchy-docs",
+        agents: { "agent-uuid": {} },
+        publicBaseUrl: 42,
+      }).ok
+    ).toBe(false);
   });
 });

--- a/packages/plugins/pinchy-docs/index.test.ts
+++ b/packages/plugins/pinchy-docs/index.test.ts
@@ -591,5 +591,20 @@ describe("pinchy-docs plugin", () => {
       expect(result.content[0].text).not.toContain("Public URL:");
       expect(result.content[0].text).toContain("Hello body.");
     });
+
+    it("buildPublicUrl strips a leading slash on relPath so the URL never contains '//'", async () => {
+      // Defensive: `listMdxFiles()` builds relPath without leading slashes,
+      // but `docs_read` accepts a user-supplied path. A path like
+      // "/guides/foo.mdx" must not collapse `${base}/${slug}/` into
+      // `${base}//guides/foo/`. Lock the contract directly on the exported
+      // helper so future call sites cannot regress it.
+      const { buildPublicUrl } = await import("./index");
+      expect(buildPublicUrl("https://docs.heypinchy.com", "/guides/foo.mdx")).toBe(
+        "https://docs.heypinchy.com/guides/foo/"
+      );
+      expect(buildPublicUrl("https://docs.heypinchy.com", "///guides/foo.mdx")).toBe(
+        "https://docs.heypinchy.com/guides/foo/"
+      );
+    });
   });
 });

--- a/packages/plugins/pinchy-docs/index.test.ts
+++ b/packages/plugins/pinchy-docs/index.test.ts
@@ -8,6 +8,7 @@ const mockRegisterTool = vi.fn();
 function createMockApi(config: {
   docsPath: string;
   agents: Record<string, Record<string, unknown>>;
+  publicBaseUrl?: string;
 }) {
   return {
     id: "pinchy-docs",
@@ -442,5 +443,153 @@ describe("pinchy-docs plugin", () => {
     expect(plugin.id).toBe("pinchy-docs");
     expect(plugin.name).toBe("Pinchy Docs");
     expect(plugin.configSchema).toBeDefined();
+  });
+
+  describe("publicBaseUrl → url mapping", () => {
+    it("docs_list includes a url field for each entry when publicBaseUrl is set", async () => {
+      writeMdx("guides/connect-email.mdx", { title: "Connect", description: "x" }, "body");
+
+      const api = createMockApi({
+        docsPath: docsRoot,
+        agents: { "agent-1": {} },
+        publicBaseUrl: "https://docs.heypinchy.com",
+      });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_list"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", {});
+      const parsed = JSON.parse(result.content[0].text);
+      const entry = parsed.find((p: any) => p.path === "guides/connect-email.mdx");
+      expect(entry.url).toBe("https://docs.heypinchy.com/guides/connect-email/");
+    });
+
+    it("docs_list omits url field when publicBaseUrl is not set (air-gapped fork)", async () => {
+      writeMdx("guides/connect-email.mdx", { title: "Connect", description: "x" }, "body");
+
+      const api = createMockApi({ docsPath: docsRoot, agents: { "agent-1": {} } });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_list"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", {});
+      const parsed = JSON.parse(result.content[0].text);
+      const entry = parsed.find((p: any) => p.path === "guides/connect-email.mdx");
+      expect(entry).toEqual({
+        path: "guides/connect-email.mdx",
+        title: "Connect",
+        description: "x",
+      });
+      expect("url" in entry).toBe(false);
+    });
+
+    it("docs_list maps index.mdx at the root to the bare base URL", async () => {
+      writeMdx("index.mdx", { title: "Home", description: "x" }, "body");
+
+      const api = createMockApi({
+        docsPath: docsRoot,
+        agents: { "agent-1": {} },
+        publicBaseUrl: "https://docs.heypinchy.com",
+      });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_list"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", {});
+      const parsed = JSON.parse(result.content[0].text);
+      const entry = parsed.find((p: any) => p.path === "index.mdx");
+      expect(entry.url).toBe("https://docs.heypinchy.com/");
+    });
+
+    it("docs_list maps subdir index.mdx to the subdir slug", async () => {
+      writeMdx("guides/index.mdx", { title: "Guides", description: "x" }, "body");
+
+      const api = createMockApi({
+        docsPath: docsRoot,
+        agents: { "agent-1": {} },
+        publicBaseUrl: "https://docs.heypinchy.com",
+      });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_list"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", {});
+      const parsed = JSON.parse(result.content[0].text);
+      const entry = parsed.find((p: any) => p.path === "guides/index.mdx");
+      expect(entry.url).toBe("https://docs.heypinchy.com/guides/");
+    });
+
+    it("docs_list strips a trailing slash on publicBaseUrl before building urls", async () => {
+      writeMdx("guides/foo.mdx", { title: "Foo", description: "x" }, "body");
+
+      const api = createMockApi({
+        docsPath: docsRoot,
+        agents: { "agent-1": {} },
+        publicBaseUrl: "https://docs.heypinchy.com/",
+      });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_list"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", {});
+      const parsed = JSON.parse(result.content[0].text);
+      const entry = parsed.find((p: any) => p.path === "guides/foo.mdx");
+      expect(entry.url).toBe("https://docs.heypinchy.com/guides/foo/");
+    });
+
+    it("docs_read prepends a citation line with the public URL when publicBaseUrl is set", async () => {
+      writeMdx("guides/connect-email.mdx", { title: "Connect", description: "x" }, "Hello body.");
+
+      const api = createMockApi({
+        docsPath: docsRoot,
+        agents: { "agent-1": {} },
+        publicBaseUrl: "https://docs.heypinchy.com",
+      });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_read"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", { path: "guides/connect-email.mdx" });
+
+      expect(result.content[0].text).toMatch(
+        /Public URL:\s*https:\/\/docs\.heypinchy\.com\/guides\/connect-email\//
+      );
+      expect(result.content[0].text).toContain("Hello body.");
+    });
+
+    it("docs_read does not prepend a citation line when publicBaseUrl is unset", async () => {
+      writeMdx("guides/connect-email.mdx", { title: "Connect", description: "x" }, "Hello body.");
+
+      const api = createMockApi({ docsPath: docsRoot, agents: { "agent-1": {} } });
+      const { default: plugin } = await import("./index");
+      plugin.register!(api as any);
+
+      const factory = mockRegisterTool.mock.calls.find(
+        (c: any[]) => c[1]?.name === "docs_read"
+      )?.[0];
+      const tool = factory({ agentId: "agent-1" });
+      const result = await tool.execute("call-1", { path: "guides/connect-email.mdx" });
+
+      expect(result.content[0].text).not.toContain("Public URL:");
+      expect(result.content[0].text).toContain("Hello body.");
+    });
   });
 });

--- a/packages/plugins/pinchy-docs/index.ts
+++ b/packages/plugins/pinchy-docs/index.ts
@@ -48,12 +48,16 @@ interface DocEntry {
  *   - strip extension and trailing `/index`
  *   - append trailing slash
  *   - `index.mdx` at the root collapses to the bare base URL
+ *   - leading slashes on relPath are stripped so concatenation can't produce
+ *     `//` (defensive: `listMdxFiles()` never emits them, but `docs_read`
+ *     accepts a user-supplied path)
  * Returns null when `baseUrl` is falsy (air-gapped fork — keep path-only output).
  */
 export function buildPublicUrl(baseUrl: string | undefined, relPath: string): string | null {
   if (!baseUrl) return null;
   const base = baseUrl.replace(/\/+$/, "");
   const slug = relPath
+    .replace(/^\/+/, "")
     .replace(/\.(mdx|md)$/i, "")
     .replace(/\/index$/i, "")
     .replace(/^index$/i, "");

--- a/packages/plugins/pinchy-docs/index.ts
+++ b/packages/plugins/pinchy-docs/index.ts
@@ -8,6 +8,7 @@ interface PluginToolContext {
 interface PluginConfig {
   docsPath: string;
   agents: Record<string, Record<string, unknown>>;
+  publicBaseUrl?: string;
 }
 
 interface PluginApi {
@@ -38,6 +39,25 @@ interface DocEntry {
   path: string;
   title: string;
   description: string;
+  url?: string;
+}
+
+/**
+ * Map a doc-relative `.mdx`/`.md` path to its rendered Astro Starlight URL.
+ * Rules mirror Starlight defaults:
+ *   - strip extension and trailing `/index`
+ *   - append trailing slash
+ *   - `index.mdx` at the root collapses to the bare base URL
+ * Returns null when `baseUrl` is falsy (air-gapped fork — keep path-only output).
+ */
+export function buildPublicUrl(baseUrl: string | undefined, relPath: string): string | null {
+  if (!baseUrl) return null;
+  const base = baseUrl.replace(/\/+$/, "");
+  const slug = relPath
+    .replace(/\.(mdx|md)$/i, "")
+    .replace(/\/index$/i, "")
+    .replace(/^index$/i, "");
+  return slug ? `${base}/${slug}/` : `${base}/`;
 }
 
 function parseFrontmatter(content: string): { title: string; description: string } {
@@ -64,7 +84,7 @@ function parseFrontmatter(content: string): { title: string; description: string
   return { title, description };
 }
 
-function listMdxFiles(root: string): DocEntry[] {
+function listMdxFiles(root: string, publicBaseUrl?: string): DocEntry[] {
   const results: DocEntry[] = [];
 
   function walk(dir: string, relBase: string) {
@@ -83,7 +103,10 @@ function listMdxFiles(root: string): DocEntry[] {
         try {
           const content = readFileSync(fullPath, "utf-8");
           const { title, description } = parseFrontmatter(content);
-          results.push({ path: relPath, title, description });
+          const docEntry: DocEntry = { path: relPath, title, description };
+          const url = buildPublicUrl(publicBaseUrl, relPath);
+          if (url) docEntry.url = url;
+          results.push(docEntry);
         } catch {
           // skip unreadable file
         }
@@ -201,7 +224,7 @@ const plugin = {
     const config = api.pluginConfig;
     if (!config) return;
 
-    const { docsPath, agents } = config;
+    const { docsPath, agents, publicBaseUrl } = config;
 
     api.registerTool(
       (ctx: PluginToolContext) => {
@@ -220,7 +243,7 @@ const plugin = {
           },
           async execute() {
             try {
-              const files = listMdxFiles(docsPath);
+              const files = listMdxFiles(docsPath, publicBaseUrl);
               return {
                 content: [
                   { type: "text", text: JSON.stringify(files, null, 2) },
@@ -285,7 +308,10 @@ const plugin = {
                 };
               }
               const content = readFileSync(safe, "utf-8");
-              return { content: [{ type: "text", text: preprocessMdx(content) }] };
+              const body = preprocessMdx(content);
+              const url = buildPublicUrl(publicBaseUrl, relPath);
+              const text = url ? `Public URL: ${url}\n\n${body}` : body;
+              return { content: [{ type: "text", text }] };
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : "Unknown error";

--- a/packages/plugins/pinchy-docs/openclaw.plugin.json
+++ b/packages/plugins/pinchy-docs/openclaw.plugin.json
@@ -17,6 +17,9 @@
         "additionalProperties": {
           "type": "object"
         }
+      },
+      "publicBaseUrl": {
+        "type": "string"
       }
     },
     "required": ["docsPath", "agents"]

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -126,6 +126,8 @@ import {
   sanitizeOpenClawConfig,
   seedRestartClassOverridesIfMissing,
   updateTelegramChannelConfig,
+  DEFAULT_DOCS_PUBLIC_BASE_URL,
+  DOCS_PUBLIC_BASE_URL_SETTING_KEY,
 } from "@/lib/openclaw-config";
 import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
 import { db } from "@/db";
@@ -2022,6 +2024,15 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.plugins.allow).toContain("pinchy-docs");
   });
 
+  it("exports a single DEFAULT_DOCS_PUBLIC_BASE_URL constant (single source of truth for the hosted-docs default)", () => {
+    // Locks in the refactor that removed the duplicated literal between
+    // build.ts and the test suite. If the hosted docs domain ever moves,
+    // grep for the constant — there must be exactly one definition.
+    expect(typeof DEFAULT_DOCS_PUBLIC_BASE_URL).toBe("string");
+    expect(DEFAULT_DOCS_PUBLIC_BASE_URL).toMatch(/^https:\/\//);
+    expect(DOCS_PUBLIC_BASE_URL_SETTING_KEY).toBe("docs_public_base_url");
+  });
+
   it("defaults pinchy-docs publicBaseUrl to https://docs.heypinchy.com when the setting is unset", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([
@@ -2043,13 +2054,13 @@ describe("regenerateOpenClawConfig", () => {
     const config = JSON.parse(written);
 
     expect(config.plugins.entries["pinchy-docs"].config.publicBaseUrl).toBe(
-      "https://docs.heypinchy.com"
+      DEFAULT_DOCS_PUBLIC_BASE_URL
     );
   });
 
   it("honours an admin-set docs_public_base_url setting for self-hosted docs", async () => {
     mockedGetSetting.mockImplementation(async (key: string) => {
-      if (key === "docs_public_base_url") return "https://docs.example.com";
+      if (key === DOCS_PUBLIC_BASE_URL_SETTING_KEY) return "https://docs.example.com";
       return null;
     });
     mockedDb.select.mockReturnValue({
@@ -2078,7 +2089,7 @@ describe("regenerateOpenClawConfig", () => {
 
   it("omits publicBaseUrl when the admin explicitly clears the setting (air-gapped fork)", async () => {
     mockedGetSetting.mockImplementation(async (key: string) => {
-      if (key === "docs_public_base_url") return "";
+      if (key === DOCS_PUBLIC_BASE_URL_SETTING_KEY) return "";
       return null;
     });
     mockedDb.select.mockReturnValue({

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2022,6 +2022,87 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.plugins.allow).toContain("pinchy-docs");
   });
 
+  it("defaults pinchy-docs publicBaseUrl to https://docs.heypinchy.com when the setting is unset", async () => {
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "smithers-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          isPersonal: true,
+          ownerId: "user-1",
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.plugins.entries["pinchy-docs"].config.publicBaseUrl).toBe(
+      "https://docs.heypinchy.com"
+    );
+  });
+
+  it("honours an admin-set docs_public_base_url setting for self-hosted docs", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "docs_public_base_url") return "https://docs.example.com";
+      return null;
+    });
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "smithers-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          isPersonal: true,
+          ownerId: "user-1",
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.plugins.entries["pinchy-docs"].config.publicBaseUrl).toBe(
+      "https://docs.example.com"
+    );
+  });
+
+  it("omits publicBaseUrl when the admin explicitly clears the setting (air-gapped fork)", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "docs_public_base_url") return "";
+      return null;
+    });
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "smithers-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          isPersonal: true,
+          ownerId: "user-1",
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect("publicBaseUrl" in config.plugins.entries["pinchy-docs"].config).toBe(false);
+  });
+
   it("writes per-agent auth-profiles.json scoped to each agent's model provider", async () => {
     const agentsData = [
       {

--- a/packages/web/src/__tests__/lib/smithers-soul.test.ts
+++ b/packages/web/src/__tests__/lib/smithers-soul.test.ts
@@ -56,6 +56,19 @@ describe("SMITHERS_SOUL_MD", () => {
     expect(SMITHERS_SOUL_MD).toContain("available in your context");
   });
 
+  it("instructs Smithers to cite the public URL rather than the file path when available", () => {
+    // The docs_list/docs_read plugin output includes a `url` field whenever the
+    // operator has a public docs site configured. The SOUL must teach Smithers
+    // to surface that URL to the user instead of the on-disk `.mdx` path, which
+    // the user cannot open. Tracked in #202.
+    const lower = SMITHERS_SOUL_MD.toLowerCase();
+    expect(lower).toContain("url");
+    expect(lower).toMatch(/prefer.*url|cite.*url|public url/);
+    // It must also acknowledge the air-gapped fallback so Smithers stays
+    // useful when no public docs URL is configured.
+    expect(lower).toMatch(/(no url|url is unavailable|url is missing|no public url)/);
+  });
+
   it("does not duplicate platform knowledge that lives in the docs", () => {
     // Docs are the single source of truth — Smithers reads them on demand via
     // docs_list/docs_read. Inlining feature summaries here makes the SOUL drift

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -465,12 +465,22 @@ export async function regenerateOpenClawConfig() {
   // platform documentation on demand. The plugin scopes itself to listed agents.
   const personalAgentIds = allAgents.filter((a) => a.isPersonal && !a.deletedAt).map((a) => a.id);
   if (personalAgentIds.length > 0) {
+    // Empty-string setting means the operator explicitly opted out (air-gapped
+    // fork without published docs) — keep path-only behaviour. `null` means
+    // unset, fall back to Pinchy's hosted docs.
+    const docsBaseUrlSetting = await getSetting("docs_public_base_url");
+    const docsConfig: Record<string, unknown> = {
+      docsPath: "/pinchy-docs",
+      agents: Object.fromEntries(personalAgentIds.map((id) => [id, {}])),
+    };
+    const resolvedDocsBaseUrl =
+      docsBaseUrlSetting === null ? "https://docs.heypinchy.com" : docsBaseUrlSetting;
+    if (resolvedDocsBaseUrl) {
+      docsConfig.publicBaseUrl = resolvedDocsBaseUrl;
+    }
     entries["pinchy-docs"] = {
       enabled: true,
-      config: {
-        docsPath: "/pinchy-docs",
-        agents: Object.fromEntries(personalAgentIds.map((id) => [id, {}])),
-      },
+      config: docsConfig,
     };
   }
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -50,6 +50,22 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
 };
 
 /**
+ * Public docs URL configuration for the bundled `pinchy-docs` plugin.
+ *
+ * `DOCS_PUBLIC_BASE_URL_SETTING_KEY` is the operator-facing settings row that
+ * overrides the default. Three-state semantics:
+ *   - `null` (unset)       → fall back to {@link DEFAULT_DOCS_PUBLIC_BASE_URL}
+ *   - `""` (empty string)  → opt-out, plugin emits path-only output for
+ *                            air-gapped forks without published docs
+ *   - any other string     → use as the public base URL
+ *
+ * Keep this as the single source of truth — tests import these constants
+ * rather than the literal so a domain move only touches one line.
+ */
+export const DOCS_PUBLIC_BASE_URL_SETTING_KEY = "docs_public_base_url";
+export const DEFAULT_DOCS_PUBLIC_BASE_URL = "https://docs.heypinchy.com";
+
+/**
  * Rewrites the user-supplied Ollama URL so OpenClaw's `isLocalBaseUrl` check
  * passes (see model-auth-CsyLGY9m.js:111 in OpenClaw 2026.4.27). Docker host
  * aliases (see DOCKER_HOST_ALIASES) get rewritten to `ollama.local`; private
@@ -465,16 +481,15 @@ export async function regenerateOpenClawConfig() {
   // platform documentation on demand. The plugin scopes itself to listed agents.
   const personalAgentIds = allAgents.filter((a) => a.isPersonal && !a.deletedAt).map((a) => a.id);
   if (personalAgentIds.length > 0) {
-    // Empty-string setting means the operator explicitly opted out (air-gapped
-    // fork without published docs) — keep path-only behaviour. `null` means
-    // unset, fall back to Pinchy's hosted docs.
-    const docsBaseUrlSetting = await getSetting("docs_public_base_url");
+    // Three-state setting (see DOCS_PUBLIC_BASE_URL_SETTING_KEY doc-comment):
+    // unset → default, empty → opt-out, value → use as-is.
+    const docsBaseUrlSetting = await getSetting(DOCS_PUBLIC_BASE_URL_SETTING_KEY);
     const docsConfig: Record<string, unknown> = {
       docsPath: "/pinchy-docs",
       agents: Object.fromEntries(personalAgentIds.map((id) => [id, {}])),
     };
     const resolvedDocsBaseUrl =
-      docsBaseUrlSetting === null ? "https://docs.heypinchy.com" : docsBaseUrlSetting;
+      docsBaseUrlSetting === null ? DEFAULT_DOCS_PUBLIC_BASE_URL : docsBaseUrlSetting;
     if (resolvedDocsBaseUrl) {
       docsConfig.publicBaseUrl = resolvedDocsBaseUrl;
     }

--- a/packages/web/src/lib/openclaw-config/index.ts
+++ b/packages/web/src/lib/openclaw-config/index.ts
@@ -9,7 +9,11 @@
 //   normalize.ts   — openclaw#75534 workarounds, removable per #215 (internal)
 //   secrets-bundle.ts — SecretsBundle assembly helper (internal)
 //   paths.ts       — CONFIG_PATH constant (internal)
-export { regenerateOpenClawConfig } from "./build";
+export {
+  regenerateOpenClawConfig,
+  DEFAULT_DOCS_PUBLIC_BASE_URL,
+  DOCS_PUBLIC_BASE_URL_SETTING_KEY,
+} from "./build";
 export {
   sanitizeOpenClawConfig,
   seedRestartClassOverridesIfMissing,

--- a/packages/web/src/lib/smithers-soul.ts
+++ b/packages/web/src/lib/smithers-soul.ts
@@ -43,6 +43,19 @@ platform-related — you MUST follow this exact procedure:
    next most relevant file. Repeat up to three files.
 5. Answer the user based ONLY on what you read.
 
+### Citing docs to the user
+
+When the user asks for a documentation link, or you want to point them at a
+page, always prefer the public URL. Each \`docs_list\` entry includes a \`url\`
+field, and \`docs_read\` prepends a "Public URL:" line, whenever a public docs
+site is configured.
+
+- Cite the public URL verbatim (e.g. \`https://docs.heypinchy.com/guides/connect-email/\`).
+- Never quote the on-disk \`.mdx\` path back to the user — they cannot open it.
+- If no URL is available (air-gapped fork without a public docs site), summarise
+  the relevant content and tell the user the docs are bundled with their
+  Pinchy instance rather than published online.
+
 ### When the docs do not cover the question
 
 This is the most important rule and you must follow it literally.


### PR DESCRIPTION
## Summary

- `docs_list` and `docs_read` now include a public HTTPS URL alongside the on-disk path when a public docs site is configured — Smithers can hand the user `https://docs.heypinchy.com/guides/connect-email/` instead of the unreachable `.mdx` path.
- New optional `publicBaseUrl` field on the `pinchy-docs` plugin config; `regenerateOpenClawConfig()` populates it from the `docs_public_base_url` setting (default `https://docs.heypinchy.com`; clearing the setting opts air-gapped forks back into path-only output).
- Smithers' SOUL gets a "Citing docs" section instructing it to prefer the public URL over the file path.

URL mapping mirrors Astro Starlight defaults: `guides/connect-email.mdx` → `<base>/guides/connect-email/`, `guides/index.mdx` → `<base>/guides/`, `index.mdx` → `<base>/`.

Closes #202

## Test plan

- [x] `pnpm -C packages/plugins/pinchy-docs test` — 32 tests (incl. 7 new URL-mapping tests covering set/unset, root index, subdir index, trailing slash, docs_read citation line, air-gap fallback)
- [x] `pnpm -C packages/web test src/__tests__/lib/openclaw-config.test.ts` — 146 tests (incl. 3 new tests covering default base URL, admin override, and explicit opt-out)
- [x] `pnpm -C packages/web test src/__tests__/lib/smithers-soul.test.ts` — 11 tests (incl. 1 new citation-instruction test)
- [x] Drift guards: `manifest-tools-drift`, `plugin-tool-coverage`, `validate-built-config`, `plugin-schema`, `secrets-bundle-plugins` — all green
- [x] Full `pnpm -C packages/web test` — 4383 passed
- [x] `pnpm -C packages/web lint` — 0 errors