### PR TITLE
fix(audit): derive outcome from result.details.error too (#404 root)

### DIFF
--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -423,6 +423,73 @@ describe("POST /api/internal/audit/tool-use", () => {
     expect(detail).not.toHaveProperty("params");
   });
 
+  it("derives outcome='failure' from result.details.error when result.isError is missing (defense-in-depth)", async () => {
+    // Issue #404 root cause: OpenClaw's tool-use audit hook strips the MCP
+    // `isError: true` flag from the result before posting to /api/internal/
+    // audit/tool-use, so the only failure signal Pinchy receives is the
+    // plugin's curated `details.error` string. Observed on staging v0.5.4:
+    // every failed `pinchy_write` (ENOENT, "Access denied: path not in
+    // write_paths", etc.) was recorded as `outcome: success` with a green
+    // checkmark, even though detail.error contained the failure message —
+    // a CISO-blocking inconsistency.
+    //
+    // Defense: when `details.error` is a non-empty string, treat it as a
+    // failure signal even if `result.isError` is absent. This lets Pinchy
+    // surface plugin-curated semantic errors correctly without waiting on
+    // the upstream OpenClaw hook to forward `isError`.
+    await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "pinchy_write",
+        agentId: "agent-1",
+        params: { path: "/workspace/uploads/test.txt", content: "x", overwrite: true },
+        result: {
+          // No isError — simulating the OC-hook-strips-isError case.
+          content: [
+            {
+              type: "text",
+              text: "ENOENT: no such file or directory, open " + "'/workspace/uploads/test.txt'",
+            },
+          ],
+          details: {
+            path: "/workspace/uploads/test.txt",
+            overwrite: true,
+            error: "ENOENT: no such file or directory, open " + "'/workspace/uploads/test.txt'",
+          },
+        },
+      })
+    );
+
+    const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+    expect(call?.outcome).toBe("failure");
+    expect(call?.error?.message).toMatch(/ENOENT/);
+    const detail = call?.detail as Record<string, unknown>;
+    expect(detail.success).toBe(false);
+    expect(detail.error).toMatch(/ENOENT/);
+  });
+
+  it("empty-string result.details.error is NOT treated as a failure signal", async () => {
+    // Guard against false-positive failure derivation: an empty
+    // `details.error` (some plugins emit `""` to mean "no error") must not
+    // flip outcome to failure. Only meaningful (non-empty) strings count.
+    await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "pinchy_write",
+        agentId: "agent-1",
+        result: {
+          content: [{ type: "text", text: "Wrote 5 bytes" }],
+          details: { path: "/workspace/uploads/x.txt", error: "" },
+        },
+      })
+    );
+
+    const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+    expect(call?.outcome).toBe("success");
+    const detail = call?.detail as Record<string, unknown>;
+    expect(detail.success).toBe(true);
+  });
+
   it("detail.success=false and detail.error set when result.isError=true without details", async () => {
     // No result.details override — endpoint must still mark detail.success
     // as false and lift the semantic error message into detail.error.

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -103,22 +103,24 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ success: true });
   }
 
-  // Derive outcome from two signals up-front so detail.success / detail.error
+  // Derive outcome from three signals up-front so detail.success / detail.error
   // stay consistent with the audit row's outcome / error columns:
   //   1. payload.error (transport/dispatch-level failure from OpenClaw's hook)
   //   2. result.isError (semantic failure — MCP convention for tools that
   //      returned normally at the protocol level but reported an error
   //      inside the result, e.g. ENOENT on pinchy_read, EEXIST on pinchy_write)
+  //   3. result.details.error (plugin-curated semantic error message) —
+  //      defence against the upstream gap noted in issue #404: OpenClaw's
+  //      tool-use audit hook was observed on staging v0.5.4 stripping the
+  //      MCP `isError` flag before forwarding the result to /api/internal/
+  //      audit/tool-use, so this is sometimes the only failure signal we
+  //      receive. Only non-empty strings count to avoid false-positive
+  //      failures from plugins that emit `details.error: ""`.
   // Transport errors take precedence because they're the more fundamental
   // failure. For semantic errors, we lift the first text content entry as
   // the error message.
   const resultObj = isObject(payload.result) ? payload.result : null;
   const resultIsError = resultObj?.isError === true;
