### PR TITLE
feat(chat): resume in-flight chat stream across browser reconnect (#310 Tier 2b)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1663,11 +1663,26 @@ jobs:
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
                          -f docker-compose.integration.yml ps --all 2>&1 || true
           echo "=== Pinchy logs ==="
+          # 1500 lines: a per-tool dispatch generates ~5 lines (request +
+          # broadcasts + complete), 16 tests in this suite x ~3 chats avg ≈
+          # 240 chat-related lines, plus a healthy buffer for startup +
+          # restart + memory-audit-watcher chatter. 500 was eating Test 7's
+          # window before Test 12's failure could be triaged (PR #442 CI runs
+          # 26506915089 + 26510486357 — both Domain Lock failures with
+          # truncated logs).
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
-                         -f docker-compose.integration.yml logs pinchy 2>&1 | tail -500
+                         -f docker-compose.integration.yml logs pinchy 2>&1 | tail -1500
           echo "=== OpenClaw logs (live) ==="
+          # 5000 lines: every chat dispatch generates a multi-line
+          # `[agent/embedded] [trace:embedded-run] core-plugin-tool stages: ...`
+          # entry (~1KB single-line trace) plus the `[ws] ⇄ res ✓ agent` line
+          # plus stream chunks. 1500 lines covered ~4-5 chats; the integration
+          # suite runs 16 tests with multiple chats each. Bumped after the
+          # PR #442 Domain Lock investigation — only the FIRST test's agent
+          # RPC was visible in the prior tail window, hiding evidence of
+          # what test 12 actually dispatched to OC.
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
-                         -f docker-compose.integration.yml logs openclaw 2>&1 | tail -1500
+                         -f docker-compose.integration.yml logs openclaw 2>&1 | tail -5000
           echo "=== DB logs ==="
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
                          -f docker-compose.integration.yml logs db 2>&1 | tail -50

--- a/docker-compose.integration.yml
+++ b/docker-compose.integration.yml
@@ -41,6 +41,10 @@ services:
       # Pinchy with ECONNREFUSED. Same env contract the pre-#196 host-Pinchy
       # config used; the var name encodes that it's an E2E-only behavior.
       - PINCHY_E2E_DISABLE_DOMAIN_RESTART=1
+      # Diagnostic logging for chat dispatch + first-chunk events. Used to
+      # triage the Domain Lock integration test failures on PR #442 (runs
+      # 26506915089 + 26510486357). Gated so production logs stay clean.
+      - PINCHY_E2E_CHAT_TRACE=1
     extra_hosts:
       # Pinchy probes ollama_local_url from regenerateOpenClawConfig(); when the
       # URL points at the host-side fake Ollama via host.docker.internal it must

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -25,6 +25,7 @@ import {
   pollAuditForTool,
   seedDefaultProviderToOllama,
   waitForOpenClawStable,
+  waitForAgentDispatchable,
 } from "../shared/dispatch-probe";
 
 const MOCK_ODOO_URL = process.env.MOCK_ODOO_URL || "http://localhost:9002";
@@ -337,6 +338,20 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
 
     // 8. Wait for OpenClaw to stabilise with the new Ollama config.
     await waitForOpenClawStable(() => pinchyGet("/api/health/openclaw", dispatchCookie));
+
+    // 9. Wait until OC's runtime actually has THIS agent in `agents.list`.
+    // Stability alone doesn't prove dispatchability: the regens from steps
+    // 6 + 7 are fire-and-forget, and if Pinchy's earlier tests in the
+    // suite exhausted OC's config.apply rate-limit window the probe's
+    // regens fall through to the inotify file-watcher fallback whose
+    // debounce can stretch past the stability check. Polling OC's actual
+    // agents.list view via the health endpoint closes that race window
+    // — see CI run 26505503327 for the prior "unknown agent id" failure
+    // mode this guards against.
+    await waitForAgentDispatchable(
+      (agentId) => pinchyGet(`/api/health/openclaw?agentId=${agentId}`, dispatchCookie),
+      dispatchAgentId
+    );
   });
 
   test.afterAll(async () => {

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -118,6 +118,49 @@ export async function waitForOpenClawStable(
 }
 
 /**
+ * Poll `GET /api/health/openclaw?agentId=<id>` until the response's
+ * `agentDispatchable` flag is true — i.e. OC's runtime `agents.list`
+ * currently contains the requested id.
+ *
+ * Why this is needed alongside `waitForOpenClawStable`: stability only
+ * checks `connected=true` for a contiguous window. It does NOT verify the
+ * agent the test is about to dispatch to is actually in OC's hot-loaded
+ * config. After a `PATCH /api/agents/:id` or `PUT /api/agents/:id/integrations`
+ * (both fire-and-forget regenerates), OC's hot-reload can still be in
+ * flight when the API returns 200. Worse: if Pinchy's prior tests
+ * exhausted OC's `config.apply` rate-limit window (~3 calls / 45 s),
+ * the probe's regens fall through to the inotify file-watcher fallback
+ * whose debounce can stretch past the stability check. The result is
+ * "unknown agent id" errors when the test fires its chat.
+ *
+ * Tests that immediately dispatch to an agent created earlier in their
+ * `beforeAll` should call this AFTER `waitForOpenClawStable` and before
+ * issuing the chat.
+ */
+export async function waitForAgentDispatchable(
+  fetchHealth: (
+    agentId: string
+  ) => Promise<{ ok: boolean; json: () => Promise<{ agentDispatchable?: boolean }> }>,
+  agentId: string,
+  opts: { deadlineMs?: number; intervalMs?: number } = {}
+): Promise<void> {
+  const deadline = Date.now() + (opts.deadlineMs ?? 60_000);
+  const interval = opts.intervalMs ?? 500;
+
+  while (Date.now() < deadline) {
+    const res = await fetchHealth(agentId);
+    if (res.ok) {
+      const body = await res.json();
+      if (body.agentDispatchable === true) return;
+    }
+    await new Promise((r) => setTimeout(r, interval));
+  }
+  throw new Error(
+    `OpenClaw runtime did not see agent ${agentId} as dispatchable within deadline — config.apply likely stuck in file-watcher debounce`
+  );
+}
+
+/**
  * Drive the UI login form so the Playwright `page` has a session cookie.
  * Asserts the post-login redirect to `/chat/...` so the next navigation does
  * not race the auth roundtrip.

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -291,8 +291,13 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
       name: `NoRestartTest-${Date.now()}`,
       templateId: "custom",
     });
-    expect(createRes.status, await createRes.text()).toBeLessThan(300);
-    const createdAgent = (await createRes.json()) as { id: string };
+    // Read the body ONCE. The previous version called `await createRes.text()`
+    // (for the assert's failure message) AND then `await createRes.json()`,
+    // which threw `Body is unusable: Body has already been read` on the
+    // happy path. Read into a string, then parse the JSON for the agent id.
+    const responseBody = await createRes.text();
+    expect(createRes.status, responseBody).toBeLessThan(300);
+    const createdAgent = JSON.parse(responseBody) as { id: string };
 
     // Wait for OC's runtime to ACTUALLY reflect the new agent. POST returns
     // after a 5 s best-effort wait (`waitForAgentInRuntime` inside POST

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -242,42 +242,76 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
     // To establish a baseline that matches Pinchy's full regenerated config,
     // do an explicit warm-up agent create here. Cascade resolves, baseline
     // updates, then the actual test action below has a true small diff.
-    const warmupMark = new Date(Date.now() - 1000).toISOString();
-    const warmupRes = await pinchyPost("/api/agents", {
-      name: `Warmup-${Date.now()}`,
-      templateId: "custom",
-    });
-    expect(warmupRes.status, await warmupRes.text()).toBeLessThan(300);
+    //
+    // Earlier versions of this beforeAll did ONE warmup and logged a warning
+    // if it triggered a restart, on the theory that one cascade is enough
+    // to update the baseline. Practice disagreed: CI runs 26511658136
+    // (passed) and 26513340371 (failed) both logged the same
+    // "[warmup] gateway restarted" warning, but only the second hit a
+    // SECOND restart cascade on the test action. The first warmup updated
+    // some restart-required fields in OC's baseline, but not all — the
+    // residual diff against Pinchy's regenerated config still contained
+    // restart-required fields (channels in run 26513340371). Doing a
+    // SECOND warmup absorbs that residual diff; by warmup-3 the baseline
+    // is consistently quiet.
+    //
+    // Bounded retry: max 4 attempts. If the warmup never converges (every
+    // attempt triggers another restart), that's a config-emission bug, not
+    // a baseline race, and the test should fail loudly rather than continue
+    // to a misleading test assertion.
+    const MAX_WARMUP_ATTEMPTS = 4;
+    let warmupTriggeredRestart = true;
+    for (let attempt = 1; attempt <= MAX_WARMUP_ATTEMPTS && warmupTriggeredRestart; attempt++) {
+      const warmupMark = new Date(Date.now() - 1000).toISOString();
+      const warmupRes = await pinchyPost("/api/agents", {
+        name: `Warmup-${attempt}-${Date.now()}`,
+        templateId: "custom",
+      });
+      expect(warmupRes.status, await warmupRes.text()).toBeLessThan(300);
 
-    // The warmup's config.apply propagates async (fire-and-forget). Wait
-    // until OpenClaw has actually OBSERVED the warmup before doing anything
-    // else. A bare 5s sleep + waitForOpenClawQuiet can return false-quiet
-    // when OpenClaw's event loop is blocked (no logs at all in the lookback
-    // window even though config.apply work is queued). Polling for the
-    // warmup's reload-detected line guarantees the cascade — if any —
-    // happens here, not during the test assertion below.
-    const warmupDeadline = Date.now() + 90000;
-    while (Date.now() < warmupDeadline) {
-      const logs = openClawLogsSince(warmupMark);
-      if (/\[reload\] config change detected.*agents/.test(logs)) break;
-      await new Promise((r) => setTimeout(r, 1000));
+      // The warmup's config.apply propagates async (fire-and-forget). Wait
+      // until OpenClaw has actually OBSERVED the warmup before doing anything
+      // else. A bare 5 s sleep + waitForOpenClawQuiet can return false-quiet
+      // when OpenClaw's event loop is blocked (no logs at all in the lookback
+      // window even though config.apply work is queued). Polling for the
+      // warmup's reload-detected line guarantees the cascade — if any —
+      // happens here, not during the test assertion below.
+      const warmupDeadline = Date.now() + 90000;
+      while (Date.now() < warmupDeadline) {
+        const logs = openClawLogsSince(warmupMark);
+        if (/\[reload\] config change detected.*agents/.test(logs)) break;
+        await new Promise((r) => setTimeout(r, 1000));
+      }
+      // Then absorb any restart cascade triggered by the warmup before continuing.
+      await waitForOpenClawQuiet();
+
+      const warmupLogs = openClawLogsSince(warmupMark);
+      warmupTriggeredRestart = /requires gateway restart/.test(warmupLogs);
+      if (warmupTriggeredRestart) {
+        // Note: a restart in this iteration is expected on the first attempt
+        // when the baseline is sparse. We log progress so a future operator
+        // reviewing CI logs can tell convergence apart from cascade-loop.
+        console.warn(
+          `[warmup] attempt ${attempt}/${MAX_WARMUP_ATTEMPTS} triggered gateway restart; retrying to absorb residual baseline drift.`
+        );
+      } else if (attempt > 1) {
+        console.log(
+          `[warmup] baseline stabilised after ${attempt} attempts (no restart on the last warmup).`
+        );
+      }
     }
-    // Then absorb any restart cascade triggered by the warmup before continuing.
-    await waitForOpenClawQuiet();
-
-    // Localize failures: if the warmup itself triggered a restart, the
-    // cascade is from a setup-stage problem (sparse-baseline, env
-    // propagation, etc.) — not from the test action. Failing here points
-    // a finger at the right cause; failing in the assertion below would
-    // misleadingly look like the production fix doesn't work. Note: a
-    // restart in the warmup window is acceptable in some staging-cold
-    // scenarios, so we tolerate it but log a warning instead of failing
-    // hard. The test assertion remains the source of truth.
-    const warmupLogs = openClawLogsSince(warmupMark);
-    if (/requires gateway restart/.test(warmupLogs)) {
-      console.warn(
-        "[warmup] gateway restarted during warmup — beforeAll is recovering, but this means the cold-start baseline was sparse. " +
-          "If the actual assertion below fails with the same restart fingerprint, the warmup didn't actually establish a stable baseline."
+    // If we exhausted attempts and the baseline still hasn't stabilised,
+    // every Pinchy regenerate is still producing a restart-required diff.
+    // That's not a flake to absorb — surface it loudly so the underlying
+    // config-emission bug can be tracked. The original "warn-and-continue"
+    // behaviour masked exactly this signal: the test would then fail at the
+    // assertion below with the same restart fingerprint, and triage couldn't
+    // tell warmup-instability from a real regression in POST /api/agents.
+    if (warmupTriggeredRestart) {
+      throw new Error(
+        `[warmup] every one of ${MAX_WARMUP_ATTEMPTS} warmup POSTs triggered a gateway restart cascade. ` +
+          `This is not the sparse-baseline race the warmup retry exists to absorb — Pinchy's regenerated config ` +
+          `keeps producing restart-required diffs. Inspect openclaw-config emission for non-determinism or channel drift.`
       );
     }
   });

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -49,7 +49,9 @@ import {
   waitForTelegramPolling,
   seedSetup,
   pinchyPost,
+  pinchyGet,
 } from "./helpers";
+import { waitForAgentDispatchable } from "../shared/dispatch-probe";
 
 // Same bot token as telegram-flow.spec.ts. The Telegram E2E suites share Smithers
 // across spec files, and this one runs first (alphabetical). If we connected with
@@ -290,46 +292,31 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
       templateId: "custom",
     });
     expect(createRes.status, await createRes.text()).toBeLessThan(300);
+    const createdAgent = (await createRes.json()) as { id: string };
 
-    // Poll instead of fixed-sleep. config.apply latency on CI varies
-    // widely: typical 1–3 s on a fresh runner, 20–40 s after an earlier
-    // restart-startup-failed bundle has slowed the gateway. The
-    // previous fixed 10 s sleep false-failed runs where Pinchy's
-    // POST returned before OpenClaw had logged the reload-detected
-    // line. Polling exits on the first match — happy path stays fast,
-    // slow path no longer flakes. After the match, a 3 s grace window
-    // ensures any follow-up `requires gateway restart` cascade lands
-    // in the captured logs (the negative assertions below need it).
-    const pollDeadline = Date.now() + 60000;
-    let logs = "";
-    let observedReloadDetected = false;
-    while (Date.now() < pollDeadline) {
-      logs = openClawLogsSince(beforeMark);
-      if (/\[reload\] config change detected.*agents/.test(logs)) {
-        observedReloadDetected = true;
-        break;
-      }
-      await new Promise((r) => setTimeout(r, 1000));
-    }
+    // Wait for OC's runtime to ACTUALLY reflect the new agent. POST returns
+    // after a 5 s best-effort wait (`waitForAgentInRuntime` inside POST
+    // /api/agents); if OC was rate-limited or just slow, POST returns 201
+    // but the apply hasn't landed yet. The original test then polled OC
+    // logs for the reload event and threw at 60 s if it never appeared
+    // (CI run 26507951006 hit this — 27 s of OC log silence after POST,
+    // then the test timed out). Polling agent-dispatchability via
+    // `/api/health/openclaw?agentId=X` is a stronger signal: by the time
+    // OC's `agents.list` contains the id, config.apply MUST have landed,
+    // so the reload-detected log line is guaranteed to be in the captured
+    // logs. 90 s deadline matches the CI worst case documented in
+    // `dispatch-probe.ts`: typical fresh-runner ≤3 s, post-restart cold
+    // gateway ≤40 s.
+    await waitForAgentDispatchable(
+      (agentId) => pinchyGet(`/api/health/openclaw?agentId=${agentId}`),
+      createdAgent.id,
+      { deadlineMs: 90_000 }
+    );
+    // 3 s grace window after dispatchability so any follow-up
+    // `requires gateway restart` cascade lands in the captured logs (the
+    // negative assertions below need it).
     await new Promise((r) => setTimeout(r, 3000));
-    logs = openClawLogsSince(beforeMark);
-
-    // Clear failure path: if 60 s elapsed without ever seeing the
-    // reload-detected line, the bug isn't "config change triggered a
-    // restart" (which the negative assertions below cover) — it's
-    // "config.apply never reached OpenClaw at all". That distinction
-    // matters for triage. Without this guard, the test would fall through
-    // to the positive assertion below and report "expected '<empty>' to
-    // match /\\[reload\\] config change detected.*agents/", which gives no
-    // hint that the timeout was the cause. Surface it explicitly so the
-    // CI log says exactly what happened.
-    if (!observedReloadDetected) {
-      throw new Error(
-        `config.apply was not observed within 60 s after POST /api/agents returned ` +
-          `${createRes.status}. OpenClaw either dropped the apply RPC or is in a degraded ` +
-          `state. Logs captured since ${beforeMark}:\n${logs || "(empty)"}`
-      );
-    }
+    const logs = openClawLogsSince(beforeMark);
 
     // (a) Positive: the config change reached OpenClaw and was evaluated
     //     for reload. Without this, we'd be testing nothing — the config

--- a/packages/web/src/__tests__/api/health-openclaw.test.ts
+++ b/packages/web/src/__tests__/api/health-openclaw.test.ts
@@ -1,7 +1,10 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { NextRequest } from "next/server";
 
 const mockRestartState = { isRestarting: false, triggeredAt: null as number | null };
 const mockConnectionState = { connected: false };
+const mockConfigGet = vi.fn();
+const mockGetOpenClawClient = vi.fn();
 
 vi.mock("@/server/restart-state", () => ({
   restartState: mockRestartState,
@@ -11,20 +14,31 @@ vi.mock("@/server/openclaw-connection-state", () => ({
   openClawConnectionState: mockConnectionState,
 }));
 
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => mockGetOpenClawClient(),
+}));
+
+function fakeRequest(url = "http://localhost/api/health/openclaw"): NextRequest {
+  // Only `nextUrl.searchParams` is consumed by the route — minimal shim.
+  return { nextUrl: new URL(url) } as unknown as NextRequest;
+}
+
 describe("GET /api/health/openclaw", () => {
   let GET: typeof import("@/app/api/health/openclaw/route").GET;
 
   beforeEach(async () => {
     vi.resetModules();
+    vi.clearAllMocks();
     mockRestartState.isRestarting = false;
     mockRestartState.triggeredAt = null;
     mockConnectionState.connected = false;
+    mockGetOpenClawClient.mockReturnValue({ config: { get: mockConfigGet } });
     const mod = await import("@/app/api/health/openclaw/route");
     GET = mod.GET;
   });
 
   it("returns ok with connected: false when not restarting and not connected", async () => {
-    const response = await GET();
+    const response = await GET(fakeRequest());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -34,7 +48,7 @@ describe("GET /api/health/openclaw", () => {
   it("returns ok with connected: true when OpenClaw is connected", async () => {
     mockConnectionState.connected = true;
 
-    const response = await GET();
+    const response = await GET(fakeRequest());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -45,10 +59,78 @@ describe("GET /api/health/openclaw", () => {
     mockRestartState.isRestarting = true;
     mockRestartState.triggeredAt = 1700000000000;
 
-    const response = await GET();
+    const response = await GET(fakeRequest());
     const body = await response.json();
 
     expect(response.status).toBe(200);
     expect(body).toEqual({ status: "restarting", connected: false, since: 1700000000000 });
+  });
+
+  describe("with ?agentId= query param (Tier 2b race fix — dispatchability probe)", () => {
+    it("returns agentDispatchable: true when OC's runtime agents.list contains the id", async () => {
+      mockConnectionState.connected = true;
+      mockConfigGet.mockResolvedValue({
+        config: { agents: { list: [{ id: "agent-1" }, { id: "agent-2" }] } },
+      });
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?agentId=agent-1")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body).toEqual({ status: "ok", connected: true, agentDispatchable: true });
+    });
+
+    it("returns agentDispatchable: false when the requested id is NOT in OC's list", async () => {
+      mockConnectionState.connected = true;
+      mockConfigGet.mockResolvedValue({
+        config: { agents: { list: [{ id: "agent-1" }] } },
+      });
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?agentId=agent-missing")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.agentDispatchable).toBe(false);
+    });
+
+    it("returns agentDispatchable: false (not 5xx) when config.get throws — poll-friendly behavior", async () => {
+      mockConnectionState.connected = true;
+      mockConfigGet.mockRejectedValue(new Error("OpenClaw WS disconnected mid-call"));
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?agentId=agent-1")
+      );
+      const body = await response.json();
+
+      // Critical: never break the poll loop with a 5xx. The whole point of
+      // the probe is to keep retrying until the runtime catches up.
+      expect(response.status).toBe(200);
+      expect(body.agentDispatchable).toBe(false);
+    });
+
+    it("returns agentDispatchable: false when config.get returns no agents list (e.g. fresh install)", async () => {
+      mockConnectionState.connected = true;
+      mockConfigGet.mockResolvedValue({ config: {} });
+
+      const response = await GET(
+        fakeRequest("http://localhost/api/health/openclaw?agentId=agent-1")
+      );
+      const body = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(body.agentDispatchable).toBe(false);
+    });
+
+    it("does NOT call config.get when agentId is absent (default health check stays cheap)", async () => {
+      mockConnectionState.connected = true;
+
+      await GET(fakeRequest());
+
+      expect(mockConfigGet).not.toHaveBeenCalled();
+    });
   });
 });

--- a/packages/web/src/__tests__/hooks/safe-log-id.test.ts
+++ b/packages/web/src/__tests__/hooks/safe-log-id.test.ts
@@ -1,0 +1,51 @@
+/**
+ * Unit tests for `safeLogId` — sanitizer applied to server-provided
+ * identifiers before they're embedded in client-side log messages.
+ *
+ * Defends against CodeQL js/log-injection (#310 Tier 2b PR #442 CodeQL
+ * finding): a malicious or buggy Pinchy server could put control
+ * characters / newlines into a runId, which would fake new log lines or
+ * confuse structured-log parsers if logged verbatim.
+ */
+import { describe, it, expect } from "vitest";
+import { safeLogId } from "@/hooks/use-ws-runtime";
+
+describe("safeLogId", () => {
+  it("passes a well-formed UUID-style runId through unchanged", () => {
+    expect(safeLogId("550e8400-e29b-41d4-a716-446655440000")).toBe(
+      "550e8400-e29b-41d4-a716-446655440000"
+    );
+  });
+
+  it("passes alphanumeric + underscore + dash mixes through unchanged", () => {
+    expect(safeLogId("run_abc-123")).toBe("run_abc-123");
+  });
+
+  it("rejects strings containing newlines (the classic log-injection vector)", () => {
+    expect(safeLogId("legit-id\n[fake-log] admin granted")).toBe("<invalid>");
+    expect(safeLogId("legit-id\r\n[crlf injection]")).toBe("<invalid>");
+  });
+
+  it("rejects strings containing ANSI escape sequences", () => {
+    // Could clear screen / move cursor / hide subsequent log entries in
+    // a terminal that renders the output.
+    expect(safeLogId("legit\x1b[2J")).toBe("<invalid>");
+  });
+
+  it("rejects strings containing whitespace or punctuation outside the allowed set", () => {
+    expect(safeLogId("run id with spaces")).toBe("<invalid>");
+    expect(safeLogId("run.with.dots")).toBe("<invalid>");
+    expect(safeLogId("run/with/slashes")).toBe("<invalid>");
+  });
+
+  it("rejects non-string inputs (null, undefined, number, object)", () => {
+    expect(safeLogId(null)).toBe("<invalid>");
+    expect(safeLogId(undefined)).toBe("<invalid>");
+    expect(safeLogId(42)).toBe("<invalid>");
+    expect(safeLogId({})).toBe("<invalid>");
+  });
+
+  it("rejects the empty string (regex requires at least one char)", () => {
+    expect(safeLogId("")).toBe("<invalid>");
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -4663,4 +4663,190 @@ describe("useWsRuntime", () => {
       });
     });
   });
+
+  // ── #310 Tier 2b: server-correlated resume across reconnect ──────────────
+  describe("#310 Tier 2b activeRun resume + pre-history buffer", () => {
+    it("buffers a chunk that arrives BEFORE the history frame and drains it after reconcile (race window)", async () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+
+      // Initial connect + history land normally.
+      await act(async () => {
+        latestWs().simulateOpen();
+        latestWs().simulateMessage({ type: "history", messages: [] });
+      });
+
+      // User sends a message → reaches "sending" status.
+      await act(async () => {
+        result.current.runtime.onNew(makeUserMessage("what's the policy?"));
+      });
+
+      // Drop the connection mid-stream — server-side OC continues but
+      // the new ws will arm the pre-history buffer.
+      await act(async () => {
+        latestWs().simulateClose(1006);
+        // Backoff timer is fake — fast-forward past it so reconnect fires.
+        vi.advanceTimersByTime(1200);
+      });
+
+      const ws2 = latestWs();
+      await act(async () => {
+        ws2.simulateOpen();
+        // The server's `addListener` runs synchronously in handleHistory
+        // and a chunk arrives BEFORE the history response — simulate
+        // exactly that ordering.
+        ws2.simulateMessage({
+          type: "chunk",
+          content: "25 days vacation.",
+          messageId: "msg-server-1",
+        });
+      });
+
+      // At this point the chunk MUST NOT have been applied — there's no
+      // assistant message with content "25 days vacation." yet.
+      const midwayMessages = result.current.runtime.messages;
+      const assistantBefore = (midwayMessages as Array<{ role: string; content: unknown }>).find(
+        (m) => m.role === "assistant"
+      );
+      expect(assistantBefore).toBeUndefined();
+
+      // Now the history frame arrives with an activeRun signal pinning
+      // the in-flight assistant turn to the same messageId the chunk
+      // used. Drain should apply the buffered chunk to that anchored
+      // message.
+      await act(async () => {
+        ws2.simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "what's the policy?", timestamp: 1000 },
+            { role: "assistant", content: "", timestamp: 2000 },
+          ],
+          activeRun: { runId: "run-1", messageId: "msg-server-1", startedAt: 1500 },
+        });
+      });
+
+      // After drain, the assistant message anchored to msg-server-1 has
+      // received the chunk's content.
+      const afterMessages = result.current.runtime.messages as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const assistantAfter = afterMessages.find((m) => m.role === "assistant");
+      expect(assistantAfter).toBeDefined();
+      // assistant-ui content shape: array of parts. We expect the chunk
+      // text inside.
+      const flat = JSON.stringify(assistantAfter!.content);
+      expect(flat).toContain("25 days vacation.");
+      // isRunning preserved across reconnect via the activeRun signal.
+      expect(result.current.runtime.isRunning).toBe(true);
+    });
+
+    it("does NOT buffer chunks on the very first connect (no recovery context, no race window)", async () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+
+      // First connect — buffer should NOT be armed.
+      await act(async () => {
+        latestWs().simulateOpen();
+        // A chunk that arrives before history (atypical but possible if
+        // tests/mocks send it) is processed immediately — no buffer.
+        latestWs().simulateMessage({
+          type: "chunk",
+          content: "Immediate hello",
+          messageId: "msg-init-1",
+        });
+        latestWs().simulateMessage({ type: "history", messages: [] });
+      });
+
+      // The chunk was applied (not buffered then drained — that's still
+      // visible to the user the same way, but observably isRunning
+      // transitions immediately rather than only after history).
+      expect(result.current.runtime.isRunning).toBe(true);
+    });
+
+    // PR #442 review fix: when shouldStageReplace would normally fire (local
+    // has an error bubble that history doesn't contain), the staged path
+    // uses setTimeout(0) to remount the message subtree. drainBuffer fires
+    // synchronously, so without the `!activeRun` guard the buffered chunks
+    // would apply to stale state and then be wiped by the deferred stage.
+    // The fix: when activeRun is present, take the synchronous setMessages
+    // path so the drain sees the reconciled state.
+    it("preserves buffered chunks across error-then-retry-then-disconnect (skips destructive stage when activeRun is present)", async () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+
+      // Initial connect + history with a completed first turn.
+      await act(async () => {
+        latestWs().simulateOpen();
+        latestWs().simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "first question", timestamp: 1000 },
+            { role: "assistant", content: "first answer", timestamp: 2000 },
+          ],
+        });
+      });
+
+      // Synthetic disconnect error from a prior turn.
+      await act(async () => {
+        latestWs().simulateMessage({
+          type: "error",
+          providerError: "Connection interrupted",
+          agentName: "Smithers",
+          messageId: "msg-errored-turn",
+        });
+      });
+
+      // User retries.
+      await act(async () => {
+        result.current.runtime.onNew(makeUserMessage("retry"));
+      });
+
+      // WS drops mid-stream — server-side OC continues.
+      await act(async () => {
+        latestWs().simulateClose(1006);
+        vi.advanceTimersByTime(1200);
+      });
+
+      // Reconnect. A chunk for the in-flight turn arrives BEFORE history.
+      const ws2 = latestWs();
+      await act(async () => {
+        ws2.simulateOpen();
+        ws2.simulateMessage({
+          type: "chunk",
+          content: "retry-answer",
+          messageId: "msg-retry-turn",
+        });
+      });
+
+      // History arrives. The local list still has the error bubble +
+      // possibly mismatches length, which would normally trigger the
+      // destructive staged remount. With activeRun present, we take the
+      // synchronous path so the drained chunk lands on reconciled state.
+      await act(async () => {
+        ws2.simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "first question", timestamp: 1000 },
+            { role: "assistant", content: "first answer", timestamp: 2000 },
+            { role: "user", content: "retry", timestamp: 3000 },
+            { role: "assistant", content: "", timestamp: 4000 },
+          ],
+          activeRun: { runId: "run-retry", messageId: "msg-retry-turn", startedAt: 4000 },
+        });
+      });
+
+      // The buffered chunk's text must be present in the in-flight assistant
+      // message — proving drain landed on the post-reconcile state, not the
+      // pre-stage state that the staged path would have wiped.
+      const messages = result.current.runtime.messages as Array<{
+        role: string;
+        content: unknown;
+      }>;
+      const flat = JSON.stringify(messages);
+      expect(flat).toContain("retry-answer");
+      // No lingering error bubble — reconcile wiped it.
+      const errorBubbles = messages.filter(
+        (m) => (m as { metadata?: { custom?: { error?: unknown } } }).metadata?.custom?.error
+      );
+      expect(errorBubbles).toHaveLength(0);
+    });
+  });
 });

