### PR TITLE
feat(agent-templates): extend CRM & Sales template with quotation-ready models

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -94,7 +94,7 @@ Each template auto-configures the agent's permissions, tools, and system instruc
 ### Sales & Customer Operations
 
 - **Sales Analyst** _(read-only)_ — Revenue analysis, customer rankings, order trends, and product margin analysis using standard cost.
-- **CRM & Sales Assistant** _(read-write)_ — Pipeline management, lead follow-up, opportunity updates and customer data maintenance.
+- **CRM & Sales Assistant** _(read-write)_ — Pipeline management, lead follow-up, opportunity updates, customer data maintenance, and end-to-end quotation building (including setting the right fiscal position so VAT applies correctly). Reads invoice payment status but never drafts or posts invoices — that's the Bookkeeper agent's job.
 - **Customer Service** _(read-write)_ — Answers order inquiries and drafts responses entirely through Odoo's mail alias and discussion thread, so agents never need external email access.
 - **Subscription Manager** _(read-only)_ — Tracks MRR, churn, renewal dates and recurring revenue across your subscription base.
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -204,6 +204,24 @@ On Ollama Cloud stacks without an explicit image model, Pinchy's built-in `image
 
 A companion verification script lives at `scripts/verify-ollama-cloud-vision.mjs` and can be re-run whenever the Ollama Cloud catalog changes: it tests each curated model against the live API and reports any drift between the `vision` flag in `ollama-cloud-models.ts` and runtime acceptance.
 
+#### CRM & Sales Assistant template gains quotation-ready Odoo models
+
+The CRM & Sales Assistant template now declares three additional Odoo models so a Sales agent can build quotations end-to-end (lead → opportunity → quote with the right VAT regime) and answer "is this invoice paid?":
+
+- **`account.fiscal.position`** _(read + write)_ — set the customer's tax regime (e.g. "EU B2B reverse-charge") on `res.partner.property_account_position_id` so future quotations auto-apply the correct taxes.
+- **`sale.order.line`** _(read + create + write)_ — inspect and revise quotation line items directly. Normal happy-path writes still go through `sale.order.order_line`.
+- **`account.move`** _(read-only)_ — look up invoice payment status. Drafting, posting, or amending invoices remains exclusive to the Bookkeeper template, which is governed by a regulated draft-first / four-eyes flow.
+
+A new `Fiscal Positions` row also appears in the Permissions UI for **every** Odoo connection (regardless of which template the agent uses), because the schema sync now probes `account.fiscal.position` as part of the standard accounting category.
+
+**Action required for existing CRM agents.** Template changes only affect newly-created agents. To grant an existing CRM & Sales Assistant agent access to the new models:
+
+1. Open the agent's settings → Permissions.
+2. Tick `account.fiscal.position` (Read + Write), `sale.order.line` (Read + Create + Write), and `account.move` (Read).
+3. Save.
+
+If you skip this step, the existing agent keeps its previous (narrower) permission set — there is no automatic migration. Newly-created agents from this template pick up the new models automatically.
+
 ## Upgrading from v0.5.3 to v0.5.4
 
 ### Breaking changes

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -1540,6 +1540,31 @@ describe("Odoo CRM & Sales Assistant template — quotation-ready model coverage
     const t = getTemplate(id)!;
     expect(t.defaultAgentsMd).toContain("account.move");
   });
