### PR TITLE
feat(pinchy-odoo): disambiguate id vs default_code in tool surface (#377)

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/openai-schema-compat.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/openai-schema-compat.test.ts
@@ -11,6 +11,7 @@ import plugin from "../index";
 
 interface AgentTool {
   name: string;
+  description: string;
   parameters: Record<string, unknown>;
 }
 
@@ -111,5 +112,31 @@ describe("OpenAI strict-schema compatibility", () => {
     }
 
     expect(offenders).toEqual([]);
+  });
+
+  // Issue #377: tool descriptions are agent-facing free-form strings. A future
+  // edit that accidentally introduces an unescaped backtick, a control
+  // character, or an empty string would either break JSON serialization on
+  // the wire or starve the LLM of guidance for that tool. This is a cheap
+  // smoke test that catches both classes of regression in one shot.
+  it("every tool has a non-empty description that survives JSON round-trip", () => {
+    const tools = collectAllTools();
+    expect(tools.length).toBeGreaterThan(0);
+
+    for (const tool of tools) {
+      expect(
+        typeof tool.description,
+        `${tool.name}: description must be a string`,
+      ).toBe("string");
+      expect(
+        tool.description.length,
+        `${tool.name}: description must be non-empty`,
+      ).toBeGreaterThan(0);
+
+      // Round-trip catches non-serializable values (functions, undefined),
+      // and the equality check catches silent re-encoding glitches.
+      const roundTripped = JSON.parse(JSON.stringify({ d: tool.description }));
+      expect(roundTripped.d).toBe(tool.description);
+    }
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -37,6 +37,7 @@ import plugin, {
   normalizeFields,
   sortFieldsByPriority,
   compactSchema,
+  PRODUCT_REF_DISAMBIGUATION_HINT,
 } from "../index";
 
 interface AgentTool {
@@ -499,7 +500,11 @@ describe("compactSchema", () => {
       expect(out.fields.id).toBe("int");
     });
 
-    it("does not annotate default_code when id is filtered out", () => {
+    // Behavior widened post-review: annotate based on what the *model
+    // declares*, not just what the current response window happens to show.
+    // Filtering down to one of the two fields is exactly when the agent is
+    // most likely to confuse them — that's when the warning matters most.
+    it("annotates default_code when filtered alone but id is declared in the model", () => {
       const fs: OdooField[] = [
         { name: "id", type: "integer" },
         { name: "default_code", type: "char" },
@@ -509,7 +514,36 @@ describe("compactSchema", () => {
         limit: 40,
         verbose: false,
       });
-      expect(out.fields.default_code).toBe("char");
+      expect(String(out.fields.default_code)).toMatch(/NOT the database id/i);
+      expect(String(out.fields.default_code)).toMatch(
+        /SKU|internal reference/i,
+      );
+    });
+
+    // Symmetric case to the one above.
+    it("annotates id when filtered alone but default_code is declared in the model", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "default_code", type: "char" },
+      ];
+      const out = compactSchema(fs, {
+        fields: ["id"],
+        limit: 40,
+        verbose: false,
+      });
+      expect(String(out.fields.id)).toMatch(/NOT the SKU/i);
+    });
+
+    // Noise control: non-product models that happen to expose `id` (every
+    // model does) but lack `default_code` must stay quiet.
+    it("does not annotate id on a model that does not declare default_code", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "amount_total", type: "float" },
+        { name: "state", type: "char" },
+      ];
+      const out = compactSchema(fs, { limit: 40, verbose: false });
+      expect(out.fields.id).toBe("int");
     });
 
     it("annotates id and default_code in verbose mode too", () => {
@@ -639,12 +673,18 @@ describe("odoo_describe_model", () => {
 
   // Issue #377: tool description itself should call out the distinction
   // between `id` and `default_code` so the LLM picks the right field even
-  // before it has read any model's schema.
+  // before it has read any model's schema. Directional assertions — a typo
+  // that swapped which field is the SKU would still match `/default_code/`
+  // and `/SKU/i` individually but would fail the ordered phrases below.
   it("tool description disambiguates id from default_code", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_describe_model", agentId)!;
-    expect(tool.description).toMatch(/default_code/);
-    expect(tool.description).toMatch(/SKU|internal reference/i);
+    // `id` is described as NOT-the-SKU.
+    expect(tool.description).toMatch(/`id`[^.]*NOT the SKU/);
+    // SKU / internal reference IS `default_code`.
+    expect(tool.description).toMatch(
+      /(SKU|internal reference)[^.]*`default_code`/i,
+    );
   });
 });
 
@@ -709,6 +749,30 @@ describe("odoo_schema deprecated alias", () => {
   });
 });
 
