### PR TITLE
fix(composer): prevent IME dead-key freeze from assistant-ui 0.14 regression

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -26,6 +26,10 @@ WORKDIR /app
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY packages/web/package.json packages/web/
+# pnpm applies pnpm.patchedDependencies during install — the patch files must be
+# present in the build context before `pnpm install`, otherwise frozen install
+# fails with ENOENT on the .patch file.
+COPY patches/ ./patches/
 
 RUN pnpm install --frozen-lockfile
 

--- a/Dockerfile.pinchy.dev
+++ b/Dockerfile.pinchy.dev
@@ -9,6 +9,9 @@ WORKDIR /app
 
 COPY pnpm-workspace.yaml package.json pnpm-lock.yaml ./
 COPY packages/web/package.json packages/web/
+# pnpm applies pnpm.patchedDependencies during install — the patch files must be
+# present in the build context before `pnpm install` (see Dockerfile.pinchy).
+COPY patches/ ./patches/
 
 RUN pnpm install --frozen-lockfile
 

--- a/package.json
+++ b/package.json
@@ -58,7 +58,10 @@
     },
     "onlyBuiltDependencies": [
       "better-sqlite3"
-    ]
+    ],
+    "patchedDependencies": {
+      "@assistant-ui/react@0.14.11": "patches/@assistant-ui__react@0.14.11.patch"
+    }
   },
   "lint-staged": {
     "packages/web/src/**/*.{ts,tsx}": [

--- a/packages/web/src/components/assistant-ui/__tests__/composer-ime-composition.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/composer-ime-composition.test.tsx
@@ -146,4 +146,25 @@ describe("ComposerPrimitive.Input IME composition (dead-key freeze guard)", () =
 
     expect(composerApi!.getState().text).toBe("é");
   });
+
+  it("recovers when the browser drops compositionend (stale-ref path)", () => {
+    // The original upstream bug (#3923): some browsers/dead-key layouts fire
+    // compositionstart but never compositionend, then deliver the resolved
+    // input with isComposing=false. The patch keeps 0.14's stale-compositionRef
+    // recovery, so that trailing non-composing input still syncs the text — the
+    // input must NOT stay stuck after a dropped compositionend. This test pins
+    // that recovery path so a future change can't reintroduce #3923 while
+    // closing the freeze.
+    composerApi = null;
+    render(<Harness />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    // No compositionend — the resolved value arrives as a plain (non-composing)
+    // change while compositionRef is still set. fireEvent.change leaves
+    // nativeEvent.isComposing falsy, modelling exactly that dropped-end input.
+    fireEvent.change(textarea, { target: { value: "é" } });
+
+    expect(composerApi!.getState().text).toBe("é");
+  });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/composer-ime-composition.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/composer-ime-composition.test.tsx
@@ -1,0 +1,149 @@
+// Regression guard for the IME / dead-key composition freeze.
+//
+// Bug history: typing an accented character such as "é" via a dead-key
+// sequence (´ then e — two keystrokes, an IME composition) froze the chat
+// input. No further characters could be entered and deletion stopped working.
+//
+// Root cause: the composer textarea is a CONTROLLED input — its value comes
+// from the assistant-ui runtime (`composer.text`). The golden rule for a
+// controlled input is that its value must NOT be written back to the DOM via
+// state/re-render while an IME composition is active; doing so aborts the
+// browser's composition session and freezes the field. assistant-ui 0.14.x
+// regressed exactly here: `ComposerPrimitive.Input`'s onChange calls
+// `setText(value)` UNCONDITIONALLY before the `if (isComposing) return` guard,
+// so the runtime text — and therefore the controlled value — mutates mid
+// composition. 0.12.x returned before `setText` and was safe.
+//
+// Why earlier tests never caught it: the sibling `thread.test.tsx` mocks
+// `@assistant-ui/react` wholesale, replacing `ComposerPrimitive.Input` with a
+// bare <textarea>. A bare textarea has none of the broken onChange logic, so a
+// composition test there would exercise the mock, not the dependency. This
+// file deliberately does NOT mock assistant-ui: it renders the REAL primitive
+// against a REAL runtime so a regression in the dependency (a version bump, a
+// removed guard) shows up HERE. This pins the assistant-ui contract our
+// Composer relies on.
+//
+// Why this is a unit test and not an E2E: the actual freeze is an OS-IME <->
+// Blink composition desync — React writes the controlled value back during a
+// composition the OS still considers active. Headless browsers drive Blink's
+// composition directly (e.g. CDP Input.imeSetComposition), bypassing the OS
+// layer, so there is nothing to desync and the freeze does not reproduce. The
+// faithfully testable, deterministic invariant is the proximate one asserted
+// here: the runtime text (which backs the controlled value) must not change
+// while a composition is active. Asserting it against the REAL primitive is
+// exactly what the previous, deleted test failed to do — it mocked the
+// primitive away and so could never see a dependency regression.
+
+import { describe, it, expect } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { useEffect, type FC } from "react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  useComposerRuntime,
+  useExternalStoreRuntime,
+  type ThreadMessageLike,
+  type ComposerRuntime,
+} from "@assistant-ui/react";
+
+// Capture the live composer runtime so the test can read `composer.text`,
+// which is the state that drives the controlled textarea value. If this state
+// changes during an active composition, the controlled value gets written back
+// to the DOM mid-composition — that is the freeze.
+let composerApi: ComposerRuntime | null = null;
+const CaptureComposer: FC = () => {
+  const composer = useComposerRuntime();
+  // Assign in an effect, not during render — render must stay side-effect free.
+  // Testing Library flushes effects on render(), so composerApi is set by the
+  // time the test reads it.
+  useEffect(() => {
+    composerApi = composer;
+  }, [composer]);
+  return null;
+};
+
+const Harness: FC = () => {
+  const runtime = useExternalStoreRuntime({
+    messages: [] as ThreadMessageLike[],
+    isRunning: false,
+    convertMessage: (m: ThreadMessageLike) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <CaptureComposer />
+      <ComposerPrimitive.Input aria-label="Message input" />
+    </AssistantRuntimeProvider>
+  );
+};
+
+// Set the textarea value the way the browser does — through the NATIVE value
+// setter. React overrides the `value` property with a tracking setter, so a
+// direct `textarea.value = x` assignment updates React's tracker and makes
+// React believe nothing changed (it then skips onChange). Going through the
+// prototype setter bypasses the tracker, exactly as Testing Library's own
+// `fireEvent.change` does internally.
+function setNativeValue(textarea: HTMLTextAreaElement, value: string) {
+  const setter = Object.getOwnPropertyDescriptor(
+    window.HTMLTextAreaElement.prototype,
+    "value"
+  )!.set!;
+  setter.call(textarea, value);
+}
+
+// Dispatch a real `input` event carrying `isComposing === true` on its native
+// event. React maps onChange to the native input event and the primitive reads
+// `e.nativeEvent.isComposing`; a normal `fireEvent.change` leaves isComposing
+// falsy, which 0.14's stale-ref recovery treats as "composition finished" — so
+// we set it explicitly to model an in-flight composition faithfully. Verified
+// against React 19: this delivers onChange with isComposing=true.
+function fireComposingInput(textarea: HTMLTextAreaElement, value: string) {
+  setNativeValue(textarea, value);
+  const ev = new Event("input", { bubbles: true });
+  Object.defineProperty(ev, "isComposing", { value: true, configurable: true });
+  act(() => {
+    fireEvent(textarea, ev);
+  });
+}
+
+describe("ComposerPrimitive.Input IME composition (dead-key freeze guard)", () => {
+  it("does NOT mutate composer text while an IME composition is active", () => {
+    composerApi = null;
+    render(<Harness />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+    expect(composerApi).not.toBeNull();
+    // Precondition: the thread composer is editable, otherwise onChange no-ops
+    // and the test would pass for the wrong reason.
+    expect(composerApi!.getState().isEditing).toBe(true);
+
+    // Dead-key sequence begins: the browser starts composing "´".
+    fireEvent.compositionStart(textarea);
+    // The composition resolves toward "é" — an `input` with isComposing=true.
+    fireComposingInput(textarea, "é");
+
+    // THE INVARIANT: runtime text (which drives the controlled value) must stay
+    // empty during the composition. If it became "é" here, React would write
+    // the controlled value back into the textarea mid-composition and freeze
+    // the field. This is RED on assistant-ui 0.14.x (setText runs before the
+    // isComposing guard) and GREEN once the guard precedes setText.
+    expect(composerApi!.getState().text).toBe("");
+  });
+
+  it("syncs the composed character to the runtime once composition ends", () => {
+    composerApi = null;
+    render(<Harness />);
+    const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+
+    fireEvent.compositionStart(textarea);
+    fireComposingInput(textarea, "é");
+    // Composition commits — compositionend always syncs the final value, so the
+    // character is not lost. This proves the guard only DEFERS the sync, it
+    // does not drop input.
+    setNativeValue(textarea, "é");
+    act(() => {
+      fireEvent.compositionEnd(textarea);
+    });
+
+    expect(composerApi!.getState().text).toBe("é");
+  });
+});

--- a/patches/@assistant-ui__react@0.14.11.patch
+++ b/patches/@assistant-ui__react@0.14.11.patch
@@ -1,0 +1,28 @@
+diff --git a/dist/primitives/composer/ComposerInput.js b/dist/primitives/composer/ComposerInput.js
+index fbd17d750fcb580328131c4daccc451e5e70fb23..1efca2824357df82346027d5473f2ead5f3146ca 100644
+--- a/dist/primitives/composer/ComposerInput.js
++++ b/dist/primitives/composer/ComposerInput.js
+@@ -156,10 +156,22 @@ const ComposerPrimitiveInput = forwardRef(({ autoFocus = false, asChild, render,
+ 			const nativeIsComposing = e.nativeEvent.isComposing === true;
+ 			if (compositionRef.current && !nativeIsComposing) compositionRef.current = false;
+ 			const isComposing = nativeIsComposing || compositionRef.current;
++			// Pinchy patch: the isComposing guard MUST precede setText. The
++			// composer textarea is controlled (value = composer.text); calling
++			// setText during an active IME composition writes the controlled
++			// value back into the DOM mid-composition, which aborts the
++			// browser's composition session and freezes the input on dead-key
++			// entry (´+e -> é, etc.). Upstream 0.14.x calls setText first; this
++			// restores the safe 0.12.x ordering while keeping 0.14's stale-ref
++			// recovery (the line above) so dead keys that never emit
++			// compositionend still sync. Remove once fixed upstream; the
++			// regression is guarded by composer-ime-composition.test.tsx, which
++			// renders this real primitive and asserts text is not mutated mid
++			// composition.
++			if (isComposing) return;
+ 			flushResourcesSync(() => {
+ 				aui.composer().setText(e.target.value);
+ 			});
+-			if (isComposing) return;
+ 			const pos = e.target.selectionStart ?? e.target.value.length;
+ 			if (pluginRegistry) for (const plugin of pluginRegistry.getPlugins()) plugin.setCursorPosition(pos);
+ 		}),

--- a/patches/README.md
+++ b/patches/README.md
@@ -1,0 +1,40 @@
+# Dependency patches
+
+`pnpm` applies every patch listed under `pnpm.patchedDependencies` in the root
+`package.json` during install (including the production `Dockerfile.pinchy`
+build). Patches are a last resort for upstream bugs we cannot wait on; each one
+must be minimal, commented in-place, and tracked for removal.
+
+## `@assistant-ui__react@0.14.11.patch`
+
+**What:** moves the `if (isComposing) return;` guard **before** the
+`setText(e.target.value)` call in `ComposerPrimitive.Input`'s `onChange`.
+
+**Why:** the composer textarea is a controlled input (`value = composer.text`).
+Upstream 0.14.x calls `setText` on every `onChange` _before_ the isComposing
+guard, so the runtime text — and therefore the controlled value — mutates while
+an IME composition is active. Writing a controlled value back into the DOM
+mid-composition aborts the browser's composition session and **freezes the chat
+input**: typing an accented character via a dead-key sequence (e.g. `´` then `e`
+→ `é`) leaves the field stuck, refusing further input and deletion.
+
+0.12.x returned before `setText` and was safe. The regression rode in with the
+0.12.26 → 0.14.11 bump (commit `f7823d907`) and is still present in 0.14.13
+(latest at time of writing). The patch keeps 0.14's stale-ref recovery line
+intact, so dead keys that never emit `compositionend` still sync.
+
+**Regression guard:** `packages/web/src/components/assistant-ui/__tests__/composer-ime-composition.test.tsx`
+renders the real (un-mocked) primitive and asserts the runtime text is not
+mutated during an active composition. It goes red on the unpatched dependency.
+
+**Remove when:** assistant-ui ships a release where `onChange` does not call
+`setText` during composition. Then bump to that version, delete this patch and
+its `pnpm.patchedDependencies` entry, and keep the test as a guard. Tracked in
+[#449](https://github.com/heypinchy/pinchy/issues/449).
+
+**Upstream:** this is a regression from the fix for
+[assistant-ui#3923](https://github.com/assistant-ui/assistant-ui/issues/3923)
+(which made the mid-composition `setText` unconditional to recover dropped
+`compositionend` events). The same code is on assistant-ui `main` at
+`packages/react/src/primitives/composer/ComposerInput.tsx`. An upstream issue
+proposing the guard reorder is pending.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -29,6 +29,11 @@ overrides:
 
 packageExtensionsChecksum: sha256-Z4t9Uf0HcxYkO7zWHwm3rH14i6p+ghtNFOa7bSyEucY=
 
+patchedDependencies:
+  '@assistant-ui/react@0.14.11':
+    hash: a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5
+    path: patches/@assistant-ui__react@0.14.11.patch
+
 importers:
 
   .:
@@ -150,10 +155,10 @@ importers:
     dependencies:
       '@assistant-ui/react':
         specifier: ^0.14.11
-        version: 0.14.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+        version: 0.14.11(patch_hash=a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       '@assistant-ui/react-markdown':
         specifier: ^0.14.1
-        version: 0.14.1(@assistant-ui/react@0.14.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
+        version: 0.14.1(@assistant-ui/react@0.14.11(patch_hash=a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@dicebear/core':
         specifier: ^9.4.2
         version: 9.4.2
@@ -7196,9 +7201,9 @@ snapshots:
       - ioredis
       - redis
 
-  '@assistant-ui/react-markdown@0.14.1(@assistant-ui/react@0.14.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
+  '@assistant-ui/react-markdown@0.14.1(@assistant-ui/react@0.14.11(patch_hash=a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)':
     dependencies:
-      '@assistant-ui/react': 0.14.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
+      '@assistant-ui/react': 0.14.11(patch_hash=a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))
       '@radix-ui/react-primitive': 2.1.4(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       '@radix-ui/react-use-callback-ref': 1.1.1(@types/react@19.2.15)(react@19.2.6)
       classnames: 2.5.1
@@ -7211,7 +7216,7 @@ snapshots:
       - react-dom
       - supports-color
 
-  '@assistant-ui/react@0.14.11(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))':
+  '@assistant-ui/react@0.14.11(patch_hash=a6e7101a2fc208279292a39526332f8f7311385c34fd3fb0cb63714b733a93f5)(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(immer@11.1.4)(react-dom@19.2.6(react@19.2.6))(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6))':
     dependencies:
       '@assistant-ui/core': 0.2.7(@assistant-ui/store@0.2.12(@assistant-ui/tap@0.5.13(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6))(@assistant-ui/tap@0.5.13(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(assistant-cloud@0.1.29)(react@19.2.6)(zustand@5.0.13(@types/react@19.2.15)(immer@11.1.4)(react@19.2.6)(use-sync-external-store@1.6.0(react@19.2.6)))
       '@assistant-ui/store': 0.2.12(@assistant-ui/tap@0.5.13(@types/react@19.2.15)(react@19.2.6))(@types/react@19.2.15)(react@19.2.6)
@@ -11167,8 +11172,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -11190,7 +11195,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -11201,22 +11206,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -11227,7 +11232,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3


### PR DESCRIPTION
## What does this PR do?

Fixes the chat composer freezing when an accented character is typed via a dead-key sequence (e.g. macOS / "U.S. International - PC" / German layout: `´` then `e` → `é`). After the composition the input accepted no further characters and `Backspace` stopped working.

### Root cause

A regression rode in with the `@assistant-ui/react` `0.12.26 → 0.14.11` bump (commit `f7823d907`). The composer textarea is a **controlled** input (`value = composer.text`). In 0.14.x, `ComposerPrimitive.Input`'s `onChange` calls `setText(e.target.value)` **before** its `if (isComposing) return;` guard, so the runtime text — and thus the controlled value — mutates during an active IME composition. Writing the controlled value back into the DOM mid-composition aborts the browser's composition session and freezes the field. 0.12.x returned before `setText` and was safe. (Upstream introduced this while fixing the *dropped-`compositionend`* case, assistant-ui#3923; it is still present on their `main`.)

### Fix

A `pnpm patch` on `@assistant-ui/react@0.14.11` moves `if (isComposing) return;` above the `setText` call, keeping 0.14's stale-`compositionRef` recovery line intact (so a dropped `compositionend` still syncs on the next non-composing input). Minimal, surgical, applied on every `pnpm install` including the production `Dockerfile.pinchy` build. Rationale and removal criteria live in `patches/README.md`; removal is tracked in #449.

### Why a `pnpm patch` and not a wrapper

The bug is inside the dependency. A Pinchy-side `onChange` wrapper was tried before and caused a separate cursor-jump regression (#413). The patch fixes the bug at its actual location, fails loudly on the next version bump, and is removable when upstream fixes it.

### Why the old test didn't catch it

`thread.test.tsx` mocks `@assistant-ui/react` wholesale — `ComposerPrimitive.Input` becomes a bare `<textarea>` with none of the broken `onChange` logic, so a composition test there would exercise the mock, not the dependency. The new guard (`composer-ime-composition.test.tsx`) renders the **real, un-mocked** primitive against a real runtime and asserts the runtime text is not mutated during an active composition — red on the unpatched 0.14.11, green with the patch.

> Note: this freeze is an OS-IME ↔ Blink desync. Headless browsers drive Blink's composition directly (e.g. CDP `Input.imeSetComposition`), bypassing the OS layer, so an E2E does not reproduce it deterministically — the dependency-boundary unit test is the faithful guard.

Refs #449

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass
