### PR TITLE
fix(image-tool): emit imageModel.primary + demote devstral vision flag

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -149,7 +149,38 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.5.3 to %%PINCHY_VERSION%%
+## Upgrading from v0.5.4 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+None.
+
+### Upgrade notes
+
+%%PINCHY_VERSION%% fixes a confusing failure mode for the built-in `image` tool on Ollama Cloud stacks and adds an explicit image-model default to remove a class of provider-selection drift.
+
+Upgrade with the standard flow:
+
+```bash
+cd /opt/pinchy
+sed -i 's/PINCHY_VERSION=v0.5.4/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+No database migration, no `docker-compose.yml` change, and no env-var changes are required.
+
+#### Image tool no longer routes to `devstral-small-2:24b`
+
+On Ollama Cloud stacks without an explicit image model, Pinchy's built-in `image` tool could pick `devstral-small-2:24b` and fail with `HTTP 400 "Image input is not enabled for this model"` mid-chat — confusing because the user never selected devstral. Two fixes ship together:
+
+- **Data correction.** `devstral-small-2:24b` is now flagged `vision: false`. Its ollama.com library page lists "Text, Image" as input types, but an empirical smoke test against the live `/v1/chat/completions` endpoint (see `scripts/verify-ollama-cloud-vision.mjs`) confirms the runtime API rejects images with HTTP 400. Devstral is Mistral's coding series, not a vision model.
+- **Explicit image-model default.** Pinchy now emits `agents.defaults.imageModel.primary` into the OpenClaw config, parallel to the existing `pdfModel` selection. Provider preference order: anthropic > google > openai > ollama-cloud. For ollama-cloud the canonical-vision line wins (`qwen3-vl:235b-instruct` > `qwen3-vl:235b` > `gemini-3-flash-preview` > `gemma4:31b`), avoiding models like `mistral-large-3:675b` or `qwen3.5:397b` that accept image input but mislabel colors.
+
+**No action required.** The new field is regenerated on startup from your existing provider settings. Operators who want to override the auto-pick can hand-edit `agents.defaults.imageModel.primary` in `openclaw.json`.
+
+A companion verification script lives at `scripts/verify-ollama-cloud-vision.mjs` and can be re-run whenever the Ollama Cloud catalog changes: it tests each curated model against the live API and reports any drift between the `vision` flag in `ollama-cloud-models.ts` and runtime acceptance.
+
+## Upgrading from v0.5.3 to v0.5.4
 
 ### Breaking changes
 
@@ -157,20 +188,20 @@ If you need to roll back after an upgrade:
 
 ### Upgrade notes
 
-%%PINCHY_VERSION%% extends the Odoo template library with read-write operator agents, hardens how those agents reference Odoo records, and irons out several chat-reliability edges. It also picks up Next.js security patches and OpenClaw 2026.5.7.
+v0.5.4 extends the Odoo template library with read-write operator agents, hardens how those agents reference Odoo records, and irons out several chat-reliability edges. It also picks up Next.js security patches and OpenClaw 2026.5.7.
 
 Upgrade with the standard flow:
 
 ```bash
 cd /opt/pinchy
-sed -i 's/PINCHY_VERSION=v0.5.3/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+sed -i 's/PINCHY_VERSION=v0.5.3/PINCHY_VERSION=v0.5.4/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 
 No database migration, no `docker-compose.yml` change, and no env-var changes are required.
 
 <Aside type="tip">
-  **Odoo users: re-sync your schema after upgrade.** %%PINCHY_VERSION%% adds six
+  **Odoo users: re-sync your schema after upgrade.** v0.5.4 adds six
   new agent templates (Bookkeeper, Project Manager, HR Operator, Warehouse
   Operator, Production Operator, Approval Manager) whose `requiredModels`
   reference Odoo models that previous Pinchy versions didn't probe (e.g.
@@ -193,7 +224,7 @@ The `odoo_schema` tool has been replaced by two narrower tools: `odoo_list_model
 
 **No action required.** A startup migration rewrites every agent's `allowed_tools` to use the new names, and the read-write Odoo operator templates (Bookkeeper, Warehouse Operator, HR Operator, etc.) ship with updated guidance for the agent.
 
-For existing agents created before %%PINCHY_VERSION%%, the old `odoo_schema` tool name is kept as a deprecated alias. The `AGENTS.md` files those agents store in their workspace still contain literal `odoo_schema` references — the alias keeps them working without any manual file editing, and routes the call through the new compact code path. You can safely ignore the alias; it will be removed in v0.6.x.
+For existing agents created before v0.5.4, the old `odoo_schema` tool name is kept as a deprecated alias. The `AGENTS.md` files those agents store in their workspace still contain literal `odoo_schema` references — the alias keeps them working without any manual file editing, and routes the call through the new compact code path. You can safely ignore the alias; it will be removed in v0.6.x.
 
 #### Six new Odoo agent templates
 
@@ -249,7 +280,7 @@ Open chats keep running in the background while you navigate within Pinchy — a
 - **Dead-key composer freeze.** Typing characters that involve dead keys (e.g. `^` + `e` → `ê`) no longer desyncs the composer input.
 - **Payload rejection visibility.** When OpenClaw rejects a payload mid-stream, the chat now surfaces a clear error status instead of leaving the spinner running.
 - **Silent stream-end retry.** A run that finishes without producing any assistant text — typically a cold-path tool call that timed out inside OpenClaw's embedded layer — now shows the standard error bubble with a **Retry** button instead of an indistinguishable "successful empty reply". Each occurrence writes a throttled `chat.silent_stream` audit entry so admins get an operational signal.
-- **Gemini 3 `thought_signature` errors are now named and explained.** When the upstream provider drops Gemini 3's required `thought_signature` field on a tool-call replay turn (upstream `openclaw/openclaw#72879`), Pinchy now shows a dedicated **transient upstream issue bubble** that names the cause and tells the user that **Retry usually clears it on the next try**. The bubble deliberately offers no "Switch model" link — the model is fine. Each occurrence writes a throttled `agent.upstream_format_error` audit entry so admins can track frequency from the audit page rather than grepping gateway logs. The upstream fix for the native Google path lands in OpenClaw 2026.5.18; %%PINCHY_VERSION%% is still pinned at 2026.5.7 and ships with the transient-issue bubble as the user-facing mitigation. The OpenClaw bump is scheduled for the next Pinchy release. ([#338](https://github.com/heypinchy/pinchy/issues/338))
+- **Gemini 3 `thought_signature` errors are now named and explained.** When the upstream provider drops Gemini 3's required `thought_signature` field on a tool-call replay turn (upstream `openclaw/openclaw#72879`), Pinchy now shows a dedicated **transient upstream issue bubble** that names the cause and tells the user that **Retry usually clears it on the next try**. The bubble deliberately offers no "Switch model" link — the model is fine. Each occurrence writes a throttled `agent.upstream_format_error` audit entry so admins can track frequency from the audit page rather than grepping gateway logs. The upstream fix for the native Google path lands in OpenClaw 2026.5.18; v0.5.4 is still pinned at 2026.5.7 and ships with the transient-issue bubble as the user-facing mitigation. The OpenClaw bump is scheduled for the next Pinchy release. ([#338](https://github.com/heypinchy/pinchy/issues/338))
 
 #### Permissions tab no longer reports false-positive dirty state
 
@@ -257,7 +288,7 @@ If an Odoo or Email connection was configured on an agent, the **Settings → Ag
 
 #### New `/api/version` endpoint + OCI image labels
 
-You can now confirm which Pinchy and OpenClaw versions are actually running without opening the UI. `GET /api/version` returns `{ pinchyVersion, openclawVersion, build, nodeEnv }` and is exempt from Domain Lock so it works from monitoring tools and the host shell. Docker images now also carry standard OCI labels (`org.opencontainers.image.version`, `org.opencontainers.image.revision`, …), so `docker inspect ghcr.io/heypinchy/pinchy:%%PINCHY_VERSION%%` reports the version and git SHA the image was built from.
+You can now confirm which Pinchy and OpenClaw versions are actually running without opening the UI. `GET /api/version` returns `{ pinchyVersion, openclawVersion, build, nodeEnv }` and is exempt from Domain Lock so it works from monitoring tools and the host shell. Docker images now also carry standard OCI labels (`org.opencontainers.image.version`, `org.opencontainers.image.revision`, …), so `docker inspect ghcr.io/heypinchy/pinchy:v0.5.4` reports the version and git SHA the image was built from.
 
 The upgrading guide's "Verify" step is updated to use `/api/version` instead of opening `http://localhost:7777` directly — the old instruction returned 403 on Domain-Lock-enabled deployments.
 

--- a/osv-scanner.toml
+++ b/osv-scanner.toml
@@ -13,3 +13,7 @@ reason = "Transitive devDep via openclaw (test tool only — not in production b
 [[IgnoredVulns]]
 id = "MAL-2026-3432"
 reason = "Transitive devDep via openclaw (test tool only — not in production build)"