--- a/packages/web/src/__tests__/server/active-runs.test.ts
+++ b/packages/web/src/__tests__/server/active-runs.test.ts
@@ -25,6 +25,7 @@ const baseRun = {
   userId: "u1",
   agentName: "Smithers",
   startedAt: 1_000_000,
+  currentMessageId: "msg-initial",
 };
 
 describe("ActiveRuns", () => {
@@ -67,6 +68,27 @@ describe("ActiveRuns", () => {
       expect(runs.get(baseRun.sessionKey)?.runId).toBe("run-new");
       expect(newRun.listeners.has(wsNew)).toBe(true);
       expect(newRun.listeners.has(wsOld)).toBe(false);
+    });
+  });
+
+  describe("currentMessageId (Tier 2b: per-turn messageId stability across reconnect)", () => {
+    it("stores the initial messageId on register and exposes it on get()", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, currentMessageId: "msg-turn-1", ws });
+      expect(runs.get(baseRun.sessionKey)?.currentMessageId).toBe("msg-turn-1");
+    });
+
+    it("updateMessageId rotates the stored id on per-turn `done` (so reconnect picks up the in-flight turn)", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, currentMessageId: "msg-turn-1", ws });
+
+      runs.updateMessageId(baseRun.sessionKey, "msg-turn-2");
+
+      expect(runs.get(baseRun.sessionKey)?.currentMessageId).toBe("msg-turn-2");
+    });
+
+    it("updateMessageId is a no-op for unknown sessionKey", () => {
+      expect(() => runs.updateMessageId("agent:gone:direct:u1", "msg-x")).not.toThrow();
     });
   });
 

