### PR TITLE
feat(memory): give agents working long-term memory (write path, prompt, compaction, watcher fix)

### DIFF
--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -237,6 +237,17 @@ OpenClaw 2026.5.12+ refuses to bind on a non-loopback interface without a `gatew
 
 Pinchy authenticates to OpenClaw Gateway using a bearer token. The token is auto-generated on first setup via `crypto.randomBytes(24)` and stored in the `gateway.auth` block of `openclaw.json`. It never appears in source control.
 
+### Volume layout and the `workspaces/` subtree
+
+Two Docker volumes back the OpenClaw integration, and the boundary between them matters:
+
+- **`openclaw-config`** holds OpenClaw's core state: `openclaw.json`, `secrets.json`, the session transcripts, and the memory SQLite index. It is mounted at `/openclaw-config` in the Pinchy container and `/root/.openclaw` in the OpenClaw container.
+- **`pinchy-workspaces`** holds per-agent workspace content (identity, instructions, `uploads/`, `workbench/`, and agent memory). It is mounted _into_ the OpenClaw config tree at the `workspaces/` subpath — `/openclaw-config/workspaces` for Pinchy and `/root/.openclaw/workspaces` for OpenClaw.
+
+A Pinchy agent's files therefore live at `workspaces/<agentId>/`, **not** under OpenClaw's native `agents/<name>/` tree. This is deliberate: it gives agent-owned content its own backup/lifecycle boundary, and it namespaces UUID-keyed Pinchy agents away from any OpenClaw-native agents created through the CLI. OpenClaw resolves each agent's `MEMORY.md` and `memory/` files _relative to_ its configured `workspace` — i.e. `workspaces/<agentId>/MEMORY.md`.
+
+Because the same volume is mounted at two different paths, two helpers in `lib/workspace.ts` are the single source of truth: `getWorkspacePath()` (Pinchy-side, for direct file I/O) and `getOpenClawWorkspacePath()` (the OpenClaw-side path written into `agents[].workspace`). Any code that watches or derives an agent's on-disk location must use these helpers; hardcoding `agents/` or `workspaces/` elsewhere is the drift that left the memory-audit watcher silently inert (issue #345).
+
 ## Channels
 
 Users don't have to reach their agents through the web UI. Pinchy supports external **channels** that connect agents to messaging platforms. Telegram is the first implemented channel; additional channels (email, Slack) are planned.

--- a/docs/src/content/docs/concepts/workspaces.mdx
+++ b/docs/src/content/docs/concepts/workspaces.mdx
@@ -16,20 +16,21 @@ A workspace typically contains:
 - **The agent's identity** — its name, role, and personality.
 - **Context files** — your personal context (for personal agents) or your organization's context (for shared agents). See [Context Management](/concepts/context/).
 - **Uploaded files** — files you drop into the chat. These land in an `uploads/` folder where the agent can read them on demand. See [Upload Files in Chat](/guides/file-uploads/).
-- **Agent deliverables** — files the agent itself produces (notes, exports, drafts) live in a `workbench/` folder. The agent can read and write here; it cannot write elsewhere.
-- **Working notes** — anything the agent or its plugins write down to remember between conversations.
+- **Agent deliverables** — files the agent itself produces (notes, exports, drafts) live in a `workbench/` folder. The agent can read and write here.
+- **The agent's memory** — what the agent has learned across conversations, kept in `MEMORY.md` (curated long-term knowledge) and dated logs under `memory/`. The agent writes these itself when it decides something is worth keeping or when you tell it to "remember this." See [Instructions vs. Memory](/explanation/instructions-vs-memory/).
 
-### The three zones
+### Who can write what
 
-Each workspace has three zones with distinct ownership. Knowing which zone owns what keeps the agent, the user, and Pinchy itself from stepping on each other:
+Each workspace separates content by who owns it. Knowing which zone owns what keeps the agent, the user, and Pinchy itself from stepping on each other:
 
-| Zone           | Who writes                           | What lives here                                                                                |
-| -------------- | ------------------------------------ | ---------------------------------------------------------------------------------------------- |
-| Workspace root | Pinchy (system)                      | Identity, personality, context, memory: SOUL.md, AGENTS.md, IDENTITY.md, USER.md, MEMORY.md, … |
-| `uploads/`     | The user, via the chat upload button | Receipts, PDFs, images, documents the user attaches                                            |
-| `workbench/`   | The agent, via `pinchy_write`        | Notes, drafts, exports, reports — anything the agent produces                                  |
+| Zone                    | Who writes                           | What lives here                                                            |
+| ----------------------- | ------------------------------------ | -------------------------------------------------------------------------- |
+| Identity files (root)   | Pinchy (system)                      | Who the agent is: SOUL.md, AGENTS.md, IDENTITY.md, USER.md                 |
+| `MEMORY.md` + `memory/` | The agent, via `pinchy_write`        | What the agent has learned: curated long-term memory and dated daily notes |
+| `uploads/`              | The user, via the chat upload button | Receipts, PDFs, images, documents the user attaches                        |
+| `workbench/`            | The agent, via `pinchy_write`        | Notes, drafts, exports, reports — anything the agent produces              |
 
-The agent can **read** all three zones. It can only **write** to `workbench/` and (for backward compatibility) `uploads/`. Attempts to write into the workspace root are rejected by the file plugin, so the agent cannot overwrite the files Pinchy uses to know who it is.
+The agent can **read** everything in its workspace. It can **write** to its memory (`MEMORY.md` and `memory/`), to `workbench/`, and — for backward compatibility — to `uploads/`. It cannot write the identity files at the workspace root: `SOUL.md`, `AGENTS.md`, `IDENTITY.md`, and `USER.md` are system-managed. The file plugin enforces this file by file, so the agent can update what it _remembers_ but never rewrite _who it is_. Writing memory requires the agent to have the `pinchy_write` capability (most agents, including the default Smithers, do).
 
 ## Personal vs. shared agent workspaces
 

--- a/docs/src/content/docs/explanation/instructions-vs-memory.mdx
+++ b/docs/src/content/docs/explanation/instructions-vs-memory.mdx
@@ -35,6 +35,7 @@ Memory and Instructions have different lifetimes and load rules:
 
 - **Memory survives compaction.** When a conversation gets long, the agent runtime compacts the chat history into a summary — older messages disappear. Memory entries do not. Anything important enough to outlive a single thread belongs in Memory, not in the chat itself.
 - **Auto-memory flushes before compaction.** The agent writes pending memory entries to disk right before compacting, so a long conversation doesn't lose unsaved learnings.
+- **You can compact on demand.** If a long conversation starts feeling sluggish or repetitive, use **Compact conversation** in the chat header's actions menu (`⋯`). It triggers the same summarization the runtime does automatically — your visible messages stay put, and it takes effect on your next message. Because auto-memory flushes first, nothing the agent meant to remember is lost.
 - **Subagent and cron sessions don't load MEMORY.md.** Background and delegated sessions intentionally skip Memory to stay focused on their task. If a piece of knowledge needs to be available to _every_ session — including cron jobs and subagents — it belongs in **Instructions**, not Memory. See the [OpenClaw memory docs](https://docs.openclaw.ai/concepts/memory) for the underlying filter logic.
 
 <Aside type="tip" title="Rule of thumb">

--- a/packages/plugins/pinchy-files/validate.test.ts
+++ b/packages/plugins/pinchy-files/validate.test.ts
@@ -185,6 +185,55 @@ describe("write-mode rejection lists allowed write paths (LLM hint)", () => {
   });
 });
 
+describe("agent memory write paths (file-granular MEMORY.md, instructions protected)", () => {
+  // Mirrors the config build.ts emits for a pinchy_write agent: MEMORY.md is a
+  // FILE entry, memory/ is a DIRECTORY entry, alongside uploads/ + workbench/.
+  // This is the runtime half of the layered guard — the build emits these
+  // paths, the plugin enforces the boundary. The security property: the agent
+  // can write its memory but NEVER its sibling instruction files.
+  const ws = "/root/.openclaw/workspaces/a";
+  const memoryConfig = {
+    allowed_paths: [`${ws}/uploads`, `${ws}/workbench`, `${ws}/MEMORY.md`, `${ws}/memory`],
+    write_paths: [`${ws}/uploads`, `${ws}/workbench`, `${ws}/MEMORY.md`, `${ws}/memory`],
+  };
+
+  it("allows writing MEMORY.md (curated long-term memory)", () => {
+    expect(() => validateAccess(memoryConfig, `${ws}/MEMORY.md`, "write")).not.toThrow();
+  });
+
+  it("allows writing a daily note under memory/", () => {
+    expect(() =>
+      validateAccess(memoryConfig, `${ws}/memory/2026-06-01.md`, "write")
+    ).not.toThrow();
+  });
+
+  it("allows reading MEMORY.md back", () => {
+    expect(() => validateAccess(memoryConfig, `${ws}/MEMORY.md`, "read")).not.toThrow();
+  });
+
+  it("DENIES writing AGENTS.md — the file-granular MEMORY.md entry must not leak to siblings", () => {
+    // The whole point of granting MEMORY.md as a file (not the workspace root):
+    // a sibling instruction file with a shared parent dir must stay read-only.
+    expect(() => validateAccess(memoryConfig, `${ws}/AGENTS.md`, "write")).toThrow(/not in write/i);
+  });
+
+  it("DENIES writing SOUL.md, IDENTITY.md, USER.md (identity stays immutable)", () => {
+    expect(() => validateAccess(memoryConfig, `${ws}/SOUL.md`, "write")).toThrow(/not in write/i);
+    expect(() => validateAccess(memoryConfig, `${ws}/IDENTITY.md`, "write")).toThrow(
+      /not in write/i
+    );
+    expect(() => validateAccess(memoryConfig, `${ws}/USER.md`, "write")).toThrow(/not in write/i);
+  });
+
+  it("DENIES writing a MEMORY.md-prefixed sibling (no prefix-escape)", () => {
+    // `MEMORY.md.bak` shares the `MEMORY.md` prefix but is a different file;
+    // the trailing-slash boundary must not let it through.
+    expect(() => validateAccess(memoryConfig, `${ws}/MEMORY.md.bak`, "write")).toThrow(
+      /not in write/i
+    );
+  });
+});
+
 describe("path-boundary matching (sibling-directory escape)", () => {
   // Allow-list entries without trailing slashes (`/foo/uploads`) used to
   // match any sibling whose name shared the prefix (`/foo/uploadsevil`)

--- a/packages/web/e2e/integration/agent-chat.spec.ts
+++ b/packages/web/e2e/integration/agent-chat.spec.ts
@@ -3,7 +3,6 @@ import { test, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import {
   FAKE_OLLAMA_CONTEXT_SAVE_USER_TOOL_TRIGGER,
-  FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE,
   FAKE_OLLAMA_DOMAIN_LOCK_TOOL_TRIGGER,
   FAKE_OLLAMA_FILES_LS_TOOL_TRIGGER,
   FAKE_OLLAMA_FILES_READ_DOCX_TOOL_TRIGGER,
@@ -180,10 +179,19 @@ test.describe("Agent chat — full integration", () => {
       await input.fill(`${FAKE_OLLAMA_DOMAIN_LOCK_TOOL_TRIGGER}: What Pinchy docs exist?`);
       await input.press("Enter");
 
-      await expect(page.getByText(FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE)).toBeVisible({
-        timeout: 30000,
-      });
-
+      // Assert on the audit entry, NOT the streamed reply text. This test's
+      // contract is its name — "tool calls write audit entries" — and the
+      // `tool.docs_list` entry can only exist if OpenClaw fully dispatched the
+      // tool, so it's a strictly stronger signal than "the reply rendered".
+      //
+      // The previous `getByText(...).toBeVisible()` gate on the streamed reply
+      // was a CI-only flake (failed on main too — run 26644436880 — on a no-op
+      // commit): under CI load the browser intermittently didn't paint the
+      // second-round stream within 30 s, even though the server-side dispatch +
+      // audit had already succeeded. The sibling pinchy-context probe below
+      // asserts purely on the audit API and is reliable; we match that. UI
+      // rendering of replies is covered separately by "Pinchy agent responds to
+      // messages via OpenClaw". (#448)
       const deadline = Date.now() + 30000;
       let foundAuditEntry = false;
       while (Date.now() < deadline) {

--- a/packages/web/e2e/integration/memory-audit.spec.ts
+++ b/packages/web/e2e/integration/memory-audit.spec.ts
@@ -1,15 +1,23 @@
 // packages/web/e2e/integration/memory-audit.spec.ts
 //
-// Proves Task 7's memory-audit watcher: writing to
-// `/openclaw-config/agents/<agentId>/MEMORY.md` inside the Pinchy container
+// Proves the memory-audit watcher: writing to an agent's real workspace path
+// `/openclaw-config/workspaces/<agentId>/MEMORY.md` inside the Pinchy container
 // emits an `agent.memory_changed` audit entry with the expected detail shape.
+//
+// This path is the SAME place a real agent's pinchy_write lands: the
+// `pinchy-workspaces` volume is mounted at `/openclaw-config/workspaces` in the
+// Pinchy container and `/root/.openclaw/workspaces` in the OpenClaw container,
+// so a write from either side is the same bytes. Writing to the OLD
+// `/openclaw-config/agents/<id>/` path is exactly the #345 trap — that subtree
+// is not where agents live, so the test would pass while production stayed
+// broken. We deliberately exercise the production layout.
 //
 // Why `docker compose exec` instead of host-side file writes:
 // Issue #196 moved the integration suite to run Pinchy in its production
-// container. The container mounts `openclaw-config` as a named Docker volume
-// (no host-visible path), so to feed the watcher we have to write the file
-// from inside the running container. We use the same `composeExec` pattern
-// the global-setup hook uses for OpenClaw config reads.
+// container. The container mounts the volumes as named Docker volumes (no
+// host-visible path), so to feed the watcher we have to write the file from
+// inside the running container. We use the same `composeExec` pattern the
+// global-setup hook uses for OpenClaw config reads.
 
 import { test, expect } from "@playwright/test";
 import { execSync } from "child_process";
@@ -21,10 +29,11 @@ const COMPOSE_FILES =
 const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
 const COMPOSE_ENV = { ...process.env, PINCHY_VERSION: process.env.PINCHY_VERSION || "local" };
 
-// Inside the Pinchy container the watcher walks /openclaw-config/agents/<id>/.
-// In production this is the `openclaw-config` Docker volume mounted at the
-// same path; the integration stack mounts the same named volume.
-const CONTAINER_DATA_PATH = "/openclaw-config";
+// Inside the Pinchy container the watcher walks the workspace base
+// `/openclaw-config/workspaces/<id>/` (WORKSPACE_BASE_PATH default — see
+// workspace.ts). In production and in the integration stack this is the
+// `pinchy-workspaces` named volume mounted at that path.
+const CONTAINER_WORKSPACE_BASE = "/openclaw-config/workspaces";
 
 function pinchyExec(cmd: string): string {
   return execSync(`docker compose ${COMPOSE_FILES} exec -T pinchy ${cmd}`, {
@@ -64,8 +73,9 @@ test.describe("memory-audit watcher emits agent.memory_changed on MEMORY.md writ
     const smithersName = smithers!.name;
 
     // 3. Compute the watched path inside the container. The watcher recognizes
-    //    `<root>/agents/<agentId>/MEMORY.md` exactly (see parse-path.ts).
-    containerMemoryPath = `${CONTAINER_DATA_PATH}/agents/${smithersId}/MEMORY.md`;
+    //    `<workspaceBase>/<agentId>/MEMORY.md` exactly (see parse-path.ts) —
+    //    the real on-disk home of an agent's memory.
+    containerMemoryPath = `${CONTAINER_WORKSPACE_BASE}/${smithersId}/MEMORY.md`;
 
     // 4. Write a unique, timestamped 3-line file via `docker exec`. The
     //    uniqueness defends against the case where a prior run left identical

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -112,9 +112,10 @@ export async function resetStack(): Promise<void> {
   // window small enough that dispatch resilience comfortably covers it.
   //
   // "Settled" = health reports connected & not-restarting continuously for 5 s
-  // (a transient reload/restart resets the streak). 90 s budget covers a
-  // worst-case cold-start restart cycle.
-  const settleDeadline = Date.now() + 90000;
+  // (a transient reload/restart resets the streak). 60 s budget covers a
+  // worst-case cold-start reload cycle while leaving headroom under the 120 s
+  // beforeAll timeout (this runs after the ~30 s container restart above).
+  const settleDeadline = Date.now() + 60000;
   let connectedSince: number | null = null;
   while (Date.now() < settleDeadline) {
     try {
@@ -133,7 +134,7 @@ export async function resetStack(): Promise<void> {
     }
     await sleep(1000);
   }
-  throw new Error("OpenClaw did not settle within 90s after reset");
+  throw new Error("OpenClaw did not settle within 60s after reset");
 }
 
 export interface ProviderSmokeTestSpec {

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -84,16 +84,56 @@ export async function resetStack(): Promise<void> {
   // openclaw.json has been picked up and the wizard route is reachable.
   // 60 s budget: container restart + Next.js cold compile can run ~30 s.
   const deadline = Date.now() + 60000;
+  let pinchyReady = false;
   while (Date.now() < deadline) {
     try {
       execSync(`curl -fsS http://localhost:7777/api/setup/status`, { stdio: "pipe" });