+
+[[IgnoredVulns]]
+id = "GHSA-w5hq-g745-h8pq"
+reason = "Transitive devDep via openclaw → @anthropic-ai/vertex-sdk → google-auth-library → gaxios → uuid@9.0.1 (test tool only — not in production build; openclaw container has its own dep chain)"

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -143,6 +143,19 @@ function isOpenClawPortResponsive(): boolean {
  * normal happy path. We can't distinguish via logs — so we TCP-probe the
  * gateway port as the definitive liveness signal. A successful connect
  * means the Node.js event loop is processing accept()s, ergo not blocked.
+ *
+ * Zombie-startup guard: SIGUSR1 → child restart → on rare CI timing the
+ * child fails to load config with `ConfigMutationConflictError` and writes
+ * a `gateway.restart_startup_failed.json` stability bundle. The process
+ * stays alive (per OpenClaw's own design) but the gateway is in a
+ * degraded state — TCP listens, WS can't fully handshake, new
+ * config.apply RPCs are rejected with "invalid handshake". Without a
+ * subsequent `[gateway] ready` line confirming recovery, declaring this
+ * state "quiet" gives the caller a false green that propagates into the
+ * actual test — which then sees ~zero log activity around its POST
+ * because OpenClaw can't process the agent-create config change.
+ * Scan a wider window for the failed-bundle marker and require a later
+ * "ready" before considering the gateway recoverable.
  */
 async function waitForOpenClawQuiet(quietMs = 30000, timeout = 240000): Promise<void> {
   const start = Date.now();
@@ -153,6 +166,27 @@ async function waitForOpenClawQuiet(quietMs = 30000, timeout = 240000): Promise<
       .filter((l) =>
         /received SIGUSR1|received SIGTERM|requires gateway restart|\[gateway\] ready/.test(l)
       );
+
+    // Zombie-startup detection. Look at a wider window than `quietMs`
+    // because the failed-bundle marker can land 30+ s before the test
+    // calls in. Pattern matches OpenClaw's actual log line:
+    //   [gateway] wrote stability bundle: .../gateway.restart_startup_failed.json
+    const wideLookback = Math.max(quietMs + 5000, 120000);
+    const wideLogs = openClawLogsSince(new Date(Date.now() - wideLookback).toISOString());
+    const failedBundleMatch = wideLogs.match(
+      /\[gateway\] wrote stability bundle:[^\n]*gateway\.restart_startup_failed/
+    );
+    if (failedBundleMatch && failedBundleMatch.index !== undefined) {
+      const afterFailure = wideLogs.slice(failedBundleMatch.index);
+      if (!/\[gateway\] ready/.test(afterFailure)) {
+        // Gateway tried to restart, hit ConfigMutationConflictError, and
+        // has not logged a successful ready line since. Port-probe lies:
+        // TCP listens but gateway is functionally dead. Keep waiting.
+        await new Promise((r) => setTimeout(r, 1000));
+        continue;
+      }
+    }
+
     if (restartMarkers.length === 0) {
       if (!isOpenClawPortResponsive()) {
         // Port unreachable → event loop blocked or container down. Keep
@@ -257,13 +291,24 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
     });
     expect(createRes.status, await createRes.text()).toBeLessThan(300);
 
-    // Give OpenClaw 10 s to process the config.apply RPC. A real restart
-    // takes ~12 s (SIGUSR1 → process exit → respawn → ready); 10 s would
-    // catch the SIGUSR1 line at minimum if a restart was triggered, even
-    // if the new gateway hasn't reported ready yet.
-    await new Promise((r) => setTimeout(r, 10000));
-
-    const logs = openClawLogsSince(beforeMark);
+    // Poll instead of fixed-sleep. config.apply latency on CI varies
+    // widely: typical 1–3 s on a fresh runner, 20–40 s after an earlier
+    // restart-startup-failed bundle has slowed the gateway. The
+    // previous fixed 10 s sleep false-failed runs where Pinchy's
+    // POST returned before OpenClaw had logged the reload-detected
+    // line. Polling exits on the first match — happy path stays fast,
+    // slow path no longer flakes. After the match, a 3 s grace window
+    // ensures any follow-up `requires gateway restart` cascade lands
+    // in the captured logs (the negative assertions below need it).
+    const pollDeadline = Date.now() + 60000;
+    let logs = "";
+    while (Date.now() < pollDeadline) {
+      logs = openClawLogsSince(beforeMark);
+      if (/\[reload\] config change detected.*agents/.test(logs)) break;
+      await new Promise((r) => setTimeout(r, 1000));
+    }
+    await new Promise((r) => setTimeout(r, 3000));
+    logs = openClawLogsSince(beforeMark);
 
     // (a) Positive: the config change reached OpenClaw and was evaluated
     //     for reload. Without this, we'd be testing nothing — the config

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -302,13 +302,34 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
     // in the captured logs (the negative assertions below need it).
     const pollDeadline = Date.now() + 60000;
     let logs = "";
+    let observedReloadDetected = false;
     while (Date.now() < pollDeadline) {
       logs = openClawLogsSince(beforeMark);
-      if (/\[reload\] config change detected.*agents/.test(logs)) break;
+      if (/\[reload\] config change detected.*agents/.test(logs)) {
+        observedReloadDetected = true;
+        break;
+      }
       await new Promise((r) => setTimeout(r, 1000));
     }
     await new Promise((r) => setTimeout(r, 3000));
     logs = openClawLogsSince(beforeMark);
+
+    // Clear failure path: if 60 s elapsed without ever seeing the
+    // reload-detected line, the bug isn't "config change triggered a
+    // restart" (which the negative assertions below cover) — it's
+    // "config.apply never reached OpenClaw at all". That distinction
+    // matters for triage. Without this guard, the test would fall through
+    // to the positive assertion below and report "expected '<empty>' to
+    // match /\\[reload\\] config change detected.*agents/", which gives no
+    // hint that the timeout was the cause. Surface it explicitly so the
+    // CI log says exactly what happened.
+    if (!observedReloadDetected) {
+      throw new Error(
+        `config.apply was not observed within 60 s after POST /api/agents returned ` +
+          `${createRes.status}. OpenClaw either dropped the apply RPC or is in a degraded ` +
+          `state. Logs captured since ${beforeMark}:\n${logs || "(empty)"}`
+      );
+    }
 
     // (a) Positive: the config change reached OpenClaw and was evaluated
     //     for reload. Without this, we'd be testing nothing — the config

--- a/packages/web/src/__tests__/lib/model-vision.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.test.ts
@@ -63,9 +63,15 @@ describe("isModelVisionCapable", () => {
       expect(isModelVisionCapable("ollama-cloud/gemma4:31b")).toBe(true);
     });
 
-    it("should return true for devstral-small-2:24b", () => {
-      // Devstral Small 2's library page lists "Text, Image" input type.
-      expect(isModelVisionCapable("ollama-cloud/devstral-small-2:24b")).toBe(true);
+    it("should return false for devstral-small-2:24b", () => {
+      // Although ollama.com/library/devstral-small-2 lists "Text, Image" as
+      // input types, the live Ollama Cloud `/v1/chat/completions` endpoint
+      // rejects image inputs with HTTP 400 "Image input is not enabled for
+      // this model". Empirical API smoke test in #416 confirmed devstral is
+      // text-only at runtime — the library-page metadata is misleading. We
+      // mark it `vision: false` so it stops being picked as an image model
+      // fallback.
+      expect(isModelVisionCapable("ollama-cloud/devstral-small-2:24b")).toBe(false);
     });
 
     it("should return false for tool-capable cloud models that are text-only", () => {

--- a/packages/web/src/__tests__/lib/ollama-cloud-image-preference-drift.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-image-preference-drift.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect } from "vitest";
+
+import { OLLAMA_CLOUD_IMAGE_PREFERENCE } from "@/lib/openclaw-config/build";
+import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+
+// `pickOllamaCloudImageModel()` in build.ts iterates
+// `OLLAMA_CLOUD_IMAGE_PREFERENCE` and returns the first ID that exists in
+// `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS`. The function does NOT re-check the
+// `vision` flag on the matched entry — it relies on this drift guard.
+//
+// Why a test instead of a runtime `m.vision &&` check: the TypeScript
+// constraint `OllamaCloudModelId` already prevents an unknown ID from
+// being added to the preference list, so the only remaining failure mode
+// is "ID exists in the catalog but was demoted to `vision: false`". That's
+// precisely the #416 fingerprint (devstral was demoted; if it had been on
+// the preference list, the demotion alone wouldn't have removed it from
+// runtime selection without this guard). Catching at test time means
+// CI fails BEFORE the bad config reaches a customer — a runtime check
+// would only catch it after deploy.
+//
+// Pattern matches the existing drift-guard tests:
+//   - manifest-tools-drift.test.ts (plugin contracts vs registerTool)
+//   - plugin-tool-coverage.test.ts (tools vs E2E assertion presence)
+describe("OLLAMA_CLOUD_IMAGE_PREFERENCE drift guard (#416)", () => {
+  it("every preference-list entry is present in the curated catalog", () => {
+    for (const id of OLLAMA_CLOUD_IMAGE_PREFERENCE) {
+      const found = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === id);
+      expect(
+        found,
+        `OLLAMA_CLOUD_IMAGE_PREFERENCE references "${id}" but it is not in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS. Either restore the catalog entry or remove the preference.`
+      ).toBeDefined();
+    }
+  });
+
+  it("every preference-list entry is flagged vision: true", () => {
+    for (const id of OLLAMA_CLOUD_IMAGE_PREFERENCE) {
+      const found = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === id);
+      expect(
+        found?.vision,
+        `OLLAMA_CLOUD_IMAGE_PREFERENCE includes "${id}" but TOOL_CAPABLE_OLLAMA_CLOUD_MODELS marks it vision: false. The image picker would route an image tool call to a text-only model — exactly the #416 failure mode. Either flip the vision flag back to true (and document why) or remove "${id}" from the preference list.`
+      ).toBe(true);
+    }
+  });
+
+  it("preference list is non-empty (otherwise ollama-cloud-only stacks lose imageModel)", () => {
+    expect(OLLAMA_CLOUD_IMAGE_PREFERENCE.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -5847,14 +5847,34 @@ describe("regenerateOpenClawConfig size-drop guard (#311)", () => {
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
     expect(config.agents.defaults.pdfModel.primary).toBe("google/gemini-2.5-flash");
   });
+});
 
-  // `agents.defaults.imageModel.primary` mirrors `pdfModel` but for the
-  // built-in `image` tool. Without it, OpenClaw scans providers in their
-  // declared order and picks the first vision-flagged model — which on an
-  // ollama-cloud-only stack used to land on `devstral-small-2:24b`
-  // alphabetically, even though the live API rejects images for that model
-  // with HTTP 400 (#416). Pinning the choice via `imageModel.primary`
-  // removes that fragility.
+// `agents.defaults.imageModel.primary` mirrors `pdfModel` but for the
+// built-in `image` tool. Without it, OpenClaw scans providers in their
+// declared order and picks the first vision-flagged model — which on an
+// ollama-cloud-only stack used to land on `devstral-small-2:24b`
+// alphabetically, even though the live API rejects images for that model
+// with HTTP 400 (#416). Pinning the choice via `imageModel.primary`
+// removes that fragility.
+//
+// These tests rely on the same mock shape as the size-drop guard block
+// above — minimal `existsSync`/secrets/validation stubs plus `getSetting`
+// indirection — so the `beforeEach` is duplicated verbatim. Kept in a
+// separate `describe` so a future bisect on #311 isn't misled by hits in
+// imageModel tests, and vice versa.
+describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedGetOrCreateGatewayToken.mockResolvedValue("test-gateway-token");
+    mockedExistsSync.mockReturnValue(true);
+    mockReadSecretsFile.mockReturnValue({});
+    mockValidateBuiltConfig.mockReturnValue({ ok: true });
+    mockGetClient.mockImplementation(() => {
+      throw new Error("OpenClaw client not initialized");
+    });
+    _resetPushGeneration();
+  });
+
   it("auto-sets agents.defaults.imageModel.primary when Anthropic is configured", async () => {
     mockedGetSetting.mockImplementation(async (key: string) =>
       key === "anthropic_api_key" ? "sk-ant-test" : null

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1442,9 +1442,11 @@ describe("regenerateOpenClawConfig", () => {
     }>;
     const byId = Object.fromEntries(models.map((m) => [m.id, m]));
 
-    // Vision-capable cloud models per ollama.com/search?c=vision&c=cloud
+    // Vision-capable cloud models per the empirical API smoke test in #416
+    // (live `/v1/chat/completions` accepts image_url payloads with HTTP 200).
+    // devstral-small-2:24b is explicitly excluded — its library page claims
+    // "Text, Image" but the runtime API rejects images with HTTP 400.
     const visionModels = [
-      "devstral-small-2:24b",
       "gemini-3-flash-preview",
       "gemma4:31b",
       "kimi-k2.5",
@@ -1461,10 +1463,12 @@ describe("regenerateOpenClawConfig", () => {
       expect(byId[id].input).toEqual(["text", "image"]);
     }
     // Spot-check that text-only models stay text-only (gemma4 was the
-    // specific counter-example the user flagged during review)
+    // specific counter-example the user flagged during review). devstral-
+    // small-2:24b joined this list after the #416 smoke test demoted it.
     expect(byId["rnj-1:8b"].input).toEqual(["text"]);
     expect(byId["qwen3-coder:480b"].input).toEqual(["text"]);
     expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
+    expect(byId["devstral-small-2:24b"].input).toEqual(["text"]);
 
     // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
     const reasoningModels = [
@@ -5842,5 +5846,84 @@ describe("regenerateOpenClawConfig size-drop guard (#311)", () => {
 
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
     expect(config.agents.defaults.pdfModel.primary).toBe("google/gemini-2.5-flash");
+  });
+
+  // `agents.defaults.imageModel.primary` mirrors `pdfModel` but for the
+  // built-in `image` tool. Without it, OpenClaw scans providers in their
+  // declared order and picks the first vision-flagged model — which on an
+  // ollama-cloud-only stack used to land on `devstral-small-2:24b`
+  // alphabetically, even though the live API rejects images for that model
+  // with HTTP 400 (#416). Pinning the choice via `imageModel.primary`
+  // removes that fragility.
+  it("auto-sets agents.defaults.imageModel.primary when Anthropic is configured", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "anthropic_api_key" ? "sk-ant-test" : null
+    );
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel).toEqual({
+      primary: "anthropic/claude-haiku-4-5-20251001",
+    });
+  });
+
+  it("does not set agents.defaults.imageModel when no provider is configured", async () => {
+    mockedGetSetting.mockResolvedValue(null);
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents?.defaults?.imageModel).toBeUndefined();
+  });
+
+  it("prefers anthropic over google when both native vision providers are configured (image)", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test";
+      if (key === "google_api_key") return "AIza-test";
+      return null;
+    });
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel.primary).toBe("anthropic/claude-haiku-4-5-20251001");
+  });
+
+  it("prefers openai over ollama-cloud in the vision-capable fallback (image)", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "openai_api_key") return "sk-openai-test";
+      if (key === "ollama_cloud_api_key") return "ollama-test";
+      return null;
+    });
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel.primary).toBe("openai/gpt-5.4-mini");
+  });
+
+  it("picks the canonical-vision ollama-cloud model when only ollama-cloud is configured", async () => {
+    // The provider's general balanced default is `qwen3-next:80b` (text-only)
+    // and several other ollama-cloud models accept image input but mislabel
+    // colors (mistral-large-3, qwen3.5:397b, kimi-k2.5/k2.6 — see the #416
+    // empirical smoke test). The image-default picker explicitly prefers the
+    // "canonical vision line" — qwen3-vl > gemini-3-flash > gemma4 — over
+    // those weaker models.
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/qwen3-vl:235b-instruct");
+  });
+
+  it("native vision providers (anthropic, google) beat ollama-cloud for imageModel", async () => {
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "google_api_key") return "AIza-test";
+      if (key === "ollama_cloud_api_key") return "ollama-test";
+      return null;
+    });
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel.primary).toBe("google/gemini-2.5-flash");
   });
 });

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -74,11 +74,18 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
+    // ollama.com/library/devstral-small-2 lists "Text, Image" in the input
+    // types, but the live `/v1/chat/completions` endpoint returns HTTP 400
+    // "Image input is not enabled for this model" on image_url payloads —
+    // confirmed by the empirical API smoke test in #416. Devstral is
+    // Mistral's coding series, not a vision model; the library page is
+    // misleading. Flagged `vision: false` so it isn't picked as an image
+    // model fallback.
     id: "devstral-small-2:24b",
     contextWindow: 393216,
     maxTokens: 8192,
     reasoning: false,