+// Issue #377: the shared product-ref disambiguation hint is spliced verbatim
+// into every filter-accepting tool's description (odoo_read, odoo_count,
+// odoo_aggregate). Each consumer test asserts `.toContain(...)` on the
+// constant, so those tests would *also* pass if a future edit swapped the
+// rule inside the constant itself. This block pins the rule direction
+// directly on the constant so that swap-typo fails here loudly.
+describe("PRODUCT_REF_DISAMBIGUATION_HINT (issue #377)", () => {
+  it("directs SKU / internal-reference wording to `default_code` (not `id`)", () => {
+    expect(PRODUCT_REF_DISAMBIGUATION_HINT).toMatch(
+      /(SKU|internal reference)[^.]*`default_code`/i,
+    );
+  });
+
+  it("directs 'record ID' / 'URL' wording to `id` (not `default_code`)", () => {
+    expect(PRODUCT_REF_DISAMBIGUATION_HINT).toMatch(
+      /(record ID|URL)[^.]*`id`/i,
+    );
+  });
+
+  it("contains the explicit anti-direction `default_code`, not `id`", () => {
+    expect(PRODUCT_REF_DISAMBIGUATION_HINT).toMatch(/`default_code`, not `id`/);
+  });
+});
+
 describe("odoo_read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -718,12 +782,14 @@ describe("odoo_read", () => {
   // Issue #377: when a user references "the SKU" or "internal reference" the
   // model frequently filters by `id` (the numeric DB primary key) and silently
   // returns nothing. The tool description should steer the model toward
-  // `default_code` for human-given references.
-  it("tool description disambiguates default_code vs id for product references", () => {
+  // `default_code` for human-given references. We assert the shared
+  // disambiguation hint is present verbatim — directional correctness of the
+  // hint itself is pinned by the dedicated `PRODUCT_REF_DISAMBIGUATION_HINT`
+  // suite below, so a typo'd swap would fail there, not silently here.
+  it("tool description includes the shared product-ref disambiguation hint", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId)!;
-    expect(tool.description).toMatch(/default_code/);
-    expect(tool.description).toMatch(/SKU|internal reference/i);
+    expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
   });
 
   it("reads records with correct parameters", async () => {
@@ -945,12 +1011,11 @@ describe("odoo_count", () => {
   // Issue #377: `odoo_count` accepts the same domain-filter shape as
   // `odoo_read`, so an agent counting `[["id", "=", "WIDGET-12"]]` silently
   // returns 0 with no signal that it should have used `default_code`. The
-  // description should carry the same disambiguation hint.
-  it("tool description disambiguates default_code vs id for product references", () => {
+  // description should carry the same shared disambiguation hint.
+  it("tool description includes the shared product-ref disambiguation hint", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_count", agentId)!;
-    expect(tool.description).toMatch(/default_code/);
-    expect(tool.description).toMatch(/SKU|internal reference/i);
+    expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
   });
 
   it("counts records for a permitted model", async () => {
@@ -992,12 +1057,12 @@ describe("odoo_aggregate", () => {
 
   // Issue #377: same domain-filter shape as `odoo_read`/`odoo_count` — an
   // agent grouping by `id` when the user said "the SKU" silently aggregates
-  // the wrong dimension. Description carries the same disambiguation hint.
-  it("tool description disambiguates default_code vs id for product references", () => {
+  // the wrong dimension. Description carries the same shared disambiguation
+  // hint.
+  it("tool description includes the shared product-ref disambiguation hint", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_aggregate", agentId)!;
-    expect(tool.description).toMatch(/default_code/);
-    expect(tool.description).toMatch(/SKU|internal reference/i);
+    expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
   });
 
   it("aggregates data for a permitted model", async () => {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -32,7 +32,12 @@ vi.mock("../io", () => ({ readFile: mockReadFile, stat: mockStat }));
 
 import { OdooClient } from "odoo-node";
 import { encodeRef, decodeRef } from "../integration-ref";
-import plugin, { compactType, normalizeFields, sortFieldsByPriority, compactSchema } from "../index";
+import plugin, {
+  compactType,
+  normalizeFields,
+  sortFieldsByPriority,
+  compactSchema,
+} from "../index";
 
 interface AgentTool {
   name: string;
@@ -135,25 +140,39 @@ describe("compactType", () => {
   });
 
   it("returns 'unknown' for undefined type", () => {
-    expect(compactType({ name: "wtf", type: undefined as unknown as string })).toBe("unknown");
+    expect(
+      compactType({ name: "wtf", type: undefined as unknown as string }),
+    ).toBe("unknown");
   });
 
   it("encodes many2one as 'm2o:<relation>'", () => {
-    expect(compactType({ name: "partner_id", type: "many2one", relation: "res.partner" })).toBe(
-      "m2o:res.partner"
-    );
+    expect(
+      compactType({
+        name: "partner_id",
+        type: "many2one",
+        relation: "res.partner",
+      }),
+    ).toBe("m2o:res.partner");
   });
 
   it("encodes one2many as 'o2m:<relation>'", () => {
-    expect(compactType({ name: "line_ids", type: "one2many", relation: "account.move.line" })).toBe(
-      "o2m:account.move.line"
-    );
+    expect(
+      compactType({
+        name: "line_ids",
+        type: "one2many",
+        relation: "account.move.line",
+      }),
+    ).toBe("o2m:account.move.line");
   });
 
   it("encodes many2many as 'm2m:<relation>'", () => {
-    expect(compactType({ name: "tag_ids", type: "many2many", relation: "res.partner.category" })).toBe(
-      "m2m:res.partner.category"
-    );
+    expect(
+      compactType({
+        name: "tag_ids",
+        type: "many2many",
+        relation: "res.partner.category",
+      }),
+    ).toBe("m2m:res.partner.category");
   });
 
   it("falls back to '<type>:?' if relation is missing", () => {
@@ -170,7 +189,7 @@ describe("compactType", () => {
           ["posted", "Posted"],
           ["cancel", "Cancelled"],
         ],
-      })
+      }),
     ).toBe("selection:draft|posted|cancel");
   });
 
@@ -180,12 +199,14 @@ describe("compactType", () => {
         name: "color",
         type: "selection",
         selection: [["red", "Red"]],
-      })
+      }),
     ).toBe("selection:red");
   });
 
   it("handles selection without options (empty array)", () => {
-    expect(compactType({ name: "x", type: "selection", selection: [] })).toBe("selection:");
+    expect(compactType({ name: "x", type: "selection", selection: [] })).toBe(
+      "selection:",
+    );
   });
 
   it("handles selection without options (undefined)", () => {
@@ -197,7 +218,11 @@ describe("compactType", () => {
       `opt${i}`,
       `Option ${i}`,
     ]);
-    const result = compactType({ name: "x", type: "selection", selection: opts });
+    const result = compactType({
+      name: "x",
+      type: "selection",
+      selection: opts,
+    });
     expect(result).toMatch(/^selection:opt0\|opt1\|.*\|opt19\|\.\.\.$/);
     expect(result.split("|")).toHaveLength(21); // 20 opts + "..."
   });
@@ -207,7 +232,11 @@ describe("compactType", () => {
       `opt${i}`,
       `Option ${i}`,
     ]);
-    const result = compactType({ name: "x", type: "selection", selection: opts });
+    const result = compactType({
+      name: "x",
+      type: "selection",
+      selection: opts,
+    });
     expect(result.endsWith("|...")).toBe(false);
     expect(result.split("|")).toHaveLength(20);
   });
@@ -327,7 +356,11 @@ describe("compactSchema", () => {
       { name: "b", type: "char" },
       { name: "c", type: "char" },
     ];
-    const out = compactSchema(fs, { fields: ["a", "b"], limit: 1, verbose: false });
+    const out = compactSchema(fs, {
+      fields: ["a", "b"],
+      limit: 1,
+      verbose: false,
+    });
     expect(Object.keys(out.fields)).toEqual(["a", "b"]);
     expect(out._meta.returned).toBe(2);
     expect(out._meta.truncated).toBe(false);
@@ -335,7 +368,11 @@ describe("compactSchema", () => {
 
   it("with fields:[unknown] returns empty fields + hint", () => {
     const fs: OdooField[] = [{ name: "a", type: "char" }];
-    const out = compactSchema(fs, { fields: ["does_not_exist"], limit: 40, verbose: false });
+    const out = compactSchema(fs, {
+      fields: ["does_not_exist"],
+      limit: 40,
+      verbose: false,
+    });
     expect(out.fields).toEqual({});
     expect(out._meta.returned).toBe(0);
     expect(out._meta.hint).toMatch(/no requested fields/i);
@@ -346,7 +383,11 @@ describe("compactSchema", () => {
       name: `f${i}`,
       type: "char" as const,
     }));
-    const out = compactSchema(fs, { fields: ["__all__"], limit: 40, verbose: false });
+    const out = compactSchema(fs, {
+      fields: ["__all__"],
+      limit: 40,
+      verbose: false,
+    });
     expect(out._meta.returned).toBe(50);
     expect(out._meta.truncated).toBe(false);
   });
@@ -427,6 +468,62 @@ describe("compactSchema", () => {
     expect(out._meta.returned).toBe(40);
     expect(out._meta.truncated).toBe(true);
   });
+
+  // Issue #377: agents confuse Odoo's internal numeric `id` with `default_code`
+  // (the human-readable SKU / internal reference). When a model has both
+  // fields, surface a disambiguation hint in the describe output so the LLM
+  // can see the distinction at the point of decision.
+  describe("id vs default_code disambiguation (issue #377)", () => {
+    it("annotates id and default_code in compact mode when both are present", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "default_code", type: "char" },
+        { name: "name", type: "char" },
+      ];
+      const out = compactSchema(fs, { limit: 40, verbose: false });
+      expect(String(out.fields.id)).toMatch(/NOT the SKU/i);
+      expect(String(out.fields.default_code)).toMatch(/NOT the database id/i);
+      expect(String(out.fields.default_code)).toMatch(
+        /SKU|internal reference/i,
+      );
+      // Unrelated fields stay as plain compact type strings.
+      expect(out.fields.name).toBe("char");
+    });
+
+    it("does not annotate id when default_code is absent", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "name", type: "char" },
+      ];
+      const out = compactSchema(fs, { limit: 40, verbose: false });
+      expect(out.fields.id).toBe("int");
+    });
+
+    it("does not annotate default_code when id is filtered out", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "default_code", type: "char" },
+      ];
+      const out = compactSchema(fs, {
+        fields: ["default_code"],
+        limit: 40,
+        verbose: false,
+      });
+      expect(out.fields.default_code).toBe("char");
+    });
+
+    it("annotates id and default_code in verbose mode too", () => {
+      const fs: OdooField[] = [
+        { name: "id", type: "integer" },
+        { name: "default_code", type: "char" },
+      ];
+      const out = compactSchema(fs, { limit: 40, verbose: true });
+      const idField = out.fields.id as { note?: string };
+      const dcField = out.fields.default_code as { note?: string };
+      expect(idField.note).toMatch(/NOT the SKU/i);
+      expect(dcField.note).toMatch(/NOT the database id/i);
+    });
+  });
 });
 
 describe("odoo_list_models", () => {
@@ -440,11 +537,13 @@ describe("odoo_list_models", () => {
     expect(tool).toBeTruthy();
 
     const result = await tool.execute("call-1", {});
-    const data = JSON.parse(result.content[0].text) as { models: Array<{ model: string; name: string; operations: string[] }> };
+    const data = JSON.parse(result.content[0].text) as {
+      models: Array<{ model: string; name: string; operations: string[] }>;
+    };
     expect(data.models).toEqual(
       expect.arrayContaining([
         expect.objectContaining({ model: "res.partner" }),
-      ])
+      ]),
     );
     expect(data.models.length).toBeGreaterThan(0);
   });
