### PR TITLE
fix: v0.5.6 secrets.json setup race + setup-wizard smoke tests for all providers

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1379,6 +1379,128 @@ jobs:
         if: always()
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml down -v
 
+  setup-wizard-e2e:
+    name: Setup Wizard E2E Tests
+    runs-on: ubuntu-latest
+    needs: build-image
+    if: >-
+      always() &&
+      (needs.build-image.result == 'success' ||
+       needs.build-image.result == 'skipped')
+    permissions:
+      contents: read
+      packages: read
+
+    env:
+      PINCHY_VERSION: latest
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: ./.github/actions/docker-mirror
+
+      - name: Log in to Docker Hub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
+
+      - name: Log in to GHCR (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: ./.github/actions/setup-pnpm
+
+      - name: Pull pre-built CI images (skip on fork PRs)
+        if: needs.build-image.result == 'success'
+        run: |
+          docker pull ${{ needs.build-image.outputs.pinchy-image }}
+          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Start test stack with mock LLM providers (CI — pre-built images)
+        if: needs.build-image.result == 'success'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up -d
+        env:
+          PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
+          OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Start test stack with mock LLM providers (fork PR fallback — local build)
+        if: needs.build-image.result == 'skipped'
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up --build -d
+        env:
+          BETTER_AUTH_SECRET: ci-test-secret-not-for-production
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Wait for services
+        run: |
+          echo "Waiting for Pinchy..."
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:7777/api/health >/dev/null 2>&1; then
+              echo "Pinchy healthy (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::Pinchy not healthy after 120s"
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Waiting for mock LLM providers..."
+          for i in $(seq 1 15); do
+            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml exec -T llm-providers-mock node -e "fetch('http://localhost:9100/control/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))" >/dev/null 2>&1; then
+              echo "Mock LLM providers healthy (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 15 ]; then
+              echo "::error::Mock LLM providers not healthy after 30s"
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs llm-providers-mock
+              exit 1
+            fi
+            sleep 2
+          done
+          echo "Waiting for OpenClaw connection..."
+          for i in $(seq 1 60); do
+            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+              echo "OpenClaw connected (attempt $i)"
+              break
+            fi
+            if [ "$i" -eq 60 ]; then
+              echo "::error::Pinchy never connected to OpenClaw"
+              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy openclaw
+              exit 1
+            fi
+            sleep 2
+          done
+
+      - uses: ./.github/actions/setup-playwright
+
+      - name: Run Setup Wizard E2E tests
+        run: pnpm -C packages/web test:e2e:setup-wizard
+        env:
+          CI: true
+          ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
+
+      - name: Show logs on failure
+        if: failure()
+        run: |
+          echo "=== Pinchy logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy 2>&1 | tail -100
+          echo "=== OpenClaw logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs openclaw 2>&1 | tail -100
+          echo "=== Mock LLM providers logs ==="
+          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs llm-providers-mock 2>&1 | tail -50
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml down -v
+
   telegram-e2e:
     name: Telegram E2E Tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1393,6 +1393,7 @@ jobs:
 
     env:
       PINCHY_VERSION: latest
+      COMPOSE_FILES: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml"
 
     steps:
       - uses: actions/checkout@v4
@@ -1423,7 +1424,7 @@ jobs:
 
       - name: Start test stack with mock LLM providers (CI — pre-built images)
         if: needs.build-image.result == 'success'
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up -d
+        run: docker compose $COMPOSE_FILES up -d
         env:
           PINCHY_IMAGE: ${{ needs.build-image.outputs.pinchy-image }}
           OPENCLAW_IMAGE: ${{ needs.build-image.outputs.openclaw-image }}
@@ -1432,7 +1433,7 @@ jobs:
 
       - name: Start test stack with mock LLM providers (fork PR fallback — local build)
         if: needs.build-image.result == 'skipped'
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up --build -d
+        run: docker compose $COMPOSE_FILES up --build -d
         env:
           BETTER_AUTH_SECRET: ci-test-secret-not-for-production
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
@@ -1447,33 +1448,33 @@ jobs:
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy not healthy after 120s"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy
+              docker compose $COMPOSE_FILES logs pinchy
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for mock LLM providers..."
           for i in $(seq 1 15); do
-            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml exec -T llm-providers-mock node -e "fetch('http://localhost:9100/control/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))" >/dev/null 2>&1; then
+            if docker compose $COMPOSE_FILES exec -T llm-providers-mock node -e "fetch('http://localhost:9100/control/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))" >/dev/null 2>&1; then
               echo "Mock LLM providers healthy (attempt $i)"
               break
             fi
             if [ "$i" -eq 15 ]; then
               echo "::error::Mock LLM providers not healthy after 30s"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs llm-providers-mock
+              docker compose $COMPOSE_FILES logs llm-providers-mock
               exit 1
             fi
             sleep 2
           done
           echo "Waiting for OpenClaw connection..."
           for i in $(seq 1 60); do
-            if docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
+            if docker compose $COMPOSE_FILES logs pinchy 2>&1 | grep -q "Connected to OpenClaw Gateway"; then
               echo "OpenClaw connected (attempt $i)"
               break
             fi
             if [ "$i" -eq 60 ]; then
               echo "::error::Pinchy never connected to OpenClaw"
-              docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy openclaw
+              docker compose $COMPOSE_FILES logs pinchy openclaw
               exit 1
             fi
             sleep 2
@@ -1491,15 +1492,15 @@ jobs:
         if: failure()
         run: |
           echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs pinchy 2>&1 | tail -100
+          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -100
           echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs openclaw 2>&1 | tail -100
+          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -100
           echo "=== Mock LLM providers logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml logs llm-providers-mock 2>&1 | tail -50
+          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -50
 
       - name: Tear down
         if: always()
-        run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml down -v
+        run: docker compose $COMPOSE_FILES down -v
 
   telegram-e2e:
     name: Telegram E2E Tests

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1491,18 +1491,12 @@ jobs:
       - name: Show logs on failure
         if: failure()
         run: |
-          # Large tail values: the wizard E2E runs 4 tests × ~2 min each
-          # with multiple pinchy/openclaw container restarts between specs.
-          # Smaller tails scrolled out the diagnostic lines we added to
-          # trace the secrets.json race (see commit 80b3311a0). The
-          # llm-providers-mock log filters /control/health, so its lines
-          # are sparse — 1000 is plenty.
           echo "=== Pinchy logs ==="
-          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -2000
+          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -200
           echo "=== OpenClaw logs ==="
-          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -2000
+          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -200
           echo "=== Mock LLM providers logs ==="
-          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -1000
+          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -100
 
       - name: Tear down
         if: always()

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1491,12 +1491,18 @@ jobs:
       - name: Show logs on failure
         if: failure()
         run: |
+          # Large tail values: the wizard E2E runs 4 tests × ~2 min each
+          # with multiple pinchy/openclaw container restarts between specs.
+          # Smaller tails scrolled out the diagnostic lines we added to
+          # trace the secrets.json race (see commit 80b3311a0). The
+          # llm-providers-mock log filters /control/health, so its lines
+          # are sparse — 1000 is plenty.
           echo "=== Pinchy logs ==="
-          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -100
+          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -2000
           echo "=== OpenClaw logs ==="
-          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -100
+          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -2000
           echo "=== Mock LLM providers logs ==="
-          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -50
+          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -1000
 
       - name: Tear down
         if: always()

--- a/config/llm-providers-mock/Dockerfile
+++ b/config/llm-providers-mock/Dockerfile
@@ -1,0 +1,7 @@
+FROM mirror.gcr.io/library/node:22-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY server.js ./
+EXPOSE 9100
+CMD ["node", "server.js"]

--- a/config/llm-providers-mock/README.md
+++ b/config/llm-providers-mock/README.md
@@ -1,0 +1,3 @@
+# llm-providers-mock
+
+A tiny Express server that mocks the HTTP surface of the LLM providers Pinchy supports (currently OpenAI; Anthropic, Google, and Ollama endpoints land in follow-up tasks). It returns deterministic responses without needing real API keys, so the E2E smoke-test harness can verify that a fresh setup wizard for each provider produces an agent that actually responds. A `/control/health` endpoint is exposed for readiness checks. To run it locally: `cd config/llm-providers-mock && npm install && node --test __tests__/*.test.js` (or `node server.js` to start the server on port 9100).

--- a/config/llm-providers-mock/__tests__/openai.test.js
+++ b/config/llm-providers-mock/__tests__/openai.test.js
@@ -1,0 +1,40 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawn } from "node:child_process";
+
+const PORT = 9100;
+let server;
+
+test.before(async () => {
+  server = spawn("node", ["server.js"], { cwd: import.meta.dirname + "/..", env: { ...process.env, PORT } });
+  await new Promise((r) => setTimeout(r, 500));
+});
+
+test.after(() => server.kill());
+
+test("GET /openai/v1/models returns OpenAI-shaped models payload", async () => {
+  const res = await fetch(`http://localhost:${PORT}/openai/v1/models`, {
+    headers: { Authorization: "Bearer sk-mock-any-key" },
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.object, "list");
+  assert.ok(body.data.find((m) => m.id === "gpt-5.5-2026-04-23"));
+});
+
+test("POST /openai/v1/chat/completions returns deterministic non-streaming response", async () => {
+  const res = await fetch(`http://localhost:${PORT}/openai/v1/chat/completions`, {
+    method: "POST",
+    headers: { Authorization: "Bearer sk-mock", "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "gpt-5.5", messages: [{ role: "user", content: "hi" }] }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.choices[0].message.role, "assistant");
+  assert.ok(body.choices[0].message.content.length > 0);
+});
+
+test("GET /control/health returns 200", async () => {
+  const res = await fetch(`http://localhost:${PORT}/control/health`);
+  assert.equal(res.status, 200);
+});

--- a/config/llm-providers-mock/__tests__/openai.test.js
+++ b/config/llm-providers-mock/__tests__/openai.test.js
@@ -7,10 +7,20 @@ let server;
 
 test.before(async () => {
   server = spawn("node", ["server.js"], { cwd: import.meta.dirname + "/..", env: { ...process.env, PORT } });
-  await new Promise((r) => setTimeout(r, 500));
+  const deadline = Date.now() + 5000;
+  while (Date.now() < deadline) {
+    try {
+      const r = await fetch(`http://localhost:${PORT}/control/health`);
+      if (r.ok) return;
+    } catch {
+      // server still booting
+    }
+    await new Promise((r) => setTimeout(r, 25));
+  }
+  throw new Error("mock server failed to become healthy within 5s");
 });
 
-test.after(() => server.kill());
+test.after(() => server?.kill());
 
 test("GET /openai/v1/models returns OpenAI-shaped models payload", async () => {
   const res = await fetch(`http://localhost:${PORT}/openai/v1/models`, {

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -98,6 +98,41 @@ test("GET /ollama-cloud/v1/models with Bearer returns models list", async () => 
   assert.ok(body.data.find((m) => m.id === "qwen3-next:80b"));
 });
 
+test("POST /anthropic/v1/messages with stream:true returns SSE event sequence pi-ai parses", async () => {
+  // pi-ai's iterateAnthropicEvents (node_modules/.../@earendil-works/pi-ai/dist/providers/anthropic.js)
+  // requires these events in order: message_start, content_block_start,
+  // content_block_delta, content_block_stop, message_delta, message_stop.
+  // Missing message_stop throws "Anthropic stream ended before message_stop".
+  const res = await fetch(`http://localhost:${PORT}/anthropic/v1/messages`, {
+    method: "POST",
+    headers: {
+      "x-api-key": "sk-ant-mock",
+      "anthropic-version": "2023-06-01",
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({
+      model: "claude-sonnet-4-6",
+      max_tokens: 1024,
+      stream: true,
+      messages: [{ role: "user", content: "hi" }],
+    }),
+  });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /event-stream/);
+  const body = await res.text();
+  for (const ev of [
+    "message_start",
+    "content_block_start",
+    "content_block_delta",
+    "content_block_stop",
+    "message_delta",
+    "message_stop",
+  ]) {
+    assert.match(body, new RegExp(`event: ${ev}`), `missing SSE event "${ev}"`);
+  }
+  assert.match(body, /Sure, happy to help/);
+});
+
 test("POST /ollama-cloud/v1/chat/completions with empty body returns 400 (auth passed, body rejected) — validation probe contract", async () => {
   // Pinchy's wizard sends body: "{}" to probe whether the Bearer is valid.
   // 400 means auth passed; 401 means invalid key. This shape MUST hold or

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -98,6 +98,21 @@ test("GET /ollama-cloud/v1/models with Bearer returns models list", async () => 
   assert.ok(body.data.find((m) => m.id === "qwen3-next:80b"));
 });
 
+test("POST /google/v1beta/models/X:streamGenerateContent with x-goog-api-key header is accepted", async () => {
+  // pi-ai's @google/genai SDK passes the key via header at chat time, not
+  // ?key= query (which only validateProviderKey uses). Live CI showed OC
+  // hitting the endpoint with x-goog-api-key and getting 403 missing-key.
+  const res = await fetch(
+    `http://localhost:${PORT}/google/v1beta/models/gemini-2.5-pro:streamGenerateContent?alt=sse`,
+    {
+      method: "POST",
+      headers: { "x-goog-api-key": "AIza-mock-header", "Content-Type": "application/json" },
+      body: JSON.stringify({ contents: [{ parts: [{ text: "hi" }] }] }),
+    }
+  );
+  assert.equal(res.status, 200);
+});
+
 test("POST /google/v1beta/models/X:streamGenerateContent?alt=sse returns SSE candidates", async () => {
   // pi-ai's @google/genai SDK calls :streamGenerateContent with alt=sse
   // (visible in mock log of prior CI runs). Response is SSE: each chunk is
@@ -120,11 +135,15 @@ test("POST /google/v1beta/models/X:streamGenerateContent?alt=sse returns SSE can
   assert.match(body, /"finishReason":\s*"STOP"/);
 });
 
-test("POST /openai/v1/responses returns SSE response.output_text.delta + response.completed", async () => {
-  // OpenAI's new Responses API. pi-ai's openai-responses provider parses
-  // events with type prefixes 'response.*' — minimum to satisfy the parser:
-  // response.created, response.output_text.delta (carries the text),
-  // response.completed (signals end). Event format: `event: <name>\ndata: <JSON>\n\n`.
+test("POST /openai/v1/responses emits state-building events pi-ai parser requires", async () => {
+  // pi-ai's openai-responses-shared.js parser is state-machine driven:
+  //   response.output_item.added  → sets currentItem (must be type=message)
+  //   response.content_part.added → pushes part into currentItem.content
+  //   response.output_text.delta  → checks currentItem.content[last].type === "output_text",
+  //                                 only then extends currentBlock.text
+  // Skipping output_item.added or content_part.added means delta events
+  // are dropped — exactly the "empty response retries exhausted, payloads=0"
+  // failure live CI showed.
   const res = await fetch(`http://localhost:${PORT}/openai/v1/responses`, {
     method: "POST",
     headers: { Authorization: "Bearer sk-mock", "Content-Type": "application/json" },
@@ -133,9 +152,19 @@ test("POST /openai/v1/responses returns SSE response.output_text.delta + respons
   assert.equal(res.status, 200);
   assert.match(res.headers.get("content-type") || "", /event-stream/);
   const body = await res.text();
-  for (const ev of ["response.created", "response.output_text.delta", "response.completed"]) {
+  for (const ev of [
+    "response.created",
+    "response.output_item.added",
+    "response.content_part.added",
+    "response.output_text.delta",
+    "response.completed",
+  ]) {
     assert.match(body, new RegExp(`event: ${ev}`), `missing SSE event "${ev}"`);
   }
+  // output_item.added must carry item.type=message with a content array
+  assert.match(body, /"type":\s*"message"/);
+  // content_part.added must carry part.type=output_text
+  assert.match(body, /"type":\s*"output_text"/);
   assert.match(body, /Sure, happy to help/);
 });
 

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -48,3 +48,24 @@ test("GET /control/health returns 200", async () => {
   const res = await fetch(`http://localhost:${PORT}/control/health`);
   assert.equal(res.status, 200);
 });
+
+test("GET /anthropic/v1/models with x-api-key returns Anthropic shape", async () => {
+  const res = await fetch(`http://localhost:${PORT}/anthropic/v1/models`, {
+    headers: { "x-api-key": "sk-ant-mock", "anthropic-version": "2023-06-01" },
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(body.data.find((m) => m.id === "claude-sonnet-4-6"));
+});
+
+test("POST /anthropic/v1/messages returns Anthropic message shape", async () => {
+  const res = await fetch(`http://localhost:${PORT}/anthropic/v1/messages`, {
+    method: "POST",
+    headers: { "x-api-key": "sk-ant-mock", "anthropic-version": "2023-06-01", "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "claude-sonnet-4-6", max_tokens: 1024, messages: [{ role: "user", content: "hi" }] }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.type, "message");
+  assert.equal(body.content[0].type, "text");
+});

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -69,3 +69,21 @@ test("POST /anthropic/v1/messages returns Anthropic message shape", async () => 
   assert.equal(body.type, "message");
   assert.equal(body.content[0].type, "text");
 });
+
+test("GET /google/v1beta/models with key query param returns Gemini shape", async () => {
+  const res = await fetch(`http://localhost:${PORT}/google/v1beta/models?key=AIza-mock`);
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.ok(body.models.find((m) => m.name === "models/gemini-2.5-pro"));
+});
+
+test("POST /google/v1beta/models/gemini-2.5-pro:generateContent returns Gemini shape", async () => {
+  const res = await fetch(`http://localhost:${PORT}/google/v1beta/models/gemini-2.5-pro:generateContent?key=AIza-mock`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify({ contents: [{ parts: [{ text: "hi" }] }] }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.candidates[0].content.parts[0].text.length > 0, true);
+});

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -87,3 +87,46 @@ test("POST /google/v1beta/models/gemini-2.5-pro:generateContent returns Gemini s
   const body = await res.json();
   assert.equal(body.candidates[0].content.parts[0].text.length > 0, true);
 });
+
+test("GET /ollama-cloud/v1/models with Bearer returns models list", async () => {
+  const res = await fetch(`http://localhost:${PORT}/ollama-cloud/v1/models`, {
+    headers: { Authorization: "Bearer sk-ollama-mock" },
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.object, "list");
+  assert.ok(body.data.find((m) => m.id === "qwen3-next:80b"));
+});
+
+test("POST /ollama-cloud/v1/chat/completions with empty body returns 400 (auth passed, body rejected) — validation probe contract", async () => {
+  // Pinchy's wizard sends body: "{}" to probe whether the Bearer is valid.
+  // 400 means auth passed; 401 means invalid key. This shape MUST hold or
+  // wizard validation breaks. See providers.ts:141.
+  const res = await fetch(`http://localhost:${PORT}/ollama-cloud/v1/chat/completions`, {
+    method: "POST",
+    headers: { Authorization: "Bearer sk-ollama-mock", "Content-Type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(res.status, 400);
+});
+
+test("POST /ollama-cloud/v1/chat/completions without Bearer returns 401", async () => {
+  const res = await fetch(`http://localhost:${PORT}/ollama-cloud/v1/chat/completions`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: "{}",
+  });
+  assert.equal(res.status, 401);
+});
+
+test("POST /ollama-cloud/v1/chat/completions with proper messages returns OpenAI-shaped response", async () => {
+  const res = await fetch(`http://localhost:${PORT}/ollama-cloud/v1/chat/completions`, {
+    method: "POST",
+    headers: { Authorization: "Bearer sk-ollama-mock", "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "qwen3-next:80b", messages: [{ role: "user", content: "hi" }] }),
+  });
+  assert.equal(res.status, 200);
+  const body = await res.json();
+  assert.equal(body.choices[0].message.role, "assistant");
+  assert.ok(body.choices[0].message.content.length > 0);
+});

--- a/config/llm-providers-mock/__tests__/providers.test.js
+++ b/config/llm-providers-mock/__tests__/providers.test.js
@@ -98,6 +98,47 @@ test("GET /ollama-cloud/v1/models with Bearer returns models list", async () => 
   assert.ok(body.data.find((m) => m.id === "qwen3-next:80b"));
 });
 
+test("POST /google/v1beta/models/X:streamGenerateContent?alt=sse returns SSE candidates", async () => {
+  // pi-ai's @google/genai SDK calls :streamGenerateContent with alt=sse
+  // (visible in mock log of prior CI runs). Response is SSE: each chunk is
+  // `data: <JSON>\n\n` with a candidates array. The final chunk carries
+  // finishReason + usageMetadata. We emit a single complete chunk; pi-ai's
+  // parser accepts a single-event stream.
+  const res = await fetch(
+    `http://localhost:${PORT}/google/v1beta/models/gemini-2.5-pro:streamGenerateContent?key=AIza-mock&alt=sse`,
+    {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ contents: [{ parts: [{ text: "hi" }] }] }),
+    }
+  );
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /event-stream/);
+  const body = await res.text();
+  assert.match(body, /^data: /m);
+  assert.match(body, /Sure, happy to help/);
+  assert.match(body, /"finishReason":\s*"STOP"/);
+});
+
+test("POST /openai/v1/responses returns SSE response.output_text.delta + response.completed", async () => {
+  // OpenAI's new Responses API. pi-ai's openai-responses provider parses
+  // events with type prefixes 'response.*' — minimum to satisfy the parser:
+  // response.created, response.output_text.delta (carries the text),
+  // response.completed (signals end). Event format: `event: <name>\ndata: <JSON>\n\n`.
+  const res = await fetch(`http://localhost:${PORT}/openai/v1/responses`, {
+    method: "POST",
+    headers: { Authorization: "Bearer sk-mock", "Content-Type": "application/json" },
+    body: JSON.stringify({ model: "gpt-5.5", input: "hi", stream: true }),
+  });
+  assert.equal(res.status, 200);
+  assert.match(res.headers.get("content-type") || "", /event-stream/);
+  const body = await res.text();
+  for (const ev of ["response.created", "response.output_text.delta", "response.completed"]) {
+    assert.match(body, new RegExp(`event: ${ev}`), `missing SSE event "${ev}"`);
+  }
+  assert.match(body, /Sure, happy to help/);
+});
+
 test("POST /anthropic/v1/messages with stream:true returns SSE event sequence pi-ai parses", async () => {
   // pi-ai's iterateAnthropicEvents (node_modules/.../@earendil-works/pi-ai/dist/providers/anthropic.js)
   // requires these events in order: message_start, content_block_start,

--- a/config/llm-providers-mock/package.json
+++ b/config/llm-providers-mock/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "llm-providers-mock",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "express": "^5.1.0"
+  }
+}

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -3,6 +3,20 @@ import express from "express";
 const app = express();
 app.use(express.json({ limit: "10mb" }));
 
+// Tiny auth helpers. Each provider has a different scheme — keep these
+// as one-liners and add new ones as new providers are added (Anthropic
+// uses x-api-key, Google uses ?key=, etc).
+function requireBearer(req, res) {
+  if (req.headers.authorization?.startsWith("Bearer ")) return true;
+  res.status(401).json({ error: { message: "Missing API key" } });
+  return false;
+}
+
+// Frozen "created" timestamp for response determinism. Mock servers
+// asserting on full response shapes (E2E snapshots, audit-log fixtures)
+// rely on this — never replace with Date.now().
+const MOCK_CREATED_AT = 1700000000;
+
 const PORT = process.env.PORT || 9100;
 
 // ---- Control ----
@@ -10,29 +24,25 @@ app.get("/control/health", (_req, res) => res.json({ ok: true }));
 
 // ---- OpenAI ----
 app.get("/openai/v1/models", (req, res) => {
-  if (!req.headers.authorization?.startsWith("Bearer ")) {
-    return res.status(401).json({ error: { message: "Missing API key" } });
-  }
+  if (!requireBearer(req, res)) return;
   res.json({
     object: "list",
     data: [
-      { id: "gpt-5.5-2026-04-23", object: "model", created: 1700000000, owned_by: "openai" },
-      { id: "gpt-5.5", object: "model", created: 1700000000, owned_by: "openai" },
-      { id: "gpt-5.4", object: "model", created: 1700000000, owned_by: "openai" },
-      { id: "gpt-5.4-mini", object: "model", created: 1700000000, owned_by: "openai" },
+      { id: "gpt-5.5-2026-04-23", object: "model", created: MOCK_CREATED_AT, owned_by: "openai" },
+      { id: "gpt-5.5", object: "model", created: MOCK_CREATED_AT, owned_by: "openai" },
+      { id: "gpt-5.4", object: "model", created: MOCK_CREATED_AT, owned_by: "openai" },
+      { id: "gpt-5.4-mini", object: "model", created: MOCK_CREATED_AT, owned_by: "openai" },
     ],
   });
 });
 
 app.post("/openai/v1/chat/completions", (req, res) => {
-  if (!req.headers.authorization?.startsWith("Bearer ")) {
-    return res.status(401).json({ error: { message: "Missing API key" } });
-  }
+  if (!requireBearer(req, res)) return;
   const reply = "Sure, happy to help! What would you like to work on?";
   res.json({
     id: "chatcmpl-mock-1",
     object: "chat.completion",
-    created: Math.floor(Date.now() / 1000),
+    created: MOCK_CREATED_AT,
     model: req.body?.model ?? "gpt-5.5",
     choices: [
       { index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" },

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -94,11 +94,68 @@ app.get("/anthropic/v1/models", (req, res) => {
 
 app.post("/anthropic/v1/messages", (req, res) => {
   if (!requireXApiKey(req, res)) return;
+  const model = req.body?.model ?? "claude-sonnet-4-6";
+
+  // pi-ai (used by OpenClaw) always sends `stream: true` on this endpoint.
+  // Return SSE with the event sequence iterateAnthropicEvents expects in
+  // node_modules/.../@earendil-works/pi-ai/dist/providers/anthropic.js —
+  // message_start, content_block_start/delta/stop, message_delta,
+  // message_stop. Missing message_stop throws "Anthropic stream ended
+  // before message_stop".
+  if (req.body?.stream) {
+    res.setHeader("Content-Type", "text/event-stream");
+    res.setHeader("Cache-Control", "no-cache");
+    res.setHeader("Connection", "keep-alive");
+    const sse = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+    res.write(
+      sse("message_start", {
+        type: "message_start",
+        message: {
+          id: "msg_mock_1",
+          type: "message",
+          role: "assistant",
+          content: [],
+          model,
+          stop_reason: null,
+          stop_sequence: null,
+          usage: { input_tokens: 10, output_tokens: 0 },
+        },
+      })
+    );
+    res.write(
+      sse("content_block_start", {
+        type: "content_block_start",
+        index: 0,
+        content_block: { type: "text", text: "" },
+      })
+    );
+    res.write(
+      sse("content_block_delta", {
+        type: "content_block_delta",
+        index: 0,
+        delta: { type: "text_delta", text: MOCK_ASSISTANT_REPLY },
+      })
+    );
+    res.write(sse("content_block_stop", { type: "content_block_stop", index: 0 }));
+    res.write(
+      sse("message_delta", {
+        type: "message_delta",
+        delta: { stop_reason: "end_turn", stop_sequence: null },
+        usage: { output_tokens: 12 },
+      })
+    );
+    res.write(sse("message_stop", { type: "message_stop" }));
+    res.end();
+    return;
+  }
+
+  // Non-streaming fallback — kept for the validateProviderKey probe path
+  // (which sends body: "{}" and only cares about the HTTP status).
   res.json({
     id: "msg_mock_1",
     type: "message",
     role: "assistant",
-    model: req.body?.model ?? "claude-sonnet-4-6",
+    model,
     content: [{ type: "text", text: MOCK_ASSISTANT_REPLY }],
     stop_reason: "end_turn",
     usage: { input_tokens: 10, output_tokens: 12 },

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -6,14 +6,11 @@ app.use(express.json({ limit: "10mb" }));
 // One-line request log so E2E CI failures show whether OpenClaw / Pinchy
 // reached the mock at all. The setup-wizard-e2e job tails this container's
 // logs on failure (see .github/workflows/ci.yml setup-wizard-e2e job).
-// Strip control characters from req.method/req.url before logging so a
-// crafted request can't forge fake log entries (CodeQL js/log-injection).
-const stripCtl = (s) =>
-  String(s)
-    .replace(/[\r\n\x00-\x1f]/g, "?")
-    .slice(0, 200);
+// JSON.stringify escapes \r/\n/control chars and quotes so a crafted
+// request can't forge fake log entries — recognized by CodeQL as a
+// sanitizer for js/log-injection.
 app.use((req, _res, next) => {
-  console.log(`[mock] ${stripCtl(req.method)} ${stripCtl(req.url)}`);
+  console.log(`[mock] ${JSON.stringify(req.method)} ${JSON.stringify(req.url)}`);
   next();
 });
 

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -1,0 +1,44 @@
+import express from "express";
+
+const app = express();
+app.use(express.json({ limit: "10mb" }));
+
+const PORT = process.env.PORT || 9100;
+
+// ---- Control ----
+app.get("/control/health", (_req, res) => res.json({ ok: true }));
+
+// ---- OpenAI ----
+app.get("/openai/v1/models", (req, res) => {
+  if (!req.headers.authorization?.startsWith("Bearer ")) {
+    return res.status(401).json({ error: { message: "Missing API key" } });
+  }
+  res.json({
+    object: "list",
+    data: [
+      { id: "gpt-5.5-2026-04-23", object: "model", created: 1700000000, owned_by: "openai" },
+      { id: "gpt-5.5", object: "model", created: 1700000000, owned_by: "openai" },
+      { id: "gpt-5.4", object: "model", created: 1700000000, owned_by: "openai" },
+      { id: "gpt-5.4-mini", object: "model", created: 1700000000, owned_by: "openai" },
+    ],
+  });
+});
+
+app.post("/openai/v1/chat/completions", (req, res) => {
+  if (!req.headers.authorization?.startsWith("Bearer ")) {
+    return res.status(401).json({ error: { message: "Missing API key" } });
+  }
+  const reply = "Sure, happy to help! What would you like to work on?";
+  res.json({
+    id: "chatcmpl-mock-1",
+    object: "chat.completion",
+    created: Math.floor(Date.now() / 1000),
+    model: req.body?.model ?? "gpt-5.5",
+    choices: [
+      { index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 12, total_tokens: 22 },
+  });
+});
+
+app.listen(PORT, () => console.log(`llm-providers-mock listening on ${PORT}`));

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -112,4 +112,39 @@ app.post("/google/v1beta/models/:model\\:generateContent", (req, res) => {
   });
 });
 
+// ---- Ollama Cloud ----
+// Ollama Cloud is OpenAI-compatible. We mount its routes under
+// /ollama-cloud/v1/* and reuse the OpenAI response shape.
+app.get("/ollama-cloud/v1/models", (req, res) => {
+  if (!requireBearer(req, res)) return;
+  res.json({
+    object: "list",
+    data: [
+      { id: "qwen3-next:80b", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
+      { id: "qwen3-coder:480b", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
+    ],
+  });
+});
+
+app.post("/ollama-cloud/v1/chat/completions", (req, res) => {
+  if (!requireBearer(req, res)) return;
+  // Validation-probe contract: Pinchy's wizard sends body: "{}" to check
+  // whether the Bearer is valid. The real ollama.com returns 400 in that
+  // case (auth passed, body rejected) and providers.ts:141 treats 400 as
+  // "key is valid". We replicate that: missing `messages` → 400.
+  if (!Array.isArray(req.body?.messages) || req.body.messages.length === 0) {
+    return res.status(400).json({ error: { message: "messages: array required" } });
+  }
+  res.json({
+    id: "chatcmpl-mock-ollama-1",
+    object: "chat.completion",
+    created: MOCK_CREATED_AT,
+    model: req.body?.model ?? "qwen3-next:80b",
+    choices: [
+      { index: 0, message: { role: "assistant", content: MOCK_ASSISTANT_REPLY }, finish_reason: "stop" },
+    ],
+    usage: { prompt_tokens: 10, completion_tokens: 12, total_tokens: 22 },
+  });
+});
+
 app.listen(PORT, () => console.log(`llm-providers-mock listening on ${PORT}`));

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -3,20 +3,6 @@ import express from "express";
 const app = express();
 app.use(express.json({ limit: "10mb" }));
 
-// One-line request log so E2E CI failures show whether OpenClaw / Pinchy
-// reached the mock at all. The setup-wizard-e2e job tails this container's
-// logs on failure (see .github/workflows/ci.yml setup-wizard-e2e job).
-// /control/health is excluded because Docker's healthcheck polls it every
-// 5s — without this filter the meaningful requests get pushed out of the
-// log tail window. JSON.stringify escapes \r/\n/control chars and quotes
-// so a crafted request can't forge fake log entries (CodeQL js/log-injection).
-app.use((req, _res, next) => {
-  if (req.url !== "/control/health") {
-    console.log(`[mock] ${JSON.stringify(req.method)} ${JSON.stringify(req.url)}`);
-  }
-  next();
-});
-
 // Tiny auth helpers. Each provider has a different scheme — keep these
 // as one-liners and add new ones as new providers are added (Anthropic
 // uses x-api-key, Google uses ?key=, etc).

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -33,7 +33,10 @@ function requireXApiKey(req, res) {
 }
 
 function requireQueryKey(req, res) {
-  if (req.query.key) return true;
+  // pi-ai's @google/genai SDK passes the key via header at chat time
+  // (x-goog-api-key); validateProviderKey uses ?key= query param. Accept
+  // both so the same handler covers the wizard probe and chat dispatch.
+  if (req.query.key || req.headers["x-goog-api-key"]) return true;
   res.status(403).json({ error: { code: 403, message: "missing key" } });
   return false;
 }
@@ -67,10 +70,13 @@ app.get("/openai/v1/models", (req, res) => {
   });
 });
 
-// OpenAI's new Responses API (replaces /chat/completions for newer models).
-// pi-ai's openai-responses provider parses SSE events with type prefix
-// `response.*`. Minimum required: response.created → response.output_text.delta
-// (carries the text) → response.completed (signals end of stream).
+// OpenAI's new Responses API (replaces /chat/completions for gpt-5.x).
+// pi-ai's openai-responses-shared.js parser is state-machine driven —
+// output_text.delta is dropped unless currentItem (set by output_item.added)
+// is type=message AND currentItem.content[last] (pushed by content_part.added)
+// is type=output_text. Live CI failure on PR #445 ("empty response retries
+// exhausted, payloads=0") was caused by skipping those two events; the
+// deltas arrived but the parser had no item/part to attach them to.
 app.post("/openai/v1/responses", (req, res) => {
   if (!requireBearer(req, res)) return;
   const model = req.body?.model ?? "gpt-5.5";
@@ -79,6 +85,15 @@ app.post("/openai/v1/responses", (req, res) => {
   res.setHeader("Connection", "keep-alive");
   const sse = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
   const responseId = "resp_mock_1";
+  const itemId = "item_mock_1";
+  const messageItem = {
+    id: itemId,
+    type: "message",
+    role: "assistant",
+    status: "in_progress",
+    content: [],
+  };
+  const outputTextPart = { type: "output_text", text: "", annotations: [] };
   const baseResponse = {
     id: responseId,
     object: "response",
@@ -90,9 +105,25 @@ app.post("/openai/v1/responses", (req, res) => {
   };
   res.write(sse("response.created", { type: "response.created", response: baseResponse }));
   res.write(
+    sse("response.output_item.added", {
+      type: "response.output_item.added",
+      output_index: 0,
+      item: messageItem,
+    })
+  );
+  res.write(
+    sse("response.content_part.added", {
+      type: "response.content_part.added",
+      item_id: itemId,
+      output_index: 0,
+      content_index: 0,
+      part: outputTextPart,
+    })
+  );
+  res.write(
     sse("response.output_text.delta", {
       type: "response.output_text.delta",
-      item_id: "item_mock_1",
+      item_id: itemId,
       output_index: 0,
       content_index: 0,
       delta: MOCK_ASSISTANT_REPLY,
@@ -106,10 +137,9 @@ app.post("/openai/v1/responses", (req, res) => {
         status: "completed",
         output: [
           {
-            id: "item_mock_1",
-            type: "message",
-            role: "assistant",
-            content: [{ type: "output_text", text: MOCK_ASSISTANT_REPLY }],
+            ...messageItem,
+            status: "completed",
+            content: [{ type: "output_text", text: MOCK_ASSISTANT_REPLY, annotations: [] }],
           },
         ],
         usage: { input_tokens: 10, output_tokens: 12, total_tokens: 22 },

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -18,6 +18,12 @@ function requireXApiKey(req, res) {
   return false;
 }
 
+function requireQueryKey(req, res) {
+  if (req.query.key) return true;
+  res.status(403).json({ error: { code: 403, message: "missing key" } });
+  return false;
+}
+
 // Frozen "created" timestamp for response determinism. Mock servers
 // asserting on full response shapes (E2E snapshots, audit-log fixtures)
 // rely on this — never replace with Date.now().
@@ -82,6 +88,27 @@ app.post("/anthropic/v1/messages", (req, res) => {
     content: [{ type: "text", text: MOCK_ASSISTANT_REPLY }],
     stop_reason: "end_turn",
     usage: { input_tokens: 10, output_tokens: 12 },
+  });
+});
+
+// ---- Google ----
+app.get("/google/v1beta/models", (req, res) => {
+  if (!requireQueryKey(req, res)) return;
+  res.json({
+    models: [
+      { name: "models/gemini-2.5-pro", displayName: "Gemini 2.5 Pro" },
+      { name: "models/gemini-2.5-flash", displayName: "Gemini 2.5 Flash" },
+    ],
+  });
+});
+
+app.post("/google/v1beta/models/:model\\:generateContent", (req, res) => {
+  if (!requireQueryKey(req, res)) return;
+  res.json({
+    candidates: [
+      { content: { role: "model", parts: [{ text: MOCK_ASSISTANT_REPLY }] }, finishReason: "STOP" },
+    ],
+    usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 8, totalTokenCount: 13 },
   });
 });
 

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -6,11 +6,14 @@ app.use(express.json({ limit: "10mb" }));
 // One-line request log so E2E CI failures show whether OpenClaw / Pinchy
 // reached the mock at all. The setup-wizard-e2e job tails this container's
 // logs on failure (see .github/workflows/ci.yml setup-wizard-e2e job).
-// JSON.stringify escapes \r/\n/control chars and quotes so a crafted
-// request can't forge fake log entries — recognized by CodeQL as a
-// sanitizer for js/log-injection.
+// /control/health is excluded because Docker's healthcheck polls it every
+// 5s — without this filter the meaningful requests get pushed out of the
+// log tail window. JSON.stringify escapes \r/\n/control chars and quotes
+// so a crafted request can't forge fake log entries (CodeQL js/log-injection).
 app.use((req, _res, next) => {
-  console.log(`[mock] ${JSON.stringify(req.method)} ${JSON.stringify(req.url)}`);
+  if (req.url !== "/control/health") {
+    console.log(`[mock] ${JSON.stringify(req.method)} ${JSON.stringify(req.url)}`);
+  }
   next();
 });
 

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -6,8 +6,14 @@ app.use(express.json({ limit: "10mb" }));
 // One-line request log so E2E CI failures show whether OpenClaw / Pinchy
 // reached the mock at all. The setup-wizard-e2e job tails this container's
 // logs on failure (see .github/workflows/ci.yml setup-wizard-e2e job).
+// Strip control characters from req.method/req.url before logging so a
+// crafted request can't forge fake log entries (CodeQL js/log-injection).
+const stripCtl = (s) =>
+  String(s)
+    .replace(/[\r\n\x00-\x1f]/g, "?")
+    .slice(0, 200);
 app.use((req, _res, next) => {
-  console.log(`[mock] ${req.method} ${req.url}`);
+  console.log(`[mock] ${stripCtl(req.method)} ${stripCtl(req.url)}`);
   next();
 });
 

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -12,6 +12,12 @@ function requireBearer(req, res) {
   return false;
 }
 
+function requireXApiKey(req, res) {
+  if (req.headers["x-api-key"]) return true;
+  res.status(401).json({ type: "error", error: { type: "authentication_error", message: "missing api key" } });
+  return false;
+}
+
 // Frozen "created" timestamp for response determinism. Mock servers
 // asserting on full response shapes (E2E snapshots, audit-log fixtures)
 // rely on this — never replace with Date.now().
@@ -48,6 +54,30 @@ app.post("/openai/v1/chat/completions", (req, res) => {
       { index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" },
     ],
     usage: { prompt_tokens: 10, completion_tokens: 12, total_tokens: 22 },
+  });
+});
+
+// ---- Anthropic ----
+app.get("/anthropic/v1/models", (req, res) => {
+  if (!requireXApiKey(req, res)) return;
+  res.json({
+    data: [
+      { id: "claude-sonnet-4-6", type: "model", display_name: "Claude Sonnet 4.6" },
+      { id: "claude-haiku-4-5-20251001", type: "model", display_name: "Claude Haiku 4.5" },
+    ],
+  });
+});
+
+app.post("/anthropic/v1/messages", (req, res) => {
+  if (!requireXApiKey(req, res)) return;
+  res.json({
+    id: "msg_mock_1",
+    type: "message",
+    role: "assistant",
+    model: req.body?.model ?? "claude-sonnet-4-6",
+    content: [{ type: "text", text: "Sure, happy to help! What would you like to work on?" }],
+    stop_reason: "end_turn",
+    usage: { input_tokens: 10, output_tokens: 12 },
   });
 });
 

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -67,6 +67,58 @@ app.get("/openai/v1/models", (req, res) => {
   });
 });
 
+// OpenAI's new Responses API (replaces /chat/completions for newer models).
+// pi-ai's openai-responses provider parses SSE events with type prefix
+// `response.*`. Minimum required: response.created → response.output_text.delta
+// (carries the text) → response.completed (signals end of stream).
+app.post("/openai/v1/responses", (req, res) => {
+  if (!requireBearer(req, res)) return;
+  const model = req.body?.model ?? "gpt-5.5";
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  const sse = (event, data) => `event: ${event}\ndata: ${JSON.stringify(data)}\n\n`;
+  const responseId = "resp_mock_1";
+  const baseResponse = {
+    id: responseId,
+    object: "response",
+    created_at: MOCK_CREATED_AT,
+    model,
+    status: "in_progress",
+    output: [],
+    usage: null,
+  };
+  res.write(sse("response.created", { type: "response.created", response: baseResponse }));
+  res.write(
+    sse("response.output_text.delta", {
+      type: "response.output_text.delta",
+      item_id: "item_mock_1",
+      output_index: 0,
+      content_index: 0,
+      delta: MOCK_ASSISTANT_REPLY,
+    })
+  );
+  res.write(
+    sse("response.completed", {
+      type: "response.completed",
+      response: {
+        ...baseResponse,
+        status: "completed",
+        output: [
+          {
+            id: "item_mock_1",
+            type: "message",
+            role: "assistant",
+            content: [{ type: "output_text", text: MOCK_ASSISTANT_REPLY }],
+          },
+        ],
+        usage: { input_tokens: 10, output_tokens: 12, total_tokens: 22 },
+      },
+    })
+  );
+  res.end();
+});
+
 app.post("/openai/v1/chat/completions", (req, res) => {
   if (!requireBearer(req, res)) return;
   res.json({
@@ -181,6 +233,29 @@ app.post("/google/v1beta/models/:model\\:generateContent", (req, res) => {
     ],
     usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 8, totalTokenCount: 13 },
   });
+});
+
+// pi-ai's @google/genai SDK uses :streamGenerateContent for chat (not the
+// non-streaming :generateContent). Response is SSE: `data: <JSON>\n\n` chunks
+// with candidates[].content.parts[].text deltas. Single-chunk emission with
+// finishReason on it is the simplest valid stream the parser accepts.
+app.post("/google/v1beta/models/:model\\:streamGenerateContent", (req, res) => {
+  if (!requireQueryKey(req, res)) return;
+  res.setHeader("Content-Type", "text/event-stream");
+  res.setHeader("Cache-Control", "no-cache");
+  res.setHeader("Connection", "keep-alive");
+  res.write(
+    `data: ${JSON.stringify({
+      candidates: [
+        {
+          content: { role: "model", parts: [{ text: MOCK_ASSISTANT_REPLY }] },
+          finishReason: "STOP",
+        },
+      ],
+      usageMetadata: { promptTokenCount: 5, candidatesTokenCount: 8, totalTokenCount: 13 },
+    })}\n\n`
+  );
+  res.end();
 });
 
 // ---- Ollama Cloud ----

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -23,6 +23,11 @@ function requireXApiKey(req, res) {
 // rely on this — never replace with Date.now().
 const MOCK_CREATED_AT = 1700000000;
 
+// Frozen assistant reply for response determinism. Shared across all
+// provider handlers so E2E specs can assert one canonical message in
+// Pinchy's chat surface. Never replace with a dynamic string.
+const MOCK_ASSISTANT_REPLY = "Sure, happy to help! What would you like to work on?";
+
 const PORT = process.env.PORT || 9100;
 
 // ---- Control ----
@@ -44,14 +49,13 @@ app.get("/openai/v1/models", (req, res) => {
 
 app.post("/openai/v1/chat/completions", (req, res) => {
   if (!requireBearer(req, res)) return;
-  const reply = "Sure, happy to help! What would you like to work on?";
   res.json({
     id: "chatcmpl-mock-1",
     object: "chat.completion",
     created: MOCK_CREATED_AT,
     model: req.body?.model ?? "gpt-5.5",
     choices: [
-      { index: 0, message: { role: "assistant", content: reply }, finish_reason: "stop" },
+      { index: 0, message: { role: "assistant", content: MOCK_ASSISTANT_REPLY }, finish_reason: "stop" },
     ],
     usage: { prompt_tokens: 10, completion_tokens: 12, total_tokens: 22 },
   });
@@ -75,7 +79,7 @@ app.post("/anthropic/v1/messages", (req, res) => {
     type: "message",
     role: "assistant",
     model: req.body?.model ?? "claude-sonnet-4-6",
-    content: [{ type: "text", text: "Sure, happy to help! What would you like to work on?" }],
+    content: [{ type: "text", text: MOCK_ASSISTANT_REPLY }],
     stop_reason: "end_turn",
     usage: { input_tokens: 10, output_tokens: 12 },
   });

--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -3,6 +3,14 @@ import express from "express";
 const app = express();
 app.use(express.json({ limit: "10mb" }));
 
+// One-line request log so E2E CI failures show whether OpenClaw / Pinchy
+// reached the mock at all. The setup-wizard-e2e job tails this container's
+// logs on failure (see .github/workflows/ci.yml setup-wizard-e2e job).
+app.use((req, _res, next) => {
+  console.log(`[mock] ${req.method} ${req.url}`);
+  next();
+});
+
 // Tiny auth helpers. Each provider has a different scheme — keep these
 // as one-liners and add new ones as new providers are added (Anthropic
 // uses x-api-key, Google uses ?key=, etc).

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -7,6 +7,14 @@ echo "OpenClaw Gateway starting..."
 # Lives on tmpfs (volume mode 0770, file mode 0600).
 SECRETS_FILE="${OPENCLAW_SECRETS_PATH:-/openclaw-secrets/secrets.json}"
 
+# Bootstrap marker — when present, signals that the gateway has already booted
+# with secrets.json present at least once during this container's lifetime, so
+# subsequent secrets writes don't need to trigger a restart-to-reinitialize.
+# Lives on tmpfs alongside secrets.json, which is the correct lifetime:
+# container restart wipes both, and the post-boot writer (mark_bootstrap_when_ready)
+# re-creates it as soon as the new gateway is healthy with the file present.
+SECRETS_BOOTSTRAP_MARKER="$(dirname "$SECRETS_FILE")/.bootstrap-applied"
+
 # Pinchy writes secrets.json as a non-root user (uid 999 in production where
 # the pinchy container drops privileges, or the test runner's uid in CI
 # integration tests). OpenClaw's secrets-file resolver checks that the file's
@@ -183,6 +191,34 @@ auto_approve_devices() {
     echo "auto_approve_devices: safety timeout (5min), stopping"
 }
 
+# Mark the secrets bootstrap as applied once the gateway is up AND secrets.json
+# exists at that point. Semantics: "the secrets-provider was initialized with
+# a present file, so subsequent file writes don't need a restart."
+#
+# On fresh installs, secrets.json doesn't exist at first boot — the inotify
+# handler will pkill, the gateway will respawn with the file present, and a
+# later call to this function (after the respawn) will mark it. The marker
+# lives on tmpfs so it's wiped on container restart, and gets re-created
+# correctly during the next post-boot wait.
+#
+# Runs in the background so it doesn't block the main script. Up to 60 s
+# polling for the gateway port to come up; gives up silently if the port
+# never opens (the health-check loop will handle restart, and a later call
+# of this helper will mark on the next successful boot).
+mark_bootstrap_when_ready() {
+    (
+        for _ in $(seq 1 60); do
+            if (echo > /dev/tcp/127.0.0.1/18789) 2>/dev/null; then
+                if [ -f "$SECRETS_FILE" ]; then
+                    touch "$SECRETS_BOOTSTRAP_MARKER" 2>/dev/null || true
+                fi
+                return
+            fi
+            sleep 1
+        done
+    ) &
+}
+
 install_plugin_deps
 scan_data_directories
 
@@ -235,10 +271,18 @@ scan_data_directories
                 # The health-check loop below will respawn it within ~10s
                 # (port-probe wait) + ~5s (gateway startup).
                 # See docs/plans/2026-05-27-setup-wizard-smoke-tests.md for context.
-                BOOTSTRAP_MARKER="$(dirname "$SECRETS_FILE")/.bootstrap-applied"
-                if [ ! -f "$BOOTSTRAP_MARKER" ]; then
-                    touch "$BOOTSTRAP_MARKER" 2>/dev/null || true
+                #
+                # The bootstrap marker is set by mark_bootstrap_when_ready
+                # after each successful gateway boot with secrets.json present,
+                # NOT here. That way a container restart on an existing customer
+                # stack (where secrets.json already exists at boot) marks the
+                # bootstrap immediately, and the next user-triggered secrets
+                # write correctly skips this restart — no 15–40 s downtime.
+                if [ ! -f "$SECRETS_BOOTSTRAP_MARKER" ]; then
                     echo "[secrets-watcher] first-time secrets.json detected, restarting gateway to reinitialize secrets-provider"
+                    # pkill -f matches the full command line. "openclaw gateway"
+                    # is unique to the gateway subcommand (other subcommands
+                    # like "openclaw devices" wouldn't match).
                     pkill -TERM -f "openclaw gateway" 2>/dev/null || true
                 fi
             fi
@@ -258,6 +302,7 @@ auto_approve_devices &
 ensure_secrets_root_owned
 echo "Starting OpenClaw Gateway..."
 openclaw gateway --port 18789 &
+mark_bootstrap_when_ready
 
 # Keep the container alive. Health-check restarts gateway if it crashes.
 # Provider API keys are resolved live from secrets.json via SecretRef —
@@ -275,6 +320,7 @@ while true; do
             scan_data_directories
             ensure_secrets_root_owned
             openclaw gateway --port 18789 &
+            mark_bootstrap_when_ready
         fi
     fi
 done

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -227,6 +227,21 @@ scan_data_directories
             if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
                 chown root:root "$SECRETS_FILE" 2>/dev/null || true
                 chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+                # First-time appearance: OpenClaw's secrets-provider was
+                # initialized at boot with "file missing" and will NOT
+                # reinitialize on inotify of openclaw.json (the secrets
+                # section diff is empty). Restart the gateway exactly once
+                # so the provider picks up the new file on the next boot.
+                # The health-check loop below will respawn it within ~10s
+                # (port-probe wait) + ~5s (gateway startup).
+                # See docs/plans/2026-05-27-setup-wizard-smoke-tests.md and
+                # https://github.com/heypinchy/pinchy/issues/<TBD> for context.
+                BOOTSTRAP_MARKER="$(dirname "$SECRETS_FILE")/.bootstrap-applied"
+                if [ ! -f "$BOOTSTRAP_MARKER" ]; then
+                    touch "$BOOTSTRAP_MARKER" 2>/dev/null || true
+                    echo "[secrets-watcher] first-time secrets.json detected, restarting gateway to reinitialize secrets-provider"
+                    pkill -TERM -f "openclaw gateway" 2>/dev/null || true
+                fi
             fi
         done
     echo "[secrets-watcher] inotifywait exited; respawning in 1s"

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -207,11 +207,19 @@ auto_approve_devices() {
 # of this helper will mark on the next successful boot).
 mark_bootstrap_when_ready() {
     (
+        # Wait for BOTH conditions: gateway port up AND secrets.json present.
+        # Returning early on port-up alone (without checking the file)
+        # breaks the Telegram E2E `agent-create-no-restart.spec.ts` test:
+        # if Pinchy writes secrets.json AFTER the port came up but BEFORE
+        # this loop ticked again, the inotify handler fires `pkill` because
+        # the marker was never set — turning a hot-reload into a full
+        # gateway restart and tripping the `no restart cascade` (#193)
+        # assertion. Requiring both means we keep polling until the next
+        # secrets-write lands, then mark, so subsequent writes correctly
+        # skip the pkill.
         for _ in $(seq 1 60); do
-            if (echo > /dev/tcp/127.0.0.1/18789) 2>/dev/null; then
-                if [ -f "$SECRETS_FILE" ]; then
-                    touch "$SECRETS_BOOTSTRAP_MARKER" 2>/dev/null || true
-                fi
+            if (echo > /dev/tcp/127.0.0.1/18789) 2>/dev/null && [ -f "$SECRETS_FILE" ]; then
+                touch "$SECRETS_BOOTSTRAP_MARKER" 2>/dev/null || true
                 return
             fi
             sleep 1

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -263,6 +263,14 @@ scan_data_directories
             if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
                 chown root:root "$SECRETS_FILE" 2>/dev/null || true
                 chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
+                # Diagnostic for setup-wizard-e2e CI investigation (PR #445):
+                # dump the first ~120 bytes (provider keys + start of payload)
+                # so we can compare what Pinchy wrote against what OC reads.
+                # `head -c` is safe for binary because secrets.json is JSON; tr
+                # strips newlines to keep the log on one line.
+                # TODO: remove once setup-wizard-e2e is stable.
+                _diag_preview=$(head -c 120 "$SECRETS_FILE" 2>/dev/null | tr -d '\n')
+                echo "[secrets-watcher] secrets.json head=${_diag_preview}"
                 # First-time appearance: OpenClaw's secrets-provider was
                 # initialized at boot with "file missing" and will NOT
                 # reinitialize on inotify of openclaw.json (the secrets

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -271,14 +271,6 @@ scan_data_directories
             if [ "$filename" = "$(basename "$SECRETS_FILE")" ]; then
                 chown root:root "$SECRETS_FILE" 2>/dev/null || true
                 chmod 0600 "$SECRETS_FILE" 2>/dev/null || true
-                # Diagnostic for setup-wizard-e2e CI investigation (PR #445):
-                # dump the first ~120 bytes (provider keys + start of payload)
-                # so we can compare what Pinchy wrote against what OC reads.
-                # `head -c` is safe for binary because secrets.json is JSON; tr
-                # strips newlines to keep the log on one line.
-                # TODO: remove once setup-wizard-e2e is stable.
-                _diag_preview=$(head -c 120 "$SECRETS_FILE" 2>/dev/null | tr -d '\n')
-                echo "[secrets-watcher] secrets.json head=${_diag_preview}"
                 # First-time appearance: OpenClaw's secrets-provider was
                 # initialized at boot with "file missing" and will NOT
                 # reinitialize on inotify of openclaw.json (the secrets

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -234,8 +234,7 @@ scan_data_directories
                 # so the provider picks up the new file on the next boot.
                 # The health-check loop below will respawn it within ~10s
                 # (port-probe wait) + ~5s (gateway startup).
-                # See docs/plans/2026-05-27-setup-wizard-smoke-tests.md and
-                # https://github.com/heypinchy/pinchy/issues/<TBD> for context.
+                # See docs/plans/2026-05-27-setup-wizard-smoke-tests.md for context.
                 BOOTSTRAP_MARKER="$(dirname "$SECRETS_FILE")/.bootstrap-applied"
                 if [ ! -f "$BOOTSTRAP_MARKER" ]; then
                     touch "$BOOTSTRAP_MARKER" 2>/dev/null || true

--- a/docker-compose.setup-wizard-test.yml
+++ b/docker-compose.setup-wizard-test.yml
@@ -15,6 +15,32 @@ services:
       timeout: 3s
       retries: 10
 
+  # Ollama-Local provider mock. Single source of truth — same source file
+  # the integration tests run as a subprocess (packages/web/e2e/shared/
+  # fake-ollama/fake-ollama-server.ts). Containerised here so the
+  # setup-wizard E2E can reach it from inside the docker network, and
+  # aliased to a *.local hostname so Pinchy's SSRF allowlist (which
+  # mirrors OpenClaw's isLocalBaseUrl: localhost / *.local / RFC1918 /
+  # docker-host-aliases) accepts the URL the wizard test types in.
+  # FAKE_OLLAMA_RESPONSE overrides the in-source FAKE_RESPONSE default
+  # so the spec asserts the same canonical reply as the API-key mocks.
+  fake-ollama:
+    build:
+      context: packages/web/e2e/shared/fake-ollama
+    environment:
+      - FAKE_OLLAMA_RESPONSE=Sure, happy to help! What would you like to work on?
+    expose:
+      - "11435"
+    networks:
+      default:
+        aliases:
+          - fake-ollama.local
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:11435/api/tags').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
   pinchy:
     environment:
       - PINCHY_PROVIDER_BASEURL_OPENAI=http://llm-providers-mock:9100/openai
@@ -24,10 +50,14 @@ services:
     depends_on:
       llm-providers-mock:
         condition: service_healthy
+      fake-ollama:
+        condition: service_healthy
 
   openclaw:
     # OpenClaw resolves models.providers.<name>.baseUrl from openclaw.json,
     # which Pinchy now emits with the override above — no extra env needed here.
     depends_on:
       llm-providers-mock:
+        condition: service_healthy
+      fake-ollama:
         condition: service_healthy

--- a/docker-compose.setup-wizard-test.yml
+++ b/docker-compose.setup-wizard-test.yml
@@ -1,0 +1,33 @@
+# docker-compose.setup-wizard-test.yml
+# Overlay: adds mock LLM provider server for setup-wizard E2E tests.
+# Usage:
+#   docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up --build -d
+
+services:
+  llm-providers-mock:
+    build:
+      context: config/llm-providers-mock
+    expose:
+      - "9100"
+    healthcheck:
+      test: ["CMD", "node", "-e", "fetch('http://localhost:9100/control/health').then(r=>r.ok?process.exit(0):process.exit(1)).catch(()=>process.exit(1))"]
+      interval: 5s
+      timeout: 3s
+      retries: 10
+
+  pinchy:
+    environment:
+      - PINCHY_PROVIDER_BASEURL_OPENAI=http://llm-providers-mock:9100/openai
+      - PINCHY_PROVIDER_BASEURL_ANTHROPIC=http://llm-providers-mock:9100/anthropic
+      - PINCHY_PROVIDER_BASEURL_GOOGLE=http://llm-providers-mock:9100/google
+      - PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD=http://llm-providers-mock:9100/ollama-cloud
+    depends_on:
+      llm-providers-mock:
+        condition: service_healthy
+
+  openclaw:
+    # OpenClaw resolves models.providers.<name>.baseUrl from openclaw.json,
+    # which Pinchy now emits with the override above — no extra env needed here.
+    depends_on:
+      llm-providers-mock:
+        condition: service_healthy

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -149,7 +149,7 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.5.5 to %%PINCHY_VERSION%%
+## Upgrading from v0.5.6 to %%PINCHY_VERSION%%
 
 ### Breaking changes
 
@@ -157,17 +157,39 @@ None.
 
 ### Upgrade notes
 
-%%PINCHY_VERSION%% is a cosmetic patch on top of v0.5.5. The v0.5.5 release-cut was performed via `gh release create` instead of `pnpm release`, which skipped the version bump in `package.json` and `packages/web/package.json`. As a result, v0.5.5 images report `"pinchyVersion": "0.5.4"` from `/api/version` even though the image tag, OCI `image.version` label, and OpenClaw runtime are all on the intended v0.5.5 wire. %%PINCHY_VERSION%% restores agreement between the tag and the reported version. There are no functional changes versus v0.5.5.
+%%PINCHY_VERSION%% fixes the v0.5.6 setup-wizard regression where Smithers replied with `No API key found for provider '<name>'` on the very first chat message after a fresh install. The bug was provider-agnostic: OpenClaw's secrets-provider initialised at gateway boot with a "file missing" state because `secrets.json` was only written after the user completed the wizard. The provider never reinitialised when Pinchy hot-reloaded `openclaw.json` (the secrets-section diff was empty), so the gateway ran the rest of the session with no provider keys until a manual container restart.
 
-If you already deployed v0.5.5, upgrade straight to %%PINCHY_VERSION%%:
+The fix is Pinchy-side: an `inotifywait` handler in `start-openclaw.sh` writes a `/openclaw-secrets/.bootstrap-applied` marker on the first appearance of `secrets.json` and SIGTERMs the gateway exactly once so the next boot picks up the file. The health-check loop respawns the gateway within ~10–40 s, and a build-time drift guard in `validateBuiltConfig` rejects emitted configs whose `SecretRef` pointers don't resolve in `secrets.json` — closing the related class of "config references a key that isn't there" bugs that would have produced the same symptom from the Pinchy side.
+
+No manual steps beyond the standard upgrade flow:
 
 ```bash
 cd /opt/pinchy
-sed -i 's/PINCHY_VERSION=v0.5.5/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+sed -i 's/PINCHY_VERSION=v0.5.6/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 
-If you are upgrading directly from v0.5.4, skip v0.5.5 and follow the v0.5.4 → v0.5.5 upgrade notes below (substituting `%%PINCHY_VERSION%%` for `v0.5.5` in the `sed` command). All v0.5.5 behaviour ships in %%PINCHY_VERSION%% unchanged.
+If you saw the "No API key found" error on v0.5.6 and restarted the OpenClaw container manually to recover, no follow-up action is needed — the secrets-provider re-reads cleanly from disk on every boot.
+
+## Upgrading from v0.5.5 to v0.5.6
+
+### Breaking changes
+
+None.
+
+### Upgrade notes
+
+v0.5.6 is a cosmetic patch on top of v0.5.5. The v0.5.5 release-cut was performed via `gh release create` instead of `pnpm release`, which skipped the version bump in `package.json` and `packages/web/package.json`. As a result, v0.5.5 images report `"pinchyVersion": "0.5.4"` from `/api/version` even though the image tag, OCI `image.version` label, and OpenClaw runtime are all on the intended v0.5.5 wire. v0.5.6 restores agreement between the tag and the reported version. There are no functional changes versus v0.5.5.
+
+If you already deployed v0.5.5, upgrade straight to v0.5.6:
+
+```bash
+cd /opt/pinchy
+sed -i 's/PINCHY_VERSION=v0.5.5/PINCHY_VERSION=v0.5.6/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+If you are upgrading directly from v0.5.4, skip v0.5.5 and follow the v0.5.4 → v0.5.5 upgrade notes below (substituting `v0.5.6` for `v0.5.5` in the `sed` command). All v0.5.5 behaviour ships in v0.5.6 unchanged.
 
 ## Upgrading from v0.5.4 to v0.5.5
 

--- a/packages/web/e2e/setup-wizard/anthropic.spec.ts
+++ b/packages/web/e2e/setup-wizard/anthropic.spec.ts
@@ -1,0 +1,20 @@
+import { test } from "@playwright/test";
+import { resetStack, runProviderSmokeTest } from "./helpers";
+
+test.describe("Setup wizard → first chat with Anthropic", () => {
+  test.beforeAll(() => resetStack());
+
+  test("fresh install: wizard → Anthropic → first Smithers message succeeds", async ({ page }) => {
+    await runProviderSmokeTest(page, {
+      provider: "anthropic",
+      // Provider button label comes from PROVIDERS[].name in
+      // packages/web/src/components/provider-key-form.tsx ("Anthropic").
+      buttonName: /anthropic/i,
+      // Placeholder from packages/web/src/lib/providers.ts ("sk-ant-...").
+      // Anthropic-specific prefix distinguishes it from the OpenAI "sk-..."
+      // placeholder so the locator can't accidentally match the wrong field.
+      placeholderRegex: /sk-ant-/i,
+      keyValue: "sk-ant-mock-test-key",
+    });
+  });
+});

--- a/packages/web/e2e/setup-wizard/anthropic.spec.ts
+++ b/packages/web/e2e/setup-wizard/anthropic.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@playwright/test";
 import { resetStack, runProviderSmokeTest } from "./helpers";
 
 test.describe("Setup wizard → first chat with Anthropic", () => {
-  test.beforeAll(() => resetStack());
+  test.beforeAll(resetStack);
 
   test("fresh install: wizard → Anthropic → first Smithers message succeeds", async ({ page }) => {
     await runProviderSmokeTest(page, {

--- a/packages/web/e2e/setup-wizard/google.spec.ts
+++ b/packages/web/e2e/setup-wizard/google.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@playwright/test";
 import { resetStack, runProviderSmokeTest } from "./helpers";
 
 test.describe("Setup wizard → first chat with Google", () => {
-  test.beforeAll(() => resetStack());
+  test.beforeAll(resetStack);
 
   test("fresh install: wizard → Google → first Smithers message succeeds", async ({ page }) => {
     await runProviderSmokeTest(page, {

--- a/packages/web/e2e/setup-wizard/google.spec.ts
+++ b/packages/web/e2e/setup-wizard/google.spec.ts
@@ -1,0 +1,19 @@
+import { test } from "@playwright/test";
+import { resetStack, runProviderSmokeTest } from "./helpers";
+
+test.describe("Setup wizard → first chat with Google", () => {
+  test.beforeAll(() => resetStack());
+
+  test("fresh install: wizard → Google → first Smithers message succeeds", async ({ page }) => {
+    await runProviderSmokeTest(page, {
+      provider: "google",
+      // Provider button label comes from PROVIDERS[].name in
+      // packages/web/src/components/provider-key-form.tsx ("Google").
+      buttonName: /^google$/i,
+      // Placeholder from packages/web/src/lib/providers.ts ("AIza..."), which
+      // is the prefix Google API keys use.
+      placeholderRegex: /AIza/i,
+      keyValue: "AIza-mock-test-key",
+    });
+  });
+});

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -1,5 +1,6 @@
 import { execSync } from "node:child_process";
 import { setTimeout as sleep } from "node:timers/promises";
+import path from "path";
 import { expect, type Page } from "@playwright/test";
 
 // Re-using the same docker-compose stack invocation across overlays. Encoded
@@ -9,6 +10,15 @@ const COMPOSE_ARGS = [
   "-f docker-compose.e2e.yml",
   "-f docker-compose.setup-wizard-test.yml",
 ].join(" ");
+
+// Playwright runs from `packages/web/` (where playwright.setup-wizard.config.ts
+// lives), but the compose files in COMPOSE_ARGS are relative to the repo root.
+// Resolve once via process.cwd() and pass as `cwd:` to every execSync call so
+// `docker compose -f docker-compose.yml ...` finds the files. (Using
+// `import.meta.dirname` here breaks Playwright's CJS-transpile loader on the
+// current pin — other e2e helpers like global-setup.ts follow the same
+// process.cwd()-based pattern.)
+const REPO_ROOT = path.resolve(process.cwd(), "../..");
 
 /**
  * Reset the test stack between specs so each test starts with a fresh
@@ -40,9 +50,12 @@ export async function resetStack(): Promise<void> {
     `docker compose ${COMPOSE_ARGS} exec -T db ` +
       `psql -U pinchy -d pinchy -c ` +
       `'TRUNCATE TABLE "user", account, agents, settings, audit_log, session, verification, groups, invites, integration_connections RESTART IDENTITY CASCADE'`,
-    { stdio: "pipe" }
+    { stdio: "pipe", cwd: REPO_ROOT }
   );
-  execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, { stdio: "pipe" });
+  execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, {
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
 
   // Poll /api/setup/status until Pinchy answers — this proves the regenerated
   // openclaw.json has been picked up and the wizard route is reachable.

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { expect, type Page } from "@playwright/test";
 
 // Re-using the same docker-compose stack invocation across overlays. Encoded
 // as a constant so the test author doesn't accidentally drift between calls.
@@ -48,4 +49,90 @@ export function resetStack(): void {
     execSync("sleep 1", { stdio: "pipe" });
   }
   throw new Error("Pinchy did not become ready within 60s after reset");
+}
+
+export interface ProviderSmokeTestSpec {
+  /** Internal provider id used only for log/test diagnostics. */
+  provider: "openai" | "anthropic" | "google" | "ollama-cloud";
+  /**
+   * Regex matching the provider's button label in the wizard. Source of truth
+   * is `PROVIDERS[provider].name` in `packages/web/src/components/provider-key-form.tsx`.
+   * Examples: /openai/i, /anthropic/i, /^google$/i, /ollama cloud/i.
+   */
+  buttonName: RegExp;
+  /**
+   * Regex matching the API-key input's placeholder text. Source of truth is
+   * `PROVIDERS[provider].placeholder` in `packages/web/src/lib/providers.ts`.
+   * Examples: /sk-/i (OpenAI/Ollama-Cloud), /sk-ant-/i (Anthropic), /AIza/i (Google).
+   */
+  placeholderRegex: RegExp;
+  /**
+   * Mock key value. The llm-providers-mock at `config/llm-providers-mock/`
+   * accepts any non-empty token, so the literal value doesn't matter for the
+   * mock — but using a realistic prefix keeps the test plausible to a reader
+   * and protects against future client-side prefix validation.
+   */
+  keyValue: string;
+}
+
+/**
+ * End-to-end smoke test for one LLM provider's setup-wizard flow.
+ *
+ * Drives the wizard through all four phases (admin account, sign-in, provider
+ * key entry, first chat) and asserts that the mock LLM's deterministic reply
+ * renders without the v0.5.6 secrets.json race surfacing as an inline error.
+ *
+ * Phase 4 is the actual regression-catcher: before the Task 12 fix, the first
+ * chat after wizard completion would race openclaw.json regeneration against
+ * secrets.json flush, and Smithers would respond with
+ * "No API key found for provider '<provider>'". Asserting the mock reply
+ * AND the absence of the error UI catches both halves.
+ */
+export async function runProviderSmokeTest(page: Page, spec: ProviderSmokeTestSpec): Promise<void> {
+  // Phase 1: admin account
+  await page.goto("/setup", { waitUntil: "networkidle" });
+  await page.getByLabel(/name/i).fill("Smoke Test Admin");
+  await page.getByLabel(/email/i).fill("smoke@test.local");
+  await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
+  await page.getByLabel(/confirm password/i).fill("smoke-test-password-123");
+  await page.getByRole("button", { name: /create account/i }).click();
+  await expect(page.getByText(/account created successfully/i)).toBeVisible({ timeout: 15000 });
+  await page.getByRole("button", { name: /continue to sign in/i }).click();
+
+  // Phase 2: sign in
+  await expect(page).toHaveURL(/\/login/);
+  await page.getByLabel(/email/i).fill("smoke@test.local");
+  await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
+  await page.getByRole("button", { name: /sign in/i }).click();
+  await expect(page).toHaveURL(/\/setup\/provider/, { timeout: 20000 });
+
+  // Phase 3: provider selection + key entry. Mock accepts any non-empty token.
+  // The submit button label in ProviderKeyForm is "Continue" (the default
+  // submitLabel) on the setup-wizard path — not "Connect" or "Save", those
+  // only appear in /settings/providers where `configuredProviders` is passed.
+  await page.getByRole("button", { name: spec.buttonName }).click();
+  await page.getByPlaceholder(spec.placeholderRegex).fill(spec.keyValue);
+  await page.getByRole("button", { name: /^continue$/i }).click();
+  await expect(page.getByText(/provider connected/i)).toBeVisible({ timeout: 15000 });
+  await page.getByRole("button", { name: /continue to pinchy/i }).click();
+
+  // Phase 4: first message — the bug surface.
+  // v0.5.6 race: openclaw.json is regenerated but secrets.json may not be
+  // flushed before the first chat hits Gateway → OpenClaw replies with
+  // "No API key found for provider '<provider>'" and Pinchy renders an error.
+  await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+  await expect(page.getByText(/i'm smithers/i)).toBeVisible({ timeout: 30000 });
+
+  const composer = page.getByPlaceholder(/send a message/i);
+  await composer.fill("Hello, are you working?");
+  await composer.press("Enter");
+
+  // Assert: Smithers' response renders. The bug surfaces as the
+  // "Smithers couldn't respond — No API key found for provider '<provider>'"
+  // toast/inline error. We assert the mock's deterministic content
+  // ("Sure, happy to help! What would you like to work on?") and that
+  // NO error UI is shown.
+  await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 30000 });
+  await expect(page.getByText(/smithers couldn't respond/i)).not.toBeVisible();
+  await expect(page.getByText(/no api key found/i)).not.toBeVisible();
 }

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -52,6 +52,29 @@ export async function resetStack(): Promise<void> {
       `'TRUNCATE TABLE "user", account, agents, settings, audit_log, session, verification, groups, invites, integration_connections RESTART IDENTITY CASCADE'`,
     { stdio: "pipe", cwd: REPO_ROOT }
   );
+
+  // Delete openclaw.json and secrets.json from their named volumes BEFORE the
+  // container restart. Without this, the next Pinchy regenerate (fired by
+  // server.ts:371 when Pinchy reconnects to OpenClaw) builds an "all state
+  // truncated" config (~1.2 KB) that's <50% of the previous test's
+  // ~4.8 KB config — tripping build.ts's #311 size-drop guard. The guard
+  // correctly refuses the write (in production it protects against partial
+  // DB-loading races), but here the drop is legitimate (resetStack just
+  // wiped everything intentionally). secrets.json is already written by the
+  // time the guard fires, so openclaw.json keeps its stale anthropic
+  // SecretRef while secrets.json no longer has the key — OpenClaw fails
+  // with "JSON pointer segment anthropic does not exist" and crash-loops
+  // for the remainder of the test suite. Deleting both files (plus the
+  // bootstrap marker) means the next Pinchy regenerate sees no existing
+  // file, skips the size-drop comparison, and writes a clean baseline.
+  execSync(
+    `docker compose ${COMPOSE_ARGS} exec -T openclaw rm -f ` +
+      `/root/.openclaw/openclaw.json ` +
+      `/openclaw-secrets/secrets.json ` +
+      `/openclaw-secrets/.bootstrap-applied`,
+    { stdio: "pipe", cwd: REPO_ROOT }
+  );
+
   execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, {
     stdio: "pipe",
     cwd: REPO_ROOT,

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -154,7 +154,15 @@ export async function runProviderSmokeTest(page: Page, spec: ProviderSmokeTestSp
   // toast/inline error. We assert the mock's deterministic content
   // ("Sure, happy to help! What would you like to work on?") and that
   // NO error UI is shown.
-  await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 30000 });
+  //
+  // 90 s budget: the wizard's "Continue" click triggers regenerateOpenClawConfig
+  // which writes openclaw.json + secrets.json. OpenClaw's secrets-watcher then
+  // pkills the gateway on first-time secrets.json appearance (config/start-openclaw.sh
+  // bootstrap-marker logic), and the health-loop respawn cycle is ~40 s.
+  // 30 s was too tight on a cold E2E stack — the test would assert before OC
+  // finished its first-real-config restart. 90 s covers the worst case
+  // (one full restart cycle + chat round-trip).
+  await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 90000 });
   await expect(page.getByText(/smithers couldn't respond/i)).not.toBeVisible();
   await expect(page.getByText(/no api key found/i)).not.toBeVisible();
 }

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -1,0 +1,51 @@
+import { execSync } from "node:child_process";
+
+// Re-using the same docker-compose stack invocation across overlays. Encoded
+// as a constant so the test author doesn't accidentally drift between calls.
+const COMPOSE_ARGS = [
+  "-f docker-compose.yml",
+  "-f docker-compose.e2e.yml",
+  "-f docker-compose.setup-wizard-test.yml",
+].join(" ");
+
+/**
+ * Reset the test stack between specs so each test starts with a fresh
+ * "setup wizard not yet completed" state. Truncates Pinchy's app tables
+ * (DB stays mounted — pgdata is preserved) and restarts pinchy + openclaw
+ * so the new admin account, settings, and agents are recreated cleanly.
+ *
+ * Volumes are NOT removed. Project memory: never run `docker compose down -v`,
+ * even in tests — pgdata is the production DB volume in non-test stacks and
+ * the safety habit is more valuable than the marginal cleanup.
+ *
+ * Table names verified against packages/web/src/db/schema.ts:
+ *   users      → pgTable("user")
+ *   accounts   → pgTable("account")
+ *   agents     → pgTable("agents")
+ *   settings   → pgTable("settings")
+ *   auditLog   → pgTable("audit_log")   (NOT "audit_events")
+ */
+export function resetStack(): void {
+  execSync(
+    `docker compose ${COMPOSE_ARGS} exec -T db ` +
+      `psql -U pinchy -d pinchy -c ` +
+      `'TRUNCATE TABLE "user", account, agents, settings, audit_log RESTART IDENTITY CASCADE'`,
+    { stdio: "pipe" }
+  );
+  execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, { stdio: "pipe" });
+
+  // Poll /api/setup/status until Pinchy answers — this proves the regenerated
+  // openclaw.json has been picked up and the wizard route is reachable.
+  // 60 s budget: container restart + Next.js cold compile can run ~30 s.
+  const deadline = Date.now() + 60000;
+  while (Date.now() < deadline) {
+    try {
+      execSync(`curl -fsS http://localhost:7777/api/setup/status`, { stdio: "pipe" });
+      return;
+    } catch {
+      // server still warming up
+    }
+    execSync("sleep 1", { stdio: "pipe" });
+  }
+  throw new Error("Pinchy did not become ready within 60s after reset");
+}

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -1,4 +1,5 @@
 import { execSync } from "node:child_process";
+import { setTimeout as sleep } from "node:timers/promises";
 import { expect, type Page } from "@playwright/test";
 
 // Re-using the same docker-compose stack invocation across overlays. Encoded
@@ -20,17 +21,25 @@ const COMPOSE_ARGS = [
  * the safety habit is more valuable than the marginal cleanup.
  *
  * Table names verified against packages/web/src/db/schema.ts:
- *   users      → pgTable("user")
- *   accounts   → pgTable("account")
- *   agents     → pgTable("agents")
- *   settings   → pgTable("settings")
- *   auditLog   → pgTable("audit_log")   (NOT "audit_events")
+ *   users                  → pgTable("user")
+ *   sessions               → pgTable("session")
+ *   accounts               → pgTable("account")
+ *   verification           → pgTable("verification")
+ *   agents                 → pgTable("agents")
+ *   groups                 → pgTable("groups")
+ *   invites                → pgTable("invites")
+ *   settings               → pgTable("settings")
+ *   auditLog               → pgTable("audit_log")   (NOT "audit_events")
+ *   integrationConnections → pgTable("integration_connections")
+ *
+ * CASCADE handles the dependent join tables (account, user_groups, agent_groups,
+ * invite_groups, channel_links, agent_connection_permissions, usage_records).
  */
-export function resetStack(): void {
+export async function resetStack(): Promise<void> {
   execSync(
     `docker compose ${COMPOSE_ARGS} exec -T db ` +
       `psql -U pinchy -d pinchy -c ` +
-      `'TRUNCATE TABLE "user", account, agents, settings, audit_log RESTART IDENTITY CASCADE'`,
+      `'TRUNCATE TABLE "user", account, agents, settings, audit_log, session, verification, groups, invites, integration_connections RESTART IDENTITY CASCADE'`,
     { stdio: "pipe" }
   );
   execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, { stdio: "pipe" });
@@ -46,7 +55,7 @@ export function resetStack(): void {
     } catch {
       // server still warming up
     }
-    execSync("sleep 1", { stdio: "pipe" });
+    await sleep(1000);
   }
   throw new Error("Pinchy did not become ready within 60s after reset");
 }

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -98,7 +98,7 @@ export async function resetStack(): Promise<void> {
 
 export interface ProviderSmokeTestSpec {
   /** Internal provider id used only for log/test diagnostics. */
-  provider: "openai" | "anthropic" | "google" | "ollama-cloud";
+  provider: "openai" | "anthropic" | "google" | "ollama-cloud" | "ollama-local";
   /**
    * Regex matching the provider's button label in the wizard. Source of truth
    * is `PROVIDERS[provider].name` in `packages/web/src/components/provider-key-form.tsx`.

--- a/packages/web/e2e/setup-wizard/ollama-cloud.spec.ts
+++ b/packages/web/e2e/setup-wizard/ollama-cloud.spec.ts
@@ -1,0 +1,24 @@
+import { test } from "@playwright/test";
+import { resetStack, runProviderSmokeTest } from "./helpers";
+
+test.describe("Setup wizard → first chat with Ollama Cloud", () => {
+  test.beforeAll(() => resetStack());
+
+  test("fresh install: wizard → Ollama Cloud → first Smithers message succeeds", async ({
+    page,
+  }) => {
+    await runProviderSmokeTest(page, {
+      provider: "ollama-cloud",
+      // Provider button label comes from PROVIDERS[].name in
+      // packages/web/src/components/provider-key-form.tsx ("Ollama Cloud").
+      // We anchor on "ollama cloud" specifically so the locator can't match
+      // the sibling "Ollama (Local)" button rendered in the same grid.
+      buttonName: /ollama cloud/i,
+      // Placeholder from packages/web/src/lib/providers.ts ("sk-..."). Same
+      // prefix as OpenAI — fine here because only one API-key input exists
+      // on the form at a time (the selected provider's).
+      placeholderRegex: /sk-/i,
+      keyValue: "sk-ollama-mock-test-key",
+    });
+  });
+});

--- a/packages/web/e2e/setup-wizard/ollama-cloud.spec.ts
+++ b/packages/web/e2e/setup-wizard/ollama-cloud.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@playwright/test";
 import { resetStack, runProviderSmokeTest } from "./helpers";
 
 test.describe("Setup wizard → first chat with Ollama Cloud", () => {
-  test.beforeAll(() => resetStack());
+  test.beforeAll(resetStack);
 
   test("fresh install: wizard → Ollama Cloud → first Smithers message succeeds", async ({
     page,

--- a/packages/web/e2e/setup-wizard/ollama-local.spec.ts
+++ b/packages/web/e2e/setup-wizard/ollama-local.spec.ts
@@ -1,0 +1,37 @@
+import { test } from "@playwright/test";
+import { resetStack, runProviderSmokeTest } from "./helpers";
+
+test.describe("Setup wizard → first chat with Ollama (Local)", () => {
+  test.beforeAll(resetStack);
+
+  test("fresh install: wizard → Ollama Local → first Smithers message succeeds", async ({
+    page,
+  }) => {
+    // Ollama-Local is URL-based, not API-key-based — the wizard renders a URL
+    // input field instead of a "Bearer ..." form. The same runProviderSmokeTest
+    // helper handles both because both end up as a single text input that the
+    // placeholder selector matches.
+    //
+    // The URL points at the `fake-ollama` sibling service in
+    // docker-compose.setup-wizard-test.yml: it's the same fake-ollama-server.ts
+    // the integration tests use as a subprocess, containerised here so
+    // setup-wizard tests reach it from inside the Docker network. The
+    // `fake-ollama.local` alias is what makes both Pinchy's SSRF allowlist
+    // (validateProviderUrl) and OpenClaw's isLocalBaseUrl accept the URL —
+    // both accept any hostname ending in `.local`.
+    await runProviderSmokeTest(page, {
+      provider: "ollama-local",
+      // Provider button label from PROVIDERS["ollama-local"].name in
+      // packages/web/src/lib/providers.ts ("Ollama (Local)"). Specific
+      // enough not to collide with "Ollama Cloud".
+      buttonName: /ollama \(local\)/i,
+      // Placeholder from PROVIDERS["ollama-local"].placeholder
+      // ("http://host.docker.internal:11434"). Matching on the docker host
+      // alias keeps the regex stable if the example port changes.
+      placeholderRegex: /host\.docker\.internal/i,
+      // Real URL Pinchy receives. Port 11435 is fake-ollama's listener
+      // (FAKE_OLLAMA_PORT in fake-ollama-server.ts).
+      keyValue: "http://fake-ollama.local:11435",
+    });
+  });
+});

--- a/packages/web/e2e/setup-wizard/openai.spec.ts
+++ b/packages/web/e2e/setup-wizard/openai.spec.ts
@@ -1,55 +1,15 @@
-import { test, expect } from "@playwright/test";
-import { resetStack } from "./helpers";
+import { test } from "@playwright/test";
+import { resetStack, runProviderSmokeTest } from "./helpers";
 
 test.describe("Setup wizard → first chat with OpenAI", () => {
   test.beforeAll(() => resetStack());
 
-  test("fresh install: wizard → provider → first Smithers message succeeds", async ({ page }) => {
-    // Phase 1: admin account
-    await page.goto("/setup", { waitUntil: "networkidle" });
-    await page.getByLabel(/name/i).fill("Smoke Test Admin");
-    await page.getByLabel(/email/i).fill("smoke@test.local");
-    await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
-    await page.getByLabel(/confirm password/i).fill("smoke-test-password-123");
-    await page.getByRole("button", { name: /create account/i }).click();
-    await expect(page.getByText(/account created successfully/i)).toBeVisible({ timeout: 15000 });
-    await page.getByRole("button", { name: /continue to sign in/i }).click();
-
-    // Phase 2: sign in
-    await expect(page).toHaveURL(/\/login/);
-    await page.getByLabel(/email/i).fill("smoke@test.local");
-    await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
-    await page.getByRole("button", { name: /sign in/i }).click();
-    await expect(page).toHaveURL(/\/setup\/provider/, { timeout: 20000 });
-
-    // Phase 3: OpenAI provider with mock key (mock accepts any non-empty Bearer).
-    // The submit button label in ProviderKeyForm is "Continue" (the default
-    // submitLabel) on the setup-wizard path — not "Connect" or "Save", those
-    // only appear in /settings/providers where `configuredProviders` is passed.
-    await page.getByRole("button", { name: /openai/i }).click();
-    await page.getByPlaceholder(/sk-/i).fill("sk-mock-test-key");
-    await page.getByRole("button", { name: /^continue$/i }).click();
-    await expect(page.getByText(/provider connected/i)).toBeVisible({ timeout: 15000 });
-    await page.getByRole("button", { name: /continue to pinchy/i }).click();
-
-    // Phase 4: first message — the bug surface.
-    // v0.5.6 race: openclaw.json is regenerated but secrets.json may not be
-    // flushed before the first chat hits Gateway → OpenClaw replies with
-    // "No API key found for provider 'openai'" and Pinchy renders an error.
-    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
-    await expect(page.getByText(/i'm smithers/i)).toBeVisible({ timeout: 30000 });
-
-    const composer = page.getByPlaceholder(/send a message/i);
-    await composer.fill("Hello, are you working?");
-    await composer.press("Enter");
-
-    // Assert: Smithers' response renders. The bug surfaces as the
-    // "Smithers couldn't respond — No API key found for provider 'openai'"
-    // toast/inline error. We assert the mock's deterministic content
-    // ("Sure, happy to help! What would you like to work on?") and that
-    // NO error UI is shown.
-    await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 30000 });
-    await expect(page.getByText(/smithers couldn't respond/i)).not.toBeVisible();
-    await expect(page.getByText(/no api key found/i)).not.toBeVisible();
+  test("fresh install: wizard → OpenAI → first Smithers message succeeds", async ({ page }) => {
+    await runProviderSmokeTest(page, {
+      provider: "openai",
+      buttonName: /openai/i,
+      placeholderRegex: /sk-/i,
+      keyValue: "sk-mock-test-key",
+    });
   });
 });

--- a/packages/web/e2e/setup-wizard/openai.spec.ts
+++ b/packages/web/e2e/setup-wizard/openai.spec.ts
@@ -2,7 +2,7 @@ import { test } from "@playwright/test";
 import { resetStack, runProviderSmokeTest } from "./helpers";
 
 test.describe("Setup wizard → first chat with OpenAI", () => {
-  test.beforeAll(() => resetStack());
+  test.beforeAll(resetStack);
 
   test("fresh install: wizard → OpenAI → first Smithers message succeeds", async ({ page }) => {
     await runProviderSmokeTest(page, {

--- a/packages/web/e2e/setup-wizard/openai.spec.ts
+++ b/packages/web/e2e/setup-wizard/openai.spec.ts
@@ -1,0 +1,55 @@
+import { test, expect } from "@playwright/test";
+import { resetStack } from "./helpers";
+
+test.describe("Setup wizard → first chat with OpenAI", () => {
+  test.beforeAll(() => resetStack());
+
+  test("fresh install: wizard → provider → first Smithers message succeeds", async ({ page }) => {
+    // Phase 1: admin account
+    await page.goto("/setup", { waitUntil: "networkidle" });
+    await page.getByLabel(/name/i).fill("Smoke Test Admin");
+    await page.getByLabel(/email/i).fill("smoke@test.local");
+    await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
+    await page.getByLabel(/confirm password/i).fill("smoke-test-password-123");
+    await page.getByRole("button", { name: /create account/i }).click();
+    await expect(page.getByText(/account created successfully/i)).toBeVisible({ timeout: 15000 });
+    await page.getByRole("button", { name: /continue to sign in/i }).click();
+
+    // Phase 2: sign in
+    await expect(page).toHaveURL(/\/login/);
+    await page.getByLabel(/email/i).fill("smoke@test.local");
+    await page.getByLabel("Password", { exact: true }).fill("smoke-test-password-123");
+    await page.getByRole("button", { name: /sign in/i }).click();
+    await expect(page).toHaveURL(/\/setup\/provider/, { timeout: 20000 });
+
+    // Phase 3: OpenAI provider with mock key (mock accepts any non-empty Bearer).
+    // The submit button label in ProviderKeyForm is "Continue" (the default
+    // submitLabel) on the setup-wizard path — not "Connect" or "Save", those
+    // only appear in /settings/providers where `configuredProviders` is passed.
+    await page.getByRole("button", { name: /openai/i }).click();
+    await page.getByPlaceholder(/sk-/i).fill("sk-mock-test-key");
+    await page.getByRole("button", { name: /^continue$/i }).click();
+    await expect(page.getByText(/provider connected/i)).toBeVisible({ timeout: 15000 });
+    await page.getByRole("button", { name: /continue to pinchy/i }).click();
+
+    // Phase 4: first message — the bug surface.
+    // v0.5.6 race: openclaw.json is regenerated but secrets.json may not be
+    // flushed before the first chat hits Gateway → OpenClaw replies with
+    // "No API key found for provider 'openai'" and Pinchy renders an error.
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+    await expect(page.getByText(/i'm smithers/i)).toBeVisible({ timeout: 30000 });
+
+    const composer = page.getByPlaceholder(/send a message/i);
+    await composer.fill("Hello, are you working?");
+    await composer.press("Enter");
+
+    // Assert: Smithers' response renders. The bug surfaces as the
+    // "Smithers couldn't respond — No API key found for provider 'openai'"
+    // toast/inline error. We assert the mock's deterministic content
+    // ("Sure, happy to help! What would you like to work on?") and that
+    // NO error UI is shown.
+    await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 30000 });
+    await expect(page.getByText(/smithers couldn't respond/i)).not.toBeVisible();
+    await expect(page.getByText(/no api key found/i)).not.toBeVisible();
+  });
+});

--- a/packages/web/e2e/shared/fake-ollama/Dockerfile
+++ b/packages/web/e2e/shared/fake-ollama/Dockerfile
@@ -1,0 +1,10 @@
+FROM mirror.gcr.io/library/node:22-slim
+WORKDIR /app
+COPY package.json ./
+RUN npm install --omit=dev
+COPY fake-ollama-server.ts fake-ollama-process.ts ./
+EXPOSE 11435
+# tsx runs the TS source directly so the container stays in lockstep with
+# the canonical fake-ollama-server.ts used by integration tests — no
+# separate build step, no risk of the container drifting from the source.
+CMD ["npx", "tsx", "fake-ollama-process.ts"]

--- a/packages/web/e2e/shared/fake-ollama/README.md
+++ b/packages/web/e2e/shared/fake-ollama/README.md
@@ -1,0 +1,21 @@
+Minimal Ollama-API mock used by Pinchy's E2E tests.
+
+Two deployment modes share the same source (`fake-ollama-server.ts`):
+
+- **Subprocess** — integration tests and Telegram E2E start the server
+  in-process via `startFakeOllama()` from a Playwright `globalSetup`
+  hook. The assistant reply is the hardcoded `FAKE_RESPONSE` constant.
+- **Container** — the setup-wizard E2E (`docker-compose.setup-wizard-test.yml`)
+  builds this directory as a sibling service. The container reads the
+  `FAKE_OLLAMA_RESPONSE` env var so the wizard spec can assert the same
+  canonical "Sure, happy to help..." reply as the API-key provider mocks.
+  Default env-var value is unset, so subprocess behaviour is unchanged.
+
+Run locally to debug:
+
+```bash
+cd packages/web/e2e/shared/fake-ollama
+npm install
+FAKE_OLLAMA_RESPONSE='hello' npx tsx fake-ollama-process.ts
+curl http://localhost:11435/api/tags
+```

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -9,8 +9,12 @@
 import * as http from "http";
 
 const MODEL_NAME = "llama3.2";
-// This string must appear in the test's expect() assertion
-const FAKE_RESPONSE = "Integration test response.";
+// Default response asserted by the integration test suite. The setup-wizard
+// E2E container overrides this via FAKE_OLLAMA_RESPONSE so its spec can
+// assert the same canonical "Sure, happy to help..." reply as the other
+// provider mocks. Default value is preserved so existing subprocess usage
+// (integration tests, telegram tests) is unchanged.
+const FAKE_RESPONSE = process.env.FAKE_OLLAMA_RESPONSE ?? "Integration test response.";
 const DOMAIN_LOCK_TOOL_TRIGGER = "E2E_DOMAIN_LOCK_DOCS_TOOL";
 const DOMAIN_LOCK_TOOL_RESPONSE = "Domain lock docs tool call completed.";
 const SLOW_STREAM_TRIGGER = "E2E_SLOW_STREAM";

--- a/packages/web/e2e/shared/fake-ollama/package.json
+++ b/packages/web/e2e/shared/fake-ollama/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "fake-ollama-container",
+  "version": "0.0.0",
+  "private": true,
+  "type": "module",
+  "dependencies": {
+    "tsx": "^4.0.0"
+  }
+}

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -18,6 +18,7 @@
     "test:e2e:ui": "playwright test --ui",
     "test:e2e:telegram": "playwright test --config playwright.telegram.config.ts",
     "test:e2e:odoo": "playwright test --config playwright.odoo.config.ts",
+    "test:e2e:setup-wizard": "playwright test --config playwright.setup-wizard.config.ts",
     "test:e2e:web": "playwright test --config playwright.web.config.ts",
     "test:e2e:email": "playwright test --config playwright.email.config.ts",
     "test:integration": "playwright test --config playwright.integration.config.ts",

--- a/packages/web/playwright.config.ts
+++ b/packages/web/playwright.config.ts
@@ -11,6 +11,7 @@ export default defineConfig({
     "**/integration/**",
     "**/e2e/web/**",
     "**/e2e/email/**",
+    "**/e2e/setup-wizard/**",
   ],
   fullyParallel: false,
   retries: 0,

--- a/packages/web/playwright.setup-wizard.config.ts
+++ b/packages/web/playwright.setup-wizard.config.ts
@@ -1,0 +1,18 @@
+import { defineConfig } from "@playwright/test";
+
+/**
+ * Playwright config for setup-wizard E2E (covers all LLM providers).
+ * Assumes the full Docker stack with llm-providers-mock is already running:
+ *   docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml up --build -d
+ */
+export default defineConfig({
+  testDir: "./e2e/setup-wizard",
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: "list",
+  timeout: 120000,
+  use: {
+    baseURL: process.env.PINCHY_URL || "http://localhost:7777",
+  },
+});

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -71,6 +71,7 @@ vi.mock("@/lib/audit", () => ({
 vi.mock("@/lib/provider-models", () => ({
   resetCache: vi.fn(),
   getDefaultModel: vi.fn().mockResolvedValue("ollama/llama3:latest"),
+  setOllamaLocalModels: vi.fn(),
   fetchOllamaLocalModelsFromUrl: vi.fn().mockResolvedValue([
     {
       id: "ollama/qwen2.5:7b",
@@ -119,7 +120,12 @@ import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
 import { requireAdmin } from "@/lib/api-auth";
-import { resetCache, getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import {
+  resetCache,
+  getDefaultModel,
+  fetchOllamaLocalModelsFromUrl,
+  setOllamaLocalModels,
+} from "@/lib/provider-models";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
 import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
@@ -351,6 +357,33 @@ describe("POST /api/setup/provider", () => {
   it("should return 400 when ollama-local is missing URL", async () => {
     const response = await POST(makeRequest({ provider: "ollama-local" }) as any);
     expect(response.status).toBe(400);
+  });
+
+  it("primes the ollama-local model cache so Smithers resolves to an ollama model", async () => {
+    // Regression for the ollama-local wizard bug: resolveModelForTemplate
+    // reads getOllamaLocalModels() (the lastOllamaLocalModels cache), which is
+    // only populated by fetchProviderModels() — NOT by the wizard's direct
+    // fetchOllamaLocalModelsFromUrl() call. Without priming the cache here,
+    // resolveOllamaLocal() sees an empty model list, throws
+    // TemplateCapabilityUnavailableError, and Smithers stays on the
+    // anthropic/claude-sonnet-4-6 cold-start fallback — so a fresh ollama-local
+    // install hits "No API key found for provider 'anthropic'" on first chat.
+    await POST(
+      makeRequest({
+        provider: "ollama-local",
+        url: "http://host.docker.internal:11434",
+      }) as any
+    );
+
+    expect(setOllamaLocalModels).toHaveBeenCalledWith([
+      {
+        id: "ollama/qwen2.5:7b",
+        name: "qwen2.5:7b",
+        parameterSize: "7B",
+        compatible: true,
+        capabilities: { tools: true, vision: false, completion: true, thinking: false },
+      },
+    ]);
   });
 
   // #296 — Save-time rejection of hosts that won't pass OpenClaw's

--- a/packages/web/src/__tests__/api/setup.test.ts
+++ b/packages/web/src/__tests__/api/setup.test.ts
@@ -232,7 +232,14 @@ describe("POST /api/setup", () => {
     expect(data.error).toBe("Password must be at least 12 characters");
   });
 
-  it("should call regenerateOpenClawConfig after creating admin and agent", async () => {
+  it("should NOT regenerate openclaw.json yet (deferred to /api/setup/provider)", async () => {
+    // Smithers' default model is "anthropic/claude-sonnet-4-6" (seedDefaultAgent
+    // fallback for cold start). Writing that into openclaw.json before any
+    // provider is configured causes OpenClaw to auto-enable anthropic and
+    // crash-loop trying to resolve its SecretRef against an empty
+    // secrets.json. /api/setup/provider runs next in the wizard flow,
+    // resolves the model against the chosen provider, and regenerates with
+    // both halves consistent.
     vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined);
     vi.mocked(db.query.agents.findFirst).mockResolvedValue(undefined);
 
@@ -243,7 +250,7 @@ describe("POST /api/setup", () => {
     });
     await POST(request as any);
 
-    expect(regenerateOpenClawConfig).toHaveBeenCalledOnce();
+    expect(regenerateOpenClawConfig).not.toHaveBeenCalled();
   });
 
   it("should call markOpenClawConfigReady after setup completes", async () => {
@@ -260,25 +267,10 @@ describe("POST /api/setup", () => {
     expect(markOpenClawConfigReady).toHaveBeenCalledOnce();
   });
 
-  it("should return 500 and not mark ready when regenerateOpenClawConfig fails", async () => {
-    vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined);
-    vi.mocked(db.query.agents.findFirst).mockResolvedValue(undefined);
-    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
-      new Error("disk full: cannot write openclaw.json")
-    );
-
-    const request = makeRequest({
-      name: "Admin User",
-      email: "admin@test.com",
-      password: "Br1ghtNova!2",
-    });
-    const response = await POST(request as any);
-    const data = await response.json();
-
-    expect(response.status).toBe(500);
-    expect(data.error).toMatch(/openclaw config/i);
-    expect(markOpenClawConfigReady).not.toHaveBeenCalled();
-  });
+  // Removed: "should return 500 and not mark ready when regenerateOpenClawConfig fails".
+  // /api/setup no longer calls regenerateOpenClawConfig — the failure path
+  // it asserted against no longer exists. /api/setup/provider owns the first
+  // regenerate now and has its own error handling.
 
   it("should return 403 when setup is already complete", async () => {
     vi.mocked(db.query.users.findFirst).mockResolvedValue({

--- a/packages/web/src/__tests__/api/setup.test.ts
+++ b/packages/web/src/__tests__/api/setup.test.ts
@@ -232,14 +232,7 @@ describe("POST /api/setup", () => {
     expect(data.error).toBe("Password must be at least 12 characters");
   });
 
-  it("should NOT regenerate openclaw.json yet (deferred to /api/setup/provider)", async () => {
-    // Smithers' default model is "anthropic/claude-sonnet-4-6" (seedDefaultAgent
-    // fallback for cold start). Writing that into openclaw.json before any
-    // provider is configured causes OpenClaw to auto-enable anthropic and
-    // crash-loop trying to resolve its SecretRef against an empty
-    // secrets.json. /api/setup/provider runs next in the wizard flow,
-    // resolves the model against the chosen provider, and regenerates with
-    // both halves consistent.
+  it("should call regenerateOpenClawConfig after creating admin and agent", async () => {
     vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined);
     vi.mocked(db.query.agents.findFirst).mockResolvedValue(undefined);
 
@@ -250,7 +243,7 @@ describe("POST /api/setup", () => {
     });
     await POST(request as any);
 
-    expect(regenerateOpenClawConfig).not.toHaveBeenCalled();
+    expect(regenerateOpenClawConfig).toHaveBeenCalledOnce();
   });
 
   it("should call markOpenClawConfigReady after setup completes", async () => {
@@ -267,10 +260,25 @@ describe("POST /api/setup", () => {
     expect(markOpenClawConfigReady).toHaveBeenCalledOnce();
   });
 
-  // Removed: "should return 500 and not mark ready when regenerateOpenClawConfig fails".
-  // /api/setup no longer calls regenerateOpenClawConfig — the failure path
-  // it asserted against no longer exists. /api/setup/provider owns the first
-  // regenerate now and has its own error handling.
+  it("should return 500 and not mark ready when regenerateOpenClawConfig fails", async () => {
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(undefined);
+    vi.mocked(db.query.agents.findFirst).mockResolvedValue(undefined);
+    vi.mocked(regenerateOpenClawConfig).mockRejectedValueOnce(
+      new Error("disk full: cannot write openclaw.json")
+    );
+
+    const request = makeRequest({
+      name: "Admin User",
+      email: "admin@test.com",
+      password: "Br1ghtNova!2",
+    });
+    const response = await POST(request as any);
+    const data = await response.json();
+
+    expect(response.status).toBe(500);
+    expect(data.error).toMatch(/openclaw config/i);
+    expect(markOpenClawConfigReady).not.toHaveBeenCalled();
+  });
 
   it("should return 403 when setup is already complete", async () => {
     vi.mocked(db.query.users.findFirst).mockResolvedValue({

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -863,19 +863,68 @@ describe("regenerateOpenClawConfig", () => {
       expect(config?.models?.providers?.openai?.baseUrl).toBe("http://llm-mock:9100/openai/v1");
     });
 
-    it("PINCHY override takes priority over SDK OPENAI_BASE_URL", async () => {
-      process.env.OPENAI_BASE_URL = "https://sdk-proxy.example.com/v1";
-      process.env.PINCHY_PROVIDER_BASEURL_OPENAI = "http://llm-mock:9100/openai";
-      mockedGetSetting.mockImplementation(async (key: string) => {
-        if (key === "openai_api_key") return "sk-openai-test";
-        return null;
-      });
+    // Locks the "PINCHY > SDK > built-in default" priority chain for every
+    // built-in provider that supports both env vars. Suffix correctness
+    // mirrors BUILTIN_PROVIDER_PATH_SUFFIX in build.ts:
+    //   openai    → "/v1"
+    //   anthropic → ""        (Anthropic SDK URL has no path suffix)
+    //   google    → "/v1beta"
+    it.each([
+      [
+        "openai",
+        "OPENAI_BASE_URL",
+        "PINCHY_PROVIDER_BASEURL_OPENAI",
+        "https://sdk-proxy.example.com/v1",
+        "http://llm-mock:9100/openai",
+        "openai_api_key",
+        "sk-openai-test",
+        "http://llm-mock:9100/openai/v1",
+      ],
+      [
+        "anthropic",
+        "ANTHROPIC_BASE_URL",
+        "PINCHY_PROVIDER_BASEURL_ANTHROPIC",
+        "https://sdk-anthropic.example.com",
+        "http://llm-mock:9100/anthropic",
+        "anthropic_api_key",
+        "sk-ant-test",
+        "http://llm-mock:9100/anthropic",
+      ],
+      [
+        "google",
+        "GOOGLE_BASE_URL",
+        "PINCHY_PROVIDER_BASEURL_GOOGLE",
+        "https://sdk-google.example.com/v1beta",
+        "http://llm-mock:9100/google",
+        "google_api_key",
+        "AIza-test-key",
+        "http://llm-mock:9100/google/v1beta",
+      ],
+    ])(
+      "PINCHY override takes priority over SDK env var for %s",
+      async (
+        provider,
+        sdkEnv,
+        pinchyEnv,
+        sdkValue,
+        pinchyValue,
+        settingKey,
+        keyValue,
+        expectedBaseUrl
+      ) => {
+        process.env[sdkEnv] = sdkValue;
+        process.env[pinchyEnv] = pinchyValue;
+        mockedGetSetting.mockImplementation(async (key: string) => {
+          if (key === settingKey) return keyValue;
+          return null;
+        });
 
-      await regenerateOpenClawConfig();
-      const written = mockedWriteFileSync.mock.calls[0][1] as string;
-      const config = JSON.parse(written);
-      expect(config?.models?.providers?.openai?.baseUrl).toBe("http://llm-mock:9100/openai/v1");
-    });
+        await regenerateOpenClawConfig();
+        const written = mockedWriteFileSync.mock.calls[0][1] as string;
+        const config = JSON.parse(written);
+        expect(config?.models?.providers?.[provider]?.baseUrl).toBe(expectedBaseUrl);
+      }
+    );
 
     it("SDK env var still works when PINCHY env var is unset (backward compat)", async () => {
       process.env.OPENAI_BASE_URL = "https://sdk-proxy.example.com/v1";

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -833,6 +833,109 @@ describe("regenerateOpenClawConfig", () => {
     );
   });
 
+  describe("PINCHY_PROVIDER_BASEURL_* takes priority over SDK env vars", () => {
+    // These env vars exist for E2E mock injection (Phase 1 of the setup-wizard
+    // smoke tests). They override the *_BASE_URL SDK convention so the
+    // emitted openclaw.json points OpenClaw at the LLM mock at chat time.
+    // Priority: PINCHY_PROVIDER_BASEURL_* > *_BASE_URL > built-in default.
+    afterEach(() => {
+      delete process.env.PINCHY_PROVIDER_BASEURL_OPENAI;
+      delete process.env.PINCHY_PROVIDER_BASEURL_ANTHROPIC;
+      delete process.env.PINCHY_PROVIDER_BASEURL_GOOGLE;
+      delete process.env.PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD;
+      delete process.env.OPENAI_BASE_URL;
+      delete process.env.ANTHROPIC_BASE_URL;
+      delete process.env.GOOGLE_BASE_URL;
+    });
+
+    it("emits PINCHY_PROVIDER_BASEURL_OPENAI override into models.providers.openai.baseUrl", async () => {
+      process.env.PINCHY_PROVIDER_BASEURL_OPENAI = "http://llm-mock:9100/openai";
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "openai_api_key") return "sk-openai-test";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      // OpenAI's baseUrl emitted into OC config includes the /v1 suffix
+      // (pi-ai appends /chat/completions to it).
+      expect(config?.models?.providers?.openai?.baseUrl).toBe("http://llm-mock:9100/openai/v1");
+    });
+
+    it("PINCHY override takes priority over SDK OPENAI_BASE_URL", async () => {
+      process.env.OPENAI_BASE_URL = "https://sdk-proxy.example.com/v1";
+      process.env.PINCHY_PROVIDER_BASEURL_OPENAI = "http://llm-mock:9100/openai";
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "openai_api_key") return "sk-openai-test";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      expect(config?.models?.providers?.openai?.baseUrl).toBe("http://llm-mock:9100/openai/v1");
+    });
+
+    it("SDK env var still works when PINCHY env var is unset (backward compat)", async () => {
+      process.env.OPENAI_BASE_URL = "https://sdk-proxy.example.com/v1";
+      delete process.env.PINCHY_PROVIDER_BASEURL_OPENAI;
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "openai_api_key") return "sk-openai-test";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      // SDK env-var value comes through verbatim (no double-suffix).
+      expect(config?.models?.providers?.openai?.baseUrl).toBe("https://sdk-proxy.example.com/v1");
+    });
+
+    it("emits PINCHY_PROVIDER_BASEURL_ANTHROPIC override with no suffix (Anthropic default has none)", async () => {
+      process.env.PINCHY_PROVIDER_BASEURL_ANTHROPIC = "http://llm-mock:9100/anthropic";
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "anthropic_api_key") return "sk-ant-test";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      // Anthropic default is "https://api.anthropic.com" (no /v1); the
+      // override stays bare too.
+      expect(config?.models?.providers?.anthropic?.baseUrl).toBe("http://llm-mock:9100/anthropic");
+    });
+
+    it("emits PINCHY_PROVIDER_BASEURL_GOOGLE override with /v1beta suffix (Google default has it)", async () => {
+      process.env.PINCHY_PROVIDER_BASEURL_GOOGLE = "http://llm-mock:9100/google";
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "google_api_key") return "AIza-test-key";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      expect(config?.models?.providers?.google?.baseUrl).toBe("http://llm-mock:9100/google/v1beta");
+    });
+
+    it("Ollama-Cloud PINCHY override emits into models.providers.ollama-cloud.baseUrl", async () => {
+      process.env.PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD = "http://llm-mock:9100/ollama-cloud";
+      mockedGetSetting.mockImplementation(async (key: string) => {
+        if (key === "ollama_cloud_api_key") return "sk-ollama-test";
+        return null;
+      });
+
+      await regenerateOpenClawConfig();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written);
+      expect(config?.models?.providers?.["ollama-cloud"]?.baseUrl).toBe(
+        "http://llm-mock:9100/ollama-cloud/v1"
+      );
+    });
+  });
+
   it("should set defaults.model from default provider", async () => {
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "default_provider") return "openai";

--- a/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/validate-built-config.test.ts
@@ -152,3 +152,111 @@ describe("validateBuiltConfig", () => {
     }
   });
 });
+
+describe("SecretRef drift guard", () => {
+  it("rejects a config whose openai.apiKey SecretRef has no matching secret", () => {
+    const config = {
+      secrets: {
+        providers: {
+          pinchy: { source: "file", path: "/openclaw-secrets/secrets.json", mode: "json" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            apiKey: { source: "file", provider: "pinchy", id: "/providers/openai/apiKey" },
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    const secretsBundle = {};
+    const result = validateBuiltConfig(config, secretsBundle);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      expect(
+        result.errors.some(
+          (e) => /secretref/i.test(e) && /models\.providers\.openai\.apiKey/.test(e)
+        )
+      ).toBe(true);
+    }
+  });
+
+  it("accepts a matching pair", () => {
+    const config = {
+      secrets: {
+        providers: {
+          pinchy: { source: "file", path: "/openclaw-secrets/secrets.json", mode: "json" },
+        },
+      },
+      models: {
+        providers: {
+          openai: {
+            apiKey: { source: "file", provider: "pinchy", id: "/providers/openai/apiKey" },
+            baseUrl: "https://api.openai.com/v1",
+            models: [],
+          },
+        },
+      },
+    };
+    const secretsBundle = {
+      providers: { openai: { apiKey: "sk-real-key" } },
+    };
+    const result = validateBuiltConfig(config, secretsBundle);
+    expect(result.ok).toBe(true);
+  });
+
+  it("rejects an empty-string secret value (treated as missing)", () => {
+    const config = {
+      models: {
+        providers: {
+          openai: {
+            apiKey: { source: "file", provider: "pinchy", id: "/providers/openai/apiKey" },
+            baseUrl: "x",
+            models: [],
+          },
+        },
+      },
+    };
+    const secretsBundle = { providers: { openai: { apiKey: "" } } };
+    const result = validateBuiltConfig(config, secretsBundle);
+    expect(result.ok).toBe(false);
+  });
+
+  it("walks nested SecretRefs inside plugin entries", () => {
+    // Defense in depth: a SecretRef hiding in a deep plugin config block should
+    // still be caught. Pinchy plugins use the API-fetch pattern (not in-config
+    // SecretRefs), so this is forward-looking — guards against future regressions.
+    const config = {
+      plugins: {
+        entries: {
+          "some-plugin": {
+            config: {
+              nested: {
+                token: { source: "file", provider: "pinchy", id: "/plugins/some-plugin/token" },
+              },
+            },
+          },
+        },
+      },
+    };
+    const secretsBundle = {};
+    const result = validateBuiltConfig(config, secretsBundle);
+    expect(result.ok).toBe(false);
+    if (!result.ok) {
+      // Full dot-path includes the deep location so reviewers can locate the dangling ref.
+      expect(
+        result.errors.some((e) => /plugins\.entries\.some-plugin\.config\.nested\.token/.test(e))
+      ).toBe(true);
+    }
+  });
+
+  it("backward compat: existing single-arg call still works", () => {
+    // The secretsBundle parameter is optional. Production tests and callers
+    // that don't yet pass it should continue to function (only SecretRef checks
+    // are skipped, plugin-manifest checks still run).
+    const config = { plugins: { allow: [], entries: {} } };
+    expect(validateBuiltConfig(config).ok).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/provider-models-baseurl-override.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-baseurl-override.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+// Use the real providers module here — we need its actual
+// resolveProviderBaseUrl, since that's what provider-models.ts wires through.
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+}));
+
+import { fetchProviderModels, resetCache } from "@/lib/provider-models";
+import { getSetting } from "@/lib/settings";
+
+// The PROVIDER_FETCH_CONFIG URLs need to honor the same per-provider env
+// overrides that validateProviderKey honors. Without this, the wizard's
+// post-save regenerateOpenClawConfig() call (which calls getDefaultModel ->
+// fetchProviderModels -> fetchModelsForProvider) hits the real provider API
+// from the test container, masking smoke-test failures. For Google, the
+// hardcoded URL also had the wrong API version (/v1/ instead of /v1beta/)
+// which silently fell through to FALLBACK_MODELS instead of using the mock.
+
+describe("provider-models baseUrl env override", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    // Return a minimal payload that satisfies the four transforms enough to
+    // not NPE — each transform reads either `data` or `models`, both empty.
+    fetchSpy = vi
+      .spyOn(globalThis, "fetch")
+      .mockResolvedValue(new Response(JSON.stringify({ data: [], models: [] }), { status: 200 }));
+    resetCache();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    resetCache();
+    delete process.env.PINCHY_PROVIDER_BASEURL_OPENAI;
+    delete process.env.PINCHY_PROVIDER_BASEURL_ANTHROPIC;
+    delete process.env.PINCHY_PROVIDER_BASEURL_GOOGLE;
+    delete process.env.PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD;
+  });
+
+  it.each([
+    [
+      "anthropic",
+      "anthropic_api_key",
+      "PINCHY_PROVIDER_BASEURL_ANTHROPIC",
+      "/v1/models",
+      "https://api.anthropic.com",
+    ],
+    [
+      "openai",
+      "openai_api_key",
+      "PINCHY_PROVIDER_BASEURL_OPENAI",
+      "/v1/models",
+      "https://api.openai.com",
+    ],
+    [
+      "google",
+      "google_api_key",
+      "PINCHY_PROVIDER_BASEURL_GOOGLE",
+      "/v1beta/models",
+      "https://generativelanguage.googleapis.com",
+    ],
+    [
+      "ollama-cloud",
+      "ollama_cloud_api_key",
+      "PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD",
+      "/v1/models",
+      "https://ollama.com",
+    ],
+  ])(
+    "model-listing for %s honors %s env override",
+    async (provider, settingsKey, envVar, suffix, defaultBase) => {
+      vi.mocked(getSetting).mockImplementation(async (key: string) => {
+        if (key === settingsKey) return "test-key";
+        return null;
+      });
+
+      // Override case
+      process.env[envVar] = "http://mock";
+      await fetchProviderModels();
+      const overrideUrl = fetchSpy.mock.lastCall![0] as string;
+      expect(overrideUrl).toContain("http://mock" + suffix);
+      delete process.env[envVar];
+      resetCache();
+
+      // Fallback case
+      await fetchProviderModels();
+      const defaultUrl = fetchSpy.mock.lastCall![0] as string;
+      expect(defaultUrl).toContain(defaultBase + suffix);
+    }
+  );
+});

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -39,6 +39,20 @@ vi.mock("@/lib/providers", () => ({
       placeholder: "http://host.docker.internal:11434",
     },
   },
+  // Mirror the real helper: fall back to the canonical host unless the
+  // matching PINCHY_PROVIDER_BASEURL_* env var is set. The tests in this
+  // file don't set those vars, so the assertions still match the original
+  // hardcoded URLs.
+  resolveProviderBaseUrl: (provider: string, fallback: string) => {
+    const envMap: Record<string, string> = {
+      anthropic: "PINCHY_PROVIDER_BASEURL_ANTHROPIC",
+      openai: "PINCHY_PROVIDER_BASEURL_OPENAI",
+      google: "PINCHY_PROVIDER_BASEURL_GOOGLE",
+      "ollama-cloud": "PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD",
+    };
+    const envVar = envMap[provider];
+    return (envVar && process.env[envVar]) || fallback;
+  },
 }));
 
 vi.mock("@/lib/settings", () => ({

--- a/packages/web/src/__tests__/lib/providers-baseurl-override.test.ts
+++ b/packages/web/src/__tests__/lib/providers-baseurl-override.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { validateProviderKey, type ProviderName } from "@/lib/providers";
+
+describe("validateProviderKey baseUrl env override", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(globalThis, "fetch").mockResolvedValue(new Response("{}", { status: 200 }));
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+    delete process.env.PINCHY_PROVIDER_BASEURL_OPENAI;
+    delete process.env.PINCHY_PROVIDER_BASEURL_ANTHROPIC;
+    delete process.env.PINCHY_PROVIDER_BASEURL_GOOGLE;
+    delete process.env.PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD;
+  });
+
+  it("uses PINCHY_PROVIDER_BASEURL_OPENAI when set, falls back to api.openai.com otherwise", async () => {
+    process.env.PINCHY_PROVIDER_BASEURL_OPENAI = "http://llm-mock:9100/openai";
+    await validateProviderKey("openai", "sk-test");
+    expect(fetchSpy).toHaveBeenCalledWith(
+      "http://llm-mock:9100/openai/v1/models",
+      expect.any(Object)
+    );
+
+    delete process.env.PINCHY_PROVIDER_BASEURL_OPENAI;
+    await validateProviderKey("openai", "sk-test");
+    expect(fetchSpy).toHaveBeenLastCalledWith(
+      "https://api.openai.com/v1/models",
+      expect.any(Object)
+    );
+  });
+
+  it.each([
+    ["anthropic", "PINCHY_PROVIDER_BASEURL_ANTHROPIC", "/v1/models", "https://api.anthropic.com"],
+    [
+      "google",
+      "PINCHY_PROVIDER_BASEURL_GOOGLE",
+      "/v1beta/models",
+      "https://generativelanguage.googleapis.com",
+    ],
+    [
+      "ollama-cloud",
+      "PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD",
+      "/v1/chat/completions",
+      "https://ollama.com",
+    ],
+  ])("provider %s respects %s env override", async (provider, envVar, suffix, defaultBase) => {
+    process.env[envVar] = "http://mock";
+    await validateProviderKey(provider as ProviderName, "key");
+    expect(fetchSpy.mock.lastCall![0]).toContain("http://mock" + suffix);
+    delete process.env[envVar];
+
+    // Fallback case — confirm we revert to the default base host.
+    await validateProviderKey(provider as ProviderName, "key");
+    expect(fetchSpy.mock.lastCall![0]).toContain(defaultBase + suffix);
+  });
+});

--- a/packages/web/src/__tests__/lib/providers.test.ts
+++ b/packages/web/src/__tests__/lib/providers.test.ts
@@ -72,7 +72,7 @@ describe("validateProviderKey", () => {
 
     expect(result).toEqual({ valid: true });
     expect(fetch).toHaveBeenCalledWith(
-      "https://generativelanguage.googleapis.com/v1/models?key=AIza-valid",
+      "https://generativelanguage.googleapis.com/v1beta/models?key=AIza-valid",
       expect.any(Object)
     );
   });

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -11,7 +11,11 @@ import { getSetting, setSetting } from "@/lib/settings";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
 import { getOpenClawClient } from "@/server/openclaw-client";
-import { resetCache, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import {
+  resetCache,
+  fetchOllamaLocalModelsFromUrl,
+  setOllamaLocalModels,
+} from "@/lib/provider-models";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
 import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
 import { SMITHERS_MODEL_HINT } from "@/lib/personal-agent";
@@ -99,6 +103,14 @@ export async function POST(request: NextRequest) {
           : "No compatible models found. Pinchy agents require tool support. Pull a compatible model: ollama pull qwen2.5:7b";
       return NextResponse.json({ error: message }, { status: 422 });
     }
+
+    // Prime the ollama-local model cache that resolveModelForTemplate reads
+    // below. The wizard fetches the model list directly (above) rather than
+    // through fetchProviderModels(), which is the only other path that
+    // populates this cache — without this, resolveModelForTemplate sees zero
+    // installed models and Smithers falls back to anthropic (see
+    // setOllamaLocalModels docstring).
+    setOllamaLocalModels(ollamaModels);
 
     // Store URL unencrypted (not a secret)
     await setSetting(config.settingsKey, url, false);

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -185,9 +185,18 @@ export async function POST(request: NextRequest) {
   // "Continue to Pinchy" navigates to /chat/:smithersId and the first
   // chat dispatch races OC's reload, hitting "invalid agent params:
   // unknown agent id" — the message never reaches the LLM and the user
-  // sees the chat hang on a fresh install. Best-effort with a 5 s cap so
-  // we don't block forever if OC is still restarting (Layer 1 bootstrap
-  // mark/pkill cycle in start-openclaw.sh).
+  // sees the chat hang on a fresh install.
+  //
+  // 30 s cap (vs the 5 s default used by POST /api/agents): on a fresh
+  // wizard the Layer 1 bootstrap pkill in start-openclaw.sh can fire
+  // mid-regenerate, taking the gateway down for ~10–40 s before respawn.
+  // Within that window the config.get poll waitForAgentInRuntime uses
+  // gets WS errors and the 5 s budget elapses while OC is still
+  // restarting — wizard returns 200, browser navigates to /chat, dispatch
+  // races, "unknown agent id". 30 s comfortably covers one restart cycle
+  // while still failing fast if OC is genuinely broken. PR #445 CI showed
+  // 23 s pass / 1.7 m fail on the same commit on the 5 s default —
+  // textbook timing flake.
   const smithersForWait = await db.query.agents.findFirst();
   if (smithersForWait) {
     let client = null;
@@ -196,7 +205,7 @@ export async function POST(request: NextRequest) {
     } catch {
       // OC client not initialised (rare in tests / pre-setup). Skip the wait.
     }
-    await waitForAgentInRuntime(client, smithersForWait.id);
+    await waitForAgentInRuntime(client, smithersForWait.id, 30000);
   }
 
   // Build a CLAUDE.md-compliant audit detail: snapshot the human-readable

--- a/packages/web/src/app/api/setup/provider/route.ts
+++ b/packages/web/src/app/api/setup/provider/route.ts
@@ -9,6 +9,8 @@ import {
 } from "@/lib/providers";
 import { getSetting, setSetting } from "@/lib/settings";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
+import { getOpenClawClient } from "@/server/openclaw-client";
 import { resetCache, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 import { resolveModelForTemplate } from "@/lib/model-resolver";
 import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver/types";
@@ -175,6 +177,27 @@ export async function POST(request: NextRequest) {
   // Regenerate full OpenClaw config (includes agent list, provider env, model defaults)
   await regenerateOpenClawConfig();
   resetCache();
+
+  // Wait until OC's runtime has Smithers visible in `agents.list`. Same race
+  // as POST /api/agents (see wait-for-agent-in-runtime.ts): Pinchy's
+  // regenerate is fire-and-forget via pushConfigInBackground, and OC applies
+  // the hot reload asynchronously. Without this gate the wizard's
+  // "Continue to Pinchy" navigates to /chat/:smithersId and the first
+  // chat dispatch races OC's reload, hitting "invalid agent params:
+  // unknown agent id" — the message never reaches the LLM and the user
+  // sees the chat hang on a fresh install. Best-effort with a 5 s cap so
+  // we don't block forever if OC is still restarting (Layer 1 bootstrap
+  // mark/pkill cycle in start-openclaw.sh).
+  const smithersForWait = await db.query.agents.findFirst();
+  if (smithersForWait) {
+    let client = null;
+    try {
+      client = getOpenClawClient();
+    } catch {
+      // OC client not initialised (rare in tests / pre-setup). Skip the wait.
+    }
+    await waitForAgentInRuntime(client, smithersForWait.id);
+  }
 
   // Build a CLAUDE.md-compliant audit detail: snapshot the human-readable
   // provider name alongside its id, and never log secrets. For URL-based

--- a/packages/web/src/app/api/setup/route.ts
+++ b/packages/web/src/app/api/setup/route.ts
@@ -3,7 +3,6 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createAdmin } from "@/lib/setup";
 import { validatePassword } from "@/lib/validate-password";
-import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { markOpenClawConfigReady } from "@/lib/openclaw-config-ready";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -29,19 +28,16 @@ export async function POST(request: NextRequest) {
     }
 
     const user = await createAdmin(name, email, password);
-    // Write OpenClaw config with the newly created Smithers agent so OpenClaw
-    // knows about it when the container restarts or the file watcher picks it up.
-    // If this fails, surface the error: the admin record was created, but the
-    // user would otherwise see a confusing "agent unavailable" screen next.
-    try {
-      await regenerateOpenClawConfig();
-    } catch (err) {
-      console.error("[setup] Failed to regenerate OpenClaw config:", err);
-      return NextResponse.json(
-        { error: "OpenClaw config write failed; check server logs and retry setup." },
-        { status: 500 }
-      );
-    }
+    // Don't regenerate openclaw.json yet — Smithers' default model
+    // ("anthropic/claude-sonnet-4-6", chosen by seedDefaultAgent as a
+    // pre-provider fallback) would trigger OpenClaw's auto-enable for
+    // anthropic, then fail to resolve its SecretRef against the still-empty
+    // secrets.json and crash-loop the gateway. /api/setup/provider runs
+    // next in the wizard flow, resolves Smithers' model against the picked
+    // provider via resolveModelForTemplate, and regenerates openclaw.json
+    // with both the agent and the matching provider in one atomic write.
+    // The provider-picker UI between these two routes doesn't talk to
+    // OpenClaw, so Smithers being absent from openclaw.json here is fine.
     markOpenClawConfigReady();
     return NextResponse.json(user, { status: 201 });
   } catch (error) {

--- a/packages/web/src/app/api/setup/route.ts
+++ b/packages/web/src/app/api/setup/route.ts
@@ -3,6 +3,7 @@ import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
 import { createAdmin } from "@/lib/setup";
 import { validatePassword } from "@/lib/validate-password";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { markOpenClawConfigReady } from "@/lib/openclaw-config-ready";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -28,16 +29,19 @@ export async function POST(request: NextRequest) {
     }
 
     const user = await createAdmin(name, email, password);
-    // Don't regenerate openclaw.json yet — Smithers' default model
-    // ("anthropic/claude-sonnet-4-6", chosen by seedDefaultAgent as a
-    // pre-provider fallback) would trigger OpenClaw's auto-enable for
-    // anthropic, then fail to resolve its SecretRef against the still-empty
-    // secrets.json and crash-loop the gateway. /api/setup/provider runs
-    // next in the wizard flow, resolves Smithers' model against the picked
-    // provider via resolveModelForTemplate, and regenerates openclaw.json
-    // with both the agent and the matching provider in one atomic write.
-    // The provider-picker UI between these two routes doesn't talk to
-    // OpenClaw, so Smithers being absent from openclaw.json here is fine.
+    // Write OpenClaw config with the newly created Smithers agent so OpenClaw
+    // knows about it when the container restarts or the file watcher picks it up.
+    // If this fails, surface the error: the admin record was created, but the
+    // user would otherwise see a confusing "agent unavailable" screen next.
+    try {
+      await regenerateOpenClawConfig();
+    } catch (err) {
+      console.error("[setup] Failed to regenerate OpenClaw config:", err);
+      return NextResponse.json(
+        { error: "OpenClaw config write failed; check server logs and retry setup." },
+        { status: 500 }
+      );
+    }
     markOpenClawConfigReady();
     return NextResponse.json(user, { status: 201 });
   } catch (error) {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1292,6 +1292,13 @@ export async function regenerateOpenClawConfig() {
     );
   }
 
+  // Diagnostic for setup-wizard-e2e CI investigation (PR #445): log which
+  // provider keys are in the bundle just before disk write, so failing E2E
+  // logs show whether Pinchy thinks it wrote anthropic/openai/etc.
+  // TODO: remove once setup-wizard-e2e is stable.
+  console.log(
+    `[openclaw-config] writeSecretsFile providers=${JSON.stringify(Object.keys(secretsBundle.providers ?? {}))}`
+  );
   writeSecretsFile(secretsBundle);
 
   // Only write if content actually changed — prevents unnecessary OpenClaw restarts.

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1278,7 +1278,7 @@ export async function regenerateOpenClawConfig() {
   // Defense in depth: validate every emitted Pinchy plugin entry against its
   // manifest before writing. Catches manifest/build.ts drift at startup rather
   // than letting OpenClaw silently reject the config at hot-reload time.
-  const validation = validateBuiltConfig(config);
+  const validation = validateBuiltConfig(config, secretsBundle);
   if (!validation.ok) {
     throw new Error(
       "[openclaw-config] Refusing to write invalid plugin config:\n  - " +

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1273,11 +1273,16 @@ export async function regenerateOpenClawConfig() {
     integrations: integrationSecrets,
     plugins: pluginSecrets,
   });
-  writeSecretsFile(secretsBundle);
 
   // Defense in depth: validate every emitted Pinchy plugin entry against its
   // manifest before writing. Catches manifest/build.ts drift at startup rather
   // than letting OpenClaw silently reject the config at hot-reload time.
+  //
+  // Run validation BEFORE writing secrets.json to disk: both inputs (config and
+  // secretsBundle) are in-memory at this point, so neither needs the other to
+  // exist on disk first. If validation throws, we want neither file to have been
+  // updated — writing secrets.json first leaves a half-updated state when
+  // validation later rejects the change.
   const validation = validateBuiltConfig(config, secretsBundle);
   if (!validation.ok) {
     throw new Error(
@@ -1286,6 +1291,8 @@ export async function regenerateOpenClawConfig() {
         "\nFix the plugin manifest or what build.ts emits."
     );
   }
+
+  writeSecretsFile(secretsBundle);
 
   // Only write if content actually changed — prevents unnecessary OpenClaw restarts.
   // Format must match what OpenClaw's writeConfigFile produces (trimEnd + "\n")

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1292,13 +1292,6 @@ export async function regenerateOpenClawConfig() {
     );
   }
 
-  // Diagnostic for setup-wizard-e2e CI investigation (PR #445): log which
-  // provider keys are in the bundle just before disk write, so failing E2E
-  // logs show whether Pinchy thinks it wrote anthropic/openai/etc.
-  // TODO: remove once setup-wizard-e2e is stable.
-  console.log(
-    `[openclaw-config] writeSecretsFile providers=${JSON.stringify(Object.keys(secretsBundle.providers ?? {}))}`
-  );
   writeSecretsFile(secretsBundle);
 
   // Only write if content actually changed — prevents unnecessary OpenClaw restarts.

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -2,7 +2,7 @@ import { readFileSync, writeFileSync } from "fs";
 import { dirname } from "path";
 import { isDeepStrictEqual } from "util";
 import { writeSecretsFile, secretRef, type SecretsBundle } from "@/lib/openclaw-secrets";
-import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { PROVIDERS, type ProviderName, resolveProviderBaseUrl } from "@/lib/providers";
 import { getDefaultModel, fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
 import { isModelVisionCapable } from "@/lib/model-vision";
 import { eq, ne } from "drizzle-orm";
@@ -42,10 +42,27 @@ import { validateBuiltConfig } from "./validate-built-config";
 // built-in provider — startup config validation rejects the file otherwise. We write
 // SDK-canonical defaults; proxy/test deployments override via env-vars.
 // Verified against openclaw@2026.4.27 dist on 2026-05-06.
+//
+// These are BARE HOSTS (no path suffix). The path suffix is appended at
+// emission time via `BUILTIN_PROVIDER_PATH_SUFFIX` so PINCHY_PROVIDER_BASEURL_*
+// overrides (which carry only the host) get the same suffix treatment. The
+// SDK env-var path (*_BASE_URL) takes precedence with its value verbatim — see
+// the emission loop below for the layering rules.
 const BUILTIN_PROVIDER_DEFAULT_BASE_URLS: Record<"anthropic" | "openai" | "google", string> = {
   anthropic: "https://api.anthropic.com",
-  openai: "https://api.openai.com/v1",
-  google: "https://generativelanguage.googleapis.com/v1beta",
+  openai: "https://api.openai.com",
+  google: "https://generativelanguage.googleapis.com",
+};
+
+// OC's per-provider path conventions. Appended to the bare host above to
+// produce the `baseUrl` that lands in openclaw.json. Anthropic exposes its API
+// at the root; OpenAI lives under /v1; Google's Generative Language API lives
+// under /v1beta. Locked against the existing SDK-env-var tests at
+// openclaw-config.test.ts:734-822, which assert the final emitted URLs.
+const BUILTIN_PROVIDER_PATH_SUFFIX: Record<"anthropic" | "openai" | "google", string> = {
+  anthropic: "",
+  openai: "/v1",
+  google: "/v1beta",
 };
 
 const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "google", string> = {
@@ -966,24 +983,40 @@ export async function regenerateOpenClawConfig() {
   // providers (breaking change from 4.x where it was optional). Without
   // baseUrl, the gateway fails to start on health-check restarts:
   //   "models.providers.anthropic.baseUrl: Invalid input: expected string, received undefined"
-  // Priority: env var override > existing file value > OC's known default.
-  // The env var path supports custom API proxies; the existing-file path
-  // preserves anything OC has enriched; the default is OC's hardcoded fallback.
-  const PROVIDER_DEFAULT_BASE_URLS: Record<string, string> = {
-    anthropic: "https://api.anthropic.com",
-    openai: "https://api.openai.com/v1",
-    google: "https://generativelanguage.googleapis.com/v1beta",
-  };
-  const existingModelProviders =
-    ((existing.models as Record<string, unknown>)?.providers as Record<string, unknown>) ?? {};
-
+  //
+  // Priority for the emitted baseUrl:
+  //   1. PINCHY_PROVIDER_BASEURL_*  — Pinchy's own host override, used by
+  //      the LLM mock in E2E/smoke tests so OpenClaw's chat traffic hits the
+  //      local stand-in instead of api.openai.com etc. The path suffix
+  //      (BUILTIN_PROVIDER_PATH_SUFFIX) is appended to keep OC's URL shape.
+  //   2. *_BASE_URL (SDK convention) — used by proxy customers in production.
+  //      The value comes through verbatim because SDK env vars already carry
+  //      the full path (e.g. https://my-proxy.example.com/v1). No double-
+  //      suffix. Covered by the regression tests immediately above.
+  //   3. Bare built-in host + path suffix — OC's canonical default.
   for (const providerName of ["anthropic", "openai", "google"] as const) {
     const apiKey = await getSetting(PROVIDERS[providerName].settingsKey);
     if (apiKey) {
-      const envOverride = process.env[BUILTIN_PROVIDER_BASE_URL_ENV_VARS[providerName]];
+      // PINCHY_PROVIDER_BASEURL_* carries only the host, so we append the
+      // path suffix to keep the OC URL shape. The SDK *_BASE_URL fallback
+      // only kicks in when the PINCHY var is unset; its value comes through
+      // verbatim because SDK convention is to include the full path
+      // (e.g. https://my-proxy.example.com/v1).
+      const pinchyOverride = process.env[`PINCHY_PROVIDER_BASEURL_${providerName.toUpperCase()}`];
+      const sdkOverride = process.env[BUILTIN_PROVIDER_BASE_URL_ENV_VARS[providerName]];
+      let baseUrl: string;
+      if (pinchyOverride) {
+        baseUrl = pinchyOverride + BUILTIN_PROVIDER_PATH_SUFFIX[providerName];
+      } else if (sdkOverride) {
+        baseUrl = sdkOverride;
+      } else {
+        baseUrl =
+          BUILTIN_PROVIDER_DEFAULT_BASE_URLS[providerName] +
+          BUILTIN_PROVIDER_PATH_SUFFIX[providerName];
+      }
       modelProviders[providerName] = {
         apiKey: secretRef(`/providers/${providerName}/apiKey`),
-        baseUrl: envOverride ?? BUILTIN_PROVIDER_DEFAULT_BASE_URLS[providerName],
+        baseUrl,
         models: getModelCatalogForProvider(providerName),
       };
     }
@@ -992,7 +1025,11 @@ export async function regenerateOpenClawConfig() {
   if (ollamaCloudKey) {
     providerSecrets["ollama-cloud"] = { apiKey: ollamaCloudKey };
     modelProviders["ollama-cloud"] = {
-      baseUrl: "https://ollama.com/v1",
+      // PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD redirects OpenClaw's Ollama-Cloud
+      // chat traffic to the smoke-test LLM mock. Ollama-Cloud has no SDK env-
+      // var convention, so the override goes straight through resolveProvider-
+      // BaseUrl() with the canonical https://ollama.com fallback.
+      baseUrl: resolveProviderBaseUrl("ollama-cloud", "https://ollama.com") + "/v1",
       apiKey: secretRef("/providers/ollama-cloud/apiKey"),
       api: "openai-completions",
       // Derived from TOOL_CAPABLE_OLLAMA_CLOUD_MODELS — see that file for

--- a/packages/web/src/lib/openclaw-config/validate-built-config.ts
+++ b/packages/web/src/lib/openclaw-config/validate-built-config.ts
@@ -53,7 +53,48 @@ function validatePinchyFilesConfig(pluginConfig: unknown, errors: string[]): voi
 
 export type BuiltConfigValidationResult = { ok: true } | { ok: false; errors: string[] };
 
-export function validateBuiltConfig(config: unknown): BuiltConfigValidationResult {
+type SecretRef = { source: "file"; provider: string; id: string };
+
+function isSecretRef(x: unknown): x is SecretRef {
+  if (!x || typeof x !== "object") return false;
+  const o = x as Record<string, unknown>;
+  return o.source === "file" && typeof o.provider === "string" && typeof o.id === "string";
+}
+
+function collectSecretRefs(
+  node: unknown,
+  path: string[],
+  out: Array<{ pathDot: string; ref: SecretRef }>
+): void {
+  if (isSecretRef(node)) {
+    out.push({ pathDot: path.join("."), ref: node });
+    return;
+  }
+  if (!node || typeof node !== "object") return;
+  if (Array.isArray(node)) {
+    node.forEach((item, i) => collectSecretRefs(item, [...path, String(i)], out));
+    return;
+  }
+  for (const [k, v] of Object.entries(node as Record<string, unknown>)) {
+    collectSecretRefs(v, [...path, k], out);
+  }
+}
+
+function resolveSecretValue(bundle: Record<string, unknown>, slashPath: string): unknown {
+  // slashPath like "/providers/openai/apiKey" → ["providers", "openai", "apiKey"]
+  const parts = slashPath.split("/").filter(Boolean);
+  let cur: unknown = bundle;
+  for (const p of parts) {
+    if (!cur || typeof cur !== "object") return undefined;
+    cur = (cur as Record<string, unknown>)[p];
+  }
+  return cur;
+}
+
+export function validateBuiltConfig(
+  config: unknown,
+  secretsBundle?: Record<string, unknown>
+): BuiltConfigValidationResult {
   if (!config || typeof config !== "object") return { ok: true };
   const plugins = (config as Record<string, unknown>).plugins as
     | { entries?: Record<string, unknown> }
@@ -81,5 +122,28 @@ export function validateBuiltConfig(config: unknown): BuiltConfigValidationResul
       validatePinchyFilesConfig(entry.config, errors);
     }
   }
+
+  // SecretRef drift guard: when the caller passes the secretsBundle that will be
+  // written to secrets.json, verify every SecretRef in the config tree resolves
+  // to a non-empty value. Catches the class of bug where build.ts emits a
+  // pointer (e.g. providers.openai.apiKey) but the bundle for that flow forgot
+  // to populate the matching secret. Symptom in production: OpenClaw silently
+  // fails at chat time with "No API key found for provider 'openai'".
+  if (secretsBundle) {
+    const refs: Array<{ pathDot: string; ref: SecretRef }> = [];
+    collectSecretRefs(config, [], refs);
+    for (const { pathDot, ref } of refs) {
+      // Only validate Pinchy's secrets-provider; other providers (e.g. env-based)
+      // resolve outside the bundle.
+      if (ref.provider !== "pinchy") continue;
+      const value = resolveSecretValue(secretsBundle, ref.id);
+      if (value === undefined || value === null || value === "") {
+        errors.push(
+          `secretref at ${pathDot} points to "${ref.id}" but no matching entry exists in secretsBundle (or value is empty)`
+        );
+      }
+    }
+  }
+
   return errors.length ? { ok: false, errors } : { ok: true };
 }

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -225,6 +225,26 @@ export function getOllamaLocalModels(): OllamaLocalModelInfo[] {
   return lastOllamaLocalModels;
 }
 
+/**
+ * Prime the ollama-local model cache that `getOllamaLocalModels()` (and
+ * therefore `resolveModelForTemplate` for the ollama-local provider) reads.
+ *
+ * Normally the cache is populated as a side effect of `fetchProviderModels()`,
+ * which runs on the dashboard's model-list fetch. The setup wizard's
+ * `POST /api/setup/provider` URL branch fetches the model list directly via
+ * `fetchOllamaLocalModelsFromUrl()` for its tool-capability check and never
+ * calls `fetchProviderModels()` — so without this primer the cache is still
+ * empty when the wizard then calls `resolveModelForTemplate` to pick Smithers'
+ * model. The resolver would see zero installed models, throw
+ * `TemplateCapabilityUnavailableError`, and leave Smithers on the
+ * anthropic/claude-sonnet-4-6 cold-start fallback — producing
+ * "No API key found for provider 'anthropic'" on the first chat of a fresh
+ * ollama-local install.
+ */
+export function setOllamaLocalModels(models: OllamaLocalModelInfo[]): void {
+  lastOllamaLocalModels = models;
+}
+
 // Per-call timeout for Ollama discovery requests. Each `/api/show` call
 // runs sequentially today, so a hanging Ollama instance with many installed
 // models could otherwise wedge the setup wizard for minutes. Five seconds

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -1,4 +1,4 @@
-import { PROVIDERS, type ProviderName } from "@/lib/providers";
+import { PROVIDERS, resolveProviderBaseUrl, type ProviderName } from "@/lib/providers";
 import { getSetting } from "@/lib/settings";
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS } from "@/lib/ollama-cloud-models";
 
@@ -89,7 +89,7 @@ interface ProviderFetchConfig {
 
 const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
   anthropic: {
-    url: () => "https://api.anthropic.com/v1/models",
+    url: () => `${resolveProviderBaseUrl("anthropic", "https://api.anthropic.com")}/v1/models`,
     headers: (apiKey) => ({
       "x-api-key": apiKey,
       "anthropic-version": "2023-06-01",
@@ -101,7 +101,7 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
       })),
   },
   openai: {
-    url: () => "https://api.openai.com/v1/models",
+    url: () => `${resolveProviderBaseUrl("openai", "https://api.openai.com")}/v1/models`,
     headers: (apiKey) => ({ Authorization: `Bearer ${apiKey}` }),
     transform: (data) =>
       (data.data as { id: string }[])
@@ -114,7 +114,8 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
         })),
   },
   google: {
-    url: (apiKey) => `https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`,
+    url: (apiKey) =>
+      `${resolveProviderBaseUrl("google", "https://generativelanguage.googleapis.com")}/v1beta/models?key=${apiKey}`,
     headers: () => ({}),
     transform: (data) =>
       (data.models as { name: string; displayName: string; supportedGenerationMethods: string[] }[])
@@ -125,7 +126,7 @@ const PROVIDER_FETCH_CONFIG: Record<ProviderName, ProviderFetchConfig> = {
         })),
   },
   "ollama-cloud": {
-    url: () => "https://ollama.com/v1/models",
+    url: () => `${resolveProviderBaseUrl("ollama-cloud", "https://ollama.com")}/v1/models`,
     headers: (apiKey) => ({ Authorization: `Bearer ${apiKey}` }),
     transform: (data) => {
       // Filter by the curated tool-capable set — see

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -66,7 +66,7 @@ export type ValidationResult =
 // E2E/smoke tests so the wizard's key-validation probe can hit a local
 // stand-in instead of the real provider. Production deployments leave these
 // unset and we fall back to the canonical hostnames.
-function resolveProviderBaseUrl(provider: ProviderName, fallback: string): string {
+export function resolveProviderBaseUrl(provider: ProviderName, fallback: string): string {
   const envMap: Partial<Record<ProviderName, string>> = {
     anthropic: "PINCHY_PROVIDER_BASEURL_ANTHROPIC",
     openai: "PINCHY_PROVIDER_BASEURL_OPENAI",

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -62,36 +62,60 @@ export type ValidationResult =
   | { valid: false; error: "no_compatible_models" }
   | { valid: false; error: "unsupported_local_host"; host: string };
 
+// Per-provider baseUrl override. Used by the LLM-providers mock server in
+// E2E/smoke tests so the wizard's key-validation probe can hit a local
+// stand-in instead of the real provider. Production deployments leave these
+// unset and we fall back to the canonical hostnames.
+function resolveProviderBaseUrl(provider: ProviderName, fallback: string): string {
+  const envMap: Partial<Record<ProviderName, string>> = {
+    anthropic: "PINCHY_PROVIDER_BASEURL_ANTHROPIC",
+    openai: "PINCHY_PROVIDER_BASEURL_OPENAI",
+    google: "PINCHY_PROVIDER_BASEURL_GOOGLE",
+    "ollama-cloud": "PINCHY_PROVIDER_BASEURL_OLLAMA_CLOUD",
+  };
+  const envVar = envMap[provider];
+  return (envVar && process.env[envVar]) || fallback;
+}
+
 function makeValidationRequest(provider: ProviderName, apiKey: string): Promise<Response> {
   switch (provider) {
     case "anthropic":
-      return fetch("https://api.anthropic.com/v1/models", {
-        headers: {
-          "x-api-key": apiKey,
-          "anthropic-version": "2023-06-01",
-        },
-      });
+      return fetch(
+        `${resolveProviderBaseUrl("anthropic", "https://api.anthropic.com")}/v1/models`,
+        {
+          headers: {
+            "x-api-key": apiKey,
+            "anthropic-version": "2023-06-01",
+          },
+        }
+      );
     case "openai":
-      return fetch("https://api.openai.com/v1/models", {
+      return fetch(`${resolveProviderBaseUrl("openai", "https://api.openai.com")}/v1/models`, {
         headers: {
           Authorization: `Bearer ${apiKey}`,
         },
       });
     case "google":
-      return fetch(`https://generativelanguage.googleapis.com/v1/models?key=${apiKey}`, {});
+      return fetch(
+        `${resolveProviderBaseUrl("google", "https://generativelanguage.googleapis.com")}/v1beta/models?key=${apiKey}`,
+        {}
+      );
     case "ollama-cloud":
       // /v1/models is a public catalog and returns 200 for any token, so it
       // can't distinguish a real key from a typo. /v1/chat/completions checks
       // auth before body validation: with an empty body a valid key gets 400,
       // an invalid key gets 401. No tokens consumed either way.
-      return fetch("https://ollama.com/v1/chat/completions", {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: "{}",
-      });
+      return fetch(
+        `${resolveProviderBaseUrl("ollama-cloud", "https://ollama.com")}/v1/chat/completions`,
+        {
+          method: "POST",
+          headers: {
+            Authorization: `Bearer ${apiKey}`,
+            "Content-Type": "application/json",
+          },
+          body: "{}",
+        }
+      );
     case "ollama-local":
       throw new Error("Use validateProviderUrl for URL-based providers");
   }


### PR DESCRIPTION
## What does this PR do?

Fixes the v0.5.6 setup-wizard regression where Smithers responds with `No API key found for provider '<name>'` on the first chat message after a fresh install, and adds a protocol-level E2E smoke-test suite (5 providers) so this class of bug is caught for every provider before each release.

What started as a single secrets.json-race fix uncovered — via the new E2E suite — **three distinct production bugs** that all produced the same user-visible "No API key found" symptom from different root causes. All three are fixed here.

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## The three root causes (all fixed)

1. **secrets-provider boot race** — OpenClaw initializes its file-mode secrets-provider once at gateway boot. On a fresh wizard install `secrets.json` doesn't exist yet, so the provider boots in "file missing" state and never reinitializes when Pinchy writes the file (OC's reload only diffs the path-unchanged `openclaw.json#/secrets` block). **Fix:** `start-openclaw.sh` inotify handler sets a `.bootstrap-applied` marker and sends a one-shot `pkill -TERM` on first `secrets.json` appearance so the gateway respawns with the file present.

2. **agent hot-reload race ("unknown agent id")** — `regenerateOpenClawConfig()` is fire-and-forget; OC applies the new `agents.list` asynchronously. The wizard navigating straight to `/chat/:smithersId` raced the reload. **Fix:** `waitForAgentInRuntime()` after regenerate in `/api/setup/provider` (30s cap, since Layer-1's bootstrap pkill can take the gateway down for 10–40s mid-regenerate).

3. **ollama-local model-cache not primed** — `resolveModelForTemplate('ollama-local')` reads a module cache only populated by `fetchProviderModels()`, which the wizard never calls. Result: resolver sees zero models, Smithers keeps the anthropic cold-start fallback, first chat hits "No API key found for anthropic". **Fix:** export `setOllamaLocalModels()` and prime the cache in the wizard URL branch.

## Defense layers

- **Layer 1** (`start-openclaw.sh`) — bootstrap-marker gateway restart on first secrets.json.
- **Layer 2** (`validate-built-config.ts`) — drift guard: `validateBuiltConfig(config, secretsBundle)` walks `openclaw.json` for `SecretRef` shapes and rejects any pointing at a missing/empty secret, at build time before the file hits disk.
- **Layer 3** (E2E) — 5 Playwright specs (OpenAI, Anthropic, Google, Ollama-Cloud, Ollama-Local) driving the full wizard → first-chat-message path per provider against protocol-level mocks.

## E2E mock architecture

- `config/llm-providers-mock/` — Express mock speaking the **real wire formats** each provider's pi-ai client uses: Anthropic SSE (`message_start`…`message_stop`), OpenAI Responses API (`/v1/responses` with `response.output_item.added`/`content_part.added`/`output_text.delta`), Google `:streamGenerateContent?alt=sse`, Ollama-Cloud OpenAI-compat. Event sequences derived from pi-ai's parsers, not guessed — so OC runs the same parser path as against a live provider.
- **Ollama-Local reuses the existing battle-tested `fake-ollama-server.ts`** (containerised), rather than a second parallel Ollama mock — single source of truth, co-evolves with the integration-test suite.
- `PINCHY_PROVIDER_BASEURL_*` env vars redirect Pinchy's three URL-touching paths (validation, model-listing, config emission) to the mocks. Production SDK env vars (`OPENAI_BASE_URL` etc.) preserved with priority PINCHY > SDK > default.
- New `setup-wizard-e2e` CI job runs all 5 specs on every build.

## Test plan

- [x] CI `setup-wizard-e2e` job green (all 5 providers, full wizard → first-message path)
- [x] All other CI jobs green (21/21)
- [x] Full vitest suite green
- [ ] Manual smoke on a fresh Hetzner box (optional — CI now covers the path that previously needed manual verification)

## Notable journey (why so many commits)

The E2E suite was authored TDD-first and run live in CI, which is the *first* end-to-end execution of these cross-component paths. Each CI run surfaced a genuine bug at a different seam (compose cwd, size-drop guard tripping on truncate, bootstrap-marker timing, the 3 root causes above, provider wire-format mismatches). Every fix is root-caused via systematic debugging with diagnostic instrumentation, then the instrumentation removed once stable. Net result: the suite earned its keep before it even merged.

## Docs

- `docs/.../upgrading.mdx` — v0.5.6 → v0.5.7 release notes.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (5 E2E specs, drift-guard unit tests, mock-server unit tests, env-override unit tests, cache-primer regression test)
- [x] I've updated the documentation
- [x] All existing tests pass