### PR TITLE
feat: audit agent memory file changes (#345)

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -68,11 +68,33 @@ exports too.
 
 ### Agent management
 
-| Event Type      | Description                                     |
-| --------------- | ----------------------------------------------- |
-| `agent.created` | A new agent was created                         |
-| `agent.updated` | An agent's settings or permissions were changed |
-| `agent.deleted` | An agent was deleted                            |
+| Event Type             | Description                                                                                                     |
+| ---------------------- | --------------------------------------------------------------------------------------------------------------- |
+| `agent.created`        | A new agent was created                                                                                         |
+| `agent.updated`        | An agent's settings or permissions were changed                                                                 |
+| `agent.deleted`        | An agent was deleted                                                                                            |
+| `agent.memory_changed` | A file in the agent's durable long-term memory (`MEMORY.md` or `memory/*.md`) was created, modified, or deleted |
+
+#### `agent.memory_changed`
+
+OpenClaw maintains durable per-agent long-term memory in `~/.openclaw/agents/<agentId>/MEMORY.md` and `~/.openclaw/agents/<agentId>/memory/*.md`. Those files are reloaded into the agent's context at every session start, so they directly shape behavior in every future conversation. Memory is written in two ways:
+
+- Explicitly, when the user or agent decides to remember something.
+- Implicitly, via the pre-compaction memory flush — a silent turn that runs before OpenClaw summarizes a long conversation and asks the agent to save important context.
+
+Pinchy watches these files and emits an audit entry on every change so an auditor can answer "the agent suddenly believes X — when and how did that get into its memory?"
+
+- `actorType`: `"agent"` — the agent whose memory changed.
+- `actorId`: the agent id.
+- `resource`: `agent:<agentId>`.
+- `detail`:
+  - `agent`: `{ id, name }` — snapshot of the agent at the time of the change.
+  - `file`: the relative path under the agent directory — either `"MEMORY.md"` or `"memory/<file>.md"`.
+  - `addedLines`: number of lines added compared to the prior snapshot.
+  - `removedLines`: number of lines removed compared to the prior snapshot.
+  - `byteSize`: size of the file in bytes after the change (`0` for deletions).
+
+The detail never contains file contents — only counts and the relative filename. Deletions surface as `byteSize: 0` and `removedLines` equal to the previous line count.
 
 ### User management
 

--- a/packages/web/e2e/integration/memory-audit.spec.ts
+++ b/packages/web/e2e/integration/memory-audit.spec.ts
@@ -1,0 +1,152 @@
+// packages/web/e2e/integration/memory-audit.spec.ts
+//
+// Proves Task 7's memory-audit watcher: writing to
+// `/openclaw-config/agents/<agentId>/MEMORY.md` inside the Pinchy container
+// emits an `agent.memory_changed` audit entry with the expected detail shape.
+//
+// Why `docker compose exec` instead of host-side file writes:
+// Issue #196 moved the integration suite to run Pinchy in its production
+// container. The container mounts `openclaw-config` as a named Docker volume
+// (no host-visible path), so to feed the watcher we have to write the file
+// from inside the running container. We use the same `composeExec` pattern
+// the global-setup hook uses for OpenClaw config reads.
+
+import { test, expect } from "@playwright/test";
+import { execSync } from "child_process";
+import path from "path";
+import { login, getSmithersAgentId } from "./helpers";
+
+const COMPOSE_FILES =
+  "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml";
+const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
+const COMPOSE_ENV = { ...process.env, PINCHY_VERSION: process.env.PINCHY_VERSION || "local" };
+
+// Inside the Pinchy container the watcher walks /openclaw-config/agents/<id>/.
+// In production this is the `openclaw-config` Docker volume mounted at the
+// same path; the integration stack mounts the same named volume.
+const CONTAINER_DATA_PATH = "/openclaw-config";
+
+function pinchyExec(cmd: string): string {
+  return execSync(`docker compose ${COMPOSE_FILES} exec -T pinchy ${cmd}`, {
+    encoding: "utf8",
+    cwd: PROJECT_ROOT,
+    env: COMPOSE_ENV,
+    stdio: ["pipe", "pipe", "pipe"],
+  }).trim();
+}
+
+test.describe("memory-audit watcher emits agent.memory_changed on MEMORY.md write", () => {
+  let containerMemoryPath = "";
+
+  test.afterEach(() => {
+    if (containerMemoryPath) {
+      try {
+        pinchyExec(`rm -f ${containerMemoryPath}`);
+      } catch {
+        // best-effort cleanup; container may already be tearing down
+      }
+      containerMemoryPath = "";
+    }
+  });
+
+  test("writes 3 new lines → audit log shows addedLines>=3 with full detail", async ({ page }) => {
+    // 1. Login as the admin so we can query both /api/agents and /api/audit.
+    await login(page);
+
+    // 2. Find Smithers (auto-created during setup). Also fetch its display name
+    //    dynamically so the assertion below works even if a future test variant
+    //    customizes the name.
+    const smithersId = await getSmithersAgentId(page);
+    const agentsRes = await page.request.get("/api/agents");
+    const agentsBody = (await agentsRes.json()) as Array<{ id: string; name: string }>;
+    const smithers = agentsBody.find((a) => a.id === smithersId);
+    expect(smithers, "Smithers row not present in /api/agents").toBeTruthy();
+    const smithersName = smithers!.name;
+
+    // 3. Compute the watched path inside the container. The watcher recognizes
+    //    `<root>/agents/<agentId>/MEMORY.md` exactly (see parse-path.ts).
+    containerMemoryPath = `${CONTAINER_DATA_PATH}/agents/${smithersId}/MEMORY.md`;
+
+    // 4. Write a unique, timestamped 3-line file via `docker exec`. The
+    //    uniqueness defends against the case where a prior run left identical
+    //    content on disk — that would make `addedLines === 0` and produce a
+    //    false negative. We don't pre-delete an existing MEMORY.md and rewrite:
+    //    that path is racy because the watcher's snapshot store after an
+    //    unlink+add depends on event ordering. Instead we rely on
+    //    `addedLines >= 3` which is robust to whatever the watcher's prior
+    //    snapshot was.
+    const stamp = `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+    const lines = [
+      `remembered fact 1 (run ${stamp})`,
+      `remembered fact 2 (run ${stamp})`,
+      `remembered fact 3 (run ${stamp})`,
+    ];
+    const content = lines.join("\n") + "\n";
+    const expectedByteSize = Buffer.byteLength(content, "utf8");
+
+    // mkdir -p the agent dir (OpenClaw creates it lazily; on a fresh stack
+    // Smithers may not have memory writes yet) then write via base64 to avoid
+    // any shell-quoting hazards around newlines or special characters.
+    const base64 = Buffer.from(content, "utf8").toString("base64");
+    pinchyExec(`mkdir -p ${path.posix.dirname(containerMemoryPath)}`);
+    pinchyExec(`sh -c 'echo ${base64} | base64 -d > ${containerMemoryPath}'`);
+
+    // 5. Poll the audit API. The watcher debounces writes through chokidar's
+    //    awaitWriteFinish (200 ms stability + 50 ms poll), plus a 250 ms poll
+    //    interval (usePolling) on the chokidar side, plus there's a
+    //    fs → handler hop and a DB insert. 30 × 500 ms = 15 s is comfortably
+    //    above the worst case under CI load.
+    type AuditEntry = {
+      eventType: string;
+      resource: string;
+      actorType: string;
+      actorId: string;
+      outcome: string;
+      detail: {
+        agent?: { id?: string; name?: string };
+        file?: string;
+        addedLines?: number;
+        removedLines?: number;
+        byteSize?: number;
+      };
+    };
+    let entry: AuditEntry | undefined;
+    for (let attempt = 0; attempt < 30; attempt++) {
+      const res = await page
+        .context()
+        .request.get(`/api/audit?eventType=agent.memory_changed&limit=50`);
+      expect(res.ok()).toBe(true);
+      const body = (await res.json()) as { entries: AuditEntry[] };
+      entry = body.entries.find(
+        (e) => e.detail?.agent?.id === smithersId && e.detail?.file === "MEMORY.md"
+      );
+      if (entry) break;
+      await page.waitForTimeout(500);
+    }
+
+    expect(
+      entry,
+      `agent.memory_changed for ${smithersId}/MEMORY.md not found in audit log`
+    ).toBeDefined();
+
+    // 6. Core shape: actor identity and resource framing.
+    expect(entry!.eventType).toBe("agent.memory_changed");
+    expect(entry!.resource).toBe(`agent:${smithersId}`);
+    expect(entry!.actorType).toBe("agent");
+    expect(entry!.actorId).toBe(smithersId);
+    expect(entry!.outcome).toBe("success");
+
+    // 7. Detail: snapshotted agent + file id + byte size match exactly.
+    expect(entry!.detail.agent).toEqual({ id: smithersId, name: smithersName });
+    expect(entry!.detail.file).toBe("MEMORY.md");
+    expect(entry!.detail.byteSize).toBe(expectedByteSize);
+
+    // 8. Line diff: we wrote 3 lines and never removed any in this write.
+    //    `>= 3` (rather than `=== 3`) is intentional — the watcher's prior
+    //    snapshot at the moment of our write is non-deterministic (an earlier
+    //    test or a stale on-disk MEMORY.md could have populated it). Three
+    //    new fact lines are guaranteed to surface as "added" regardless.
+    expect(entry!.detail.addedLines).toBeGreaterThanOrEqual(3);
+    expect(entry!.detail.removedLines).toBeGreaterThanOrEqual(0);
+  });
+});

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -38,6 +38,7 @@
     "bcryptjs": "^3.0.3",
     "better-auth": "^1.6.11",
     "browser-image-compression": "^2.0.2",
+    "chokidar": "^5.0.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
     "cmdk": "^1.1.1",

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -240,23 +240,31 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   const betterAuthUrlWarning = getBetterAuthUrlStartupWarning(process.env, getCachedDomain());
   if (betterAuthUrlWarning) console.warn(betterAuthUrlWarning);
 
-  // Start the memory-audit watcher after bootInits resolves. Guarded by
-  // setupWasComplete: on a fresh install the `agents/` directory under
-  // OPENCLAW_DATA_PATH may not exist yet and the agents table is empty,
-  // so we skip and let the next process restart (after setup) pick it up.
+  // Start the memory-audit watcher after bootInits resolves. We start it
+  // unconditionally — chokidar copes with a missing watch root by emitting
+  // `ready` with an empty snapshot map, and `handleMemoryFileEvent` short-
+  // circuits to no-op for files whose agentId has no row in `agents`. This
+  // means the watcher is correctly active across all process states:
+  //
+  //   - Fresh install pre-setup: nothing to watch, nothing fires.
+  //   - Post-setup, same process: the user completes the wizard, OpenClaw
+  //     comes online, and Smithers' first MEMORY.md write is captured
+  //     without requiring a Pinchy restart.
+  //   - Production cold start: identical to today, plus tightens the
+  //     "first boot after setup" window where the previous guard left
+  //     the watcher dormant until the next container restart.
+  //
   // The lazy `await import(...)` is intentional — bootstrap pulls in `@/db`
   // and we want DB modules evaluated only after bootInits has completed.
   // Errors during watcher boot are logged but not rethrown: this watcher is
   // non-critical to Pinchy's operation (the API audit log works without it).
   let stopMemoryAuditWatcher: (() => Promise<void>) | null = null;
-  if (setupWasComplete) {
-    try {
-      const { bootstrapMemoryAuditWatcher } = await import("./src/lib/memory-audit-watcher");
-      stopMemoryAuditWatcher = await bootstrapMemoryAuditWatcher({});
-      console.log("[pinchy] memory audit watcher started");
-    } catch (err) {
-      console.error("[pinchy] failed to start memory audit watcher", err);
-    }
+  try {
+    const { bootstrapMemoryAuditWatcher } = await import("./src/lib/memory-audit-watcher");
+    stopMemoryAuditWatcher = await bootstrapMemoryAuditWatcher({});
+    console.log("[pinchy] memory audit watcher started");
+  } catch (err) {
+    console.error("[pinchy] failed to start memory audit watcher", err);
   }
 
   // Graceful shutdown: stop the usage poller interval, close the memory-audit

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -227,18 +227,6 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   await new Promise<void>((resolve) => server.listen(port, resolve));
   console.log(`Pinchy ready on http://localhost:${port}`);
 
-  // Graceful shutdown: stop the usage poller interval so Node can exit,
-  // then close the HTTP server. Without this, a SIGTERM (e.g. from Docker
-  // Compose) leaves the setInterval dangling and the process hangs until
-  // the container's kill-grace period expires.
-  registerShutdownHandlers([
-    () => stopUsagePoller(),
-    () =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      }),
-  ]);
-
   // Run boot initializations AFTER the server is listening. The healthcheck
   // endpoint returns 503 until markOpenClawConfigReady() is called inside
   // bootInits(), at which point Docker Compose marks the container healthy.
@@ -251,6 +239,45 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   // Lock value to be useful.
   const betterAuthUrlWarning = getBetterAuthUrlStartupWarning(process.env, getCachedDomain());
   if (betterAuthUrlWarning) console.warn(betterAuthUrlWarning);
+
+  // Start the memory-audit watcher after bootInits resolves. Guarded by
+  // setupWasComplete: on a fresh install the `agents/` directory under
+  // OPENCLAW_DATA_PATH may not exist yet and the agents table is empty,
+  // so we skip and let the next process restart (after setup) pick it up.
+  // The lazy `await import(...)` is intentional — bootstrap pulls in `@/db`
+  // and we want DB modules evaluated only after bootInits has completed.
+  // Errors during watcher boot are logged but not rethrown: this watcher is
+  // non-critical to Pinchy's operation (the API audit log works without it).
+  let stopMemoryAuditWatcher: (() => Promise<void>) | null = null;
+  if (setupWasComplete) {
+    try {
+      const { bootstrapMemoryAuditWatcher } = await import("./src/lib/memory-audit-watcher");
+      stopMemoryAuditWatcher = await bootstrapMemoryAuditWatcher({});
+      console.log("[pinchy] memory audit watcher started");
+    } catch (err) {
+      console.error("[pinchy] failed to start memory audit watcher", err);
+    }
+  }
+
+  // Graceful shutdown: stop the usage poller interval, close the memory-audit
+  // watcher, then close the HTTP server. Without this, a SIGTERM (e.g. from
+  // Docker Compose) leaves the setInterval dangling and the process hangs
+  // until the container's kill-grace period expires.
+  //
+  // Note: registration happens AFTER bootInits() + watcher boot so the
+  // memory-audit stop fn can be included in the array. A SIGTERM arriving
+  // during the bootInits or watcher-boot phase will therefore not be handled
+  // gracefully; that window is short (a few seconds at most) and the
+  // alternative (mutable wrapper / re-registration) adds noise for negligible
+  // benefit.
+  registerShutdownHandlers([
+    () => stopUsagePoller(),
+    () => (stopMemoryAuditWatcher ? stopMemoryAuditWatcher() : Promise.resolve()),
+    () =>
+      new Promise<void>((resolve) => {
+        server.close(() => resolve());
+      }),
+  ]);
 
   // Connect to OpenClaw AFTER bootInits so the gateway token and config are
   // ready. On a completed install, bootInits() has already run

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -1,0 +1,22 @@
+import { describe, it, expectTypeOf } from "vitest";
+import type { AuditLogEntry, AuditEventType } from "@/lib/audit";
+
+describe("AuditLogEntry agent.memory_changed", () => {
+  it("accepts the expected detail shape", () => {
+    const entry: AuditLogEntry = {
+      actorType: "agent",
+      actorId: "agent-123",
+      eventType: "agent.memory_changed",
+      resource: "agent:agent-123",
+      outcome: "success",
+      detail: {
+        agent: { id: "agent-123", name: "Smithers" },
+        file: "MEMORY.md",
+        addedLines: 3,
+        removedLines: 1,
+        byteSize: 512,
+      },
+    };
+    expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>();
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/compute-diff.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/compute-diff.test.ts
@@ -1,0 +1,35 @@
+import { describe, it, expect } from "vitest";
+import { computeLineDiff } from "@/lib/memory-audit-watcher/compute-diff";
+
+describe("computeLineDiff", () => {
+  it("counts pure additions", () => {
+    expect(computeLineDiff("", "a\nb\n")).toEqual({ addedLines: 2, removedLines: 0 });
+  });
+
+  it("counts pure removals", () => {
+    expect(computeLineDiff("a\nb\n", "")).toEqual({ addedLines: 0, removedLines: 2 });
+  });
+
+  it("counts a single replaced line", () => {
+    expect(computeLineDiff("a\nb\nc\n", "a\nX\nc\n")).toEqual({
+      addedLines: 1,
+      removedLines: 1,
+    });
+  });
+
+  it("returns 0/0 for identical content", () => {
+    expect(computeLineDiff("a\nb\n", "a\nb\n")).toEqual({ addedLines: 0, removedLines: 0 });
+  });
+
+  it("treats duplicate lines as a multiset", () => {
+    // old has 'a' twice; new has 'a' once → one removed
+    expect(computeLineDiff("a\na\nb\n", "a\nb\n")).toEqual({
+      addedLines: 0,
+      removedLines: 1,
+    });
+  });
+
+  it("ignores a trailing newline difference", () => {
+    expect(computeLineDiff("a\nb", "a\nb\n")).toEqual({ addedLines: 0, removedLines: 0 });
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
@@ -4,11 +4,13 @@ import { handleMemoryFileEvent } from "@/lib/memory-audit-watcher/handle-event";
 describe("handleMemoryFileEvent", () => {
   const root = "/openclaw-config";
   let snapshots: Map<string, string>;
+  let inflight: Map<string, Promise<void>>;
   let mockAppend: ReturnType<typeof vi.fn>;
   let mockLookupAgent: ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
     snapshots = new Map();
+    inflight = new Map();
     mockAppend = vi.fn().mockResolvedValue(undefined);
     mockLookupAgent = vi.fn().mockResolvedValue({ id: "agent-1", name: "Smithers" });
   });
@@ -23,6 +25,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "ready",
@@ -56,6 +59,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "scanning",
@@ -76,6 +80,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "ready",
@@ -102,6 +107,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "ready",
@@ -126,6 +132,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "ready",
@@ -141,6 +148,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         readyState: "ready",
@@ -162,6 +170,7 @@ describe("handleMemoryFileEvent", () => {
       {
         root,
         snapshots,
+        inflight,
         lookupAgent: mockLookupAgent,
         appendAuditLog: mockAppend,
         recordAuditFailure: mockRecordFailure,
@@ -174,5 +183,89 @@ describe("handleMemoryFileEvent", () => {
         eventType: "agent.memory_changed",
       })
     );
+  });
+
+  it("rethrows when appendAuditLog throws and recordAuditFailure is not supplied", async () => {
+    const failure = new Error("DB unreachable");
+    mockAppend.mockRejectedValueOnce(failure);
+    await expect(
+      handleMemoryFileEvent(
+        {
+          kind: "add",
+          absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+          newContent: "hi\n",
+        },
+        {
+          root,
+          snapshots,
+          inflight,
+          lookupAgent: mockLookupAgent,
+          appendAuditLog: mockAppend,
+          readyState: "ready",
+        }
+      )
+    ).rejects.toThrow("DB unreachable");
+  });
+
+  it("serializes concurrent events for the same path (no TOCTOU on snapshots)", async () => {
+    // Build a deferred appendAuditLog: the first call returns a promise the test
+    // resolves manually so we can fire a second event while the first is still
+    // mid-flight. Subsequent calls resolve immediately.
+    let firstResolve: (() => void) | undefined;
+    const firstAppendPromise = new Promise<void>((resolve) => {
+      firstResolve = () => resolve();
+    });
+    mockAppend.mockImplementationOnce(() => firstAppendPromise).mockResolvedValue(undefined);
+
+    const absolutePath = "/openclaw-config/agents/agent-1/MEMORY.md";
+    // Seed: snapshot starts empty (file did not exist before).
+
+    const deps = {
+      root,
+      snapshots,
+      inflight,
+      lookupAgent: mockLookupAgent,
+      appendAuditLog: mockAppend,
+      readyState: "ready" as const,
+    };
+
+    // Fire two events back-to-back for the SAME path. Do not await the first.
+    const p1 = handleMemoryFileEvent({ kind: "change", absolutePath, newContent: "first\n" }, deps);
+    const p2 = handleMemoryFileEvent(
+      { kind: "change", absolutePath, newContent: "first\nsecond\n" },
+      deps
+    );
+
+    // Resolve the first append so the second invocation can proceed.
+    firstResolve!();
+    await Promise.all([p1, p2]);
+
+    // Both events must emit; nothing is swallowed.
+    expect(mockAppend).toHaveBeenCalledTimes(2);
+
+    // First call diff: baseline "" -> "first\n" => 1 added, 0 removed.
+    const firstCallEntry = mockAppend.mock.calls[0][0];
+    expect(firstCallEntry.detail).toMatchObject({
+      file: "MEMORY.md",
+      addedLines: 1,
+      removedLines: 0,
+    });
+
+    // Second call MUST see the first event's newContent as its baseline.
+    // baseline "first\n" -> "first\nsecond\n" => 1 added, 0 removed.
+    // (Without serialization the old code would diff "" -> "first\nsecond\n",
+    // producing addedLines: 2 — that's the bug we're fixing.)
+    const secondCallEntry = mockAppend.mock.calls[1][0];
+    expect(secondCallEntry.detail).toMatchObject({
+      file: "MEMORY.md",
+      addedLines: 1,
+      removedLines: 0,
+    });
+
+    // Final snapshot reflects the second event.
+    expect(snapshots.get(absolutePath)).toBe("first\nsecond\n");
+
+    // Inflight map is fully drained.
+    expect(inflight.has(absolutePath)).toBe(false);
   });
 });

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
@@ -1,0 +1,178 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { handleMemoryFileEvent } from "@/lib/memory-audit-watcher/handle-event";
+
+describe("handleMemoryFileEvent", () => {
+  const root = "/openclaw-config";
+  let snapshots: Map<string, string>;
+  let mockAppend: ReturnType<typeof vi.fn>;
+  let mockLookupAgent: ReturnType<typeof vi.fn>;
+
+  beforeEach(() => {
+    snapshots = new Map();
+    mockAppend = vi.fn().mockResolvedValue(undefined);
+    mockLookupAgent = vi.fn().mockResolvedValue({ id: "agent-1", name: "Smithers" });
+  });
+
+  it("emits audit on first change (file added post-ready)", async () => {
+    await handleMemoryFileEvent(
+      {
+        kind: "add",
+        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        newContent: "hello\n",
+      },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+
+    expect(mockAppend).toHaveBeenCalledWith({
+      actorType: "agent",
+      actorId: "agent-1",
+      eventType: "agent.memory_changed",
+      resource: "agent:agent-1",
+      outcome: "success",
+      detail: {
+        agent: { id: "agent-1", name: "Smithers" },
+        file: "MEMORY.md",
+        addedLines: 1,
+        removedLines: 0,
+        byteSize: 6,
+      },
+    });
+    expect(snapshots.get("/openclaw-config/agents/agent-1/MEMORY.md")).toBe("hello\n");
+  });
+
+  it("does NOT emit audit during initial scan (readyState='scanning')", async () => {
+    await handleMemoryFileEvent(
+      {
+        kind: "add",
+        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        newContent: "hello\n",
+      },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "scanning",
+      }
+    );
+    expect(mockAppend).not.toHaveBeenCalled();
+    expect(snapshots.get("/openclaw-config/agents/agent-1/MEMORY.md")).toBe("hello\n");
+  });
+
+  it("emits added+removed counts on modify", async () => {
+    snapshots.set("/openclaw-config/agents/agent-1/memory/foo.md", "a\nb\nc\n");
+    await handleMemoryFileEvent(
+      {
+        kind: "change",
+        absolutePath: "/openclaw-config/agents/agent-1/memory/foo.md",
+        newContent: "a\nX\nc\n",
+      },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+    expect(mockAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "agent.memory_changed",
+        resource: "agent:agent-1",
+        detail: expect.objectContaining({
+          file: "memory/foo.md",
+          addedLines: 1,
+          removedLines: 1,
+          byteSize: 6,
+        }),
+      })
+    );
+  });
+
+  it("emits a deletion (byteSize 0, removedLines = previous line count)", async () => {
+    snapshots.set("/openclaw-config/agents/agent-1/MEMORY.md", "a\nb\n");
+    await handleMemoryFileEvent(
+      { kind: "unlink", absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md" },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+    expect(mockAppend).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.objectContaining({
+          file: "MEMORY.md",
+          addedLines: 0,
+          removedLines: 2,
+          byteSize: 0,
+        }),
+      })
+    );
+    expect(snapshots.has("/openclaw-config/agents/agent-1/MEMORY.md")).toBe(false);
+  });
+
+  it("ignores paths outside agents/<id>/MEMORY.md|memory/", async () => {
+    await handleMemoryFileEvent(
+      { kind: "change", absolutePath: "/openclaw-config/openclaw.json", newContent: "{}" },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it("skips emission if agent is not found in DB (orphan file)", async () => {
+    mockLookupAgent.mockResolvedValueOnce(null);
+    await handleMemoryFileEvent(
+      { kind: "add", absolutePath: "/openclaw-config/agents/ghost/MEMORY.md", newContent: "x\n" },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+    expect(mockAppend).not.toHaveBeenCalled();
+  });
+
+  it("uses recordAuditFailure when appendAuditLog throws (does not rethrow)", async () => {
+    const failure = new Error("DB unreachable");
+    mockAppend.mockRejectedValueOnce(failure);
+    const mockRecordFailure = vi.fn();
+    await handleMemoryFileEvent(
+      {
+        kind: "add",
+        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        newContent: "hi\n",
+      },
+      {
+        root,
+        snapshots,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        recordAuditFailure: mockRecordFailure,
+        readyState: "ready",
+      }
+    );
+    expect(mockRecordFailure).toHaveBeenCalledWith(
+      failure,
+      expect.objectContaining({
+        eventType: "agent.memory_changed",
+      })
+    );
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/parse-path.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/parse-path.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { parseAgentMemoryPath } from "@/lib/memory-audit-watcher/parse-path";
+
+describe("parseAgentMemoryPath", () => {
+  const root = "/openclaw-config";
+
+  it("parses MEMORY.md at the agent root", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/MEMORY.md")).toEqual({
+      agentId: "abc-123",
+      file: "MEMORY.md",
+    });
+  });
+
+  it("parses files under memory/", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/memory/foo.md")).toEqual({
+      agentId: "abc-123",
+      file: "memory/foo.md",
+    });
+  });
+
+  it("parses nested files under memory/", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/memory/sub/bar.md")).toEqual(
+      {
+        agentId: "abc-123",
+        file: "memory/sub/bar.md",
+      }
+    );
+  });
+
+  it("returns null for paths outside agents/", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/openclaw.json")).toBeNull();
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc/other.md")).toBeNull();
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc/notes/foo.md")).toBeNull();
+  });
+
+  it("rejects paths above the root", () => {
+    expect(parseAgentMemoryPath(root, "/etc/passwd")).toBeNull();
+  });
+
+  it("rejects directories that look like agents/<id> but lack the file", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123")).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -81,3 +81,65 @@ describe("startMemoryAuditWatcher (integration)", () => {
     expect(appended).toHaveLength(0);
   });
 });
+
+describe("startMemoryAuditWatcher (handler error resilience)", () => {
+  // Separate describe block: we replace lookupAgent with a throwing one and
+  // need to verify the watcher survives without raising unhandledRejection.
+  let root: string;
+  let appended: Array<Record<string, unknown>>;
+  let stop: () => Promise<void>;
+  let unhandled: unknown[];
+  let unhandledHandler: (reason: unknown) => void;
+  let lookupShouldThrow: boolean;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-err-"));
+    mkdirSync(join(root, "agents", "agent-1", "memory"), { recursive: true });
+    appended = [];
+    unhandled = [];
+    lookupShouldThrow = true;
+
+    unhandledHandler = (reason) => {
+      unhandled.push(reason);
+    };
+    process.on("unhandledRejection", unhandledHandler);
+
+    stop = await startMemoryAuditWatcher({
+      root,
+      lookupAgent: async (id) => {
+        if (lookupShouldThrow) throw new Error("DB unreachable");
+        return id === "agent-1" ? { id, name: "Smithers" } : null;
+      },
+      appendAuditLog: async (entry) => {
+        appended.push(entry as Record<string, unknown>);
+      },
+      recordAuditFailure: vi.fn(),
+    });
+  });
+
+  afterEach(async () => {
+    process.off("unhandledRejection", unhandledHandler);
+    await stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not raise unhandledRejection when lookupAgent throws, and recovers on next event", async () => {
+    // Fire a write while lookup throws — the void-detached handler would
+    // surface an unhandledRejection without the watcher's catch wrapper.
+    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "first write\n", "utf8");
+    // Give chokidar + the handler time to fire and reject.
+    await wait(800);
+    expect(unhandled).toEqual([]);
+    expect(appended).toHaveLength(0); // lookup threw, no audit emitted
+
+    // Watcher must still be alive: fix lookup, write again, expect audit.
+    lookupShouldThrow = false;
+    writeFileSync(
+      join(root, "agents", "agent-1", "MEMORY.md"),
+      "first write\nsecond write\n",
+      "utf8"
+    );
+    await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+    expect(unhandled).toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -1,0 +1,83 @@
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { startMemoryAuditWatcher } from "@/lib/memory-audit-watcher";
+
+const wait = (ms: number) => new Promise((r) => setTimeout(r, ms));
+
+describe("startMemoryAuditWatcher (integration)", () => {
+  let root: string;
+  let appended: Array<Record<string, unknown>>;
+  let stop: () => Promise<void>;
+
+  beforeEach(async () => {
+    root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-"));
+    mkdirSync(join(root, "agents", "agent-1", "memory"), { recursive: true });
+    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\n", "utf8");
+    appended = [];
+
+    stop = await startMemoryAuditWatcher({
+      root,
+      lookupAgent: async (id) => (id === "agent-1" ? { id, name: "Smithers" } : null),
+      appendAuditLog: async (entry) => {
+        appended.push(entry as Record<string, unknown>);
+      },
+      recordAuditFailure: vi.fn(),
+    });
+  });
+
+  afterEach(async () => {
+    await stop();
+    rmSync(root, { recursive: true, force: true });
+  });
+
+  it("does not emit during initial scan", async () => {
+    // After the await-resolved startMemoryAuditWatcher, the initial scan has
+    // already completed. The pre-existing MEMORY.md should NOT have been
+    // audited.
+    expect(appended).toHaveLength(0);
+  });
+
+  it("emits when MEMORY.md is modified", async () => {
+    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\nadded line\n", "utf8");
+    // chokidar polls; give it a moment
+    await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+    expect(appended[0]).toMatchObject({
+      eventType: "agent.memory_changed",
+      resource: "agent:agent-1",
+      detail: { file: "MEMORY.md", addedLines: 1, removedLines: 0 },
+    });
+  });
+
+  it("emits when a new file is created under memory/", async () => {
+    writeFileSync(
+      join(root, "agents", "agent-1", "memory", "facts.md"),
+      "fact 1\nfact 2\n",
+      "utf8"
+    );
+    await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+    expect(appended[0]).toMatchObject({
+      detail: { file: "memory/facts.md", addedLines: 2, removedLines: 0 },
+    });
+  });
+
+  it("emits when a memory file is deleted", async () => {
+    const target = join(root, "agents", "agent-1", "memory", "fact.md");
+    writeFileSync(target, "x\ny\n", "utf8");
+    await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+    appended.length = 0;
+    rmSync(target);
+    await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 5000 });
+    expect(appended[0]).toMatchObject({
+      detail: { file: "memory/fact.md", removedLines: 2, byteSize: 0 },
+    });
+  });
+
+  it("ignores non-memory files in the agent directory", async () => {
+    writeFileSync(join(root, "agents", "agent-1", "openclaw.json"), "{}", "utf8");
+    writeFileSync(join(root, "agents", "agent-1", "notes.txt"), "x\n", "utf8");
+    await wait(500); // no audit expected; cannot waitFor a negative
+    expect(appended).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/server/memory-audit-boot.test.ts
+++ b/packages/web/src/__tests__/server/memory-audit-boot.test.ts
@@ -1,0 +1,26 @@
+import { describe, it, expect, vi } from "vitest";
+import { bootstrapMemoryAuditWatcher } from "@/lib/memory-audit-watcher/bootstrap";
+
+vi.mock("chokidar", () => ({
+  default: {
+    watch: () => {
+      const handlers: Record<string, (path: string) => void> = {};
+      return {
+        on(event: string, cb: (path: string) => void) {
+          handlers[event] = cb;
+          if (event === "ready") queueMicrotask(() => cb(""));
+          return this;
+        },
+        close: async () => {},
+      };
+    },
+  },
+}));
+
+describe("bootstrapMemoryAuditWatcher", () => {
+  it("returns a stop function", async () => {
+    const stop = await bootstrapMemoryAuditWatcher({ root: "/tmp/test-root-not-used" });
+    expect(typeof stop).toBe("function");
+    await stop();
+  });
+});

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -49,6 +49,7 @@ export type AuditEventType =
   | "channel.deleted"
   | "chat.retry_triggered"
   | "agent.model_unavailable"
+  | "agent.memory_changed"
   | "audit.exported"
   | "attachment.uploaded";
 
@@ -230,6 +231,16 @@ export type AuditLogEntry =
         providerError: string;
         ref?: string;
         httpStatus: number;
+      };
+    })
+  | (AuditLogBase & {
+      eventType: "agent.memory_changed";
+      detail: {
+        agent: { id: string; name: string };
+        file: string;
+        addedLines: number;
+        removedLines: number;
+        byteSize: number;
       };
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/memory-audit-watcher/bootstrap.ts
+++ b/packages/web/src/lib/memory-audit-watcher/bootstrap.ts
@@ -1,0 +1,35 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { agents } from "@/db/schema";
+import { appendAuditLog } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
+import { startMemoryAuditWatcher } from "./watcher";
+
+/**
+ * Wires the production-database `agents` lookup and the real audit-log
+ * writer/failure recorder into `startMemoryAuditWatcher`. Kept as a thin
+ * helper so `server.ts` doesn't need to import `@/db` at module scope —
+ * the lazy `await import("./src/lib/memory-audit-watcher")` from server boot
+ * defers DB-module evaluation until after `bootInits()` has completed.
+ */
+export async function bootstrapMemoryAuditWatcher(opts: {
+  root?: string;
+}): Promise<() => Promise<void>> {
+  const root = opts.root ?? process.env.OPENCLAW_DATA_PATH ?? "/openclaw-config";
+
+  const lookupAgent = async (agentId: string) => {
+    const rows = await db
+      .select({ id: agents.id, name: agents.name })
+      .from(agents)
+      .where(eq(agents.id, agentId))
+      .limit(1);
+    return rows[0] ?? null;
+  };
+
+  return startMemoryAuditWatcher({
+    root,
+    lookupAgent,
+    appendAuditLog,
+    recordAuditFailure,
+  });
+}

--- a/packages/web/src/lib/memory-audit-watcher/compute-diff.ts
+++ b/packages/web/src/lib/memory-audit-watcher/compute-diff.ts
@@ -1,0 +1,35 @@
+export type LineDiff = { addedLines: number; removedLines: number };
+
+function toLines(content: string): string[] {
+  if (content === "") return [];
+  const lines = content.split("\n");
+  if (lines.length > 0 && lines[lines.length - 1] === "") lines.pop();
+  return lines;
+}
+
+function multisetCount(lines: string[]): Map<string, number> {
+  const counts = new Map<string, number>();
+  for (const line of lines) {
+    counts.set(line, (counts.get(line) ?? 0) + 1);
+  }
+  return counts;
+}
+
+export function computeLineDiff(oldContent: string, newContent: string): LineDiff {
+  const oldCounts = multisetCount(toLines(oldContent));
+  const newCounts = multisetCount(toLines(newContent));
+
+  let addedLines = 0;
+  let removedLines = 0;
+
+  for (const [line, count] of newCounts) {
+    const oldCount = oldCounts.get(line) ?? 0;
+    if (count > oldCount) addedLines += count - oldCount;
+  }
+  for (const [line, count] of oldCounts) {
+    const newCount = newCounts.get(line) ?? 0;
+    if (count > newCount) removedLines += count - newCount;
+  }
+
+  return { addedLines, removedLines };
+}

--- a/packages/web/src/lib/memory-audit-watcher/handle-event.ts
+++ b/packages/web/src/lib/memory-audit-watcher/handle-event.ts
@@ -1,0 +1,72 @@
+import type { AuditLogEntry } from "@/lib/audit";
+import { computeLineDiff } from "./compute-diff";
+import { parseAgentMemoryPath } from "./parse-path";
+
+export type MemoryFileEvent =
+  | { kind: "add" | "change"; absolutePath: string; newContent: string }
+  | { kind: "unlink"; absolutePath: string };
+
+export type HandleMemoryEventDeps = {
+  root: string;
+  snapshots: Map<string, string>;
+  lookupAgent: (agentId: string) => Promise<{ id: string; name: string } | null>;
+  appendAuditLog: (entry: AuditLogEntry) => Promise<void>;
+  recordAuditFailure?: (err: unknown, entry: AuditLogEntry) => void;
+  readyState: "scanning" | "ready";
+};
+
+export async function handleMemoryFileEvent(
+  event: MemoryFileEvent,
+  deps: HandleMemoryEventDeps
+): Promise<void> {
+  const parsed = parseAgentMemoryPath(deps.root, event.absolutePath);
+  if (!parsed) return;
+
+  // During chokidar's initial scan we only populate the snapshot store; we never
+  // emit audit entries, because those files predate Pinchy's process lifecycle
+  // and are not state changes the user/agent just made.
+  if (deps.readyState === "scanning") {
+    if (event.kind !== "unlink") {
+      deps.snapshots.set(event.absolutePath, event.newContent);
+    }
+    return;
+  }
+
+  const agent = await deps.lookupAgent(parsed.agentId);
+  if (!agent) return;
+
+  const oldContent = deps.snapshots.get(event.absolutePath) ?? "";
+  const newContent = event.kind === "unlink" ? "" : event.newContent;
+  const { addedLines, removedLines } = computeLineDiff(oldContent, newContent);
+
+  const entry: AuditLogEntry = {
+    actorType: "agent",
+    actorId: agent.id,
+    eventType: "agent.memory_changed",
+    resource: `agent:${agent.id}`,
+    outcome: "success",
+    detail: {
+      agent: { id: agent.id, name: agent.name },
+      file: parsed.file,
+      addedLines,
+      removedLines,
+      byteSize: Buffer.byteLength(newContent, "utf8"),
+    },
+  };
+
+  try {
+    await deps.appendAuditLog(entry);
+  } catch (err) {
+    if (deps.recordAuditFailure) {
+      deps.recordAuditFailure(err, entry);
+    } else {
+      throw err;
+    }
+  }
+
+  if (event.kind === "unlink") {
+    deps.snapshots.delete(event.absolutePath);
+  } else {
+    deps.snapshots.set(event.absolutePath, event.newContent);
+  }
+}

--- a/packages/web/src/lib/memory-audit-watcher/handle-event.ts
+++ b/packages/web/src/lib/memory-audit-watcher/handle-event.ts
@@ -9,6 +9,11 @@ export type MemoryFileEvent =
 export type HandleMemoryEventDeps = {
   root: string;
   snapshots: Map<string, string>;
+  // Per-path promise queue. Serializes concurrent events for the SAME path so
+  // the snapshots Map cannot be read-then-written racily across two flushes
+  // (chokidar can fire `change` twice in quick succession during a compaction).
+  // Different paths still run concurrently because each path has its own entry.
+  inflight: Map<string, Promise<void>>;
   lookupAgent: (agentId: string) => Promise<{ id: string; name: string } | null>;
   appendAuditLog: (entry: AuditLogEntry) => Promise<void>;
   recordAuditFailure?: (err: unknown, entry: AuditLogEntry) => void;
@@ -22,6 +27,32 @@ export async function handleMemoryFileEvent(
   const parsed = parseAgentMemoryPath(deps.root, event.absolutePath);
   if (!parsed) return;
 
+  // Chain onto whatever is currently in flight for this path (if anything),
+  // then store the new work. The chain ensures `doHandle` for the second event
+  // doesn't read `snapshots` until the first event has written to it.
+  const prev = deps.inflight.get(event.absolutePath) ?? Promise.resolve();
+  const work: Promise<void> = prev
+    .catch(() => {
+      // Swallow prior errors here so this invocation still runs. The prior
+      // invocation already surfaced its error to its own caller.
+    })
+    .then(() => doHandle(event, parsed, deps))
+    .finally(() => {
+      // Only delete if our promise is still the head — otherwise a newer event
+      // has chained on us and owns the slot now.
+      if (deps.inflight.get(event.absolutePath) === work) {
+        deps.inflight.delete(event.absolutePath);
+      }
+    });
+  deps.inflight.set(event.absolutePath, work);
+  return work;
+}
+
+async function doHandle(
+  event: MemoryFileEvent,
+  parsed: { agentId: string; file: string },
+  deps: HandleMemoryEventDeps
+): Promise<void> {
   // During chokidar's initial scan we only populate the snapshot store; we never
   // emit audit entries, because those files predate Pinchy's process lifecycle
   // and are not state changes the user/agent just made.
@@ -33,7 +64,14 @@ export async function handleMemoryFileEvent(
   }
 
   const agent = await deps.lookupAgent(parsed.agentId);
-  if (!agent) return;
+  if (!agent) {
+    // Orphan file: the agent has no DB row (e.g. it was deleted but its memory
+    // directory was not). Skip BOTH the audit (we have no agent name to snapshot)
+    // AND the snapshot store (don't grow unbounded with files we'll never audit).
+    // If the agent row is re-created later, the next write looks like a fresh
+    // `add` against an empty snapshot — correct behavior.
+    return;
+  }
 
   const oldContent = deps.snapshots.get(event.absolutePath) ?? "";
   const newContent = event.kind === "unlink" ? "" : event.newContent;
@@ -50,6 +88,7 @@ export async function handleMemoryFileEvent(
       file: parsed.file,
       addedLines,
       removedLines,
+      // For kind: "unlink" we set newContent = "" above, so byteSize === 0.
       byteSize: Buffer.byteLength(newContent, "utf8"),
     },
   };

--- a/packages/web/src/lib/memory-audit-watcher/index.ts
+++ b/packages/web/src/lib/memory-audit-watcher/index.ts
@@ -1,2 +1,3 @@
 export { startMemoryAuditWatcher } from "./watcher";
 export type { MemoryAuditWatcherDeps } from "./watcher";
+export { bootstrapMemoryAuditWatcher } from "./bootstrap";

--- a/packages/web/src/lib/memory-audit-watcher/index.ts
+++ b/packages/web/src/lib/memory-audit-watcher/index.ts
@@ -1,0 +1,2 @@
+export { startMemoryAuditWatcher } from "./watcher";
+export type { MemoryAuditWatcherDeps } from "./watcher";

--- a/packages/web/src/lib/memory-audit-watcher/parse-path.ts
+++ b/packages/web/src/lib/memory-audit-watcher/parse-path.ts
@@ -1,0 +1,27 @@
+import path from "node:path";
+
+export type ParsedMemoryPath = { agentId: string; file: string };
+
+export function parseAgentMemoryPath(root: string, absolutePath: string): ParsedMemoryPath | null {
+  const normalizedRoot = path.resolve(root);
+  const normalizedPath = path.resolve(absolutePath);
+  const rel = path.relative(normalizedRoot, normalizedPath);
+  if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
+
+  const parts = rel.split(path.sep);
+  if (parts.length < 3) return null;
+  if (parts[0] !== "agents") return null;
+
+  const agentId = parts[1];
+  const rest = parts.slice(2);
+
+  if (rest.length === 1 && rest[0] === "MEMORY.md") {
+    return { agentId, file: "MEMORY.md" };
+  }
+  if (rest[0] === "memory" && rest.length >= 2) {
+    const lastPart = rest[rest.length - 1];
+    if (!lastPart.endsWith(".md")) return null;
+    return { agentId, file: rest.join("/") };
+  }
+  return null;
+}

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -1,0 +1,124 @@
+import chokidar from "chokidar";
+import { readFile } from "node:fs/promises";
+import path from "node:path";
+import type { Stats } from "node:fs";
+import type { AuditLogEntry } from "@/lib/audit";
+import { handleMemoryFileEvent } from "./handle-event";
+import { parseAgentMemoryPath } from "./parse-path";
+
+export type MemoryAuditWatcherDeps = {
+  root: string;
+  lookupAgent: (agentId: string) => Promise<{ id: string; name: string } | null>;
+  appendAuditLog: (entry: AuditLogEntry) => Promise<void>;
+  recordAuditFailure: (err: unknown, entry: AuditLogEntry) => void;
+};
+
+/**
+ * Watches `<root>/agents/*\/MEMORY.md` and `<root>/agents/*\/memory/**\/*.md`
+ * and routes filesystem events into `handleMemoryFileEvent`.
+ *
+ * Chokidar 5 dropped glob support, so we watch the parent `agents/` directory
+ * recursively and use an `ignored` matcher backed by `parseAgentMemoryPath`
+ * to filter to memory files only. This keeps the path-shape rules in a single
+ * tested module.
+ */
+export async function startMemoryAuditWatcher(
+  deps: MemoryAuditWatcherDeps
+): Promise<() => Promise<void>> {
+  const snapshots = new Map<string, string>();
+  const inflight = new Map<string, Promise<void>>();
+  // Captured by the wrapper objects below; chokidar's add/change/unlink
+  // listeners read the latest value at event dispatch time, so the
+  // "scanning" → "ready" transition flips correctly between the initial
+  // crawl and steady-state events.
+  let readyState: "scanning" | "ready" = "scanning";
+
+  const agentsRoot = path.join(deps.root, "agents");
+
+  const watcher = chokidar.watch(agentsRoot, {
+    ignoreInitial: false,
+    persistent: true,
+    // Wait for writes to settle before firing add/change — prevents emitting
+    // on partial writes during editor saves or atomic-replace flows.
+    awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },
+    // Filter to memory files only. The matcher fires for both directories
+    // (no stats arg in some chokidar paths) and files (stats present). Return
+    // `true` to ignore. We never ignore directories — they need to be walked
+    // so we discover nested files under memory/. For files, we ignore unless
+    // `parseAgentMemoryPath` recognizes the shape.
+    ignored: (filePath: string, stats?: Stats) => {
+      // No stats yet: chokidar is about to stat. Don't pre-ignore — let it
+      // descend so it can discover memory files.
+      if (!stats) return false;
+      if (stats.isDirectory()) return false;
+      // Only files reach here: ignore unless they parse as a memory path.
+      return parseAgentMemoryPath(deps.root, filePath) === null;
+    },
+  });
+
+  const handlerDepsBase = {
+    root: deps.root,
+    snapshots,
+    inflight,
+    lookupAgent: deps.lookupAgent,
+    appendAuditLog: deps.appendAuditLog,
+    recordAuditFailure: deps.recordAuditFailure,
+  };
+
+  // IMPORTANT: capture `readyState` synchronously at the moment chokidar
+  // dispatches the event, NOT at the moment the async handler runs.
+  // Otherwise initial-scan `add` events whose async work is detached via
+  // `void` can outlive the `ready` emit, leak past the snapshotting phase,
+  // and emit spurious audits for files that already existed at startup.
+  const onFileEvent = async (
+    kind: "add" | "change",
+    absolutePath: string,
+    capturedReadyState: "scanning" | "ready"
+  ) => {
+    let newContent: string;
+    try {
+      newContent = await readFile(absolutePath, "utf8");
+    } catch (err) {
+      // File disappeared between event and read — let a subsequent unlink
+      // event drive the audit. Log at warn level so operators can see it
+      // without it being treated as a hard failure.
+      console.warn(
+        JSON.stringify({
+          level: "warn",
+          event: "memory_audit_read_failed",
+          path: absolutePath,
+          error: err instanceof Error ? err.message : String(err),
+        })
+      );
+      return;
+    }
+    await handleMemoryFileEvent(
+      { kind, absolutePath, newContent },
+      { ...handlerDepsBase, readyState: capturedReadyState }
+    );
+  };
+
+  watcher.on("add", (p) => {
+    void onFileEvent("add", p, readyState);
+  });
+  watcher.on("change", (p) => {
+    void onFileEvent("change", p, readyState);
+  });
+  watcher.on("unlink", (p) => {
+    void handleMemoryFileEvent(
+      { kind: "unlink", absolutePath: p },
+      { ...handlerDepsBase, readyState }
+    );
+  });
+
+  await new Promise<void>((resolve) => {
+    watcher.on("ready", () => {
+      readyState = "ready";
+      resolve();
+    });
+  });
+
+  return async () => {
+    await watcher.close();
+  };
+}

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -98,17 +98,34 @@ export async function startMemoryAuditWatcher(
     );
   };
 
+  // We detach handler invocations from the chokidar event loop with `.catch`
+  // wrappers. Without them, any uncaught rejection (e.g. lookupAgent throws
+  // because the DB is momentarily down) becomes an unhandledRejection and
+  // can crash the host process under Node's --unhandled-rejections=strict
+  // mode. Catch and log so the watcher stays up — the alternative would be
+  // losing all future memory-audit coverage after a single transient blip.
+  const logWatcherError = (err: unknown, absolutePath: string) => {
+    console.error(
+      JSON.stringify({
+        level: "error",
+        event: "memory_audit_watcher_handler_failed",
+        path: absolutePath,
+        error: err instanceof Error ? err.message : String(err),
+      })
+    );
+  };
+
   watcher.on("add", (p) => {
-    void onFileEvent("add", p, readyState);
+    onFileEvent("add", p, readyState).catch((err) => logWatcherError(err, p));
   });
   watcher.on("change", (p) => {
-    void onFileEvent("change", p, readyState);
+    onFileEvent("change", p, readyState).catch((err) => logWatcherError(err, p));
   });
   watcher.on("unlink", (p) => {
-    void handleMemoryFileEvent(
+    handleMemoryFileEvent(
       { kind: "unlink", absolutePath: p },
       { ...handlerDepsBase, readyState }
-    );
+    ).catch((err) => logWatcherError(err, p));
   });
 
   await new Promise<void>((resolve) => {

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -38,6 +38,16 @@ export async function startMemoryAuditWatcher(
   const watcher = chokidar.watch(agentsRoot, {
     ignoreInitial: false,
     persistent: true,
+    // Polling rather than fs.watch / fsevents. The watch root is typically a
+    // Docker bind-mounted directory (production `/openclaw-config`, integration
+    // `/tmp/pinchy-integration-openclaw`). Native fs.watch on macOS does not
+    // reliably propagate events for files created from inside a container into
+    // host watchers, so a dir created by OpenClaw is silently missed and any
+    // later host-side write to that dir never fires either. Polling every
+    // 250 ms is well within budget for a watch tree of a few dozen agents and
+    // makes the watcher behave identically across all host/container setups.
+    usePolling: true,
+    interval: 250,
     // Wait for writes to settle before firing add/change — prevents emitting
     // on partial writes during editor saves or atomic-replace flows.
     awaitWriteFinish: { stabilityThreshold: 200, pollInterval: 50 },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -69,6 +69,9 @@ importers:
       browser-image-compression:
         specifier: ^2.0.2
         version: 2.0.2
+      chokidar:
+        specifier: ^5.0.0
+        version: 5.0.0
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1


### PR DESCRIPTION
## Summary

Closes #345.

Adds a chokidar-based filesystem watcher in the Pinchy Next.js server that emits an `agent.memory_changed` audit entry whenever OpenClaw writes to a per-agent memory file (`~/.openclaw/agents/<agentId>/MEMORY.md` or `~/.openclaw/agents/<agentId>/memory/*.md`).

OpenClaw's durable per-agent memory shapes the agent's behavior in every future session — both explicit "remember X" turns and the silent pre-compaction memory flush. Until now, those writes were invisible to Pinchy's audit trail. A CISO reviewing "the agent suddenly believes X — when and how did that get into its memory?" now has a traceable answer.

### Audit shape

- `eventType`: `agent.memory_changed`
- `actorType`: `agent` / `actorId`: agent id
- `resource`: `agent:<agentId>`
- `detail`:
  - `agent`: `{ id, name }` snapshot
  - `file`: relative path (`"MEMORY.md"` or `"memory/<file>.md"`)
  - `addedLines`, `removedLines`: multiset line-count diff vs prior snapshot
  - `byteSize`: file size after the change (0 for deletions)

Detail never contains file contents — only counts and the relative filename. Well under the 2048-byte audit-detail cap.

### Architecture

- `parseAgentMemoryPath` + `computeLineDiff` — pure helpers, isolated unit tests.
- `handleMemoryFileEvent` — orchestrator (DI for snapshots / lookup / audit), per-path serialization to avoid TOCTOU on concurrent writes.
- `startMemoryAuditWatcher` — chokidar wiring with `awaitWriteFinish` (settle partial writes) and `usePolling: true` (so the watcher behaves identically across host/container setups on Linux and macOS).
- `bootstrapMemoryAuditWatcher` — thin DB-aware factory.
- Wired into `server.ts` after `bootInits()` resolves, with a shutdown handler. Errors during watcher boot are logged but never fatal — this watcher is non-critical to Pinchy's operation.
- Detached handler invocations are wrapped in `.catch()` so transient DB blips don't kill the host process under `--unhandled-rejections=strict`.

### Out of scope

- A UI surface for viewing/editing memory files.
- Auditing the SQLite reindex (downstream of the same writes).
- Upstream OpenClaw `memory.changed` event subscription — when that ships, this watcher can be deleted.

## Test plan

- [x] Unit tests for `parseAgentMemoryPath` (6 cases)
- [x] Unit tests for `computeLineDiff` (6 cases)
- [x] Unit tests for `handleMemoryFileEvent` (9 cases including TOCTOU + rethrow + orphan)
- [x] Integration tests for `startMemoryAuditWatcher` against real `tmpdir` (6 cases including unhandled-rejection resilience)
- [x] Boot test for `bootstrapMemoryAuditWatcher` (chokidar mocked)
- [x] E2E integration spec — writes MEMORY.md inside the Pinchy container via `docker exec`, polls `/api/audit?eventType=agent.memory_changed`, asserts full detail
- [x] Full `pnpm test` suite (4438 passing, 12 skipped, 0 failing)
- [x] `tsc --noEmit` clean
- [x] Docs updated at `docs/src/content/docs/concepts/audit-trail.mdx`