### PR TITLE
docs(v0.5.4): finalise pre-release notes and CHANGELOG pointer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,27 +1,6 @@
 # Changelog
 
-All notable changes to this project will be documented in this file.
+Pinchy release notes live in two places:
 
-The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/).
-
-## [Unreleased]
-
-### Added
-
-- **Startup warning when Domain Lock is configured but `BETTER_AUTH_URL` is unset.** Better Auth's own `baseURL` detection does not read Pinchy's Domain Lock value (verified on staging v0.5.4 — Better Auth still logged `Base URL could not be determined`). A Domain-Locked deployment without `BETTER_AUTH_URL` silently sends password-reset and email-verification links pointing at the wrong host. Pinchy now logs `⚠ Domain Lock is configured (<domain>) but BETTER_AUTH_URL is unset…` on every startup of such a deployment, with the exact env-var assignment to copy-paste. The existing `BETTER_AUTH_URL is set` warning is retained, but is now emitted after `bootInits()` so both arms share a single call site. (#352)
-
-### Fixed
-
-- **Pinchy-Odoo: `odoo_read`, `odoo_count`, `odoo_aggregate` now accepted by OpenAI's strict function-calling validator.** The `filters` parameter schema declared a nested array (`type: "array"` of `type: "array"`) without an inner `items` definition. OpenAI rejected the request with `400 Invalid schema for function 'odoo_aggregate': In context=('properties','filters','items'), array schema missing items.`, surfaced in the UI as `OpenClaw error chunk: LLM request failed: provider rejected the request schema or tool payload`. Anthropic and Ollama accept the looser schema, so the regression was invisible on those providers. A new drift-guard test (`openai-schema-compat`) walks every Pinchy-Odoo tool schema and fails the build if any `type: array` is missing `items`.
-
-### Breaking Changes
-
-- **Pinchy-Odoo: opaque self-refs on every record.** `odoo_create` now returns `{id, _pinchy_ref}` (was `{id}`), and every record from `odoo_read` gains a `_pinchy_ref` field. Read-write operator templates (Bookkeeper, Warehouse Operator, HR Operator, Project Manager, Production Operator, Approval Manager) can now chain `odoo_create` → `odoo_attach_file` directly: pass the returned `_pinchy_ref` as `targetRef`. The previous behaviour — `odoo_create` returning only a raw integer `id` with no path for the LLM to obtain a valid encrypted ref — made `odoo_attach_file` unreachable in fresh-create flows. The field is named `_pinchy_ref` (not `ref`) to avoid shadowing Odoo's own `ref` field on `account.move` / `account.payment` etc. Old downstream tools that accept raw `ids` (`odoo_write`, `odoo_delete`, etc.) are unchanged.
-
-- **Pinchy-Odoo: read-write operator templates now request all foreign-key lookup models they need.** Bookkeeper-style agents previously could not enumerate `account.account` (chart of accounts) when posting bills, because the template only listed write targets (`account.move`, `account.move.line`) and not the read-only models referenced by their foreign keys (`account_id`, `currency_id`, …). Same fix applied to CRM Assistant, Procurement Agent, Project Manager, Production Operator and Approval Manager. The Odoo sync probe list now also includes `res.users` so manager assignments work without a manual "Add model" step. A new drift-guard test (`agent-templates-fk-deps`) keeps the requiredModels list in sync with realistic FK dependencies for future template changes. Existing Odoo connections need a re-sync (Settings → Integrations → Odoo → ⋯ → Sync now) to pick up the new models.
-
-- **Pinchy-Odoo: integration-ref encryption key now auto-provisioned through pinchy-web.** Before %%PINCHY_VERSION%%, `odoo_attach_file` and related write tools could fail with "Invalid integration reference" on freshly upgraded deployments because the `PINCHY_REF_TOKEN_KEY` env var was not set and the in-container `/app/secrets` fallback directory didn't exist in the OpenClaw image. pinchy-web now generates a key on first `regenerateOpenClawConfig()` call, persists it in the settings DB (alongside `openclaw_gateway_token`), and materialises it into the shared `secrets.json` bundle so the OC-side `pinchy-odoo` plugin can read it. No customer action required; the key is created automatically on the next pinchy startup after upgrade. Setting `PINCHY_REF_TOKEN_KEY` as an env-var override is still respected for dev/test.
-
-- **Pinchy-Odoo `odoo_schema` tool replaced.** Splits into `odoo_list_models` (lists permitted models — cheap discovery) and `odoo_describe_model` (compact-by-default field schema with optional `fields` filter, `limit`, and `verbose` parameters). Existing agents are auto-migrated on next startup: any agent with `odoo_schema` in its allowed-tools list gets `odoo_list_models` + `odoo_describe_model` instead. Reduces typical schema-call context cost by ~90 % and unblocks Bookkeeper-style flows on response-format-sensitive models (`ollama-cloud/gemini-3-flash-preview`). The old `odoo_schema` tool name is kept as a deprecated alias so existing `AGENTS.md` files that reference it (Bookkeeper, HR Operator, Warehouse Operator, etc. created before v0.5.4) keep working — calls through the alias now use the compact format too. The alias is slated for removal in v0.6.x.
-
-- chat: Open chats keep running in the background while you navigate within Pinchy. A pulse dot in the sidebar shows active agents; a red dot indicates an error on the last turn. (#199)
+- **[Upgrading guide](https://docs.heypinchy.com/guides/upgrading/)** — canonical per-version breaking changes and upgrade instructions.
+- **[GitHub Releases](https://github.com/heypinchy/pinchy/releases)** — full release notes (auto-generated, prepended with the upgrading-guide section for that version).

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -98,15 +98,23 @@ Pinchy watches these files and emits an audit entry on every change so an audito
 
 The detail never contains file contents — only counts and the relative filename. Deletions surface as `byteSize: 0` and `removedLines` equal to the previous line count.
 
+### Chat runtime
+
+| Event Type                      | Description                                                                                                                                                                                                                                                                                                                                               |
+| ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `chat.background_run_completed` | A chat run finished after the user navigated away from the chat page (a "background run"). Detail records `agent.{id,name}` and the run's wall-clock `durationMs`. Used together with the sidebar pulse dot for the per-agent background-runtime feature.                                                                                                 |
+| `chat.silent_stream`            | A streaming run ended without producing any assistant text — typically a cold-path tool call that timed out inside OpenClaw's embedded layer. Throttled per `(agent, model)` so a degraded provider can't flood the log via user retries. Detail captures `agent.{id,name}`, `model`, the originating `providerError`, and `reason: "silent_stream_end"`. |
+
 ### User management
 
-| Event Type            | Description                                     |
-| --------------------- | ----------------------------------------------- |
-| `user.invited`        | An admin invited a new user                     |
-| `user.updated`        | A user's profile was changed                    |
-| `user.role_updated`   | A user's role was changed (e.g. member → admin) |
-| `user.groups_updated` | A user's group memberships were changed         |
-| `user.deleted`        | A user account was deleted                      |
+| Event Type            | Description                                                                                                                                                                                                                                        |
+| --------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `user.invited`        | An admin invited a new user                                                                                                                                                                                                                        |
+| `user.invite_blocked` | An admin attempted to invite a user but the action was refused by a licence/seat-cap guard. Detail records the (redacted) `email`, the chosen `role`, the `reason` (e.g. `seat_cap`), and the relevant licence counters (`seatsUsed`, `maxUsers`). |
+| `user.updated`        | A user's profile was changed                                                                                                                                                                                                                       |
+| `user.role_updated`   | A user's role was changed (e.g. member → admin)                                                                                                                                                                                                    |
+| `user.groups_updated` | A user's group memberships were changed                                                                                                                                                                                                            |
+| `user.deleted`        | A user account was deleted                                                                                                                                                                                                                         |
 
 ### Group management
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -219,6 +219,16 @@ Every read-write Odoo operator template now declares the `vision` capability in 
 
 When an Odoo tool returns a record, related-record references are now emitted as opaque, encrypted tokens (`pinchy_ref:v1:…`) rather than raw `(id, label)` tuples. The pinchy-odoo plugin transparently resolves these tokens on subsequent calls, so an agent can no longer fabricate or substitute a numeric ID it never saw. Existing agents pick up the new behavior automatically; no configuration change is required.
 
+#### Self-refs on `odoo_create` and `odoo_read` (`_pinchy_ref`)
+
+Every record the plugin returns now carries a `_pinchy_ref` field — an opaque, encrypted token that identifies the record itself (alongside the raw integer `id`). `odoo_create` returns `{id, _pinchy_ref}` instead of just `{id}`, and every record returned by `odoo_read` carries one.
+
+This closes a release-blocker gap surfaced on staging in late v0.5.3 testing: the `odoo_attach_file` tool only accepts opaque references for `targetRef`, but `odoo_create`'s old `{id}`-only response left agents no path to a valid token for a record they had just created. They would fabricate strings like `"account.move,37"`, which the plugin correctly rejected with `"Invalid integration reference"` — making `odoo_create` → `odoo_attach_file` chains (the entire Bookkeeper "book this bill and attach the PDF" flow) effectively unreachable.
+
+The field is named `_pinchy_ref` rather than `ref` to avoid shadowing Odoo's own `ref` field, which exists on `account.move`, `account.payment`, and others as a string holding payment-reference identifiers (`"INV/2026/0001"` etc.). The underscore prefix signals "Pinchy-added, not Odoo data" so the LLM's view of actual Odoo records stays lossless.
+
+Tools that already accept raw integer IDs (`odoo_write`, `odoo_delete`) are unchanged. Existing agents pick up the new behavior automatically; the operator-template `AGENTS.md` files have been updated to teach agents about the `_pinchy_ref` field, so old agents continue to work via the shared instruction shipped in their template prompt.
+
 #### Odoo file attachment (new `odoo_attach_file` tool)
 
 Read-write Odoo operator templates can now attach uploaded files to Odoo records as `ir.attachment`. The Bookkeeper template uses this to link receipt images to the corresponding vendor bill; the Warehouse Operator can attach delivery notes to pickings; the HR Operator can attach medical certificates to leave requests; and so on for the Project Manager, Production Operator, and Approval Manager.
@@ -239,7 +249,7 @@ Open chats keep running in the background while you navigate within Pinchy — a
 - **Dead-key composer freeze.** Typing characters that involve dead keys (e.g. `^` + `e` → `ê`) no longer desyncs the composer input.
 - **Payload rejection visibility.** When OpenClaw rejects a payload mid-stream, the chat now surfaces a clear error status instead of leaving the spinner running.
 - **Silent stream-end retry.** A run that finishes without producing any assistant text — typically a cold-path tool call that timed out inside OpenClaw's embedded layer — now shows the standard error bubble with a **Retry** button instead of an indistinguishable "successful empty reply". Each occurrence writes a throttled `chat.silent_stream` audit entry so admins get an operational signal.
-- **Gemini 3 `thought_signature` errors are now named and explained.** When the upstream provider drops Gemini 3's required `thought_signature` field on a tool-call replay turn (upstream `openclaw/openclaw#72879` — fixed in OpenClaw 2026.5.18 for the native Google path, still open for OpenAI-compat in `openclaw/openclaw#34008`), Pinchy now shows a dedicated **transient upstream issue bubble** that names the cause and tells the user that **Retry usually clears it on the next try**. The bubble deliberately offers no "Switch model" link — the model is fine. Each occurrence writes a throttled `agent.upstream_format_error` audit entry so admins can track frequency from the audit page rather than grepping gateway logs. ([#338](https://github.com/heypinchy/pinchy/issues/338))
+- **Gemini 3 `thought_signature` errors are now named and explained.** When the upstream provider drops Gemini 3's required `thought_signature` field on a tool-call replay turn (upstream `openclaw/openclaw#72879`), Pinchy now shows a dedicated **transient upstream issue bubble** that names the cause and tells the user that **Retry usually clears it on the next try**. The bubble deliberately offers no "Switch model" link — the model is fine. Each occurrence writes a throttled `agent.upstream_format_error` audit entry so admins can track frequency from the audit page rather than grepping gateway logs. The upstream fix for the native Google path lands in OpenClaw 2026.5.18; %%PINCHY_VERSION%% is still pinned at 2026.5.7 and ships with the transient-issue bubble as the user-facing mitigation. The OpenClaw bump is scheduled for the next Pinchy release. ([#338](https://github.com/heypinchy/pinchy/issues/338))
 
 #### Permissions tab no longer reports false-positive dirty state
 
@@ -251,10 +261,17 @@ You can now confirm which Pinchy and OpenClaw versions are actually running with
 
 The upgrading guide's "Verify" step is updated to use `/api/version` instead of opening `http://localhost:7777` directly — the old instruction returned 403 on Domain-Lock-enabled deployments.
 
+#### Startup warning when Domain Lock is set but `BETTER_AUTH_URL` is unset
+
+Better Auth's own `baseURL` autodetection does not read Pinchy's Domain Lock value (verified on a staging v0.5.4 install where Better Auth still logged `Base URL could not be determined`). On a Domain-Locked deployment, that gap silently sends password-reset and email-verification links pointing at the wrong host.
+
+Pinchy now logs a clear `⚠ Domain Lock is configured (<your-domain>) but BETTER_AUTH_URL is unset…` warning on every startup of such a deployment, with the exact env-var assignment to copy-paste into your `.env`. The existing `BETTER_AUTH_URL is set` line is retained for the positive case. If you are running with Domain Lock today, check your pinchy container logs after this upgrade and add `BETTER_AUTH_URL=https://<your-domain>` to `/opt/pinchy/.env` if the warning appears. ([#352](https://github.com/heypinchy/pinchy/issues/352))
+
 #### Runtime and dependency updates
 
-- **OpenClaw 2026.5.7** (was 2026.5.3) — picked up via `Dockerfile.openclaw` and the bundled `openclaw-node 0.8.0`.
+- **OpenClaw 2026.5.7** (was 2026.5.3) — picked up via `Dockerfile.openclaw` and the bundled `openclaw-node 0.9.0`.
 - **Next.js 16.2.6** (was 16.2.4) — addresses [GHSA-wfc6-r584-vfw7](https://github.com/advisories/GHSA-wfc6-r584-vfw7) and [GHSA-26hh-7cqf-hhc6](https://github.com/advisories/GHSA-26hh-7cqf-hhc6).
+- **`ws` 8.20.1** (was 8.20.0) — addresses [GHSA-58qx-3vcg-4xpx](https://github.com/advisories/GHSA-58qx-3vcg-4xpx) (uninitialized memory disclosure).
 
 ## Upgrading from v0.5.2 to v0.5.3
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2991,8 +2991,8 @@ packages:
   '@types/node@25.6.0':
     resolution: {integrity: sha512-+qIYRKdNYJwY3vRCZMdJbPLJAtGjQBudzZzdzwQYkEPQd+PJGixUL5QfvCLDaULoLv+RhT3LDkwEfKaAkgSmNQ==}
 
-  '@types/node@25.7.0':
-    resolution: {integrity: sha512-z+pdZyxE+RTQE9AcboAZCb4otwcrvgHD+GlBpPgn0emDVt0ohrTMhAwlr2Wd9nZ+nihhYFxO2pThz3C5qSu2Eg==}
+  '@types/node@25.9.1':
+    resolution: {integrity: sha512-xfrlY7UD5rMJk3ZVJP8BNzS28J36YJg+xp+LPXV1TdWxr8uMH5A860QNxYDGQe/ylDSgjxE52Q9VnO7p75tJxg==}
 
   '@types/pdfkit@0.17.6':
     resolution: {integrity: sha512-tIwzxk2uWKp0Cq9JIluQXJid77lYhF52EsIOwhsMF4iWLA6YneoBR1xVKYYdAysHuepUB0OX4tdwMiUDdGKmig==}
@@ -6670,8 +6670,8 @@ packages:
   undici-types@7.19.2:
     resolution: {integrity: sha512-qYVnV5OEm2AW8cJMCpdV20CDyaN3g0AjDlOGf1OW4iaDEx8MwdtChUp4zu4H0VP3nDRF/8RKWH+IPp9uW0YGZg==}
 
-  undici-types@7.21.0:
-    resolution: {integrity: sha512-w9IMgQrz4O0YN1LtB7K5P63vhlIOvC7opSmouCJ+ZywlPAlO9gIkJ+otk6LvGpAs2wg4econaCz3TvQ9xPoyuQ==}
+  undici-types@7.24.6:
+    resolution: {integrity: sha512-WRNW+sJgj5OBN4/0JpHFqtqzhpbnV0GuB+OozA9gCL7a993SmU+1JBZCzLNxYsbMfIeDL+lTsphD5jN5N+n0zg==}
 
   undici@7.25.0:
     resolution: {integrity: sha512-xXnp4kTyor2Zq+J1FfPI6Eq3ew5h6Vl0F/8d9XU5zZQf1tX9s2Su1/3PiMmUANFULpmksxkClamIZcaUqryHsQ==}
@@ -10133,7 +10133,7 @@ snapshots:
   '@types/body-parser@1.19.6':
     dependencies:
       '@types/connect': 3.4.38
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/chai@5.2.3':
     dependencies:
@@ -10142,7 +10142,7 @@ snapshots:
 
   '@types/connect@3.4.38':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/d3-array@3.2.2': {}
 
@@ -10182,7 +10182,7 @@ snapshots:
 
   '@types/express-serve-static-core@5.1.1':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
       '@types/qs': 6.15.1
       '@types/range-parser': 1.2.7
       '@types/send': 1.2.1
@@ -10220,9 +10220,9 @@ snapshots:
     dependencies:
       undici-types: 7.19.2
 
-  '@types/node@25.7.0':
+  '@types/node@25.9.1':
     dependencies:
-      undici-types: 7.21.0
+      undici-types: 7.24.6
 
   '@types/pdfkit@0.17.6':
     dependencies:
@@ -10246,12 +10246,12 @@ snapshots:
 
   '@types/send@1.2.1':
     dependencies:
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/serve-static@2.2.0':
     dependencies:
       '@types/http-errors': 2.0.5
-      '@types/node': 25.7.0
+      '@types/node': 25.9.1
 
   '@types/unist@2.0.11': {}
 
@@ -14499,7 +14499,7 @@ snapshots:
 
   undici-types@7.19.2: {}
 
-  undici-types@7.21.0: {}
+  undici-types@7.24.6: {}
 
   undici@7.25.0: {}
 


### PR DESCRIPTION
## Summary

Pre-release polish for v0.5.4. Five doc gaps + one transitive-dep bump.

### Docs
- **`upgrading.mdx`: correct OpenClaw 2026.5.18 claim** — the thought_signature upstream fix lands in 5.18 but v0.5.4 still pins 5.7. The v0.5.4 user-facing mitigation (transient-issue bubble + audit signal) is what ships; OC bump is scheduled for v0.5.5.
- **`upgrading.mdx`: add dedicated `_pinchy_ref` subsection** — the self-ref field on `odoo_create` / `odoo_read` is the v0.5.4 release-blocker fix. Spelling it out so admins know about the new response shape and Customer-Agents know what to chain into `odoo_attach_file.targetRef`.
- **`upgrading.mdx`: add Domain Lock + `BETTER_AUTH_URL` startup-warning subsection** ([#352](https://github.com/heypinchy/pinchy/issues/352)).
- **`upgrading.mdx`: add `ws` 8.20.1 bullet** (GHSA-58qx-3vcg-4xpx, moderate — below `--audit-level=high` so not a hard blocker, but worth picking up).
- **`upgrading.mdx`: correct `openclaw-node` line** (was: 0.8.0 → is: 0.9.0).
- **`audit-trail.mdx`: add "Chat runtime" section** — `chat.background_run_completed` (#199) and `chat.silent_stream` (#320) are emitted in code but were missing from the reference table.
- **`audit-trail.mdx`: add `user.invite_blocked` to User management table** — licence/seat-cap refusal currently emitted but undocumented.

### CHANGELOG
- **Replace `CHANGELOG.md` skeleton with a pointer** to the upgrading guide and GitHub Releases. Pinchy's per-version upgrade story already lives in `docs/src/content/docs/guides/upgrading.mdx` (which the release workflow auto-prepends to the GitHub Release body), so the Keep-a-Changelog Unreleased section was redundant and going stale. Same pattern PostHog / Mattermost use for their self-hosted enterprise repos.

### Dependency
- **`ws` 8.20.0 → 8.20.1** via `pnpm up ws@latest`. Closes GHSA-58qx-3vcg-4xpx.

## Test plan

- [x] `pnpm audit --prod --audit-level=high` — clean
- [x] `pnpm -C docs build` — clean (`/api/version` page, all 42 pages built)
- [x] `pnpm -C packages/web exec tsc --noEmit` — clean
- [x] `pnpm -C packages/web test --run` — 4565 / 4579 pass (1 known flake: macOS chokidar polling on `memory-audit-watcher`; Linux-CI uses inotify and is immune — see `aaa02d65`)
- [ ] CI green
- [ ] Render the upgrading section locally to spot-check formatting