### PR TITLE
feat(auth): warn when Domain Lock is set but BETTER_AUTH_URL is unset

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
 
 ## [Unreleased]
 
+### Added
+
+- **Startup warning when Domain Lock is configured but `BETTER_AUTH_URL` is unset.** Better Auth's own `baseURL` detection does not read Pinchy's Domain Lock value (verified on staging v0.5.4 — Better Auth still logged `Base URL could not be determined`). A Domain-Locked deployment without `BETTER_AUTH_URL` silently sends password-reset and email-verification links pointing at the wrong host. Pinchy now logs `⚠ Domain Lock is configured (<domain>) but BETTER_AUTH_URL is unset…` on every startup of such a deployment, with the exact env-var assignment to copy-paste. The existing `BETTER_AUTH_URL is set` warning is retained, but is now emitted after `bootInits()` so both arms share a single call site. (#352)
+
 ### Fixed
 
 - **Pinchy-Odoo: `odoo_read`, `odoo_count`, `odoo_aggregate` now accepted by OpenAI's strict function-calling validator.** The `filters` parameter schema declared a nested array (`type: "array"` of `type: "array"`) without an inner `items` definition. OpenAI rejected the request with `400 Invalid schema for function 'odoo_aggregate': In context=('properties','filters','items'), array schema missing items.`, surfaced in the UI as `OpenClaw error chunk: LLM request failed: provider rejected the request schema or tool payload`. Anthropic and Ollama accept the looser schema, so the regression was invisible on those providers. A new drift-guard test (`openai-schema-compat`) walks every Pinchy-Odoo tool schema and fails the build if any `type: array` is missing `items`.

--- a/docs/src/content/docs/guides/domain-lock.mdx
+++ b/docs/src/content/docs/guides/domain-lock.mdx
@@ -133,6 +133,13 @@ From this point on, only the locked domain can reach the app. Use the same hostn
   and restart Pinchy.
 </Aside>
 
+<Aside type="caution">
+  If Domain Lock is configured but `BETTER_AUTH_URL` is unset, Pinchy logs a
+  warning on every startup — Better Auth cannot derive the base URL from the
+  Domain Lock value, so password reset and email verification links would point
+  to the wrong host. Set `BETTER_AUTH_URL` to your locked domain and restart.
+</Aside>
+
 ## Remove the lock
 
 If the business needs change (different domain, temporary maintenance URL, etc.):

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -26,9 +26,6 @@ import { SERVER_WS_MAX_PAYLOAD_BYTES } from "./src/lib/limits";
 
 logCapture.install();
 
-const betterAuthUrlWarning = getBetterAuthUrlStartupWarning();
-if (betterAuthUrlWarning) console.warn(betterAuthUrlWarning);
-
 if (process.env.PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT === "1") {
   // Surface this loud at startup. Production deployments must NEVER set this
   // — it disables Better Auth's brute-force protection on /sign-in/*. The
@@ -247,6 +244,13 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   // bootInits(), at which point Docker Compose marks the container healthy.
   const { bootInits } = await import("./src/lib/boot-inits");
   const setupWasComplete = await bootInits();
+
+  // Emit BETTER_AUTH_URL diagnostics now that bootInits has populated the
+  // domain cache. Both arms of the warning (URL-set explanation and
+  // URL-unset-but-Domain-Locked misconfiguration) need an accurate Domain
+  // Lock value to be useful.
+  const betterAuthUrlWarning = getBetterAuthUrlStartupWarning(process.env, getCachedDomain());
+  if (betterAuthUrlWarning) console.warn(betterAuthUrlWarning);
 
   // Connect to OpenClaw AFTER bootInits so the gateway token and config are
   // ready. On a completed install, bootInits() has already run

--- a/packages/web/src/__tests__/lib/auth-env-warning.test.ts
+++ b/packages/web/src/__tests__/lib/auth-env-warning.test.ts
@@ -2,15 +2,18 @@ import { describe, expect, it } from "vitest";
 import { getBetterAuthUrlStartupWarning } from "@/lib/auth-env-warning";
 
 describe("getBetterAuthUrlStartupWarning", () => {
-  it("does not warn when BETTER_AUTH_URL is unset or empty", () => {
-    expect(getBetterAuthUrlStartupWarning({})).toBeNull();
-    expect(getBetterAuthUrlStartupWarning({ BETTER_AUTH_URL: "" })).toBeNull();
+  it("does not warn when BETTER_AUTH_URL is unset and Domain Lock is not configured", () => {
+    expect(getBetterAuthUrlStartupWarning({}, null)).toBeNull();
+    expect(getBetterAuthUrlStartupWarning({ BETTER_AUTH_URL: "" }, null)).toBeNull();
   });
 
   it("explains what BETTER_AUTH_URL controls when set", () => {
-    const warning = getBetterAuthUrlStartupWarning({
-      BETTER_AUTH_URL: "https://pinchy.example.com",
-    });
+    const warning = getBetterAuthUrlStartupWarning(
+      {
+        BETTER_AUTH_URL: "https://pinchy.example.com",
+      },
+      null
+    );
 
     expect(warning).toContain("Domain Lock");
     // Must name the concrete things BETTER_AUTH_URL still controls, not the
@@ -20,10 +23,50 @@ describe("getBetterAuthUrlStartupWarning", () => {
   });
 
   it("does not say BETTER_AUTH_URL is unused", () => {
-    const warning = getBetterAuthUrlStartupWarning({
-      BETTER_AUTH_URL: "https://pinchy.example.com",
-    });
+    const warning = getBetterAuthUrlStartupWarning(
+      {
+        BETTER_AUTH_URL: "https://pinchy.example.com",
+      },
+      null
+    );
 
     expect(warning).not.toContain("no longer used");
+  });
+
+  it("warns when Domain Lock is set but BETTER_AUTH_URL is unset", () => {
+    const warning = getBetterAuthUrlStartupWarning({}, "pinchy.example.com");
+
+    expect(warning).not.toBeNull();
+    // Operator needs to know exactly which env var and which feature is at risk.
+    expect(warning).toContain("BETTER_AUTH_URL");
+    expect(warning).toContain("Domain Lock");
+    expect(warning).toMatch(/email verification|password reset/i);
+  });
+
+  it("includes the locked domain in the suggested BETTER_AUTH_URL value", () => {
+    const warning = getBetterAuthUrlStartupWarning({}, "pinchy.example.com");
+
+    // Without the concrete URL, ops staff have to look up the locked domain
+    // from Settings → Security; with it, the fix is copy-paste.
+    expect(warning).toContain("https://pinchy.example.com");
+  });
+
+  it("treats an empty BETTER_AUTH_URL as unset for the Domain-Lock check", () => {
+    const warning = getBetterAuthUrlStartupWarning({ BETTER_AUTH_URL: "" }, "pinchy.example.com");
+
+    // Same misconfiguration as fully-unset — the warning must fire.
+    expect(warning).not.toBeNull();
+    expect(warning).toContain("BETTER_AUTH_URL");
+  });
+
+  it("does not double-warn when both BETTER_AUTH_URL and Domain Lock are set", () => {
+    const warning = getBetterAuthUrlStartupWarning(
+      { BETTER_AUTH_URL: "https://pinchy.example.com" },
+      "pinchy.example.com"
+    );
+
+    // The URL-set warning wins — the missing-URL message must not appear too.
+    expect(warning).not.toBeNull();
+    expect(warning).not.toMatch(/is unset|not set/i);
   });
 });

--- a/packages/web/src/__tests__/lib/auth-env-warning.test.ts
+++ b/packages/web/src/__tests__/lib/auth-env-warning.test.ts
@@ -69,4 +69,11 @@ describe("getBetterAuthUrlStartupWarning", () => {
     expect(warning).not.toBeNull();
     expect(warning).not.toMatch(/is unset|not set/i);
   });
+
+  it("treats an empty domain string the same as no Domain Lock", () => {
+    // getCachedDomain() returns string | null, but a defensive caller could
+    // pass "" — mirror the BETTER_AUTH_URL empty-string handling so neither
+    // arm fires on a meaningless value.
+    expect(getBetterAuthUrlStartupWarning({}, "")).toBeNull();
+  });
 });

--- a/packages/web/src/__tests__/security/auth-config-consistency.test.ts
+++ b/packages/web/src/__tests__/security/auth-config-consistency.test.ts
@@ -96,6 +96,29 @@ describe("auth config consistency", () => {
     expect(content).not.toContain("BETTER_AUTH_URL is set but no longer used");
   });
 
+  it("getBetterAuthUrlStartupWarning should require the domain argument (no default)", () => {
+    // A default value on `domain` silently disables the Domain-Lock arm if a
+    // future caller forgets the second argument. Force every call site to
+    // pass a value (getCachedDomain() returns null when unconfigured).
+    const content = readFileSync(
+      resolve(PROJECT_ROOT, "packages/web/src/lib/auth-env-warning.ts"),
+      "utf-8"
+    );
+    expect(content).not.toMatch(/domain:\s*string\s*\|\s*null\s*=\s*null/);
+  });
+
+  it("server.ts should emit the BETTER_AUTH_URL warning after bootInits populates the domain cache", () => {
+    // The Domain-Lock arm of the warning needs getCachedDomain() to return a
+    // real value, which requires bootInits() → loadDomainCache() to have run
+    // first. A module-load call would always see `null` and never warn.
+    const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/server.ts"), "utf-8");
+    const bootInitsIdx = content.indexOf("await bootInits()");
+    const warningCallIdx = content.indexOf("getBetterAuthUrlStartupWarning(");
+    expect(bootInitsIdx).toBeGreaterThan(-1);
+    expect(warningCallIdx).toBeGreaterThan(-1);
+    expect(warningCallIdx).toBeGreaterThan(bootInitsIdx);
+  });
+
   it("auth.ts should configure trustedOrigins for dynamic origin detection", () => {
     const content = readFileSync(resolve(PROJECT_ROOT, "packages/web/src/lib/auth.ts"), "utf-8");
     expect(content).toContain("trustedOrigins");

--- a/packages/web/src/lib/auth-env-warning.ts
+++ b/packages/web/src/lib/auth-env-warning.ts
@@ -14,8 +14,8 @@
  * domain cache, otherwise the Domain-Lock arm of this check is a no-op.
  */
 export function getBetterAuthUrlStartupWarning(
-  env: NodeJS.ProcessEnv = process.env,
-  domain: string | null = null
+  env: NodeJS.ProcessEnv,
+  domain: string | null
 ): string | null {
   if (env.BETTER_AUTH_URL) {
     return (
@@ -26,7 +26,7 @@ export function getBetterAuthUrlStartupWarning(
     );
   }
 
-  if (domain) {
+  if (domain && domain.length > 0) {
     return (
       `⚠ Domain Lock is configured (${domain}) but BETTER_AUTH_URL is unset. ` +
       "Outbound links in email verification and password reset emails will be wrong. " +

--- a/packages/web/src/lib/auth-env-warning.ts
+++ b/packages/web/src/lib/auth-env-warning.ts
@@ -1,12 +1,38 @@
+/**
+ * Two related-but-independent settings interact here:
+ *   - `BETTER_AUTH_URL` (env var): the public origin Better Auth writes into
+ *     email verification / password reset links.
+ *   - Domain Lock (DB setting): the hostname Pinchy itself accepts requests on.
+ *
+ * Better Auth's own baseURL detection does *not* read our Domain Lock value
+ * (verified on staging v0.5.4 — Better Auth still logged
+ * "[better-auth] Base URL could not be determined"). So a Domain-Locked
+ * deployment without `BETTER_AUTH_URL` will send password-reset emails with
+ * broken links. We warn loudly on startup in that case.
+ *
+ * Pass `domain` from `getCachedDomain()` *after* `bootInits()` has loaded the
+ * domain cache, otherwise the Domain-Lock arm of this check is a no-op.
+ */
 export function getBetterAuthUrlStartupWarning(
-  env: NodeJS.ProcessEnv = process.env
+  env: NodeJS.ProcessEnv = process.env,
+  domain: string | null = null
 ): string | null {
-  if (!env.BETTER_AUTH_URL) return null;
+  if (env.BETTER_AUTH_URL) {
+    return (
+      "⚠ BETTER_AUTH_URL is set. Request-host trust is now configured via Domain Lock " +
+      "(Settings → Security). BETTER_AUTH_URL only controls outbound URLs Better Auth " +
+      "writes into email verification and password reset links — make sure it matches " +
+      "the hostname your users actually open Pinchy at."
+    );
+  }
 
-  return (
-    "⚠ BETTER_AUTH_URL is set. Request-host trust is now configured via Domain Lock " +
-    "(Settings → Security). BETTER_AUTH_URL only controls outbound URLs Better Auth " +
-    "writes into email verification and password reset links — make sure it matches " +
-    "the hostname your users actually open Pinchy at."
-  );
+  if (domain) {
+    return (
+      `⚠ Domain Lock is configured (${domain}) but BETTER_AUTH_URL is unset. ` +
+      "Outbound links in email verification and password reset emails will be wrong. " +
+      `Set BETTER_AUTH_URL=https://${domain} in your environment and restart Pinchy.`
+    );
+  }
+
+  return null;
 }


### PR DESCRIPTION
## Summary

- Extend `getBetterAuthUrlStartupWarning()` with a second arm that fires when Domain Lock is configured but `BETTER_AUTH_URL` is unset. Better Auth's own `baseURL` detection does *not* read our Domain Lock value (verified on staging v0.5.4 — Better Auth still logged `Base URL could not be determined`), so a Domain-Locked deployment without `BETTER_AUTH_URL` silently sends password-reset/email-verification links pointing at the wrong host.
- Move the warning call site from module-load to *after* `bootInits()` so the domain cache is populated. Both arms now share a single call site.
- Update `domain-lock.mdx` to mention the warning and `CHANGELOG.md` under `[Unreleased] → Added`.

This is item 2 from the revised plan in #352. Item 3 (set `BETTER_AUTH_URL` on `staging.heypinchy.com`) is an Ops task — please run it after merge so staging logs go quiet. Item 4 (have Pinchy hand its Domain Lock value to Better Auth's `baseURL` config) is explicitly deferred as "might be larger".

## Test plan

- [x] `pnpm test src/__tests__/lib/auth-env-warning.test.ts` — 7/7 (4 new cases: Domain Lock set + URL unset, locked-domain echoed in suggestion, empty-string URL treated as unset, no double-warn)
- [x] `pnpm test` — full suite, 4374 passed (no regressions)
- [x] `pnpm exec tsc --noEmit`
- [x] `pnpm lint` — 0 errors
- [ ] Verify on staging after deploy: with `BETTER_AUTH_URL` unset and Domain Lock configured, container logs the new `⚠ Domain Lock is configured (staging.heypinchy.com) but BETTER_AUTH_URL is unset…` line on startup.

Refs #352