### PR TITLE
chore: gitignore mock-server package-lock.json files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,4 +61,9 @@ docker-compose.local.yml
 # but we don't need to commit their lockfiles — CI rebuilds from package.json)
 packages/plugins/*/pnpm-lock.yaml
 packages/plugins/*/package-lock.json
+# Mock-server lockfiles (config/*-mock/): same rationale — the mock Dockerfiles
+# run `npm install` from package.json at build time and never consume a lockfile.
+# A local `npm install` (e.g. running the mock's node --test suite) generates one;
+# keep it out of the tree so it doesn't get committed by accident.
+config/*-mock/package-lock.json
 .pnpm-store/


### PR DESCRIPTION
## What does this PR do?

Follow-up to #445. The `llm-providers-mock` and `gmail-mock` Dockerfiles run `npm install` from `package.json` at build time and never consume a lockfile (no `npm ci`). A local `npm install` — e.g. running the mock's `node --test` suite during development — generates a `package-lock.json` that shows up as untracked.

Ignore it under `config/*-mock/`, mirroring the existing `packages/plugins/*` lockfile rule and the gmail-mock convention (which tracks only `Dockerfile`/`package.json`/`server.js`).

This commit was authored against #445 but landed after that PR merged, so it needs its own one-liner PR.

## Type of change

- [x] 🔧 Tooling / CI

## Test plan

- [x] `git status` clean after a local `npm install` in `config/llm-providers-mock/`
- [x] Mock Dockerfiles unaffected (they `npm install` from package.json, no lockfile dependency)

## Checklist

- [x] My code follows the project's style
- [x] All existing tests pass (no code change — .gitignore only)