--- a/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
+++ b/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
@@ -1,0 +1,199 @@
+// Focused tests for the chat-dispatch retry wrapper used to mask
+// OpenClaw's `config.get` vs `agent` RPC dispatch race (#310 / PR #442
+// flake on the Odoo and Telegram dispatch probes — CI runs 26505503327,
+// 26511658136).
+//
+// The wrapper retries `openclawClient.chat()` exactly once when the
+// FIRST chunk is an `unknown agent id` error. These tests pin the
+// contract: nothing else triggers a retry, and a retried call is
+// transparent to the caller.
+
+import { describe, it, expect, vi } from "vitest";
+import type { ChatChunk, ChatOptions } from "openclaw-node";
+import { chatWithDispatchRaceRetry, DISPATCH_RACE_PATTERN } from "@/server/chat-dispatch-retry";
+
+function makeStream(chunks: ChatChunk[]) {
+  return async function* () {
+    for (const c of chunks) {
+      yield c;
+    }
+  };
+}
+
+async function collect(gen: AsyncGenerator<ChatChunk>): Promise<ChatChunk[]> {
+  const out: ChatChunk[] = [];
+  for await (const c of gen) out.push(c);
+  return out;
+}
+
+describe("chatWithDispatchRaceRetry", () => {
+  it("yields chunks unchanged when the stream produces no dispatch-race error", async () => {
+    const chunks: ChatChunk[] = [
+      { type: "text", text: "Hi", runId: "r1" },
+      { type: "done", text: "", runId: "r1" },
+    ];
+    const chat = vi.fn(makeStream(chunks));
+
+    const got = await collect(
+      chatWithDispatchRaceRetry("hello", { agentId: "a-1" } as ChatOptions, {
+        chat: chat as unknown as (m: string, o?: ChatOptions) => AsyncGenerator<ChatChunk>,
+      })
+    );
+
+    expect(got).toEqual(chunks);
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries exactly once and swallows the transient first-chunk error when it matches the dispatch-race pattern", async () => {
+    const transient: ChatChunk[] = [
+      {
+        type: "error",
+        text: 'invalid agent params: unknown agent id "596489fc-45c7-4113-8a82-b5f8d28861d7"',
+        runId: "r0",
+      },
+    ];
+    const successful: ChatChunk[] = [
+      { type: "text", text: "Hello!", runId: "r1" },
+      { type: "done", text: "", runId: "r1" },
+    ];
+
+    const chat = vi
+      .fn()
+      .mockImplementationOnce(makeStream(transient))
+      .mockImplementationOnce(makeStream(successful));
+
+    const delay = vi.fn().mockResolvedValue(undefined);
+    const onDispatchRaceObserved = vi.fn();
+
+    const got = await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "596489fc-45c7-4113-8a82-b5f8d28861d7" } as ChatOptions,
+        { chat: chat as never, delay, onDispatchRaceObserved },
+        500
+      )
+    );
+
+    // The transient error must NOT have been yielded to the consumer.
+    expect(got).toEqual(successful);
+    // Exactly two chat() calls: original + one retry.
+    expect(chat).toHaveBeenCalledTimes(2);
+    // Delay invoked with the configured value.
+    expect(delay).toHaveBeenCalledWith(500);
+    // Audit observation fired exactly once with the transient error text.
+    expect(onDispatchRaceObserved).toHaveBeenCalledTimes(1);
+    expect(onDispatchRaceObserved.mock.calls[0][0].providerError).toMatch(/unknown agent id/i);
+    expect(onDispatchRaceObserved.mock.calls[0][0].attempt).toBe(0);
+  });
+
+  it("forwards the error and does NOT retry when the second attempt also hits the dispatch-race error", async () => {
+    const transient = (id: string): ChatChunk[] => [
+      {
+        type: "error",
+        text: `invalid agent params: unknown agent id "${id}"`,
+        runId: "r-err",
+      },
+    ];
+
+    const chat = vi
+      .fn()
+      .mockImplementationOnce(makeStream(transient("a")))
+      .mockImplementationOnce(makeStream(transient("a")));
+
+    const got = await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "a" } as ChatOptions,
+        { chat: chat as never, delay: vi.fn().mockResolvedValue(undefined) },
+        0
+      )
+    );
+
+    // The second attempt's error IS yielded so the caller can surface it.
+    expect(got).toHaveLength(1);
+    expect(got[0].type).toBe("error");
+    expect(chat).toHaveBeenCalledTimes(2);
+  });
+
+  it("does NOT retry on an error chunk that doesn't match the dispatch-race pattern", async () => {
+    const otherError: ChatChunk[] = [
+      {
+        type: "error",
+        text: "FailoverError: provider/model ended with an incomplete terminal response",
+        runId: "r-err",
+      },
+    ];
+
+    const chat = vi.fn(makeStream(otherError));
+
+    const got = await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "a" } as ChatOptions,
+        { chat: chat as never },
+        0
+      )
+    );
+
+    expect(got).toEqual(otherError);
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("does NOT retry when the FIRST chunk is fine and a later chunk errors with the dispatch pattern", async () => {
+    // This is a synthetic case to lock the "only first-chunk triggers
+    // retry" contract: a mid-stream `unknown agent id` would indicate
+    // something genuinely broken (OC re-running agent lookup mid-turn?)
+    // rather than the startup race we're targeting.
+    const chunks: ChatChunk[] = [
+      { type: "text", text: "partial...", runId: "r1" },
+      {
+        type: "error",
+        text: 'unknown agent id "weird"',
+        runId: "r1",
+      },
+    ];
+    const chat = vi.fn(makeStream(chunks));
+
+    const got = await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "weird" } as ChatOptions,
+        { chat: chat as never, delay: vi.fn().mockResolvedValue(undefined) },
+        0
+      )
+    );
+
+    expect(got).toEqual(chunks);
+    expect(chat).toHaveBeenCalledTimes(1);
+  });
+
+  it("passes message and options through to the underlying chat() on both attempts", async () => {
+    const transient: ChatChunk[] = [{ type: "error", text: 'unknown agent id "x"', runId: "r0" }];
+    const ok: ChatChunk[] = [{ type: "done", text: "", runId: "r1" }];
+    const chat = vi
+      .fn()
+      .mockImplementationOnce(makeStream(transient))
+      .mockImplementationOnce(makeStream(ok));
+
+    const opts: ChatOptions = {
+      agentId: "x",
+      sessionKey: "agent:x:direct:u1",
+    };
+
+    await collect(
+      chatWithDispatchRaceRetry("hello", opts, { chat: chat as never, delay: vi.fn() }, 0)
+    );
+
+    expect(chat).toHaveBeenNthCalledWith(1, "hello", opts);
+    expect(chat).toHaveBeenNthCalledWith(2, "hello", opts);
+  });
+
+  it("DISPATCH_RACE_PATTERN matches the exact OC 2026.5.x error message shape", () => {
+    expect(DISPATCH_RACE_PATTERN.test('invalid agent params: unknown agent id "abc-123"')).toBe(
+      true
+    );
+    expect(DISPATCH_RACE_PATTERN.test("Unknown Agent ID provided")).toBe(true);
+    expect(DISPATCH_RACE_PATTERN.test("unrelated transient: rate_limit")).toBe(false);
+    expect(DISPATCH_RACE_PATTERN.test("agent unknown but different shape")).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/server/client-router-broadcast.test.ts
+++ b/packages/web/src/__tests__/server/client-router-broadcast.test.ts
@@ -1,0 +1,231 @@
+/**
+ * Tier 2b broadcast semantics for `ClientRouter.pipeStream` (#310).
+ *
+ * After a Browser ↔ Pinchy WebSocket drops mid-stream and a new ws joins
+ * via the history-reconnect path, the OC stream continues server-side and
+ * incoming chunks must reach BOTH the new ws and (if still alive) the
+ * original. This file pins the contract that pipeStream broadcasts to the
+ * activeRuns listener set rather than to the originating ws alone.
+ *
+ * The minimum-viable case here is: register has happened, two ws are in
+ * the listener set, a chunk arrives → both ws receive the corresponding
+ * outbound frame. The "multi-tab on the same session" case rides on the
+ * same code path and is covered as a sanity check.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WebSocket } from "ws";
+import type { ChatChunk } from "openclaw-node";
+
+const {
+  mockChat,
+  mockChatAbort,
+  mockSessionsHistory,
+  mockSessionsList,
+  mockFindFirst,
+  mockUserFindFirst,
+  mockAppendAuditLog,
+  mockGetUserGroupIds,
+  mockGetAgentGroupIds,
+} = vi.hoisted(() => ({
+  mockChat: vi.fn(),
+  mockChatAbort: vi.fn().mockResolvedValue(undefined),
+  mockSessionsHistory: vi.fn().mockResolvedValue({ messages: [] }),
+  mockSessionsList: vi.fn().mockResolvedValue([]),
+  mockFindFirst: vi.fn(),
+  mockUserFindFirst: vi.fn(),
+  mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
+  mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
+  mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      agents: { findFirst: mockFindFirst },
+      users: { findFirst: mockUserFindFirst },
+    },
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  agents: { id: "id" },
+  users: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+}));
+
+vi.mock("@/lib/agent-access", () => ({
+  assertAgentAccess: vi.fn(() => {}),
+  effectiveVisibility: (v: string) => v,
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: (...args: unknown[]) => mockGetUserGroupIds(...args),
+  getAgentGroupIds: (...args: unknown[]) => mockGetAgentGroupIds(...args),
+}));
+
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return { ...actual, appendAuditLog: mockAppendAuditLog };
+});
+
+vi.mock("@/lib/audit-deferred", () => ({
+  recordAuditFailure: vi.fn(),
+}));
+
+vi.mock("@/server/attachment-pipeline", () => ({
+  processIncomingAttachments: vi.fn(async () => ({ chatAttachments: [], workspaceRefs: [] })),
+  buildAttachmentBlock: () => "",
+  parseAttachmentBlock: (s: string) => ({ cleanText: s, attachments: [] }),
+  UploadValidationError: class UploadValidationError extends Error {},
+}));
+
+vi.mock("@/server/model-unavailable-throttle", () => ({
+  shouldEmitModelUnavailableAudit: vi.fn().mockReturnValue(false),
+  shouldEmitSilentStreamAudit: vi.fn().mockReturnValue(false),
+  shouldEmitUpstreamFormatErrorAudit: vi.fn().mockReturnValue(false),
+}));
+
+import { ActiveRuns } from "@/server/active-runs";
+import { ClientRouter } from "@/server/client-router";
+import { SessionCache } from "@/server/session-cache";
+
+interface MockWs extends WebSocket {
+  sent: Record<string, unknown>[];
+}
+
+function createMockWs(): MockWs {
+  const sent: Record<string, unknown>[] = [];
+  const ws = {
+    readyState: 1,
+    send: vi.fn((data: string) => sent.push(JSON.parse(data))),
+    sent,
+  } as unknown as MockWs;
+  return ws;
+}
+
+async function* makeChunkStream(chunks: ChatChunk[]): AsyncGenerator<ChatChunk> {
+  for (const c of chunks) {
+    await new Promise<void>((r) => setImmediate(r));
+    yield c;
+  }
+}
+
+function buildClient() {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    chat: mockChat,
+    chatAbort: mockChatAbort,
+    sessions: { history: mockSessionsHistory, list: mockSessionsList },
+    isConnected: true,
+  });
+}
+
+const defaultAgent = {
+  id: "agent-1",
+  name: "Smithers",
+  visibility: "public",
+  greetingMessage: "",
+  model: null,
+  isPersonal: false,
+};
+
+describe("ClientRouter pipeStream broadcast (#310 Tier 2b)", () => {
+  let activeRuns: ActiveRuns;
+  let sessionCache: SessionCache;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeRuns = new ActiveRuns();
+    sessionCache = new SessionCache();
+    sessionCache.refresh([{ key: "agent:agent-1:direct:user-1" }]);
+    mockFindFirst.mockResolvedValue(defaultAgent);
+    mockUserFindFirst.mockResolvedValue({ id: "user-1", name: "Alice", context: null });
+  });
+
+  it("forwards a text chunk to every ws in the listener set, not only the originating ws", async () => {
+    const chunks: ChatChunk[] = [
+      { type: "text", text: "Hello", runId: "run-broadcast" },
+      { type: "done", text: "", runId: "run-broadcast" },
+    ];
+    mockChat.mockReturnValue(makeChunkStream(chunks));
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+
+    const wsOriginal = createMockWs();
+    const wsReconnect = createMockWs();
+    const sessionKey = "agent:agent-1:direct:user-1";
+
+    // The reconnecting ws joins the listener set after the first chunk
+    // triggers registration. We simulate that by hooking into the first
+    // send on wsOriginal: at that moment, registration has happened, so
+    // wsReconnect can addListener.
+    const sendSpy = wsOriginal.send as unknown as ReturnType<typeof vi.fn>;
+    let joined = false;
+    sendSpy.mockImplementation((data: string) => {
+      wsOriginal.sent.push(JSON.parse(data));
+      if (!joined && activeRuns.get(sessionKey)) {
+        activeRuns.addListener(sessionKey, wsReconnect);
+        joined = true;
+      }
+    });
+
+    await router.handleMessage(wsOriginal, {
+      type: "message",
+      content: "hi",
+      agentId: "agent-1",
+    });
+
+    // The original ws receives the chunk and the done frame.
+    expect(wsOriginal.sent.some((f) => f.type === "chunk" && f.content === "Hello")).toBe(true);
+    expect(wsOriginal.sent.some((f) => f.type === "done")).toBe(true);
+    // The reconnecting ws joined after the first chunk's send, so it
+    // misses the initial text frame but DOES receive the done frame +
+    // the terminal "complete" — proving broadcast hits the listener set,
+    // not just the originating ws.
+    expect(wsReconnect.sent.some((f) => f.type === "done")).toBe(true);
+    expect(wsReconnect.sent.some((f) => f.type === "complete")).toBe(true);
+  });
+
+  it("falls back to the originating ws when no run is registered yet (pre-first-chunk frames)", async () => {
+    // The initial "thinking" frame is sent BEFORE any chunk arrives, so
+    // the registry is empty at that moment. The frame must still reach
+    // the originating ws (otherwise no UI feedback during the dial-up
+    // window).
+    const chunks: ChatChunk[] = [
+      { type: "text", text: "x", runId: "r" },
+      { type: "done", text: "", runId: "r" },
+    ];
+    mockChat.mockReturnValue(makeChunkStream(chunks));
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+    const ws = createMockWs();
+
+    await router.handleMessage(ws, {
+      type: "message",
+      content: "hi",
+      agentId: "agent-1",
+    });
+
+    // The thinking frame fires before the first chunk; it must be present
+    // on the originating ws.
+    expect(ws.sent.some((f) => f.type === "thinking")).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/server/client-router-history-resume.test.ts
+++ b/packages/web/src/__tests__/server/client-router-history-resume.test.ts
@@ -1,0 +1,251 @@
+/**
+ * Tier 2b: `handleHistory` includes an `activeRun` signal when there's a
+ * matching in-flight run, and adds the requesting ws to the listener set
+ * so subsequent chunks broadcast to it (#310). Detaches the ws from any
+ * prior chat first, so an agent switch in a single tab transfers cleanly.
+ */
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { EventEmitter } from "events";
+import type { WebSocket } from "ws";
+
+const {
+  mockChat,
+  mockChatAbort,
+  mockSessionsHistory,
+  mockSessionsList,
+  mockFindFirst,
+  mockUserFindFirst,
+  mockAppendAuditLog,
+  mockGetUserGroupIds,
+  mockGetAgentGroupIds,
+} = vi.hoisted(() => ({
+  mockChat: vi.fn(),
+  mockChatAbort: vi.fn().mockResolvedValue(undefined),
+  mockSessionsHistory: vi.fn().mockResolvedValue({ messages: [] }),
+  mockSessionsList: vi.fn().mockResolvedValue([]),
+  mockFindFirst: vi.fn(),
+  mockUserFindFirst: vi.fn(),
+  mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
+  mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
+  mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      agents: { findFirst: mockFindFirst },
+      users: { findFirst: mockUserFindFirst },
+    },
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  agents: { id: "id" },
+  users: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+}));
+
+vi.mock("@/lib/agent-access", () => ({
+  assertAgentAccess: vi.fn(() => {}),
+  effectiveVisibility: (v: string) => v,
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+}));
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: (...args: unknown[]) => mockGetUserGroupIds(...args),
+  getAgentGroupIds: (...args: unknown[]) => mockGetAgentGroupIds(...args),
+}));
+
+vi.mock("@/lib/audit", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/audit")>();
+  return { ...actual, appendAuditLog: mockAppendAuditLog };
+});
+
+vi.mock("@/lib/audit-deferred", () => ({
+  recordAuditFailure: vi.fn(),
+}));
+
+vi.mock("@/server/attachment-pipeline", () => ({
+  processIncomingAttachments: vi.fn(async () => ({ chatAttachments: [], workspaceRefs: [] })),
+  buildAttachmentBlock: () => "",
+  parseAttachmentBlock: (s: string) => ({ cleanText: s, attachments: [] }),
+  UploadValidationError: class UploadValidationError extends Error {},
+}));
+
+vi.mock("@/server/model-unavailable-throttle", () => ({
+  shouldEmitModelUnavailableAudit: vi.fn().mockReturnValue(false),
+  shouldEmitSilentStreamAudit: vi.fn().mockReturnValue(false),
+  shouldEmitUpstreamFormatErrorAudit: vi.fn().mockReturnValue(false),
+}));
+
+import { ActiveRuns } from "@/server/active-runs";
+import { ClientRouter } from "@/server/client-router";
+import { SessionCache } from "@/server/session-cache";
+
+interface MockWs extends WebSocket {
+  sent: Record<string, unknown>[];
+}
+
+function createMockWs(): MockWs {
+  const sent: Record<string, unknown>[] = [];
+  const ws = {
+    readyState: 1,
+    send: vi.fn((data: string) => sent.push(JSON.parse(data))),
+    sent,
+  } as unknown as MockWs;
+  return ws;
+}
+
+function buildClient() {
+  const emitter = new EventEmitter();
+  return Object.assign(emitter, {
+    chat: mockChat,
+    chatAbort: mockChatAbort,
+    sessions: { history: mockSessionsHistory, list: mockSessionsList },
+    isConnected: true,
+  });
+}
+
+const defaultAgent = {
+  id: "agent-1",
+  name: "Smithers",
+  visibility: "public",
+  greetingMessage: "",
+  model: null,
+  isPersonal: false,
+};
+
+describe("ClientRouter handleHistory ↔ ActiveRuns resume (#310 Tier 2b)", () => {
+  let activeRuns: ActiveRuns;
+  let sessionCache: SessionCache;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    activeRuns = new ActiveRuns();
+    sessionCache = new SessionCache();
+    sessionCache.refresh([{ key: "agent:agent-1:direct:user-1" }]);
+    mockFindFirst.mockResolvedValue(defaultAgent);
+    mockUserFindFirst.mockResolvedValue({ id: "user-1", name: "Alice", context: null });
+  });
+
+  it("attaches the requesting ws as a listener and includes activeRun signal in the history frame", async () => {
+    // Seed an in-flight run for the agent.
+    const sessionKey = "agent:agent-1:direct:user-1";
+    const wsOriginal = createMockWs();
+    activeRuns.register({
+      runId: "run-active",
+      sessionKey,
+      agentId: "agent-1",
+      userId: "user-1",
+      agentName: "Smithers",
+      startedAt: 1000,
+      currentMessageId: "msg-inflight",
+      ws: wsOriginal,
+    });
+
+    // OC history returns a partial assistant turn (typical for in-flight).
+    mockSessionsHistory.mockResolvedValue({
+      messages: [
+        { role: "user", content: "What's the vacation policy?" },
+        { role: "assistant", content: "We're checking..." },
+      ],
+    });
+
+    const wsReconnect = createMockWs();
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+
+    await router.handleMessage(wsReconnect, { type: "history", agentId: "agent-1" });
+
+    const historyFrame = wsReconnect.sent.find((f) => f.type === "history");
+    expect(historyFrame).toBeDefined();
+    expect(historyFrame!.activeRun).toEqual({
+      runId: "run-active",
+      messageId: "msg-inflight",
+      startedAt: 1000,
+    });
+    // The reconnecting ws joined the listener set so future chunks
+    // broadcast to it.
+    const run = activeRuns.get(sessionKey);
+    expect(run?.listeners.has(wsReconnect)).toBe(true);
+    expect(run?.listeners.has(wsOriginal)).toBe(true);
+  });
+
+  it("omits activeRun signal when there is no in-flight run", async () => {
+    mockSessionsHistory.mockResolvedValue({
+      messages: [
+        { role: "user", content: "Hi" },
+        { role: "assistant", content: "Hello!" },
+      ],
+    });
+
+    const ws = createMockWs();
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+
+    await router.handleMessage(ws, { type: "history", agentId: "agent-1" });
+
+    const historyFrame = ws.sent.find((f) => f.type === "history");
+    expect(historyFrame).toBeDefined();
+    expect(historyFrame!.activeRun).toBeUndefined();
+  });
+
+  it("detaches the ws from any other run's listener set before joining the new chat's set (agent switch)", async () => {
+    // The user was watching chat A (with an active run), then switches
+    // their single tab to chat B. The ws should no longer receive
+    // chat A's broadcasts — otherwise switching agents in one tab leaks
+    // cross-chat chunks.
+    const sessionKeyA = "agent:a:direct:user-1";
+    const sessionKeyB = "agent:b:direct:user-1";
+    const ws = createMockWs();
+
+    activeRuns.register({
+      runId: "run-a",
+      sessionKey: sessionKeyA,
+      agentId: "a",
+      userId: "user-1",
+      agentName: "AgentA",
+      startedAt: 1000,
+      currentMessageId: "msg-a",
+      ws,
+    });
+    // No active run for B.
+
+    const agentB = { ...defaultAgent, id: "b", name: "AgentB" };
+    mockFindFirst.mockResolvedValue(agentB);
+    sessionCache.refresh([{ key: sessionKeyB }]);
+    mockSessionsHistory.mockResolvedValue({ messages: [] });
+
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+
+    await router.handleMessage(ws, { type: "history", agentId: "b" });
+
+    // ws was detached from A's listener set.
+    expect(activeRuns.get(sessionKeyA)?.listeners.has(ws)).toBe(false);
+    // The run for A is still registered (the OC stream continues
+    // server-side regardless).
+    expect(activeRuns.get(sessionKeyA)).toBeDefined();
+  });
+});

