### PR TITLE
fix(composer): preserve cursor when editing mid-text (v0.5.4 regression)

### DIFF
--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -541,6 +541,37 @@ describe("Composer input vs send disabled state", () => {
 
     expect(setText).toHaveBeenCalledWith("é");
   });
+
+  it("does NOT call setText when the change keeps runtime text in sync (mid-text cursor preservation)", async () => {
+    // Regression guard for the cursor-jump bug introduced alongside the
+    // dead-key fix: the unconditional setText() on every change caused
+    // assistant-ui's primitive to imperatively rewrite textarea.value on
+    // every keystroke, which collapses the cursor selection to the end of
+    // the text. Effect for the user: when editing in the middle of an
+    // existing draft, every typed character jumps the cursor back to the
+    // end — only the first character lands at the intended position.
+    //
+    // Fix: skip setText when runtime state already matches the textarea's
+    // current value. The dead-key sync still fires (test above) because
+    // there runtime is stale; here runtime is fresh and there is nothing
+    // to sync, so the primitive's own state handling stays uninterrupted
+    // and cursor selection is preserved by the browser.
+    const { useComposerRuntime } = await import("@assistant-ui/react");
+    const setText = vi.fn();
+    vi.mocked(useComposerRuntime).mockReturnValue({
+      getState: () => ({ isEditing: true, text: "helloX world" }),
+      setText,
+    } as never);
+
+    await renderComposerWith({ kind: "ready" });
+
+    const input = screen.getByRole("textbox");
+    // User typed "X" in the middle of "hello world", runtime's own onChange
+    // handler already absorbed it — getState().text matches the textarea.
+    fireEvent.change(input, { target: { value: "helloX world" } });
+
+    expect(setText).not.toHaveBeenCalled();
+  });
 });
 
 describe("ComposerAction Send/Stop mutual exclusion (#207)", () => {

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -281,7 +281,18 @@ const ComposerTextInput: FC = () => {
   const syncNonComposingChange = (event: ChangeEvent<HTMLTextAreaElement>) => {
     const isComposing = (event.nativeEvent as { isComposing?: boolean }).isComposing === true;
     if (isComposing || !composerRuntime?.getState().isEditing) return;
-    composerRuntime.setText(event.currentTarget.value);
+    const newValue = event.currentTarget.value;
+    // Skip the sync when the primitive already absorbed the change (the
+    // common case for regular typing). Calling setText() here would still
+    // make assistant-ui's primitive imperatively rewrite textarea.value on
+    // every keystroke, which collapses the cursor selection to the end and
+    // breaks mid-text editing. The setText path stays available for the
+    // dead-key recovery covered by the sibling test: when composition
+    // started without a matching compositionend, runtime text diverges
+    // from the textarea's actual value and the next regular keystroke
+    // pushes the divergence back into runtime here.
+    if (composerRuntime.getState().text === newValue) return;
+    composerRuntime.setText(newValue);
   };
 
   return (


### PR DESCRIPTION
## Summary

**v0.5.4 release blocker — regression vs. v0.5.3 production.** Editing in the middle of an existing chat-composer draft loses the cursor after every typed character: the first character lands at the intended position, the next jumps back to the end of the text. Reproduced on staging running 670703fdf, not on v0.5.3 production.

## Root cause

The dead-key sync in [`7044e12ea`](https://github.com/heypinchy/pinchy/commit/7044e12ea02cb356dad6078a41f57ddf3a04ec34) added an `onChange` handler that calls `composerRuntime.setText(value)` on **every** non-composing keystroke. Intent: recover from broken dead-key sequences (compositionstart without a matching compositionend leaves runtime out of sync). Side effect: assistant-ui's primitive imperatively writes back to `textarea.value` on every `setText`, which collapses the textarea's selection to the end of the text.

## Fix

Skip `setText` when `composerRuntime.getState().text` already matches the textarea's value. For ordinary typing the primitive's own onChange has already absorbed the change, so we have nothing to sync — the early return leaves the browser's cursor management untouched. For the dead-key recovery path, runtime is stale and value diverges, so `setText` still fires on the next regular keystroke.

## Tests

- **New:** `does NOT call setText when the change keeps runtime text in sync (mid-text cursor preservation)` — regression guard.
- **Existing dead-key test stays green:** the mock returns `getState: () => ({ isEditing: true })` (no `text` field), so the equality check yields `undefined === "é"` → false → `setText` fires as before.

## Test plan

- [x] `pnpm -C packages/web exec vitest run src/components/assistant-ui/__tests__/thread.test.tsx` — 37/37 pass (1 new, 36 prior)
- [x] `pnpm -C packages/web exec tsc --noEmit` — clean
- [ ] CI green
- [ ] Post-merge staging redeploy: type "hello world", click between "hello" and "world", type "X" — caret should stay after "X". Type another character — should still stay in the middle, not jump.