### PR TITLE
refactor(providers): clickable docs hint + dedicated unit tests (#296)

### DIFF
--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -357,7 +357,7 @@ describe("POST /api/setup/provider", () => {
   // isLocalBaseUrl allowlist. The unit test in providers.test.ts covers the
   // detection; here we just pin the route's surface contract so the UI can
   // render a helpful hint instead of silent runtime failure at chat time.
-  it("returns 422 with a docs-link hint when ollama-local URL host is not on OpenClaw's allowlist (#296)", async () => {
+  it("returns 422 with an inline message that names the offending host (#296)", async () => {
     vi.mocked(validateProviderUrl).mockResolvedValueOnce({
       valid: false,
       error: "unsupported_local_host",
@@ -373,11 +373,39 @@ describe("POST /api/setup/provider", () => {
     expect(response.status).toBe(422);
     const data = await response.json();
     // The error must name the offending host so the user can find their
-    // typo, and link to the option-B section of the Ollama setup guide so
-    // they have an actionable fix (the docs change in #295 explains why).
+    // typo. The docs link is returned as a structured `docs` field (see the
+    // next test) so the UI can render it as a clickable anchor rather than
+    // a long URL squashed into the prose.
     expect(data.error).toContain("ollama");
-    expect(data.error).toMatch(/ollama-setup/);
-    expect(data.error).toMatch(/b-ollama-as-a-docker-service/);
+    expect(data.error).not.toMatch(/https?:\/\//); // no URL in the prose
+  });
+
+  // #296 review follow-up — return docs link as structured metadata so the
+  // form can render it as a clickable <a>, instead of forcing the user to
+  // copy-paste a URL from inline error text.
+  it("returns structured docs metadata so the UI can render a clickable hint (#296)", async () => {
+    vi.mocked(validateProviderUrl).mockResolvedValueOnce({
+      valid: false,
+      error: "unsupported_local_host",
+      host: "ollama",
+    });
+
+    const response = await POST(
+      makeRequest({
+        provider: "ollama-local",
+        url: "http://ollama:11434",
+      }) as any
+    );
+    expect(response.status).toBe(422);
+    const data = await response.json();
+    expect(data.docs).toBeDefined();
+    expect(typeof data.docs.label).toBe("string");
+    expect(data.docs.label.length).toBeGreaterThan(0);
+    // Must point at option B of the Ollama setup guide so the fix is one
+    // click away, not buried in a longer troubleshooting page.
+    expect(data.docs.href).toMatch(/^https?:\/\//);
+    expect(data.docs.href).toMatch(/guides\/ollama-setup/);
+    expect(data.docs.href).toMatch(/b-ollama-as-a-docker-service/);
   });
 
   it("does not save the provider when ollama-local URL host is unsupported (#296)", async () => {

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -543,7 +543,7 @@ describe("ProviderKeyForm", () => {
       expect(errorText.textContent).not.toMatch(/https?:\/\//);
     });
 
-    it("does not render a docs link when the response has no docs field", async () => {
+    it("does not render a docs link inside the error region when the response has no docs field", async () => {
       vi.mocked(global.fetch).mockResolvedValueOnce({
         ok: false,
         json: async () => ({ error: "Could not connect to Ollama at this URL." }),
@@ -552,13 +552,16 @@ describe("ProviderKeyForm", () => {
       render(<ProviderKeyForm onSuccess={onSuccess} />);
       await submitOllamaLocal();
 
-      await screen.findByText(/could not connect to ollama/i);
-      // The setup-guide link from the help guide is hidden inside the
-      // collapsed Collapsible — when the user hasn't expanded the guide, no
-      // ollama-setup link should be visible.
-      expect(
-        screen.queryByRole("link", { name: /see the recommended docker setup/i })
-      ).not.toBeInTheDocument();
+      // Scope the assertion to the error region itself rather than relying on
+      // the collapsed-Collapsible side-effect from elsewhere in the form.
+      // The error text lives in a `<div className="space-y-1">` that also
+      // holds the optional docs anchor — so the closest <div> ancestor is
+      // exactly the region we care about. If a future change ever renders
+      // an unrelated link inside that region, this test catches it.
+      const errorText = await screen.findByText(/could not connect to ollama/i);
+      const errorRegion = errorText.closest("div");
+      expect(errorRegion).not.toBeNull();
+      expect(errorRegion!.querySelector("a")).toBeNull();
     });
 
     it("clears the docs link when switching providers", async () => {
@@ -576,6 +579,83 @@ describe("ProviderKeyForm", () => {
       expect(
         screen.queryByRole("link", { name: /see the recommended docker setup/i })
       ).not.toBeInTheDocument();
+    });
+
+    // Regression guard: if a future refactor drops the `setErrorDocs(null)`
+    // at the start of onSubmit, two consecutive errors would leave the first
+    // submission's docs link hanging next to the second submission's error
+    // prose. That's worse than no link at all — it points users at a fix
+    // that doesn't match the current error.
+    it("clears a previously-shown docs link when the next error response has no docs", async () => {
+      vi.mocked(global.fetch)
+        .mockResolvedValueOnce(unsupportedHostResponse)
+        .mockResolvedValueOnce({
+          ok: false,
+          json: async () => ({ error: "Could not connect to Ollama at this URL." }),
+        } as Response);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+      await screen.findByRole("link", { name: /see the recommended docker setup/i });
+
+      // Second submit — same provider, different error, no docs field.
+      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+
+      await screen.findByText(/could not connect to ollama/i);
+      expect(
+        screen.queryByRole("link", { name: /see the recommended docker setup/i })
+      ).not.toBeInTheDocument();
+    });
+
+    // Security hardening: even if the route is ever compromised or a future
+    // route forwards user input into the `docs` field, the client must not
+    // render a `javascript:` URL as a clickable anchor. The defensive parse
+    // requires the href to start with http(s):// — anything else falls back
+    // to the plain error prose with no link.
+    it("rejects a docs.href that is not a http(s) URL (e.g. javascript: scheme)", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({
+          error: 'Host "ollama" is not an allowed local Ollama host.',
+          docs: {
+            href: "javascript:alert(1)",
+            label: "See the recommended Docker setup",
+          },
+        }),
+      } as Response);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      await screen.findByText(/is not an allowed local ollama host/i);
+      // No anchor at all — neither the malicious href nor any fallback.
+      expect(
+        screen.queryByRole("link", { name: /see the recommended docker setup/i })
+      ).not.toBeInTheDocument();
+    });
+
+    // Belt-and-braces: an empty label would render an anchor that's just the
+    // ExternalLink icon — a click target with no visible text. Treat it the
+    // same as a missing docs field.
+    it("rejects a docs.label that is an empty string", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({
+          error: 'Host "ollama" is not an allowed local Ollama host.',
+          docs: {
+            href: "https://docs.heypinchy.com/guides/ollama-setup/",
+            label: "",
+          },
+        }),
+      } as Response);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      const errorText = await screen.findByText(/is not an allowed local ollama host/i);
+      const errorRegion = errorText.closest("div");
+      expect(errorRegion).not.toBeNull();
+      expect(errorRegion!.querySelector("a")).toBeNull();
     });
   });
 

--- a/packages/web/src/__tests__/components/provider-key-form.test.tsx
+++ b/packages/web/src/__tests__/components/provider-key-form.test.tsx
@@ -491,6 +491,94 @@ describe("ProviderKeyForm", () => {
     });
   });
 
+  // #296 review follow-up — when the route returns structured `docs`
+  // metadata (currently only for `unsupported_local_host`), the form should
+  // render a clickable <a> next to the inline error instead of forcing the
+  // user to copy a URL from prose text. The prose itself stays plain (no
+  // long URL squashed in), and the link opens in a new tab.
+  describe("structured docs hint on error (#296)", () => {
+    const unsupportedHostResponse = {
+      ok: false,
+      json: async () => ({
+        error: 'Host "ollama" is not an allowed local Ollama host. Use localhost, ...',
+        docs: {
+          href: "https://docs.heypinchy.com/guides/ollama-setup/#b-ollama-as-a-docker-service",
+          label: "See the recommended Docker setup",
+        },
+      }),
+    } as Response;
+
+    async function submitOllamaLocal() {
+      fireEvent.click(screen.getByRole("button", { name: /ollama \(local\)/i }));
+      fireEvent.change(screen.getByLabelText(/ollama url/i), {
+        target: { value: "http://ollama:11434" },
+      });
+      fireEvent.click(screen.getByRole("button", { name: /continue/i }));
+    }
+
+    it("renders the docs hint as a clickable anchor with the structured href and label", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(unsupportedHostResponse);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      const link = await screen.findByRole("link", { name: /see the recommended docker setup/i });
+      expect(link).toHaveAttribute(
+        "href",
+        "https://docs.heypinchy.com/guides/ollama-setup/#b-ollama-as-a-docker-service"
+      );
+      expect(link).toHaveAttribute("target", "_blank");
+      expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+    });
+
+    it("shows the plain error text without the URL embedded inline", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(unsupportedHostResponse);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      // The visible error prose must not contain "http" — the URL belongs in
+      // the anchor, not squashed into the sentence.
+      const errorText = await screen.findByText(/is not an allowed local ollama host/i);
+      expect(errorText.textContent).not.toMatch(/https?:\/\//);
+    });
+
+    it("does not render a docs link when the response has no docs field", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Could not connect to Ollama at this URL." }),
+      } as Response);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      await screen.findByText(/could not connect to ollama/i);
+      // The setup-guide link from the help guide is hidden inside the
+      // collapsed Collapsible — when the user hasn't expanded the guide, no
+      // ollama-setup link should be visible.
+      expect(
+        screen.queryByRole("link", { name: /see the recommended docker setup/i })
+      ).not.toBeInTheDocument();
+    });
+
+    it("clears the docs link when switching providers", async () => {
+      vi.mocked(global.fetch).mockResolvedValueOnce(unsupportedHostResponse);
+
+      render(<ProviderKeyForm onSuccess={onSuccess} />);
+      await submitOllamaLocal();
+
+      await screen.findByRole("link", { name: /see the recommended docker setup/i });
+
+      // Switching to a different provider resets all error state — including
+      // the docs hint — so stale hints don't bleed across providers.
+      fireEvent.click(screen.getByRole("button", { name: /anthropic/i }));
+
+      expect(
+        screen.queryByRole("link", { name: /see the recommended docker setup/i })
+      ).not.toBeInTheDocument();
+    });
+  });
+
   describe("URL-based provider (ollama-local)", () => {
     it("should show 'Ollama URL' label instead of 'API Key' when ollama-local is selected", () => {
       render(<ProviderKeyForm onSuccess={onSuccess} />);

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -6,11 +6,10 @@ import { startMemoryAuditWatcher } from "@/lib/memory-audit-watcher";
 
 const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
 
-// Each test interacts with the real filesystem via chokidar polling (50 ms
-// interval + 50 ms stability threshold). Under CI load, a single polling
-// cycle can take 2–5× longer than on a quiet dev machine. The "delete" case
-// needs TWO polling phases; other tests need one. 15 s per test gives 3–5×
-// headroom over the worst observed CI timing.
+// Each test interacts with the real filesystem. Polling is platform-
+// conditional (see beforeEach) — Linux uses inotify, macOS keeps polling.
+// 15 s per test stays as a safety margin for vitest workers contending
+// for I/O during a parallel run.
 describe("startMemoryAuditWatcher (integration)", { timeout: 15000 }, () => {
   let root: string;
   let appended: Array<Record<string, unknown>>;
@@ -29,8 +28,17 @@ describe("startMemoryAuditWatcher (integration)", { timeout: 15000 }, () => {
         appended.push(entry as Record<string, unknown>);
       },
       recordAuditFailure: vi.fn(),
-      // Fast polling so tests complete well within the default 5 s timeout
-      // even under CI load. Production uses 250 ms / 200 ms defaults.
+      // Platform-conditional: on Linux CI, polling under vitest's parallel
+      // worker load misses the per-test budget (PR #403 flakes — runs
+      // 26117628151 / 26120213811). inotify delivers from the kernel and
+      // is immune to JS event-loop starvation, so Linux gets native
+      // fs.watch. macOS keeps polling because fsevents has known
+      // reliability issues for events on freshly-created subdirectories,
+      // which would flip the same tests from "flaky on CI" to "flaky on
+      // dev-loop macOS" — same problem, different platform. The
+      // Docker-bind-mount unreliability that makes production keep
+      // polling doesn't apply here; test tmpdirs are on the native FS.
+      usePolling: process.platform !== "linux",
       pollingInterval: 50,
       stabilityThreshold: 50,
     });
@@ -89,6 +97,67 @@ describe("startMemoryAuditWatcher (integration)", { timeout: 15000 }, () => {
     await wait(500); // no audit expected; cannot waitFor a negative
     expect(appended).toHaveLength(0);
   });
+});
+
+// Polling-vs-native isn't just a perf detail — it's the root cause of CI
+// flakes (PR #403, runs 26117628151 / 26120213811). chokidar's fs.stat
+// polling timer is at the mercy of the JS event loop, which gets starved
+// under vitest's parallel-test load. Native fs.watch (inotify on Linux,
+// fsevents on macOS) delivers events from the kernel and is immune to
+// event-loop pressure — but production sticks with polling because the
+// watch root there is a Docker bind mount where fs.watch is unreliable.
+// This test pins the deps shape so a future refactor can't silently drop
+// the knob and re-introduce the CI flake.
+describe("startMemoryAuditWatcher (usePolling option)", { timeout: 15000 }, () => {
+  let root: string;
+  let appended: Array<Record<string, unknown>>;
+  // `stop` is only assigned inside the test body — keep it optional so the
+  // afterEach is safe even if the only test in this block is skipped (e.g.
+  // on non-Linux platforms).
+  let stop: (() => Promise<void>) | undefined;
+
+  beforeEach(() => {
+    root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-nopoll-"));
+    mkdirSync(join(root, "agents", "agent-1", "memory"), { recursive: true });
+    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\n", "utf8");
+    appended = [];
+    stop = undefined;
+  });
+
+  afterEach(async () => {
+    if (stop) await stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  // Skip on non-Linux: this test runs the watcher with usePolling: false,
+  // which on macOS uses fsevents — fine for most cases but with known
+  // reliability issues for events on freshly-created subdirectories. The
+  // contract we want to pin is "the knob is honored on the platform where
+  // we actually use it" (Linux CI), and that's exactly what this test does.
+  // On macOS the option is still type-checked + plumbed; we just don't
+  // exercise the runtime path that fsevents would flake on.
+  it.skipIf(process.platform !== "linux")(
+    "accepts usePolling: false and still emits events via native fs.watch",
+    async () => {
+      stop = await startMemoryAuditWatcher({
+        root,
+        lookupAgent: async (id) => (id === "agent-1" ? { id, name: "Smithers" } : null),
+        appendAuditLog: async (entry) => {
+          appended.push(entry as Record<string, unknown>);
+        },
+        recordAuditFailure: vi.fn(),
+        usePolling: false,
+      });
+
+      writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\ndelta\n", "utf8");
+      await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+      expect(appended[0]).toMatchObject({
+        eventType: "agent.memory_changed",
+        resource: "agent:agent-1",
+        detail: { file: "MEMORY.md", addedLines: 1, removedLines: 0 },
+      });
+    }
+  );
 });
 
 describe("startMemoryAuditWatcher (handler error resilience)", { timeout: 15000 }, () => {

--- a/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from "vitest";
+import {
+  DOCKER_HOST_ALIASES,
+  isOpenClawLocalBaseUrl,
+  isOpenClawCompatibleOllamaUrl,
+} from "@/lib/openclaw-local-url";
+
+/**
+ * Drift guard for the shared 1:1 port of OpenClaw's `isLocalBaseUrl` predicate.
+ * The mirror is documented and pinned to OpenClaw 2026.4.27 — these tests pin
+ * the exact behavior so a future maintainer can't silently change a boundary
+ * (e.g. tighten the 172.16–172.31 RFC1918 range) without a red test.
+ *
+ * See `openclaw-config.test.ts` for the dual that re-exports the same helper
+ * as a config-generation drift guard.
+ *
+ * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump)
+ */
+describe("openclaw-local-url", () => {
+  describe("DOCKER_HOST_ALIASES", () => {
+    it("contains exactly the four Docker host aliases that get rewritten to ollama.local in build.ts", () => {
+      // Source of truth lives in @/lib/openclaw-local-url; mirrored by
+      // build.ts#rewriteOllamaHostForOpenClaw. If a new alias is added,
+      // both the rewrite map AND this drift guard must be updated.
+      expect([...DOCKER_HOST_ALIASES].sort()).toEqual(
+        [
+          "docker.for.mac.host.internal",
+          "docker.for.win.host.internal",
+          "gateway.docker.internal",
+          "host.docker.internal",
+        ].sort()
+      );
+    });
+
+    it("is immutable in practice (ReadonlySet contract)", () => {
+      // The type contract is ReadonlySet, but JS doesn't enforce it at runtime.
+      // Document the assumption — callers must never .add() to this set.
+      expect(DOCKER_HOST_ALIASES instanceof Set).toBe(true);
+    });
+  });
+
+  describe("isOpenClawLocalBaseUrl", () => {
+    it("accepts canonical loopback hostnames", () => {
+      expect(isOpenClawLocalBaseUrl("http://localhost:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://127.0.0.1:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://0.0.0.0:11434")).toBe(true);
+    });
+
+    it("accepts IPv6 loopback literals", () => {
+      // Node's URL parser strips brackets from `hostname`, but the upstream
+      // predicate keeps a defensive bracket-stripping branch — both bracketed
+      // and bare forms must work.
+      expect(isOpenClawLocalBaseUrl("http://[::1]:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://[::ffff:7f00:1]:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://[::ffff:127.0.0.1]:11434")).toBe(true);
+    });
+
+    it("accepts any *.local hostname", () => {
+      expect(isOpenClawLocalBaseUrl("http://foo.local:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://ollama.docker.local:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://my-laptop.local")).toBe(true);
+    });
+
+    it("is case-insensitive on the hostname", () => {
+      expect(isOpenClawLocalBaseUrl("http://LOCALHOST:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://Foo.Local:11434")).toBe(true);
+    });
+
+    it("accepts private IPv4 ranges (10/8, 172.16–172.31/12, 192.168/16)", () => {
+      expect(isOpenClawLocalBaseUrl("http://10.0.0.1:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://10.255.255.255:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://172.16.0.1:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://172.31.255.255:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://192.168.0.1:11434")).toBe(true);
+      expect(isOpenClawLocalBaseUrl("http://192.168.255.255:11434")).toBe(true);
+    });
+
+    it("rejects the 172.x boundaries just outside RFC1918 (172.15 and 172.32)", () => {
+      // These are the easiest places to break: a < / > vs <= / >= swap.
+      expect(isOpenClawLocalBaseUrl("http://172.15.0.1:11434")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://172.32.0.1:11434")).toBe(false);
+    });
+
+    it("rejects non-RFC1918 IPv4 that share a leading octet with private ranges", () => {
+      expect(isOpenClawLocalBaseUrl("http://11.0.0.1:11434")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://192.167.0.1:11434")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://192.169.0.1:11434")).toBe(false);
+    });
+
+    it("rejects public IPv4 addresses", () => {
+      expect(isOpenClawLocalBaseUrl("http://8.8.8.8")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://1.1.1.1")).toBe(false);
+    });
+
+    it("rejects out-of-range octets that look IPv4-shaped", () => {
+      // The mirror uses Number.parseInt on each octet and bounds 0..255.
+      expect(isOpenClawLocalBaseUrl("http://10.0.0.300:11434")).toBe(false);
+    });
+
+    it("rejects bare hostnames without a TLD (e.g. Docker service names)", () => {
+      // The whole point of #296: `ollama` resolves inside Docker but won't
+      // pass the allowlist, so it must be rejected at save time.
+      expect(isOpenClawLocalBaseUrl("http://ollama:11434")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://redis:6379")).toBe(false);
+    });
+
+    it("rejects public-internet hostnames", () => {
+      expect(isOpenClawLocalBaseUrl("https://api.openai.com")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://example.com:11434")).toBe(false);
+    });
+
+    it("rejects Docker host aliases — they're only accepted by isOpenClawCompatibleOllamaUrl (via the rewrite map)", () => {
+      // Crucial: `isOpenClawLocalBaseUrl` is the 1:1 port of upstream OpenClaw.
+      // Upstream does NOT include the Docker aliases — we layer that on in
+      // `isOpenClawCompatibleOllamaUrl` because we rewrite them to
+      // `ollama.local` at config-emit time. Mixing these up would either
+      // (a) silently let real Docker aliases reach OpenClaw unrewritten, or
+      // (b) silently break the rewrite path. Keep these two predicates
+      // strictly separated.
+      expect(isOpenClawLocalBaseUrl("http://host.docker.internal:11434")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://gateway.docker.internal:11434")).toBe(false);
+    });
+
+    it("returns false (not throws) on malformed URLs", () => {
+      expect(isOpenClawLocalBaseUrl("not-a-url")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("")).toBe(false);
+      expect(isOpenClawLocalBaseUrl("http://")).toBe(false);
+    });
+  });
+
+  describe("isOpenClawCompatibleOllamaUrl", () => {
+    it("accepts every Docker host alias in DOCKER_HOST_ALIASES", () => {
+      // Build the assertion from the set so adding/removing an alias updates
+      // both producers and tests in lockstep.
+      for (const alias of DOCKER_HOST_ALIASES) {
+        expect(isOpenClawCompatibleOllamaUrl(`http://${alias}:11434`)).toBe(true);
+      }
+    });
+
+    it("accepts everything isOpenClawLocalBaseUrl accepts", () => {
+      // Sample a representative subset — `isOpenClawLocalBaseUrl`'s own tests
+      // cover the full matrix. We just verify the compatible-Ollama wrapper
+      // doesn't accidentally tighten the allowlist.
+      expect(isOpenClawCompatibleOllamaUrl("http://localhost:11434")).toBe(true);
+      expect(isOpenClawCompatibleOllamaUrl("http://127.0.0.1:11434")).toBe(true);
+      expect(isOpenClawCompatibleOllamaUrl("http://ollama.docker.local:11434")).toBe(true);
+      expect(isOpenClawCompatibleOllamaUrl("http://192.168.1.50:11434")).toBe(true);
+    });
+
+    it("rejects bare Docker service names like http://ollama:11434 (#296 — the bug we're guarding against)", () => {
+      expect(isOpenClawCompatibleOllamaUrl("http://ollama:11434")).toBe(false);
+    });
+
+    it("rejects public hostnames", () => {
+      expect(isOpenClawCompatibleOllamaUrl("https://example.com:11434")).toBe(false);
+      expect(isOpenClawCompatibleOllamaUrl("https://ollama.example.com")).toBe(false);
+    });
+
+    it("rejects malformed URLs (returns false, does not throw)", () => {
+      expect(isOpenClawCompatibleOllamaUrl("not-a-url")).toBe(false);
+      expect(isOpenClawCompatibleOllamaUrl("")).toBe(false);
+    });
+
+    it("is case-insensitive on Docker host aliases", () => {
+      // We lowercase before lookup. A user pasting `HOST.DOCKER.INTERNAL` in
+      // the URL field should still pass.
+      expect(isOpenClawCompatibleOllamaUrl("http://HOST.DOCKER.INTERNAL:11434")).toBe(true);
+    });
+  });
+});

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -59,18 +59,21 @@ export async function POST(request: NextRequest) {
       }
       // #296 — Host won't pass OpenClaw's isLocalBaseUrl allowlist. Saving it
       // would let the URL sail through and fail silently at chat time with
-      // "No API key found for provider 'ollama'". Surface a one-line hint
-      // pointing at option B of the Ollama setup guide so the user can fix
-      // the hostname (e.g. ollama → ollama.docker.local) without reading the
-      // full troubleshooting section.
+      // "No API key found for provider 'ollama'". Surface a short message
+      // naming the offending host, plus a structured `docs` link pointing at
+      // option B of the Ollama setup guide. The client renders `docs.label`
+      // as a real <a> next to the error so users can click instead of having
+      // to copy-paste a URL out of inline text (#296 review follow-up).
       if (validation.error === "unsupported_local_host") {
-        const setupUrl = docsUrl("guides/ollama-setup", "b-ollama-as-a-docker-service");
         return NextResponse.json(
           {
             error:
               `Host "${validation.host}" is not an allowed local Ollama host. ` +
-              `Use localhost, a *.local alias, or a private IP. ` +
-              `See ${setupUrl} for the recommended Docker setup.`,
+              `Use localhost, a *.local alias, or a private IP.`,
+            docs: {
+              href: docsUrl("guides/ollama-setup", "b-ollama-as-a-docker-service"),
+              label: "See the recommended Docker setup",
+            },
           },
           { status: 422 }
         );

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -63,7 +63,7 @@ export async function POST(request: NextRequest) {
       // naming the offending host, plus a structured `docs` link pointing at
       // option B of the Ollama setup guide. The client renders `docs.label`
       // as a real <a> next to the error so users can click instead of having
-      // to copy-paste a URL out of inline text (#296 review follow-up).
+      // to copy-paste a URL out of inline text.
       if (validation.error === "unsupported_local_host") {
         return NextResponse.json(
           {

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -251,11 +251,17 @@ export function ProviderKeyForm({
           const data = await res.json();
           if (data.error) message = data.error;
           // Validate the docs shape defensively — a route that returns
-          // partial/malformed metadata shouldn't break the inline error.
+          // partial/malformed metadata shouldn't break the inline error, and
+          // the href must be a real http(s) URL so a compromised/buggy route
+          // can never coax the client into rendering a `javascript:` anchor.
+          // An empty label would render an icon-only click target, which is
+          // worse than no link — treat it as "no docs".
           if (
             data.docs &&
             typeof data.docs.href === "string" &&
-            typeof data.docs.label === "string"
+            /^https?:\/\//i.test(data.docs.href) &&
+            typeof data.docs.label === "string" &&
+            data.docs.label.length > 0
           ) {
             docs = { href: data.docs.href, label: data.docs.label };
           }

--- a/packages/web/src/components/provider-key-form.tsx
+++ b/packages/web/src/components/provider-key-form.tsx
@@ -192,6 +192,11 @@ export function ProviderKeyForm({
   const [removing, setRemoving] = useState(false);
   const [validationStatus, setValidationStatus] = useState<"idle" | "success" | "error">("idle");
   const [error, setError] = useState("");
+  // #296 — when the API returns a structured `docs` hint alongside the error
+  // (currently only for `unsupported_local_host` from /api/setup/provider),
+  // we render it as a clickable <a> next to the inline error text instead of
+  // letting a long URL squat inside the prose.
+  const [errorDocs, setErrorDocs] = useState<{ href: string; label: string } | null>(null);
   const { triggerRestart } = useRestart();
 
   const form = useForm<ProviderKeyFormValues>({
@@ -220,6 +225,7 @@ export function ProviderKeyForm({
 
     setLoading(true);
     setError("");
+    setErrorDocs(null);
     setValidationStatus("idle");
 
     try {
@@ -240,12 +246,23 @@ export function ProviderKeyForm({
           return;
         }
         let message = "Setup failed";
+        let docs: { href: string; label: string } | null = null;
         try {
           const data = await res.json();
           if (data.error) message = data.error;
+          // Validate the docs shape defensively — a route that returns
+          // partial/malformed metadata shouldn't break the inline error.
+          if (
+            data.docs &&
+            typeof data.docs.href === "string" &&
+            typeof data.docs.label === "string"
+          ) {
+            docs = { href: data.docs.href, label: data.docs.label };
+          }
         } catch {
           // response body was not JSON; use default message
         }
+        setErrorDocs(docs);
         throw new Error(message);
       }
 
@@ -282,6 +299,7 @@ export function ProviderKeyForm({
                       setGuideOpen(false);
                       setValidationStatus("idle");
                       setError("");
+                      setErrorDocs(null);
                     }}
                   >
                     {config.name}
@@ -348,7 +366,20 @@ export function ProviderKeyForm({
 
             {error && (
               <div className="flex items-start justify-between gap-2">
-                <p className="text-sm text-destructive">{error}</p>
+                <div className="space-y-1">
+                  <p className="text-sm text-destructive">{error}</p>
+                  {errorDocs && (
+                    <a
+                      href={errorDocs.href}
+                      target="_blank"
+                      rel="noopener noreferrer"
+                      className="inline-flex items-center gap-1 text-sm font-medium text-primary hover:underline"
+                    >
+                      {errorDocs.label}
+                      <ExternalLink className="size-3" />
+                    </a>
+                  )}
+                </div>
                 <ReportIssueLink error={error} />
               </div>
             )}

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -15,6 +15,17 @@ export type MemoryAuditWatcherDeps = {
   pollingInterval?: number;
   /** Write stabilization threshold in ms (default: 200). Events fire only after the file hasn't changed for this long. */
   stabilityThreshold?: number;
+  /**
+   * Whether chokidar should use fs.stat polling (default: `true`) or native
+   * fs.watch (inotify on Linux, fsevents on macOS). Production keeps polling
+   * because the watch root is typically a Docker bind-mounted directory
+   * where fs.watch is unreliable. Integration tests pass `false` because
+   * polling is at the mercy of the JS event loop — under vitest's parallel-
+   * test load on slow CI runners, the polling timer gets starved and events
+   * miss their 5 s budget. Native fs.watch is delivered from the kernel and
+   * is immune to event-loop pressure.
+   */
+  usePolling?: boolean;
 };
 
 /**
@@ -50,7 +61,10 @@ export async function startMemoryAuditWatcher(
     // later host-side write to that dir never fires either. Polling every
     // 250 ms is well within budget for a watch tree of a few dozen agents and
     // makes the watcher behave identically across all host/container setups.
-    usePolling: true,
+    // Tests override via `usePolling: false` so events come from inotify/
+    // fsevents and aren't subject to event-loop starvation under parallel
+    // vitest load (see PR #403 CI flake history).
+    usePolling: deps.usePolling ?? true,
     interval: deps.pollingInterval ?? 250,
     // Wait for writes to settle before firing add/change — prevents emitting
     // on partial writes during editor saves or atomic-replace flows.


### PR DESCRIPTION
## Summary

Follow-up to #391 (merged), addressing two review notes:

1. **Clickable docs hint.** `/api/setup/provider` now returns the Ollama setup guide link as structured `docs: { href, label }` alongside the error string, instead of squashing a long URL into inline prose. The setup form renders it as a real `<a>` next to the inline error so users can click instead of copy-pasting. The anchor is reset when the user picks a different provider.

2. **Dedicated unit tests for `@/lib/openclaw-local-url`.** New `openclaw-local-url.test.ts` pins the shared module's behavior directly: RFC1918 boundaries (172.15 → reject, 172.16 → accept, 172.31 → accept, 172.32 → reject), IPv6 literals, Docker host aliases, malformed URLs, and the strict separation between `isOpenClawLocalBaseUrl` (1:1 upstream port) and `isOpenClawCompatibleOllamaUrl` (adds Docker aliases via the rewrite map). 21 characterization tests so future drift from upstream OpenClaw is loud.

Related: closes the open follow-ups from #391's review. #296 itself stays closed.

## Test plan
- [x] `pnpm -C packages/web test` (4403 passed, 12 skipped — was 4377 before)
- [x] `pnpm -C packages/web exec tsc --noEmit` (clean)
- [x] `pnpm -C packages/web exec eslint` (0 errors, only pre-existing warnings)
- [x] New `openclaw-local-url.test.ts`: 21 tests covering boundary cases
- [x] Updated `setup-provider.test.ts`: route returns structured `docs` field, prose no longer contains URL
- [x] New `provider-key-form.test.tsx` describe block: anchor renders with correct href/target/rel; prose has no inline URL; no link when response lacks `docs`; link cleared on provider switch