-  const semanticErrorMessage =
-    resultIsError && resultObj
-      ? (extractFirstTextContent(resultObj) ?? "Tool returned an error")
-      : null;
-  const outcome: "success" | "failure" = payload.error || resultIsError ? "failure" : "success";
 
   // Plugin can override the audit detail by returning result.details.
   // Used by tools whose params contain sensitive data (e.g. pinchy_write.content).
@@ -127,6 +129,25 @@ export async function POST(request: NextRequest) {
     resultObj && isObject(resultObj.details)
       ? (resultObj.details as Record<string, unknown>)
       : null;
+  const detailsErrorString =
+    typeof resultDetails?.error === "string" && resultDetails.error.length > 0
+      ? resultDetails.error
+      : null;
+
+  // semantic = "the tool returned successfully at protocol level but
+  // signalled a failure inside its result". That covers both `isError: true`
+  // (the MCP convention) and the OC-hook-strips-isError fallback path where
+  // only `details.error` arrives. In both cases the most user-friendly
+  // message lives in content[0].text; fall back to details.error and finally
+  // a generic string so the audit row's `error.message` is never empty when
+  // outcome=failure.
+  const hasSemanticFailure = resultIsError || Boolean(detailsErrorString);
+  const semanticErrorMessage =
+    hasSemanticFailure && resultObj
+      ? (extractFirstTextContent(resultObj) ?? detailsErrorString ?? "Tool returned an error")
+      : null;
+  const outcome: "success" | "failure" =
+    payload.error || hasSemanticFailure ? "failure" : "success";
 
   const detailError = resolveDetailError({
     payloadError: payload.error,


### PR DESCRIPTION
## Summary

**v0.5.4 release blocker.** Issue #404's first-pass fix relied on OpenClaw's tool-use audit hook forwarding `result.isError`. Staging audit data after today's :next deploy (`a0cab1b6a`) proves that hypothesis wrong — the OC hook strips `isError` before posting to `/api/internal/audit/tool-use`. So Pinchy's existing derivation still computes `outcome: success` for failed tools.

## Concrete staging evidence

Sterling Ollama agent trying `pinchy_write` on an empty workspace (no `uploads/` dir), running on `:next` for SHA `a0cab1b6a`:

| timestamp | outcome | detail.success | detail.error |
|---|---|---|---|
| 11:11:07 | ✅ success | true | ENOENT: no such file or directory, open '/root/.openclaw/workspaces/c1b7ab58…/uploads/test.txt' |
| 11:11:02 | ✅ success | true | Access denied: path not in write_paths |
| 11:10:23 | ✅ success | true | ENOENT: no such file or directory, open '/root/.openclaw/workspaces/c1b7ab58…/uploads/test.txt' |

Outcome column shows ✅ green; detail JSON shows a clear failure message. **A CISO-blocking inconsistency.**

## Fix (defense-in-depth)

Add a third failure signal alongside `payload.error` and `result.isError`: a **non-empty string in `result.details.error`**. Plugins already populate this field (it's how the existing `detail.error` column gets filled), so the signal is reliably present even when OC drops `isError`.

- Empty-string `details.error` is explicitly excluded — some plugins emit `""` to mean "no error".
- `semanticErrorMessage` is extended to cover the new path so the top-level `error.message` column stays populated (previously a stripped-`isError` failure produced `outcome: failure` with `error: null`, which was half-consistent).
- Transport (`payload.error`) and `isError` precedence are unchanged.

## Tests

- New: `derives outcome='failure' from result.details.error when result.isError is missing (defense-in-depth)` — the actual staging scenario.
- New: `empty-string result.details.error is NOT treated as a failure signal` — guards against false positives.
- All 26 existing audit-tool-use tests stay green (no behavioural change for the `isError`-present path).

## Test plan

- [x] `pnpm -C packages/web exec vitest run src/__tests__/api/internal-audit-tool-use.test.ts` — 28/28 pass
- [x] `pnpm -C packages/web exec tsc --noEmit` — clean
- [x] `pnpm -C packages/web test --run` — 4572/4586 pass (1 known macOS-local chokidar polling flake on `memory-audit-watcher`, Linux CI is immune via inotify)
- [ ] CI green
- [ ] Post-merge staging: redeploy, then deliberately trigger a `pinchy_write` failure (writing to a path outside the workspace allow-list, or with `overwrite=false` on an existing file). Audit row should show ✗ red with the error message visible.

## Closes #404 (this time for real)