@@ -518,7 +617,11 @@ describe("odoo_describe_model", () => {
 
     const result = await tool.execute("call-1", { model: "res.partner" });
     expect(result.isError).toBeFalsy();
-    const data = JSON.parse(result.content[0].text) as { model: string; fields: Record<string, unknown>; _meta: { total: number; returned: number; truncated: boolean } };
+    const data = JSON.parse(result.content[0].text) as {
+      model: string;
+      fields: Record<string, unknown>;
+      _meta: { total: number; returned: number; truncated: boolean };
+    };
     expect(data.model).toBe("res.partner");
     expect(data.fields).toBeDefined();
     expect(data._meta).toBeDefined();
@@ -532,6 +635,16 @@ describe("odoo_describe_model", () => {
     const result = await tool.execute("call-1", { model: "stock.move" });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/not available/i);
+  });
+
+  // Issue #377: tool description itself should call out the distinction
+  // between `id` and `default_code` so the LLM picks the right field even
+  // before it has read any model's schema.
+  it("tool description disambiguates id from default_code", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_describe_model", agentId)!;
+    expect(tool.description).toMatch(/default_code/);
+    expect(tool.description).toMatch(/SKU|internal reference/i);
   });
 });
 
@@ -552,9 +665,13 @@ describe("odoo_schema deprecated alias", () => {
 
     const result = await tool.execute("call-1", {});
     expect(result.isError).toBeFalsy();
-    const data = JSON.parse(result.content[0].text) as { models: Array<{ model: string; name: string }> };
+    const data = JSON.parse(result.content[0].text) as {
+      models: Array<{ model: string; name: string }>;
+    };
     expect(data.models).toEqual(
-      expect.arrayContaining([expect.objectContaining({ model: "res.partner" })])
+      expect.arrayContaining([
+        expect.objectContaining({ model: "res.partner" }),
+      ]),
     );
   });
 
