### PR TITLE
ci: CI speedup — concurrency, caches, build-once-run-many, CodeQL

### DIFF
--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -14,7 +14,11 @@ runs:
       id: pw-version
       shell: bash
       run: |
-        version=$(node -e "console.log(require('./packages/web/node_modules/@playwright/test/package.json').version)" 2>/dev/null || echo "unknown")
+        version=$(node -e "console.log(require('./packages/web/node_modules/@playwright/test/package.json').version)" 2>/dev/null)
+        if [ -z "$version" ]; then
+          echo "::error::Could not resolve Playwright version from node_modules — run setup-pnpm first" >&2
+          exit 1
+        fi
         echo "version=${version}" >> $GITHUB_OUTPUT
 
     - name: Cache Playwright browsers
@@ -27,9 +31,13 @@ runs:
     - name: Install Playwright browsers + deps
       if: steps.pw-cache.outputs.cache-hit != 'true'
       shell: bash
-      run: pnpm -C packages/web exec playwright install --with-deps ${{ inputs.browsers }}
+      env:
+        BROWSERS: ${{ inputs.browsers }}
+      run: pnpm -C packages/web exec playwright install --with-deps $BROWSERS
 
     - name: Install Playwright system deps only (cache hit)
       if: steps.pw-cache.outputs.cache-hit == 'true'
       shell: bash
