### PR TITLE
fix(restart): keep overlay correct during OC deferred restarts

### DIFF
--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -460,6 +460,11 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       if (hasConnected) {
         console.log("Disconnected from OpenClaw Gateway, reconnecting...");
       }
+      // Re-show the restart overlay if OC disconnects within the deferred-
+      // restart window (OC defers gateway restart until active runs drain;
+      // this can be minutes after the initial notifyRestart + notifyReady
+      // handshake, leaving users with no overlay during the actual outage).
+      restartState.notifyDisconnect();
     });
 
     openclawClient.on("error", (err) => {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -408,9 +408,11 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       hasConnected = true;
       errorLogged = false;
       openClawConnectionState.connected = true;
-      if (restartState.isRestarting) {
-        restartState.notifyReady();
-      }
+      // notifyConnect only flips ready if a disconnect was seen since the
+      // last notifyRestart — protects against false-ready during OC's
+      // deferred-restart window where the WS stays up while OC waits for
+      // active agent runs to finish.
+      restartState.notifyConnect();
 
       if (firstConnect) {
         // Signal to OpenClaw container that device approval succeeded.
@@ -457,6 +459,9 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
 
     openclawClient.on("disconnected", () => {
       openClawConnectionState.connected = false;
+      // Record the disconnect so the next reconnect can legitimately flip
+      // restartState back to ready (gates the false-ready bug fixed in #-this-PR).
+      restartState.notifyDisconnect();
       if (hasConnected) {
         console.log("Disconnected from OpenClaw Gateway, reconnecting...");
       }

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -408,11 +408,9 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       hasConnected = true;
       errorLogged = false;
       openClawConnectionState.connected = true;
-      // notifyConnect only flips ready if a disconnect was seen since the
-      // last notifyRestart — protects against false-ready during OC's
-      // deferred-restart window where the WS stays up while OC waits for
-      // active agent runs to finish.
-      restartState.notifyConnect();
+      if (restartState.isRestarting) {
+        restartState.notifyReady();
+      }
 
       if (firstConnect) {
         // Signal to OpenClaw container that device approval succeeded.
@@ -459,9 +457,6 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
 
     openclawClient.on("disconnected", () => {
       openClawConnectionState.connected = false;
-      // Record the disconnect so the next reconnect can legitimately flip
-      // restartState back to ready (gates the false-ready bug fixed in #-this-PR).
-      restartState.notifyDisconnect();
       if (hasConnected) {
         console.log("Disconnected from OpenClaw Gateway, reconnecting...");
       }

--- a/packages/web/src/__tests__/components/restart-provider.test.tsx
+++ b/packages/web/src/__tests__/components/restart-provider.test.tsx
@@ -198,10 +198,15 @@ describe("RestartProvider", () => {
       await vi.advanceTimersByTimeAsync(31_000);
     });
 
-    // Should show error state instead of spinner
+    // Should show secondary tier instead of spinner — copy is the honest
+    // "OC is finishing up active conversations" message rather than the
+    // generic "this took longer than expected" that we used to ship.
     await waitFor(() => {
-      expect(screen.queryByText(/applying changes/i)).not.toBeInTheDocument();
-      expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument();
+      expect(screen.queryByText(/hang tight/i)).not.toBeInTheDocument();
+      expect(screen.getByText(/still working on it/i)).toBeInTheDocument();
+      expect(
+        screen.getByText(/finishing up active conversations before applying changes/i)
+      ).toBeInTheDocument();
       expect(screen.getByText(/report this issue/i)).toBeInTheDocument();
     });
   });
@@ -338,11 +343,11 @@ describe("RestartProvider", () => {
       screen.getByText("trigger").click();
     });
 
-    // Cross the 30 s timeout — overlay flips to "taking longer".
+    // Cross the 30 s timeout — overlay flips to the secondary tier.
     await act(async () => {
       await vi.advanceTimersByTimeAsync(31_000);
     });
-    expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument();
+    expect(screen.getByText(/still working on it/i)).toBeInTheDocument();
 
     // After timed-out polling cadence (5 s in the new impl), the next ok response
     // must un-stick the overlay without a browser reload.
@@ -351,8 +356,8 @@ describe("RestartProvider", () => {
     });
 
     await waitFor(() => {
-      expect(screen.queryByText(/taking longer than expected/i)).not.toBeInTheDocument();
-      expect(screen.queryByText(/applying changes/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/still working on it/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/hang tight/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/__tests__/components/restart-provider.test.tsx
+++ b/packages/web/src/__tests__/components/restart-provider.test.tsx
@@ -360,4 +360,51 @@ describe("RestartProvider", () => {
       expect(screen.queryByText(/hang tight/i)).not.toBeInTheDocument();
     });
   });
+
+  it("triggerRestart resets timedOut and diagnostics from a prior cycle", async () => {
+    // Defense-in-depth: checkHealth already resets these when status flips
+    // to "ok", so most flows clean up correctly. But if a non-recovery path
+    // ever flips isRestarting back to true (the only public way is
+    // triggerRestart from useRestart), we must not show the timeout tier
+    // immediately — that would look like the previous restart instantly
+    // timed out again.
+    const { RestartProvider, useRestart } = await import("@/components/restart-provider");
+
+    function Consumer() {
+      const { triggerRestart } = useRestart();
+      return <button onClick={triggerRestart}>trigger</button>;
+    }
+
+    render(
+      <RestartProvider>
+        <Consumer />
+      </RestartProvider>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    // First cycle: trigger, hit the 30 s timeout (timedOut=true), then NEVER
+    // recover via checkHealth — instead trigger again manually.
+    fetchResponses = [{ status: "restarting" as const, since: Date.now() }];
+    fetchCallCount = 0;
+
+    await act(async () => {
+      screen.getByText("trigger").click();
+    });
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(screen.getByText(/still working on it/i)).toBeInTheDocument();
+
+    // Second trigger — should reset to the spinner tier, not stay timed-out.
+    await act(async () => {
+      screen.getByText("trigger").click();
+    });
+
+    expect(screen.getByText(/hang tight/i)).toBeInTheDocument();
+    expect(screen.queryByText(/still working on it/i)).not.toBeInTheDocument();
+  });
 });

--- a/packages/web/src/__tests__/components/restart-provider.test.tsx
+++ b/packages/web/src/__tests__/components/restart-provider.test.tsx
@@ -301,4 +301,58 @@ describe("RestartProvider", () => {
       expect(screen.queryByText(/applying changes/i)).not.toBeInTheDocument();
     });
   });
+
+  it("recovers from timed-out state when a later poll returns ok", async () => {
+    // Production incident 2026-05-28: OC's restart was deferred ~3.5 min because
+    // active background tasks blocked the gateway restart. The overlay flipped
+    // into the "timed out" tier after 30 s, polling stopped, and the user was
+    // stranded even though OC came back fine. Polling must keep running (at a
+    // slower cadence) so the recovered server state un-sticks the overlay.
+    const { RestartProvider, useRestart } = await import("@/components/restart-provider");
+
+    function Consumer() {
+      const { triggerRestart } = useRestart();
+      return <button onClick={triggerRestart}>trigger</button>;
+    }
+
+    render(
+      <RestartProvider>
+        <Consumer />
+      </RestartProvider>
+    );
+
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(100);
+    });
+
+    // First 16 polls report "restarting" (covers ~30 s at 2 s + a couple slow
+    // polls after the 30 s timeout flips to SLOW_POLL_INTERVAL_MS=5 s),
+    // then poll 17+ reports "ok" (OC reconnected).
+    fetchResponses = [
+      ...Array.from({ length: 16 }, () => ({ status: "restarting" as const, since: Date.now() })),
+      { status: "ok" as const },
+    ];
+    fetchCallCount = 0;
+
+    await act(async () => {
+      screen.getByText("trigger").click();
+    });
+
+    // Cross the 30 s timeout — overlay flips to "taking longer".
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(31_000);
+    });
+    expect(screen.getByText(/taking longer than expected/i)).toBeInTheDocument();
+
+    // After timed-out polling cadence (5 s in the new impl), the next ok response
+    // must un-stick the overlay without a browser reload.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(10_000);
+    });
+
+    await waitFor(() => {
+      expect(screen.queryByText(/taking longer than expected/i)).not.toBeInTheDocument();
+      expect(screen.queryByText(/applying changes/i)).not.toBeInTheDocument();
+    });
+  });
 });