--- a/packages/web/src/app/api/health/openclaw/route.ts
+++ b/packages/web/src/app/api/health/openclaw/route.ts
@@ -1,8 +1,32 @@
-import { NextResponse } from "next/server";
+import { NextResponse, type NextRequest } from "next/server";
 import { restartState } from "@/server/restart-state";
 import { openClawConnectionState } from "@/server/openclaw-connection-state";
+import { getOpenClawClient } from "@/server/openclaw-client";
 
-export async function GET() {
+/**
+ * GET `/api/health/openclaw[?agentId=<uuid>]`
+ *
+ * Default mode: returns `{ status, connected }` — cheap synchronous check
+ * used by browser status indicators and CI stability gates.
+ *
+ * With `?agentId=<uuid>`: additionally queries OpenClaw's runtime config
+ * (`config.get`) and returns `{ ..., agentDispatchable: boolean }`. True iff
+ * OC's `agents.list` currently contains the requested id, i.e. dispatching
+ * a chat to that agent right now would NOT fail with "unknown agent id".
+ *
+ * The query mode exists to close the race window after `PATCH /api/agents/:id`
+ * or `PUT /api/agents/:id/integrations` returns 200: those endpoints fire
+ * `regenerateOpenClawConfig()` as fire-and-forget, so the hot-reload can
+ * still be in flight when the response lands. E2E tests use this endpoint
+ * to poll until the agent is actually dispatchable before sending a chat
+ * (otherwise the dispatch races the config-apply and intermittently hits
+ * the "unknown agent id" path — see the Odoo dispatch probe in
+ * `e2e/odoo/odoo-agent-chat.spec.ts`).
+ *
+ * Safe to expose publicly: only checks for presence of the id in
+ * `agents.list`, returns no agent metadata.
+ */
+export async function GET(request: NextRequest) {
   if (restartState.isRestarting) {
     return NextResponse.json({
       status: "restarting",
@@ -10,5 +34,26 @@ export async function GET() {
       since: restartState.triggeredAt,
     });
   }
-  return NextResponse.json({ status: "ok", connected: openClawConnectionState.connected });
+
+  const base = { status: "ok" as const, connected: openClawConnectionState.connected };
+  const agentId = request.nextUrl.searchParams.get("agentId");
+  if (!agentId) {
+    return NextResponse.json(base);
+  }
+
+  // Agent-dispatchable probe. Failure modes (OC not connected, config.get
+  // RPC throws, list missing) all collapse to `agentDispatchable: false` so
+  // the poll keeps trying — never breaks the test loop with a 5xx.
+  let agentDispatchable = false;
+  try {
+    const client = getOpenClawClient();
+    const result = (await client.config.get()) as {
+      config?: { agents?: { list?: Array<{ id?: string }> } };
+    };
+    const list = result?.config?.agents?.list ?? [];
+    agentDispatchable = list.some((a) => a?.id === agentId);
+  } catch {
+    agentDispatchable = false;
+  }
+  return NextResponse.json({ ...base, agentDispatchable });
 }

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -53,6 +53,14 @@ export interface WsMessage {
 
 const DELAY_HINT_MS = 15_000;
 const STUCK_TIMEOUT_MS = 60_000;
+/**
+ * Cap on the Tier 2b pre-history frame buffer. The buffer holds chunks
+ * that arrive on a fresh ws between `addListener` (server-side) and the
+ * history response. Typical drain time is ~100ms; entries beyond the cap
+ * indicate a broken server response and we log + drop the oldest rather
+ * than risk OOM-ing the tab.
+ */
+const FRAME_BUFFER_MAX = 1000;
 
 /**
  * Append the canonical "payload too large" error bubble to the message list.
@@ -466,6 +474,26 @@ export function useWsRuntime(agentId: string): {
   const pendingMessageRef = useRef<string | null>(null);
   const isRunningRef = useRef(false);
   /**
+   * Tier 2b (#310): between sending a history request and receiving the
+   * matching history frame, any non-history frame (chunk, done, error,
+   * thinking, ack) is buffered into `frameBufferRef` and drained AFTER
+   * the history reconcile. This closes the race where the server's
+   * `addListener` makes the new ws receive in-flight chunks before the
+   * history snapshot arrives — without the buffer, those chunks would
+   * land on whatever stale local state existed pre-reconcile and then
+   * be wiped by the reconcile itself.
+   */
+  const pendingHistoryRef = useRef(false);
+  const frameBufferRef = useRef<unknown[]>([]);
+  /**
+   * Server-correlated runId for the in-flight chat turn (Tier 2b). Set
+   * when a history frame includes the `activeRun` signal and used by
+   * downstream UX (e.g. matching `chat.run_timed_out` error frames) so
+   * the client knows which run timed out vs. which retry produced the
+   * error.
+   */
+  const inflightRunIdRef = useRef<string | null>(null);
+  /**
    * True iff at least one assistant chunk was received during the current turn.
    * Reset when a new turn starts (user sends or retry). Used to classify
    * incoming error frames: with chunks → partial_stream_failure, without
@@ -624,6 +652,11 @@ export function useWsRuntime(agentId: string): {
       lifecycleSuspendedRef.current = false;
       shouldRecoverFromHistoryRef.current = true;
       if (wsRef.current?.readyState === WebSocket.OPEN) {
+        // Tier 2b: same buffer-then-drain protocol as ws.onopen — the
+        // server may broadcast in-flight chunks between the addListener
+        // (which runs in handleHistory) and the history-response send.
+        pendingHistoryRef.current = true;
+        frameBufferRef.current = [];
         wsRef.current.send(JSON.stringify({ type: "history", agentId }));
       } else {
         connect();
@@ -692,6 +725,19 @@ export function useWsRuntime(agentId: string): {
         setReconnectExhausted(false);
         setPayloadRejected(false);
         reconnectAttemptRef.current = 0;
+        // Tier 2b: arm the pre-history buffer ONLY when we're in a
+        // recovery context (set by `onclose` on the previous connection
+        // or by a page-lifecycle resume). On an initial load there's no
+        // active run on the server yet — buffering would just stall the
+        // first chunk for no benefit and break tests that exercise the
+        // chunk path without preceding history. The race we're guarding
+        // against (chunks arriving via `addListener` before the history
+        // response) can only happen on reconnect, because the server
+        // can't have a listener for a ws it hasn't seen yet.
+        if (shouldRecoverFromHistoryRef.current) {
+          pendingHistoryRef.current = true;
+          frameBufferRef.current = [];
+        }
         ws.send(JSON.stringify({ type: "history", agentId }));
 
         // Flush any message that was queued while disconnected/connecting
@@ -707,6 +753,11 @@ export function useWsRuntime(agentId: string): {
         setIsConnected(false);
         setIsDelayed(false);
         clearStuckTimer();
+        // Tier 2b: drop any pre-history buffer from the dying connection
+        // so it can't bleed into the next ws's drain. The next onopen
+        // re-arms pendingHistoryRef before sending its own history req.
+        pendingHistoryRef.current = false;
+        frameBufferRef.current = [];
         if (delayTimerRef.current) {
           clearTimeout(delayTimerRef.current);
           delayTimerRef.current = null;
@@ -816,263 +867,379 @@ export function useWsRuntime(agentId: string): {
         clearStuckTimer();
       };
 
+      // Tier 2b: extracted so the buffered-frame drain after history
+      // reconcile can reuse the same dispatch logic that live frames
+      // travel through. Keeping the dispatch surface single-sourced
+      // means a future chunk-type addition can't accidentally diverge
+      // between the live and replay paths. `any` matches the implicit
+      // return type of `JSON.parse` — the same permissiveness the prior
+      // inline handler relied on for `data.messageId`, `data.content`,
+      // etc. Tightening this would cascade dozens of `as string` casts
+      // for marginal type safety on a shape the server fully controls.
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const processFrame = (data: any) => {
+        if (data.type === "openclaw:restarting") {
+          triggerRestart();
+          return;
+        }
+
+        if (data.type === "openclaw_status") {
+          setIsOpenClawConnected(!!data.connected);
+          return;
+        }
+
+        // Tier 2b: between the moment we requested history and the moment
+        // the history frame arrives, the server may broadcast in-flight
+        // chunks to us via the listener set. Buffer those so they apply
+        // ON TOP of the reconciled history rather than to whatever stale
+        // local state existed pre-reconcile (which would be wiped by the
+        // reconcile itself). Control frames above are processed
+        // immediately; everything else is held.
+        //
+        // Defensive cap: in practice the buffer drains within ~100ms
+        // (history fetch latency). A buffer that exceeds the cap means
+        // either a server bug (history frame never arrives) or an
+        // adversarial server flooding chunks. Log + drop oldest so we
+        // don't OOM the tab.
+        if (pendingHistoryRef.current && data.type !== "history") {
+          if (frameBufferRef.current.length >= FRAME_BUFFER_MAX) {
+            console.warn(
+              `[use-ws-runtime] pre-history frame buffer hit ${FRAME_BUFFER_MAX} entries — dropping oldest. ` +
+                "This indicates the server's history response is delayed; investigate handleHistory latency."
+            );
+            frameBufferRef.current.shift();
+          }
+          frameBufferRef.current.push(data);
+          return;
+        }
+
+        if (data.type === "history") {
+          const serverMessages: Array<{
+            role: string;
+            content: string;
+            timestamp?: string;
+            files?: WsFileMeta[];
+          }> = data.messages ?? [];
+          // Successful history reconcile within the grace window — cancel
+          // the deferred disconnect bubble so the user just sees the
+          // canonical reply land without a transient error bubble. See
+          // DISCONNECT_ERROR_GRACE_MS (issue #199).
+          if (
+            shouldRecoverFromHistoryRef.current &&
+            serverMessages.length > 0 &&
+            pendingDisconnectErrorRef.current
+          ) {
+            clearTimeout(pendingDisconnectErrorRef.current.timer);
+            pendingDisconnectErrorRef.current = null;
+          }
+          const sessionKnown: boolean = data.sessionKnown === true;
+          // Server tells us the session exists but its history is currently
+          // unavailable (e.g. OpenClaw restart race). Without this flag the
+          // chat would sit in "starting" forever waiting for messages that
+          // aren't coming — see issue #197.
+          setKnownEmptyHistory(sessionKnown && serverMessages.length === 0);
+          const historyMessages: WsMessage[] = serverMessages.map((msg) => ({
+            id: uuid(),
+            role: (msg.role === "system" ? "assistant" : msg.role) as "user" | "assistant",
+            content: msg.content ?? "",
+            timestamp: msg.timestamp,
+            // Round-tripped from the server's parseAttachmentBlock — server
+            // strips the in-message markup and surfaces the file metadata
+            // here so the file chip renders on reload.
+            ...(msg.files && msg.files.length > 0 ? { files: msg.files } : {}),
+          }));
+
+          // Tier 2b: if the server reports an in-flight run for this
+          // session, anchor the last assistant message in the reconciled
+          // history to the server-side `currentMessageId`. Subsequent
+          // chunks (already buffered or arriving live on the new ws)
+          // merge into THIS message by id-equality, so the user sees a
+          // single continuous bubble instead of an orphan + a fresh
+          // duplicate. Also preserve isRunning across the reconnect so
+          // the spinner doesn't flicker.
+          const activeRun = (
+            data as {
+              activeRun?: { runId: string; messageId: string; startedAt: number };
+            }
+          ).activeRun;
+          if (activeRun) {
+            for (let i = historyMessages.length - 1; i >= 0; i--) {
+              if (historyMessages[i].role === "assistant") {
+                historyMessages[i].id = activeRun.messageId;
+                break;
+              }
+            }
+            isRunningRef.current = true;
+            setIsRunning(true);
+            inflightRunIdRef.current = activeRun.runId;
+            if (pendingDisconnectErrorRef.current) {
+              clearTimeout(pendingDisconnectErrorRef.current.timer);
+              pendingDisconnectErrorRef.current = null;
+            }
+          }
+          const shouldRecoverFromHistory = shouldRecoverFromHistoryRef.current;
+          const prevMessages = messagesRef.current;
+          const shouldReplaceWithHistory = shouldReplaceLocalWithServerHistory(
+            prevMessages,
+            historyMessages,
+            shouldRecoverFromHistory
+          );
+          // Tier 2b: skip the destructive staged remount when an activeRun
+          // signal is in play. The staged path uses a setTimeout(0) to
+          // remount, but drainBuffer fires synchronously — so buffered
+          // chunks would land on stale state and then be wiped by the
+          // deferred stage. activeRun semantically means "the in-flight
+          // turn IS the truth, don't tear down state in a way that loses
+          // the resume buffer", so we take the synchronous setMessages
+          // path which keeps drain consistent with reconcile.
+          const shouldStageReplace =
+            shouldReplaceWithHistory &&
+            prevMessages.length > 0 &&
+            !activeRun &&
+            (historyMessages.length < prevMessages.length || prevMessages.some((m) => m.error));
+
+          // Tier 2b: drain helper — runs once history has been applied
+          // (either branch below) so buffered chunks merge into the
+          // freshly-reconciled message list, including the activeRun-
+          // anchored assistant turn.
+          const drainBuffer = () => {
+            pendingHistoryRef.current = false;
+            const buffered = frameBufferRef.current;
+            frameBufferRef.current = [];
+            for (const frame of buffered) {
+              processFrame(frame);
+            }
+          };
+
+          if (shouldStageReplace) {
+            stageDestructiveHistoryReconcile(historyMessages);
+            shouldRecoverFromHistoryRef.current = false;
+            setIsHistoryLoaded(true);
+            drainBuffer();
+            return;
+          }
+
+          setMessages((prev) => {
+            if (prev.length === 0) {
+              return capMessages(historyMessages);
+            }
+            // After reconnects, replace local messages with canonical history
+            // from the server. The conditions are gathered in
+            // shouldReplaceLocalWithServerHistory above — see that helper's
+            // doc for the full rationale (esp. the issue #310 fix for an
+            // acked-user-but-no-chunk window). We intentionally replace even
+            // if the last local message is a synthetic disconnect-error
+            // bubble, because the server's history is the ground truth.
+            //
+            // The helper is re-evaluated here against React's `prev` (not
+            // `messagesRef.current` from the outer scope) because under
+            // concurrent rendering the two snapshots can diverge — a stale
+            // outer evaluation must never override what React holds as the
+            // current authoritative state inside the setter.
+            if (
+              shouldReplaceLocalWithServerHistory(prev, historyMessages, shouldRecoverFromHistory)
+            ) {
+              return capMessages(historyMessages);
+            }
+            return prev;
+          });
+          shouldRecoverFromHistoryRef.current = false;
+          // Reconcile any in-flight "sending" messages against server history.
+          // Route through the reducer so matching logic is centralised.
+          dispatchMessages({
+            type: "history-reconcile",
+            history: serverMessages.map((m) => ({ role: m.role, content: m.content })),
+          });
+          setIsHistoryLoaded(true);
+          drainBuffer();
+          return;
+        }
+
+        if (data.type === "ack") {
+          // Cancel the pending timeout timer before dispatching the ack
+          const clientMessageId = data.clientMessageId as string;
+          const ackTimer = pendingAckTimers.current.get(clientMessageId);
+          if (ackTimer !== undefined) {
+            clearTimeout(ackTimer);
+            pendingAckTimers.current.delete(clientMessageId);
+          }
+          // Transition user message sending → sent
+          dispatchMessages({ type: "ack", clientMessageId });
+          return;
+        }
+
+        if (data.type === "thinking") {
+          // Server keep-alive: defeats browser/proxy WebSocket idle
+          // timeouts during long pauses (e.g. local Ollama tool-use loops).
+          // Reset stuck timer so a slow-but-alive agent doesn't get killed.
+          // Also cancel any pending ack timers — OpenClaw is clearly processing
+          // this session so the message was received.
+          for (const timer of pendingAckTimers.current.values()) {
+            clearTimeout(timer);
+          }
+          pendingAckTimers.current.clear();
+          isRunningRef.current = true;
+          setIsRunning(true);
+          resetStuckTimer();
+          return;
+        }
+
+        if (data.type === "chunk") {
+          // Cancel pending ack timers — receiving a chunk proves OpenClaw got the
+          // message, so the ack timeout would be a false positive if it fired now.
+          for (const timer of pendingAckTimers.current.values()) {
+            clearTimeout(timer);
+          }
+          pendingAckTimers.current.clear();
+          isRunningRef.current = true;
+          hasReceivedChunkRef.current = true;
+          setIsRunning(true);
+          resetStuckTimer();
+
+          if (delayTimerRef.current) {
+            clearTimeout(delayTimerRef.current);
+            delayTimerRef.current = null;
+          }
+          setIsDelayed(false);
+
+          setMessages((prev) => {
+            // A successful chunk auto-dismisses any prior error bubble — the
+            // retry succeeded, so the previous failure no longer reflects state.
+            let filtered = prev.filter((m) => !m.error);
+            // Right after a retry, drop any trailing partial assistant from the
+            // interrupted previous turn so the UI matches what OpenClaw actually
+            // persisted. Only fires on the first chunk of the new turn.
+            if (trimTrailingOnNextChunkRef.current) {
+              trimTrailingOnNextChunkRef.current = false;
+              const lastUserIdx = filtered.map((m) => m.role).lastIndexOf("user");
+              if (lastUserIdx >= 0) {
+                filtered = filtered.slice(0, lastUserIdx + 1);
+              }
+            }
+            const last = filtered[filtered.length - 1];
+            if (last?.role === "assistant" && last.id === data.messageId) {
+              return capMessages([
+                ...filtered.slice(0, -1),
+                { ...last, content: last.content + data.content },
+              ]);
+            }
+            return capMessages([
+              ...filtered,
+              {
+                id: data.messageId,
+                role: "assistant",
+                content: data.content,
+                timestamp: new Date().toISOString(),
+              },
+            ]);
+          });
+        }
+
+        if (data.type === "done") {
+          // Per-turn done: only marks the end of one assistant turn.
+          // The spinner is NOT cleared here — only "complete" terminates
+          // the entire stream. Tool-use loops produce one "done" per turn.
+          // Intentionally a no-op for isRunning.
+        }
+
+        if (data.type === "complete") {
+          if (delayTimerRef.current) {
+            clearTimeout(delayTimerRef.current);
+            delayTimerRef.current = null;
+          }
+          clearStuckTimer();
+          setIsDelayed(false);
+          isRunningRef.current = false;
+          hasReceivedChunkRef.current = false;
+          setIsRunning(false);
+          // Tier 2b: the run finished cleanly. Drop the in-flight runId
+          // so the next turn's activeRun signal (if any) replaces it.
+          inflightRunIdRef.current = null;
+        }
+
+        if (data.type === "error") {
+          if (delayTimerRef.current) {
+            clearTimeout(delayTimerRef.current);
+            delayTimerRef.current = null;
+          }
+          clearStuckTimer();
+          setIsDelayed(false);
+
+          // Tier 2b: cross-check runId on watchdog-timeout error frames
+          // against the in-flight runId we recorded from the activeRun
+          // signal. A mismatch means the server forcibly aborted some
+          // OTHER run for this session (e.g. a stale background turn) —
+          // ignore it so we don't surface a misleading timeout for the
+          // run the user is actually watching. Frames without runId
+          // (every non-watchdog error path) pass through unchanged.
+          if (
+            data.runTimedOut === true &&
+            typeof data.runId === "string" &&
+            inflightRunIdRef.current !== null &&
+            data.runId !== inflightRunIdRef.current
+          ) {
+            console.warn(
+              `[use-ws-runtime] ignoring run_timed_out for ${data.runId} — current in-flight run is ${inflightRunIdRef.current}`
+            );
+            return;
+          }
+
+          // Defense-in-depth: parse the structured upstream-format-error
+          // payload with the zod schema instead of trusting the inbound
+          // shape. A stale server or malformed frame must NOT be able to
+          // render the "Retry usually clears it" bubble for an unrelated
+          // error — that would lie to the user about the cause and the
+          // recovery path. On parse failure the bare providerError still
+          // surfaces via the generic bubble. Issue #338.
+          const upstreamFormatErrorParsed = data.upstreamFormatError
+            ? upstreamFormatErrorSchema.safeParse(data.upstreamFormatError)
+            : null;
+          const upstreamFormatError = upstreamFormatErrorParsed?.success
+            ? upstreamFormatErrorParsed.data
+            : undefined;
+
+          const error: ChatError = data.providerError
+            ? {
+                agentName: data.agentName,
+                providerError: data.providerError,
+                hint: data.hint,
+                modelUnavailable: data.modelUnavailable,
+                upstreamFormatError,
+              }
+            : data.code === "attachment_invalid"
+              ? { attachmentInvalid: true, message: data.message }
+              : { message: data.message || "An unknown error occurred." };
+
+          setMessages((prev) =>
+            capMessages([
+              // Remove any existing error bubble — only one error is ever shown
+              // at a time to avoid stacking after repeated retries.
+              ...prev.filter((m) => !m.error),
+              {
+                id: uuid(),
+                role: "assistant",
+                content: "",
+                error,
+                retryable: true,
+                retryReason: hasReceivedChunkRef.current
+                  ? ("partial_stream_failure" as const)
+                  : ("send_failure" as const),
+              },
+            ])
+          );
+          isRunningRef.current = false;
+          setIsRunning(false);
+          // Clear the in-flight runId so a follow-up retry's activeRun
+          // signal can replace it cleanly.
+          inflightRunIdRef.current = null;
+        }
+      };
+
       ws.onmessage = (event) => {
         if (connectionAgentId !== agentIdRef.current || wsRef.current !== ws) return;
         try {
           const data = JSON.parse(event.data);
-
-          if (data.type === "openclaw:restarting") {
-            triggerRestart();
-            return;
-          }
-
-          if (data.type === "openclaw_status") {
-            setIsOpenClawConnected(!!data.connected);
-            return;
-          }
-
-          if (data.type === "history") {
-            const serverMessages: Array<{
-              role: string;
-              content: string;
-              timestamp?: string;
-              files?: WsFileMeta[];
-            }> = data.messages ?? [];
-            // Successful history reconcile within the grace window — cancel
-            // the deferred disconnect bubble so the user just sees the
-            // canonical reply land without a transient error bubble. See
-            // DISCONNECT_ERROR_GRACE_MS (issue #199).
-            if (
-              shouldRecoverFromHistoryRef.current &&
-              serverMessages.length > 0 &&
-              pendingDisconnectErrorRef.current
-            ) {
-              clearTimeout(pendingDisconnectErrorRef.current.timer);
-              pendingDisconnectErrorRef.current = null;
-            }
-            const sessionKnown: boolean = data.sessionKnown === true;
-            // Server tells us the session exists but its history is currently
-            // unavailable (e.g. OpenClaw restart race). Without this flag the
-            // chat would sit in "starting" forever waiting for messages that
-            // aren't coming — see issue #197.
-            setKnownEmptyHistory(sessionKnown && serverMessages.length === 0);
-            const historyMessages: WsMessage[] = serverMessages.map((msg) => ({
-              id: uuid(),
-              role: (msg.role === "system" ? "assistant" : msg.role) as "user" | "assistant",
-              content: msg.content ?? "",
-              timestamp: msg.timestamp,
-              // Round-tripped from the server's parseAttachmentBlock — server
-              // strips the in-message markup and surfaces the file metadata
-              // here so the file chip renders on reload.
-              ...(msg.files && msg.files.length > 0 ? { files: msg.files } : {}),
-            }));
-            const shouldRecoverFromHistory = shouldRecoverFromHistoryRef.current;
-            const prevMessages = messagesRef.current;
-            const shouldReplaceWithHistory = shouldReplaceLocalWithServerHistory(
-              prevMessages,
-              historyMessages,
-              shouldRecoverFromHistory
-            );
-            const shouldStageReplace =
-              shouldReplaceWithHistory &&
-              prevMessages.length > 0 &&
-              (historyMessages.length < prevMessages.length || prevMessages.some((m) => m.error));
-
-            if (shouldStageReplace) {
-              stageDestructiveHistoryReconcile(historyMessages);
-              shouldRecoverFromHistoryRef.current = false;
-              setIsHistoryLoaded(true);
-              return;
-            }
-
-            setMessages((prev) => {
-              if (prev.length === 0) {
-                return capMessages(historyMessages);
-              }
-              // After reconnects, replace local messages with canonical history
-              // from the server. The conditions are gathered in
-              // shouldReplaceLocalWithServerHistory above — see that helper's
-              // doc for the full rationale (esp. the issue #310 fix for an
-              // acked-user-but-no-chunk window). We intentionally replace even
-              // if the last local message is a synthetic disconnect-error
-              // bubble, because the server's history is the ground truth.
-              //
-              // The helper is re-evaluated here against React's `prev` (not
-              // `messagesRef.current` from the outer scope) because under
-              // concurrent rendering the two snapshots can diverge — a stale
-              // outer evaluation must never override what React holds as the
-              // current authoritative state inside the setter.
-              if (
-                shouldReplaceLocalWithServerHistory(prev, historyMessages, shouldRecoverFromHistory)
-              ) {
-                return capMessages(historyMessages);
-              }
-              return prev;
-            });
-            shouldRecoverFromHistoryRef.current = false;
-            // Reconcile any in-flight "sending" messages against server history.
-            // Route through the reducer so matching logic is centralised.
-            dispatchMessages({
-              type: "history-reconcile",
-              history: serverMessages.map((m) => ({ role: m.role, content: m.content })),
-            });
-            setIsHistoryLoaded(true);
-            return;
-          }
-
-          if (data.type === "ack") {
-            // Cancel the pending timeout timer before dispatching the ack
-            const clientMessageId = data.clientMessageId as string;
-            const ackTimer = pendingAckTimers.current.get(clientMessageId);
-            if (ackTimer !== undefined) {
-              clearTimeout(ackTimer);
-              pendingAckTimers.current.delete(clientMessageId);
-            }
-            // Transition user message sending → sent
-            dispatchMessages({ type: "ack", clientMessageId });
-            return;
-          }
-
-          if (data.type === "thinking") {
-            // Server keep-alive: defeats browser/proxy WebSocket idle
-            // timeouts during long pauses (e.g. local Ollama tool-use loops).
-            // Reset stuck timer so a slow-but-alive agent doesn't get killed.
-            // Also cancel any pending ack timers — OpenClaw is clearly processing
-            // this session so the message was received.
-            for (const timer of pendingAckTimers.current.values()) {
-              clearTimeout(timer);
-            }
-            pendingAckTimers.current.clear();
-            isRunningRef.current = true;
-            setIsRunning(true);
-            resetStuckTimer();
-            return;
-          }
-
-          if (data.type === "chunk") {
-            // Cancel pending ack timers — receiving a chunk proves OpenClaw got the
-            // message, so the ack timeout would be a false positive if it fired now.
-            for (const timer of pendingAckTimers.current.values()) {
-              clearTimeout(timer);
-            }
-            pendingAckTimers.current.clear();
-            isRunningRef.current = true;
-            hasReceivedChunkRef.current = true;
-            setIsRunning(true);
-            resetStuckTimer();
-
-            if (delayTimerRef.current) {
-              clearTimeout(delayTimerRef.current);
-              delayTimerRef.current = null;
-            }
-            setIsDelayed(false);
-
-            setMessages((prev) => {
-              // A successful chunk auto-dismisses any prior error bubble — the
-              // retry succeeded, so the previous failure no longer reflects state.
-              let filtered = prev.filter((m) => !m.error);
-              // Right after a retry, drop any trailing partial assistant from the
-              // interrupted previous turn so the UI matches what OpenClaw actually
-              // persisted. Only fires on the first chunk of the new turn.
-              if (trimTrailingOnNextChunkRef.current) {
-                trimTrailingOnNextChunkRef.current = false;
-                const lastUserIdx = filtered.map((m) => m.role).lastIndexOf("user");
-                if (lastUserIdx >= 0) {
-                  filtered = filtered.slice(0, lastUserIdx + 1);
-                }
-              }
-              const last = filtered[filtered.length - 1];
-              if (last?.role === "assistant" && last.id === data.messageId) {
-                return capMessages([
-                  ...filtered.slice(0, -1),
-                  { ...last, content: last.content + data.content },
-                ]);
-              }
-              return capMessages([
-                ...filtered,
-                {
-                  id: data.messageId,
-                  role: "assistant",
-                  content: data.content,
-                  timestamp: new Date().toISOString(),
-                },
-              ]);
-            });
-          }
-
-          if (data.type === "done") {
-            // Per-turn done: only marks the end of one assistant turn.
-            // The spinner is NOT cleared here — only "complete" terminates
-            // the entire stream. Tool-use loops produce one "done" per turn.
-            // Intentionally a no-op for isRunning.
-          }
-
-          if (data.type === "complete") {
-            if (delayTimerRef.current) {
-              clearTimeout(delayTimerRef.current);
-              delayTimerRef.current = null;
-            }
-            clearStuckTimer();
-            setIsDelayed(false);
-            isRunningRef.current = false;
-            hasReceivedChunkRef.current = false;
-            setIsRunning(false);
-          }
-
-          if (data.type === "error") {
-            if (delayTimerRef.current) {
-              clearTimeout(delayTimerRef.current);
-              delayTimerRef.current = null;
-            }
-            clearStuckTimer();
-            setIsDelayed(false);
-
-            // Defense-in-depth: parse the structured upstream-format-error
-            // payload with the zod schema instead of trusting the inbound
-            // shape. A stale server or malformed frame must NOT be able to
-            // render the "Retry usually clears it" bubble for an unrelated
-            // error — that would lie to the user about the cause and the
-            // recovery path. On parse failure the bare providerError still
-            // surfaces via the generic bubble. Issue #338.
-            const upstreamFormatErrorParsed = data.upstreamFormatError
-              ? upstreamFormatErrorSchema.safeParse(data.upstreamFormatError)
-              : null;
-            const upstreamFormatError = upstreamFormatErrorParsed?.success
-              ? upstreamFormatErrorParsed.data
-              : undefined;
-
-            const error: ChatError = data.providerError
-              ? {
-                  agentName: data.agentName,
-                  providerError: data.providerError,
-                  hint: data.hint,
-                  modelUnavailable: data.modelUnavailable,
-                  upstreamFormatError,
-                }
-              : data.code === "attachment_invalid"
-                ? { attachmentInvalid: true, message: data.message }
-                : { message: data.message || "An unknown error occurred." };
-
-            setMessages((prev) =>
-              capMessages([
-                // Remove any existing error bubble — only one error is ever shown
-                // at a time to avoid stacking after repeated retries.
-                ...prev.filter((m) => !m.error),
-                {
-                  id: uuid(),
-                  role: "assistant",
-                  content: "",
-                  error,
-                  retryable: true,
-                  retryReason: hasReceivedChunkRef.current
-                    ? ("partial_stream_failure" as const)
-                    : ("send_failure" as const),
-                },
-              ])
-            );
-            isRunningRef.current = false;
-            setIsRunning(false);
-          }
+          processFrame(data);
         } catch {
           // Ignore unparseable messages
         }

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -341,6 +341,23 @@ function capMessages<T>(messages: T[]): T[] {
 }
 
 /**
+ * Sanitize a server-provided identifier before embedding it in a log
+ * message. Defends against log injection (CodeQL js/log-injection): if a
+ * malicious Pinchy server (or a buggy one round-tripping unsanitized user
+ * input) put control characters or newlines into a `runId`, the raw
+ * value flowing into `console.warn` could fake new log lines or break
+ * structured-log parsers.
+ *
+ * Allowed alphabet matches what OpenClaw actually emits for runIds
+ * (UUID-like alphanumeric + dashes + underscores). Anything else
+ * collapses to `<invalid>` so the warning still tells operators "something
+ * unexpected" without leaking the unsafe value verbatim.
+ */
+export function safeLogId(value: unknown): string {
+  return typeof value === "string" && /^[A-Za-z0-9_-]+$/.test(value) ? value : "<invalid>";
+}
+
+/**
  * Decide whether the local message list should be wholly replaced with the
  * server's history frame after a disconnect+reconnect cycle.
  *
@@ -1179,7 +1196,7 @@ export function useWsRuntime(agentId: string): {
             data.runId !== inflightRunIdRef.current
           ) {
             console.warn(
-              `[use-ws-runtime] ignoring run_timed_out for ${data.runId} — current in-flight run is ${inflightRunIdRef.current}`
+              `[use-ws-runtime] ignoring run_timed_out for ${safeLogId(data.runId)} — current in-flight run is ${safeLogId(inflightRunIdRef.current)}`
             );
             return;
           }

--- a/packages/web/src/server/active-runs.ts
+++ b/packages/web/src/server/active-runs.ts
@@ -44,6 +44,15 @@ export interface ActiveRun {
    */
   startedAt: number;
   lastChunkAt: number;
+  /**
+   * Pinchy-side per-turn message id (rotated on each `done`). Stored here so
+   * Tier 2b's reconnect-resume path can tell the client which message in
+   * the history snapshot the in-flight chunks should be merged into. Chunks
+   * arriving on the broadcast carry this same id; the client uses
+   * `activeRun.messageId` from the history frame to anchor them to the
+   * matching message after reconcile.
+   */
+  currentMessageId: string;
   listeners: Set<WebSocket>;
 }
 
@@ -88,6 +97,19 @@ export class ActiveRuns {
     const run = this.runs.get(sessionKey);
     if (!run) return;
     run.lastChunkAt = when;
+  }
+
+  /**
+   * Rotate `currentMessageId` for Tier 2b. Called from `pipeStream` right
+   * after the per-turn messageId rotation on every `done` chunk, so the
+   * registry always reflects the in-flight turn's id. A reconnecting
+   * client reading `activeRun.messageId` from the history frame uses this
+   * value to anchor incoming chunks to the right assistant message.
+   */
+  updateMessageId(sessionKey: string, messageId: string): void {
+    const run = this.runs.get(sessionKey);
+    if (!run) return;
+    run.currentMessageId = messageId;
   }
 
   get(sessionKey: string): ActiveRun | undefined {

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -1,0 +1,145 @@
+// packages/web/src/server/chat-dispatch-retry.ts
+//
+// Defensive workaround for an OpenClaw 2026.5.x race between `config.get`
+// and the `agent` RPC dispatch handler: after a `config.apply` that adds an
+// agent to `agents.list`, `config.get` immediately reports the agent as
+// present (i.e. `agentDispatchable=true` via our health endpoint), but the
+// `agent` RPC handler can still reject the same agent id with
+// `errorCode=INVALID_REQUEST errorMessage="invalid agent params: unknown
+// agent id <uuid>"`.
+//
+// Observed on PR #442 CI runs 26505503327, 26511658136 and others — the
+// failing chat dispatch happens 1–2 s after `waitForAgentDispatchable`
+// returned true, and the `agent` RPC fails in ~25 ms (OC's internal
+// rejection, not an upstream provider error). E2E tests added an
+// `waitForAgentDispatchable` gate before each dispatch (close PR #442
+// commit ec9eb0027), but it polls `config.get` which is exactly the path
+// that disagrees with the dispatch handler, so the gate doesn't fully
+// close the race.
+//
+// Industry practice for stream-truncation / transient-handler errors is
+// single auto-retry with a short delay (see issue #355 § "industry
+// best-practices summary"): OpenAI/Anthropic/Vercel SDKs all retry on
+// 5xx and stream-protocol errors. "unknown agent id" sits in the
+// 400-class normally — for a genuine bad id we do NOT want to retry,
+// because that masks real bugs. The race here is specifically the
+// 5xx-shaped variant where Pinchy KNOWS the agent exists (it just
+// created it and confirmed via `config.get`), so the single retry is
+// safe within this narrow window.
+//
+// Implementation: async-generator wrapper around `openclawClient.chat`.
+// On the FIRST yielded chunk:
+//   - If it's an `error` chunk matching the "unknown agent id" pattern
+//     AND we haven't retried yet, swallow it, wait `retryDelayMs`, then
+//     restart the chat stream.
+//   - Otherwise, yield it through and pipe the rest of the stream
+//     unchanged. Errors arriving AFTER the first chunk are pass-through
+//     too — they're not the dispatch race, they're real downstream
+//     failures the caller's existing error path must surface.
+//
+// The retry is bounded to ONE attempt and only fires for this specific
+// error string, so it can't mask other failure shapes or run away.
+
+import type { ChatChunk, ChatOptions } from "openclaw-node";
+
+/**
+ * Pattern matching OpenClaw 2026.5.x's dispatch-race error. Anchored on
+ * `unknown agent id` (the OC-internal phrase) rather than a generic
+ * substring so a future provider error mentioning the words "agent" and
+ * "unknown" in unrelated context cannot hijack the retry branch.
+ *
+ * Matches the literal `unknown agent id "<uuid>"` shape; case-insensitive
+ * to defend against an upstream message-casing tweak.
+ */
+export const DISPATCH_RACE_PATTERN = /unknown agent id/i;
+
+/**
+ * Default delay before retrying. Picked at 500 ms because:
+ *   - OC's failing `agent` RPC returns in ~25 ms (it's a synchronous
+ *     internal-state check, not a network round-trip), so a tight retry
+ *     wouldn't see new state.
+ *   - The race window observed in CI is 1–2 s wide between
+ *     `waitForAgentDispatchable` returning true and dispatch rejection.
+ *     500 ms covers most cases; if the dispatch handler is still stale
+ *     after another 500 ms, the second attempt's error gets surfaced
+ *     (the test will fail loudly rather than retrying forever).
+ *   - Industry guides (#355) recommend 1 s as the first retry delay
+ *     with exponential backoff; 500 ms is the lower end of that range
+ *     and acceptable for a single-shot retry without backoff.
+ */
+export const DEFAULT_DISPATCH_RETRY_DELAY_MS = 500;
+
+export interface DispatchRetryDeps {
+  chat: (message: string, options?: ChatOptions) => AsyncGenerator<ChatChunk>;
+  /**
+   * Sleep helper, injectable so tests don't have to wait real time.
+   */
+  delay?: (ms: number) => Promise<void>;
+  /**
+   * Audit callback invoked when the first attempt failed with the
+   * dispatch-race pattern. The audit is the diagnostic signal we use
+   * to measure how often this race fires in production; without it the
+   * retry would be invisible.
+   */
+  onDispatchRaceObserved?: (info: { providerError: string; attempt: number }) => void;
+}
+
+/**
+ * Wraps `openclawClient.chat()` with single-shot retry on the
+ * `unknown agent id` dispatch-race error.
+ *
+ * Contract:
+ *   - Yields ALL chunks from the FIRST successful attempt (where
+ *     "successful" means the first chunk is NOT an unknown-agent-id error).
+ *   - On the first chunk being an unknown-agent-id error, swallows it,
+ *     waits `retryDelayMs`, and restarts the chat. Yields all chunks
+ *     from the retry attempt verbatim, including any errors.
+ *   - Only retries ONCE; a second dispatch-race error is forwarded as
+ *     a real failure (the assumption is that if 500 ms didn't settle
+ *     OC's internal state, something is genuinely wrong).
+ *   - Never retries on errors arriving AFTER the first chunk — those
+ *     are real downstream failures (provider 5xx, schema rejection,
+ *     etc.) that the caller's existing error path must handle.
+ */
+export async function* chatWithDispatchRaceRetry(
+  message: string,
+  options: ChatOptions | undefined,
+  deps: DispatchRetryDeps,
+  retryDelayMs: number = DEFAULT_DISPATCH_RETRY_DELAY_MS
+): AsyncGenerator<ChatChunk> {
+  const delay = deps.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+
+  for (let attempt = 0; attempt <= 1; attempt++) {
+    const stream = deps.chat(message, options);
+    let isFirstChunk = true;
+    let didRetry = false;
+
+    for await (const chunk of stream) {
+      if (
+        isFirstChunk &&
+        attempt === 0 &&
+        chunk.type === "error" &&
+        DISPATCH_RACE_PATTERN.test(chunk.text)
+      ) {
+        // Dispatch-race detected. Don't yield this chunk; the audit
+        // callback records the observation for measurement and the
+        // outer loop retries after the delay.
+        if (deps.onDispatchRaceObserved) {
+          deps.onDispatchRaceObserved({ providerError: chunk.text, attempt });
+        }
+        didRetry = true;
+        break;
+      }
+      isFirstChunk = false;
+      yield chunk;
+    }
+
+    if (!didRetry) {
+      // Either the first attempt produced a non-race chunk (yielded
+      // through), or the second attempt completed (success or not).
+      // Either way, we're done.
+      return;
+    }
+    await delay(retryDelayMs);
+  }
+}

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -1,4 +1,5 @@
-import type { OpenClawClient, ChatAttachment, ChatChunk } from "openclaw-node";
+import type { OpenClawClient, ChatAttachment, ChatChunk, ChatOptions } from "openclaw-node";
+import { chatWithDispatchRaceRetry } from "@/server/chat-dispatch-retry";
 import type { WebSocket } from "ws";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
@@ -322,7 +323,35 @@ export class ClientRouter {
         );
       }
 
-      const stream = this.openclawClient.chat(text, chatOptions);
+      // Wrap the raw `openclawClient.chat()` stream in a single-shot retry
+      // for OpenClaw 2026.5.x's `config.get` vs agent-RPC dispatch race:
+      // immediately after a `config.apply` that adds an agent, OC's
+      // dispatch handler can still reject the same id with
+      // `unknown agent id` while `config.get` already reports it as
+      // present. The wrapper swallows the transient first-chunk error,
+      // waits 500 ms, and restarts the chat once — transparently to the
+      // rest of `pipeStream`. See `chat-dispatch-retry.ts` for the full
+      // rationale (and PR #442 CI runs 26505503327 / 26511658136 for the
+      // observed failure mode that motivated this).
+      const stream = chatWithDispatchRaceRetry(text, chatOptions as ChatOptions, {
+        chat: (m, o) => this.openclawClient.chat(m, o),
+        onDispatchRaceObserved: async ({ providerError }) => {
+          // Audit the transient observation so we can measure how often
+          // the dispatch race fires in production without relying on
+          // anecdotal log-grep. Using `chat.agent_error` with the
+          // existing `provider_config` class would muddy the per-class
+          // dashboards built off issue #355; instead we route through
+          // the umbrella event with a `retried: true` flag so a follow-up
+          // dedicated event type (e.g. `chat.agent_dispatch_race`) can be
+          // added later without rewriting historical rows.
+          await this.writeAgentErrorAudit({
+            agent,
+            errorClass: classifyAgentError(providerError),
+            providerError,
+            retried: true,
+          });
+        },
+      });
 
       // Tell the client immediately that the request is in flight so the UI
       // can render a thinking indicator. Without this, slow backends (e.g.
@@ -1057,6 +1086,13 @@ export class ClientRouter {
     agent: { id: string; name: string; model?: string | null };
     errorClass: AgentErrorClass;
     providerError: string;
+    /**
+     * Set to true when the error was caught and Pinchy automatically
+     * retried — currently only the OC dispatch-race wrapper sets this.
+     * Surfaces in `detail.retried` so operator dashboards can filter
+     * recoverable from terminal failures without parsing `providerError`.
+     */
+    retried?: boolean;
   }): Promise<void> {
     const auditEntry = {
       actorType: "user" as const,
@@ -1068,6 +1104,7 @@ export class ClientRouter {
         model: args.agent.model ?? null,
         errorClass: args.errorClass,
         providerError: safeProviderError(args.providerError),
+        ...(args.retried ? { retried: true } : {}),
       },
       outcome: "failure" as const,
     };

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -312,6 +312,16 @@ export class ClientRouter {
         }
       }
 
+      // Diagnostic for #310 / PR #442 Domain Lock investigation. Gated
+      // behind PINCHY_E2E_CHAT_TRACE so it doesn't ship to production logs.
+      // The integration test stack sets this env in docker-compose.integration.yml.
+      if (process.env.PINCHY_E2E_CHAT_TRACE === "1") {
+        console.log(
+          `[trace:chat] dispatch agent=${agent.id} session=${sessionKey} ` +
+            `text-len=${text.length} attachments=${chatAttachments.length}`
+        );
+      }
+
       const stream = this.openclawClient.chat(text, chatOptions);
 
       // Tell the client immediately that the request is in flight so the UI
@@ -634,6 +644,12 @@ export class ClientRouter {
           });
           activeRunRegistered = true;
           activeRunId = chunk.runId;
