### PR TITLE
fix(chat): reconcile history when WS dropped before first chunk (#310)

### DIFF
--- a/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
+++ b/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
@@ -1,0 +1,112 @@
+/**
+ * Unit tests for `shouldReplaceLocalWithServerHistory` — the decision
+ * function that gates whole-list reconcile on the history frame after a
+ * disconnect+reconnect cycle. The renderHook suite already exercises this
+ * through the public surface; these tests pin the regression-protection
+ * branches (esp. the queued-while-disconnected case) at the function level
+ * so a refactor that drops the status guard fails fast and locally.
+ */
+import { describe, it, expect } from "vitest";
+import { shouldReplaceLocalWithServerHistory, type WsMessage } from "@/hooks/use-ws-runtime";
+
+function user(content: string, status?: "sending" | "sent" | "failed"): WsMessage {
+  return { id: `u-${content}`, role: "user", content, status };
+}
+
+function assistant(content: string, opts: { error?: boolean } = {}): WsMessage {
+  return {
+    id: `a-${content}`,
+    role: "assistant",
+    content,
+    ...(opts.error ? { error: { disconnected: true } } : {}),
+  };
+}
+
+describe("shouldReplaceLocalWithServerHistory", () => {
+  it("returns false when recovery flag is not set (initial load)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("hi", "sent")],
+        [user("hi"), assistant("hello")],
+        false
+      )
+    ).toBe(false);
+  });
+
+  it("returns false when server history is empty (OpenClaw unreachable)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory([user("hi", "sent"), assistant("partial")], [], true)
+    ).toBe(false);
+  });
+
+  it("returns true when local list is empty (initial reconcile after reconnect)", () => {
+    expect(shouldReplaceLocalWithServerHistory([], [user("hi"), assistant("hello")], true)).toBe(
+      true
+    );
+  });
+
+  it("returns true when last non-error local message is an assistant turn (mid-stream disconnect)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("hi", "sent"), assistant("partial reply")],
+        [user("hi"), assistant("complete reply")],
+        true
+      )
+    ).toBe(true);
+  });
+
+  it("treats trailing error bubble as non-blocking when an assistant turn precedes it", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("hi", "sent"), assistant("partial"), assistant("error", { error: true })],
+        [user("hi"), assistant("complete")],
+        true
+      )
+    ).toBe(true);
+  });
+
+  // Issue #310: WS dropped between ack and first chunk. Last local message is
+  // an acked user, history has the assistant reply we never saw.
+  it("returns true when last is acked-user AND server history is strictly longer (#310)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("what's the vacation policy?", "sent")],
+        [user("what's the vacation policy?"), assistant("25 days.")],
+        true
+      )
+    ).toBe(true);
+  });
+
+  // Regression guard: a "sending" status means the message was queued during
+  // the disconnect (not yet sent on the new connection). Replacing local with
+  // history would drop the queued message.
+  it("returns false when last user message has status=sending (queued during disconnect)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("queued offline", "sending")],
+        [user("previous turn"), assistant("previous reply")],
+        true
+      )
+    ).toBe(false);
+  });
+
+  // Regression guard: a failed message must not be silently wiped — the user
+  // sees a retry affordance in the UI tied to it.
+  it("returns false when last user message has status=failed", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [user("failed to send", "failed")],
+        [user("old"), assistant("old reply")],
+        true
+      )
+    ).toBe(false);
+  });
+
+  // Equal-length defends against accidentally adopting a stale-but-different
+  // history (e.g. cached pre-disconnect state) when local has progressed.
+  it("returns false when last is acked-user but server history is not strictly longer", () => {
+    expect(shouldReplaceLocalWithServerHistory([user("hi", "sent")], [user("hi")], true)).toBe(
+      false
+    );
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -4386,6 +4386,85 @@ describe("useWsRuntime", () => {
       expect(result.current.isOrphaned).toBe(false);
     });
 
+    // Issue #310: production users saw "The agent didn't respond" even though
+    // the assistant reply had landed safely on OpenClaw. Root cause: the WS
+    // dropped between ack and the first chunk, so the last non-error local
+    // message was the user's send. The reconcile gate at use-ws-runtime.ts
+    // required `lastNonError.role === "assistant"`, which fails in this
+    // window — server history was ignored and the orphan stuck around.
+    it("reconciles from history when WS dropped before any assistant chunk arrived (#310)", async () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+
+      // Connect, load empty history
+      await act(async () => {
+        latestWs().simulateOpen();
+        latestWs().simulateMessage({ type: "history", messages: [] });
+      });
+
+      // User sends; receive ack but NO chunk yet
+      await act(async () => {
+        result.current.runtime.onNew(makeUserMessage("what's the vacation policy?"));
+      });
+      const ws = latestWs();
+      const sentPayload = JSON.parse(ws.send.mock.calls.at(-1)![0] as string) as {
+        clientMessageId: string;
+      };
+      await act(async () => {
+        ws.simulateMessage({ type: "ack", clientMessageId: sentPayload.clientMessageId });
+      });
+
+      // WS drops BEFORE any assistant chunk arrives
+      await act(async () => {
+        ws.simulateClose();
+      });
+
+      // Reconnect after backoff — OpenClaw completed the turn while we were
+      // gone, so server history contains the full user + assistant pair.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(1000);
+      });
+      await act(async () => {
+        latestWs().simulateOpen();
+        latestWs().simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "what's the vacation policy?", timestamp: 1000 },
+            { role: "assistant", content: "25 days of paid leave per year.", timestamp: 2000 },
+          ],
+        });
+      });
+
+      // Advance past the disconnect-bubble grace window — bubble must stay
+      // cancelled because reconcile landed within the window.
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(2000);
+      });
+      // Flush the staged-replace timer (stageDestructiveHistoryReconcile uses
+      // a 0ms setTimeout to remount the message subtree before swapping).
+      await act(async () => {
+        await vi.advanceTimersByTimeAsync(50);
+      });
+
+      const messages = result.current.runtime.messages as Array<{
+        role: string;
+        content: Array<{ text: string }>;
+        metadata?: { custom?: { error?: unknown } };
+      }>;
+
+      // No synthetic disconnect bubble — reconcile happened in time
+      const errorBubbles = messages.filter(
+        (m) => m.role === "assistant" && m.metadata?.custom?.error
+      );
+      expect(errorBubbles).toHaveLength(0);
+
+      // Canonical assistant reply must be the last message
+      expect(messages.at(-1)?.role).toBe("assistant");
+      expect(messages.at(-1)?.content[0].text).toBe("25 days of paid leave per year.");
+
+      // isOrphaned must be false — the orphan was healed via reconcile
+      expect(result.current.isOrphaned).toBe(false);
+    });
+
     describe("binary file attachments (PDF)", () => {
       it("includes PDF attachment as image_url content part with filename in WS payload", async () => {
         const { result } = renderHook(() => useWsRuntime("agent-1"));

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -362,6 +362,15 @@ function capMessages<T>(messages: T[]): T[] {
  * queued during the disconnect (see `pendingMessagesRef` handling). The
  * server hasn't acknowledged it yet, so a longer history must be from a
  * previous turn — replacing would silently drop the queued message.
+ *
+ * Known limit (in scope for #310 Tier 2, not this gate): the `status ===
+ * "sent"` guard also excludes user messages whose `status` is `undefined`,
+ * which happens when the last user message in `prevMessages` came from a
+ * prior history reconcile (history-derived messages don't carry a delivery
+ * status). This blocks reconcile in a rare multi-tab scenario where Tab A
+ * opens a chat with an in-flight assistant turn from Tab B, then Tab A's
+ * WS drops before the chunks arrive. Tier 2 closes this via the server-
+ * side `activeRun` signal — see #310 follow-ups.
  */
 export function shouldReplaceLocalWithServerHistory(
   prevMessages: WsMessage[],
@@ -866,6 +875,12 @@ export function useWsRuntime(agentId: string): {
               // acked-user-but-no-chunk window). We intentionally replace even
               // if the last local message is a synthetic disconnect-error
               // bubble, because the server's history is the ground truth.
+              //
+              // The helper is re-evaluated here against React's `prev` (not
+              // `messagesRef.current` from the outer scope) because under
+              // concurrent rendering the two snapshots can diverge — a stale
+              // outer evaluation must never override what React holds as the
+              // current authoritative state inside the setter.
               if (
                 shouldReplaceLocalWithServerHistory(prev, historyMessages, shouldRecoverFromHistory)
               ) {

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -332,6 +332,54 @@ function capMessages<T>(messages: T[]): T[] {
   return messages.slice(messages.length - MAX_BUNDLED_MESSAGES);
 }
 
+/**
+ * Decide whether the local message list should be wholly replaced with the
+ * server's history frame after a disconnect+reconnect cycle.
+ *
+ * The flag `shouldRecoverFromHistory` is set when the WS closed or a page-
+ * lifecycle event suspended us — i.e. we may have missed frames while the
+ * client wasn't listening. Server history is the canonical record in that
+ * case, so we adopt it.
+ *
+ * Conditions:
+ *   - Recovery flag is set (otherwise this is an ordinary initial load —
+ *     the status reducer handles in-flight reconciliation).
+ *   - History is non-empty (an empty frame can mean "upstream OpenClaw is
+ *     unreachable", which is never canonical when we already have content).
+ *   - The last non-error local message either is an assistant turn
+ *     (mid-stream disconnect — server is canonical), OR is an acked user
+ *     turn AND server history is strictly longer than what we have locally.
+ *
+ * The second clause is the fix for issue #310: when the WS drops between
+ * `ack` and the first chunk, the local list ends with an acked user
+ * message. OpenClaw still completes the turn and persists the reply, so
+ * server history has [..., user, assistant] while local has [..., user].
+ * Without this clause the reconcile gate fires `false`, the synthetic
+ * "The agent didn't respond." orphan bubble surfaces, and retries pile up
+ * duplicate user turns.
+ *
+ * Why the `status === "sent"` guard: a "sending" user message is one we
+ * queued during the disconnect (see `pendingMessagesRef` handling). The
+ * server hasn't acknowledged it yet, so a longer history must be from a
+ * previous turn — replacing would silently drop the queued message.
+ */
+export function shouldReplaceLocalWithServerHistory(
+  prevMessages: WsMessage[],
+  historyMessages: WsMessage[],
+  shouldRecoverFromHistory: boolean
+): boolean {
+  if (!shouldRecoverFromHistory) return false;
+  if (historyMessages.length === 0) return false;
+
+  const lastNonError = [...prevMessages].reverse().find((m) => !m.error);
+  if (!lastNonError) return true;
+
+  if (lastNonError.role === "assistant") return true;
+
+  // lastNonError.role === "user"
+  return lastNonError.status === "sent" && historyMessages.length > prevMessages.length;
+}
+
 export function useWsRuntime(agentId: string): {
   runtime: AssistantRuntime;
   isRunning: boolean;
@@ -790,10 +838,11 @@ export function useWsRuntime(agentId: string): {
             }));
             const shouldRecoverFromHistory = shouldRecoverFromHistoryRef.current;
             const prevMessages = messagesRef.current;
-            const shouldReplaceWithHistory =
-              shouldRecoverFromHistory &&
-              historyMessages.length > 0 &&
-              [...prevMessages].reverse().find((m) => !m.error)?.role === "assistant";
+            const shouldReplaceWithHistory = shouldReplaceLocalWithServerHistory(
+              prevMessages,
+              historyMessages,
+              shouldRecoverFromHistory
+            );
             const shouldStageReplace =
               shouldReplaceWithHistory &&
               prevMessages.length > 0 &&
@@ -811,20 +860,16 @@ export function useWsRuntime(agentId: string): {
                 return capMessages(historyMessages);
               }
               // After reconnects, replace local messages with canonical history
-              // from the server. Skip the wipe when server history is empty
-              // (typically because upstream OpenClaw is unreachable and Pinchy
-              // returned an empty history) — empty can't be canonical when we
-              // already have local messages.
-              // Note: we intentionally replace even if the last local message is
-              // a synthetic disconnect-error bubble, because the server's history
-              // is the ground truth after reconnect.
-              if (shouldRecoverFromHistory && historyMessages.length > 0) {
-                // Only replace if the last non-error message is an assistant turn
-                // (i.e. we were in the middle of a response when disconnected).
-                const lastNonError = [...prev].reverse().find((m) => !m.error);
-                if (lastNonError?.role === "assistant") {
-                  return capMessages(historyMessages);
-                }
+              // from the server. The conditions are gathered in
+              // shouldReplaceLocalWithServerHistory above — see that helper's
+              // doc for the full rationale (esp. the issue #310 fix for an
+              // acked-user-but-no-chunk window). We intentionally replace even
+              // if the last local message is a synthetic disconnect-error
+              // bubble, because the server's history is the ground truth.
+              if (
+                shouldReplaceLocalWithServerHistory(prev, historyMessages, shouldRecoverFromHistory)
+              ) {
+                return capMessages(historyMessages);
               }
               return prev;
             });


### PR DESCRIPTION
## Summary

Tier 1 client-side fix for #310 ("The agent didn't respond" with duplicate retries on production).

- Extracts the post-disconnect reconcile gate into a pure helper, `shouldReplaceLocalWithServerHistory`, and broadens it to handle the "WS dropped between ack and first chunk" window.
- Adds the `status === "sent"` guard to protect queued messages from being silently wiped when server history is older than what the user just typed.
- Adds 9 unit tests for the helper (all branches incl. two regression-protection paths) and 1 end-to-end test through `useWsRuntime` reproducing the exact #310 scenario.

## Why now

This is a defensive client patch — small, localized, low-risk. Tier 2 (architectural — `active_run_id`, immediate heartbeat + watchdog, visibility-trigger) needs a brainstorming/design pass and is queued for v0.6.0 per the analysis in #310.

Tier 1 stays valuable even after Tier 2 lands (browser-killed tab, suspended laptop returning without OC context, etc.). Cutting it as a standalone v0.5.7 patch ships the user-visible fix while the architectural work cooks.

## Root cause recap

`useWsRuntime` set `shouldRecoverFromHistoryRef.current = true` on disconnect, and on the next history frame it ran:

```ts
const shouldReplaceWithHistory =
  shouldRecoverFromHistory &&
  historyMessages.length > 0 &&
  [...prevMessages].reverse().find((m) => !m.error)?.role === "assistant";
```

That gate covers the "we were mid-stream" case fine. It misses "we got `ack` but no chunk before the socket died" — the last non-error local message is the acked user send, not an assistant turn. The server still completed the run and persisted the reply, so server history has `[…, user, assistant]` while local has `[…, user]`. Without reconcile the synthetic "The agent didn't respond." orphan bubble surfaces, the user hits Retry, the second turn produces a *different* reply, and the chat fills with duplicate user turns.

## Fix shape

```ts
export function shouldReplaceLocalWithServerHistory(
  prevMessages: WsMessage[],
  historyMessages: WsMessage[],
  shouldRecoverFromHistory: boolean
): boolean {
  if (!shouldRecoverFromHistory) return false;
  if (historyMessages.length === 0) return false;
  const lastNonError = [...prevMessages].reverse().find((m) => !m.error);
  if (!lastNonError) return true;
  if (lastNonError.role === "assistant") return true;
  // lastNonError.role === "user"
  return lastNonError.status === "sent" && historyMessages.length > prevMessages.length;
}
```

`status === "sent"` is the regression guard: messages queued *during* disconnect have `status === "sending"` and must survive reconcile (they're queued to send on the next WS open).

## Test plan

- [x] New unit test (`should-replace-local-with-server-history.test.ts`) — 9 cases, all helper branches + queued/failed user message protection
- [x] New end-to-end test in `use-ws-runtime.test.ts` reproducing #310: ack → close → reconnect with history → orphan bubble absent, assistant reply present, `isOrphaned === false`
- [x] Full web test suite: 5027 passed, 0 failed
- [x] `pnpm lint` — 0 errors, no new warnings in changed files
- [x] `tsc --noEmit` — clean
- [ ] Manual verification on staging: send a message, kill the WS via DevTools Network → Disable, wait ~2s, re-enable → orphan bubble must auto-heal into the assistant reply without F5

## Follow-ups (tracked under #310, not this PR)

- Tier 2 (v0.6.0): `active_run_id` correlation, server-side immediate heartbeat + watchdog, `visibilitychange` reconcile trigger
- Tier 3 (RFC): Upstash/Discord-style publisher–subscriber decoupling for fully resumable streams

Closes part of #310. The issue stays open for Tier 2 / Tier 3.