--- a/packages/web/src/__tests__/server/restart-state.test.ts
+++ b/packages/web/src/__tests__/server/restart-state.test.ts
@@ -89,6 +89,80 @@ describe("restartState", () => {
     expect(mod2.restartState.isRestarting).toBe(true);
   });
 
+  describe("notifyDisconnect — deferred-restart re-fire", () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
+    it("re-fires notifyRestart when OC disconnects shortly after a completed restart", () => {
+      // Scenario: config write → notifyRestart → OC reconnects (notifyReady) →
+      // OC defers the real restart for active runs → OC disconnects 2 min later
+      // → notifyDisconnect must re-show the overlay.
+      const restartingListener = vi.fn();
+      restartState.on("restarting", restartingListener);
+
+      restartState.notifyRestart(); // config saved, overlay shown
+      restartState.notifyReady(); // OC reconnected (pre-restart handshake)
+      expect(restartState.isRestarting).toBe(false);
+
+      // Advance 2 min — still within the deferred window
+      vi.advanceTimersByTime(2 * 60_000);
+
+      restartState.notifyDisconnect(); // OC actually goes down for its restart
+
+      expect(restartState.isRestarting).toBe(true);
+      expect(restartingListener).toHaveBeenCalledTimes(2); // once for original, once for re-fire
+    });
+
+    it("is a no-op when isRestarting is already true (overlay already visible)", () => {
+      const restartingListener = vi.fn();
+      restartState.on("restarting", restartingListener);
+
+      restartState.notifyRestart();
+      expect(restartState.isRestarting).toBe(true);
+
+      restartState.notifyDisconnect();
+
+      // Should not have fired a second restarting event
+      expect(restartingListener).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op when disconnect happens after the deferred window expires", () => {
+      // DEFERRED_RESTART_WINDOW_MS = 10 min; a disconnect >10 min after the
+      // last trigger is unrelated to the original restart.
+      restartState.notifyRestart();
+      restartState.notifyReady();
+
+      vi.advanceTimersByTime(11 * 60_000); // past the window
+
+      restartState.notifyDisconnect();
+
+      expect(restartState.isRestarting).toBe(false);
+    });
+
+    it("is a no-op when notifyRestart was never called", () => {
+      restartState.notifyDisconnect();
+      expect(restartState.isRestarting).toBe(false);
+    });
+
+    it("emits 'restarting' on re-fire so the WS broadcaster shows the overlay", () => {
+      const listener = vi.fn();
+      restartState.on("restarting", listener);
+
+      restartState.notifyRestart();
+      restartState.notifyReady();
+      vi.advanceTimersByTime(60_000);
+
+      restartState.notifyDisconnect();
+
+      expect(listener).toHaveBeenCalledTimes(2);
+    });
+  });
+
   describe("auto-clear safety net", () => {
     beforeEach(() => {
       vi.useFakeTimers();

--- a/packages/web/src/__tests__/server/restart-state.test.ts
+++ b/packages/web/src/__tests__/server/restart-state.test.ts
@@ -98,65 +98,101 @@ describe("restartState", () => {
       vi.useRealTimers();
     });
 
-    it("auto-clears isRestarting after 60s if notifyReady never arrives", () => {
-      // notifyRestart assumes a corresponding OC restart will fire notifyReady
-      // via server.ts's reconnect handler. But OC may treat the file change as
-      // a no-op (e.g., byte diff but no functional diff) and never restart —
-      // in which case isRestarting would stay true forever, blocking the UI
-      // overlay and any test polling /api/health/openclaw for status="ok".
-      restartState.notifyRestart();
-      expect(restartState.isRestarting).toBe(true);
-      expect(restartState.triggeredAt).not.toBeNull();
-
-      vi.advanceTimersByTime(59_999);
-      expect(restartState.isRestarting).toBe(true);
-
-      vi.advanceTimersByTime(2);
-      expect(restartState.isRestarting).toBe(false);
-      // Auto-clear must take the full notifyReady() path — both flags reset —
-      // so any future caller relying on `triggeredAt == null` as the
-      // "not restarting" tell sees consistent state.
-      expect(restartState.triggeredAt).toBeNull();
-    });
-
-    it("emits 'ready' when auto-clear fires", () => {
+    it("auto-clear does NOT fire ready while no OC disconnect has happened since notifyRestart", () => {
+      // Production incident 2026-05-28: OC deferred its restart ~3.5 min because
+      // active background tasks blocked the channels-block reload. WS stayed
+      // connected the entire time. The old 60 s auto-clear used to lie here
+      // — it called notifyReady() while OC had not yet even started restarting.
       const listener = vi.fn();
       restartState.on("ready", listener);
 
       restartState.notifyRestart();
       vi.advanceTimersByTime(60_001);
 
+      expect(restartState.isRestarting).toBe(true);
+      expect(listener).not.toHaveBeenCalled();
+    });
+
+    it("auto-clears when OC disconnect+reconnect cycle completes", () => {
+      // The real signal that OC's restart finished: the WS dropped and then
+      // reconnected. server.ts wires notifyDisconnect/notifyConnect into the
+      // openclaw-node client events.
+      restartState.notifyRestart();
+      restartState.notifyDisconnect();
+      expect(restartState.isRestarting).toBe(true);
+
+      restartState.notifyConnect();
+      expect(restartState.isRestarting).toBe(false);
+      expect(restartState.triggeredAt).toBeNull();
+    });
+
+    it("notifyConnect without a prior disconnect keeps restarting state (deferred restart)", () => {
+      // If OC defers — WS stays up — a stray reconnect signal (e.g. from
+      // openclaw-node reconnect-attempt churn) must NOT clear the state. Only
+      // a real disconnect-then-reconnect cycle counts.
+      restartState.notifyRestart();
+      restartState.notifyConnect();
+
+      expect(restartState.isRestarting).toBe(true);
+      expect(restartState.triggeredAt).not.toBeNull();
+    });
+
+    it("emits 'ready' on disconnect+reconnect cycle", () => {
+      const listener = vi.fn();
+      restartState.on("ready", listener);
+
+      restartState.notifyRestart();
+      restartState.notifyDisconnect();
+      restartState.notifyConnect();
+
       expect(listener).toHaveBeenCalledOnce();
     });
 
-    it("cancels auto-clear when notifyReady fires first", () => {
+    it("hard-caps at 10 min so a hot-reload-only write cannot strand the overlay", () => {
+      // Edge case: OC decides the config change is hot-reloadable and never
+      // disconnects. We'd otherwise wait for a disconnect that never comes.
+      // After MAX_RESTART_AGE_MS we give up and clear so the overlay closes.
+      const listener = vi.fn();
+      restartState.on("ready", listener);
+
+      restartState.notifyRestart();
+      vi.advanceTimersByTime(60_001);
+      expect(listener).not.toHaveBeenCalled();
+
+      // 10 min total since notifyRestart — hard cap fires.
+      vi.advanceTimersByTime(10 * 60_000 - 60_001 + 1);
+      expect(restartState.isRestarting).toBe(false);
+      expect(listener).toHaveBeenCalledOnce();
+    });
+
+    it("cancels safety net when notifyReady fires explicitly", () => {
       restartState.notifyRestart();
       vi.advanceTimersByTime(10_000);
 
       restartState.notifyReady();
       expect(restartState.isRestarting).toBe(false);
 
-      // Advance past the original 60s — auto-clear must not fire a redundant
-      // ready event (which would confuse the WS broadcaster).
+      // Advance past the original 10 min hard cap — must not fire a redundant
+      // ready event (which would confuse downstream listeners).
       const readyListener = vi.fn();
       restartState.on("ready", readyListener);
-      vi.advanceTimersByTime(60_000);
+      vi.advanceTimersByTime(10 * 60_000);
 
       expect(readyListener).not.toHaveBeenCalled();
     });
 
-    it("resets the 60s window when notifyRestart is called again", () => {
+    it("resets the safety window when notifyRestart is called again", () => {
       restartState.notifyRestart();
-      vi.advanceTimersByTime(50_000);
+      vi.advanceTimersByTime(5 * 60_000);
 
-      // A second notifyRestart (e.g., another channel mutation) restarts the
-      // safety-net countdown — don't auto-clear 10s after the second call.
+      // A second notifyRestart restarts the hard-cap countdown.
       restartState.notifyRestart();
-      vi.advanceTimersByTime(20_000);
+      vi.advanceTimersByTime(8 * 60_000);
 
       expect(restartState.isRestarting).toBe(true);
 
-      vi.advanceTimersByTime(40_001);
+      // 10 min after the SECOND notifyRestart → hard cap.
+      vi.advanceTimersByTime(2 * 60_000 + 1);
       expect(restartState.isRestarting).toBe(false);
     });
   });

--- a/packages/web/src/__tests__/server/restart-state.test.ts
+++ b/packages/web/src/__tests__/server/restart-state.test.ts
@@ -98,101 +98,65 @@ describe("restartState", () => {
       vi.useRealTimers();
     });
 
-    it("auto-clear does NOT fire ready while no OC disconnect has happened since notifyRestart", () => {
-      // Production incident 2026-05-28: OC deferred its restart ~3.5 min because
-      // active background tasks blocked the channels-block reload. WS stayed
-      // connected the entire time. The old 60 s auto-clear used to lie here
-      // — it called notifyReady() while OC had not yet even started restarting.
-      const listener = vi.fn();
-      restartState.on("ready", listener);
-
+    it("auto-clears isRestarting after 60s if notifyReady never arrives", () => {
+      // notifyRestart assumes a corresponding OC restart will fire notifyReady
+      // via server.ts's reconnect handler. But OC may treat the file change as
+      // a no-op (e.g., byte diff but no functional diff) and never restart —
+      // in which case isRestarting would stay true forever, blocking the UI
+      // overlay and any test polling /api/health/openclaw for status="ok".
       restartState.notifyRestart();
-      vi.advanceTimersByTime(60_001);
-
       expect(restartState.isRestarting).toBe(true);
-      expect(listener).not.toHaveBeenCalled();
-    });
+      expect(restartState.triggeredAt).not.toBeNull();
 
-    it("auto-clears when OC disconnect+reconnect cycle completes", () => {
-      // The real signal that OC's restart finished: the WS dropped and then
-      // reconnected. server.ts wires notifyDisconnect/notifyConnect into the
-      // openclaw-node client events.
-      restartState.notifyRestart();
-      restartState.notifyDisconnect();
+      vi.advanceTimersByTime(59_999);
       expect(restartState.isRestarting).toBe(true);
 
-      restartState.notifyConnect();
+      vi.advanceTimersByTime(2);
       expect(restartState.isRestarting).toBe(false);
+      // Auto-clear must take the full notifyReady() path — both flags reset —
+      // so any future caller relying on `triggeredAt == null` as the
+      // "not restarting" tell sees consistent state.
       expect(restartState.triggeredAt).toBeNull();
     });
 
-    it("notifyConnect without a prior disconnect keeps restarting state (deferred restart)", () => {
-      // If OC defers — WS stays up — a stray reconnect signal (e.g. from
-      // openclaw-node reconnect-attempt churn) must NOT clear the state. Only
-      // a real disconnect-then-reconnect cycle counts.
-      restartState.notifyRestart();
-      restartState.notifyConnect();
-
-      expect(restartState.isRestarting).toBe(true);
-      expect(restartState.triggeredAt).not.toBeNull();
-    });
-
-    it("emits 'ready' on disconnect+reconnect cycle", () => {
-      const listener = vi.fn();
-      restartState.on("ready", listener);
-
-      restartState.notifyRestart();
-      restartState.notifyDisconnect();
-      restartState.notifyConnect();
-
-      expect(listener).toHaveBeenCalledOnce();
-    });
-
-    it("hard-caps at 10 min so a hot-reload-only write cannot strand the overlay", () => {
-      // Edge case: OC decides the config change is hot-reloadable and never
-      // disconnects. We'd otherwise wait for a disconnect that never comes.
-      // After MAX_RESTART_AGE_MS we give up and clear so the overlay closes.
+    it("emits 'ready' when auto-clear fires", () => {
       const listener = vi.fn();
       restartState.on("ready", listener);
 
       restartState.notifyRestart();
       vi.advanceTimersByTime(60_001);
-      expect(listener).not.toHaveBeenCalled();
 
-      // 10 min total since notifyRestart — hard cap fires.
-      vi.advanceTimersByTime(10 * 60_000 - 60_001 + 1);
-      expect(restartState.isRestarting).toBe(false);
       expect(listener).toHaveBeenCalledOnce();
     });
 
-    it("cancels safety net when notifyReady fires explicitly", () => {
+    it("cancels auto-clear when notifyReady fires first", () => {
       restartState.notifyRestart();
       vi.advanceTimersByTime(10_000);
 
       restartState.notifyReady();
       expect(restartState.isRestarting).toBe(false);
 
-      // Advance past the original 10 min hard cap — must not fire a redundant
-      // ready event (which would confuse downstream listeners).
+      // Advance past the original 60s — auto-clear must not fire a redundant
+      // ready event (which would confuse the WS broadcaster).
       const readyListener = vi.fn();
       restartState.on("ready", readyListener);
-      vi.advanceTimersByTime(10 * 60_000);
+      vi.advanceTimersByTime(60_000);
 
       expect(readyListener).not.toHaveBeenCalled();
     });
 
-    it("resets the safety window when notifyRestart is called again", () => {
+    it("resets the 60s window when notifyRestart is called again", () => {
       restartState.notifyRestart();
-      vi.advanceTimersByTime(5 * 60_000);
+      vi.advanceTimersByTime(50_000);
 
-      // A second notifyRestart restarts the hard-cap countdown.
+      // A second notifyRestart (e.g., another channel mutation) restarts the
+      // safety-net countdown — don't auto-clear 10s after the second call.
       restartState.notifyRestart();
-      vi.advanceTimersByTime(8 * 60_000);
+      vi.advanceTimersByTime(20_000);
 
       expect(restartState.isRestarting).toBe(true);
 
-      // 10 min after the SECOND notifyRestart → hard cap.
-      vi.advanceTimersByTime(2 * 60_000 + 1);
+      vi.advanceTimersByTime(40_001);
       expect(restartState.isRestarting).toBe(false);
     });
   });

--- a/packages/web/src/components/restart-provider.tsx
+++ b/packages/web/src/components/restart-provider.tsx
@@ -54,6 +54,13 @@ export function RestartProvider({ children }: { children: React.ReactNode }) {
 
   const triggerRestart = useCallback(() => {
     setIsRestarting(true);
+    // Defense-in-depth: clear any leftover state from a previous restart
+    // cycle so the new overlay starts in the spinner tier, not the
+    // timed-out tier. checkHealth already resets these on "ok", but
+    // triggerRestart is the only public path that can flip isRestarting
+    // back to true without going through checkHealth first.
+    setTimedOut(false);
+    setDiagnostics(null);
   }, []);
 
   // Mount-time health check — subscribes to external health endpoint

--- a/packages/web/src/components/restart-provider.tsx
+++ b/packages/web/src/components/restart-provider.tsx
@@ -20,6 +20,11 @@ export function useRestart() {
 }
 
 const POLL_INTERVAL_MS = 2000;
+// After 30 s we flip into the "timed out" tier. Polling keeps running, just at
+// a slower cadence — OC's restart can be legitimately deferred for minutes when
+// active agent runs block the gateway restart, and we want the overlay to clear
+// itself once OC genuinely comes back (rather than stranding the user).
+const SLOW_POLL_INTERVAL_MS = 5000;
 const TIMEOUT_MS = 30_000;
 
 export function RestartProvider({ children }: { children: React.ReactNode }) {
@@ -35,6 +40,10 @@ export function RestartProvider({ children }: { children: React.ReactNode }) {
       const data = await res.json();
       if (data.status === "ok") {
         setIsRestarting(false);
+        // Also reset the timed-out tier and stale diagnostics so a recovery
+        // after the 30 s timeout fully un-sticks the overlay.
+        setTimedOut(false);
+        setDiagnostics(null);
       } else if (data.status === "restarting") {
         setIsRestarting(true);
       }
@@ -63,14 +72,18 @@ export function RestartProvider({ children }: { children: React.ReactNode }) {
     };
   }, []);
 
-  // Poll while restarting
+  // Poll while restarting. Even past the 30 s timeout we keep polling — just at
+  // SLOW_POLL_INTERVAL_MS — so a recovered server state un-sticks the overlay.
   useEffect(() => {
-    if (isRestarting && !timedOut) {
-      pollingRef.current = setInterval(checkHealth, POLL_INTERVAL_MS);
-    } else if (pollingRef.current) {
-      clearInterval(pollingRef.current);
-      pollingRef.current = null;
+    if (!isRestarting) {
+      if (pollingRef.current) {
+        clearInterval(pollingRef.current);
+        pollingRef.current = null;
+      }
+      return;
     }
+    const interval = timedOut ? SLOW_POLL_INTERVAL_MS : POLL_INTERVAL_MS;
+    pollingRef.current = setInterval(checkHealth, interval);
     return () => {
       if (pollingRef.current) {
         clearInterval(pollingRef.current);

--- a/packages/web/src/components/restart-provider.tsx
+++ b/packages/web/src/components/restart-provider.tsx
@@ -131,9 +131,10 @@ export function RestartProvider({ children }: { children: React.ReactNode }) {
           <div className="flex flex-col items-center gap-4 text-center max-w-sm px-4">
             {timedOut ? (
               <>
-                <p className="text-lg font-medium">This is taking longer than expected</p>
+                <p className="text-lg font-medium">Still working on it</p>
                 <p className="text-sm text-muted-foreground">
-                  The agent runtime did not come back up.
+                  OpenClaw is finishing up active conversations before applying changes. This can
+                  take a few minutes — you can keep using Pinchy in another tab.
                 </p>
                 {diagnostics && (
                   <div className="w-full rounded-lg border bg-muted/50 p-3 space-y-2">

--- a/packages/web/src/server/restart-state.ts
+++ b/packages/web/src/server/restart-state.ts
@@ -12,14 +12,24 @@ const KEY = Symbol.for("pinchy.restartState");
 // without dragging tests through their full timeouts.
 const AUTO_CLEAR_MS = 60_000;
 
+// How long after the last notifyRestart() call a subsequent OC disconnect
+// should re-show the overlay. OC's deferred restart (active-run drain) has
+// been measured at up to ~3.5 min in production; 10 min gives a generous
+// buffer while still filtering truly unrelated disconnects.
+const DEFERRED_RESTART_WINDOW_MS = 10 * 60_000;
+
 class RestartState extends EventEmitter {
   isRestarting = false;
   triggeredAt: number | null = null;
+  // Persists through notifyReady() so notifyDisconnect() can detect a
+  // deferred-restart disconnect that arrives after the ready handshake.
+  private lastTriggeredAt: number | null = null;
   private autoClearTimer: ReturnType<typeof setTimeout> | null = null;
 
   notifyRestart() {
     this.isRestarting = true;
     this.triggeredAt = Date.now();
+    this.lastTriggeredAt = this.triggeredAt;
     this.emit("restarting");
 
     if (this.autoClearTimer) clearTimeout(this.autoClearTimer);
@@ -33,11 +43,25 @@ class RestartState extends EventEmitter {
     if (!this.isRestarting) return;
     this.isRestarting = false;
     this.triggeredAt = null;
+    // lastTriggeredAt is intentionally NOT cleared here — notifyDisconnect()
+    // needs it to detect a deferred-restart disconnect that arrives after
+    // this ready handshake.
     if (this.autoClearTimer) {
       clearTimeout(this.autoClearTimer);
       this.autoClearTimer = null;
     }
     this.emit("ready");
+  }
+
+  // Called by the OC disconnect handler in server.ts. If OC goes down within
+  // DEFERRED_RESTART_WINDOW_MS of the last notifyRestart() and the overlay is
+  // not already showing, re-fire notifyRestart() so the UI shows the overlay
+  // for the actual restart (OC defers gateway restart until active runs drain).
+  notifyDisconnect() {
+    if (this.isRestarting) return; // overlay already showing
+    if (this.lastTriggeredAt === null) return; // no restart ever triggered
+    if (Date.now() - this.lastTriggeredAt > DEFERRED_RESTART_WINDOW_MS) return; // window expired
+    this.notifyRestart();
   }
 }
 

--- a/packages/web/src/server/restart-state.ts
+++ b/packages/web/src/server/restart-state.ts
@@ -2,42 +2,70 @@ import { EventEmitter } from "events";
 
 const KEY = Symbol.for("pinchy.restartState");
 
-// Safety net: every notifyRestart() ships with the implicit contract that a
-// corresponding notifyReady() fires via the OC reconnect handler in server.ts.
-// But that contract leaks at the edges — OC may treat a file write as no-op
-// (byte diff with no functional diff in its compare hash) and never restart,
-// in which case notifyReady never arrives and isRestarting stays true forever,
-// stranding the client overlay and any /api/health/openclaw poller. 60 s comfortably
-// covers OC's worst-case container restart (~45 s including supervised lock recovery)
-// without dragging tests through their full timeouts.
-const AUTO_CLEAR_MS = 60_000;
+// Hard cap on how long the "restarting" overlay can stay up before we give
+// up and clear it. Only used as a last-resort safety net for the case where
+// OC decides the config change is hot-reloadable and never disconnects — in
+// which case our disconnect+reconnect gate would otherwise wait forever.
+// 10 min comfortably covers the worst legitimate deferred-restart window
+// observed in production (OC waits for active agent runs before restarting,
+// and runs can be several minutes).
+const MAX_RESTART_AGE_MS = 10 * 60_000;
+// How often the safety net re-checks once the initial window has lapsed.
+const SAFETY_INTERVAL_MS = 60_000;
 
 class RestartState extends EventEmitter {
   isRestarting = false;
   triggeredAt: number | null = null;
-  private autoClearTimer: ReturnType<typeof setTimeout> | null = null;
+  private safetyTimer: ReturnType<typeof setTimeout> | null = null;
+  private disconnectSeenSinceRestart = false;
 
   notifyRestart() {
     this.isRestarting = true;
     this.triggeredAt = Date.now();
+    this.disconnectSeenSinceRestart = false;
     this.emit("restarting");
+    this.scheduleSafetyCheck();
+  }
 
-    if (this.autoClearTimer) clearTimeout(this.autoClearTimer);
-    this.autoClearTimer = setTimeout(() => {
-      this.autoClearTimer = null;
-      this.notifyReady();
-    }, AUTO_CLEAR_MS);
+  // Wired to openclaw-node's "disconnected" event in server.ts. Records that
+  // the WS dropped at least once since the last notifyRestart() — i.e. OC
+  // really did go down to apply the change. Without this gate, a stale
+  // reconnect event during a deferred-restart window would clear the state
+  // prematurely (the "AUTO_CLEAR lies" bug fixed by #-the-PR-this-lives-in).
+  notifyDisconnect() {
+    if (this.isRestarting) this.disconnectSeenSinceRestart = true;
+  }
+
+  // Wired to openclaw-node's "connected" event in server.ts. Only flips ready
+  // when we've already seen a disconnect since the restart was requested.
+  notifyConnect() {
+    if (!this.isRestarting) return;
+    if (this.disconnectSeenSinceRestart) this.notifyReady();
   }
 
   notifyReady() {
     if (!this.isRestarting) return;
     this.isRestarting = false;
     this.triggeredAt = null;
-    if (this.autoClearTimer) {
-      clearTimeout(this.autoClearTimer);
-      this.autoClearTimer = null;
+    this.disconnectSeenSinceRestart = false;
+    if (this.safetyTimer) {
+      clearTimeout(this.safetyTimer);
+      this.safetyTimer = null;
     }
     this.emit("ready");
+  }
+
+  private scheduleSafetyCheck() {
+    if (this.safetyTimer) clearTimeout(this.safetyTimer);
+    this.safetyTimer = setTimeout(() => {
+      this.safetyTimer = null;
+      const age = this.triggeredAt ? Date.now() - this.triggeredAt : 0;
+      if (age >= MAX_RESTART_AGE_MS) {
+        this.notifyReady();
+        return;
+      }
+      this.scheduleSafetyCheck();
+    }, SAFETY_INTERVAL_MS);
   }
 }
 

--- a/packages/web/src/server/restart-state.ts
+++ b/packages/web/src/server/restart-state.ts
@@ -2,70 +2,42 @@ import { EventEmitter } from "events";
 
 const KEY = Symbol.for("pinchy.restartState");
 
-// Hard cap on how long the "restarting" overlay can stay up before we give
-// up and clear it. Only used as a last-resort safety net for the case where
-// OC decides the config change is hot-reloadable and never disconnects — in
-// which case our disconnect+reconnect gate would otherwise wait forever.
-// 10 min comfortably covers the worst legitimate deferred-restart window
-// observed in production (OC waits for active agent runs before restarting,
-// and runs can be several minutes).
-const MAX_RESTART_AGE_MS = 10 * 60_000;
-// How often the safety net re-checks once the initial window has lapsed.
-const SAFETY_INTERVAL_MS = 60_000;
+// Safety net: every notifyRestart() ships with the implicit contract that a
+// corresponding notifyReady() fires via the OC reconnect handler in server.ts.
+// But that contract leaks at the edges — OC may treat a file write as no-op
+// (byte diff with no functional diff in its compare hash) and never restart,
+// in which case notifyReady never arrives and isRestarting stays true forever,
+// stranding the client overlay and any /api/health/openclaw poller. 60 s comfortably
+// covers OC's worst-case container restart (~45 s including supervised lock recovery)
+// without dragging tests through their full timeouts.
+const AUTO_CLEAR_MS = 60_000;
 
 class RestartState extends EventEmitter {
   isRestarting = false;
   triggeredAt: number | null = null;
-  private safetyTimer: ReturnType<typeof setTimeout> | null = null;
-  private disconnectSeenSinceRestart = false;
+  private autoClearTimer: ReturnType<typeof setTimeout> | null = null;
 
   notifyRestart() {
     this.isRestarting = true;
     this.triggeredAt = Date.now();
-    this.disconnectSeenSinceRestart = false;
     this.emit("restarting");
-    this.scheduleSafetyCheck();
-  }
 
-  // Wired to openclaw-node's "disconnected" event in server.ts. Records that
-  // the WS dropped at least once since the last notifyRestart() — i.e. OC
-  // really did go down to apply the change. Without this gate, a stale
-  // reconnect event during a deferred-restart window would clear the state
-  // prematurely (the "AUTO_CLEAR lies" bug fixed by #-the-PR-this-lives-in).
-  notifyDisconnect() {
-    if (this.isRestarting) this.disconnectSeenSinceRestart = true;
-  }
-
-  // Wired to openclaw-node's "connected" event in server.ts. Only flips ready
-  // when we've already seen a disconnect since the restart was requested.
-  notifyConnect() {
-    if (!this.isRestarting) return;
-    if (this.disconnectSeenSinceRestart) this.notifyReady();
+    if (this.autoClearTimer) clearTimeout(this.autoClearTimer);
+    this.autoClearTimer = setTimeout(() => {
+      this.autoClearTimer = null;
+      this.notifyReady();
+    }, AUTO_CLEAR_MS);
   }
 
   notifyReady() {
     if (!this.isRestarting) return;
     this.isRestarting = false;
     this.triggeredAt = null;
-    this.disconnectSeenSinceRestart = false;
-    if (this.safetyTimer) {
-      clearTimeout(this.safetyTimer);
-      this.safetyTimer = null;
+    if (this.autoClearTimer) {
+      clearTimeout(this.autoClearTimer);
+      this.autoClearTimer = null;
     }
     this.emit("ready");
-  }
-
-  private scheduleSafetyCheck() {
-    if (this.safetyTimer) clearTimeout(this.safetyTimer);
-    this.safetyTimer = setTimeout(() => {
-      this.safetyTimer = null;
-      const age = this.triggeredAt ? Date.now() - this.triggeredAt : 0;
-      if (age >= MAX_RESTART_AGE_MS) {
-        this.notifyReady();
-        return;
-      }
-      this.scheduleSafetyCheck();
-    }, SAFETY_INTERVAL_MS);
   }
 }
 


### PR DESCRIPTION
## Summary

Fix the case where entering a Telegram bot token (or any other channels-block config change) strands the user in the \"Restarting…\" overlay. Observed on production 2026-05-28: bot-token entered at ~07:59, OC deferred its gateway restart by ~3.5 minutes because two background agent runs were active, the client's 30 s timeout fired and stopped polling, the browser was stuck even though OC came back fine at 08:03:35.

Three TDD fixes in one commit:

**1. Frontend polling continues past the 30 s timeout (`restart-provider.tsx`)**  
After 30 s we slow from 2 s to 5 s polling instead of stopping. Any `ok` response resets the timed-out tier and stale diagnostics. Overlay un-sticks without a browser reload. **This is the core fix for the production UX issue.**

**2. `triggerRestart()` resets timedOut + diagnostics from a prior cycle**  
Defense-in-depth: if `triggerRestart()` is called while the UI is in the timeout tier (e.g., the user triggered two back-to-back restarts), the overlay resets to the spinner tier instead of staying stuck at "Still working on it".

**3. `restartState.notifyDisconnect()` re-fires the overlay for deferred restarts**  
New method in `restart-state.ts`. When OC disconnects within `DEFERRED_RESTART_WINDOW_MS` (10 min) of the last `notifyRestart()` and the overlay isn't already showing, it re-fires `notifyRestart()`. Wired into server.ts's `disconnected` handler. Closes the gap where OC finishes the pre-restart handshake (`notifyReady`), the overlay clears, but OC then actually goes down 2–3 min later for the real restart — leaving users with no overlay during the outage.

## Honest copy

Changed the timeout-tier copy from the alarming "This is taking longer than expected / The agent runtime did not come back up" to "Still working on it / OpenClaw is finishing up active conversations before applying changes. This can take a few minutes — you can keep using Pinchy in another tab."

## What got reverted (and why)

Initially also tried to gate server-side `AUTO_CLEAR_MS` on a real disconnect+reconnect cycle — Telegram E2E (`Multi-Bot Telegram`) failed because hot-reload (no disconnect) kept `isRestarting=true` until the 10-min hard cap. Reverted; Fix #3 (`notifyDisconnect`) addresses the same UX gap from the other direction without touching the 60 s safety net.

## Test plan

- [x] `pnpm -C packages/web test src/__tests__/server/restart-state.test.ts` — 17/17 pass (5 new notifyDisconnect tests).
- [x] `pnpm -C packages/web test src/__tests__/components/restart-provider.test.tsx` — 9/9 pass (recovery + triggerRestart-reset tests).
- [x] `pnpm test` (full web suite) — 375 test files, 5094 tests pass.
- [x] `pnpm --filter @pinchy/web lint` — 0 errors.
- [ ] Telegram E2E rerun — pending CI.
- [ ] Manual production verification after merge + deploy.