-    vision: true,
+    vision: false,
   },
   {
     id: "gemini-3-flash-preview",

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -15,7 +15,11 @@ import {
 import { getSetting } from "@/lib/settings";
 import { computeDeniedGroups } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
+import {
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
+  OLLAMA_CLOUD_COST,
+  type OllamaCloudModelId,
+} from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
 import { getOpenClawWorkspacePath } from "@/lib/workspace";
 import { CONFIG_PATH } from "./paths";
@@ -186,6 +190,66 @@ async function resolveDefaultPdfModel(): Promise<string | null> {
   return null;
 }
 
+/**
+ * Resolve a vision-capable model to use for the built-in `image` tool.
+ *
+ * Same provider order as PDF: native vision (anthropic, google) > vision
+ * fallback (openai, ollama-cloud). Without this field, OpenClaw scans
+ * providers in their declared order and picks the first vision-flagged
+ * model — which on an ollama-cloud-only stack used to land on
+ * `devstral-small-2:24b` alphabetically, even though the live API rejects
+ * images for that model with HTTP 400 (#416). Pinning the choice removes
+ * that fragility.
+ *
+ * For `ollama-cloud`, the empirical smoke test in #416 showed several
+ * vision-flagged models (`mistral-large-3:675b`, `qwen3.5:397b`,
+ * `kimi-k2.5`/`k2.6`) accept image input but mislabel colors. Prefer the
+ * canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`)
+ * for the explicit primary, falling back to `getDefaultModel` if none of
+ * those are surfaced (defensive — the curated list guarantees they are).
+ */
+const IMAGE_MODEL_PREFERENCE: readonly ProviderName[] = [
+  "anthropic", // native vision
+  "google", // native vision
+  "openai", // native vision
+  "ollama-cloud", // vision fallback
+];
+
+// Best-vision ollama-cloud picks, in preference order. Subset of
+// TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — TypeScript rejects unknown IDs.
+const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
+  "qwen3-vl:235b-instruct",
+  "qwen3-vl:235b",
+  "gemini-3-flash-preview",
+  "gemma4:31b",
+];
+
+function pickOllamaCloudImageModel(): string | null {
+  for (const id of OLLAMA_CLOUD_IMAGE_PREFERENCE) {
+    if (TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.some((m) => m.id === id)) {
+      return `ollama-cloud/${id}`;
+    }
+  }
+  return null;
+}
+
+async function resolveDefaultImageModel(): Promise<string | null> {
+  for (const provider of IMAGE_MODEL_PREFERENCE) {
+    // eslint-disable-next-line security/detect-object-injection
+    const key = await getSetting(PROVIDERS[provider].settingsKey);
+    if (!key) continue;
+    if (provider === "ollama-cloud") {
+      const picked = pickOllamaCloudImageModel();
+      if (picked) return picked;
+      continue;
+    }
+    const model = await getDefaultModel(provider);
+    if (!model) continue;
+    if (isModelVisionCapable(model)) return model;
+  }
+  return null;
+}
+
 export async function regenerateOpenClawConfig() {
   // `readExistingConfig` distinguishes two recoverable failure modes:
   //   - ENOENT / parse error → returns {} (cold start; we build the first config from scratch).
@@ -307,6 +371,16 @@ export async function regenerateOpenClawConfig() {
   const pdfModel = await resolveDefaultPdfModel();
   if (pdfModel) {
     pinchyDefaults.pdfModel = { primary: pdfModel };
+  }
+
+  // Auto-set imageModel for the built-in `image` tool. Without this,
+  // OpenClaw falls through to provider image defaults and may pick a
+  // vision-flagged model whose runtime API rejects images (e.g.
+  // devstral-small-2 on ollama-cloud, #416). The explicit pin removes that
+  // failure mode and lets ops override via settings if needed.
+  const imageModel = await resolveDefaultImageModel();
+  if (imageModel) {
+    pinchyDefaults.imageModel = { primary: imageModel };
   }
 
   // Build agents list with OpenClaw-side workspace paths, tools.deny, and plugin configs

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -203,10 +203,16 @@ async function resolveDefaultPdfModel(): Promise<string | null> {
  *
  * For `ollama-cloud`, the empirical smoke test in #416 showed several
  * vision-flagged models (`mistral-large-3:675b`, `qwen3.5:397b`,
- * `kimi-k2.5`/`k2.6`) accept image input but mislabel colors. Prefer the
- * canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`)
- * for the explicit primary, falling back to `getDefaultModel` if none of
- * those are surfaced (defensive — the curated list guarantees they are).
+ * `kimi-k2.5`/`k2.6`) accept image input but mislabel colors. We pin the
+ * choice to the canonical vision line (`qwen3-vl` >
+ * `gemini-3-flash-preview` > `gemma4`) via the typed
+ * `OLLAMA_CLOUD_IMAGE_PREFERENCE` list. The TypeScript constraint on that
+ * list (must be `OllamaCloudModelId`) means an unknown ID fails to
+ * compile, so a runtime fallback to `getDefaultModel("ollama-cloud")`
+ * would only fire if every preference entry were removed from the curated
+ * list — at which point the right action is to update the preference list,
+ * not silently route to the provider's balanced text-only default. So we
+ * skip the provider in that case and continue down the preference order.
  */
 const IMAGE_MODEL_PREFERENCE: readonly ProviderName[] = [
   "anthropic", // native vision
@@ -217,7 +223,13 @@ const IMAGE_MODEL_PREFERENCE: readonly ProviderName[] = [
 
 // Best-vision ollama-cloud picks, in preference order. Subset of
 // TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — TypeScript rejects unknown IDs.
-const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
+// Exported for the drift-guard test in
+// `__tests__/lib/ollama-cloud-image-preference-drift.test.ts`, which
+// asserts every entry here is still flagged `vision: true` in the curated
+// catalog. That keeps the preference list and the vision flags from
+// silently de-syncing (e.g. if a future catalog update demotes one of
+// these models the way #416 demoted devstral).
+export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   "qwen3-vl:235b-instruct",
   "qwen3-vl:235b",
   "gemini-3-flash-preview",

--- a/scripts/verify-ollama-cloud-vision.mjs
+++ b/scripts/verify-ollama-cloud-vision.mjs
@@ -27,7 +27,7 @@ import { fileURLToPath } from "node:url";
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MODELS_TS = resolve(
   __dirname,
-  "../packages/web/src/lib/ollama-cloud-models.ts"
+  "../packages/web/src/lib/ollama-cloud-models.ts",
 );
 
 // 64×64 solid-red PNG (base64). Small but big enough that vision pipelines
@@ -52,21 +52,47 @@ function parseArgs(argv) {
   return args;
 }
 
+// Tight allowlist for model IDs as they appear in the curated source file.
+// Ollama Cloud IDs use lowercase letters, digits, and the punctuation set
+// `[.:_-]` (e.g. `qwen3-vl:235b-instruct`, `gpt-oss:120b`, `deepseek-v3.1:671b`).
+// Validating against this pattern at parse time gives the outbound HTTP
+// request a guaranteed-safe shape and prevents anything pathological from
+// flowing from the file into the network sink. CodeQL recognises this as
+// a sanitizer for the "file data → outbound request" finding.
+const MODEL_ID_PATTERN = /^[a-z0-9][a-z0-9.:_-]*$/;
+
 function extractModelEntries(source) {
-  // Parse the literal-object entries inside TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.
-  // The file is a const tuple of objects with `id` and `vision` fields. A
-  // proper TS parser is overkill for this one-shot script; the regex
-  // matches the exact layout the file already uses.
+  // Parse the `id` / `vision` pairs inside TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.
+  // Strategy: strip line and block comments first (each with a simple
+  // non-backtracking regex — no nested quantifiers, no ReDoS risk), then
+  // run a flat match-pair regex over the cleaned source. The previous
+  // single-regex approach used an alternation-with-quantifier inside the
+  // object body that could backtrack catastrophically on adversarial input.
+  // A proper TS parser is overkill for a one-shot script; this two-pass
+  // approach is both faster and easier to reason about.
+  const stripped = source
+    // Line comments: `//…\n`. `[^\n]*` cannot backtrack across newlines.
+    .replace(/\/\/[^\n]*/g, "")
+    // Block comments: `/*…*/`. Lazy `[\s\S]*?` paired with a single
+    // terminator means no alternation-induced backtracking.
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+
   const entries = [];
-  const objectRegex =
-    /\{\s*(?:\/\/[^\n]*\n\s*|\/\*[\s\S]*?\*\/\s*)*id:\s*"([^"]+)"[\s\S]*?vision:\s*(true|false)[\s\S]*?\}/g;
+  const pairRegex = /id:\s*"([^"]+)"\s*,[\s\S]*?vision:\s*(true|false)/g;
   let match;
-  while ((match = objectRegex.exec(source)) !== null) {
-    entries.push({ id: match[1], vision: match[2] === "true" });
+  while ((match = pairRegex.exec(stripped)) !== null) {
+    const id = match[1];
+    if (!MODEL_ID_PATTERN.test(id)) {
+      throw new Error(
+        `verify-ollama-cloud-vision: parsed model ID "${id}" does not match the safe ID allowlist (${MODEL_ID_PATTERN}). ` +
+          `Refusing to send this to the Ollama Cloud API — fix the source file or widen the pattern deliberately.`,
+      );
+    }
+    entries.push({ id, vision: match[2] === "true" });
   }
   if (entries.length === 0) {
     throw new Error(
-      "verify-ollama-cloud-vision: no model entries parsed from ollama-cloud-models.ts"
+      "verify-ollama-cloud-vision: no model entries parsed from ollama-cloud-models.ts",
     );
   }
   return entries;
@@ -80,7 +106,10 @@ async function testModel(id, apiKey) {
       {
         role: "user",
         content: [
-          { type: "text", text: "What color is this image? Respond with one word." },
+          {
+            type: "text",
+            text: "What color is this image? Respond with one word.",
+          },
           { type: "image_url", image_url: { url: TEST_IMAGE_DATA_URL } },
         ],
       },
@@ -106,7 +135,7 @@ async function main() {
   const apiKey = process.env.OLLAMA_CLOUD_API_KEY;
   if (!apiKey) {
     process.stdout.write(
-      "OLLAMA_CLOUD_API_KEY is unset — skipping verify-ollama-cloud-vision (exit 0).\n"
+      "OLLAMA_CLOUD_API_KEY is unset — skipping verify-ollama-cloud-vision (exit 0).\n",
     );
     process.exit(0);
   }
@@ -122,7 +151,9 @@ async function main() {
 
   const drift = [];
   for (const model of targets) {
-    process.stdout.write(`testing ${model.id} (flag: vision=${model.vision})… `);
+    process.stdout.write(
+      `testing ${model.id} (flag: vision=${model.vision})… `,
+    );
     let result;
     try {
       result = await testModel(model.id, apiKey);
@@ -138,7 +169,8 @@ async function main() {
     }
 
     const apiAccepts = result.status === 200;
-    const apiRejectsImage = result.status >= 400 && bodyRejectsImage(result.body);
+    const apiRejectsImage =
+      result.status >= 400 && bodyRejectsImage(result.body);
 
     if (model.vision && apiAccepts) {
       process.stdout.write("OK (api accepts)\n");
@@ -171,7 +203,7 @@ async function main() {
     process.stderr.write(JSON.stringify(drift, null, 2) + "\n");
     process.stderr.write(
       `\n${drift.length} model(s) drift from runtime API. ` +
-        "Fix flags in packages/web/src/lib/ollama-cloud-models.ts.\n"
+        "Fix flags in packages/web/src/lib/ollama-cloud-models.ts.\n",
     );
     process.exit(1);
   }

--- a/scripts/verify-ollama-cloud-vision.mjs
+++ b/scripts/verify-ollama-cloud-vision.mjs
@@ -1,0 +1,185 @@
+#!/usr/bin/env node
+// Verify Pinchy's curated Ollama Cloud vision flags against the live API.
+//
+// For each model flagged `vision: true` in
+// packages/web/src/lib/ollama-cloud-models.ts, this script POSTs a tiny test
+// image to https://ollama.com/v1/chat/completions and asserts the response
+// is HTTP 200. For each `vision: false` model, it asserts the response is
+// HTTP 4xx with the "image input is not enabled" signal. Any mismatch
+// exits 1.
+//
+// Why this exists: ollama.com/library/<name> pages claim "Text, Image" for
+// models whose runtime API rejects images (e.g. devstral-small-2:24b — see
+// #416). The library metadata cannot be trusted; this script tests the
+// strict layer (live API) directly.
+//
+// Usage:
+//   OLLAMA_CLOUD_API_KEY=... node scripts/verify-ollama-cloud-vision.mjs
+//   OLLAMA_CLOUD_API_KEY=... node scripts/verify-ollama-cloud-vision.mjs --only=qwen3-vl:235b
+//
+// Exits 0 on full agreement, 1 on any drift. Skips with exit 0 if
+// OLLAMA_CLOUD_API_KEY is unset (so CI can run it conditionally).
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODELS_TS = resolve(
+  __dirname,
+  "../packages/web/src/lib/ollama-cloud-models.ts"
+);
+
+// 64×64 solid-red PNG (base64). Small but big enough that vision pipelines
+// with minimum-image-size guards (e.g. gemini-3-flash-preview's "Unable to
+// process input image" on 4×4) still accept it. Generated once and pinned.
+const TEST_IMAGE_PNG_BASE64 =
+  "iVBORw0KGgoAAAANSUhEUgAAAEAAAABACAYAAACqaXHeAAAAQ0lEQVR4nO3OQQ0AAAjAMOZf9DCAj1QQ" +
+  "OPe8Sgl8L4DEAAhAACAAEYAARAACEAEIQAQgABGAAEQAAhABCEAEIAARgABEAALwGwOcXgABolNDOgAAAABJRU5ErkJggg==";
+const TEST_IMAGE_DATA_URL = `data:image/png;base64,${TEST_IMAGE_PNG_BASE64}`;
+
+const NOT_SUPPORTED_PATTERNS = [
+  /image input is not enabled/i,
+  /this model does not support image input/i,
+  /does not support images/i,
+];
+
+function parseArgs(argv) {
+  const args = { only: null };
+  for (const a of argv) {
+    if (a.startsWith("--only=")) args.only = a.slice("--only=".length);
+  }
+  return args;
+}
+
+function extractModelEntries(source) {
+  // Parse the literal-object entries inside TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.
+  // The file is a const tuple of objects with `id` and `vision` fields. A
+  // proper TS parser is overkill for this one-shot script; the regex
+  // matches the exact layout the file already uses.
+  const entries = [];
+  const objectRegex =
+    /\{\s*(?:\/\/[^\n]*\n\s*|\/\*[\s\S]*?\*\/\s*)*id:\s*"([^"]+)"[\s\S]*?vision:\s*(true|false)[\s\S]*?\}/g;
+  let match;
+  while ((match = objectRegex.exec(source)) !== null) {
+    entries.push({ id: match[1], vision: match[2] === "true" });
+  }
+  if (entries.length === 0) {
+    throw new Error(
+      "verify-ollama-cloud-vision: no model entries parsed from ollama-cloud-models.ts"
+    );
+  }
+  return entries;
+}
+
+async function testModel(id, apiKey) {
+  const body = {
+    model: id,
+    max_tokens: 16,
+    messages: [
+      {
+        role: "user",
+        content: [
+          { type: "text", text: "What color is this image? Respond with one word." },
+          { type: "image_url", image_url: { url: TEST_IMAGE_DATA_URL } },
+        ],
+      },
+    ],
+  };
+  const res = await fetch("https://ollama.com/v1/chat/completions", {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Authorization: `Bearer ${apiKey}`,
+    },
+    body: JSON.stringify(body),
+  });
+  const text = await res.text();
+  return { status: res.status, body: text };
+}
+
+function bodyRejectsImage(bodyText) {
+  return NOT_SUPPORTED_PATTERNS.some((re) => re.test(bodyText));
+}
+
+async function main() {
+  const apiKey = process.env.OLLAMA_CLOUD_API_KEY;
+  if (!apiKey) {
+    process.stdout.write(
+      "OLLAMA_CLOUD_API_KEY is unset — skipping verify-ollama-cloud-vision (exit 0).\n"
+    );
+    process.exit(0);
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const source = readFileSync(MODELS_TS, "utf8");
+  const all = extractModelEntries(source);
+  const targets = args.only ? all.filter((m) => m.id === args.only) : all;
+  if (targets.length === 0) {
+    process.stderr.write(`No models matched --only=${args.only}\n`);
+    process.exit(1);
+  }
+
+  const drift = [];
+  for (const model of targets) {
+    process.stdout.write(`testing ${model.id} (flag: vision=${model.vision})… `);
+    let result;
+    try {
+      result = await testModel(model.id, apiKey);
+    } catch (err) {
+      process.stdout.write(`NETWORK ERROR: ${err.message}\n`);
+      drift.push({
+        id: model.id,
+        flag: model.vision,
+        actual: "network-error",
+        detail: err.message,
+      });
+      continue;
+    }
+
+    const apiAccepts = result.status === 200;
+    const apiRejectsImage = result.status >= 400 && bodyRejectsImage(result.body);
+
+    if (model.vision && apiAccepts) {
+      process.stdout.write("OK (api accepts)\n");
+      continue;
+    }
+    if (!model.vision && apiRejectsImage) {
+      process.stdout.write("OK (api rejects)\n");
+      continue;
+    }
+    if (!model.vision && result.status === 200) {
+      // The model is marked text-only but the API actually accepts images.
+      // Could be a candidate for promotion, but the flag side is conservative
+      // — flag this so a human decides.
+      process.stdout.write("DRIFT (flag=false but API accepts)\n");
+    } else if (model.vision && apiRejectsImage) {
+      process.stdout.write("DRIFT (flag=true but API rejects images)\n");
+    } else {
+      process.stdout.write(`UNEXPECTED status=${result.status}\n`);
+    }
+    drift.push({
+      id: model.id,
+      flag: model.vision,
+      status: result.status,
+      bodySnippet: result.body.slice(0, 200),
+    });
+  }
+
+  if (drift.length > 0) {
+    process.stderr.write("\n=== DRIFT REPORT ===\n");
+    process.stderr.write(JSON.stringify(drift, null, 2) + "\n");
+    process.stderr.write(
+      `\n${drift.length} model(s) drift from runtime API. ` +
+        "Fix flags in packages/web/src/lib/ollama-cloud-models.ts.\n"
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(`\nAll ${targets.length} model(s) match runtime API.\n`);
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err.stack || err.message}\n`);
+  process.exit(1);
+});


### PR DESCRIPTION
## What does this PR do?

Fixes a confusing failure mode for the built-in `image` tool on Ollama Cloud stacks: Smithers (or any agent without an explicit `imageModel`) could route an image tool call to `devstral-small-2:24b`, which then 400s with `"Image input is not enabled for this model"` mid-chat — even though the user never selected devstral.

Two stacked fixes:

1. **Data correction.** `devstral-small-2:24b` is now `vision: false`. The `ollama.com/library/devstral-small-2` page lists "Text, Image" as input types, but the live `/v1/chat/completions` endpoint rejects images with HTTP 400 — proven by the empirical API smoke test in the issue. Devstral is Mistral's coding series, not a vision model.

2. **Explicit `agents.defaults.imageModel.primary` emission.** Mirrors the existing `pdfModel` pattern. Provider order: anthropic → google → openai → ollama-cloud. For ollama-cloud specifically, picks from the canonical-vision line (`qwen3-vl:235b-instruct` > `qwen3-vl:235b` > `gemini-3-flash-preview` > `gemma4:31b`), skipping the "accept-but-mislabel-colors" tier (`mistral-large-3:675b`, `qwen3.5:397b`, `kimi-k2.x`) identified by the empirical test.

Without (2), OpenClaw falls back to scanning provider model lists and picking the first vision-flagged model alphabetically — which is exactly how `devstral-small-2:24b` won the slot on a clean ollama-cloud-only stack. Pinning the choice removes that fragility for the future too.

Closes #416

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature (auto-default `imageModel.primary`)
- [x] 📝 Documentation
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI (verification script)

## What changed

| File | Why |
|---|---|
| [`packages/web/src/lib/ollama-cloud-models.ts`](packages/web/src/lib/ollama-cloud-models.ts) | Flip `devstral-small-2:24b` to `vision: false` with inline comment explaining library-page-vs-runtime divergence. |
| [`packages/web/src/lib/openclaw-config/build.ts`](packages/web/src/lib/openclaw-config/build.ts) | New `resolveDefaultImageModel()` + `IMAGE_MODEL_PREFERENCE` + `OLLAMA_CLOUD_IMAGE_PREFERENCE` + emission into `pinchyDefaults.imageModel`. |
| [`packages/web/src/__tests__/lib/model-vision.test.ts`](packages/web/src/__tests__/lib/model-vision.test.ts) | Corrected expectation: devstral is no longer vision-capable. |
| [`packages/web/src/__tests__/lib/openclaw-config.test.ts`](packages/web/src/__tests__/lib/openclaw-config.test.ts) | Five new tests for `imageModel.primary` selection — auto-pick, no-provider, anthropic-over-google, openai-over-ollama-cloud, ollama-cloud canonical-vision. Also fixed the existing vision-models list to drop devstral. |
| [`scripts/verify-ollama-cloud-vision.mjs`](scripts/verify-ollama-cloud-vision.mjs) | One-shot drift-checker against the live Ollama Cloud API. Posts a 64×64 test PNG to every curated model and reports any flag/runtime mismatch. Skips cleanly when `OLLAMA_CLOUD_API_KEY` is unset. |
| [`docs/src/content/docs/guides/upgrading.mdx`](docs/src/content/docs/guides/upgrading.mdx) | New "v0.5.4 → %%PINCHY_VERSION%%" section explaining both fixes. Also concretized the prior "v0.5.3 → %%PINCHY_VERSION%%" header to "v0.5.3 → v0.5.4" + concretized inline placeholder references so the next docs build doesn't rewrite historical strings. |

## Design notes for reviewers

- **Why a separate `imageModel` instead of letting it follow the chat model?** Same reason `pdfModel` is separate today: a user might want a fast text model for chat but a stronger vision model for explicit image-tool calls. Per-agent override can come later if needed.
- **Why singular `primary` (not `tools.media.image.models` list)?** Consistency with `pdfModel`. Multi-model fallback list is a follow-up if a customer hits the need.
- **Why hard-code the ollama-cloud preference instead of letting `getDefaultModel("ollama-cloud")` decide?** The provider's general balanced default is `qwen3-next:80b` (text-only), and several vision-flagged models accept images but mislabel them. The image-default deserves a different lens than the chat-default.
- **Pre-existing PDF test for ollama-cloud-only still expects `gemini-3-flash-preview`** (not `qwen3-vl`). That's intentional — PDF and image use different ollama-cloud preference orders. PDF prefers gemini for its 1M context; image prefers qwen3-vl for accuracy.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style (lint + prettier clean)
- [x] I've added tests for new functionality (5 new openclaw-config tests + corrected model-vision test)
- [x] I've updated the documentation (new upgrading.mdx section)
- [x] All existing tests pass (4578 vitest tests + typecheck)

## Test plan

- [x] `pnpm -C packages/web test` — 4578 passed, 13 skipped
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm -C packages/web format:check` — clean
- [x] `tsc --noEmit` — exit 0
- [x] `node scripts/verify-ollama-cloud-vision.mjs` (no env var) — skips with exit 0
- [ ] Manual staging verification: trigger image tool with Smithers — audit log should show `tool.image` ✓ success on a vision-capable model
- [ ] Optional: run `OLLAMA_CLOUD_API_KEY=... node scripts/verify-ollama-cloud-vision.mjs` against staging's key to confirm 33/33 models match the curated `vision` flags