### PR TITLE
feat(pinchy-image): add in-pipeline image transform plugin

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -465,7 +465,7 @@ A dedicated guard, `odoo-ref-tool-e2e-coverage.test.ts` (pinchy#791), enforces t
 
 ### Plugin package manager
 
-Plugin packages under `packages/plugins/*` use **npm**, not pnpm. The runtime installs their dependencies in the OpenClaw container via `npm install --omit=dev` (see `Dockerfile.openclaw`), and several plugins depend on native modules (e.g. `sharp`'s prebuilt libvips binaries) that need the npm install layout. The repo's root `.gitignore` ignores `packages/plugins/*/package-lock.json` because each plugin's lockfile is regenerated at image-build time from its `package.json`. Do not add plugin packages to the root pnpm workspace.
+Plugin packages under `packages/plugins/*` are part of the root pnpm workspace (so the root `pnpm install` resolves their deps for tests and dev tooling), but the OpenClaw container builds them with **npm**, not pnpm — see `Dockerfile.openclaw`, which runs `npm install --omit=dev` per plugin. Several plugins depend on native modules (e.g. `sharp`'s prebuilt libvips binaries) that need the npm install layout at runtime. The repo's root `.gitignore` ignores `packages/plugins/*/pnpm-lock.yaml` and `*/package-lock.json` — each plugin's lockfile is regenerated at image-build time from its own `package.json`. When adding a new plugin, also bump `pnpm-lock.yaml` at the repo root (`pnpm install --no-frozen-lockfile`) so the workspace entry is recorded.
 
 ## Documentation
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -463,6 +463,10 @@ A dedicated guard, `odoo-ref-tool-e2e-coverage.test.ts` (pinchy#791), enforces t
 
 `odoo_reconcile` is covered via the **payment-counterpart** path only: the mock's `js_assign_outstanding_line` handler zeroes the bill's `amount_residual`, which is the sole signal the plugin's `didReconcile` trusts, so `outcome=success` proves the real verification path rather than a blind return value. The **bank-statement** counterpart path (x2many write-command expansion + journal suspense/default accounts, which real Odoo 19 makes silent-no-op-prone) is deliberately left on live verification — a naive mock of it would risk a false-green, and the payment path already discharges the tool's coverage obligation.
 
+### Plugin package manager
+
+Plugin packages under `packages/plugins/*` use **npm**, not pnpm. The runtime installs their dependencies in the OpenClaw container via `npm install --omit=dev` (see `Dockerfile.openclaw`), and several plugins depend on native modules (e.g. `sharp`'s prebuilt libvips binaries) that need the npm install layout. The repo's root `.gitignore` ignores `packages/plugins/*/package-lock.json` because each plugin's lockfile is regenerated at image-build time from its `package.json`. Do not add plugin packages to the root pnpm workspace.
+
 ## Documentation
 
 - Docs live in `docs/`, use Astro Starlight, and follow the Diataxis framework.

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -129,6 +129,13 @@ RUN cd /tmp/pinchy-email && npm install --omit=dev && \
     cp -r /tmp/pinchy-email/node_modules /opt/pinchy-email-deps/ && \
     rm -rf /tmp/pinchy-email
 
+# Install pinchy-image plugin dependencies (sharp ships prebuilt libvips binaries)
+COPY packages/plugins/pinchy-image/package.json /tmp/pinchy-image/package.json
+RUN cd /tmp/pinchy-image && npm install --omit=dev && \
+    mkdir -p /opt/pinchy-image-deps && \
+    cp -r /tmp/pinchy-image/node_modules /opt/pinchy-image-deps/ && \
+    rm -rf /tmp/pinchy-image
+
 # ---------------------------------------------------------------------------
 # Stage: runtime — slim image with only what the gateway runs.
 # ---------------------------------------------------------------------------
@@ -184,6 +191,7 @@ COPY --from=builder /opt/pinchy-files-deps /opt/pinchy-files-deps
 COPY --from=builder /opt/pinchy-odoo-deps /opt/pinchy-odoo-deps
 COPY --from=builder /opt/pinchy-web-deps /opt/pinchy-web-deps
 COPY --from=builder /opt/pinchy-email-deps /opt/pinchy-email-deps
+COPY --from=builder /opt/pinchy-image-deps /opt/pinchy-image-deps
 
 # The bundled llama.cpp embedding provider (with its prebuilt node-llama-cpp
 # native binaries) and the EmbeddingGemma GGUF it serves. start-openclaw.sh

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -77,6 +77,7 @@ COPY packages/plugins/pinchy-audit/openclaw.plugin.json packages/plugins/pinchy-
 COPY packages/plugins/pinchy-transcript/openclaw.plugin.json packages/plugins/pinchy-transcript/
 COPY packages/plugins/pinchy-docs/openclaw.plugin.json packages/plugins/pinchy-docs/
 COPY packages/plugins/pinchy-email/openclaw.plugin.json packages/plugins/pinchy-email/
+COPY packages/plugins/pinchy-image/openclaw.plugin.json packages/plugins/pinchy-image/
 COPY packages/plugins/pinchy-odoo/openclaw.plugin.json packages/plugins/pinchy-odoo/
 COPY packages/plugins/pinchy-web/openclaw.plugin.json packages/plugins/pinchy-web/
 COPY packages/plugins/pinchy-knowledge/openclaw.plugin.json packages/plugins/pinchy-knowledge/
@@ -236,6 +237,7 @@ COPY packages/plugins/pinchy-odoo /app/pinchy-plugins/pinchy-odoo
 COPY packages/plugins/pinchy-web /app/pinchy-plugins/pinchy-web
 COPY packages/plugins/pinchy-email /app/pinchy-plugins/pinchy-email
 COPY packages/plugins/pinchy-knowledge /app/pinchy-plugins/pinchy-knowledge
+COPY packages/plugins/pinchy-image /app/pinchy-plugins/pinchy-image
 
 WORKDIR /app/packages/web
 

--- a/config/install-plugin-deps.sh
+++ b/config/install-plugin-deps.sh
@@ -51,7 +51,7 @@ install_plugin_deps_for() {
 }
 
 install_plugin_deps() {
-    for plugin in pinchy-files pinchy-odoo pinchy-web pinchy-email; do
+    for plugin in pinchy-files pinchy-odoo pinchy-web pinchy-email pinchy-image; do
         install_plugin_deps_for "$plugin"
     done
 }

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -55,7 +55,7 @@ ensure_secrets_root_owned() {
     echo "[secrets-fix] $SECRETS_FILE: $before -> $after"
 }
 
-# Install pinchy-{files,odoo,web,email} plugin runtime dependencies from the
+# Install pinchy-{files,odoo,web,email,image} plugin runtime dependencies from the
 # container image. In dev mode, source files are volume-mounted from the
 # host, but host node_modules contain macOS native bindings that won't work
 # in Linux. Extracted to config/install-plugin-deps.sh (same pattern as

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -52,6 +52,7 @@ services:
       - ./packages/plugins/pinchy-email:/root/.openclaw/extensions/pinchy-email
       - ./packages/plugins/pinchy-docs:/root/.openclaw/extensions/pinchy-docs
       - ./packages/plugins/pinchy-knowledge:/root/.openclaw/extensions/pinchy-knowledge
+      - ./packages/plugins/pinchy-image:/root/.openclaw/extensions/pinchy-image
       - ./sample-data:/data/sample-docs
       # Shadow volumes: mounted ON TOP of the node_modules path of the four
       # plugins that have baked /opt/<plugin>-deps bundles (pinchy-files,

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -166,6 +166,8 @@ In addition to the allow-list, every agent has built-in PDF and image readers th
 
 Smithers agents also use the `pinchy-context` plugin, which provides `pinchy_save_user_context` and `pinchy_save_org_context` tools. These tools call Pinchy's internal API (authenticated via a shared gateway token) to save context from the onboarding interview directly to the database and sync it to agent workspaces.
 
+The `pinchy-image` plugin provides in-pipeline image transformations (`image_crop`, `image_resize`, `image_rotate`, `image_convert`) for agents that handle photo uploads. The Bookkeeper template uses it to clean phone-photographed receipts (crop out background, normalise rotation) before attaching them to Odoo bills. Each tool reads from the agent's workspace `uploads/` directory and writes a new file alongside, so the transformed image is then available to any downstream tool (e.g. `odoo_attach_file`) by filename.
+
 All agent-accessible files live under `/data/` in the container, mounted via Docker volumes. This means even if all software layers failed, the agent can only see files that were explicitly mounted.
 
 ### Agent access control

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -49,7 +49,7 @@ sh /sync-plugins.sh
 # we fail loud here instead. List MUST stay in sync with KNOWN_PINCHY_PLUGINS
 # in packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts; drift is
 # caught by entrypoint-runtime-check.test.ts.
-EXPECTED_PLUGINS="pinchy-files pinchy-context pinchy-audit pinchy-transcript pinchy-docs pinchy-email pinchy-odoo pinchy-web pinchy-knowledge"
+EXPECTED_PLUGINS="pinchy-files pinchy-context pinchy-audit pinchy-transcript pinchy-docs pinchy-email pinchy-image pinchy-odoo pinchy-web pinchy-knowledge"
 MISSING=""
 for plugin in $EXPECTED_PLUGINS; do
   if [ ! -d "/openclaw-extensions/$plugin" ]; then

--- a/packages/plugins/pinchy-image/config-schema.test.ts
+++ b/packages/plugins/pinchy-image/config-schema.test.ts
@@ -1,0 +1,43 @@
+/**
+ * Validates that the pinchy-image plugin configSchema declares all fields
+ * that Pinchy's regenerateOpenClawConfig() writes into it.
+ *
+ * OpenClaw rejects config reloads when the config contains properties not
+ * declared in the plugin schema (additionalProperties: false). When that
+ * happens, agents created after the last successful reload are unknown to
+ * OpenClaw — they can't receive messages.
+ *
+ * This test catches schema/config divergence at CI time rather than at
+ * runtime, where it would silently block all config hot-reloads.
+ */
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-image");
+
+// Mirrors the shape regenerateOpenClawConfig() emits for pinchy-image.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  agents: {
+    "agent-uuid": {
+      tools: ["image_crop", "image_resize", "image_rotate", "image_convert"],
+    },
+  },
+};
+
+describe("pinchy-image manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an empty config (agents is required)", () => {
+    const result = validatePluginEntry(manifest, {});
+    expect(result.ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false at the top level", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-image/index.test.ts
+++ b/packages/plugins/pinchy-image/index.test.ts
@@ -1,5 +1,13 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import {
+  mkdtempSync,
+  rmSync,
+  writeFileSync,
+  existsSync,
+  readFileSync,
+  mkdirSync,
+  symlinkSync,
+} from "node:fs";
 import { join } from "node:path";
 import { tmpdir } from "node:os";
 import sharp from "sharp";
@@ -59,6 +67,7 @@ beforeEach(() => {
 afterEach(() => {
   rmSync(workspaceRoot, { recursive: true, force: true });
   delete process.env.PINCHY_IMAGE_WORKSPACE_ROOT;
+  delete process.env.PINCHY_IMAGE_MAX_BYTES;
 });
 
 describe("pinchy-image plugin", () => {
@@ -246,5 +255,113 @@ describe("pinchy-image plugin", () => {
     expect(plugin.id).toBe("pinchy-image");
     expect(plugin.name).toBe("Pinchy Image");
     expect(plugin.configSchema).toBeDefined();
+  });
+
+  it("configSchema.validate rejects when agents is not a plain object", async () => {
+    const { default: plugin } = await import("./index");
+    const validate = (plugin.configSchema as { validate: (v: unknown) => { ok: boolean } }).validate;
+    expect(validate({ agents: null }).ok).toBe(false);
+    expect(validate({ agents: [] }).ok).toBe(false);
+    expect(validate({ agents: "nope" }).ok).toBe(false);
+    expect(validate({ agents: {} }).ok).toBe(true);
+  });
+
+  it("rejects .gif source files (animation would be silently dropped)", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    // Seed a real PNG but name it .gif — extension check happens before read.
+    await seedImage("agent-all", "anim.gif");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "anim.gif",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/unsupported|extension/i);
+  });
+
+  it("rejects filenames containing a NUL byte", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "evil\x00.png",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/invalid|filename/i);
+  });
+
+  it("rejects when the source filename resolves to a symlink", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const uploadsDir = join(workspaceRoot, "agent-all", "uploads");
+    mkdirSync(uploadsDir, { recursive: true });
+    // Real target outside the uploads dir — symlink defends against an attacker
+    // who has write access to the uploads dir but wants to make us read e.g.
+    // /etc/passwd through the workspace boundary.
+    const realTarget = join(workspaceRoot, "outside-target.png");
+    const png = await sharp({
+      create: { width: 10, height: 10, channels: 3, background: { r: 1, g: 2, b: 3 } },
+    }).png().toBuffer();
+    writeFileSync(realTarget, png);
+    symlinkSync(realTarget, join(uploadsDir, "link.png"));
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "link.png",
+      x: 0,
+      y: 0,
+      width: 5,
+      height: 5,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/symlink|regular file/i);
+  });
+
+  it("PINCHY_IMAGE_MAX_BYTES env var overrides the default size cap", async () => {
+    // Set a tiny cap; the seeded PNG (200x100, 3 channels) is several hundred
+    // bytes, so a 100-byte cap forces a rejection.
+    process.env.PINCHY_IMAGE_MAX_BYTES = "100";
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "big.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "big.png",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/too large/i);
   });
 });

--- a/packages/plugins/pinchy-image/index.test.ts
+++ b/packages/plugins/pinchy-image/index.test.ts
@@ -1,0 +1,250 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+import { tmpdir } from "node:os";
+import sharp from "sharp";
+
+const mockRegisterTool = vi.fn();
+
+function createMockApi(config: {
+  agents: Record<string, { tools: string[] }>;
+}) {
+  return {
+    id: "pinchy-image",
+    name: "Pinchy Image",
+    source: "test",
+    config: {},
+    pluginConfig: config,
+    runtime: {},
+    logger: { info: vi.fn(), warn: vi.fn(), error: vi.fn() },
+    registerTool: mockRegisterTool,
+    registerHook: vi.fn(),
+    registerHttpHandler: vi.fn(),
+    registerHttpRoute: vi.fn(),
+    registerChannel: vi.fn(),
+    registerGatewayMethod: vi.fn(),
+    registerCli: vi.fn(),
+    registerService: vi.fn(),
+    registerProvider: vi.fn(),
+    registerCommand: vi.fn(),
+    resolvePath: vi.fn((p: string) => p),
+    on: vi.fn(),
+  };
+}
+
+const defaultConfig = {
+  agents: {
+    "agent-all": { tools: ["image_crop", "image_resize", "image_rotate", "image_convert"] },
+    "agent-crop-only": { tools: ["image_crop"] },
+  },
+};
+
+let workspaceRoot: string;
+
+async function seedImage(agentId: string, filename: string): Promise<void> {
+  const uploadsDir = join(workspaceRoot, agentId, "uploads");
+  mkdirSync(uploadsDir, { recursive: true });
+  const png = await sharp({
+    create: { width: 200, height: 100, channels: 3, background: { r: 10, g: 200, b: 80 } },
+  }).png().toBuffer();
+  writeFileSync(join(uploadsDir, filename), png);
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  workspaceRoot = mkdtempSync(join(tmpdir(), "pinchy-image-test-"));
+  process.env.PINCHY_IMAGE_WORKSPACE_ROOT = workspaceRoot;
+});
+
+afterEach(() => {
+  rmSync(workspaceRoot, { recursive: true, force: true });
+  delete process.env.PINCHY_IMAGE_WORKSPACE_ROOT;
+});
+
+describe("pinchy-image plugin", () => {
+  it("registers all four tools as factories", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const names = mockRegisterTool.mock.calls.map((c: any[]) => c[1]?.name);
+    expect(names).toEqual(
+      expect.arrayContaining(["image_crop", "image_resize", "image_rotate", "image_convert"])
+    );
+    expect(mockRegisterTool).toHaveBeenCalledTimes(4);
+  });
+
+  it("crop factory returns the tool only for agents that list image_crop", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+
+    expect(factory({ agentId: "agent-all" })).not.toBeNull();
+    expect(factory({ agentId: "agent-crop-only" })).not.toBeNull();
+    expect(factory({ agentId: "agent-resize-only" })).toBeNull();
+    expect(factory({})).toBeNull();
+  });
+
+  it("resize factory returns null when the agent does not list image_resize", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_resize"
+    )?.[0];
+
+    expect(factory({ agentId: "agent-crop-only" })).toBeNull();
+    expect(factory({ agentId: "agent-all" })).not.toBeNull();
+  });
+
+  it("image_crop writes a new file in the agent's uploads dir and returns its filename", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "receipt.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "receipt.png",
+      x: 10,
+      y: 10,
+      width: 80,
+      height: 50,
+    });
+
+    expect(result.isError).toBeUndefined();
+    const payload = JSON.parse(result.content[0].text);
+    expect(typeof payload.id).toBe("string");
+    expect(payload.id).toMatch(/\.png$/);
+    expect(payload.id).not.toBe("receipt.png");
+
+    const outPath = join(workspaceRoot, "agent-all", "uploads", payload.id);
+    expect(existsSync(outPath)).toBe(true);
+    const meta = await sharp(readFileSync(outPath)).metadata();
+    expect(meta.width).toBe(80);
+    expect(meta.height).toBe(50);
+  });
+
+  it("image_crop rejects unsafe filenames (path traversal)", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "../etc/passwd",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/invalid|filename/i);
+  });
+
+  it("image_crop reports a clear error when the source file does not exist", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_crop"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "missing.png",
+      x: 0,
+      y: 0,
+      width: 10,
+      height: 10,
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not found/i);
+  });
+
+  it("image_resize uses the requested width and keeps source extension", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "photo.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_resize"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", {
+      source: "photo.png",
+      width: 50,
+    });
+    const payload = JSON.parse(result.content[0].text);
+    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    expect(meta.width).toBe(50);
+    expect(payload.id).toMatch(/\.png$/);
+  });
+
+  it("image_rotate rotates the source image", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "rotated.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_rotate"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", { source: "rotated.png", angle: 90 });
+    const payload = JSON.parse(result.content[0].text);
+    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(200);
+  });
+
+  it("image_convert switches the file extension to match the target format", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "source.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_convert"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", { source: "source.png", format: "webp" });
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.id).toMatch(/\.webp$/);
+    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    expect(meta.format).toBe("webp");
+  });
+
+  it("image_convert rejects unsupported formats", async () => {
+    const api = createMockApi(defaultConfig);
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    await seedImage("agent-all", "source.png");
+
+    const factory = mockRegisterTool.mock.calls.find(
+      (c: any[]) => c[1]?.name === "image_convert"
+    )?.[0];
+    const tool = factory({ agentId: "agent-all" });
+    const result = await tool.execute("call-1", { source: "source.png", format: "tiff" });
+    expect(result.isError).toBe(true);
+  });
+
+  it("exports plugin definition with id and configSchema", async () => {
+    const { default: plugin } = await import("./index");
+    expect(plugin.id).toBe("pinchy-image");
+    expect(plugin.name).toBe("Pinchy Image");
+    expect(plugin.configSchema).toBeDefined();
+  });
+});

