### PR TITLE
fix: post-merge review of OC bump PRs (#421 + #432)

### DIFF
--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -91,6 +91,20 @@ vi.mock("@/lib/openclaw-config", () => ({
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
 }));
 
+// Mocks for the post-regenerate "wait until OC has the agent" gate. Without
+// these the route falls through the `getOpenClawClient()` catch (no global
+// __openclawClient set in test env) and the polling code is never exercised
+// here — leaving a regression like "someone removes the try/catch" invisible
+// to the route's own unit tests.
+const mockOpenClawClient = { config: { get: vi.fn() } };
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: vi.fn(() => mockOpenClawClient),
+}));
+const mockWaitForAgentInRuntime = vi.fn().mockResolvedValue(true);
+vi.mock("@/lib/wait-for-agent-in-runtime", () => ({
+  waitForAgentInRuntime: (...args: unknown[]) => mockWaitForAgentInRuntime(...args),
+}));
+
 vi.mock("@/lib/path-validation", () => ({
   validateAllowedPaths: vi.fn((paths: string[]) =>
     paths.map((p) => (p.endsWith("/") ? p : p + "/"))
@@ -179,6 +193,34 @@ import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 describe("POST /api/agents", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+  });
+
+  it("waits for the freshly-created agent to land in OC's runtime before returning 201", async () => {
+    // The route's contract is "201 means the agent is dispatch-ready" — not
+    // "201 means we've queued a config.apply". Without the post-regenerate
+    // `waitForAgentInRuntime` gate, an immediate programmatic dispatch
+    // (Odoo / Web Search / Email / Telegram E2E suites) races the OC
+    // hot-reload and hits `invalid agent params: unknown agent id`. Lock
+    // the gate in so a future refactor can't silently drop it back to the
+    // fire-and-forget regenerate.
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Race Guard", templateId: "custom" }),
+    });
+
+    const response = await POST(request);
+    expect(response.status).toBe(201);
+
+    expect(regenerateOpenClawConfig).toHaveBeenCalled();
+    expect(mockWaitForAgentInRuntime).toHaveBeenCalledTimes(1);
+    expect(mockWaitForAgentInRuntime).toHaveBeenCalledWith(mockOpenClawClient, "new-agent-id");
+
+    // Order matters: the wait must be called AFTER the regenerate, not before
+    // (otherwise we'd poll for an agent OC doesn't know about yet) and AFTER
+    // the workspace/audit setup is committed in the route.
+    const regenInvocations = vi.mocked(regenerateOpenClawConfig).mock.invocationCallOrder;
+    const waitInvocations = mockWaitForAgentInRuntime.mock.invocationCallOrder;
+    expect(waitInvocations[0]).toBeGreaterThan(regenInvocations[0]);
   });
 
   it("should return 403 for non-admin users", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2112,6 +2112,87 @@ describe("regenerateOpenClawConfig", () => {
     expect(config?.models?.providers?.ollama?.request?.allowPrivateNetwork).toBe(true);
   });
 
+  it("does NOT set allowPrivateNetwork on the public LLM providers (anthropic/openai/google/ollama-cloud)", async () => {
+    // The SSRF opt-in is scoped to `ollama-local` because that's the only
+    // built-in provider that legitimately targets private / .local / RFC
+    // 1918 addresses. Public providers all resolve to TLS-protected
+    // public APIs and must stay on the default-deny so a misconfigured
+    // URL can't accidentally hit an internal service.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-test";
+      if (key === "openai_api_key") return "sk-test";
+      if (key === "google_api_key") return "gk-test";
+      if (key === "ollama_cloud_api_key") return "ol-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const providers = config?.models?.providers ?? {};
+    for (const name of ["anthropic", "openai", "google", "ollama-cloud"] as const) {
+      // The flag must be absent — not `false`, not present at all.
+      // eslint-disable-next-line security/detect-object-injection
+      expect(providers[name]?.request?.allowPrivateNetwork).toBeUndefined();
+      // And no other shape leaks the flag at the outer level either.
+      // eslint-disable-next-line security/detect-object-injection
+      expect(providers[name]?.allowPrivateNetwork).toBeUndefined();
+    }
+  });
+
+  it("preserves OC-enriched sibling channels sub-blocks (e.g. channels.defaults) on a real telegram change (#193 follow-up)", async () => {
+    // build.ts:1182 spreads `...existingChannels` into the new config.channels
+    // when the telegram block changed. Without that spread, OC-side enriched
+    // sibling sub-blocks (`channels.defaults` for heartbeat/botLoopProtection,
+    // `channels.modelByChannel`, other channels' configs) would get stripped
+    // — and since OC 2026.5.x has no `channels` entry in BASE_RELOAD_RULES,
+    // the resulting diff falls through to restart-class and re-triggers the
+    // very cascade #193 / agent-create-no-restart is supposed to catch.
+    // This pin guards against an accidental revert to `{ telegram: ... }`
+    // only.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-id-with-bot") return "BOT123:secret";
+      return null;
+    });
+    // Mock an agent in the DB with a telegram bot, plus an OC-enriched
+    // `channels.defaults` block already on disk.
+    mockedDb.select.mockReturnValueOnce({
+      from: vi.fn().mockResolvedValue([
+        {
+          id: "agent-id-with-bot",
+          name: "Bot Agent",
+          isPersonal: false,
+          ownerId: "user-1",
+          createdAt: new Date(),
+          deletedAt: null,
+        },
+      ]),
+    } as unknown as ReturnType<typeof mockedDb.select>);
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan" },
+        channels: {
+          defaults: { heartbeat: { mode: "visible" } },
+          telegram: { enabled: true, dmPolicy: "pairing", accounts: { "stale-agent": {} } },
+        },
+      }) as unknown as Buffer
+    );
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json.tmp")
+    );
+    expect(written).toBeDefined();
+    const config = JSON.parse(String(written![1]));
+    // The OC-enriched sibling sub-block survives the regenerate even though
+    // telegram itself changed (accounts swapped from "stale-agent" to the
+    // current bot agent).
+    expect(config.channels.defaults).toEqual({ heartbeat: { mode: "visible" } });
+    expect(config.channels.telegram.accounts).toHaveProperty("agent-id-with-bot");
+  });
+
   it("emits models: [] when fetchOllamaLocalModelsFromUrl returns empty (Ollama unreachable at config-regen time)", async () => {
     // The setup wizard validates that ≥1 tool-capable model exists before
     // saving the URL, so this state means Ollama went away after setup.

--- a/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
@@ -374,6 +374,42 @@ describe("supplementPayloadWithOcConfig", () => {
     expect(result.update.lastCheckedAt).toBe("T1");
     expect(result.canvasHost.port).toBe(18790);
   });
+
+  it("merges OC-enriched sibling channel sub-blocks (e.g. channels.defaults) absent from payload (#193 follow-up)", () => {
+    // OC 2026.5.x enriches `channels.defaults` (heartbeat visibility,
+    // botLoopProtection) at runtime alongside Pinchy-owned `channels.telegram`.
+    // Without merging absent siblings, the supplemented config.apply payload
+    // would lack `channels.defaults` and OC's reload classifier would flag a
+    // channels diff. Since `channels` has no entry in BASE_RELOAD_RULES, that
+    // diff falls through to the restart-class default-deny and triggers the
+    // cascade #193 catches.
+    const payload = JSON.stringify({
+      gateway: { mode: "local" },
+      channels: {
+        telegram: { enabled: true, dmPolicy: "pairing", accounts: { "agent-1": {} } },
+      },
+    });
+    const result = JSON.parse(
+      supplementPayloadWithOcConfig(payload, {
+        channels: {
+          defaults: { heartbeat: { mode: "visible" } },
+          modelByChannel: { telegram: { primary: "ollama/llama3.2" } },
+          telegram: { enabled: true, dmPolicy: "pairing", accounts: { "agent-1": {} } },
+        },
+      })
+    );
+
+    // Sibling sub-blocks absent from payload land from source.
+    expect(result.channels.defaults).toEqual({ heartbeat: { mode: "visible" } });
+    expect(result.channels.modelByChannel).toEqual({
+      telegram: { primary: "ollama/llama3.2" },
+    });
+    // Pinchy-owned telegram block is untouched (source merge would have
+    // skipped duplicate-key fields anyway, but this pin documents the
+    // intent: payload wins for keys it owns).
+    expect(result.channels.telegram.enabled).toBe(true);
+    expect(result.channels.telegram.accounts).toEqual({ "agent-1": {} });
+  });
 });
 
 describe("configsAreEquivalentUpToOpenClawMetadata", () => {

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -8,6 +8,8 @@ import { eq } from "drizzle-orm";
 import { validateInviteToken, claimInvite, getInviteGroupIds } from "@/lib/invites";
 import { seedPersonalAgent } from "@/lib/personal-agent";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
+import { getOpenClawClient } from "@/server/openclaw-client";
 import { validatePassword } from "@/lib/validate-password";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -86,9 +88,26 @@ export async function POST(request: NextRequest) {
       .values(groupIds.map((groupId) => ({ userId: result.user.id, groupId })));
   }
 
-  await seedPersonalAgent(result.user.id, invite.role === "admin");
+  const personalAgent = await seedPersonalAgent(result.user.id, invite.role === "admin");
   await claimInvite(invite.tokenHash, result.user.id);
   await regenerateOpenClawConfig();
+
+  // Same race POST /api/agents guards against (#193 follow-up): the
+  // newly-seeded personal agent isn't visible in OC's runtime until the
+  // fire-and-forget config.apply finishes its hot-reload. The invite-
+  // claimed user typically lands on the chat page immediately after this
+  // response, so we wait until OC's runtime acknowledges the agent before
+  // returning 201. Best-effort with a 5 s cap; falls through silently if
+  // OC isn't connected (test env, pre-setup state).
+  let client = null;
+  try {
+    client = getOpenClawClient();
+  } catch {
+    // OC client not initialised — skip the wait.
+  }
+  if (personalAgent?.id) {
+    await waitForAgentInRuntime(client, personalAgent.id);
+  }
 
   return NextResponse.json({ success: true }, { status: 201 });
 }

--- a/packages/web/src/lib/boot-inits.ts
+++ b/packages/web/src/lib/boot-inits.ts
@@ -108,8 +108,18 @@ export async function bootInits(): Promise<boolean> {
       console.log("[pinchy] Seeded gateway.auth.token into openclaw.json (pre-wizard bootstrap)");
     }
   } catch (err) {
+    // The seed needs the DB (`getOrCreateGatewayToken` reads/writes a settings
+    // row). If it fails here on a fresh install, openclaw.json carries no
+    // `gateway.auth.token` and OC 2026.5.12+ will sit in its "Refusing to bind
+    // gateway to lan without auth" restart loop until either the DB recovers
+    // and a later `regenerateOpenClawConfig` writes the token, or the wizard
+    // is run. Don't gate `markOpenClawConfigReady()` on this — Pinchy itself
+    // must come up so the operator can fix the underlying DB issue. But make
+    // the consequence loud so the operator isn't left wondering why OC's
+    // healthcheck stays red.
     console.error(
-      "[pinchy] Failed to seed gateway token:",
+      "[pinchy] FATAL: gateway token seed failed — OpenClaw will refuse to bind " +
+        "until the token is written. Underlying error:",
       err instanceof Error ? err.message : err
     );
   }

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -210,35 +210,6 @@ export function updateTelegramChannelConfig(
 }
 
 /**
- * Ensure Pinchy's restart-class overrides are present in openclaw.json BEFORE
- * OpenClaw starts. Writes ONLY the fields that, when missing-then-added later
- * via WS config.apply, hit OC 5.3's BASE_RELOAD_RULES_TAIL `gateway` /
- * `discovery` / `canvasHost` / `update` rules (kind:"restart") and trigger
- * a SIGUSR1 → in-process restart that crashes with
- * `ConfigMutationConflictError: config changed since last load` (OC 5.3
- * stale-snapshot bug in `prepareGatewayStartupConfig → ensureGatewayStartupAuth →
- * replaceConfigFile`). The cascade is the failure mode behind the Telegram
- * E2E `agent-create-no-restart.spec.ts` "OpenClaw never quiet for 30000ms"
- * flake on this branch.
- *
- * Why a targeted write rather than running full `regenerateOpenClawConfig()`
- * unconditionally in bootInits: the full regenerate broke the integration
- * test's basic chat (`Pinchy agent responds via OpenClaw`) — the agent failed
- * with `404 status code (no body)` from fake-ollama on `ollama/llama3.2`,
- * apparently because the bootInits-time regenerate's models/agents block
- * (built from an empty DB) interfered with later setup-wizard regenerate +
- * OC's model registry refresh on hot-reload. Restricting the bootInits write
- * to ONLY the gateway/discovery/canvasHost/update fields avoids that
- * interaction while still aligning OC's compare baseline.
- *
- * This function is idempotent: if the file already has all four overrides
- * with their expected values, no write happens. The skip path also handles
- * the production case (Docker-managed named volume populated from the image's
- * baked-in `config/openclaw.json`, which already carries these fields) — the
- * volume content matches Pinchy's expected overrides → no write → no diff
- * surface for OC to react to.
- */
-/**
  * Land `gateway.auth.token` in `openclaw.json` if it's not already set, so
  * the OpenClaw container can start on a fresh install (pre-setup-wizard).
  *
@@ -313,6 +284,35 @@ export async function seedGatewayTokenIfMissing(): Promise<boolean> {
   return true;
 }
 
+/**
+ * Ensure Pinchy's restart-class overrides are present in openclaw.json BEFORE
+ * OpenClaw starts. Writes ONLY the fields that, when missing-then-added later
+ * via WS config.apply, hit OC 5.3's BASE_RELOAD_RULES_TAIL `gateway` /
+ * `discovery` / `canvasHost` / `update` rules (kind:"restart") and trigger
+ * a SIGUSR1 → in-process restart that crashes with
+ * `ConfigMutationConflictError: config changed since last load` (OC 5.3
+ * stale-snapshot bug in `prepareGatewayStartupConfig → ensureGatewayStartupAuth →
+ * replaceConfigFile`). The cascade is the failure mode behind the Telegram
+ * E2E `agent-create-no-restart.spec.ts` "OpenClaw never quiet for 30000ms"
+ * flake on this branch.
+ *
+ * Why a targeted write rather than running full `regenerateOpenClawConfig()`
+ * unconditionally in bootInits: the full regenerate broke the integration
+ * test's basic chat (`Pinchy agent responds via OpenClaw`) — the agent failed
+ * with `404 status code (no body)` from fake-ollama on `ollama/llama3.2`,
+ * apparently because the bootInits-time regenerate's models/agents block
+ * (built from an empty DB) interfered with later setup-wizard regenerate +
+ * OC's model registry refresh on hot-reload. Restricting the bootInits write
+ * to ONLY the gateway/discovery/canvasHost/update fields avoids that
+ * interaction while still aligning OC's compare baseline.
+ *
+ * This function is idempotent: if the file already has all four overrides
+ * with their expected values, no write happens. The skip path also handles
+ * the production case (Docker-managed named volume populated from the image's
+ * baked-in `config/openclaw.json`, which already carries these fields) — the
+ * volume content matches Pinchy's expected overrides → no write → no diff
+ * surface for OC to react to.
+ */
 export function seedRestartClassOverridesIfMissing(): boolean {
   let existing: Record<string, unknown>;
   try {


### PR DESCRIPTION
## Summary

An independent review of the OC 2026.5.7 → 2026.5.20 bump (PRs #421 + #432) caught seven follow-up items. None of them are bugs that ship today — the merged behaviour is correct end-to-end on CI — but they close real coverage gaps the original PRs left open. Memory rules call this out explicitly (*layered guardrails*, *drift guards for paired lists*, *vorbestehende Fehler immer fixen*).

## Items addressed

### Coverage holes
1. **`agents-create.test.ts` did not exercise the wait gate.** Mocks for `@/server/openclaw-client` and `@/lib/wait-for-agent-in-runtime` were missing, so every route test fell through `getOpenClawClient()`'s catch and hit the null-client early return. A regression that dropped the gate would have passed CI. New regression-locking assertion now verifies `waitForAgentInRuntime` is called with the new agent id *after* `regenerateOpenClawConfig`.

2. **No test for the `...existingChannels` spread.** A revert to `{ telegram: ... }` alone would strip OC-enriched siblings like `channels.defaults` and silently re-trigger the #193 restart cascade. New test pre-populates a `defaults` sibling and asserts it survives.

3. **No test for the sibling-channel merge in `supplementFromSource`.** This was the final fix that turned Telegram E2E green; pinning it down.

### Reach gaps
4. **`POST /api/invite/claim` was missing the same wait gate.** The invite-claimed user lands on chat immediately after the response, so their first dispatch can race the OC hot-reload exactly like #421's race in `POST /api/agents`. Added the same best-effort gate. `POST /api/users/[userId]` is a soft-delete path — no fresh agent to dispatch to, no gate needed.

5. **`seedGatewayTokenIfMissing` failure was silent.** A failed seed would land Pinchy in a state where OC would silently sit in "Refusing to bind gateway to lan without auth" with no smoking gun in Pinchy's logs. We can't block `markOpenClawConfigReady` (the operator needs Pinchy up to fix the DB issue), but the failure mode is now loud — the error message spells out the consequence.

7. **No negative assertion for `allowPrivateNetwork`.** Original test pinned it on `ollama` but didn't pin its absence on the public providers (`anthropic`, `openai`, `google`, `ollama-cloud`). A "let me default it everywhere" refactor would now fail.

### Doc/style
6. **Orphaned JSDoc in `targeted.ts:213-240`.** PR #421 inserted `seedGatewayTokenIfMissing` between `seedRestartClassOverridesIfMissing`'s docstring and its function, leaving the older function undocumented. Doc moved back.

## Test plan

- [x] `pnpm -C packages/web test` — 4660 passed (4 new), 13 skipped
- [x] `pnpm -C packages/web lint` — 0 errors
- [ ] CI full pipeline (this PR)