+
+  it("AGENTS.md spells out the Bookkeeper boundary so a reword can't silently drop it", () => {
+    // Critical safety boundary: a CRM agent must never draft, post, or amend
+    // invoices. Test #3 enforces this at the permission level
+    // (account.move = read only), this test guards the prose instruction the
+    // LLM actually reads at runtime. If someone reworks AGENTS.md and drops
+    // the boundary sentence, this fails.
+    const t = getTemplate(id)!;
+    expect(t.defaultAgentsMd).toMatch(/never.*(draft|post|amend).*invoic/i);
+    expect(t.defaultAgentsMd.toLowerCase()).toContain("bookkeeper");
+  });
+
+  it("AGENTS.md warns about the sale.order confirmation → invoice path explicitly", () => {
+    // sale.order write access lets the agent confirm a quotation (state →
+    // "sale"). Confirming a sale order in Odoo doesn't auto-post an invoice,
+    // but the downstream workflow has an explicit "Create Invoice" action
+    // (Odoo method: `_create_invoices`) that would bypass the account.move
+    // read-only boundary. A generic "don't modify invoices" isn't enough —
+    // the AGENTS.md must name the confirmation path so the LLM understands
+    // *why* this is a separate restriction from generic account.move writes.
+    const t = getTemplate(id)!;
+    const lower = t.defaultAgentsMd.toLowerCase();
+    expect(lower).toContain("confirm"); // mentions sale order confirmation
+    expect(lower).toMatch(/_create_invoices|create invoice/); // names the forbidden action
+  });
 });
 
 describe("MODEL_CATEGORIES — accounting category covers fiscal positions", () => {

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -8,6 +8,7 @@ import {
   generateAgentsMd,
   pickSuggestedName,
 } from "@/lib/agent-templates";
+import { MODEL_CATEGORIES } from "@/lib/integrations/odoo-sync";
 import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
 import { TEMPLATE_ICON_COMPONENTS } from "@/lib/template-icons";
 import { getOdooToolsForAccessLevel } from "@/lib/tool-registry";
@@ -1469,5 +1470,87 @@ describe("Odoo Approval Manager template (cross-module approvals)", () => {
 
   it("appears in getTemplateList", () => {
     expect(getTemplateList().some((t) => t.id === "odoo-approval-manager")).toBe(true);
+  });
+});
+
+describe("Odoo CRM & Sales Assistant template — quotation-ready model coverage", () => {
+  // The CRM template builds quotations end-to-end: leads → opportunities →
+  // sale.order with priced lines and the correct VAT regime on the customer.
+  // That workflow needs three extras beyond the original Sales/CRM models:
+  //
+  //   - account.fiscal.position (read+write) — store the customer's tax
+  //     regime on res.partner so subsequent quotes auto-apply the right
+  //     taxes. Without write, the agent can never set up a new customer.
+  //   - sale.order.line (read+create+write) — quotation line items are
+  //     written via the parent sale.order in normal flows, but reading and
+  //     editing individual lines is required for revisions and inspections.
+  //   - account.move (read) — let the agent check invoice/payment status
+  //     when a customer asks "is this paid?". Deliberately read-only;
+  //     invoice creation belongs to the Bookkeeper template.
+  const id = "odoo-crm-assistant";
+
+  it("grants read+write on account.fiscal.position (tax regime on contacts)", () => {
+    const t = getTemplate(id)!;
+    const fp = t.odooConfig!.requiredModels.find((m) => m.model === "account.fiscal.position");
+    expect(fp, "account.fiscal.position missing from requiredModels").toBeDefined();
+    expect(fp!.operations).toContain("read");
+    expect(fp!.operations).toContain("write");
+  });
+
+  it("grants read+create+write on sale.order.line (quotation line items)", () => {
+    const t = getTemplate(id)!;
+    const line = t.odooConfig!.requiredModels.find((m) => m.model === "sale.order.line");
+    expect(line, "sale.order.line missing from requiredModels").toBeDefined();
+    expect(line!.operations).toContain("read");
+    expect(line!.operations).toContain("create");
+    expect(line!.operations).toContain("write");
+  });
+
+  it("grants read on account.move but never create or write (Bookkeeper owns invoicing)", () => {
+    // Status lookups only: a Sales agent must not draft, post, or amend
+    // invoices. That's the Bookkeeper template's responsibility and is
+    // regulated (UID, sequential numbering, posting rules).
+    const t = getTemplate(id)!;
+    const move = t.odooConfig!.requiredModels.find((m) => m.model === "account.move");
+    expect(move, "account.move missing from requiredModels").toBeDefined();
+    expect(move!.operations).toContain("read");
+    expect(move!.operations).not.toContain("create");
+    expect(move!.operations).not.toContain("write");
+  });
+
+  it("keeps account.tax as read-only (already in template — guards against regression)", () => {
+    const t = getTemplate(id)!;
+    const tax = t.odooConfig!.requiredModels.find((m) => m.model === "account.tax");
+    expect(tax).toBeDefined();
+    expect(tax!.operations).toContain("read");
+    expect(tax!.operations).not.toContain("write");
+  });
+
+  it("AGENTS.md mentions account.fiscal.position with its quotation purpose", () => {
+    const t = getTemplate(id)!;
+    expect(t.defaultAgentsMd).toContain("account.fiscal.position");
+  });
+
+  it("AGENTS.md mentions sale.order.line for quotation line items", () => {
+    const t = getTemplate(id)!;
+    expect(t.defaultAgentsMd).toContain("sale.order.line");
+  });
+
+  it("AGENTS.md mentions account.move for invoice/payment status lookups", () => {
+    const t = getTemplate(id)!;
+    expect(t.defaultAgentsMd).toContain("account.move");
+  });
+});
+
+describe("MODEL_CATEGORIES — accounting category covers fiscal positions", () => {
+  // The schema sync only probes models listed in MODEL_CATEGORIES. Any model
+  // a template requires must be in this list, otherwise the
+  // template-integration-coverage drift guard fails (and the Create button
+  // stays disabled forever). This direct check makes the intent obvious in
+  // failure output.
+  it("includes account.fiscal.position in the accounting category", () => {
+    const accounting = MODEL_CATEGORIES.find((c) => c.id === "accounting");
+    expect(accounting, "accounting category missing").toBeDefined();
+    expect(accounting!.models.some((m) => m.model === "account.fiscal.position")).toBe(true);
   });
 });

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -420,17 +420,22 @@ You manage the sales pipeline — tracking leads, following up on opportunities,
 ## Available Data
 - **crm.lead** — Leads and opportunities. Key fields: \`name\`, \`partner_id\`, \`type\` ("lead"=unqualified, "opportunity"=qualified), \`stage_id\`, \`probability\`, \`expected_revenue\`, \`user_id\` (salesperson), \`date_deadline\`, \`date_open\`, \`date_closed\`
 - **crm.stage** — Pipeline stages. Key fields: \`name\`, \`sequence\`
-- **sale.order** — Quotations/orders. Key fields: \`name\`, \`partner_id\`, \`amount_total\`, \`state\`, \`date_order\`
-- **res.partner** — Contacts. Key fields: \`name\`, \`email\`, \`phone\`, \`company_type\` ("person", "company"), \`customer_rank\`
+- **sale.order** — Quotations/orders. Key fields: \`name\`, \`partner_id\`, \`amount_total\`, \`state\`, \`date_order\`, \`fiscal_position_id\`
+- **sale.order.line** — Quotation line items. Key fields: \`order_id\`, \`product_id\`, \`product_uom_qty\` (quantity!), \`price_unit\` (tax-exclusive net price), \`tax_id\`, \`price_subtotal\`. Lines are normally created inline via \`sale.order.order_line\`; read this model directly to inspect or revise existing lines.
+- **res.partner** — Contacts. Key fields: \`name\`, \`email\`, \`phone\`, \`company_type\` ("person", "company"), \`customer_rank\`, \`property_account_position_id\` (the customer's default fiscal position)
+- **account.tax** — VAT/tax rules. Key fields: \`name\` (e.g. "0% EU Service"), \`amount\`, \`type_tax_use\` ("sale", "purchase"). Use this to look up the right tax for a quotation line by readable name instead of guessing IDs.
+- **account.fiscal.position** — Tax regimes (e.g. "EU B2B reverse-charge", "Export non-EU"). Key fields: \`name\`, \`auto_apply\`, \`country_id\`, \`vat_required\`. Set this on \`res.partner.property_account_position_id\` so subsequent quotes auto-apply the right taxes.
+- **account.move** — Invoices and journal entries. **Read-only** for this agent. Key fields: \`name\`, \`partner_id\`, \`move_type\` ("out_invoice"=customer invoice, "out_refund"=credit note), \`state\` ("draft", "posted", "cancel"), \`payment_state\` ("paid", "not_paid", "partial", "in_payment"), \`amount_total\`, \`invoice_date\`, \`invoice_date_due\`. Use this to answer "is this invoice paid?" — never to draft or post invoices.
 - **mail.message** — Messages. Key fields: \`res_id\`, \`model\`, \`body\`, \`date\`, \`author_id\`
 - **mail.activity** — Activities. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`, \`state\` ("overdue", "today", "planned")
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
 ## Capabilities
-- **Read** all models listed above
-- **Create** leads, contacts, sales orders, messages, and activities
-- **Update** lead stages, contact info, order details, and activity status
+- **Read** all models listed above, including invoices (\`account.move\`) for status checks
+- **Create** leads, contacts, sales orders + lines, messages, and activities
+- **Update** lead stages, contact info (including the customer's fiscal position), order details, quotation lines, and activity status
+- **Never** draft, post, or amend invoices (\`account.move\`) — that's the Bookkeeper agent's job
 
 ${ODOO_QUERY_INSTRUCTIONS}
 
@@ -445,6 +450,12 @@ Use \`odoo_read\` on \`mail.activity\` with \`filters: [["state", "=", "overdue"
 ### Win rate per salesperson
 Use \`odoo_aggregate\` on \`crm.lead\` with \`groupby: ["user_id"]\` and count won vs total.
 
+### Set the right tax regime on a customer
+Look up the matching \`account.fiscal.position\` by \`name\` (e.g. "EU B2B reverse-charge") with \`odoo_read\`, then \`odoo_write\` the \`res.partner.property_account_position_id\` so future quotations auto-apply the correct taxes.
+
+### Check if an invoice is paid
+Use \`odoo_read\` on \`account.move\` with \`filters: [["name", "=", "INV/2026/0001"]]\` and inspect \`payment_state\`. Do **not** create or modify invoices — defer to the Bookkeeper agent.
+
 ${ODOO_OUTPUT_FORMATTING}
 
 ${ODOO_RULES}
@@ -454,9 +465,12 @@ ${ODOO_RULES}
       { model: "crm.lead", operations: ["read", "create", "write"] },
       { model: "crm.stage", operations: ["read"] },
       { model: "sale.order", operations: ["read", "create", "write"] },
+      { model: "sale.order.line", operations: ["read", "create", "write"] },
       { model: "res.partner", operations: ["read", "create", "write"] },
       { model: "product.product", operations: ["read"] },
       { model: "account.tax", operations: ["read"] },
+      { model: "account.fiscal.position", operations: ["read", "write"] },
+      { model: "account.move", operations: ["read"] },
       { model: "res.currency", operations: ["read"] },
       { model: "mail.message", operations: ["read", "create"] },
       { model: "mail.activity", operations: ["read", "create", "write"] },

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -436,6 +436,7 @@ You manage the sales pipeline — tracking leads, following up on opportunities,
 - **Create** leads, contacts, sales orders + lines, messages, and activities
 - **Update** lead stages, contact info (including the customer's fiscal position), order details, quotation lines, and activity status
 - **Never** draft, post, or amend invoices (\`account.move\`) — that's the Bookkeeper agent's job
+- You may **confirm** a sale order (\`state\` → "sale"), but never trigger the downstream "Create Invoice" action (Odoo method \`_create_invoices\`). If a customer needs an invoice, hand off to the Bookkeeper agent
 
 ${ODOO_QUERY_INSTRUCTIONS}
 

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -76,6 +76,7 @@ export const MODEL_CATEGORIES: ModelCategory[] = [
       { model: "account.journal", name: "Journals" },
       { model: "account.account", name: "Accounts" },
       { model: "account.tax", name: "Taxes" },
+      { model: "account.fiscal.position", name: "Fiscal Positions" },
       { model: "account.payment.term", name: "Payment Terms" },
       { model: "account.analytic.account", name: "Analytic Accounts" },
       { model: "account.analytic.line", name: "Analytic Lines" },


### PR DESCRIPTION
## Summary

- Adds `account.fiscal.position` (read+write), `sale.order.line` (read+create+write), and `account.move` (read-only) to the CRM & Sales Assistant template — the three models a sales agent needs to build quotations end-to-end (lead → opportunity → quote with the right VAT regime) and answer "is this invoice paid?".
- Registers `account.fiscal.position` in `MODEL_CATEGORIES` so the schema sync probes it and the Permissions UI can surface it. Previously the model was simply absent — agents couldn't grant access even manually.
- Updates the template's `AGENTS.md` with field hints for the new models, an explicit Bookkeeper boundary (never draft/post/amend invoices), and two new analysis patterns ("Set the right tax regime on a customer", "Check if an invoice is paid").

## Why read-only on `account.move`?

Drafting, posting, and amending invoices belongs to the Bookkeeper template — that workflow is regulated (UID, sequential numbering, posting rules) and already governed by the existing draft-first / four-eyes pattern in `odoo-bookkeeper`. A Sales agent only ever needs to **look up** invoice status when a customer asks. Granting `create`/`write` here would open a second, ungoverned invoicing path.

## Impact on existing agents

Template changes only affect newly-created agents. Existing CRM agents must have the three new permissions added manually in their settings. The new `account.fiscal.position` model now also appears in the Permissions UI for **any** agent on a connected Odoo, not only those created from this template.

## Test Plan

- [x] New TDD tests in `agent-templates.test.ts` (8 cases) — pass
- [x] Drift guard (`template-integration-coverage.test.ts`) — pass; confirms every required model is probed by the sync
- [x] Template validation (`odoo-template-validation.test.ts`) — pass
- [x] `pnpm -C packages/web test` — 4654 passed, only preexisting flaky `memory-audit-watcher` unaffected by this change
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm exec tsc --noEmit` — clean
- [ ] Manual on a staging Odoo: create a new CRM agent, confirm all three new permissions are set, and exercise the "set fiscal position on a customer" + "look up invoice payment_state" flows.