-      return;
+      pinchyReady = true;
+      break;
     } catch {
       // server still warming up
     }
     await sleep(1000);
   }
-  throw new Error("Pinchy did not become ready within 60s after reset");
+  if (!pinchyReady) throw new Error("Pinchy did not become ready within 60s after reset");
+
+  // Then wait for OpenClaw to fully SETTLE before handing off to the wizard.
+  //
+  // The container restart triggers a cold-start config cascade: Pinchy's
+  // on-connect `regenerateOpenClawConfig()` rewrites openclaw.json, which OC
+  // hot-reloads (and may gateway-restart on). If we start the wizard while this
+  // cascade is still in flight, the wizard's OWN config writes (provider save +
+  // first-time secrets.json bootstrap pkill) stack on top of it — and OC 5.3's
+  // `config.apply` rate-limit (~3/45 s) then defers the agent-list apply by up
+  // to ~2 min. That's exactly the 114 s "unknown agent id" gap seen on the
+  // ollama-local flake (PR #448, OC log 13:22:04 dispatch → 13:23:58 ready):
+  // the first chat raced a storm the resilient dispatch retry then had to
+  // absorb. Letting the cold-start cascade drain first keeps the wizard's
+  // window small enough that dispatch resilience comfortably covers it.
+  //
+  // "Settled" = health reports connected & not-restarting continuously for 5 s
+  // (a transient reload/restart resets the streak). 90 s budget covers a
+  // worst-case cold-start restart cycle.
+  const settleDeadline = Date.now() + 90000;
+  let connectedSince: number | null = null;
+  while (Date.now() < settleDeadline) {
+    try {
+      const out = execSync(`curl -fsS http://localhost:7777/api/health/openclaw`, {
+        stdio: "pipe",
+      }).toString();
+      const health = JSON.parse(out) as { connected?: boolean; status?: string };
+      if (health.connected && health.status === "ok") {
+        connectedSince ??= Date.now();
+        if (Date.now() - connectedSince >= 5000) return;
+      } else {
+        connectedSince = null;
+      }
+    } catch {
+      connectedSince = null;
+    }
+    await sleep(1000);
+  }
+  throw new Error("OpenClaw did not settle within 90s after reset");
 }
 
 export interface ProviderSmokeTestSpec {

--- a/packages/web/src/__tests__/api/agent-session-compact.test.ts
+++ b/packages/web/src/__tests__/api/agent-session-compact.test.ts
@@ -41,6 +41,10 @@ describe("POST /api/agents/[agentId]/sessions/compact", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Reset modules so the per-session compaction throttle (module-level state
+    // in @/lib/compact-throttle) starts fresh each test and doesn't leak a
+    // recorded timestamp from one test into the next.
+    vi.resetModules();
     mockGetSession.mockResolvedValue({
       user: { id: "user-1", email: "user@test.com", role: "member" },
     });
@@ -91,5 +95,18 @@ describe("POST /api/agents/[agentId]/sessions/compact", () => {
     mockCompact.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
     const res = await POST(makeRequest(), ctx as never);
     expect(res.status).toBe(502);
+  });
+
+  it("throttles a rapid second compaction of the same session (429, no second OC call)", async () => {
+    const first = await POST(makeRequest(), ctx as never);
+    expect(first.status).toBe(200);
+    expect(mockCompact).toHaveBeenCalledTimes(1);
+
+    // A second compaction of the same per-user session within the throttle
+    // window is rejected BEFORE reaching OpenClaw — the UI debounces the button,
+    // this guards direct API spamming from fanning out sessions.compact RPCs.
+    const second = await POST(makeRequest(), ctx as never);
+    expect(second.status).toBe(429);
+    expect(mockCompact).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/__tests__/api/agent-session-compact.test.ts
+++ b/packages/web/src/__tests__/api/agent-session-compact.test.ts
@@ -1,0 +1,95 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+const mockCompact = vi.fn();
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ sessions: { compact: mockCompact } }),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest(body: Record<string, unknown> = {}) {
+  return new NextRequest("http://localhost/api/agents/agent-1/sessions/compact", {
+    method: "POST",
+    headers: { "Content-Type": "application/json" },
+    body: JSON.stringify(body),
+  });
+}
+
+const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("POST /api/agents/[agentId]/sessions/compact", () => {
+  let POST: typeof import("@/app/api/agents/[agentId]/sessions/compact/route").POST;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-1", email: "user@test.com", role: "member" },
+    });
+    // Default: access granted (getAgentWithAccess returns the agent row).
+    mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
+    mockCompact.mockResolvedValue({ ok: true });
+
+    const mod = await import("@/app/api/agents/[agentId]/sessions/compact/route");
+    POST = mod.POST;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await POST(makeRequest(), ctx as never);
+    expect(res.status).toBe(401);
+    expect(mockCompact).not.toHaveBeenCalled();
+  });
+
+  it("propagates the access decision from getAgentWithAccess (403/404)", async () => {
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+    const res = await POST(makeRequest(), ctx as never);
+    expect(res.status).toBe(403);
+    expect(mockCompact).not.toHaveBeenCalled();
+  });
+
+  it("compacts the per-user session and returns 200 on success", async () => {
+    const res = await POST(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+    // Per-user session scoping: agent:<agentId>:direct:<userId>.
+    expect(mockCompact).toHaveBeenCalledTimes(1);
+    expect(mockCompact.mock.calls[0][0]).toBe("agent:agent-1:direct:user-1");
+  });
+
+  it("forwards maxLines to OpenClaw when provided", async () => {
+    await POST(makeRequest({ maxLines: 200 }), ctx as never);
+    expect(mockCompact).toHaveBeenCalledWith("agent:agent-1:direct:user-1", { maxLines: 200 });
+  });
+
+  it("returns 400 on an invalid body (maxLines not a positive int)", async () => {
+    const res = await POST(makeRequest({ maxLines: -5 }), ctx as never);
+    expect(res.status).toBe(400);
+    expect(mockCompact).not.toHaveBeenCalled();
+  });
+
+  it("returns 502 (not 500) when OpenClaw compaction fails — UI can toast it", async () => {
+    mockCompact.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
+    const res = await POST(makeRequest(), ctx as never);
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/web/src/__tests__/components/session-actions-menu.test.tsx
+++ b/packages/web/src/__tests__/components/session-actions-menu.test.tsx
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { toast } from "sonner";
+import { SessionActionsMenu } from "@/components/session-actions-menu";
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+function jsonResponse(body: unknown, init: { ok?: boolean; status?: number } = {}): Response {
+  const text = JSON.stringify(body);
+  return {
+    ok: init.ok ?? true,
+    status: init.status ?? 200,
+    json: async () => body,
+    text: async () => text,
+  } as unknown as Response;
+}
+
+describe("SessionActionsMenu", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  async function openMenuAndCompact(user: ReturnType<typeof userEvent.setup>) {
+    await user.click(screen.getByRole("button", { name: /conversation actions/i }));
+    await user.click(screen.getByRole("menuitem", { name: /compact/i }));
+  }
+
+  it("POSTs to the agent's compact endpoint and toasts success", async () => {
+    const user = userEvent.setup();
+    fetchSpy.mockResolvedValue(jsonResponse({ ok: true }));
+
+    render(<SessionActionsMenu agentId="agent-1" />);
+    await openMenuAndCompact(user);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [url, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(url).toBe("/api/agents/agent-1/sessions/compact");
+    expect(opts.method).toBe("POST");
+
+    await waitFor(() => expect(toast.success).toHaveBeenCalled());
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  it("surfaces the server error message via toast.error on failure", async () => {
+    const user = userEvent.setup();
+    fetchSpy.mockResolvedValue(
+      jsonResponse({ error: "Failed to compact session" }, { ok: false, status: 502 })
+    );
+
+    render(<SessionActionsMenu agentId="agent-1" />);
+    await openMenuAndCompact(user);
+
+    await waitFor(() => expect(toast.error).toHaveBeenCalledWith("Failed to compact session"));
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/compact-throttle.test.ts
+++ b/packages/web/src/__tests__/lib/compact-throttle.test.ts
@@ -1,0 +1,28 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+
+// Re-import per test so the module-level Map starts fresh (the throttle is
+// intentionally stateful across calls within a process).
+describe("allowCompaction", () => {
+  beforeEach(() => vi.resetModules());
+
+  it("allows the first compaction, throttles a second within the window", async () => {
+    const { allowCompaction, COMPACT_MIN_INTERVAL_MS } = await import("@/lib/compact-throttle");
+    expect(allowCompaction("k", 1000)).toBe(true);
+    expect(allowCompaction("k", 1000 + COMPACT_MIN_INTERVAL_MS - 1)).toBe(false);
+  });
+
+  it("allows again once the window has fully elapsed", async () => {
+    const { allowCompaction, COMPACT_MIN_INTERVAL_MS } = await import("@/lib/compact-throttle");
+    expect(allowCompaction("k", 1000)).toBe(true);
+    expect(allowCompaction("k", 1000 + COMPACT_MIN_INTERVAL_MS)).toBe(true);
+  });
+
+  it("throttles per session key independently", async () => {
+    const { allowCompaction } = await import("@/lib/compact-throttle");
+    expect(allowCompaction("a", 1000)).toBe(true);
+    // A different session is unaffected by `a`'s recent compaction.
+    expect(allowCompaction("b", 1000)).toBe(true);
+    // `a` again within the window is throttled.
+    expect(allowCompaction("a", 1000)).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
@@ -2,7 +2,9 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { handleMemoryFileEvent } from "@/lib/memory-audit-watcher/handle-event";
 
 describe("handleMemoryFileEvent", () => {
-  const root = "/openclaw-config";
+  // Workspace base: agents live at `<root>/<agentId>/` (no `agents/` prefix —
+  // see workspace.ts / #345).
+  const root = "/openclaw-config/workspaces";
   let snapshots: Map<string, string>;
   let inflight: Map<string, Promise<void>>;
   let mockAppend: ReturnType<typeof vi.fn>;
@@ -19,7 +21,7 @@ describe("handleMemoryFileEvent", () => {
     await handleMemoryFileEvent(
       {
         kind: "add",
-        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        absolutePath: "/openclaw-config/workspaces/agent-1/MEMORY.md",
         newContent: "hello\n",
       },
       {
@@ -46,14 +48,14 @@ describe("handleMemoryFileEvent", () => {
         byteSize: 6,
       },
     });
-    expect(snapshots.get("/openclaw-config/agents/agent-1/MEMORY.md")).toBe("hello\n");
+    expect(snapshots.get("/openclaw-config/workspaces/agent-1/MEMORY.md")).toBe("hello\n");
   });
 
   it("does NOT emit audit during initial scan (readyState='scanning')", async () => {
     await handleMemoryFileEvent(
       {
         kind: "add",
-        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        absolutePath: "/openclaw-config/workspaces/agent-1/MEMORY.md",
         newContent: "hello\n",
       },
       {
@@ -66,15 +68,15 @@ describe("handleMemoryFileEvent", () => {
       }
     );
     expect(mockAppend).not.toHaveBeenCalled();
-    expect(snapshots.get("/openclaw-config/agents/agent-1/MEMORY.md")).toBe("hello\n");
+    expect(snapshots.get("/openclaw-config/workspaces/agent-1/MEMORY.md")).toBe("hello\n");
   });
 
   it("emits added+removed counts on modify", async () => {
-    snapshots.set("/openclaw-config/agents/agent-1/memory/foo.md", "a\nb\nc\n");
+    snapshots.set("/openclaw-config/workspaces/agent-1/memory/foo.md", "a\nb\nc\n");
     await handleMemoryFileEvent(
       {
         kind: "change",
-        absolutePath: "/openclaw-config/agents/agent-1/memory/foo.md",
+        absolutePath: "/openclaw-config/workspaces/agent-1/memory/foo.md",
         newContent: "a\nX\nc\n",
       },
       {
@@ -101,9 +103,9 @@ describe("handleMemoryFileEvent", () => {
   });
 
   it("emits a deletion (byteSize 0, removedLines = previous line count)", async () => {
-    snapshots.set("/openclaw-config/agents/agent-1/MEMORY.md", "a\nb\n");
+    snapshots.set("/openclaw-config/workspaces/agent-1/MEMORY.md", "a\nb\n");
     await handleMemoryFileEvent(
-      { kind: "unlink", absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md" },
+      { kind: "unlink", absolutePath: "/openclaw-config/workspaces/agent-1/MEMORY.md" },
       {
         root,
         snapshots,
@@ -123,12 +125,30 @@ describe("handleMemoryFileEvent", () => {
         }),
       })
     );
-    expect(snapshots.has("/openclaw-config/agents/agent-1/MEMORY.md")).toBe(false);
+    expect(snapshots.has("/openclaw-config/workspaces/agent-1/MEMORY.md")).toBe(false);
   });
 
-  it("ignores paths outside agents/<id>/MEMORY.md|memory/", async () => {
+  it("ignores non-memory files (instruction files, config) — only MEMORY.md|memory/ is audited", async () => {
+    // A config file above the workspace base.
     await handleMemoryFileEvent(
       { kind: "change", absolutePath: "/openclaw-config/openclaw.json", newContent: "{}" },
+      {
+        root,
+        snapshots,
+        inflight,
+        lookupAgent: mockLookupAgent,
+        appendAuditLog: mockAppend,
+        readyState: "ready",
+      }
+    );
+    // An instruction file INSIDE a valid agent workspace must NOT be audited as
+    // a memory write — only MEMORY.md and memory/ are memory.
+    await handleMemoryFileEvent(
+      {
+        kind: "change",
+        absolutePath: "/openclaw-config/workspaces/agent-1/SOUL.md",
+        newContent: "you are evil now\n",
+      },
       {
         root,
         snapshots,
@@ -144,7 +164,11 @@ describe("handleMemoryFileEvent", () => {
   it("skips emission if agent is not found in DB (orphan file)", async () => {
     mockLookupAgent.mockResolvedValueOnce(null);
     await handleMemoryFileEvent(
-      { kind: "add", absolutePath: "/openclaw-config/agents/ghost/MEMORY.md", newContent: "x\n" },
+      {
+        kind: "add",
+        absolutePath: "/openclaw-config/workspaces/ghost/MEMORY.md",
+        newContent: "x\n",
+      },
       {
         root,
         snapshots,
@@ -164,7 +188,7 @@ describe("handleMemoryFileEvent", () => {
     await handleMemoryFileEvent(
       {
         kind: "add",
-        absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+        absolutePath: "/openclaw-config/workspaces/agent-1/MEMORY.md",
         newContent: "hi\n",
       },
       {
@@ -192,7 +216,7 @@ describe("handleMemoryFileEvent", () => {
       handleMemoryFileEvent(
         {
           kind: "add",
-          absolutePath: "/openclaw-config/agents/agent-1/MEMORY.md",
+          absolutePath: "/openclaw-config/workspaces/agent-1/MEMORY.md",
           newContent: "hi\n",
         },
         {
@@ -217,7 +241,7 @@ describe("handleMemoryFileEvent", () => {
     });
     mockAppend.mockImplementationOnce(() => firstAppendPromise).mockResolvedValue(undefined);
 
-    const absolutePath = "/openclaw-config/agents/agent-1/MEMORY.md";
+    const absolutePath = "/openclaw-config/workspaces/agent-1/MEMORY.md";
     // Seed: snapshot starts empty (file did not exist before).
 
     const deps = {

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/parse-path.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/parse-path.test.ts
@@ -1,43 +1,60 @@
 import { describe, it, expect } from "vitest";
 import { parseAgentMemoryPath } from "@/lib/memory-audit-watcher/parse-path";
 
+// Pinchy agents live under `<workspaceBase>/<agentId>/` (see workspace.ts), so
+// a memory file is `<root>/<agentId>/MEMORY.md` — NOT `<root>/agents/<id>/…`.
+// The watcher watches the workspace base directly; the agentId is the first
+// path segment under the root.
 describe("parseAgentMemoryPath", () => {
-  const root = "/openclaw-config";
+  const root = "/openclaw-config/workspaces";
 
   it("parses MEMORY.md at the agent root", () => {
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/MEMORY.md")).toEqual({
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc-123/MEMORY.md")).toEqual({
       agentId: "abc-123",
       file: "MEMORY.md",
     });
   });
 
   it("parses files under memory/", () => {
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/memory/foo.md")).toEqual({
-      agentId: "abc-123",
-      file: "memory/foo.md",
-    });
-  });
-
-  it("parses nested files under memory/", () => {
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123/memory/sub/bar.md")).toEqual(
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc-123/memory/foo.md")).toEqual(
       {
         agentId: "abc-123",
-        file: "memory/sub/bar.md",
+        file: "memory/foo.md",
       }
     );
   });
 
-  it("returns null for paths outside agents/", () => {
-    expect(parseAgentMemoryPath(root, "/openclaw-config/openclaw.json")).toBeNull();
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc/other.md")).toBeNull();
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc/notes/foo.md")).toBeNull();
+  it("parses nested files under memory/", () => {
+    expect(
+      parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc-123/memory/sub/bar.md")
+    ).toEqual({
+      agentId: "abc-123",
+      file: "memory/sub/bar.md",
+    });
+  });
+
+  it("returns null for non-memory files at the agent root", () => {
+    // Instruction files and other workspace files must never be audited as
+    // memory writes.
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc/SOUL.md")).toBeNull();
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc/AGENTS.md")).toBeNull();
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc/notes/foo.md")).toBeNull();
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc/uploads/x.md")).toBeNull();
+  });
+
+  it("returns null for files directly under the root (no agent segment)", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/openclaw.json")).toBeNull();
   });
 
   it("rejects paths above the root", () => {
     expect(parseAgentMemoryPath(root, "/etc/passwd")).toBeNull();
   });
 
-  it("rejects directories that look like agents/<id> but lack the file", () => {
-    expect(parseAgentMemoryPath(root, "/openclaw-config/agents/abc-123")).toBeNull();
+  it("rejects the agent directory itself (no file)", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc-123")).toBeNull();
+  });
+
+  it("rejects the memory/ directory itself (no file)", () => {
+    expect(parseAgentMemoryPath(root, "/openclaw-config/workspaces/abc-123/memory")).toBeNull();
   });
 });

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher-path-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher-path-drift.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { parseAgentMemoryPath } from "@/lib/memory-audit-watcher/parse-path";
+import { getWorkspaceBasePath, getWorkspacePath } from "@/lib/workspace";
+
+// Drift guard for issue #345.
+//
+// The memory-audit watcher and the workspace-path code MUST agree on where an
+// agent's files live on disk. #345 shipped a watcher that hardcoded
+// `agents/<id>/` while real Pinchy agents live under `workspaces/<id>/`, so the
+// watcher silently watched the wrong subtree and never fired in production.
+//
+// This test pins the two together: it takes the canonical path that
+// `getWorkspacePath()` produces (the SAME helper build.ts / ensureWorkspace use
+// to place real agent files) and feeds it through the watcher's parser with
+// `getWorkspaceBasePath()` as the root (the SAME base the bootstrap passes to
+// the watcher). If anyone changes the on-disk layout in workspace.ts without
+// updating parse-path.ts (or vice versa), this round-trip breaks — which is
+// exactly the drift that produced the dead-code watcher.
+describe("watcher ⇄ workspace path drift guard (#345)", () => {
+  const agentId = "test-id";
+  const base = getWorkspaceBasePath();
+
+  it("round-trips MEMORY.md at the workspace root", () => {
+    const memoryPath = `${getWorkspacePath(agentId)}/MEMORY.md`;
+    expect(parseAgentMemoryPath(base, memoryPath)).toEqual({
+      agentId,
+      file: "MEMORY.md",
+    });
+  });
+
+  it("round-trips a daily note under memory/", () => {
+    const dailyPath = `${getWorkspacePath(agentId)}/memory/2026-06-01.md`;
+    expect(parseAgentMemoryPath(base, dailyPath)).toEqual({
+      agentId,
+      file: "memory/2026-06-01.md",
+    });
+  });
+
+  it("does NOT match instruction files (SOUL.md / AGENTS.md stay un-audited)", () => {
+    expect(parseAgentMemoryPath(base, `${getWorkspacePath(agentId)}/SOUL.md`)).toBeNull();
+    expect(parseAgentMemoryPath(base, `${getWorkspacePath(agentId)}/AGENTS.md`)).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher-real-fs.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher-real-fs.test.ts
@@ -47,12 +47,16 @@ describe.skipIf(process.platform !== "linux")(
       // the NEW content — making the subsequent diff degenerate to
       // addedLines=0. Run 26291361464 hit exactly that on Linux.
       //
-      // Instead: empty agents/ at startup, then create MEMORY.md after
-      // the watcher is ready. The "add" event now fires in "ready"
+      // Instead: empty workspace base at startup, then create MEMORY.md
+      // after the watcher is ready. The "add" event now fires in "ready"
       // state and emits an audit directly with no scan-phase snapshot
       // to race against.
+      //
+      // `root` is the workspace base; agents live at `<root>/<agentId>/`
+      // (no `agents/` prefix — see workspace.ts / #345). The base dir is
+      // created empty by mkdtempSync; the agent subdir is created in the
+      // test body after the watcher is ready.
       root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-realfs-"));
-      mkdirSync(join(root, "agents"), { recursive: true });
       appended = [];
 
       // `usePolling: false` → inotify on Linux. We deliberately do NOT use
@@ -81,8 +85,8 @@ describe.skipIf(process.platform !== "linux")(
       // The "add" event for the new file fires in "ready" state, so it
       // becomes a real audit emission with a clean diff: empty snapshot
       // → 2 added lines.
-      mkdirSync(join(root, "agents", "agent-1"), { recursive: true });
-      writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\nadded line\n", "utf8");
+      mkdirSync(join(root, "agent-1"), { recursive: true });
+      writeFileSync(join(root, "agent-1", "MEMORY.md"), "initial\nadded line\n", "utf8");
 
       // Poll for the event rather than sleeping a fixed amount — inotify is
       // usually sub-100 ms but the stability-threshold window has to elapse

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/watcher.test.ts
@@ -103,8 +103,8 @@ describe("startMemoryAuditWatcher (chokidar wiring)", () => {
     // for that read to succeed. We only mock chokidar's event source.
     setupMockState();
     root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-"));
-    mkdirSync(join(root, "agents", "agent-1", "memory"), { recursive: true });
-    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\n", "utf8");
+    mkdirSync(join(root, "agent-1", "memory"), { recursive: true });
+    writeFileSync(join(root, "agent-1", "MEMORY.md"), "initial\n", "utf8");
     appended = [];
 
     stop = await startMemoryAuditWatcher({
@@ -140,8 +140,8 @@ describe("startMemoryAuditWatcher (chokidar wiring)", () => {
   });
 
   it("routes a 'change' event into an audit-log append", async () => {
-    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "initial\nadded line\n", "utf8");
-    lastFakeWatcher!.emit("change", join(root, "agents", "agent-1", "MEMORY.md"));
+    writeFileSync(join(root, "agent-1", "MEMORY.md"), "initial\nadded line\n", "utf8");
+    lastFakeWatcher!.emit("change", join(root, "agent-1", "MEMORY.md"));
     await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 2000 });
     expect(appended[0]).toMatchObject({
       eventType: "agent.memory_changed",
@@ -151,12 +151,8 @@ describe("startMemoryAuditWatcher (chokidar wiring)", () => {
   });
 
   it("routes an 'add' event (post-ready) into an audit-log append", async () => {
-    writeFileSync(
-      join(root, "agents", "agent-1", "memory", "facts.md"),
-      "fact 1\nfact 2\n",
-      "utf8"
-    );
-    lastFakeWatcher!.emit("add", join(root, "agents", "agent-1", "memory", "facts.md"));
+    writeFileSync(join(root, "agent-1", "memory", "facts.md"), "fact 1\nfact 2\n", "utf8");
+    lastFakeWatcher!.emit("add", join(root, "agent-1", "memory", "facts.md"));
     await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 2000 });
     expect(appended[0]).toMatchObject({
       detail: { file: "memory/facts.md", addedLines: 2, removedLines: 0 },
@@ -165,7 +161,7 @@ describe("startMemoryAuditWatcher (chokidar wiring)", () => {
 
   it("routes an 'unlink' event into a deletion audit-log append", async () => {
     // Seed a known-good snapshot first by firing an "add" with content on disk.
-    const target = join(root, "agents", "agent-1", "memory", "fact.md");
+    const target = join(root, "agent-1", "memory", "fact.md");
     writeFileSync(target, "x\ny\n", "utf8");
     lastFakeWatcher!.emit("add", target);
     await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 2000 });
@@ -194,7 +190,6 @@ describe("startMemoryAuditWatcher (usePolling option)", () => {
     (chokidar.watch as ReturnType<typeof vi.fn>).mockClear();
 
     const root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-poll-"));
-    mkdirSync(join(root, "agents"), { recursive: true });
     try {
       const stop = await startMemoryAuditWatcher({
         root,
@@ -218,7 +213,6 @@ describe("startMemoryAuditWatcher (usePolling option)", () => {
     (chokidar.watch as ReturnType<typeof vi.fn>).mockClear();
 
     const root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-poll-default-"));
-    mkdirSync(join(root, "agents"), { recursive: true });
     try {
       const stop = await startMemoryAuditWatcher({
         root,
@@ -251,8 +245,8 @@ describe("startMemoryAuditWatcher (handler error resilience)", () => {
   beforeEach(async () => {
     setupMockState();
     root = mkdtempSync(join(tmpdir(), "pinchy-memwatch-err-"));
-    mkdirSync(join(root, "agents", "agent-1", "memory"), { recursive: true });
-    writeFileSync(join(root, "agents", "agent-1", "MEMORY.md"), "first write\n", "utf8");
+    mkdirSync(join(root, "agent-1", "memory"), { recursive: true });
+    writeFileSync(join(root, "agent-1", "MEMORY.md"), "first write\n", "utf8");
     appended = [];
     unhandled = [];
     lookupShouldThrow = true;
@@ -286,7 +280,7 @@ describe("startMemoryAuditWatcher (handler error resilience)", () => {
     // Fire a change event while lookup throws — the void-detached handler
     // would surface an unhandledRejection without the watcher's catch
     // wrapper.
-    lastFakeWatcher!.emit("change", join(root, "agents", "agent-1", "MEMORY.md"));
+    lastFakeWatcher!.emit("change", join(root, "agent-1", "MEMORY.md"));
     // Yield enough microtasks for the async chain (readFile, lookupAgent,
     // .catch) to settle.
     await wait(50);
@@ -296,12 +290,8 @@ describe("startMemoryAuditWatcher (handler error resilience)", () => {
     // Watcher must still be alive: fix lookup, fire another event, expect
     // the audit to come through this time.
     lookupShouldThrow = false;
-    writeFileSync(
-      join(root, "agents", "agent-1", "MEMORY.md"),
-      "first write\nsecond write\n",
-      "utf8"
-    );
-    lastFakeWatcher!.emit("change", join(root, "agents", "agent-1", "MEMORY.md"));
+    writeFileSync(join(root, "agent-1", "MEMORY.md"), "first write\nsecond write\n", "utf8");
+    lastFakeWatcher!.emit("change", join(root, "agent-1", "MEMORY.md"));
     await vi.waitFor(() => expect(appended.length).toBe(1), { timeout: 2000 });
     expect(unhandled).toEqual([]);
   });

--- a/packages/web/src/__tests__/lib/memory-prompt.test.ts
+++ b/packages/web/src/__tests__/lib/memory-prompt.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { buildMemoryPromptBlock } from "@/lib/memory-prompt";
+
+describe("buildMemoryPromptBlock", () => {
+  it("returns a ## Memory block when the agent has pinchy_write", () => {
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block).not.toBeNull();
+    expect(block!).toContain("## Memory");
+  });
+
+  it("names pinchy_write as the write tool (the missing piece behind the hallucination)", () => {
+    // The root cause of the production hallucination (#368): the agent knew
+    // memory lived in MEMORY.md but not HOW to write it. The block must name
+    // the write tool explicitly.
+    const block = buildMemoryPromptBlock(["pinchy_write", "pinchy_read"]);
+    expect(block!).toContain("pinchy_write");
+  });
+
+  it("points at both MEMORY.md and the memory/ daily-log location", () => {
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!).toContain("MEMORY.md");
+    expect(block!).toContain("memory/");
+  });
+
+  it("names the read/recall tools so the agent can find what it stored", () => {
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!).toContain("memory_search");
+  });
+
+  it("clarifies that SOUL.md / AGENTS.md are platform-managed and not writable", () => {
+    // Prevents the inverse failure: an agent trying to 'remember' by editing
+    // its own instructions. It must know those are off-limits.
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!).toContain("SOUL.md");
+    expect(block!).toContain("AGENTS.md");
+  });
+
+  it("returns null when the agent cannot write (no pinchy_write)", () => {
+    // No write path → telling the agent it can persist memory would be a lie
+    // and reproduce the hallucination from the other direction.
+    expect(buildMemoryPromptBlock([])).toBeNull();
+    expect(buildMemoryPromptBlock(["pinchy_read"])).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1228,10 +1228,14 @@ describe("regenerateOpenClawConfig", () => {
 
     // workbench/ is the agent's primary write zone. uploads/ stays writable
     // for backward-compat with custom AGENTS.md files that historically told
-    // the agent to write there (#418).
+    // the agent to write there (#418). MEMORY.md (file) + memory/ (dir) are
+    // the agent's persistent memory — a write-capable agent gets them too so
+    // it can actually persist what it's told to remember.
     expect(agentConfig.write_paths).toEqual([
       "/root/.openclaw/workspaces/writer/uploads",
       "/root/.openclaw/workspaces/writer/workbench",
+      "/root/.openclaw/workspaces/writer/MEMORY.md",
+      "/root/.openclaw/workspaces/writer/memory",
     ]);
   });
 
@@ -1282,13 +1286,62 @@ describe("regenerateOpenClawConfig", () => {
 
     expect(agentConfig).toBeDefined();
     expect(agentConfig.write_paths).toBeUndefined();
+    // A read-only agent gets no memory paths at all — memory is only writable,
+    // so without a write path there's nothing to grant.
+    expect(agentConfig.allowed_paths).not.toContain("/root/.openclaw/workspaces/reader/MEMORY.md");
+    expect(agentConfig.allowed_paths).not.toContain("/root/.openclaw/workspaces/reader/memory");
+  });
+
+  it("grants MEMORY.md + memory/ as writable memory when pinchy_write is present", async () => {
+    // The reason agents could never persist memory: group:fs is denied and
+    // pinchy_write only covered uploads/ + workbench/. A write-capable agent
+    // now gets MEMORY.md (curated long-term) and memory/ (daily logs) so it
+    // can actually write what the user tells it to remember.
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "writer",
+          name: "Writer Agent",
+          model: "anthropic/claude-opus-4-7",
+          createdAt: new Date(),
+          allowedTools: ["pinchy_write"],
+          pluginConfig: null,
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const agentConfig = config.plugins.entries["pinchy-files"]?.config?.agents?.["writer"];
+
+    const memoryFile = "/root/.openclaw/workspaces/writer/MEMORY.md";
+    const memoryDir = "/root/.openclaw/workspaces/writer/memory";
+
+    // Writable.
+    expect(agentConfig.write_paths).toContain(memoryFile);
+    expect(agentConfig.write_paths).toContain(memoryDir);
+    // And in allowed_paths to satisfy the subset invariant (write ⊆ allowed).
+    expect(agentConfig.allowed_paths).toContain(memoryFile);
+    expect(agentConfig.allowed_paths).toContain(memoryDir);
+
+    // Crucial security property: MEMORY.md is granted as a FILE, so the sibling
+    // instruction files are NOT writable — the agent can rewrite its memory but
+    // never its identity/instructions (validate.ts trailing-slash boundary).
+    expect(agentConfig.write_paths).not.toContain("/root/.openclaw/workspaces/writer/SOUL.md");
+    expect(agentConfig.write_paths).not.toContain("/root/.openclaw/workspaces/writer/AGENTS.md");
+    expect(agentConfig.write_paths).not.toContain("/root/.openclaw/workspaces/writer/IDENTITY.md");
+    expect(agentConfig.write_paths).not.toContain("/root/.openclaw/workspaces/writer/USER.md");
   });
 
   it("never lists the workspace root in allowed_paths or write_paths (hard-deny invariant)", async () => {
     // Regression guard: the workspace root holds Pinchy-managed system files
-    // (SOUL.md, AGENTS.md, IDENTITY.md, USER.md, MEMORY.md). Including it in
-    // either list would let the agent overwrite its own identity. Only the
-    // uploads/ and workbench/ subdirs may appear. See #418 acceptance criteria.
+    // (SOUL.md, AGENTS.md, IDENTITY.md, USER.md). Granting the bare root would
+    // let the agent overwrite its own identity. Memory is granted file-granular
+    // (MEMORY.md) and dir-granular (memory/) — never the root — so the agent can
+    // write its memory but not its instructions. Only uploads/, workbench/,
+    // MEMORY.md and memory/ may appear. See #418 acceptance criteria.
     mockedDb.select.mockReturnValue({
       from: mockFrom([
         {

--- a/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
+++ b/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
@@ -1,12 +1,13 @@
 // Focused tests for the chat-dispatch retry wrapper used to mask
 // OpenClaw's `config.get` vs `agent` RPC dispatch race (#310 / PR #442
 // flake on the Odoo and Telegram dispatch probes — CI runs 26505503327,
-// 26511658136).
+// 26511658136; ollama-local setup-wizard flake — PR #448).
 //
-// The wrapper retries `openclawClient.chat()` exactly once when the
-// FIRST chunk is an `unknown agent id` error. These tests pin the
-// contract: nothing else triggers a retry, and a retried call is
-// transparent to the caller.
+// The wrapper retries `openclawClient.chat()` with bounded exponential
+// backoff while the FIRST chunk is an `unknown agent id` error. These tests
+// pin the contract: only that error and only on the first chunk triggers a
+// retry; the retry loop is bounded by a wall-clock budget; and a retried
+// call is transparent to the caller.
 
 import { describe, it, expect, vi } from "vitest";
 import type { ChatChunk, ChatOptions } from "openclaw-node";
@@ -20,10 +21,29 @@ function makeStream(chunks: ChatChunk[]) {
   };
 }
 
+function raceError(id = "596489fc-45c7-4113-8a82-b5f8d28861d7"): ChatChunk[] {
+  return [{ type: "error", text: `invalid agent params: unknown agent id "${id}"`, runId: "r0" }];
+}
+
 async function collect(gen: AsyncGenerator<ChatChunk>): Promise<ChatChunk[]> {
   const out: ChatChunk[] = [];
   for await (const c of gen) out.push(c);
   return out;
+}
+
+/**
+ * Fake clock: `delay(ms)` advances `now` by `ms` synchronously (resolving
+ * immediately) so backoff/budget logic is exercised deterministically without
+ * real timers.
+ */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    delay: vi.fn(async (ms: number) => {
+      t += ms;
+    }),
+  };
 }
 
 describe("chatWithDispatchRaceRetry", () => {
@@ -44,75 +64,104 @@ describe("chatWithDispatchRaceRetry", () => {
     expect(chat).toHaveBeenCalledTimes(1);
   });
 
-  it("retries exactly once and swallows the transient first-chunk error when it matches the dispatch-race pattern", async () => {
-    const transient: ChatChunk[] = [
-      {
-        type: "error",
-        text: 'invalid agent params: unknown agent id "596489fc-45c7-4113-8a82-b5f8d28861d7"',
-        runId: "r0",
-      },
-    ];
+  it("retries the transient first-chunk race error until the agent dispatches, swallowing it", async () => {
     const successful: ChatChunk[] = [
       { type: "text", text: "Hello!", runId: "r1" },
       { type: "done", text: "", runId: "r1" },
     ];
-
+    // Three transient failures, then success — proves we retry MORE than once
+    // (the old single-retry contract could not survive a multi-second reload).
     const chat = vi
       .fn()
-      .mockImplementationOnce(makeStream(transient))
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream(raceError()))
       .mockImplementationOnce(makeStream(successful));
 
-    const delay = vi.fn().mockResolvedValue(undefined);
+    const clock = fakeClock();
     const onDispatchRaceObserved = vi.fn();
 
     const got = await collect(
       chatWithDispatchRaceRetry(
         "hello",
         { agentId: "596489fc-45c7-4113-8a82-b5f8d28861d7" } as ChatOptions,
-        { chat: chat as never, delay, onDispatchRaceObserved },
-        500
+        { chat: chat as never, delay: clock.delay, now: clock.now, onDispatchRaceObserved },
+        { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 90000 }
       )
     );
 
-    // The transient error must NOT have been yielded to the consumer.
     expect(got).toEqual(successful);
-    // Exactly two chat() calls: original + one retry.
-    expect(chat).toHaveBeenCalledTimes(2);
-    // Delay invoked with the configured value.
-    expect(delay).toHaveBeenCalledWith(500);
-    // Audit observation fired exactly once with the transient error text.
+    expect(chat).toHaveBeenCalledTimes(4);
+    // Audited ONCE per raced dispatch (not once per retry) so a long storm
+    // doesn't flood the audit log.
     expect(onDispatchRaceObserved).toHaveBeenCalledTimes(1);
     expect(onDispatchRaceObserved.mock.calls[0][0].providerError).toMatch(/unknown agent id/i);
-    expect(onDispatchRaceObserved.mock.calls[0][0].attempt).toBe(0);
   });
 
-  it("forwards the error and does NOT retry when the second attempt also hits the dispatch-race error", async () => {
-    const transient = (id: string): ChatChunk[] => [
-      {
-        type: "error",
-        text: `invalid agent params: unknown agent id "${id}"`,
-        runId: "r-err",
-      },
-    ];
-
+  it("uses exponential backoff capped at maxDelayMs", async () => {
+    // Fail enough times to exceed the cap, then succeed.
     const chat = vi
       .fn()
-      .mockImplementationOnce(makeStream(transient("a")))
-      .mockImplementationOnce(makeStream(transient("a")));
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream(raceError()))
+      .mockImplementationOnce(makeStream([{ type: "done", text: "", runId: "r1" }]));
+
+    const clock = fakeClock();
+
+    await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "a" } as ChatOptions,
+        { chat: chat as never, delay: clock.delay, now: clock.now },
+        { baseDelayMs: 500, maxDelayMs: 2000, maxTotalMs: 90000 }
+      )
+    );
+
+    // 500, 1000, 2000, 2000 (capped) — exponential then clamped.
+    expect(clock.delay.mock.calls.map((c) => c[0])).toEqual([500, 1000, 2000, 2000]);
+  });
+
+  it("surfaces the race error once the wall-clock budget is exhausted (bounded, never infinite)", async () => {
+    // Always fails — the loop must terminate at the budget and yield the error.
+    const chat = vi.fn(makeStream(raceError("a")));
+    const clock = fakeClock();
 
     const got = await collect(
       chatWithDispatchRaceRetry(
         "hello",
         { agentId: "a" } as ChatOptions,
-        { chat: chat as never, delay: vi.fn().mockResolvedValue(undefined) },
-        0
+        { chat: chat as never, delay: clock.delay, now: clock.now },
+        { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 3000 }
       )
     );
 
-    // The second attempt's error IS yielded so the caller can surface it.
+    // The final error IS yielded so the caller surfaces "Smithers couldn't respond".
     expect(got).toHaveLength(1);
     expect(got[0].type).toBe("error");
-    expect(chat).toHaveBeenCalledTimes(2);
+    expect(DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
+    // Never slept past the budget.
+    expect(clock.now()).toBeLessThanOrEqual(3000);
+  });
+
+  it("does not retry at all when maxTotalMs is 0 (single attempt, surface error)", async () => {
+    const chat = vi.fn(makeStream(raceError("a")));
+    const clock = fakeClock();
+
+    const got = await collect(
+      chatWithDispatchRaceRetry(
+        "hello",
+        { agentId: "a" } as ChatOptions,
+        { chat: chat as never, delay: clock.delay, now: clock.now },
+        { maxTotalMs: 0 }
+      )
+    );
+
+    expect(got).toHaveLength(1);
+    expect(got[0].type).toBe("error");
+    expect(chat).toHaveBeenCalledTimes(1);
+    expect(clock.delay).not.toHaveBeenCalled();
   });
 
   it("does NOT retry on an error chunk that doesn't match the dispatch-race pattern", async () => {
@@ -123,16 +172,10 @@ describe("chatWithDispatchRaceRetry", () => {
         runId: "r-err",
       },
     ];
-
     const chat = vi.fn(makeStream(otherError));
 
     const got = await collect(
-      chatWithDispatchRaceRetry(
-        "hello",
-        { agentId: "a" } as ChatOptions,
-        { chat: chat as never },
-        0
-      )
+      chatWithDispatchRaceRetry("hello", { agentId: "a" } as ChatOptions, { chat: chat as never })
     );
 
     expect(got).toEqual(otherError);
@@ -140,48 +183,37 @@ describe("chatWithDispatchRaceRetry", () => {
   });
 
   it("does NOT retry when the FIRST chunk is fine and a later chunk errors with the dispatch pattern", async () => {
-    // This is a synthetic case to lock the "only first-chunk triggers
-    // retry" contract: a mid-stream `unknown agent id` would indicate
-    // something genuinely broken (OC re-running agent lookup mid-turn?)
-    // rather than the startup race we're targeting.
     const chunks: ChatChunk[] = [
       { type: "text", text: "partial...", runId: "r1" },
-      {
-        type: "error",
-        text: 'unknown agent id "weird"',
-        runId: "r1",
-      },
+      { type: "error", text: 'unknown agent id "weird"', runId: "r1" },
     ];
     const chat = vi.fn(makeStream(chunks));
 
     const got = await collect(
-      chatWithDispatchRaceRetry(
-        "hello",
-        { agentId: "weird" } as ChatOptions,
-        { chat: chat as never, delay: vi.fn().mockResolvedValue(undefined) },
-        0
-      )
+      chatWithDispatchRaceRetry("hello", { agentId: "weird" } as ChatOptions, {
+        chat: chat as never,
+      })
     );
 
     expect(got).toEqual(chunks);
     expect(chat).toHaveBeenCalledTimes(1);
   });
 
-  it("passes message and options through to the underlying chat() on both attempts", async () => {
-    const transient: ChatChunk[] = [{ type: "error", text: 'unknown agent id "x"', runId: "r0" }];
-    const ok: ChatChunk[] = [{ type: "done", text: "", runId: "r1" }];
+  it("passes message and options through to the underlying chat() on every attempt", async () => {
     const chat = vi
       .fn()
-      .mockImplementationOnce(makeStream(transient))
-      .mockImplementationOnce(makeStream(ok));
+      .mockImplementationOnce(makeStream(raceError("x")))
+      .mockImplementationOnce(makeStream([{ type: "done", text: "", runId: "r1" }]));
 
-    const opts: ChatOptions = {
-      agentId: "x",
-      sessionKey: "agent:x:direct:u1",
-    };
+    const opts: ChatOptions = { agentId: "x", sessionKey: "agent:x:direct:u1" };
+    const clock = fakeClock();
 
     await collect(
-      chatWithDispatchRaceRetry("hello", opts, { chat: chat as never, delay: vi.fn() }, 0)
+      chatWithDispatchRaceRetry("hello", opts, {
+        chat: chat as never,
+        delay: clock.delay,
+        now: clock.now,
+      })
     );
 
     expect(chat).toHaveBeenNthCalledWith(1, "hello", opts);

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -2547,6 +2547,45 @@ describe("ClientRouter", () => {
       );
     });
 
+    it("injects the ## Memory capability block when the agent has pinchy_write", async () => {
+      mockUserFindFirst.mockResolvedValue({ id: "user-1", name: "Alice", context: null });
+      mockFindFirst.mockResolvedValue({ ...defaultAgent, allowedTools: ["pinchy_write"] });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const callArgs = mockChat.mock.calls[0][1];
+      expect(callArgs.extraSystemPrompt).toContain("## Memory");
+      expect(callArgs.extraSystemPrompt).toContain("pinchy_write");
+    });
+
+    it("does NOT inject the memory block when the agent cannot write (no pinchy_write)", async () => {
+      mockUserFindFirst.mockResolvedValue({ id: "user-1", name: "Alice", context: null });
+      mockFindFirst.mockResolvedValue({ ...defaultAgent, allowedTools: [] });
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      const callArgs = mockChat.mock.calls[0][1];
+      expect(callArgs.extraSystemPrompt ?? "").not.toContain("## Memory");
+    });
+
     it("should NOT inject name when user has no name set", async () => {
       mockUserFindFirst.mockResolvedValue({ id: "user-1", name: null, context: null });
       async function* fakeStream() {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -720,6 +720,63 @@ describe("ClientRouter", () => {
     }
   });
 
+  it("DOES keep the client alive while a KNOWN dispatch-race retry is in flight (not a hang)", async () => {
+    // Distinct from the hang case above: here OpenClaw actively rejects with
+    // "unknown agent id" (a transient apply-lag during a config reload), so the
+    // resilient retry kicks in and can stay silent for up to ~90 s. The client
+    // stuck-timer is 60 s — without a keep-alive the retry would land after the
+    // browser already gave up. We re-emit `thinking` ONLY because a race was
+    // observed; a generic hang (test above) never triggers this, so the
+    // stuck-timer still surfaces real hangs.
+    vi.useFakeTimers();
+    try {
+      const clientWs = createMockClientWs();
+      let resolveHang: () => void = () => {};
+
+      async function* raceError() {
+        yield {
+          type: "error" as const,
+          text: 'invalid agent params: unknown agent id "agent-1"',
+          runId: "r0",
+        };
+      }
+      async function* hang() {
+        await new Promise<void>((r) => (resolveHang = r));
+      }
+      // Attempt 0 hits the race; the retry then hangs (OC still applying).
+      mockChat.mockReturnValueOnce(raceError()).mockReturnValue(hang());
+
+      const handlePromise = router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi",
+        agentId: "agent-1",
+      });
+
+      // Initial thinking + consume the race error (starts the keep-alive) +
+      // drain the 500 ms backoff into the hanging retry attempt.
+      await vi.advanceTimersByTimeAsync(0);
+      await vi.advanceTimersByTimeAsync(600);
+
+      const before = clientWs.sent
+        .map((s) => JSON.parse(s))
+        .filter((m: any) => m.type === "thinking").length;
+
+      // Past one keep-alive interval — a fresh `thinking` must have fired.
+      await vi.advanceTimersByTimeAsync(20_000);
+
+      const after = clientWs.sent
+        .map((s) => JSON.parse(s))
+        .filter((m: any) => m.type === "thinking").length;
+
+      expect(after).toBeGreaterThan(before);
+
+      resolveHang();
+      await handlePromise;
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
   it("should send a thinking message before consuming the stream so the UI can show a spinner", async () => {
     const clientWs = createMockClientWs();
     let firstSent: unknown = null;

--- a/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
@@ -11,6 +11,7 @@ import { getAgentWithAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { compactSessionSchema } from "@/lib/schemas/sessions";
+import { allowCompaction } from "@/lib/compact-throttle";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -34,6 +35,18 @@ export const POST = withAuth<RouteContext>(async (request, { params }, session) 
   // agent:<agentId>:direct:<userId>. OpenClaw validates that the agentId in the
   // key matches the agentId argument — see MEMORY.md "OpenClaw Sessions API".
   const sessionKey = `agent:${agentId}:direct:${session.user.id!}`;
+
+  // Throttle repeated compactions of the same session. The UI debounces via a
+  // disabled button; this guards direct API spamming from fanning out
+  // sessions.compact RPCs (compacting again seconds later is a no-op anyway).
+  if (!allowCompaction(sessionKey)) {
+    return NextResponse.json(
+      {
+        error: "You just compacted this conversation — please wait a moment before doing it again.",
+      },
+      { status: 429 }
+    );
+  }
 
   try {
     const client = getOpenClawClient();

--- a/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
@@ -1,0 +1,51 @@
+// audit-exempt: session compaction is non-destructive housekeeping — OpenClaw
+// summarizes the in-context transcript while the full session JSONL is retained
+// on disk. No data is deleted, no permission or security state changes, so the
+// governance value of an audit row is low. (User-triggered, so a SOC2 "who
+// compacted when" attribution gap is accepted; trivially upgradable to a
+// chat.session_compacted event later if needed.) Sanctioned in the Agent
+// Memory System design review.
+import { NextResponse } from "next/server";
+import { withAuth } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
+import { parseRequestBody } from "@/lib/api-validation";
+import { getOpenClawClient } from "@/server/openclaw-client";
+import { compactSessionSchema } from "@/lib/schemas/sessions";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
+
+/**
+ * Manually compact the caller's chat session with this agent. Lets a user
+ * shrink a long-running conversation's context (which degrades model quality
+ * as it grows) without losing the on-disk transcript. Compaction takes effect
+ * on the next turn; we deliberately do NOT force a history reload so the user's
+ * visible messages don't vanish from under them.
+ */
+export const POST = withAuth<RouteContext>(async (request, { params }, session) => {
+  const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+
+  const parsed = await parseRequestBody(compactSessionSchema, request);
+  if ("error" in parsed) return parsed.error;
+
+  // Per-user session scoping, identical to ClientRouter.computeSessionKey:
+  // agent:<agentId>:direct:<userId>. OpenClaw validates that the agentId in the
+  // key matches the agentId argument — see MEMORY.md "OpenClaw Sessions API".
+  const sessionKey = `agent:${agentId}:direct:${session.user.id!}`;
+
+  try {
+    const client = getOpenClawClient();
+    await client.sessions.compact(
+      sessionKey,
+      parsed.data.maxLines !== undefined ? { maxLines: parsed.data.maxLines } : undefined
+    );
+  } catch {
+    // OpenClaw unreachable / mid-reconnect. 502 (not 500) so the client can
+    // surface a retryable "couldn't compact" toast rather than a hard error.
+    return NextResponse.json({ error: "Failed to compact session" }, { status: 502 });
+  }
+
+  return NextResponse.json({ ok: true });
+});

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -10,6 +10,7 @@ import { getAgentAvatarSvg } from "@/lib/avatar";
 import Link from "next/link";
 import { Settings } from "lucide-react";
 import { MobileChatHeader } from "@/components/mobile-chat-header";
+import { SessionActionsMenu } from "@/components/session-actions-menu";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type ChatStatus, useChatStatus } from "@/hooks/use-chat-status";
@@ -222,6 +223,7 @@ export function Chat({
                       </TooltipProvider>
                     </div>
                     <div className="flex items-center gap-3">
+                      <SessionActionsMenu agentId={agentId} />
                       {canEdit && (
                         <Link
                           href={`/chat/${agentId}/settings`}

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -223,7 +223,7 @@ export function Chat({
                       </TooltipProvider>
                     </div>
                     <div className="flex items-center gap-3">
-                      <SessionActionsMenu agentId={agentId} />
+                      {hasInitialContent && <SessionActionsMenu agentId={agentId} />}
                       {canEdit && (
                         <Link
                           href={`/chat/${agentId}/settings`}

--- a/packages/web/src/components/session-actions-menu.tsx
+++ b/packages/web/src/components/session-actions-menu.tsx
@@ -1,0 +1,63 @@
+"use client";
+
+import { useState } from "react";
+import { MoreHorizontal } from "lucide-react";
+import { toast } from "sonner";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { apiPost, ApiError } from "@/lib/api-client";
+import type { CompactSessionRequest } from "@/lib/schemas/sessions";
+
+/**
+ * Overflow menu in the chat header for actions on the current conversation.
+ * Today it holds a single action — "Compact conversation" — which asks
+ * OpenClaw to summarize the in-context transcript so a long chat stops
+ * degrading model quality. Compaction takes effect on the next message and we
+ * deliberately do NOT reload history, so the user's visible messages don't
+ * vanish from under them.
+ */
+export function SessionActionsMenu({ agentId }: { agentId: string }) {
+  const [isCompacting, setIsCompacting] = useState(false);
+
+  async function handleCompact() {
+    setIsCompacting(true);
+    try {
+      await apiPost<{ ok: boolean }, CompactSessionRequest>(
+        `/api/agents/${agentId}/sessions/compact`,
+        {}
+      );
+      toast.success("Conversation compacted. It takes effect on your next message.");
+    } catch (e) {
+      toast.error(
+        e instanceof ApiError ? e.message : "Couldn't compact the conversation. Please try again."
+      );
+    } finally {
+      setIsCompacting(false);
+    }
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button
+          variant="ghost"
+          size="icon"
+          aria-label="Conversation actions"
+          className="text-muted-foreground hover:text-foreground size-7"
+        >
+          <MoreHorizontal className="size-5" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="end">
+        <DropdownMenuItem onSelect={handleCompact} disabled={isCompacting}>
+          Compact conversation
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/web/src/lib/compact-throttle.ts
+++ b/packages/web/src/lib/compact-throttle.ts
@@ -1,0 +1,29 @@
+// Per-session-key throttle for manual conversation compaction.
+//
+// Compaction summarizes a session's in-context transcript — doing it again
+// seconds later is wasteful (nothing has changed) and, abused via direct API
+// calls, would fan out `sessions.compact` RPCs to OpenClaw. The chat UI already
+// debounces (the menu item disables while a request is in flight); this is the
+// server-side guard for non-UI callers.
+//
+// In-memory + per-instance — defense-in-depth, not a distributed guarantee.
+// State resets on server restart, which is fine for a throttle.
+
+const lastCompactAt = new Map<string, number>();
+
+/** Minimum gap between compactions of the same session. */
+export const COMPACT_MIN_INTERVAL_MS = 10_000;
+
+/**
+ * Returns true and records the timestamp if a compaction of `sessionKey` is
+ * allowed now; returns false if one was already recorded within
+ * `COMPACT_MIN_INTERVAL_MS`. The clock is injectable for deterministic tests.
+ */
+export function allowCompaction(sessionKey: string, nowMs: number = Date.now()): boolean {
+  const last = lastCompactAt.get(sessionKey);
+  if (last !== undefined && nowMs - last < COMPACT_MIN_INTERVAL_MS) {
+    return false;
+  }
+  lastCompactAt.set(sessionKey, nowMs);
+  return true;
+}

--- a/packages/web/src/lib/memory-audit-watcher/bootstrap.ts
+++ b/packages/web/src/lib/memory-audit-watcher/bootstrap.ts
@@ -3,6 +3,7 @@ import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
+import { getWorkspaceBasePath } from "@/lib/workspace";
 import { startMemoryAuditWatcher } from "./watcher";
 
 /**
@@ -15,7 +16,12 @@ import { startMemoryAuditWatcher } from "./watcher";
 export async function bootstrapMemoryAuditWatcher(opts: {
   root?: string;
 }): Promise<() => Promise<void>> {
-  const root = opts.root ?? process.env.OPENCLAW_DATA_PATH ?? "/openclaw-config";
+  // Watch the workspace base (`<base>/<agentId>/MEMORY.md`), NOT the OpenClaw
+  // config root. Derived from workspace.ts so the watch root stays in lockstep
+  // with where agent files are actually written — see #345 (the old
+  // `OPENCLAW_DATA_PATH` + hardcoded `agents/` join watched a tree that never
+  // existed, so the watcher was dead code).
+  const root = opts.root ?? getWorkspaceBasePath();
 
   const lookupAgent = async (agentId: string) => {
     const rows = await db

--- a/packages/web/src/lib/memory-audit-watcher/parse-path.ts
+++ b/packages/web/src/lib/memory-audit-watcher/parse-path.ts
@@ -8,12 +8,16 @@ export function parseAgentMemoryPath(root: string, absolutePath: string): Parsed
   const rel = path.relative(normalizedRoot, normalizedPath);
   if (rel.startsWith("..") || path.isAbsolute(rel)) return null;
 
+  // Layout: `<root>/<agentId>/MEMORY.md` and `<root>/<agentId>/memory/**/*.md`.
+  // The watch root IS the workspace base (see workspace.ts), so the agentId is
+  // the first segment under the root — there is no `agents/` prefix. Hardcoding
+  // `agents/` here is exactly the #345 drift that made the watcher dead code;
+  // the round-trip in watcher-path-drift.test.ts pins this to workspace.ts.
   const parts = rel.split(path.sep);
-  if (parts.length < 3) return null;
-  if (parts[0] !== "agents") return null;
+  if (parts.length < 2) return null;
 
-  const agentId = parts[1];
-  const rest = parts.slice(2);
+  const agentId = parts[0];
+  const rest = parts.slice(1);
 
   if (rest.length === 1 && rest[0] === "MEMORY.md") {
     return { agentId, file: "MEMORY.md" };

--- a/packages/web/src/lib/memory-audit-watcher/watcher.ts
+++ b/packages/web/src/lib/memory-audit-watcher/watcher.ts
@@ -1,6 +1,5 @@
 import chokidar from "chokidar";
 import { readFile } from "node:fs/promises";
-import path from "node:path";
 import type { Stats } from "node:fs";
 import type { AuditLogEntry } from "@/lib/audit";
 import { handleMemoryFileEvent } from "./handle-event";
@@ -29,10 +28,14 @@ export type MemoryAuditWatcherDeps = {
 };
 
 /**
- * Watches `<root>/agents/*\/MEMORY.md` and `<root>/agents/*\/memory/**\/*.md`
- * and routes filesystem events into `handleMemoryFileEvent`.
+ * Watches `<root>/*\/MEMORY.md` and `<root>/*\/memory/**\/*.md` and routes
+ * filesystem events into `handleMemoryFileEvent`. `root` is the workspace base
+ * (`getWorkspaceBasePath()`), so each immediate child directory is an agent
+ * workspace — there is no `agents/` prefix (that mismatch was the #345
+ * dead-code bug). The bootstrap derives `root` from workspace.ts so this stays
+ * in lockstep with where agent files actually live.
  *
- * Chokidar 5 dropped glob support, so we watch the parent `agents/` directory
+ * Chokidar 5 dropped glob support, so we watch the workspace base directory
  * recursively and use an `ignored` matcher backed by `parseAgentMemoryPath`
  * to filter to memory files only. This keeps the path-shape rules in a single
  * tested module.
@@ -48,9 +51,7 @@ export async function startMemoryAuditWatcher(
   // crawl and steady-state events.
   let readyState: "scanning" | "ready" = "scanning";
 
-  const agentsRoot = path.join(deps.root, "agents");
-
-  const watcher = chokidar.watch(agentsRoot, {
+  const watcher = chokidar.watch(deps.root, {
     ignoreInitial: false,
     persistent: true,
     // Polling rather than fs.watch / fsevents. The watch root is typically a

--- a/packages/web/src/lib/memory-prompt.ts
+++ b/packages/web/src/lib/memory-prompt.ts
@@ -1,0 +1,35 @@
+/**
+ * Builds the `## Memory` capability block injected into an agent's
+ * `extraSystemPrompt`.
+ *
+ * Why this lives in the system prompt and NOT in AGENTS.md / SOUL.md:
+ * persisting memory is a PLATFORM capability every write-capable agent has,
+ * not agent-specific behavior a user authored. AGENTS.md is user-editable;
+ * baking a core capability there would let a user silently delete it and
+ * would drift per-agent. extraSystemPrompt is rebuilt by OpenClaw every turn,
+ * so the hint is always present and always current.
+ *
+ * Gated on `pinchy_write`: an agent with no write path literally cannot
+ * persist memory (group:fs is denied; pinchy_write is the only writer — see
+ * build.ts). Telling such an agent it has memory would reproduce the
+ * hallucination this whole change fixes (#368), just from the other side.
+ */
+export function buildMemoryPromptBlock(allowedTools: string[]): string | null {
+  if (!allowedTools.includes("pinchy_write")) return null;
+
+  return [
+    "## Memory",
+    "You have persistent memory that survives across conversations:",
+    "- **Long-term** — `MEMORY.md` holds curated, durable knowledge worth keeping.",
+    "- **Daily notes** — append raw observations to `memory/YYYY-MM-DD.md`.",
+    "",
+    "Write to these with your `pinchy_write` tool. Your memory is indexed " +
+      "automatically — recall it later with `memory_search` and `memory_get`. " +
+      "When the user asks you to remember something, actually write it; don't " +
+      "just say you will.",
+    "",
+    "Your identity and instructions (`SOUL.md`, `AGENTS.md`) are " +
+      "platform-managed and not writable — don't try to change who you are by " +
+      "editing them; use your memory instead.",
+  ].join("\n");
+}

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -459,10 +459,33 @@ export async function regenerateOpenClawConfig() {
 
     const agentFilesConfig: Record<string, unknown> = { allowed_paths: allowedPaths };
     if (allowedTools.includes("pinchy_write")) {
+      // Persistent agent memory (OpenClaw-managed): MEMORY.md holds curated
+      // long-term knowledge, memory/ holds daily logs. A write-capable agent
+      // gets them so it can actually persist what the user tells it to
+      // remember — without a write path it sees memory_search but can never
+      // write, which led agents to hallucinate saved memories (#368).
+      //
+      // MEMORY.md is granted as a FILE, not the workspace root: the
+      // trailing-slash boundary in pinchy-files validate.ts makes the entry
+      // match exactly that file and NOT its siblings (SOUL.md, AGENTS.md,
+      // IDENTITY.md, USER.md), so the agent can rewrite its memory but never
+      // its identity or instructions. memory/ is a directory entry (subtree).
+      const workspaceMemoryFile = `${getOpenClawWorkspacePath(agent.id)}/MEMORY.md`;
+      const workspaceMemoryDir = `${getOpenClawWorkspacePath(agent.id)}/memory`;
+
+      // Both lists: write_paths ⊆ allowed_paths is enforced build-time
+      // (validate-built-config.ts) and runtime (pinchy-files validate.ts).
+      agentFilesConfig.allowed_paths = [...allowedPaths, workspaceMemoryFile, workspaceMemoryDir];
+
       // uploads/ stays writable for backward-compat with existing custom
       // AGENTS.md that told the agent to write there. New guidance points
       // agents at workbench/.
-      agentFilesConfig.write_paths = [workspaceUploads, workspaceWorkbench];
+      agentFilesConfig.write_paths = [
+        workspaceUploads,
+        workspaceWorkbench,
+        workspaceMemoryFile,
+        workspaceMemoryDir,
+      ];
     }
     pluginConfigs["pinchy-files"][agent.id] = agentFilesConfig;
 

--- a/packages/web/src/lib/schemas/sessions.ts
+++ b/packages/web/src/lib/schemas/sessions.ts
@@ -1,0 +1,14 @@
+import { z } from "zod";
+
+/**
+ * Body for `POST /api/agents/[agentId]/sessions/compact`.
+ *
+ * `maxLines` is optional — when omitted, OpenClaw uses its own default
+ * compaction threshold. Shared between the route handler (parseRequestBody)
+ * and the client component (typed request body via z.infer).
+ */
+export const compactSessionSchema = z.object({
+  maxLines: z.number().int().positive().max(100_000).optional(),
+});
+
+export type CompactSessionRequest = z.infer<typeof compactSessionSchema>;

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -1,13 +1,58 @@
 import { writeFileSync, readFileSync, existsSync, mkdirSync, rmSync } from "fs";
 import { join } from "path";
 
+// =============================================================================
+// Agent on-disk layout — READ THIS before touching any code that resolves an
+// agent's filesystem path (watchers, plugins, backup tooling, memory code).
+// =============================================================================
+//
+// A Pinchy agent's files live under `workspaces/<agentId>/`, NOT under the
+// OpenClaw-native `agents/<name>/` tree. This is deliberate and has bitten us
+// before (see issue #345: the memory-audit watcher hardcoded `agents/<id>/`
+// and silently watched the wrong subtree, so it never fired for real agents).
+//
+// Why `workspaces/<agentId>/`:
+//
+//   1. Separate Docker volume, separate lifecycle. The `pinchy-workspaces`
+//      volume is mounted INTO the OpenClaw config tree at the `workspaces/`
+//      subpath. Agent-owned content (SOUL.md, AGENTS.md, uploads/, workbench/,
+//      MEMORY.md, memory/) can be backed up, migrated, or sized independently
+//      of OpenClaw's core config (openclaw.json, secrets.json, sessions/, the
+//      memory SQLite index). You can reset workspaces without touching the
+//      OpenClaw trust root.
+//
+//   2. The SAME volume has two mount points, so paths differ per container:
+//        - Pinchy container:   /openclaw-config/workspaces/<agentId>   (WORKSPACE_BASE_PATH)
+//        - OpenClaw container:  /root/.openclaw/workspaces/<agentId>   (OPENCLAW_WORKSPACE_PREFIX)
+//      `getWorkspacePath()` returns the Pinchy-side path (for code that reads/
+//      writes files directly). `getOpenClawWorkspacePath()` returns the path we
+//      write into openclaw.json's `agents[].workspace` field (what OpenClaw
+//      itself sees). They point at the same bytes via the shared volume.
+//
+//   3. Namespacing away from OpenClaw-native agents. OpenClaw's own CLI
+//      onboarding creates agents under `agents/<name>/`. Pinchy agents are
+//      UUID-keyed and live under `workspaces/<uuid>/` so they never collide
+//      with or get confused for OpenClaw-native agents.
+//
+// OpenClaw resolves an agent's MEMORY.md and memory/ files RELATIVE TO the
+// `workspace` field — i.e. `workspaces/<agentId>/MEMORY.md`, NOT
+// `agents/<agentId>/MEMORY.md`. Any code that needs an agent's on-disk
+// location MUST derive it from `getWorkspacePath()` / `getOpenClawWorkspacePath()`.
+// Never hardcode `agents/` or `workspaces/` elsewhere — that is exactly the
+// drift that produced the dead-code watcher in #345.
+// =============================================================================
+
 export const ALLOWED_FILES = ["SOUL.md", "AGENTS.md"] as const;
 export type WorkspaceFile = (typeof ALLOWED_FILES)[number];
 
 const DEFAULT_WORKSPACE_BASE_PATH = "/openclaw-config/workspaces";
 const DEFAULT_OPENCLAW_WORKSPACE_PREFIX = "/root/.openclaw/workspaces";
 
-function getWorkspaceBasePath(): string {
+// Exported so the memory-audit watcher derives its watch root from the SAME
+// source build.ts / ensureWorkspace use for agent file paths — see the layout
+// note above and the #345 drift guard in
+// __tests__/lib/memory-audit-watcher/watcher-path-drift.test.ts.
+export function getWorkspaceBasePath(): string {
   return process.env.WORKSPACE_BASE_PATH || DEFAULT_WORKSPACE_BASE_PATH;
 }
 
@@ -33,6 +78,11 @@ export function getWorkspacePath(agentId: string): string {
   return join(getWorkspaceBasePath(), agentId);
 }
 
+// Canonical OpenClaw-side path resolver — the path OpenClaw itself sees and
+// the value written into openclaw.json's `agents[].workspace`. OpenClaw
+// resolves MEMORY.md / memory/ relative to this. See the top-of-file layout
+// note: anything that watches or derives agent memory paths MUST use this,
+// never a hardcoded `agents/` prefix.
 export function getOpenClawWorkspacePath(agentId: string): string {
   assertValidAgentId(agentId);
   const prefix = process.env.OPENCLAW_WORKSPACE_PREFIX || DEFAULT_OPENCLAW_WORKSPACE_PREFIX;

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -1,145 +1,152 @@
 // packages/web/src/server/chat-dispatch-retry.ts
 //
-// Defensive workaround for an OpenClaw 2026.5.x race between `config.get`
-// and the `agent` RPC dispatch handler: after a `config.apply` that adds an
-// agent to `agents.list`, `config.get` immediately reports the agent as
-// present (i.e. `agentDispatchable=true` via our health endpoint), but the
-// `agent` RPC handler can still reject the same agent id with
-// `errorCode=INVALID_REQUEST errorMessage="invalid agent params: unknown
-// agent id <uuid>"`.
+// Defensive wrapper for the window after a fresh-install setup (or any
+// config-reload / gateway restart) where Pinchy has created an agent and
+// confirmed it via `config.get`, but OpenClaw's `agent` RPC dispatch handler
+// still rejects the id with `errorCode=INVALID_REQUEST errorMessage="invalid
+// agent params: unknown agent id <uuid>"`.
 //
-// Observed on PR #442 CI runs 26505503327, 26511658136 and others — the
-// failing chat dispatch happens 1–2 s after `waitForAgentDispatchable`
-// returned true, and the `agent` RPC fails in ~25 ms (OC's internal
-// rejection, not an upstream provider error). E2E tests added an
-// `waitForAgentDispatchable` gate before each dispatch (close PR #442
-// commit ec9eb0027), but it polls `config.get` which is exactly the path
-// that disagrees with the dispatch handler, so the gate doesn't fully
-// close the race.
+// Why a BOUNDED RETRY LOOP rather than a single shot:
 //
-// Industry practice for stream-truncation / transient-handler errors is
-// single auto-retry with a short delay (see issue #355 § "industry
-// best-practices summary"): OpenAI/Anthropic/Vercel SDKs all retry on
-// 5xx and stream-protocol errors. "unknown agent id" sits in the
-// 400-class normally — for a genuine bad id we do NOT want to retry,
-// because that masks real bugs. The race here is specifically the
-// 5xx-shaped variant where Pinchy KNOWS the agent exists (it just
-// created it and confirmed via `config.get`), so the single retry is
-// safe within this narrow window.
+// `config.get` reads the config FILE; the dispatch handler checks the APPLIED
+// runtime `agents.list`. The two diverge until OC finishes applying the
+// reload. Normally that lag is 1–2 s. But on a fresh install the lag balloons:
+// the cold-start regeneration storm (firstConnect seed + provider save +
+// agent-model update) plus OC 5.3's `config.apply` rate-limit (~3 calls per
+// 45 s) plus the secrets-bootstrap gateway pkill (config/start-openclaw.sh,
+// ~40 s respawn) push the real `agents.list` apply out by up to ~90–120 s.
+// Observed directly on PR #448 CI: the first chat dispatched at 13:22:04 hit
+// "unknown agent id" and the agent only became dispatchable at 13:23:58 —
+// a 114 s gap that a single 500 ms retry could never bridge, surfacing
+// "Smithers couldn't respond" on a brand-new user's first message.
 //
-// Implementation: async-generator wrapper around `openclawClient.chat`.
-// On the FIRST yielded chunk:
-//   - If it's an `error` chunk matching the "unknown agent id" pattern
-//     AND we haven't retried yet, swallow it, wait `retryDelayMs`, then
-//     restart the chat stream.
-//   - Otherwise, yield it through and pipe the rest of the stream
-//     unchanged. Errors arriving AFTER the first chunk are pass-through
-//     too — they're not the dispatch race, they're real downstream
-//     failures the caller's existing error path must surface.
+// `config.get`-based readiness gates (waitForAgentInRuntime, the
+// `agentDispatchable` health probe) CANNOT close this race: they poll the same
+// file-vs-runtime-divergent path. The only reliable readiness signal is a
+// dispatch that actually succeeds — so we retry the real dispatch with
+// exponential backoff until it lands or a wall-clock budget elapses.
 //
-// The retry is bounded to ONE attempt and only fires for this specific
-// error string, so it can't mask other failure shapes or run away.
+// Safety: this ONLY retries the literal `unknown agent id` shape, and ONLY
+// when it is the FIRST chunk. For an agent Pinchy just created and confirmed,
+// that error is ALWAYS the transient apply-lag — a genuinely bad id would be a
+// Pinchy bug (Pinchy owns the id), and after the budget we surface the error
+// rather than loop forever. Errors after the first chunk, and any other error
+// shape, pass straight through to the caller's existing error path. So the
+// loop cannot mask provider failures, schema rejections, or stream truncation.
 
 import type { ChatChunk, ChatOptions } from "openclaw-node";
 
 /**
  * Pattern matching OpenClaw 2026.5.x's dispatch-race error. Anchored on
- * `unknown agent id` (the OC-internal phrase) rather than a generic
- * substring so a future provider error mentioning the words "agent" and
- * "unknown" in unrelated context cannot hijack the retry branch.
- *
- * Matches the literal `unknown agent id "<uuid>"` shape; case-insensitive
- * to defend against an upstream message-casing tweak.
+ * `unknown agent id` (the OC-internal phrase) rather than a generic substring
+ * so a future provider error mentioning the words "agent" and "unknown" in
+ * unrelated context cannot hijack the retry branch. Case-insensitive to defend
+ * against an upstream message-casing tweak.
  */
 export const DISPATCH_RACE_PATTERN = /unknown agent id/i;
 
-/**
- * Default delay before retrying. Picked at 500 ms because:
- *   - OC's failing `agent` RPC returns in ~25 ms (it's a synchronous
- *     internal-state check, not a network round-trip), so a tight retry
- *     wouldn't see new state.
- *   - The race window observed in CI is 1–2 s wide between
- *     `waitForAgentDispatchable` returning true and dispatch rejection.
- *     500 ms covers most cases; if the dispatch handler is still stale
- *     after another 500 ms, the second attempt's error gets surfaced
- *     (the test will fail loudly rather than retrying forever).
- *   - Industry guides (#355) recommend 1 s as the first retry delay
- *     with exponential backoff; 500 ms is the lower end of that range
- *     and acceptable for a single-shot retry without backoff.
- */
-export const DEFAULT_DISPATCH_RETRY_DELAY_MS = 500;
+/** Backoff/budget policy for the dispatch-race retry loop. */
+export interface DispatchRetryPolicy {
+  /** Delay before the first retry; doubles each attempt. Default 500 ms. */
+  baseDelayMs?: number;
+  /** Upper bound on a single backoff delay (caps the exponential). Default 5 s. */
+  maxDelayMs?: number;
+  /**
+   * Total wall-clock budget for retrying. Once exceeded, the last race error is
+   * yielded so the caller surfaces it. Default 90 s — comfortably covers one
+   * gateway restart + a `config.apply` rate-limit window; bounded so a
+   * genuinely-unknown agent can't hang the chat forever.
+   */
+  maxTotalMs?: number;
+}
+
+const DEFAULT_POLICY: Required<DispatchRetryPolicy> = {
+  baseDelayMs: 500,
+  maxDelayMs: 5000,
+  maxTotalMs: 90000,
+};
 
 export interface DispatchRetryDeps {
   chat: (message: string, options?: ChatOptions) => AsyncGenerator<ChatChunk>;
-  /**
-   * Sleep helper, injectable so tests don't have to wait real time.
-   */
+  /** Sleep helper, injectable so tests don't wait real time. */
   delay?: (ms: number) => Promise<void>;
+  /** Clock, injectable so tests drive the wall-clock budget deterministically. */
+  now?: () => number;
   /**
-   * Audit callback invoked when the first attempt failed with the
-   * dispatch-race pattern. The audit is the diagnostic signal we use
-   * to measure how often this race fires in production; without it the
-   * retry would be invisible.
+   * Invoked once per observed dispatch-race failure (each retry). The audit
+   * this drives is how we measure the race in production; without it the retry
+   * loop would be invisible.
    */
   onDispatchRaceObserved?: (info: { providerError: string; attempt: number }) => void;
 }
 
 /**
- * Wraps `openclawClient.chat()` with single-shot retry on the
+ * Wraps `openclawClient.chat()` with a bounded exponential-backoff retry on the
  * `unknown agent id` dispatch-race error.
  *
  * Contract:
- *   - Yields ALL chunks from the FIRST successful attempt (where
- *     "successful" means the first chunk is NOT an unknown-agent-id error).
- *   - On the first chunk being an unknown-agent-id error, swallows it,
- *     waits `retryDelayMs`, and restarts the chat. Yields all chunks
- *     from the retry attempt verbatim, including any errors.
- *   - Only retries ONCE; a second dispatch-race error is forwarded as
- *     a real failure (the assumption is that if 500 ms didn't settle
- *     OC's internal state, something is genuinely wrong).
- *   - Never retries on errors arriving AFTER the first chunk — those
- *     are real downstream failures (provider 5xx, schema rejection,
- *     etc.) that the caller's existing error path must handle.
+ *   - Yields ALL chunks from the first attempt whose first chunk is NOT an
+ *     unknown-agent-id error.
+ *   - While the first chunk IS an unknown-agent-id error, swallows it, waits a
+ *     backoff delay (exponential, capped at `maxDelayMs`), and restarts the
+ *     chat — repeating until success or the `maxTotalMs` budget is exhausted.
+ *   - On budget exhaustion, yields the final race error so the caller surfaces
+ *     it (never loops forever).
+ *   - Never retries on errors arriving AFTER the first chunk, or on any error
+ *     not matching the dispatch-race pattern — those are real downstream
+ *     failures the caller's error path must handle.
  */
 export async function* chatWithDispatchRaceRetry(
   message: string,
   options: ChatOptions | undefined,
   deps: DispatchRetryDeps,
-  retryDelayMs: number = DEFAULT_DISPATCH_RETRY_DELAY_MS
+  policy: DispatchRetryPolicy = {}
 ): AsyncGenerator<ChatChunk> {
+  const { baseDelayMs, maxDelayMs, maxTotalMs } = { ...DEFAULT_POLICY, ...policy };
   const delay = deps.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? Date.now;
 
-  for (let attempt = 0; attempt <= 1; attempt++) {
+  const start = now();
+  for (let attempt = 0; ; attempt++) {
     const stream = deps.chat(message, options);
     let isFirstChunk = true;
-    let didRetry = false;
+    let raceError: ChatChunk | null = null;
 
     for await (const chunk of stream) {
-      if (
-        isFirstChunk &&
-        attempt === 0 &&
-        chunk.type === "error" &&
-        DISPATCH_RACE_PATTERN.test(chunk.text)
-      ) {
-        // Dispatch-race detected. Don't yield this chunk; the audit
-        // callback records the observation for measurement and the
-        // outer loop retries after the delay.
-        if (deps.onDispatchRaceObserved) {
-          deps.onDispatchRaceObserved({ providerError: chunk.text, attempt });
-        }
-        didRetry = true;
+      if (isFirstChunk && chunk.type === "error" && DISPATCH_RACE_PATTERN.test(chunk.text)) {
+        // Dispatch-race detected on the first chunk. Don't yield it; record the
+        // observation and let the loop decide whether to retry or give up.
+        raceError = chunk;
         break;
       }
       isFirstChunk = false;
       yield chunk;
     }
 
-    if (!didRetry) {
-      // Either the first attempt produced a non-race chunk (yielded
-      // through), or the second attempt completed (success or not).
-      // Either way, we're done.
+    if (!raceError) {
+      // First attempt produced a non-race chunk (yielded through), or a retry
+      // attempt completed. Either way we're done.
       return;
     }
-    await delay(retryDelayMs);
+
+    // Audit ONCE per raced dispatch (on the first observation), not once per
+    // retry — a long storm can take ~15 attempts and we don't want 15 audit
+    // rows skewing the per-class dashboards (#355).
+    if (attempt === 0) {
+      deps.onDispatchRaceObserved?.({ providerError: raceError.text, attempt });
+    }
+
+    const elapsed = now() - start;
+    const remaining = maxTotalMs - elapsed;
+    if (remaining <= 0) {
+      // Budget exhausted — surface the error rather than retry forever.
+      yield raceError;
+      return;
+    }
+
+    // Exponential backoff capped at maxDelayMs, and never sleeping past the
+    // remaining budget.
+    const backoff = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
+    await delay(Math.min(backoff, remaining));
   }
 }

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -33,6 +33,11 @@
 // rather than loop forever. Errors after the first chunk, and any other error
 // shape, pass straight through to the caller's existing error path. So the
 // loop cannot mask provider failures, schema rejections, or stream truncation.
+//
+// No orphaned OC runs: a retried attempt failed because OC REJECTED the
+// dispatch ("unknown agent id", ~25 ms, before any run is created), so there is
+// no server-side run to leak. Breaking the `for await` on the rejection also
+// returns the underlying chat generator, releasing its request.
 
 import type { ChatChunk, ChatOptions } from "openclaw-node";
 

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -4,6 +4,7 @@ import type { WebSocket } from "ws";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { isEnterprise } from "@/lib/enterprise";
+import { buildMemoryPromptBlock } from "@/lib/memory-prompt";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { ActiveRuns } from "@/server/active-runs";
@@ -218,8 +219,17 @@ export class ClientRouter {
         chatOptions.clientMessageId = message.clientMessageId;
       }
 
-      // Build extraSystemPrompt from user name + context + greeting
+      // Build extraSystemPrompt from memory capability + user name + context +
+      // greeting. The memory block goes first: it's a stable platform
+      // capability, not per-turn context. We inject it here (not AGENTS.md)
+      // because it's a capability every write-capable agent has and must not
+      // be user-editable — see memory-prompt.ts.
       const extraPromptParts: string[] = [];
+      const allowedTools = (agent.allowedTools as string[] | null) ?? [];
+      const memoryBlock = buildMemoryPromptBlock(allowedTools);
+      if (memoryBlock) {
+        extraPromptParts.push(memoryBlock);
+      }
       const user = await db.query.users.findFirst({
         where: eq(users.id, this.userId),
       });

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -343,9 +343,29 @@ export class ClientRouter {
       // rest of `pipeStream`. See `chat-dispatch-retry.ts` for the full
       // rationale (and PR #442 CI runs 26505503327 / 26511658136 for the
       // observed failure mode that motivated this).
+      // Keep-alive for the resilient dispatch-race retry. Started ONLY when a
+      // dispatch-race is actually observed (see onDispatchRaceObserved below) —
+      // a known transient apply-lag, NOT a generic hang — so the deliberate
+      // "no heartbeats before first chunk" contract (let the client stuck-timer
+      // surface real OC hangs) is preserved for the hang case.
+      let dispatchRaceKeepAlive: ReturnType<typeof setInterval> | null = null;
+
       const stream = chatWithDispatchRaceRetry(text, chatOptions as ChatOptions, {
         chat: (m, o) => this.openclawClient.chat(m, o),
         onDispatchRaceObserved: async ({ providerError }) => {
+          // The resilient retry (chat-dispatch-retry.ts) can stay silent for up
+          // to ~90 s while OpenClaw applies the agent into its runtime. The
+          // browser's stuck-timer (STUCK_TIMEOUT_MS, use-ws-runtime.ts) fires
+          // after 60 s of silence and falsely times the run out — so once we
+          // KNOW we're in a dispatch-race, re-emit `thinking` every 20 s to keep
+          // the UI waiting through the OC restart. The first real chunk also
+          // resets that timer, making this redundant-but-harmless once the
+          // reply streams. Cleared in the finally below.
+          if (!dispatchRaceKeepAlive) {
+            dispatchRaceKeepAlive = setInterval(() => {
+              this.sendToClient(clientWs, { type: "thinking", messageId });
+            }, 20000);
+          }
           // Audit the transient observation so we can measure how often
           // the dispatch race fires in production without relying on
           // anecdotal log-grep. Using `chat.agent_error` with the
@@ -372,7 +392,11 @@ export class ClientRouter {
         messageId,
       });
 
-      await this.pipeStream(clientWs, stream, agent, sessionKey, messageId);
+      try {
+        await this.pipeStream(clientWs, stream, agent, sessionKey, messageId);
+      } finally {
+        if (dispatchRaceKeepAlive) clearInterval(dispatchRaceKeepAlive);
+      }
     } catch (err) {
       this.sendToClient(clientWs, {
         type: "error",


### PR DESCRIPTION
## Why

A production agent gave contradictory answers about whether it could write its own memory, then **hallucinated a memory write that never happened** — no `agent.memory_changed` ever landed in the audit trail. Root-cause investigation found Pinchy agents could not write memory **at all**:

- OpenClaw's `group:fs` (`write`/`edit`/`apply_patch`) is denied at config-generation time.
- `pinchy_write` was scoped to `uploads/` + `workbench/` only — never `MEMORY.md` or `memory/`.
- The read tools (`memory_search`/`memory_get`) were *not* denied, so the agent **saw** memory tools and assumed it could write — with no write path. Hence the hallucination.

Separately, the `memory-audit-watcher` shipped under #345 was **dead code**: it watched `<root>/agents/<id>/` while Pinchy agents live under `<workspaceBase>/<id>/`, so `agent.memory_changed` had never fired in production.

OpenClaw already provides the entire memory subsystem (workspace-relative `MEMORY.md` + dated `memory/` logs, SQLite/FTS indexing, `memory_search`/`memory_get`, `sessions.compact`). This PR does **not** reimplement any of it — it opens a narrow write path, tells the agent how to use it, surfaces compaction, and fixes the watcher.

## What changed

**Fix #1 — file-granular memory write path** (`build.ts`)
Agents with `pinchy_write` now get `<workspace>/MEMORY.md` (file) and `<workspace>/memory` (dir) in both `allowed_paths` and `write_paths`. MEMORY.md is granted as a **file**, so the trailing-slash boundary in pinchy-files `validate.ts` matches exactly that file and **never** its siblings — `SOUL.md`, `AGENTS.md`, `IDENTITY.md`, `USER.md` stay immutable. The agent can rewrite its memory but never its identity.

**Fix #2 — capability hint in the system prompt** (`client-router.ts` + `memory-prompt.ts`)
A `## Memory` block is injected into `extraSystemPrompt` for write-capable agents. It names `pinchy_write` as the write tool (the missing piece behind the hallucination), points at MEMORY.md + `memory/YYYY-MM-DD.md`, names `memory_search`/`memory_get` for recall, and clarifies SOUL.md/AGENTS.md are platform-managed. It lives in the system prompt — **not** AGENTS.md — because persisting memory is a platform capability, not user-editable agent behavior, and extraSystemPrompt is rebuilt every turn.

**Fix #3 — manual compaction** (`/api/agents/[agentId]/sessions/compact` + `SessionActionsMenu`)
Pinchy disables OpenClaw's daily session reset, so long chats accumulate context and model quality drifts. A "Compact conversation" item in the chat-header overflow menu calls `openclaw-node sessions.compact` (already in 0.11.0). 502 (not 500) on OpenClaw failure so the client toasts a retryable error; no forced history reload so visible messages don't vanish. The route is `audit-exempt` (non-destructive housekeeping — JSONL retained, no permission/security state change; sanctioned in design review).

**Fix #4 — repair the dead watcher** (`memory-audit-watcher/*`)
Single-sourced off `workspace.ts`: the watch root is now `getWorkspaceBasePath()` and the parser expects `<root>/<agentId>/MEMORY.md`. A drift guard round-trips `getWorkspacePath()` through `parseAgentMemoryPath(getWorkspaceBasePath(), …)` so the layout can't silently drift again. **The integration E2E previously wrote to the same dead `agents/` path** — it was green while production was broken; it now exercises the real `/openclaw-config/workspaces/<id>/MEMORY.md` (the `pinchy-workspaces` volume).

**Docs**
- `concepts/workspaces.mdx`: zones table now shows MEMORY.md + memory/ as agent-writable, separate from system-managed identity files.
- `explanation/instructions-vs-memory.mdx`: documents the new manual Compact action.
- `architecture.mdx` + `workspace.ts`: permanent note on the `workspaces/` Docker volume layout, so the path rationale that #345 missed is recorded.

## Test plan

All TDD (RED → GREEN, no weakened tests).

- [x] `pnpm -C packages/web test` — 5146 passed / 13 skipped
- [x] `pnpm -C packages/plugins/pinchy-files test` — 138 passed
- [x] `tsc --noEmit` — exit 0
- [x] New/updated: parse-path, watcher-path-drift, handle-event, watcher(-real-fs), openclaw-config (memory paths), pinchy-files validate (memory boundary), memory-prompt, client-router wiring, compact route, SessionActionsMenu, workspaces docs
- [x] Audit-log requirement guard passes (`audit-exempt` detected)

### Needs staging verification (cannot be checked locally)
- [ ] `sessions.compact` transcript-vs-context behavior against a live OpenClaw (we deliberately do not reload history).
- [ ] End-to-end: a real agent writes memory via `pinchy_write` → `agent.memory_changed` fires → appears in the audit trail. (The integration E2E CI job now covers the real path.)

## Issues
- Fixes #345 (dead memory-audit watcher)
- Addresses #368 (Instructions vs. Memory — agents can now actually persist memory)

## Out of scope / deferred
- #369 (shared-channel memory leak) — structural fix is per-(agent×user) OC agents; this plumbing stays valid under that model.
- "Start a new chat" feature (replaces the rejected "reset" concept) — no issue yet.
- Auditing user-triggered compaction — exempt for now, upgradable to `chat.session_compacted` later.