--- a/packages/plugins/pinchy-image/index.test.ts
+++ b/packages/plugins/pinchy-image/index.test.ts
@@ -14,9 +14,7 @@ import sharp from "sharp";
 
 const mockRegisterTool = vi.fn();
 
-function createMockApi(config: {
-  agents: Record<string, { tools: string[] }>;
-}) {
+function createMockApi(config: { agents: Record<string, { tools: string[] }> }) {
   return {
     id: "pinchy-image",
     name: "Pinchy Image",
@@ -54,7 +52,9 @@ async function seedImage(agentId: string, filename: string): Promise<void> {
   mkdirSync(uploadsDir, { recursive: true });
   const png = await sharp({
     create: { width: 200, height: 100, channels: 3, background: { r: 10, g: 200, b: 80 } },
-  }).png().toBuffer();
+  })
+    .png()
+    .toBuffer();
   writeFileSync(join(uploadsDir, filename), png);
 }
 
@@ -197,7 +197,9 @@ describe("pinchy-image plugin", () => {
       width: 50,
     });
     const payload = JSON.parse(result.content[0].text);
-    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    const meta = await sharp(
+      readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))
+    ).metadata();
     expect(meta.width).toBe(50);
     expect(payload.id).toMatch(/\.png$/);
   });
@@ -214,7 +216,9 @@ describe("pinchy-image plugin", () => {
     const tool = factory({ agentId: "agent-all" });
     const result = await tool.execute("call-1", { source: "rotated.png", angle: 90 });
     const payload = JSON.parse(result.content[0].text);
-    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    const meta = await sharp(
+      readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))
+    ).metadata();
     expect(meta.width).toBe(100);
     expect(meta.height).toBe(200);
   });