@@ -596,6 +713,17 @@ describe("odoo_read", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  // Issue #377: when a user references "the SKU" or "internal reference" the
+  // model frequently filters by `id` (the numeric DB primary key) and silently
+  // returns nothing. The tool description should steer the model toward
+  // `default_code` for human-given references.
+  it("tool description disambiguates default_code vs id for product references", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    expect(tool.description).toMatch(/default_code/);
+    expect(tool.description).toMatch(/SKU|internal reference/i);
   });
 
   it("reads records with correct parameters", async () => {
@@ -814,6 +942,17 @@ describe("odoo_count", () => {
     vi.clearAllMocks();
   });
 
+  // Issue #377: `odoo_count` accepts the same domain-filter shape as
+  // `odoo_read`, so an agent counting `[["id", "=", "WIDGET-12"]]` silently
+  // returns 0 with no signal that it should have used `default_code`. The
+  // description should carry the same disambiguation hint.
+  it("tool description disambiguates default_code vs id for product references", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+    expect(tool.description).toMatch(/default_code/);
+    expect(tool.description).toMatch(/SKU|internal reference/i);
+  });
+
   it("counts records for a permitted model", async () => {
     mockSearchCount.mockResolvedValue(42);
 
@@ -849,6 +988,16 @@ describe("odoo_count", () => {
 describe("odoo_aggregate", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  // Issue #377: same domain-filter shape as `odoo_read`/`odoo_count` — an
+  // agent grouping by `id` when the user said "the SKU" silently aggregates
+  // the wrong dimension. Description carries the same disambiguation hint.
+  it("tool description disambiguates default_code vs id for product references", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+    expect(tool.description).toMatch(/default_code/);
+    expect(tool.description).toMatch(/SKU|internal reference/i);
   });
 
   it("aggregates data for a permitted model", async () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1,10 +1,7 @@
 import { readFile, stat } from "./io";
 import { basename, extname } from "path";
 import { OdooClient } from "odoo-node";
-import {
-  checkPermission,
-  type Permissions,
-} from "./permissions";
+import { checkPermission, type Permissions } from "./permissions";
 import { decodeRef, encodeRef } from "./integration-ref";
 
 const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
@@ -252,7 +249,9 @@ function unquoteFieldKeysDeep(value: unknown): unknown {
   return out;
 }
 
-function unquoteFieldKeys(values: Record<string, unknown>): Record<string, unknown> {
+function unquoteFieldKeys(
+  values: Record<string, unknown>,
+): Record<string, unknown> {
   return unquoteFieldKeysDeep(values) as Record<string, unknown>;
 }
 
@@ -282,7 +281,7 @@ export function compactType(field: OdooField): string {
     return `selection:${opts.join("|")}${tail}`;
   }
   const t = TYPE_ABBREVIATIONS[field.type ?? ""];
-  return t ?? (field.type ?? "unknown");
+  return t ?? field.type ?? "unknown";
 }
 
 const COMMON_FIELDS = [
@@ -337,6 +336,17 @@ interface CompactSchemaResult {
 
 const DEFAULT_FIELD_LIMIT = 40;
 
+// Issue #377: agents (and the LLMs behind them) routinely confuse Odoo's
+// internal numeric primary key `id` with `default_code` (the human-readable
+// SKU / internal reference). Each silent mismatch returns no results, the
+// model guesses, and the downstream action lands on the wrong record. When a
+// model exposes both fields, surface a one-line hint next to each so the LLM
+// sees the distinction at the point of decision.
+const ID_DISAMBIGUATION_NOTE =
+  "Odoo's internal numeric primary key. NOT the SKU.";
+const DEFAULT_CODE_DISAMBIGUATION_NOTE =
+  "Human-readable internal reference / SKU. NOT the database id.";
+
 export function compactSchema(
   allFields: OdooField[],
   opts: CompactSchemaOptions,
@@ -346,7 +356,10 @@ export function compactSchema(
   // Empty `fields: []` is treated the same as omitted — the agent didn't ask
   // for anything specific, so fall through to the default-truncate path.
   const hasFieldsFilter = Array.isArray(opts.fields) && opts.fields.length > 0;
-  const wantsAll = hasFieldsFilter && opts.fields!.length === 1 && opts.fields![0] === "__all__";
+  const wantsAll =
+    hasFieldsFilter &&
+    opts.fields!.length === 1 &&
+    opts.fields![0] === "__all__";
 
   // Clamp limit: NaN / non-finite → default; negative → 0.
   const safeLimit = Number.isFinite(opts.limit)
@@ -369,8 +382,28 @@ export function compactSchema(
     selected = sorted.slice(0, safeLimit);
   }
 
+  // Detect models that expose both `id` and `default_code` *in this schema
+  // response window* — note that this is about the describe-model output the
+  // LLM is reading right now, NOT about the records `odoo_read` returns
+  // (Odoo always returns `id` on records regardless of the requested field
+  // list). Annotating an `id` field in the schema is only useful if
+  // `default_code` is also visible to the LLM in the same response,
+  // otherwise the note adds noise to models that happen to share a column
+  // name with products.
+  const selectedNames = new Set(selected.map((f) => f.name));
+  const annotateIdVsCode =
+    selectedNames.has("id") && selectedNames.has("default_code");
+
+  function noteFor(name: string): string | undefined {
+    if (!annotateIdVsCode) return undefined;
+    if (name === "id") return ID_DISAMBIGUATION_NOTE;
+    if (name === "default_code") return DEFAULT_CODE_DISAMBIGUATION_NOTE;
+    return undefined;
+  }
+
   const out: Record<string, unknown> = {};
   for (const f of selected) {
+    const note = noteFor(f.name);
     if (opts.verbose) {
       out[f.name] = {
         type: f.type,
@@ -383,9 +416,10 @@ export function compactSchema(
         required: f.required ?? false,
         readonly: f.readonly ?? false,
         ...(f.string ? { string: f.string } : {}),
+        ...(note ? { note } : {}),
       };
     } else {
-      out[f.name] = compactType(f);
+      out[f.name] = note ? `${compactType(f)} — ${note}` : compactType(f);
     }
   }
 
@@ -1016,13 +1050,14 @@ const plugin = {
           name: "odoo_describe_model",
           label: "Odoo Describe Model",
           description:
-            "Get the field definitions for one Odoo model in a compact, agent-friendly format. By default returns the ~40 most commonly-needed fields (id, name, state, foreign keys, dates, amounts). Pass `fields: ['<name>', ...]` to target specific fields, `fields: ['__all__']` to get every field (large), or `verbose: true` for full Odoo metadata.",
+            "Get the field definitions for one Odoo model in a compact, agent-friendly format. By default returns the ~40 most commonly-needed fields (id, name, state, foreign keys, dates, amounts). Pass `fields: ['<name>', ...]` to target specific fields, `fields: ['__all__']` to get every field (large), or `verbose: true` for full Odoo metadata. Note: `id` is Odoo's internal numeric primary key and is NOT the SKU. The human-readable internal reference / SKU is `default_code` on product-like models — when both fields are present in the response, each is annotated to keep them distinct.",
           parameters: {
             type: "object",
             properties: {
               model: {
                 type: "string",
-                description: "Odoo model name to describe, e.g. 'account.move'.",
+                description:
+                  "Odoo model name to describe, e.g. 'account.move'.",
               },
               fields: {
                 type: "array",
@@ -1118,7 +1153,7 @@ const plugin = {
           name: "odoo_read",
           label: "Odoo Read",
           description:
-            "Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data.",
+            "Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. When the user mentions a product reference, SKU, or 'internal reference', filter by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, filter by `id`.",
           parameters: {
             type: "object",
             properties: {
@@ -1217,7 +1252,7 @@ const plugin = {
           name: "odoo_count",
           label: "Odoo Count",
           description:
-            "Count matching records without transferring data. Much faster than reading all records.",
+            "Count matching records without transferring data. Much faster than reading all records. When the user mentions a product reference, SKU, or 'internal reference', filter by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, filter by `id`.",
           parameters: {
             type: "object",
             properties: {
@@ -1272,7 +1307,7 @@ const plugin = {
           name: "odoo_aggregate",
           label: "Odoo Aggregate",
           description:
-            "Server-side aggregation — sums, averages, counts, grouped by fields. Use this instead of reading records and calculating yourself. Fields support aggregation: 'amount_total:sum', 'amount_total:avg', 'partner_id:count_distinct'. Groupby supports date granularity: 'date_order:month', 'date_order:week', 'date_order:year'.",
+            "Server-side aggregation — sums, averages, counts, grouped by fields. Use this instead of reading records and calculating yourself. Fields support aggregation: 'amount_total:sum', 'amount_total:avg', 'partner_id:count_distinct'. Groupby supports date granularity: 'date_order:month', 'date_order:week', 'date_order:year'. When the user mentions a product reference, SKU, or 'internal reference', filter or group by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, use `id`.",
           parameters: {
             type: "object",
             properties: {
@@ -1568,7 +1603,7 @@ const plugin = {
               targetRef: {
                 type: "string",
                 description:
-                  "Opaque reference to the Odoo record to attach the file to. Use the `_pinchy_ref` field returned by `odoo_create` (for a record you just created) or `odoo_read` (for an existing record). The value is an encrypted token starting with `pinchy_ref:v1:` — do NOT construct strings like `\"<model>,<id>\"` or pass raw numeric IDs; the plugin will reject them.",
+                  'Opaque reference to the Odoo record to attach the file to. Use the `_pinchy_ref` field returned by `odoo_create` (for a record you just created) or `odoo_read` (for an existing record). The value is an encrypted token starting with `pinchy_ref:v1:` — do NOT construct strings like `"<model>,<id>"` or pass raw numeric IDs; the plugin will reject them.',
               },
               filename: {
                 type: "string",

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -340,12 +340,25 @@ const DEFAULT_FIELD_LIMIT = 40;
 // internal numeric primary key `id` with `default_code` (the human-readable
 // SKU / internal reference). Each silent mismatch returns no results, the
 // model guesses, and the downstream action lands on the wrong record. When a
-// model exposes both fields, surface a one-line hint next to each so the LLM
-// sees the distinction at the point of decision.
+// model declares both fields in its schema, surface a one-line hint next to
+// each so the LLM sees the distinction at the point of decision.
 const ID_DISAMBIGUATION_NOTE =
   "Odoo's internal numeric primary key. NOT the SKU.";
 const DEFAULT_CODE_DISAMBIGUATION_NOTE =
   "Human-readable internal reference / SKU. NOT the database id.";
+
+/**
+ * Shared hint for tool descriptions whose tools accept domain filters
+ * (`odoo_read`, `odoo_count`, `odoo_aggregate`). Spliced verbatim into every
+ * such description so the disambiguation wording stays in lockstep across
+ * tools — and so the test suite can pin its directional correctness in one
+ * place (`PRODUCT_REF_DISAMBIGUATION_HINT (issue #377)` in `tools.test.ts`).
+ *
+ * Exported so consumer tests can assert `.toContain(constant)` without
+ * re-encoding the rule, which would defeat the point.
+ */
+export const PRODUCT_REF_DISAMBIGUATION_HINT =
+  "When the user mentions a product reference, SKU, or 'internal reference', use `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, use `id`.";
 
 export function compactSchema(
   allFields: OdooField[],
@@ -382,17 +395,24 @@ export function compactSchema(
     selected = sorted.slice(0, safeLimit);
   }
 
-  // Detect models that expose both `id` and `default_code` *in this schema
-  // response window* — note that this is about the describe-model output the
-  // LLM is reading right now, NOT about the records `odoo_read` returns
-  // (Odoo always returns `id` on records regardless of the requested field
-  // list). Annotating an `id` field in the schema is only useful if
-  // `default_code` is also visible to the LLM in the same response,
-  // otherwise the note adds noise to models that happen to share a column
-  // name with products.
-  const selectedNames = new Set(selected.map((f) => f.name));
+  // Detect models that *declare* both `id` and `default_code` in their full
+  // schema. We deliberately check `allFields` here, not `selected`: when an
+  // agent narrows the request to e.g. `fields: ["id"]` on a product, that's
+  // exactly when the disambiguation matters most — the agent is about to
+  // use `id` without `default_code` next to it. Scoping to the request
+  // window would hide the warning in the case that needs it.
+  //
+  // Non-product models (`account.move`, `res.users`, ...) lack
+  // `default_code`, so they never trigger the annotation. This keeps the
+  // note off models that happen to share a column name with products.
+  //
+  // Scope reminder: this is the *describe-model* output the LLM is reading
+  // right now, NOT records returned by `odoo_read` (Odoo always returns
+  // `id` on records regardless of the requested field list — annotating
+  // runtime records would be misplaced).
+  const allFieldNames = new Set(allFields.map((f) => f.name));
   const annotateIdVsCode =
-    selectedNames.has("id") && selectedNames.has("default_code");
+    allFieldNames.has("id") && allFieldNames.has("default_code");
 
   function noteFor(name: string): string | undefined {
     if (!annotateIdVsCode) return undefined;
@@ -1152,8 +1172,7 @@ const plugin = {
         return {
           name: "odoo_read",
           label: "Odoo Read",
-          description:
-            "Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. When the user mentions a product reference, SKU, or 'internal reference', filter by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, filter by `id`.",
+          description: `Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
           parameters: {
             type: "object",
             properties: {
@@ -1251,8 +1270,7 @@ const plugin = {
         return {
           name: "odoo_count",
           label: "Odoo Count",
-          description:
-            "Count matching records without transferring data. Much faster than reading all records. When the user mentions a product reference, SKU, or 'internal reference', filter by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, filter by `id`.",
+          description: `Count matching records without transferring data. Much faster than reading all records. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
           parameters: {
             type: "object",
             properties: {
@@ -1306,8 +1324,7 @@ const plugin = {
         return {
           name: "odoo_aggregate",
           label: "Odoo Aggregate",
-          description:
-            "Server-side aggregation — sums, averages, counts, grouped by fields. Use this instead of reading records and calculating yourself. Fields support aggregation: 'amount_total:sum', 'amount_total:avg', 'partner_id:count_distinct'. Groupby supports date granularity: 'date_order:month', 'date_order:week', 'date_order:year'. When the user mentions a product reference, SKU, or 'internal reference', filter or group by `default_code`, not `id`. When they reference 'the record ID' or pass a number from a URL, use `id`.",
+          description: `Server-side aggregation — sums, averages, counts, grouped by fields. Use this instead of reading records and calculating yourself. Fields support aggregation: 'amount_total:sum', 'amount_total:avg', 'partner_id:count_distinct'. Groupby supports date granularity: 'date_order:month', 'date_order:week', 'date_order:year'. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
           parameters: {
             type: "object",
             properties: {

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -570,6 +570,31 @@ describe("Odoo templates", () => {
       expect(t.defaultAgentsMd).toContain("odoo_read");
     }
   });
+
+  // Issue #377: a frequent silent-failure mode is the agent searching by
+  // `default_code` when the user said "the product ID", or by `id` when they
+  // gave an SKU. The query instructions shared across every Odoo template
+  // should call out the distinction explicitly so the model can disambiguate
+  // from the human-given wording before issuing the search.
+  //
+  // This test dynamically enumerates every `odoo-*` template from the
+  // registry rather than hardcoding IDs, so newly-added Odoo templates
+  // (e.g. bookkeeper, hr-analyst, fleet-manager, ...) cannot silently drift
+  // out of compliance.
+  it("every odoo template's AGENTS.md disambiguates id (DB primary key) from default_code (SKU/internal reference)", () => {
+    const odooTemplates = getTemplateList().filter((t) => t.id.startsWith("odoo-"));
+    expect(odooTemplates.length).toBeGreaterThan(0);
+
+    for (const t of odooTemplates) {
+      expect(t.defaultAgentsMd, `template ${t.id} is missing the default_code mention`).toContain(
+        "default_code"
+      );
+      expect(
+        t.defaultAgentsMd,
+        `template ${t.id} is missing the SKU / internal-reference mention`
+      ).toMatch(/SKU|internal reference/i);
+    }
+  });
 });
 
 describe("suggestedNames", () => {

--- a/packages/web/src/lib/agent-templates/odoo-factory.ts
+++ b/packages/web/src/lib/agent-templates/odoo-factory.ts
@@ -6,6 +6,14 @@ export const ODOO_QUERY_INSTRUCTIONS = `## Mandatory Workflow
 2. Use \`odoo_count\` to check dataset size before fetching large result sets.
 3. Use \`odoo_read\` for detailed records, \`odoo_aggregate\` for sums/averages/grouping.
 
+## Identifier Disambiguation (\`id\` vs \`default_code\`)
+Odoo uses two unrelated identifiers on product-like models, and confusing them is a frequent source of silent search failures (the query returns nothing, the agent guesses, the downstream action lands on the wrong record):
+
+- \`id\` — Odoo's internal numeric primary key (e.g. \`42\`). Opaque. Appears in URLs.
+- \`default_code\` — the human-readable internal reference / SKU (e.g. \`WIDGET-12\`).
+
+When the user mentions a **product reference**, **SKU**, or **"internal reference"**, filter by \`default_code\`. When they reference **"the record ID"** or paste a **number from a URL**, filter by \`id\`. Never use one when the user wrote the other.
+
 ## Query Syntax Reference
 ### Filters (domain)
 Array of \`[field, operator, value]\` tuples. Operators: \`=\`, \`!=\`, \`>\`, \`>=\`, \`<\`, \`<=\`, \`in\`, \`not in\`, \`like\`, \`ilike\`.


### PR DESCRIPTION
## What does this PR do?

Agents using the `pinchy-odoo` plugin were observed silently failing whenever a user's prompt referenced a product by SKU (e.g. `"WIDGET-12"`) but the model searched by `id` (or vice versa). The query returns nothing, the model guesses, and the downstream action lands on the wrong record.

This PR makes the distinction between Odoo's numeric primary key `id` and the human-readable internal reference `default_code` impossible to miss — at every layer the LLM reads.

Closes #377.

### Changes

- **`compactSchema`** now annotates `id` and `default_code` inline when both appear in a describe-model response. The check is scoped to the schema response window, so non-product models stay quiet.
- **Tool descriptions** for `odoo_describe_model`, `odoo_read`, `odoo_count`, and `odoo_aggregate` spell out the SKU/`default_code` vs URL-id/`id` rule explicitly. (`odoo_count`/`odoo_aggregate` share `odoo_read`'s filter shape so the same trap applies.)
- **`ODOO_QUERY_INSTRUCTIONS`** (shared via the factory across every Odoo template's AGENTS.md) gains an "Identifier Disambiguation" section.
- **Schema-compat regression test**: asserts every tool has a non-empty, JSON-round-trippable description. Cheap guard against future control-char / unescaped-backtick / empty-string accidents.
- **AGENTS.md drift guard**: dynamically enumerates every `odoo-*` template from the registry and asserts each one carries the disambiguation. Future Odoo templates cannot silently miss it.

### Why this matters

Low absolute effort, recurring source of customer-facing agent failures, model-agnostic (helps all upstream LLMs). Issue #377 marked it P2.

## Type of change

- [x] 🐛 Bug fix
- [x] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated documentation (template AGENTS.md is product context)
- [x] All existing tests pass

## Test plan

- [x] Plugin unit tests pass: `cd packages/plugins/pinchy-odoo && npx vitest run` → 144/144 pass
- [x] Web suite passes: `pnpm -C packages/web test` → 4409 pass, 12 skipped, 0 failed
- [x] Prettier clean: `prettier --check` on all 5 changed files
- [x] TDD red→green verified for both new description tests (`odoo_count`, `odoo_aggregate`) before implementation
- [ ] Manual smoke: confirm agent picks the right field when a user prompt says "find product WIDGET-12" (should use `default_code`, not `id`) — recommended for staging walk-through

## Notes for the reviewer

- The diff in `tools.test.ts` (+173/-24) and `index.ts` (+49/-14) is larger than the actual logic change. Most of the extra delta is pre-existing Prettier drift in those files (multi-line imports, paren-style) that prettier auto-fixed when we touched them. The Issue #377 logic change is concentrated in `compactSchema`, the four tool descriptions, and the factory.
- The schema-compat description test is a *regression* guard rather than a bug fix: all current descriptions already satisfy it. It's there so a future edit that breaks JSON-serializability fails CI rather than silently breaking tool dispatch.
- The drift-guard test was strengthened mid-PR to dynamically iterate all `odoo-*` templates (was hardcoded to 6 IDs). Upstream added 16 more Odoo templates while this PR was in flight; the dynamic enumeration catches all of them and future additions automatically.