-      run: pnpm -C packages/web exec playwright install-deps ${{ inputs.browsers }}
+      env:
+        BROWSERS: ${{ inputs.browsers }}
+      run: pnpm -C packages/web exec playwright install-deps $BROWSERS

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -1,0 +1,35 @@
+name: "Setup Playwright with browser cache"
+description: "Caches ~/.cache/ms-playwright between runs. Installs missing browsers + system deps."
+
+inputs:
+  browsers:
+    description: "Browsers to install (space-separated)"
+    required: false
+    default: "chromium"
+
+runs:
+  using: composite
+  steps:
+    - name: Resolve Playwright version
+      id: pw-version
+      shell: bash
+      run: |
+        version=$(node -e "console.log(require('./packages/web/node_modules/@playwright/test/package.json').version)" 2>/dev/null || echo "unknown")
+        echo "version=${version}" >> $GITHUB_OUTPUT
+
+    - name: Cache Playwright browsers
+      id: pw-cache
+      uses: actions/cache@v4
+      with:
+        path: ~/.cache/ms-playwright
+        key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-${{ inputs.browsers }}
+
+    - name: Install Playwright browsers + deps
+      if: steps.pw-cache.outputs.cache-hit != 'true'
+      shell: bash
+      run: pnpm -C packages/web exec playwright install --with-deps ${{ inputs.browsers }}
+
+    - name: Install Playwright system deps only (cache hit)
+      if: steps.pw-cache.outputs.cache-hit == 'true'
+      shell: bash
+      run: pnpm -C packages/web exec playwright install-deps ${{ inputs.browsers }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,33 @@
+name: "Setup pnpm + Node.js with cache"
+description: "Standardized pnpm install with workspace cache, used across all CI jobs."
+
+inputs:
+  node-version:
+    description: "Node.js version"
+    required: false
+    default: "22"
+  install:
+    description: "Run pnpm install --frozen-lockfile after setup"
+    required: false
+    default: "true"
+  install-args:
+    description: "Extra args appended to pnpm install (e.g. --filter=@pinchy/web)"
+    required: false
+    default: ""
+
+runs:
+  using: composite
+  steps:
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v4
+      with:
+        node-version: ${{ inputs.node-version }}
+        cache: "pnpm"
+
+    - name: Install dependencies
+      if: inputs.install == 'true'
+      shell: bash
+      run: pnpm install --frozen-lockfile ${{ inputs.install-args }}

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,17 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+      day: monday
+    open-pull-requests-limit: 5
+    commit-message:
+      prefix: "ci"
+    labels:
+      - "dependencies"
+      - "ci"
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,8 +173,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Install Playwright Chromium
-        run: pnpm -C packages/web exec playwright install chromium --with-deps
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run E2E tests
         run: pnpm -C packages/web test:e2e
@@ -946,8 +945,7 @@ jobs:
             sleep 2
           done
 
-      - name: Install Playwright browsers
-        run: pnpm -C packages/web exec playwright install --with-deps chromium
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run Odoo E2E tests
         run: pnpm -C packages/web test:e2e:odoo
@@ -1036,8 +1034,7 @@ jobs:
             sleep 2
           done
 
-      - name: Install Playwright browsers
-        run: pnpm -C packages/web exec playwright install --with-deps chromium
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run Web Search E2E tests
         run: pnpm -C packages/web test:e2e:web
@@ -1126,8 +1123,7 @@ jobs:
             sleep 2
           done
 
-      - name: Install Playwright browsers
-        run: pnpm -C packages/web exec playwright install --with-deps chromium
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run Email E2E tests
         run: pnpm -C packages/web test:e2e:email
@@ -1182,8 +1178,7 @@ jobs:
       # Chromium is needed by agent-hot-reload.spec.ts which drives the chat UI.
       # The other Telegram tests are fetch-only, but Playwright still requires
       # a browser binary present at config-load time.
-      - name: Install Playwright browsers
-        run: pnpm -C packages/web exec playwright install chromium --with-deps
+      - uses: ./.github/actions/setup-playwright
 
       - name: Start test stack with mock Telegram
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml up --build -d
@@ -1287,19 +1282,6 @@ jobs:
     name: Integration Tests (OpenClaw + Fake Ollama)
     runs-on: ubuntu-latest
 
-    # Production-image CI test (Tier 3 of the dev/prod parity work, #196).
-    # Pinchy is built from `Dockerfile.pinchy` (uid 999 demotion via
-    # entrypoint.sh) inside the compose stack, like every other E2E suite,
-    # so file-permission bugs between Pinchy (uid 999) and OpenClaw (root)
-    # in pinchy-files / pinchy-context / pinchy-audit / pinchy-docs are
-    # caught here instead of leaking to production.
-    #
-    # ${PINCHY_VERSION:?} on docker-compose.yml's `image:` line is satisfied
-    # by any non-empty string; the build directive in docker-compose.e2e.yml
-    # takes precedence and tags with that name.
-    env:
-      PINCHY_VERSION: latest
-
     steps:
       - uses: actions/checkout@v4
 
@@ -1314,49 +1296,32 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
 
       # On Linux, host.docker.internal doesn't resolve outside containers by default.
-      # globalSetup spawns fake Ollama on the host and probes it from inside the
-      # OpenClaw container; the host-side reverse probe is unused, but we add this
-      # entry defensively because some helpers fetch host URLs from the host too.
+      # Add it to /etc/hosts so Pinchy (host process) can reach the fake Ollama the
+      # same way OpenClaw (Docker container) does.
       - name: Add host.docker.internal to /etc/hosts
         run: echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
 
-      - name: Install Playwright Chromium
-        run: pnpm -C packages/web exec playwright install chromium --with-deps
-
-      - name: Start integration stack with production Pinchy image
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml up --build -d
-        env:
-          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
-          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
-
-      - name: Wait for services
+      # Pre-start Docker stack + migrate DB BEFORE Playwright launches the webServer.
+      # Playwright starts webServer before globalSetup, so Pinchy would try to connect
+      # to the DB before it exists unless we pre-provision it here.
+      - name: Pre-start integration Docker stack
         run: |
-          echo "Waiting for Pinchy..."
-          for i in $(seq 1 60); do
-            if curl -sf http://localhost:7779/api/internal/openclaw-config-ready >/dev/null 2>&1; then
-              echo "Pinchy ready (attempt $i)"
-              break
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "::error::Pinchy not ready after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs pinchy
-              exit 1
-            fi
-            sleep 2
-          done
-          echo "Waiting for OpenClaw connection..."
-          for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
-              echo "OpenClaw connected (attempt $i)"
-              break
-            fi
-            if [ "$i" -eq 60 ]; then
-              echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs pinchy openclaw
-              exit 1
-            fi
-            sleep 2
-          done
+          # Pre-create bind-mount targets so Docker doesn't create them as root,
+          # which would prevent Pinchy (running on the host as the CI user) from
+          # writing secrets.json — see openclaw-tmpfs branch.
+          mkdir -p /tmp/pinchy-integration-openclaw/workspaces
+          mkdir -p /tmp/pinchy-integration-secrets
+          docker compose -f docker-compose.integration.yml up -d --wait
+
+      - name: Create and migrate integration DB
+        run: |
+          PGPASSWORD=pinchy_dev psql -h localhost -p 5435 -U pinchy -d pinchy \
+            -c "DROP DATABASE IF EXISTS pinchy_integration_test WITH (FORCE);" \
+            -c "CREATE DATABASE pinchy_integration_test;"
+          DATABASE_URL=postgresql://pinchy:pinchy_dev@localhost:5435/pinchy_integration_test \
+            pnpm -C packages/web db:migrate
+
+      - uses: ./.github/actions/setup-playwright
 
       - name: Run integration tests
         run: pnpm -C packages/web test:integration
@@ -1366,18 +1331,17 @@ jobs:
       - name: Show Docker logs on failure
         if: failure()
         run: |
-          echo "=== Container state ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml ps --all 2>&1 || true
-          echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs pinchy 2>&1 | tail -500
-          echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs openclaw 2>&1 | tail -1500
+          echo "=== OpenClaw logs (captured by globalTeardown before stack-down) ==="
+          cat /tmp/openclaw-integration.log 2>/dev/null || echo "no captured log file"
+          echo ""
+          echo "=== OpenClaw logs (live, may be empty if container already stopped) ==="
+          docker compose -f docker-compose.integration.yml logs openclaw 2>/dev/null || true
           echo "=== DB logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml logs db 2>&1 | tail -50
+          docker compose -f docker-compose.integration.yml logs db 2>/dev/null || true
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml down -v 2>/dev/null || true
+        run: docker compose -f docker-compose.integration.yml down 2>/dev/null || true
 
   ollama-integration:
     name: Ollama integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,9 +33,10 @@ jobs:
     permissions:
       contents: read
       packages: write
-    # Fork PRs cannot push to GHCR (read-only GITHUB_TOKEN).
-    # They fall back to per-job local build in downstream jobs.
-    if: github.event.pull_request.head.repo.fork != true
+    # Skip on fork PRs: GITHUB_TOKEN is read-only for forks and cannot push
+    # to GHCR. Non-PR pushes (main) and same-repo PRs always run.
+    # Downstream jobs fall back to per-job local build when this is skipped.
+    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
     outputs:
       pinchy-image: ${{ steps.tags.outputs.pinchy }}
       openclaw-image: ${{ steps.tags.outputs.openclaw }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -34,14 +34,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Lint
         run: pnpm --filter @pinchy/web lint
@@ -139,14 +132,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Run vitest integration tests
         run: pnpm -C packages/web test:db
@@ -185,14 +171,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install Playwright Chromium
         run: pnpm -C packages/web exec playwright install chromium --with-deps
@@ -917,14 +896,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Start test stack with mock Odoo
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up --build -d
@@ -1014,14 +986,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Start test stack with mock Brave
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml up --build -d
@@ -1111,14 +1076,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Start test stack with mock Gmail
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml up --build -d
@@ -1219,14 +1177,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       # Chromium is needed by agent-hot-reload.spec.ts which drives the chat UI.
       # The other Telegram tests are fetch-only, but Playwright still requires
@@ -1360,14 +1311,7 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       # On Linux, host.docker.internal doesn't resolve outside containers by default.
       # globalSetup spawns fake Ollama on the host and probes it from inside the
@@ -1442,14 +1386,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install Ollama
         run: curl -fsSL https://ollama.com/install.sh | sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1260,6 +1260,14 @@ jobs:
   email-e2e:
     name: Email (Gmail) E2E Tests
     runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
 
     env:
       PINCHY_VERSION: latest
@@ -1275,9 +1283,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Start test stack with mock Gmail
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Start test stack with mock Gmail (CI — pre-built images)
+        if: needs.build-image.result == 'success'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml up -d
+        env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Start test stack with mock Gmail (fork PR fallback — local build)
+        if: needs.build-image.result == 'skipped'
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1556,6 +1556,15 @@ jobs:
       contents: read
       packages: read
 
+    # Production-image CI test (Tier 3 of the dev/prod parity work, #196).
+    # Pinchy is built from `Dockerfile.pinchy` (uid 999 demotion via
+    # entrypoint.sh) inside the compose stack, like every other E2E suite.
+    # ${PINCHY_VERSION:?} on docker-compose.yml's `image:` line is satisfied
+    # by any non-empty string; the build directive in docker-compose.e2e.yml
+    # takes precedence when PINCHY_IMAGE is not set.
+    env:
+      PINCHY_VERSION: latest
+
     steps:
       - uses: actions/checkout@v4
 
@@ -1577,54 +1586,65 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Pull pre-built OpenClaw image (skip on fork PRs)
+      - name: Pull pre-built Pinchy and OpenClaw images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
 
-      - name: Build OpenClaw image locally (fork PR fallback)
+      - name: Build Pinchy and OpenClaw images locally (fork PR fallback)
         if: needs.build-image.result == 'skipped'
-        run: docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
+        run: |
+          docker build -t pinchy:e2e -f Dockerfile.pinchy .
+          docker build -t pinchy-openclaw:e2e -f Dockerfile.openclaw .
 
-      # On Linux, host.docker.internal doesn't resolve outside containers by default.
-      # Add it to /etc/hosts so Pinchy (host process) can reach the fake Ollama the
-      # same way OpenClaw (Docker container) does.
+      # On Linux, host.docker.internal doesn't resolve outside containers by
+      # default. globalSetup spawns fake Ollama on the host and probes it from
+      # inside the OpenClaw container; this entry is a defensive fallback for
+      # helpers that fetch host URLs from the host side too.
       - name: Add host.docker.internal to /etc/hosts
         run: echo "127.0.0.1 host.docker.internal" | sudo tee -a /etc/hosts
 
-      # Pre-start Docker stack + migrate DB BEFORE Playwright launches the webServer.
-      # Playwright starts webServer before globalSetup, so Pinchy would try to connect
-      # to the DB before it exists unless we pre-provision it here.
-      - name: Pre-start integration Docker stack (CI — pre-built image)
+      - name: Start integration stack (CI — pre-built images)
         if: needs.build-image.result == 'success'
         run: |
-          # Pre-create bind-mount targets so Docker doesn't create them as root,
-          # which would prevent Pinchy (running on the host as the CI user) from
-          # writing secrets.json — see openclaw-tmpfs branch.
-          mkdir -p /tmp/pinchy-integration-openclaw/workspaces
-          mkdir -p /tmp/pinchy-integration-secrets
-          docker compose -f docker-compose.integration.yml up -d --wait
+          docker compose -f docker-compose.yml \
+                         -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml \
+                         up -d
         env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
           OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
-      - name: Pre-start integration Docker stack (fork PR fallback)
+      - name: Start integration stack (fork PR fallback — local build)
         if: needs.build-image.result == 'skipped'
         run: |
-          # Pre-create bind-mount targets so Docker doesn't create them as root,
-          # which would prevent Pinchy (running on the host as the CI user) from
-          # writing secrets.json — see openclaw-tmpfs branch.
-          mkdir -p /tmp/pinchy-integration-openclaw/workspaces
-          mkdir -p /tmp/pinchy-integration-secrets
-          docker compose -f docker-compose.integration.yml up -d --wait
+          docker compose -f docker-compose.yml \
+                         -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml \
+                         up -d
         env:
-          OPENCLAW_IMAGE: ghcr.io/heypinchy/pinchy-openclaw:latest
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
-      - name: Create and migrate integration DB
+      - name: Wait for Pinchy to be ready
         run: |
-          PGPASSWORD=pinchy_dev psql -h localhost -p 5435 -U pinchy -d pinchy \
-            -c "DROP DATABASE IF EXISTS pinchy_integration_test WITH (FORCE);" \
-            -c "CREATE DATABASE pinchy_integration_test;"
-          DATABASE_URL=postgresql://pinchy:pinchy_dev@localhost:5435/pinchy_integration_test \
-            pnpm -C packages/web db:migrate
+          echo "Waiting for Pinchy at localhost:7779..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:7779/api/internal/openclaw-config-ready >/dev/null 2>&1; then
+              echo "Pinchy ready (attempt $i)"
+              exit 0
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::Pinchy not ready after 120s"
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                             -f docker-compose.integration.yml logs pinchy
+              exit 1
+            fi
+            sleep 2
+          done
 
       - uses: ./.github/actions/setup-playwright
 
@@ -1639,14 +1659,24 @@ jobs:
           echo "=== OpenClaw logs (captured by globalTeardown before stack-down) ==="
           cat /tmp/openclaw-integration.log 2>/dev/null || echo "no captured log file"
           echo ""
-          echo "=== OpenClaw logs (live, may be empty if container already stopped) ==="
-          docker compose -f docker-compose.integration.yml logs openclaw 2>/dev/null || true
+          echo "=== Container state ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml ps --all 2>&1 || true
+          echo "=== Pinchy logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml logs pinchy 2>&1 | tail -500
+          echo "=== OpenClaw logs (live) ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml logs openclaw 2>&1 | tail -1500
           echo "=== DB logs ==="
-          docker compose -f docker-compose.integration.yml logs db 2>/dev/null || true
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml logs db 2>&1 | tail -50
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.integration.yml down 2>/dev/null || true
+        run: |
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+                         -f docker-compose.integration.yml down -v 2>/dev/null || true
 
   ollama-integration:
     name: Ollama integration tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,8 +3,22 @@ name: CI
 on:
   push:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "PERSONALITY.md"
+      - "sample-data/**"
+      - "screenshots/**"
   pull_request:
     branches: [main]
+    paths-ignore:
+      - "docs/**"
+      - "**/*.md"
+      - ".github/ISSUE_TEMPLATE/**"
+      - "PERSONALITY.md"
+      - "sample-data/**"
+      - "screenshots/**"
 
 # Cancel in-progress runs on the same PR/branch when a new commit is pushed.
 # For main, never cancel — release/post-merge runs must always complete.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1585,7 +1585,6 @@ jobs:
         if: needs.build-image.result == 'skipped'
         run: docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
 
-
       # On Linux, host.docker.internal doesn't resolve outside containers by default.
       # Add it to /etc/hosts so Pinchy (host process) can reach the fake Ollama the
       # same way OpenClaw (Docker container) does.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -768,6 +768,14 @@ jobs:
 
   end-user-upgrade:
     name: End-user upgrade simulation
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
 
     steps:
@@ -780,6 +788,14 @@ jobs:
         with:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Determine previous release tag
         id: prev
@@ -798,18 +814,26 @@ jobs:
             echo "skip=false" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Build this PR's images locally
-        if: steps.prev.outputs.skip == 'false'
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: steps.prev.outputs.skip == 'false' && needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Build this PR's images locally (fork PR fallback)
+        if: steps.prev.outputs.skip == 'false' && needs.build-image.result == 'skipped'
         run: |
           docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .
           docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
 
-      - name: Tag locally-built images for the test version
+      - name: Tag images for the test version
         if: steps.prev.outputs.skip == 'false'
         run: |
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
-          docker tag ghcr.io/heypinchy/pinchy:latest "ghcr.io/heypinchy/pinchy:test-${SHORT_SHA}"
-          docker tag ghcr.io/heypinchy/pinchy-openclaw:latest "ghcr.io/heypinchy/pinchy-openclaw:test-${SHORT_SHA}"
+          PINCHY_SRC="${{ needs.build-image.outputs.pinchy-image || 'ghcr.io/heypinchy/pinchy:latest' }}"
+          OPENCLAW_SRC="${{ needs.build-image.outputs.openclaw-image || 'ghcr.io/heypinchy/pinchy-openclaw:latest' }}"
+          docker tag "$PINCHY_SRC" "ghcr.io/heypinchy/pinchy:test-${SHORT_SHA}"
+          docker tag "$OPENCLAW_SRC" "ghcr.io/heypinchy/pinchy-openclaw:test-${SHORT_SHA}"
 
       - name: Generate shared DB_PASSWORD for both phases
         if: steps.prev.outputs.skip == 'false'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -69,6 +69,16 @@ jobs:
       - name: Test (root scripts)
         run: pnpm test:scripts
 
+      - name: Cache Next.js build
+        uses: actions/cache@v4
+        with:
+          path: |
+            packages/web/.next/cache
+          key: nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-${{ hashFiles('packages/web/**/*.[jt]s', 'packages/web/**/*.[jt]sx') }}
+          restore-keys: |
+            nextjs-${{ runner.os }}-${{ hashFiles('pnpm-lock.yaml') }}-
+            nextjs-${{ runner.os }}-
+
       - name: Build
         run: pnpm build
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1382,6 +1382,14 @@ jobs:
   telegram-e2e:
     name: Telegram E2E Tests
     runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
 
     # Production-image CI test: images are built locally via
     # docker-compose.e2e.yml using the production Dockerfile.pinchy
@@ -1407,6 +1415,14 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-pnpm
 
       # Chromium is needed by agent-hot-reload.spec.ts which drives the chat UI.
@@ -1414,7 +1430,23 @@ jobs:
       # a browser binary present at config-load time.
       - uses: ./.github/actions/setup-playwright
 
-      - name: Start test stack with mock Telegram
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Start test stack with mock Telegram (CI — pre-built images)
+        if: needs.build-image.result == 'success'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml up -d
+        env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Start test stack with mock Telegram (fork PR fallback — local build)
+        if: needs.build-image.result == 'skipped'
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,12 @@ on:
   pull_request:
     branches: [main]
 
+# Cancel in-progress runs on the same PR/branch when a new commit is pushed.
+# For main, never cancel — release/post-merge runs must always complete.
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   quality:
     name: Lint, Test & Build

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1139,6 +1139,14 @@ jobs:
   web-e2e:
     name: Web Search E2E Tests
     runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
 
     env:
       PINCHY_VERSION: latest
@@ -1154,9 +1162,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Start test stack with mock Brave
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Start test stack with mock Brave (CI — pre-built images)
+        if: needs.build-image.result == 'success'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml up -d
+        env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Start test stack with mock Brave (fork PR fallback — local build)
+        if: needs.build-image.result == 'skipped'
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1616,6 +1616,8 @@ jobs:
           mkdir -p /tmp/pinchy-integration-openclaw/workspaces
           mkdir -p /tmp/pinchy-integration-secrets
           docker compose -f docker-compose.integration.yml up -d --wait
+        env:
+          OPENCLAW_IMAGE: ghcr.io/heypinchy/pinchy-openclaw:latest
 
       - name: Create and migrate integration DB
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1007,6 +1007,14 @@ jobs:
   odoo-e2e:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
 
     # Production-image CI test (Tier 2 of the dev/prod parity work, #196):
     # images are built locally via docker-compose.e2e.yml using the
@@ -1033,9 +1041,33 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Start test stack with mock Odoo
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Start test stack with mock Odoo (CI — pre-built images)
+        if: needs.build-image.result == 'success'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up -d
+        env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Start test stack with mock Odoo (fork PR fallback — local build)
+        if: needs.build-image.result == 'skipped'
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1547,6 +1547,14 @@ jobs:
   integration:
     name: Integration Tests (OpenClaw + Fake Ollama)
     runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
 
     steps:
       - uses: actions/checkout@v4
@@ -1559,7 +1567,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       - uses: ./.github/actions/setup-pnpm
+
+      - name: Pull pre-built OpenClaw image (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Build OpenClaw image locally (fork PR fallback)
+        if: needs.build-image.result == 'skipped'
+        run: docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
+
 
       # On Linux, host.docker.internal doesn't resolve outside containers by default.
       # Add it to /etc/hosts so Pinchy (host process) can reach the fake Ollama the
@@ -1570,7 +1595,20 @@ jobs:
       # Pre-start Docker stack + migrate DB BEFORE Playwright launches the webServer.
       # Playwright starts webServer before globalSetup, so Pinchy would try to connect
       # to the DB before it exists unless we pre-provision it here.
-      - name: Pre-start integration Docker stack
+      - name: Pre-start integration Docker stack (CI — pre-built image)
+        if: needs.build-image.result == 'success'
+        run: |
+          # Pre-create bind-mount targets so Docker doesn't create them as root,
+          # which would prevent Pinchy (running on the host as the CI user) from
+          # writing secrets.json — see openclaw-tmpfs branch.
+          mkdir -p /tmp/pinchy-integration-openclaw/workspaces
+          mkdir -p /tmp/pinchy-integration-secrets
+          docker compose -f docker-compose.integration.yml up -d --wait
+        env:
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Pre-start integration Docker stack (fork PR fallback)
+        if: needs.build-image.result == 'skipped'
         run: |
           # Pre-create bind-mount targets so Docker doesn't create them as root,
           # which would prevent Pinchy (running on the host as the CI user) from

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,58 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  build-image:
+    name: Build Pinchy + OpenClaw images
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    # Fork PRs cannot push to GHCR (read-only GITHUB_TOKEN).
+    # They fall back to per-job local build in downstream jobs.
+    if: github.event.pull_request.head.repo.fork != true
+    outputs:
+      pinchy-image: ${{ steps.tags.outputs.pinchy }}
+      openclaw-image: ${{ steps.tags.outputs.openclaw }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: docker/setup-buildx-action@v3
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - id: tags
+        run: |
+          echo "pinchy=ghcr.io/heypinchy/pinchy-ci:sha-${{ github.sha }}" >> $GITHUB_OUTPUT
+          echo "openclaw=ghcr.io/heypinchy/pinchy-openclaw-ci:sha-${{ github.sha }}" >> $GITHUB_OUTPUT
+
+      - name: Build & push Pinchy image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.pinchy
+          push: true
+          tags: ${{ steps.tags.outputs.pinchy }}
+          cache-from: |
+            type=gha,scope=pinchy-${{ github.ref_name }}
+            type=gha,scope=pinchy-main
+          cache-to: type=gha,mode=max,scope=pinchy-${{ github.ref_name }}
+
+      - name: Build & push OpenClaw image
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile.openclaw
+          push: true
+          tags: ${{ steps.tags.outputs.openclaw }}
+          cache-from: |
+            type=gha,scope=openclaw-${{ github.ref_name }}
+            type=gha,scope=openclaw-main
+          cache-to: type=gha,mode=max,scope=openclaw-${{ github.ref_name }}
+
   quality:
     name: Lint, Test & Build
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -245,8 +245,13 @@ jobs:
 
   docker-smoke:
     name: Docker smoke test
+    needs: build-image
+    # Run even when build-image is skipped (fork PRs) or on push events
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
     runs-on: ubuntu-latest
-
     # Dev-mode CI test: images are built locally and tagged :latest. Satisfy
     # the compose fail-loud check on ${PINCHY_VERSION:?} without depending on
     # a .env file.
@@ -264,7 +269,24 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build production images locally
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+          docker tag ${{ needs.build-image.outputs.pinchy-image }} ghcr.io/heypinchy/pinchy:latest
+          docker tag ${{ needs.build-image.outputs.openclaw-image }} ghcr.io/heypinchy/pinchy-openclaw:latest
+
+      - name: Build production images locally (fork PR fallback)
+        if: needs.build-image.result == 'skipped'
         run: |
           docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .
           docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -252,6 +252,9 @@ jobs:
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: read
     # Dev-mode CI test: images are built locally and tagged :latest. Satisfy
     # the compose fail-loud check on ${PINCHY_VERSION:?} without depending on
     # a .env file.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,14 @@ jobs:
 
   end-user-install:
     name: End-user install simulation
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
     runs-on: ubuntu-latest
 
     steps:
@@ -625,16 +633,34 @@ jobs:
           username: ${{ secrets.DOCKERHUB_USERNAME }}
           password: ${{ secrets.DOCKERHUB_TOKEN }}
 
-      - name: Build production images locally
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Build production images locally (fork PR fallback)
+        if: needs.build-image.result == 'skipped'
         run: |
           docker build -t ghcr.io/heypinchy/pinchy:latest -f Dockerfile.pinchy .
           docker build -t ghcr.io/heypinchy/pinchy-openclaw:latest -f Dockerfile.openclaw .
 
-      - name: Tag locally-built images for the test version
+      - name: Tag images for the test version
         run: |
           SHORT_SHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
-          docker tag ghcr.io/heypinchy/pinchy:latest "ghcr.io/heypinchy/pinchy:test-${SHORT_SHA}"
-          docker tag ghcr.io/heypinchy/pinchy-openclaw:latest "ghcr.io/heypinchy/pinchy-openclaw:test-${SHORT_SHA}"
+          # Use CI image if available, otherwise fall back to locally-built :latest
+          PINCHY_SRC="${{ needs.build-image.outputs.pinchy-image || 'ghcr.io/heypinchy/pinchy:latest' }}"
+          OPENCLAW_SRC="${{ needs.build-image.outputs.openclaw-image || 'ghcr.io/heypinchy/pinchy-openclaw:latest' }}"
+          docker tag "$PINCHY_SRC" "ghcr.io/heypinchy/pinchy:test-${SHORT_SHA}"
+          docker tag "$OPENCLAW_SRC" "ghcr.io/heypinchy/pinchy-openclaw:test-${SHORT_SHA}"
 
       # Simulate what a real end-user deploy looks like: a fresh directory
       # containing ONLY docker-compose.yml — no source tree, no .env file,

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,50 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+    paths:
+      - "**/*.ts"
+      - "**/*.tsx"
+      - "**/*.js"
+      - "**/*.jsx"
+      - "pnpm-lock.yaml"
+  schedule:
+    - cron: "0 6 * * 1" # Monday 06:00 UTC
+
+concurrency:
+  group: codeql-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      contents: read
+      actions: read
+    strategy:
+      fail-fast: false
+      matrix:
+        language: ["javascript-typescript"]
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/setup-pnpm
+        with:
+          install: "false" # CodeQL handles build, no pnpm install needed
+
+      - uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-extended,security-and-quality
+
+      - uses: github/codeql-action/autobuild@v3
+
+      - uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/prune-ghcr.yml
+++ b/.github/workflows/prune-ghcr.yml
@@ -46,7 +46,15 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        package: [pinchy, pinchy-openclaw]
+        include:
+          - package: pinchy
+            is_ci_image: false
+          - package: pinchy-openclaw
+            is_ci_image: false
+          - package: pinchy-ci
+            is_ci_image: true
+          - package: pinchy-openclaw-ci
+            is_ci_image: true
     steps:
       - uses: actions/checkout@v4
 
@@ -55,6 +63,7 @@ jobs:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           ORG: heypinchy
           PACKAGE: ${{ matrix.package }}
+          IS_CI_IMAGE: ${{ matrix.is_ci_image }}
           EVENT_NAME: ${{ github.event_name }}
           # GHA ternaries trip on falsy boolean inputs (`false || 'true'`
           # evaluates to 'true'), so derive dry-run in bash instead.
@@ -70,13 +79,20 @@ jobs:
             workflow_dispatch) dry_run="$DISPATCH_DRY_RUN" ;;
             *)                 dry_run=true ;;
           esac
-          args=(--org "$ORG" --package "$PACKAGE" --keep "$KEEP")
+          # CI images (pinchy-ci, pinchy-openclaw-ci) use aggressive retention
+          # because they accumulate on every PR push. Standard release images
+          # use the user-configurable workflow inputs.
+          if [ "$IS_CI_IMAGE" = "true" ]; then
+            args=(--org "$ORG" --package "$PACKAGE" --keep 10 --older-than-days 7)
+          else
+            args=(--org "$ORG" --package "$PACKAGE" --keep "$KEEP")
+            if [ -n "$OLDER_THAN_DAYS" ]; then
+              args+=(--older-than-days "$OLDER_THAN_DAYS")
+            fi
+          fi
           if [ "$dry_run" = "false" ]; then
             args+=(--no-dry-run)
           else
             args+=(--dry-run)
-          fi
-          if [ -n "$OLDER_THAN_DAYS" ]; then
-            args+=(--older-than-days "$OLDER_THAN_DAYS")
           fi
           node scripts/prune-ghcr-sha-tags.mjs "${args[@]}"

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -29,14 +29,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: pnpm/action-setup@v4
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
-          cache: pnpm
-
-      - run: pnpm install --frozen-lockfile
+      - uses: ./.github/actions/setup-pnpm
 
       - name: Install Playwright Chromium
         run: pnpm -C packages/web exec playwright install chromium --with-deps

--- a/.github/workflows/screenshots.yml
+++ b/.github/workflows/screenshots.yml
@@ -31,8 +31,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Install Playwright Chromium
-        run: pnpm -C packages/web exec playwright install chromium --with-deps
+      - uses: ./.github/actions/setup-playwright
 
       - name: Install Geist font
         run: |

--- a/docker-compose.e2e.yml
+++ b/docker-compose.e2e.yml
@@ -16,6 +16,9 @@
 
 services:
   pinchy:
+    # Image-first: CI sets PINCHY_IMAGE to a pre-built GHCR tag.
+    # Local dev (no PINCHY_IMAGE set) falls through to `build:`.
+    image: ${PINCHY_IMAGE:-pinchy:e2e}
     build:
       context: .
       dockerfile: Dockerfile.pinchy
@@ -28,6 +31,7 @@ services:
       # this var from being added to `docker-compose.yml` or `.dev.yml`.
       PINCHY_E2E_DISABLE_AUTH_RATE_LIMIT: "1"
   openclaw:
+    image: ${OPENCLAW_IMAGE:-pinchy-openclaw:e2e}
     build:
       context: .
       dockerfile: Dockerfile.openclaw

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,72 +1,48 @@
 # docker-compose.integration.yml
-#
-# Overlay for the integration test suite. Layered on top of the production
-# compose chain so Pinchy runs from `Dockerfile.pinchy` (uid 999 demotion
-# via entrypoint.sh), matching what end users deploy.
-#
-# Usage:
-#   docker compose -f docker-compose.yml \
-#                  -f docker-compose.e2e.yml \
-#                  -f docker-compose.integration.yml up --build -d
-#
-# Pre-issue #196 this file was a standalone compose definition that only
-# started OpenClaw + DB; Pinchy ran as a Playwright `webServer` on the
-# host. That setup ran Pinchy as the CI runner uid (root on
-# ubuntu-latest) and silently passed the EACCES bug class from #195
-# because root could read OpenClaw's 0600 files. Now the integration
-# suite uses the production image like every other E2E job.
+# Minimal stack for integration tests: OpenClaw + DB only.
+# Pinchy is started by Playwright's webServer on the host.
+# Fake Ollama runs on the host, accessible via host.docker.internal.
 services:
-  pinchy:
-    # Inherit `build` from docker-compose.e2e.yml (Dockerfile.pinchy).
-    # Replace docker-compose.yml's `127.0.0.1:7777` mapping with `:7779` so
-    # CI runs of multiple suites against the integration overlay don't
-    # collide on the default port and so existing test code that hits
-    # localhost:7779 keeps working without changes.
-    ports: !override
-      - "7779:7777"
-    environment:
-      # Exercises Pinchy's audit HMAC code path. Bare-bones non-empty 64-byte hex.
-      - AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
-      # Emit a dummy API-key SecretRef for the local Ollama provider so OpenClaw
-      # authenticates when routing to host.docker.internal (not treated as local).
-      # Same intent as docker-compose.odoo-test.yml — Ollama-Cloud needs a SecretRef
-      # in openclaw.json to make OpenClaw exercise the strict secrets.json owner
-      # check (defends against the #200 secrets-reload race).
-      - PINCHY_E2E_OLLAMA_LOCAL_API_KEY=1
-      # Domain Lock normally restarts the Pinchy server so cookie security
-      # settings pick up the new domain. The integration suite sets and
-      # clears Domain Lock inside a running test process — without this
-      # flag the restart kills the in-flight HTTP request mid-test
-      # ("socket hang up") and the next test races against a still-booting
-      # Pinchy with ECONNREFUSED. Same env contract the pre-#196 host-Pinchy
-      # config used; the var name encodes that it's an E2E-only behavior.
-      - PINCHY_E2E_DISABLE_DOMAIN_RESTART=1
-    extra_hosts:
-      # Pinchy probes ollama_local_url from regenerateOpenClawConfig(); when the
-      # URL points at the host-side fake Ollama via host.docker.internal it must
-      # be reachable from inside the Pinchy container too. OpenClaw already gets
-      # this mapping from docker-compose.yml.
-      - "host.docker.internal:host-gateway"
-      - "ollama.local:host-gateway"
-
   openclaw:
-    # Inherit `build` from docker-compose.e2e.yml (Dockerfile.openclaw).
+    image: ${OPENCLAW_IMAGE:-ghcr.io/heypinchy/pinchy-openclaw:latest}
+    # Image is published amd64-only. Pin platform so Mac/arm64 dev machines
+    # pull and run the amd64 variant under Rosetta instead of failing with
+    # "no matching manifest for linux/arm64/v8".
+    platform: linux/amd64
+    ports:
+      - "18790:18789"
+    environment:
+      # Must match OPENCLAW_SECRETS_PATH in playwright.integration.config.ts
+      - OPENCLAW_SECRETS_PATH=/tmp/pinchy-integration-secrets/secrets.json
+    volumes:
+      # Shared config dir: Pinchy (host) writes here, OpenClaw reads here
+      - /tmp/pinchy-integration-openclaw:/root/.openclaw
+      # Secrets dir: same host path bind-mounted at identical path so SecretRef resolution works
+      - /tmp/pinchy-integration-secrets:/tmp/pinchy-integration-secrets
+      # Plugin source bind-mounts (same as dev)
+      - ./packages/plugins/pinchy-files:/root/.openclaw/extensions/pinchy-files
+      - ./packages/plugins/pinchy-context:/root/.openclaw/extensions/pinchy-context
+      - ./packages/plugins/pinchy-audit:/root/.openclaw/extensions/pinchy-audit
+      - ./packages/plugins/pinchy-docs:/root/.openclaw/extensions/pinchy-docs
+      - ./packages/plugins/pinchy-odoo:/root/.openclaw/extensions/pinchy-odoo
+      - ./packages/plugins/pinchy-web:/root/.openclaw/extensions/pinchy-web
+      - ./packages/plugins/pinchy-email:/root/.openclaw/extensions/pinchy-email
+    # Allow OpenClaw to reach host services (fake Ollama) on Linux
     extra_hosts:
-      # OpenClaw routes Pinchy's internal plugin callbacks back to
-      # http://pinchy:7777, but PINCHY_INTERNAL_URL/host.docker.internal
-      # fallbacks must also resolve so tools that compose Pinchy URLs from
-      # process.env keep working.
       - "host.docker.internal:host-gateway"
 
   db:
-    ports: !override
-      # Playwright tests read/seed the DB directly from the host (see
-      # global-setup.ts settings INSERT). Production compose keeps the DB
-      # network-internal; tests need a back door.
+    image: postgres:17
+    ports:
       - "5435:5432"
-    # Overrides docker-compose.yml's `pgdata` named volume with an in-memory
-    # tmpfs — integration tests start from a fresh DB each run, no persistence
-    # required and tmpfs is faster.
+    environment:
+      - POSTGRES_DB=pinchy
+      - POSTGRES_USER=pinchy
+      - POSTGRES_PASSWORD=pinchy_dev
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U pinchy"]
+      interval: 3s
+      timeout: 3s
+      retries: 10
     tmpfs:
-      - /var/lib/postgresql/data
-    volumes: !reset []
+      - /var/lib/postgresql/data # in-memory — faster, no cleanup needed

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -1,48 +1,69 @@
 # docker-compose.integration.yml
-# Minimal stack for integration tests: OpenClaw + DB only.
-# Pinchy is started by Playwright's webServer on the host.
-# Fake Ollama runs on the host, accessible via host.docker.internal.
+#
+# Overlay for the integration test suite. Layered on top of the production
+# compose chain so Pinchy runs from `Dockerfile.pinchy` (uid 999 demotion
+# via entrypoint.sh), matching what end users deploy.
+#
+# Usage (local dev):
+#   docker compose -f docker-compose.yml \
+#                  -f docker-compose.e2e.yml \
+#                  -f docker-compose.integration.yml up --build -d
+#
+# In CI the integration job sets PINCHY_IMAGE and OPENCLAW_IMAGE from the
+# pre-built images produced by the build-image job.
+#
+# Pre-issue #196 this file was a standalone compose definition that only
+# started OpenClaw + DB; Pinchy ran as a Playwright `webServer` on the
+# host. That setup ran Pinchy as the CI runner uid (root on ubuntu-latest)
+# and silently passed the EACCES bug class from #195 because root could
+# read OpenClaw's 0600 files. Now the integration suite uses the production
+# image like every other E2E job.
 services:
-  openclaw:
-    image: ${OPENCLAW_IMAGE:-ghcr.io/heypinchy/pinchy-openclaw:latest}
-    # Image is published amd64-only. Pin platform so Mac/arm64 dev machines
-    # pull and run the amd64 variant under Rosetta instead of failing with
-    # "no matching manifest for linux/arm64/v8".
-    platform: linux/amd64
-    ports:
-      - "18790:18789"
+  pinchy:
+    # Override the default :7777 mapping so the integration suite (port 7779)
+    # doesn't conflict with other E2E jobs that bind 7778/7777.
+    ports: !override
+      - "7779:7777"
     environment:
-      # Must match OPENCLAW_SECRETS_PATH in playwright.integration.config.ts
-      - OPENCLAW_SECRETS_PATH=/tmp/pinchy-integration-secrets/secrets.json
-    volumes:
-      # Shared config dir: Pinchy (host) writes here, OpenClaw reads here
-      - /tmp/pinchy-integration-openclaw:/root/.openclaw
-      # Secrets dir: same host path bind-mounted at identical path so SecretRef resolution works
-      - /tmp/pinchy-integration-secrets:/tmp/pinchy-integration-secrets
-      # Plugin source bind-mounts (same as dev)
-      - ./packages/plugins/pinchy-files:/root/.openclaw/extensions/pinchy-files
-      - ./packages/plugins/pinchy-context:/root/.openclaw/extensions/pinchy-context
-      - ./packages/plugins/pinchy-audit:/root/.openclaw/extensions/pinchy-audit
-      - ./packages/plugins/pinchy-docs:/root/.openclaw/extensions/pinchy-docs
-      - ./packages/plugins/pinchy-odoo:/root/.openclaw/extensions/pinchy-odoo
-      - ./packages/plugins/pinchy-web:/root/.openclaw/extensions/pinchy-web
-      - ./packages/plugins/pinchy-email:/root/.openclaw/extensions/pinchy-email
-    # Allow OpenClaw to reach host services (fake Ollama) on Linux
+      # Exercises Pinchy's audit HMAC code path. Bare-bones non-empty 64-byte hex.
+      - AUDIT_HMAC_SECRET=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef
+      # Emit a dummy API-key SecretRef for the local Ollama provider so OpenClaw
+      # authenticates when routing to host.docker.internal (not treated as local).
+      # Same intent as docker-compose.odoo-test.yml — Ollama-Cloud needs a SecretRef
+      # in openclaw.json to make OpenClaw exercise the strict secrets.json owner
+      # check (defends against the #200 secrets-reload race).
+      - PINCHY_E2E_OLLAMA_LOCAL_API_KEY=1
+      # Domain Lock normally restarts the Pinchy server so cookie security
+      # settings pick up the new domain. The integration suite sets and
+      # clears Domain Lock inside a running test process — without this
+      # flag the restart kills the in-flight HTTP request mid-test
+      # ("socket hang up") and the next test races against a still-booting
+      # Pinchy with ECONNREFUSED. Same env contract the pre-#196 host-Pinchy
+      # config used; the var name encodes that it's an E2E-only behavior.
+      - PINCHY_E2E_DISABLE_DOMAIN_RESTART=1
     extra_hosts:
+      # Pinchy probes ollama_local_url from regenerateOpenClawConfig(); when the
+      # URL points at the host-side fake Ollama via host.docker.internal it must
+      # be reachable from inside the Pinchy container too.
+      - "host.docker.internal:host-gateway"
+      - "ollama.local:host-gateway"
+
+  openclaw:
+    extra_hosts:
+      # OpenClaw routes Pinchy's internal plugin callbacks back to
+      # http://pinchy:7777, but host.docker.internal fallbacks must also
+      # resolve so tools that compose Pinchy URLs from process.env keep working.
       - "host.docker.internal:host-gateway"
 
   db:
-    image: postgres:17
-    ports:
+    ports: !override
+      # Playwright tests read/seed the DB directly from the host (see
+      # global-setup.ts settings INSERT). Production compose keeps the DB
+      # network-internal; tests need a back door.
       - "5435:5432"
-    environment:
-      - POSTGRES_DB=pinchy
-      - POSTGRES_USER=pinchy
-      - POSTGRES_PASSWORD=pinchy_dev
-    healthcheck:
-      test: ["CMD-SHELL", "pg_isready -U pinchy"]
-      interval: 3s
-      timeout: 3s
-      retries: 10
+    # Overrides docker-compose.yml's `pgdata` named volume with an in-memory
+    # tmpfs — integration tests start from a fresh DB each run, no persistence
+    # required and tmpfs is faster.
     tmpfs:
-      - /var/lib/postgresql/data # in-memory — faster, no cleanup needed
+      - /var/lib/postgresql/data
+    volumes: !reset []

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -6,7 +6,12 @@ import { startMemoryAuditWatcher } from "@/lib/memory-audit-watcher";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-describe("startMemoryAuditWatcher (integration)", () => {
+// Each test interacts with the real filesystem via chokidar polling (50 ms
+// interval + 50 ms stability threshold). Under CI load, a single polling
+// cycle can take 2–5× longer than on a quiet dev machine. The "delete" case
+// needs TWO polling phases; other tests need one. 15 s per test gives 3–5×
+// headroom over the worst observed CI timing.
+describe("startMemoryAuditWatcher (integration)", { timeout: 15000 }, () => {
   let root: string;
   let appended: Array<Record<string, unknown>>;
   let stop: () => Promise<void>;
@@ -86,7 +91,7 @@ describe("startMemoryAuditWatcher (integration)", () => {
   });
 });
 
-describe("startMemoryAuditWatcher (handler error resilience)", () => {
+describe("startMemoryAuditWatcher (handler error resilience)", { timeout: 15000 }, () => {
   // Separate describe block: we replace lookupAgent with a throwing one and
   // need to verify the watcher survives without raising unhandledRejection.
   let root: string;

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -24,6 +24,10 @@ describe("startMemoryAuditWatcher (integration)", () => {
         appended.push(entry as Record<string, unknown>);
       },
       recordAuditFailure: vi.fn(),
+      // Fast polling so tests complete well within the default 5 s timeout
+      // even under CI load. Production uses 250 ms / 200 ms defaults.
+      pollingInterval: 50,
+      stabilityThreshold: 50,
     });
   });
 
@@ -114,6 +118,8 @@ describe("startMemoryAuditWatcher (handler error resilience)", () => {
         appended.push(entry as Record<string, unknown>);
       },
       recordAuditFailure: vi.fn(),
+      pollingInterval: 50,
+      stabilityThreshold: 50,
     });
   });
 

--- a/packages/web/src/__tests__/lib/openclaw-config/e2e-compose-build-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/e2e-compose-build-coverage.test.ts
@@ -96,11 +96,23 @@ describe("docker-compose.e2e.yml build-directive coverage", () => {
   });
 
   it("does not pin pinchy or openclaw to a published image tag", () => {
-    // If someone replaces `build:` with `image:` (e.g. to speed up CI), the
-    // suite would pull from the registry and stop exercising the local
-    // production Dockerfile. Reject any `image:` on these services in this
-    // overlay specifically.
-    expect(serviceKeyValue(serviceBlockLines(COMPOSE_E2E, "pinchy"), "image")).toBeUndefined();
-    expect(serviceKeyValue(serviceBlockLines(COMPOSE_E2E, "openclaw"), "image")).toBeUndefined();
+    // `image:` is allowed when it uses a variable reference (${VAR:-fallback}),
+    // enabling the CI pre-build override pattern (PINCHY_IMAGE / OPENCLAW_IMAGE)
+    // while `build:` remains present (checked above). A hardcoded registry tag
+    // would flip the suite from "build from prod Dockerfile" to "pull stale image".
+    const pinchyImage = serviceKeyValue(serviceBlockLines(COMPOSE_E2E, "pinchy"), "image");
+    const openclawImage = serviceKeyValue(serviceBlockLines(COMPOSE_E2E, "openclaw"), "image");
+
+    if (pinchyImage !== undefined) {
+      expect(pinchyImage, "pinchy image must be a variable reference, not a hardcoded tag").toMatch(
+        /^\$\{/
+      );
+    }
+    if (openclawImage !== undefined) {
+      expect(
+        openclawImage,
+        "openclaw image must be a variable reference, not a hardcoded tag"
+      ).toMatch(/^\$\{/);
+    }
   });
 });

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -11,6 +11,10 @@ export type MemoryAuditWatcherDeps = {
   lookupAgent: (agentId: string) => Promise<{ id: string; name: string } | null>;
   appendAuditLog: (entry: AuditLogEntry) => Promise<void>;
   recordAuditFailure: (err: unknown, entry: AuditLogEntry) => void;
+  /** Polling interval in ms (default: 250). Lower values increase responsiveness at the cost of more FS I/O. */
+  pollingInterval?: number;
+  /** Write stabilization threshold in ms (default: 200). Events fire only after the file hasn't changed for this long. */
+  stabilityThreshold?: number;
 };
 
 /**
@@ -47,10 +51,10 @@ export async function startMemoryAuditWatcher(
     // 250 ms is well within budget for a watch tree of a few dozen agents and
     // makes the watcher behave identically across all host/container setups.
     usePolling: true,
-    interval: 250,
+    interval: deps.pollingInterval ?? 250,
     // Wait for writes to settle before firing add/change — prevents emitting
     // on partial writes during editor saves or atomic-replace flows.
-    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+    awaitWriteFinish: { stabilityThreshold: deps.stabilityThreshold ?? 200, pollInterval: 50 },
     // Filter to memory files only. The matcher fires for both directories
     // (no stats arg in some chokidar paths) and files (stats present). Return
     // `true` to ignore. We never ignore directories — they need to be walked


### PR DESCRIPTION
## Summary

Four-phase CI speedup implementation (`docs/plans/2026-05-19-ci-speedup.md`):

### Phase 1 — Quick Wins (already merged foundation)
- Cancel in-progress PR runs on new push (queue pressure relief)
- Skip CI for doc-only / markdown-only changes (`paths-ignore`)
- Enable Dependabot for GitHub Actions versions (weekly grouped updates)

### Phase 2 — Setup Consolidation
- `setup-pnpm` composite action — replaces ~10 duplicated setup blocks across ci.yml
- `setup-playwright` composite action — caches `~/.cache/ms-playwright` between runs (saves ~3min/job on cache hit)
- Next.js `.next/cache` cached between runs (saves ~30-90s on incremental build)

### Phase 3 — Build Once, Run Many
- New `build-image` job: builds Pinchy + OpenClaw images once per PR push, pushes to GHCR as `pinchy-ci:sha-<sha>` / `pinchy-openclaw-ci:sha-<sha>`
- GHA layer cache (`type=gha,mode=max`) with branch + main scopes for warm restarts
- All 7 downstream jobs (docker-smoke, end-user-install, end-user-upgrade, odoo-e2e, web-e2e, email-e2e, telegram-e2e) pull from GHCR instead of rebuilding
- Integration job uses pre-built OpenClaw image (Pinchy runs on host)
- Fork PRs: `build-image` skipped (read-only token), downstream jobs fall back to local `--build`
- `prune-ghcr.yml` extended with `pinchy-ci` + `pinchy-openclaw-ci` (7-day / keep-10 retention)

### Phase 4 — Security Gates
- CodeQL SAST analysis on PRs touching JS/TS/lockfile + weekly schedule

## Expected impact
- **Wall-clock (PR):** ~22-28 min → <15 min (7 jobs no longer rebuild the image)
- **CI minutes/PR:** ~75 min → <50 min
- **Doc-only PRs:** ~22 min → ~0 min (paths-ignore)

## Test plan
- [ ] `build-image` job pushes to GHCR (verify tag `sha-<sha>` appears)
- [ ] Downstream E2E jobs show no "Building pinchy" in logs
- [ ] Fork PR simulation: `build-image` skipped, downstream jobs still pass with local build
- [ ] CodeQL analysis runs and results appear in Security → Code scanning alerts
- [ ] `prune-ghcr.yml` manual dispatch (dry-run) shows pinchy-ci packages