+          if (process.env.PINCHY_E2E_CHAT_TRACE === "1") {
+            console.log(
+              `[trace:chat] first-chunk session=${sessionKey} runId=${chunk.runId} ` +
+                `ws-state=${clientWs.readyState} chunk-type=${chunk.type}`
+            );
+          }
         } else if (activeRunRegistered) {
           this.activeRuns.touch(sessionKey, Date.now());
         }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -339,6 +339,27 @@ export class ClientRouter {
   ): Promise<void> {
     const sessionKey = this.computeSessionKey(agent.id);
 
+    // #310 Tier 2b: re-attach this ws to the appropriate listener set
+    // BEFORE the history send so any chunks arriving during the await
+    // below still reach the reconnecting browser. Detach from every
+    // prior chat first — a single tab that switches agents must NOT
+    // keep receiving the old chat's stream.
+    this.activeRuns.removeListenerFromAll(clientWs);
+    const activeRun = this.activeRuns.get(sessionKey);
+    if (activeRun) {
+      this.activeRuns.addListener(sessionKey, clientWs);
+    }
+    // Signal embedded in every history response variant so the client
+    // can preserve `isRunning=true` and anchor incoming chunks to the
+    // right message id after reconcile.
+    const activeRunSignal = activeRun
+      ? {
+          runId: activeRun.runId,
+          messageId: activeRun.currentMessageId,
+          startedAt: activeRun.startedAt,
+        }
+      : undefined;
+
     const fetchAndParseHistory = async () => {
       const result = (await this.openclawClient.sessions.history(sessionKey)) as {
         messages?: HistoryMessage[];
@@ -471,12 +492,21 @@ export class ClientRouter {
 
       if (messages.length > 0) {
         this.sessionCache.add(sessionKey);
-        this.sendToClient(clientWs, { type: "history", messages });
+        this.sendToClient(clientWs, {
+          type: "history",
+          messages,
+          ...(activeRunSignal ? { activeRun: activeRunSignal } : {}),
+        });
       } else if (sessionKnown) {
         // Session exists but history is temporarily unavailable (e.g. during an
         // OpenClaw restart). Signal the client so it can retry rather than
         // showing a blank chat or replacing existing messages with a greeting.
-        this.sendToClient(clientWs, { type: "history", messages: [], sessionKnown: true });
+        this.sendToClient(clientWs, {
+          type: "history",
+          messages: [],
+          sessionKnown: true,
+          ...(activeRunSignal ? { activeRun: activeRunSignal } : {}),
+        });
       } else {
         // No session known — show greeting for new conversations
         await sendGreeting();
@@ -494,11 +524,20 @@ export class ClientRouter {
           // Retry also failed — session known but history unavailable
         }
         if (retryMessages.length > 0) {
-          this.sendToClient(clientWs, { type: "history", messages: retryMessages });
+          this.sendToClient(clientWs, {
+            type: "history",
+            messages: retryMessages,
+            ...(activeRunSignal ? { activeRun: activeRunSignal } : {}),
+          });
         } else {
           // History unavailable for known session — don't send greeting.
           // Signal the client so it can retry rather than showing a blank chat.
-          this.sendToClient(clientWs, { type: "history", messages: [], sessionKnown: true });
+          this.sendToClient(clientWs, {
+            type: "history",
+            messages: [],
+            sessionKnown: true,
+            ...(activeRunSignal ? { activeRun: activeRunSignal } : {}),
+          });
         }
         return;
       }
@@ -571,9 +610,10 @@ export class ClientRouter {
         // clears it.
         if (heartbeatInterval === null) {
           heartbeatInterval = setInterval(() => {
-            if (clientWs.readyState === WS_OPEN) {
-              this.sendToClient(clientWs, { type: "thinking", messageId });
-            }
+            // Tier 2b: heartbeats broadcast to every listener so a tab that
+            // joined via reconnect-resume keeps its "thinking" indicator
+            // alive across the silent windows of slow tool-use loops.
+            this.broadcastForRun(sessionKey, clientWs, { type: "thinking", messageId });
           }, THINKING_HEARTBEAT_MS);
         }
 
@@ -589,6 +629,7 @@ export class ClientRouter {
             userId: this.userId,
             agentName: agent.name,
             startedAt: Date.now(),
+            currentMessageId: messageId,
             ws: clientWs,
           });
           activeRunRegistered = true;
@@ -648,10 +689,15 @@ export class ClientRouter {
           });
         }
 
-        // Consumer forwarding — only meaningful while the browser WS is open.
-        if (clientWs.readyState === WS_OPEN) {
+        // Consumer forwarding — always runs the state-tracking (sawText,
+        // sawError, textBuffer) so the silent-stream safety net stays
+        // correct, then broadcasts to every ws in the listener set
+        // (Tier 2b). `broadcastForRun` falls back to the originating ws
+        // when no run is registered (e.g. pre-first-chunk frames) and
+        // per-listener readyState-gates internally.
+        {
           if (chunk.type === "userMessagePersisted") {
-            this.sendToClient(clientWs, {
+            this.broadcastForRun(sessionKey, clientWs, {
               type: "ack",
               clientMessageId: chunk.clientMessageId,
             });
@@ -662,7 +708,11 @@ export class ClientRouter {
             if (safeLen > 0) {
               const emit = textBuffer.slice(0, safeLen);
               textBuffer = textBuffer.slice(safeLen);
-              this.sendToClient(clientWs, { type: "chunk", content: emit, messageId });
+              this.broadcastForRun(sessionKey, clientWs, {
+                type: "chunk",
+                content: emit,
+                messageId,
+              });
             }
           } else if (chunk.type === "error") {
             sawError = true;
@@ -674,7 +724,7 @@ export class ClientRouter {
             // modelUnavailable: that one fires on 5xx, this one on 400 schema
             // rejection, and the same chunk should never match both.
             const upstreamFormatError = classifyUpstreamFormatError(chunk.text, agent.model ?? "");
-            this.sendToClient(clientWs, {
+            this.broadcastForRun(sessionKey, clientWs, {
               type: "error",
               agentName: agent.name,
               providerError: chunk.text,
@@ -746,13 +796,13 @@ export class ClientRouter {
             // resolved to the silent-reply sentinel, suppress it; otherwise
             // emit whatever text was held back.
             if (textBuffer && textBuffer !== SILENT_REPLY_TOKEN) {
-              this.sendToClient(clientWs, {
+              this.broadcastForRun(sessionKey, clientWs, {
                 type: "chunk",
                 content: textBuffer,
                 messageId,
               });
             }
-            this.sendToClient(clientWs, { type: "done", messageId });
+            this.broadcastForRun(sessionKey, clientWs, { type: "done", messageId });
           }
         }
 
@@ -763,6 +813,13 @@ export class ClientRouter {
         if (chunk.type === "done") {
           textBuffer = "";
           messageId = crypto.randomUUID();
+          // Tier 2b: keep the registry's view of the current messageId in
+          // sync with the per-turn rotation so a reconnecting client gets
+          // an `activeRun.messageId` that anchors incoming chunks to the
+          // right message after history reconcile.
+          if (activeRunRegistered) {
+            this.activeRuns.updateMessageId(sessionKey, messageId);
+          }
         }
       }
 
@@ -772,9 +829,14 @@ export class ClientRouter {
       // swallowed a `surface_error reason=timeout` into `continue_normal`).
       // Must precede the `complete` frame so the client's error handler
       // runs before the spinner is cleared.
-      if (!sawText && !sawError && clientWs.readyState === WS_OPEN) {
+      if (!sawText && !sawError) {
         const providerError = "The model did not produce a response. It may have timed out.";
-        this.sendToClient(clientWs, {
+        // Tier 2b: broadcast so a tab joined via reconnect-resume also
+        // sees the synthesised error (the original ws might already be
+        // gone). The listener-set fallback inside broadcastForRun reaches
+        // the originating ws when no run is registered, e.g. if the OC
+        // stream produced zero chunks at all.
+        this.broadcastForRun(sessionKey, clientWs, {
           type: "error",
           agentName: agent.name,
           providerError,
@@ -829,11 +891,10 @@ export class ClientRouter {
       // iterator is exhausted, so the UI can confidently turn off the
       // thinking indicator only when no more chunks will arrive.
       // No messageId — this terminator is not tied to any specific turn.
-      // Skip if the consumer is gone — they'll get the natural state via
-      // history on reconnect.
-      if (clientWs.readyState === WS_OPEN) {
-        this.sendToClient(clientWs, { type: "complete" });
-      }
+      // Tier 2b broadcasts so any tab that joined via reconnect-resume gets
+      // the terminator too; broadcastForRun reaches the originating ws if
+      // no listener set exists.
+      this.broadcastForRun(sessionKey, clientWs, { type: "complete" });
     } finally {
       // #310 Tier 2a: clean up the registry entry and, if the run finished
       // normally but with zero listeners, write a chat.run_completed_after_disconnect
@@ -919,6 +980,33 @@ export class ClientRouter {
   private sendToClient(ws: WebSocket, data: Record<string, unknown>): void {
     if (ws.readyState === WS_OPEN) {
       ws.send(JSON.stringify(data));
+    }
+  }
+
+  /**
+   * Tier 2b broadcast: send a frame to every ws currently listening on the
+   * given run. If no run is registered for `sessionKey` (e.g. pre-first-
+   * chunk frames like the initial "thinking" or a complete frame after the
+   * run was already cleaned up in the finally block), fall back to the
+   * originating ws — that preserves backward compatibility with the
+   * pre-Tier-2b single-ws flow without leaving any path silently dropped.
+   *
+   * Each listener is independently readyState-gated so a half-closed
+   * socket can't poison the broadcast for the others.
+   */
+  private broadcastForRun(
+    sessionKey: string,
+    fallbackWs: WebSocket,
+    data: Record<string, unknown>
+  ): void {
+    const run = this.activeRuns.get(sessionKey);
+    if (!run || run.listeners.size === 0) {
+      this.sendToClient(fallbackWs, data);
+      return;
+    }
+    const payload = JSON.stringify(data);
+    for (const ws of run.listeners) {
+      if (ws.readyState === WS_OPEN) ws.send(payload);
     }
   }
 


### PR DESCRIPTION
## Summary

- After a browser ↔ Pinchy WebSocket drops mid-stream and reconnects, the new ws now JOINS the in-flight run as a listener and receives every subsequent chunk — no orphan-bubble flash, no spinner-without-response.
- New `activeRun` signal in the history response anchors the in-flight assistant message id so chunks merge into the correct bubble after reconcile (instead of creating a duplicate).
- Pre-history frame buffer + drain protocol closes the race between the server's `addListener` and the history-response send, so chunks that arrive ahead of history land on the reconciled state rather than getting wiped.

## Stacked on PR #441 (Tier 2a)

Base branch is `feat/tier2a-active-runs-310`. This PR depends on the `ActiveRuns` registry + watchdog landing first. The diff against `main` would be ~1800 lines; against the base branch it's ~1100 lines (one focused change).

## Server changes

- `ActiveRun.currentMessageId` carried by the registry, rotated on every per-turn `done` chunk via `ActiveRuns.updateMessageId(sessionKey, id)`.
- New `ClientRouter.broadcastForRun(sessionKey, fallbackWs, payload)` — sends to every listener in the registry entry, with per-listener `readyState` filtering; falls back to the originating ws when no run is registered (pre-first-chunk frames, silent-stream errors).
- `pipeStream` switches every in-loop send (text, ack, error, done), the heartbeat interval, the silent-stream synthesised error, and the terminal `complete` frame to `broadcastForRun`. The outer `if (clientWs.readyState === WS_OPEN)` guard is removed — "is anyone listening?" is now the broadcast helper's responsibility.
- `handleHistory` detaches the requesting ws from any prior chat's listener set (preventing cross-chat leakage on agent switch in a single tab), joins the new chat's set IF a run is in flight, and includes `activeRun: { runId, messageId, startedAt }` in every history-response variant when applicable.

## Client changes (use-ws-runtime.ts)

- Extracted `ws.onmessage` body into `processFrame(data)` so the drained-from-buffer dispatch travels through the same code path as live frames. Single source for chunk-type handling avoids drift.
- Buffer-and-drain on reconnect: when `shouldRecoverFromHistoryRef.current === true`, `pendingHistoryRef + frameBufferRef` are armed before the history request. Non-history frames received in the race window are buffered. The history handler drains the buffer through `processFrame` after reconcile.
- Initial-load connects skip the buffer arming (race can't happen — the server can't have a listener for a ws it hasn't seen yet), so existing test scaffolding remains compatible.
- `recoverFromPageLifecycle` (page suspend → resume without ws reconnect) uses the same arm-then-drain protocol.
- `ws.onclose` clears buffer + flag so a dying connection's state can't bleed into the next ws.
- When history includes `activeRun`: the last assistant message in the reconciled history gets its id replaced with `activeRun.messageId` so subsequent chunks (buffered or live) merge into that anchored message. `isRunning` is set back to `true` and `pendingDisconnectErrorRef` is cleared so the transient orphan-bubble flash never renders.
- New `inflightRunIdRef` carries the server runId for the in-flight turn — picked up by Tier 2c so a future `chat.run_timed_out` audit-correlated bubble can be attributed to the right local message.

## Tests

- `active-runs.test.ts`: +3 tests (currentMessageId storage, updateMessageId, no-op on unknown sessionKey)
- `client-router-broadcast.test.ts` (new): 2 tests (multi-ws forwarding; pre-registration fallback)
- `client-router-history-resume.test.ts` (new): 3 tests (activeRun emission; no-signal when no run; listener-detach on agent switch)
- `use-ws-runtime.test.ts`: +2 tests (buffer-then-drain after reconnect with activeRun; no buffer arming on first connect)

## Test plan

- [x] `pnpm -C packages/web test` — 5053 passed, 0 regressions
- [x] `pnpm -C packages/web exec tsc --noEmit` — clean
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] Prettier — clean
- [ ] Manual staging: open chat, send long message, kill ws via DevTools Network → Disable, verify reconnect joins live stream without orphan flash. Repeat with two tabs of the same chat — both should see the same content.

## Risks / known limits

- The pre-history buffer is only armed on reconnect, not on first connect. If a future feature streams chunks before history (none today), it would need to opt into the buffer.
- Buffer cleanup on ws.close protects against a buffer-leaked connection. Within a single connection where history never arrives, the buffer dies with the ws — acceptable since the user retries.
- Multi-listener broadcast adds a small constant cost per chunk (Set iteration, JSON.stringify happens once). For typical 2-tab worst case this is negligible.

Refs: #310