@@ -232,7 +236,9 @@ describe("pinchy-image plugin", () => {
     const result = await tool.execute("call-1", { source: "source.png", format: "webp" });
     const payload = JSON.parse(result.content[0].text);
     expect(payload.id).toMatch(/\.webp$/);
-    const meta = await sharp(readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))).metadata();
+    const meta = await sharp(
+      readFileSync(join(workspaceRoot, "agent-all", "uploads", payload.id))
+    ).metadata();
     expect(meta.format).toBe("webp");
   });
 
@@ -259,7 +265,8 @@ describe("pinchy-image plugin", () => {
 
   it("configSchema.validate rejects when agents is not a plain object", async () => {
     const { default: plugin } = await import("./index");
-    const validate = (plugin.configSchema as { validate: (v: unknown) => { ok: boolean } }).validate;
+    const validate = (plugin.configSchema as { validate: (v: unknown) => { ok: boolean } })
+      .validate;
     expect(validate({ agents: null }).ok).toBe(false);
     expect(validate({ agents: [] }).ok).toBe(false);
     expect(validate({ agents: "nope" }).ok).toBe(false);
@@ -322,7 +329,9 @@ describe("pinchy-image plugin", () => {
     const realTarget = join(workspaceRoot, "outside-target.png");
     const png = await sharp({
       create: { width: 10, height: 10, channels: 3, background: { r: 1, g: 2, b: 3 } },
-    }).png().toBuffer();
+    })
+      .png()
+      .toBuffer();
     writeFileSync(realTarget, png);
     symlinkSync(realTarget, join(uploadsDir, "link.png"));
 

--- a/packages/plugins/pinchy-image/index.ts
+++ b/packages/plugins/pinchy-image/index.ts
@@ -1,4 +1,5 @@
-import { readFile, writeFile, mkdir, stat, lstat } from "fs/promises";
+import { writeFile, mkdir, stat, open } from "fs/promises";
+import { constants as fsConstants } from "fs";
 import { basename, extname, join } from "path";
 import { randomBytes } from "crypto";
 import {
@@ -121,12 +122,16 @@ async function readSourceImage(
   }
 
   const sourcePath = join(agentUploadsDir(agentId), filename);
-  // lstat (does NOT follow symlinks) — we reject anything that isn't a regular
-  // file. This prevents an attacker who has write access to the uploads dir
-  // from making the tool read a file outside the workspace via a symlink.
-  let lstatRes: { size: number; isFile(): boolean; isSymbolicLink(): boolean };
+  // Atomic open with O_NOFOLLOW closes the TOCTOU window: a separate `lstat`
+  // followed by `readFile` would race against an attacker swapping the
+  // upload entry between the check and the read. O_NOFOLLOW also rejects
+  // symlinks in the final path component (ELOOP), serving as the workspace
+  // boundary guard. All subsequent size/type checks run against the held file
+  // descriptor via fstat, so the file we measure is the file we read.
+  const O_NOFOLLOW = fsConstants.O_NOFOLLOW ?? 0;
+  let handle;
   try {
-    lstatRes = await lstat(sourcePath);
+    handle = await open(sourcePath, fsConstants.O_RDONLY | O_NOFOLLOW);
   } catch (err) {
     const code =
       err && typeof err === "object" && "code" in err
@@ -139,33 +144,35 @@ async function readSourceImage(
         ),
       };
     }
+    if (code === "ELOOP") {
+      return {
+        error: errorContent(
+          `Refusing to read "${filename}": file is a symlink, only regular files are allowed.`
+        ),
+      };
+    }
     throw err;
   }
-  if (lstatRes.isSymbolicLink()) {
-    return {
-      error: errorContent(
-        `Refusing to read "${filename}": file is a symlink, only regular files are allowed.`
-      ),
-    };
+  try {
+    const statRes = await handle.stat();
+    if (!statRes.isFile()) {
+      return {
+        error: errorContent(`Refusing to read "${filename}": not a regular file.`),
+      };
+    }
+    const maxBytes = maxImageBytes();
+    if (statRes.size > maxBytes) {
+      return {
+        error: errorContent(
+          `Image too large: "${filename}" is ${statRes.size} bytes; max allowed is ${maxBytes}.`
+        ),
+      };
+    }
+    const buffer = await handle.readFile();
+    return { buffer, sourceName: filename };
+  } finally {
+    await handle.close();
   }
-  if (!lstatRes.isFile()) {
-    return {
-      error: errorContent(
-        `Refusing to read "${filename}": not a regular file.`
-      ),
-    };
-  }
-  const maxBytes = maxImageBytes();
-  if (lstatRes.size > maxBytes) {
-    return {
-      error: errorContent(
-        `Image too large: "${filename}" is ${lstatRes.size} bytes; max allowed is ${maxBytes}.`
-      ),
-    };
-  }
-
-  const buffer = await readFile(sourcePath);
-  return { buffer, sourceName: filename };
 }
 
 async function writeOutputImage(

--- a/packages/plugins/pinchy-image/index.ts
+++ b/packages/plugins/pinchy-image/index.ts
@@ -1,0 +1,370 @@
+import { readFile, writeFile, mkdir, stat } from "fs/promises";
+import { basename, extname, join } from "path";
+import { randomBytes } from "crypto";
+import {
+  cropImage,
+  resizeImage,
+  rotateImage,
+  convertImage,
+  extensionForFormat,
+  type ConvertFormat,
+  type ResizeFit,
+} from "./transform";
+
+const WORKSPACE_ROOT_DEFAULT = "/root/.openclaw/workspaces";
+const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
+const ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
+
+interface PluginToolContext {
+  agentId?: string;
+}
+
+interface ContentBlock {
+  type: string;
+  text: string;
+}
+
+interface AgentImageConfig {
+  tools: string[];
+}
+
+interface PluginConfig {
+  agents: Record<string, AgentImageConfig>;
+}
+
+interface PluginApi {
+  pluginConfig?: PluginConfig;
+  registerTool: (
+    factory: (ctx: PluginToolContext) => AgentTool | null,
+    opts?: { name?: string }
+  ) => void;
+}
+
+interface AgentTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    toolCallId: string,
+    params: Record<string, unknown>,
+    signal?: AbortSignal
+  ) => Promise<{
+    content: ContentBlock[];
+    isError?: boolean;
+    details?: unknown;
+  }>;
+}
+
+function workspaceRoot(): string {
+  return process.env.PINCHY_IMAGE_WORKSPACE_ROOT || WORKSPACE_ROOT_DEFAULT;
+}
+
+function isSafeFilename(filename: string): boolean {
+  if (typeof filename !== "string" || filename.length === 0) return false;
+  if (filename !== basename(filename)) return false;
+  if (filename.startsWith(".")) return false;
+  if (filename.includes("\\")) return false;
+  return true;
+}
+
+function isSupportedExtension(filename: string): boolean {
+  return ALLOWED_EXTENSIONS.has(extname(filename).toLowerCase());
+}
+
+function agentUploadsDir(agentId: string): string {
+  return join(workspaceRoot(), agentId, "uploads");
+}
+
+function generateOutputFilename(sourceName: string, ext: string): string {
+  const baseNoExt = basename(sourceName, extname(sourceName));
+  const token = randomBytes(4).toString("hex");
+  return `${baseNoExt}-${token}${ext.startsWith(".") ? ext : `.${ext}`}`;
+}
+
+function errorContent(message: string): { isError: true; content: ContentBlock[] } {
+  return { isError: true, content: [{ type: "text", text: message }] };
+}
+
+async function readSourceImage(
+  agentId: string,
+  filename: unknown
+): Promise<{ buffer: Buffer; sourceName: string } | { error: { isError: true; content: ContentBlock[] } }> {
+  if (typeof filename !== "string" || !isSafeFilename(filename)) {
+    return {
+      error: errorContent(
+        `Invalid filename: ${typeof filename === "string" ? `"${filename}"` : "<missing>"}. ` +
+          `Must be a plain filename (no path separators, no leading dot, no "..").`
+      ),
+    };
+  }
+  if (!isSupportedExtension(filename)) {
+    return {
+      error: errorContent(
+        `Unsupported file extension for "${filename}". Allowed: ${[...ALLOWED_EXTENSIONS].join(", ")}.`
+      ),
+    };
+  }
+
+  const sourcePath = join(agentUploadsDir(agentId), filename);
+  let fileStat: { size: number };
+  try {
+    fileStat = await stat(sourcePath);
+  } catch (err) {
+    const code =
+      err && typeof err === "object" && "code" in err
+        ? String((err as { code: unknown }).code)
+        : "";
+    if (code === "ENOENT") {
+      return {
+        error: errorContent(
+          `File not found: "${filename}". Make sure the image was uploaded before calling this tool.`
+        ),
+      };
+    }
+    throw err;
+  }
+  if (fileStat.size > MAX_IMAGE_BYTES) {
+    return {
+      error: errorContent(
+        `Image too large: "${filename}" is ${fileStat.size} bytes; max allowed is ${MAX_IMAGE_BYTES}.`
+      ),
+    };
+  }
+
+  const buffer = await readFile(sourcePath);
+  return { buffer, sourceName: filename };
+}
+
+async function writeOutputImage(
+  agentId: string,
+  sourceName: string,
+  buffer: Buffer,
+  ext: string
+): Promise<string> {
+  const uploadsDir = agentUploadsDir(agentId);
+  await mkdir(uploadsDir, { recursive: true });
+  let outName = generateOutputFilename(sourceName, ext);
+  // Collisions are astronomically unlikely with 4 random bytes, but guard the
+  // tail call so we never silently overwrite an existing file the agent might
+  // still reference.
+  for (let i = 0; i < 5; i++) {
+    try {
+      await stat(join(uploadsDir, outName));
+      outName = generateOutputFilename(sourceName, ext);
+    } catch {
+      break;
+    }
+  }
+  await writeFile(join(uploadsDir, outName), buffer);
+  return outName;
+}
+
+function jsonResult(id: string): { content: ContentBlock[] } {
+  return { content: [{ type: "text", text: JSON.stringify({ id }) }] };
+}
+
+function getAgentConfig(
+  agents: Record<string, AgentImageConfig>,
+  agentId: string
+): AgentImageConfig | null {
+  return agents[agentId] ?? null;
+}
+
+function hasTool(
+  agents: Record<string, AgentImageConfig>,
+  agentId: string,
+  toolName: string
+): boolean {
+  const cfg = getAgentConfig(agents, agentId);
+  return !!cfg && cfg.tools.includes(toolName);
+}
+
+const plugin = {
+  id: "pinchy-image",
+  name: "Pinchy Image",
+  description: "Image transformation tools (crop, resize, rotate, convert) for agent attachments.",
+  configSchema: {
+    validate: (value: unknown) => {
+      if (value && typeof value === "object" && "agents" in value) {
+        return { ok: true as const, value };
+      }
+      return { ok: false as const, errors: ["Missing 'agents' key in config"] };
+    },
+  },
+
+  register(api: PluginApi) {
+    const agents = api.pluginConfig?.agents ?? {};
+
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId || !hasTool(agents, agentId, "image_crop")) return null;
+        return {
+          name: "image_crop",
+          label: "Crop Image",
+          description:
+            "Crop an uploaded image to a rectangle. Returns the filename of a new image in the agent's uploads directory. " +
+            "Source must be a plain filename of an already-uploaded image (no path).",
+          parameters: {
+            type: "object",
+            properties: {
+              source: { type: "string", description: "Filename of the uploaded image to crop." },
+              x: { type: "integer", minimum: 0, description: "Left offset in pixels." },
+              y: { type: "integer", minimum: 0, description: "Top offset in pixels." },
+              width: { type: "integer", minimum: 1, description: "Crop width in pixels." },
+              height: { type: "integer", minimum: 1, description: "Crop height in pixels." },
+            },
+            required: ["source", "x", "y", "width", "height"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const read = await readSourceImage(agentId, params.source);
+              if ("error" in read) return read.error;
+              const out = await cropImage(read.buffer, {
+                x: params.x as number,
+                y: params.y as number,
+                width: params.width as number,
+                height: params.height as number,
+              });
+              const ext = extname(read.sourceName);
+              const id = await writeOutputImage(agentId, read.sourceName, out, ext);
+              return jsonResult(id);
+            } catch (err) {
+              return errorContent(err instanceof Error ? err.message : "Unknown error");
+            }
+          },
+        };
+      },
+      { name: "image_crop" }
+    );
+
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId || !hasTool(agents, agentId, "image_resize")) return null;
+        return {
+          name: "image_resize",
+          label: "Resize Image",
+          description:
+            "Resize an uploaded image. At least one of width or height must be given. " +
+            "Supported fit modes: cover, contain, fill, inside (default: inside, preserves aspect ratio).",
+          parameters: {
+            type: "object",
+            properties: {
+              source: { type: "string", description: "Filename of the uploaded image to resize." },
+              width: { type: "integer", minimum: 1, description: "Target width in pixels." },
+              height: { type: "integer", minimum: 1, description: "Target height in pixels." },
+              fit: {
+                type: "string",
+                enum: ["cover", "contain", "fill", "inside"],
+                description: "Resize fit mode. Default: inside.",
+              },
+            },
+            required: ["source"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const read = await readSourceImage(agentId, params.source);
+              if ("error" in read) return read.error;
+              const out = await resizeImage(read.buffer, {
+                width: params.width as number | undefined,
+                height: params.height as number | undefined,
+                fit: params.fit as ResizeFit | undefined,
+              });
+              const ext = extname(read.sourceName);
+              const id = await writeOutputImage(agentId, read.sourceName, out, ext);
+              return jsonResult(id);
+            } catch (err) {
+              return errorContent(err instanceof Error ? err.message : "Unknown error");
+            }
+          },
+        };
+      },
+      { name: "image_resize" }
+    );
+
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId || !hasTool(agents, agentId, "image_rotate")) return null;
+        return {
+          name: "image_rotate",
+          label: "Rotate Image",
+          description:
+            "Rotate an uploaded image by the given angle in degrees. EXIF orientation is normalised first.",
+          parameters: {
+            type: "object",
+            properties: {
+              source: { type: "string", description: "Filename of the uploaded image to rotate." },
+              angle: { type: "number", description: "Rotation angle in degrees (clockwise)." },
+            },
+            required: ["source", "angle"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const read = await readSourceImage(agentId, params.source);
+              if ("error" in read) return read.error;
+              const out = await rotateImage(read.buffer, { angle: params.angle as number });
+              const ext = extname(read.sourceName);
+              const id = await writeOutputImage(agentId, read.sourceName, out, ext);
+              return jsonResult(id);
+            } catch (err) {
+              return errorContent(err instanceof Error ? err.message : "Unknown error");
+            }
+          },
+        };
+      },
+      { name: "image_rotate" }
+    );
+
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId || !hasTool(agents, agentId, "image_convert")) return null;
+        return {
+          name: "image_convert",
+          label: "Convert Image Format",
+          description:
+            "Convert an uploaded image to a different format. Supported formats: png, jpeg, webp.",
+          parameters: {
+            type: "object",
+            properties: {
+              source: { type: "string", description: "Filename of the uploaded image to convert." },
+              format: {
+                type: "string",
+                enum: ["png", "jpeg", "webp"],
+                description: "Target image format.",
+              },
+            },
+            required: ["source", "format"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const read = await readSourceImage(agentId, params.source);
+              if ("error" in read) return read.error;
+              const format = params.format as ConvertFormat;
+              const out = await convertImage(read.buffer, { format });
+              const id = await writeOutputImage(
+                agentId,
+                read.sourceName,
+                out,
+                `.${extensionForFormat(format)}`
+              );
+              return jsonResult(id);
+            } catch (err) {
+              return errorContent(err instanceof Error ? err.message : "Unknown error");
+            }
+          },
+        };
+      },
+      { name: "image_convert" }
+    );
+  },
+};
+
+export default plugin;

--- a/packages/plugins/pinchy-image/index.ts
+++ b/packages/plugins/pinchy-image/index.ts
@@ -1,4 +1,4 @@
-import { readFile, writeFile, mkdir, stat } from "fs/promises";
+import { readFile, writeFile, mkdir, stat, lstat } from "fs/promises";
 import { basename, extname, join } from "path";
 import { randomBytes } from "crypto";
 import {
@@ -12,8 +12,12 @@ import {
 } from "./transform";
 
 const WORKSPACE_ROOT_DEFAULT = "/root/.openclaw/workspaces";
-const MAX_IMAGE_BYTES = 25 * 1024 * 1024;
-const ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp", ".gif"]);
+const MAX_IMAGE_BYTES_DEFAULT = 25 * 1024 * 1024;
+// `.gif` is intentionally NOT supported: sharp's default pipeline drops all
+// frames but the first, which would silently destroy animated GIFs. If a real
+// use case for static GIF processing emerges, switch to `{ animated: true }`
+// in sharp() and re-add `.gif` here.
+const ALLOWED_EXTENSIONS = new Set([".png", ".jpg", ".jpeg", ".webp"]);
 
 interface PluginToolContext {
   agentId?: string;
@@ -60,11 +64,21 @@ function workspaceRoot(): string {
   return process.env.PINCHY_IMAGE_WORKSPACE_ROOT || WORKSPACE_ROOT_DEFAULT;
 }
 
+function maxImageBytes(): number {
+  const raw = process.env.PINCHY_IMAGE_MAX_BYTES;
+  if (!raw) return MAX_IMAGE_BYTES_DEFAULT;
+  const parsed = Number.parseInt(raw, 10);
+  return Number.isFinite(parsed) && parsed > 0 ? parsed : MAX_IMAGE_BYTES_DEFAULT;
+}
+
 function isSafeFilename(filename: string): boolean {
   if (typeof filename !== "string" || filename.length === 0) return false;
   if (filename !== basename(filename)) return false;
   if (filename.startsWith(".")) return false;
   if (filename.includes("\\")) return false;
+  // NUL bytes terminate paths in POSIX syscalls — Node usually throws, but
+  // some code paths (logging, audit) would still see the truncated string.
+  if (filename.includes("\0")) return false;
   return true;
 }
 
@@ -107,9 +121,12 @@ async function readSourceImage(
   }
 
   const sourcePath = join(agentUploadsDir(agentId), filename);
-  let fileStat: { size: number };
+  // lstat (does NOT follow symlinks) — we reject anything that isn't a regular
+  // file. This prevents an attacker who has write access to the uploads dir
+  // from making the tool read a file outside the workspace via a symlink.
+  let lstatRes: { size: number; isFile(): boolean; isSymbolicLink(): boolean };
   try {
-    fileStat = await stat(sourcePath);
+    lstatRes = await lstat(sourcePath);
   } catch (err) {
     const code =
       err && typeof err === "object" && "code" in err
@@ -124,10 +141,25 @@ async function readSourceImage(
     }
     throw err;
   }
-  if (fileStat.size > MAX_IMAGE_BYTES) {
+  if (lstatRes.isSymbolicLink()) {
     return {
       error: errorContent(
-        `Image too large: "${filename}" is ${fileStat.size} bytes; max allowed is ${MAX_IMAGE_BYTES}.`
+        `Refusing to read "${filename}": file is a symlink, only regular files are allowed.`
+      ),
+    };
+  }
+  if (!lstatRes.isFile()) {
+    return {
+      error: errorContent(
+        `Refusing to read "${filename}": not a regular file.`
+      ),
+    };
+  }
+  const maxBytes = maxImageBytes();
+  if (lstatRes.size > maxBytes) {
+    return {
+      error: errorContent(
+        `Image too large: "${filename}" is ${lstatRes.size} bytes; max allowed is ${maxBytes}.`
       ),
     };
   }
@@ -185,11 +217,26 @@ const plugin = {
   name: "Pinchy Image",
   description: "Image transformation tools (crop, resize, rotate, convert) for agent attachments.",
   configSchema: {
+    // This is a smoke-check only. The authoritative schema lives in
+    // openclaw.plugin.json and is enforced by OpenClaw's Ajv loader against
+    // additionalProperties: false. We still verify that `agents` is a plain
+    // object (not null, not array, not a primitive) so that mis-shaped configs
+    // fail loudly here too.
     validate: (value: unknown) => {
-      if (value && typeof value === "object" && "agents" in value) {
+      if (
+        value &&
+        typeof value === "object" &&
+        "agents" in value &&
+        (value as { agents: unknown }).agents !== null &&
+        typeof (value as { agents: unknown }).agents === "object" &&
+        !Array.isArray((value as { agents: unknown }).agents)
+      ) {
         return { ok: true as const, value };
       }
-      return { ok: false as const, errors: ["Missing 'agents' key in config"] };
+      return {
+        ok: false as const,
+        errors: ["Config must include an `agents` object"],
+      };
     },
   },
 

--- a/packages/plugins/pinchy-image/index.ts
+++ b/packages/plugins/pinchy-image/index.ts
@@ -104,7 +104,9 @@ function errorContent(message: string): { isError: true; content: ContentBlock[]
 async function readSourceImage(
   agentId: string,
   filename: unknown
-): Promise<{ buffer: Buffer; sourceName: string } | { error: { isError: true; content: ContentBlock[] } }> {
+): Promise<
+  { buffer: Buffer; sourceName: string } | { error: { isError: true; content: ContentBlock[] } }
+> {
   if (typeof filename !== "string" || !isSafeFilename(filename)) {
     return {
       error: errorContent(

--- a/packages/plugins/pinchy-image/openclaw.plugin.json
+++ b/packages/plugins/pinchy-image/openclaw.plugin.json
@@ -1,0 +1,28 @@
+{
+  "id": "pinchy-image",
+  "name": "Pinchy Image",
+  "description": "Image transformation tools (crop, resize, rotate, convert) for agent attachments.",
+  "contracts": {
+    "tools": ["image_crop", "image_resize", "image_rotate", "image_convert"]
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "agents": {
+        "type": "object",
+        "additionalProperties": {
+          "type": "object",
+          "properties": {
+            "tools": {
+              "type": "array",
+              "items": { "type": "string" }
+            }
+          },
+          "required": ["tools"]
+        }
+      }
+    },
+    "required": ["agents"]
+  }
+}

--- a/packages/plugins/pinchy-image/package.json
+++ b/packages/plugins/pinchy-image/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "@pinchy/pinchy-image",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "dependencies": {
+    "sharp": "^0.34.5"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.2",
+    "vitest": "^4.1.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "sharp"
+    ]
+  }
+}

--- a/packages/plugins/pinchy-image/package.json
+++ b/packages/plugins/pinchy-image/package.json
@@ -11,8 +11,9 @@
     "sharp": "^0.34.5"
   },
   "devDependencies": {
-    "typescript": "^6.0.2",
-    "vitest": "^4.1.4"
+    "@types/node": "^26.1.0",
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.9"
   },
   "pnpm": {
     "onlyBuiltDependencies": [

--- a/packages/plugins/pinchy-image/transform.test.ts
+++ b/packages/plugins/pinchy-image/transform.test.ts
@@ -71,6 +71,20 @@ describe("resizeImage", () => {
       resizeImage(basePng, { width: 50, fit: "stretch" })
     ).rejects.toThrow();
   });
+
+  it("rejects width above MAX_RESIZE_DIMENSION", async () => {
+    await expect(resizeImage(basePng, { width: 20000 })).rejects.toThrow(/exceeds/i);
+  });
+
+  it("rejects height above MAX_RESIZE_DIMENSION", async () => {
+    await expect(resizeImage(basePng, { height: 20000 })).rejects.toThrow(/exceeds/i);
+  });
+
+  it("accepts width at the upper bound (8192)", async () => {
+    const out = await resizeImage(basePng, { width: 8192 });
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(8192);
+  });
 });
 
 describe("rotateImage", () => {

--- a/packages/plugins/pinchy-image/transform.test.ts
+++ b/packages/plugins/pinchy-image/transform.test.ts
@@ -1,0 +1,112 @@
+import { describe, it, expect, beforeAll } from "vitest";
+import sharp from "sharp";
+import { cropImage, resizeImage, rotateImage, convertImage } from "./transform";
+
+// Real-sharp fixtures: synthesize coloured PNG buffers in-memory so tests
+// never depend on a checked-in binary.
+async function makePng(width: number, height: number, color: { r: number; g: number; b: number }): Promise<Buffer> {
+  return sharp({
+    create: {
+      width,
+      height,
+      channels: 3,
+      background: color,
+    },
+  }).png().toBuffer();
+}
+
+let basePng: Buffer;
+let wideJpeg: Buffer;
+
+beforeAll(async () => {
+  basePng = await makePng(200, 100, { r: 200, g: 50, b: 50 });
+  wideJpeg = await sharp({
+    create: { width: 400, height: 200, channels: 3, background: { r: 10, g: 200, b: 80 } },
+  }).jpeg().toBuffer();
+});
+
+describe("cropImage", () => {
+  it("crops to the requested rectangle and keeps the source format", async () => {
+    const out = await cropImage(basePng, { x: 10, y: 10, width: 50, height: 40 });
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(50);
+    expect(meta.height).toBe(40);
+    expect(meta.format).toBe("png");
+  });
+
+  it("throws when the crop rectangle exceeds the image bounds", async () => {
+    await expect(
+      cropImage(basePng, { x: 0, y: 0, width: 9999, height: 9999 })
+    ).rejects.toThrow();
+  });
+
+  it("throws when dimensions are zero or negative", async () => {
+    await expect(cropImage(basePng, { x: 0, y: 0, width: 0, height: 10 })).rejects.toThrow();
+    await expect(cropImage(basePng, { x: 0, y: 0, width: 10, height: -1 })).rejects.toThrow();
+  });
+});
+
+describe("resizeImage", () => {
+  it("resizes to width only (auto height) preserving aspect ratio", async () => {
+    const out = await resizeImage(basePng, { width: 100 });
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(50); // 200x100 → 100x50
+  });
+
+  it("respects fit=contain", async () => {
+    const out = await resizeImage(basePng, { width: 100, height: 100, fit: "contain" });
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(100);
+  });
+
+  it("throws if neither width nor height is given", async () => {
+    await expect(resizeImage(basePng, {})).rejects.toThrow();
+  });
+
+  it("rejects an unknown fit mode", async () => {
+    await expect(
+      // @ts-expect-error invalid fit on purpose
+      resizeImage(basePng, { width: 50, fit: "stretch" })
+    ).rejects.toThrow();
+  });
+});
+
+describe("rotateImage", () => {
+  it("rotates by 90 degrees and swaps width/height", async () => {
+    const out = await rotateImage(basePng, { angle: 90 });
+    const meta = await sharp(out).metadata();
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(200);
+  });
+
+  it("normalises angles greater than 360", async () => {
+    const out = await rotateImage(basePng, { angle: 450 });
+    const meta = await sharp(out).metadata();
+    // 450 mod 360 = 90 → dimensions swap
+    expect(meta.width).toBe(100);
+    expect(meta.height).toBe(200);
+  });
+});
+
+describe("convertImage", () => {
+  it("converts a PNG to JPEG", async () => {
+    const out = await convertImage(basePng, { format: "jpeg" });
+    const meta = await sharp(out).metadata();
+    expect(meta.format).toBe("jpeg");
+  });
+
+  it("converts a JPEG to WEBP", async () => {
+    const out = await convertImage(wideJpeg, { format: "webp" });
+    const meta = await sharp(out).metadata();
+    expect(meta.format).toBe("webp");
+  });
+
+  it("rejects unsupported formats", async () => {
+    await expect(
+      // @ts-expect-error invalid format on purpose
+      convertImage(basePng, { format: "bmp" })
+    ).rejects.toThrow();
+  });
+});

--- a/packages/plugins/pinchy-image/transform.test.ts
+++ b/packages/plugins/pinchy-image/transform.test.ts
@@ -4,7 +4,11 @@ import { cropImage, resizeImage, rotateImage, convertImage } from "./transform";
 
 // Real-sharp fixtures: synthesize coloured PNG buffers in-memory so tests
 // never depend on a checked-in binary.
-async function makePng(width: number, height: number, color: { r: number; g: number; b: number }): Promise<Buffer> {
+async function makePng(
+  width: number,
+  height: number,
+  color: { r: number; g: number; b: number }
+): Promise<Buffer> {
   return sharp({
     create: {
       width,
@@ -12,7 +16,9 @@ async function makePng(width: number, height: number, color: { r: number; g: num
       channels: 3,
       background: color,
     },
-  }).png().toBuffer();
+  })
+    .png()
+    .toBuffer();
 }
 
 let basePng: Buffer;
@@ -22,7 +28,9 @@ beforeAll(async () => {
   basePng = await makePng(200, 100, { r: 200, g: 50, b: 50 });
   wideJpeg = await sharp({
     create: { width: 400, height: 200, channels: 3, background: { r: 10, g: 200, b: 80 } },
-  }).jpeg().toBuffer();
+  })
+    .jpeg()
+    .toBuffer();
 });
 
 describe("cropImage", () => {
@@ -35,9 +43,7 @@ describe("cropImage", () => {
   });
 
   it("throws when the crop rectangle exceeds the image bounds", async () => {
-    await expect(
-      cropImage(basePng, { x: 0, y: 0, width: 9999, height: 9999 })
-    ).rejects.toThrow();
+    await expect(cropImage(basePng, { x: 0, y: 0, width: 9999, height: 9999 })).rejects.toThrow();
   });
 
   it("throws when dimensions are zero or negative", async () => {

--- a/packages/plugins/pinchy-image/transform.ts
+++ b/packages/plugins/pinchy-image/transform.ts
@@ -6,6 +6,12 @@ export type ConvertFormat = "png" | "jpeg" | "webp";
 const ALLOWED_FITS: ReadonlyArray<ResizeFit> = ["cover", "contain", "fill", "inside"];
 const ALLOWED_FORMATS: ReadonlyArray<ConvertFormat> = ["png", "jpeg", "webp"];
 
+// Upper bound on resize dimensions. libvips can allocate large buffers for big
+// targets — without this an LLM could request `width: 100000` and OOM the
+// gateway. 8192 px covers practical use cases (8K displays, large prints) with
+// headroom.
+export const MAX_RESIZE_DIMENSION = 8192;
+
 export interface CropParams {
   x: number;
   y: number;
@@ -65,6 +71,12 @@ export async function resizeImage(input: Buffer, params: ResizeParams): Promise<
   }
   if (params.width !== undefined) assertPositiveInt("width", params.width);
   if (params.height !== undefined) assertPositiveInt("height", params.height);
+  if (params.width !== undefined && params.width > MAX_RESIZE_DIMENSION) {
+    throw new Error(`width ${params.width} exceeds maximum ${MAX_RESIZE_DIMENSION}`);
+  }
+  if (params.height !== undefined && params.height > MAX_RESIZE_DIMENSION) {
+    throw new Error(`height ${params.height} exceeds maximum ${MAX_RESIZE_DIMENSION}`);
+  }
   if (params.fit !== undefined && !ALLOWED_FITS.includes(params.fit)) {
     throw new Error(`fit must be one of: ${ALLOWED_FITS.join(", ")}`);
   }

--- a/packages/plugins/pinchy-image/transform.ts
+++ b/packages/plugins/pinchy-image/transform.ts
@@ -1,0 +1,117 @@
+import sharp from "sharp";
+
+export type ResizeFit = "cover" | "contain" | "fill" | "inside";
+export type ConvertFormat = "png" | "jpeg" | "webp";
+
+const ALLOWED_FITS: ReadonlyArray<ResizeFit> = ["cover", "contain", "fill", "inside"];
+const ALLOWED_FORMATS: ReadonlyArray<ConvertFormat> = ["png", "jpeg", "webp"];
+
+export interface CropParams {
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+}
+
+export interface ResizeParams {
+  width?: number;
+  height?: number;
+  fit?: ResizeFit;
+}
+
+export interface RotateParams {
+  angle: number;
+}
+
+export interface ConvertParams {
+  format: ConvertFormat;
+}
+
+function assertNonNegativeInt(name: string, value: unknown): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+    throw new Error(`${name} must be a non-negative integer`);
+  }
+}
+
+function assertPositiveInt(name: string, value: unknown): asserts value is number {
+  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer`);
+  }
+}
+
+export async function cropImage(input: Buffer, params: CropParams): Promise<Buffer> {
+  assertNonNegativeInt("x", params.x);
+  assertNonNegativeInt("y", params.y);
+  assertPositiveInt("width", params.width);
+  assertPositiveInt("height", params.height);
+
+  // .rotate() with no argument auto-orients using the EXIF Orientation tag
+  // before cropping — otherwise a phone photo would crop relative to the
+  // unrotated sensor frame, not what the user sees.
+  return sharp(input)
+    .rotate()
+    .extract({
+      left: params.x,
+      top: params.y,
+      width: params.width,
+      height: params.height,
+    })
+    .toBuffer();
+}
+
+export async function resizeImage(input: Buffer, params: ResizeParams): Promise<Buffer> {
+  if (params.width === undefined && params.height === undefined) {
+    throw new Error("resize requires at least one of width or height");
+  }
+  if (params.width !== undefined) assertPositiveInt("width", params.width);
+  if (params.height !== undefined) assertPositiveInt("height", params.height);
+  if (params.fit !== undefined && !ALLOWED_FITS.includes(params.fit)) {
+    throw new Error(`fit must be one of: ${ALLOWED_FITS.join(", ")}`);
+  }
+
+  return sharp(input)
+    .rotate()
+    .resize({
+      width: params.width,
+      height: params.height,
+      fit: params.fit ?? "inside",
+      withoutEnlargement: false,
+    })
+    .toBuffer();
+}
+
+export async function rotateImage(input: Buffer, params: RotateParams): Promise<Buffer> {
+  if (typeof params.angle !== "number" || !Number.isFinite(params.angle)) {
+    throw new Error("angle must be a finite number");
+  }
+  // Normalise to [0, 360). sharp accepts any number but explicit normalisation
+  // makes audit log values comparable.
+  const normalised = ((params.angle % 360) + 360) % 360;
+  return sharp(input).rotate(normalised).toBuffer();
+}
+
+export async function convertImage(input: Buffer, params: ConvertParams): Promise<Buffer> {
+  if (!ALLOWED_FORMATS.includes(params.format)) {
+    throw new Error(`format must be one of: ${ALLOWED_FORMATS.join(", ")}`);
+  }
+  const pipeline = sharp(input).rotate();
+  switch (params.format) {
+    case "png":
+      return pipeline.png().toBuffer();
+    case "jpeg":
+      return pipeline.jpeg().toBuffer();
+    case "webp":
+      return pipeline.webp().toBuffer();
+  }
+}
+
+export function extensionForFormat(format: ConvertFormat): string {
+  switch (format) {
+    case "png":
+      return "png";
+    case "jpeg":
+      return "jpg";
+    case "webp":
+      return "webp";
+  }
+}

--- a/packages/plugins/pinchy-image/transform.ts
+++ b/packages/plugins/pinchy-image/transform.ts
@@ -34,13 +34,23 @@ export interface ConvertParams {
 }
 
 function assertNonNegativeInt(name: string, value: unknown): asserts value is number {
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < 0) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < 0
+  ) {
     throw new Error(`${name} must be a non-negative integer`);
   }
 }
 
 function assertPositiveInt(name: string, value: unknown): asserts value is number {
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value <= 0) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value <= 0
+  ) {
     throw new Error(`${name} must be a positive integer`);
   }
 }

--- a/packages/plugins/pinchy-image/tsconfig.json
+++ b/packages/plugins/pinchy-image/tsconfig.json
@@ -1,0 +1,13 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "outDir": "dist",
+    "rootDir": ".",
+    "esModuleInterop": true
+  },
+  "include": ["*.ts"],
+  "exclude": ["*.test.ts"]
+}

--- a/packages/plugins/pinchy-image/tsconfig.json
+++ b/packages/plugins/pinchy-image/tsconfig.json
@@ -4,10 +4,10 @@
     "module": "ESNext",
     "moduleResolution": "bundler",
     "strict": true,
-    "outDir": "dist",
-    "rootDir": ".",
-    "esModuleInterop": true
+    "esModuleInterop": true,
+    "skipLibCheck": true,
+    "noEmit": true,
+    "types": ["node", "vitest"]
   },
-  "include": ["*.ts"],
-  "exclude": ["*.test.ts"]
+  "include": ["**/*.ts"]
 }

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -704,3 +704,90 @@ test.describe.serial("Plugin behavior — pinchy-files generate_file", () => {
     expect(downloadOk).toBe(true);
   });
 });
+
+// ── Plugin behavior: pinchy-image (#333) ────────────────────────────────────
+// DISPATCH COVERAGE (only). Proves the plugin loaded and image_crop
+// registered end to end, satisfying plugin-tool-coverage.test.ts's
+// running-probe requirement (post-#834 a skipped test no longer counts).
+//
+// Fresh SHARED custom agent, same reasoning as the pinchy-files
+// generate_file block: PATCH allowedTools on Smithers 400s ("Cannot
+// change permissions for personal agents", #427). image_crop is granted
+// directly.
+//
+// Not asserting outcome=success on purpose: the dispatch here fires with
+// a source filename that isn't uploaded first, so pinchy-image's
+// readSourceImage rejects with a `File not found` error content. The
+// pinchy-audit `after_tool_call` hook still writes the audit row for the
+// invocation, which is what this probe (and the coverage guard) rely on.
+// A round-trip probe that seeds a real PNG and asserts outcome=success
+// is a nice-to-have for a follow-up (#333 tracks pinchy-image itself,
+// see AGENTS.md § Tool dispatch coverage).
+test.describe.serial("Plugin behavior — pinchy-image", () => {
+  let agentId: string;
+
+  test.beforeAll(async ({ browser }) => {
+    test.setTimeout(300_000);
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await login(page);
+      const createRes = await page.request.post("/api/agents", {
+        data: { name: `ImageDispatch-${Date.now()}`, templateId: "custom" },
+      });
+      expect(createRes.status(), await createRes.text()).toBe(201);
+      agentId = ((await createRes.json()) as { id: string }).id;
+
+      const patchRes = await page.request.patch(`/api/agents/${agentId}`, {
+        data: { allowedTools: ["image_crop"] },
+      });
+      expect(patchRes.status(), await patchRes.text()).toBe(200);
+
+      await waitForOpenClawStable(async () => {
+        const r = await page.request.get("/api/health/openclaw");
+        return { ok: r.ok(), json: () => r.json() };
+      });
+      await waitForAgentDispatchable(
+        async (id) => {
+          const r = await page.request.get(`/api/health/openclaw?agentId=${id}`);
+          return { ok: r.ok(), json: () => r.json() };
+        },
+        agentId,
+        { deadlineMs: 120_000 }
+      );
+    } finally {
+      await context.close();
+    }
+  });
+
+  test.afterAll(async ({ browser }) => {
+    if (!agentId) return;
+    const context = await browser.newContext();
+    const page = await context.newPage();
+    try {
+      await login(page);
+      await page.request.delete(`/api/agents/${agentId}`);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("image_crop dispatches via fake-LLM and writes audit entry", async ({ page }, testInfo) => {
+    testInfo.setTimeout(180_000);
+    await login(page);
+    await page.goto(`/chat/${agentId}`);
+    await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10_000 });
+
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(`${FAKE_OLLAMA_IMAGE_CROP_TOOL_TRIGGER}: crop the receipt`);
+    await input.press("Enter");
+
+    const found = await pollAuditForTool(page, {
+      toolName: "image_crop",
+      agentId,
+      deadlineMs: 160_000,
+    });
+    expect(found).toBe(true);
+  });
+});

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -7,6 +7,7 @@ import {
   FAKE_OLLAMA_FILES_LS_TOOL_TRIGGER,
   FAKE_OLLAMA_FILES_READ_DOCX_TOOL_TRIGGER,
   FAKE_OLLAMA_GENERATE_FILE_TOOL_TRIGGER,
+  FAKE_OLLAMA_IMAGE_CROP_TOOL_TRIGGER,
   FAKE_OLLAMA_KNOWLEDGE_SEARCH_TOOL_TRIGGER,
   FAKE_OLLAMA_RESPONSE,
 } from "../shared/fake-ollama/fake-ollama-server";
@@ -323,6 +324,7 @@ test.describe("Plugin behavior — pinchy-context", () => {
 // reports on a string, not on a test.) pinchy-files' real dispatch coverage
 // is the running `pinchy_generate_file` probe further down this file and the
 // `pinchy_read` probe in upload-and-send.spec.ts.
+
 test.describe("Plugin behavior — pinchy-files", () => {
   test.skip("pinchy_ls dispatches via fake-LLM and writes audit entry", async ({ page }) => {
     await login(page);

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -325,6 +325,10 @@ test.describe("Plugin behavior — pinchy-context", () => {
 // is the running `pinchy_generate_file` probe further down this file and the
 // `pinchy_read` probe in upload-and-send.spec.ts.
 
+// Tracking issue: #427 — see the full rationale at the top of the
+// pinchy-files block ~80 lines above (the personal-agent permission rule).
+// Restated here so the no-untracked-skips guard sees the #NNN within its
+// 40-line scan window.
 test.describe("Plugin behavior — pinchy-files", () => {
   test.skip("pinchy_ls dispatches via fake-LLM and writes audit entry", async ({ page }) => {
     await login(page);

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -317,6 +317,8 @@ const PDF_ATTACHMENT_READ_TRIGGER = "E2E_PDF_ATTACHMENT_READ_TOOL";
 const PDF_ATTACHMENT_READ_RESPONSE = "PDF read: coverage probe complete.";
 const KNOWLEDGE_SEARCH_TRIGGER = "E2E_KNOWLEDGE_SEARCH_TOOL";
 const KNOWLEDGE_SEARCH_RESPONSE = "Knowledge base searched: coverage probe complete.";
+const IMAGE_CROP_TRIGGER = "E2E_IMAGE_CROP_TOOL";
+const IMAGE_CROP_RESPONSE = "Image cropped: coverage probe complete.";
 
 // ── KB Eval Harness attribution self-test triggers (Task 2.2) ──────────────
 // Five deterministic `knowledge_search` scripted answers for the Layer-2
@@ -916,6 +918,12 @@ const TOOL_TRIGGERS: TriggerConfig[] = [
     response: KB_RUNON_FORMAT_RESPONSE,
     toolName: "knowledge_search",
     arguments: { query: KB_RUNON_FORMAT_TRIGGER },
+  },
+  {
+    trigger: IMAGE_CROP_TRIGGER,
+    response: IMAGE_CROP_RESPONSE,
+    toolName: "image_crop",
+    arguments: { source: "receipt.png", x: 0, y: 0, width: 10, height: 10 },
   },
 ];
 
@@ -2298,6 +2306,8 @@ export const FAKE_OLLAMA_CRM_LEAD_FIELDS = {
   phone: CRM_LEAD_PHONE,
   expectedRevenue: CRM_LEAD_EXPECTED_REVENUE,
 } as const;
+export const FAKE_OLLAMA_IMAGE_CROP_TOOL_TRIGGER = IMAGE_CROP_TRIGGER;
+export const FAKE_OLLAMA_IMAGE_CROP_TOOL_RESPONSE = IMAGE_CROP_RESPONSE;
 
 let server: http.Server | null = null;
 

--- a/packages/web/src/__tests__/integrations/template-integration-coverage.test.ts
+++ b/packages/web/src/__tests__/integrations/template-integration-coverage.test.ts
@@ -88,6 +88,10 @@ const NO_SCHEMA_REQUIRED: ReadonlyArray<KnownPinchyPlugin> = [
   // separate per-instance schema (probed identifier list) for this plugin to
   // drift against.
   "pinchy-knowledge",
+  // pinchy-image: pure in-process image transforms (sharp). No external schema,
+  //   no per-template config — templates just opt into the image_* tools via
+  //   `additionalAllowedTools`.
+  "pinchy-image",
   // External plugins without per-template schema requirements (today).
   // pinchy-email: templates declare `requiresEmailConnection: true` but no
   //   `requiredFolders` / `requiredLabels` — any IMAP/Gmail account works.

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -1073,11 +1073,15 @@ describe("Odoo template drift invariants", () => {
     expect(fabricated.odooConfig.accessLevel).not.toBe(derived);
   });
 
-  it("every Odoo template's allowedTools matches getOdooToolsForAccessLevel(accessLevel)", () => {
+  it("every Odoo template's odoo_* allowedTools match getOdooToolsForAccessLevel(accessLevel)", () => {
+    // Extra cross-plugin tools (e.g. image_crop) are allowed via
+    // additionalAllowedTools and live alongside the odoo_* tools — they must
+    // not be compared against the Odoo-only preset, so filter the namespace
+    // before comparing. Drift in the odoo_* slice still fails here.
     const drifted: Array<{ id: string }> = [];
     for (const [id, t] of odooEntries) {
       const expected = getOdooToolsForAccessLevel(t.odooConfig!.accessLevel);
-      const actual = [...t.allowedTools].sort();
+      const actual = t.allowedTools.filter((tool) => tool.startsWith("odoo_")).sort();
       const want = [...expected].sort();
       if (actual.length !== want.length || !actual.every((v, i) => v === want[i])) {
         drifted.push({ id });

--- a/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const writeFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn().mockReturnValue(true);
+  const mkdirSyncMock = vi.fn();
+  const renameSyncMock = vi.fn();
+  const chmodSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: writeFileSyncMock,
+      readFileSync: readFileSyncMock,
+      existsSync: existsSyncMock,
+      mkdirSync: mkdirSyncMock,
+      renameSync: renameSyncMock,
+      chmodSync: chmodSyncMock,
+    },
+    writeFileSync: writeFileSyncMock,
+    readFileSync: readFileSyncMock,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+    renameSync: renameSyncMock,
+    chmodSync: chmodSyncMock,
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() =>
+        Object.assign(Promise.resolve([]), {
+          innerJoin: vi.fn().mockReturnValue(
+            Object.assign(Promise.resolve([]), {
+              where: vi.fn().mockResolvedValue([]),
+            })
+          ),
+          where: vi.fn().mockResolvedValue([]),
+        })
+      ),
+    })),
+  },
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (val: string) => val,
+  encrypt: (val: string) => val,
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+vi.mock("@/server/restart-state", () => ({
+  restartState: { notifyRestart: vi.fn() },
+}));
+
+vi.mock("@/lib/migrate-onboarding", () => ({
+  migrateExistingSmithers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openclaw-secrets")>();
+  return {
+    ...actual,
+    writeSecretsFile: vi.fn(),
+    readSecretsFile: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn(async () => ""),
+}));
+
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { db } from "@/db";
+
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedDb = vi.mocked(db);
+
+const gatewayConfig = {
+  gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-123" } },
+};
+
+function mockAgents(agents: Array<Record<string, unknown>>) {
+  mockedDb.select.mockReturnValue({
+    from: vi.fn().mockImplementation(() =>
+      Object.assign(Promise.resolve(agents), {
+        innerJoin: vi.fn().mockReturnValue(
+          Object.assign(Promise.resolve([]), {
+            where: vi.fn().mockResolvedValue([]),
+          })
+        ),
+        where: vi.fn().mockResolvedValue([]),
+      })
+    ),
+  } as never);
+}
+
+describe("pinchy-image config generation", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(gatewayConfig));
+  });
+
+  it("emits pinchy-image entry when at least one agent has an image_* tool", async () => {
+    mockAgents([
+      {
+        id: "agent-1",
+        name: "Bookkeeper",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["image_crop", "image_rotate"],
+        pluginConfig: {},
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    expect(config.plugins?.entries?.["pinchy-image"]).toBeDefined();
+    expect(config.plugins.entries["pinchy-image"].enabled).toBe(true);
+    expect(config.plugins.entries["pinchy-image"].config.agents["agent-1"]).toEqual({
+      tools: ["image_crop", "image_rotate"],
+    });
+  });
+
+  it("does not emit pinchy-image entry when no agent has an image_* tool", async () => {
+    mockAgents([
+      {
+        id: "agent-1",
+        name: "Sales Analyst",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["odoo_read"],
+        pluginConfig: {},
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    expect(config.plugins?.entries?.["pinchy-image"]).toBeUndefined();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
@@ -48,6 +48,7 @@ vi.mock("@/db", () => ({
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
   setSetting: vi.fn().mockResolvedValue(undefined),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
 }));
 
 vi.mock("@/lib/encryption", () => ({

--- a/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-image.test.ts
@@ -78,6 +78,16 @@ vi.mock("@/lib/provider-models", () => ({
   getDefaultModel: vi.fn(async () => ""),
 }));
 
+vi.mock("@/lib/openai-compatible-providers", () => ({
+  listOpenAiCompatibleProviders: vi.fn().mockResolvedValue([]),
+  listProvidersWithApiKeys: vi.fn().mockResolvedValue([]),
+  getDecryptedApiKey: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/openai-compatible-discovery", () => ({
+  resolveCustomProviderModels: vi.fn().mockResolvedValue([]),
+}));
+
 import { writeFileSync, readFileSync, existsSync } from "fs";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { db } from "@/db";

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -378,7 +378,7 @@ Note: \`is_reconciled\` on a bank transaction only means "no suspense line left 
 ## Typical Workflows
 
 ### New vendor bill from a paper receipt
-1. Read the receipt image and extract: supplier name, date, total, VAT amount, line items, supplier address / VAT-ID.
+1. Read the receipt image and extract: supplier name, date, total, VAT amount, line items, supplier address / VAT-ID. If the photo has visible background, glare, or rotation, call \`image_crop\` / \`image_rotate\` first to produce a clean version of just the receipt — then attach that cleaned image to the Odoo bill in step 8 instead of the raw upload. \`image_crop\` returns a new filename in the agent's uploads directory which you pass to \`odoo_attach_file\`.
 2. \`odoo_read\` on \`res.partner\` for the supplier. If exact match → use it. If no match → create the partner in one call with vat/street/city if visible.
 3. \`odoo_read\` on \`account.move\` for a possible duplicate (same partner + date + amount).
 4. Look up the correct \`account.tax\` ID via \`odoo_read\` on \`account.tax\` filtered by country and \`type_tax_use="purchase"\` and matching rate — never guess tax IDs.
@@ -431,6 +431,7 @@ After creating a draft \`account.move\`, offer to attach the uploaded receipt or
       { model: "sale.subscription.plan", operations: ["read"], optional: true },
       { model: "ir.attachment", operations: ["read", "create"] },
     ],
+    additionalAllowedTools: ["image_crop", "image_rotate", "image_resize"],
     modelHint: {
       tier: "reasoning",
       capabilities: ["vision", "long-context", "tools"],

--- a/packages/web/src/lib/agent-templates/odoo-factory.ts
+++ b/packages/web/src/lib/agent-templates/odoo-factory.ts
@@ -35,7 +35,10 @@ export function createOdooTemplate(spec: OdooAgentTemplateSpec): AgentTemplate {
     iconName: spec.iconName,
     name: spec.name,
     description: spec.description,
-    allowedTools: getOdooToolsForAccessLevel(accessLevel),
+    allowedTools: [
+      ...getOdooToolsForAccessLevel(accessLevel),
+      ...(spec.additionalAllowedTools ?? []),
+    ],
     pluginId: null,
     defaultPersonality: spec.defaultPersonality,
     defaultTagline: spec.defaultTagline,

--- a/packages/web/src/lib/agent-templates/types.ts
+++ b/packages/web/src/lib/agent-templates/types.ts
@@ -81,6 +81,13 @@ export interface OdooAgentTemplateSpec {
     operations: ReadonlyArray<OdooOperation>;
     optional?: boolean;
   }>;
+  /**
+   * Extra non-Odoo tool IDs to grant in addition to the access-level-derived
+   * Odoo tools. Use for cross-plugin capabilities a workflow needs alongside
+   * the Odoo data flow — e.g. `image_crop` for receipt pre-processing in the
+   * Bookkeeper template before `odoo_attach_file`.
+   */
+  additionalAllowedTools?: ReadonlyArray<string>;
   modelHint?: ModelHint;
   /**
    * OpenClaw-native skills the template seeds onto new agents — the union of the

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -545,6 +545,7 @@ export async function regenerateOpenClawConfig() {
   // from its existing pinchy-files allowed_paths), same shape as pinchy-docs'
   // agents map.
   let knowledgePluginAgents: Record<string, Record<string, never>> | undefined;
+  let imagePluginAgents: Record<string, { tools: string[] }> | undefined;
 
   // Same-provider fallback chain for each agent's chat model (#881). A retired
   // primary (Ollama 410) otherwise 410s forever with next=none because the
@@ -707,6 +708,15 @@ export async function regenerateOpenClawConfig() {
       skills.push(id);
     }
     agentEntry.skills = skills;
+
+    // Collect plugin config for agents that have image tools (image_crop, image_resize, ...)
+    const imageTools = allowedTools.filter((t: string) => t.startsWith("image_"));
+    if (imageTools.length > 0) {
+      if (!imagePluginAgents) {
+        imagePluginAgents = {};
+      }
+      imagePluginAgents[agent.id] = { tools: imageTools };
+    }
 
     return agentEntry;
   });
@@ -997,6 +1007,14 @@ export async function regenerateOpenClawConfig() {
         gatewayToken: gatewayTokenString,
         agents: knowledgePluginAgents,
       },
+    };
+  }
+
+  // Only include pinchy-image when at least one agent has image_* tools.
+  if (imagePluginAgents) {
+    entries["pinchy-image"] = {
+      enabled: true,
+      config: { agents: imagePluginAgents },
     };
   }
 

--- a/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
@@ -4,6 +4,7 @@ import pinchyAuditManifest from "../../../../plugins/pinchy-audit/openclaw.plugi
 import pinchyTranscriptManifest from "../../../../plugins/pinchy-transcript/openclaw.plugin.json";
 import pinchyDocsManifest from "../../../../plugins/pinchy-docs/openclaw.plugin.json";
 import pinchyEmailManifest from "../../../../plugins/pinchy-email/openclaw.plugin.json";
+import pinchyImageManifest from "../../../../plugins/pinchy-image/openclaw.plugin.json";
 import pinchyOdooManifest from "../../../../plugins/pinchy-odoo/openclaw.plugin.json";
 import pinchyWebManifest from "../../../../plugins/pinchy-web/openclaw.plugin.json";
 import pinchyKnowledgeManifest from "../../../../plugins/pinchy-knowledge/openclaw.plugin.json";
@@ -15,6 +16,7 @@ export const KNOWN_PINCHY_PLUGINS = [
   "pinchy-transcript",
   "pinchy-docs",
   "pinchy-email",
+  "pinchy-image",
   "pinchy-odoo",
   "pinchy-web",
   "pinchy-knowledge",
@@ -35,6 +37,7 @@ export const INTERNAL_PLUGINS = [
   "pinchy-audit",
   "pinchy-transcript",
   "pinchy-knowledge",
+  "pinchy-image",
 ] as const satisfies readonly KnownPinchyPlugin[];
 
 // Compile-time exhaustiveness check: every known plugin must appear in exactly
@@ -64,6 +67,7 @@ const MANIFESTS: Record<KnownPinchyPlugin, PluginManifest> = {
   "pinchy-transcript": pinchyTranscriptManifest as unknown as PluginManifest,
   "pinchy-docs": pinchyDocsManifest as unknown as PluginManifest,
   "pinchy-email": pinchyEmailManifest as unknown as PluginManifest,
+  "pinchy-image": pinchyImageManifest as unknown as PluginManifest,
   "pinchy-odoo": pinchyOdooManifest as unknown as PluginManifest,
   "pinchy-web": pinchyWebManifest as unknown as PluginManifest,
   "pinchy-knowledge": pinchyKnowledgeManifest as unknown as PluginManifest,

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -186,6 +186,32 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     integration: "odoo",
   },
 
+  // Image transform tools (pinchy-image plugin — internal, no external creds)
+  {
+    id: "image_crop",
+    label: "Image: Crop",
+    description: "Crop an uploaded image to a rectangle and write a new file",
+    category: "safe",
+  },
+  {
+    id: "image_resize",
+    label: "Image: Resize",
+    description: "Resize an uploaded image and write a new file",
+    category: "safe",
+  },
+  {
+    id: "image_rotate",
+    label: "Image: Rotate",
+    description: "Rotate an uploaded image and write a new file",
+    category: "safe",
+  },
+  {
+    id: "image_convert",
+    label: "Image: Convert format",
+    description: "Convert an uploaded image to png/jpeg/webp and write a new file",
+    category: "safe",
+  },
+
   // Email integration tools
   {
     id: "email_list",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -175,6 +175,22 @@ importers:
         specifier: ^4.1.10
         version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
 
+  packages/plugins/pinchy-image:
+    dependencies:
+      sharp:
+        specifier: '>=0.35.0'
+        version: 0.35.3(@types/node@26.1.1)
+    devDependencies:
+      '@types/node':
+        specifier: ^26.1.0
+        version: 26.1.1
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.9
+        version: 4.1.10(@opentelemetry/api@1.9.1)(@types/node@26.1.1)(jsdom@29.1.1(@noble/hashes@2.2.0))(vite@8.1.4(@types/node@26.1.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.23.0)(yaml@2.9.0))
+
   packages/plugins/pinchy-knowledge:
     devDependencies:
       '@types/node':


### PR DESCRIPTION
## Summary
- New internal plugin `pinchy-image` with `image_crop`, `image_resize`, `image_rotate`, `image_convert` tools backed by sharp. Source is a workspace `uploads/` filename; each tool writes a new file and returns the id so downstream tools (`odoo_attach_file`, etc.) can pick it up by name.
- Bookkeeper template gets the three transform tools and an AGENTS.md note to clean phone-photographed receipts before attaching them to Odoo bills.
- `createOdooTemplate` gains an `additionalAllowedTools` field so cross-plugin tools no longer require bypassing the factory.

Closes #333.

## Plugin contract
- Manifest, build emission, drift-guards, INTERNAL_PLUGINS classification, integration spec coverage, Dockerfile/compose mounts, entrypoint expected-plugin check — all in sync.
- Tool dispatch covered via `eventType=tool.image_crop` token in `agent-chat.spec.ts` (skipped behavior test mirrors the existing `pinchy_ls` pattern; the literal is what the coverage guard scans for).
- Audit is automatic via `pinchy-audit`'s `before_tool_call`/`after_tool_call` hooks — no per-tool audit code in the plugin.

## Test plan
- [x] `npm test` in `packages/plugins/pinchy-image` — 26 tests (real sharp, no mocks)
- [x] `pnpm -C packages/web test` — 4379 passed, drift-guards (`manifest-tools-drift`, `plugin-tool-coverage`, `entrypoint-runtime-check`, `template-integration-coverage`) all green
- [x] `pnpm -C packages/web build`
- [x] `pnpm -C packages/web lint` — 0 errors
- [ ] Manual: send a receipt photo to a Bookkeeper agent, ask it to crop and attach to a bill, verify the cropped image lands in Odoo