### PR TITLE
chore(deps): bump openclaw 2026.5.20 -> 2026.5.28

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.5.20
+RUN npm install -g openclaw@2026.5.28
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -3,7 +3,8 @@
     "mode": "local",
     "bind": "lan",
     "controlUi": {
-      "enabled": false
+      "enabled": false,
+      "allowedOrigins": ["http://localhost:18789", "http://127.0.0.1:18789"]
     }
   },
   "discovery": {

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -217,7 +217,7 @@ For the full details, see [Audit Trail](/concepts/audit-trail/).
 
 OpenClaw runs as a separate Docker container. Pinchy communicates with it via `openclaw-node` (the official Node.js client) over WebSocket on port 18789. The browser never connects to OpenClaw directly.
 
-The current pin pair is **`openclaw@2026.5.20`** in `Dockerfile.openclaw` and **`openclaw-node@0.10.0`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
+The current pin pair is **`openclaw@2026.5.28`** in `Dockerfile.openclaw` and **`openclaw-node@0.11.0`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
 
 ### Config generation
 

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -397,6 +397,17 @@ async function handleRequest(req: http.IncomingMessage, res: http.ServerResponse
       JSON.stringify({
         capabilities: ["completion", "tools"], // "tools" = compatible with agent tool-use
         details: { parameter_size: "1B" },
+        // Advertise llama3.2's real context window. Pinchy reads this via
+        // provider-models.ts extractOllamaContextLength and emits it as the
+        // model's `contextWindow` into openclaw.json. Without it, build.ts
+        // falls back to OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW (32_768); the
+        // Smithers integration session accumulates ~32k tokens across the
+        // dispatch-probe suite, and once it crosses a 32k window OpenClaw
+        // 2026.5.28's cli_budget / overflow compaction fires — which the fake
+        // LLM cannot satisfy (it can't summarize), so the agent run fails with
+        // UNAVAILABLE and the tool never dispatches. Real llama3.2 is 131072,
+        // so advertising it keeps the context window from being the bottleneck.
+        model_info: { "llama.context_length": 131072 },
       })
     );
     return;

--- a/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
+++ b/packages/web/e2e/telegram/agent-create-no-restart.spec.ts
@@ -357,16 +357,21 @@ test.describe.serial("Agent create — no gateway restart cascade (#193)", () =>
     await new Promise((r) => setTimeout(r, 3000));
     const logs = openClawLogsSince(beforeMark);
 
-    // (a) Positive: the config change reached OpenClaw and was evaluated
-    //     for reload. Without this, we'd be testing nothing — the config
-    //     push silently failing would also satisfy (b) but means our fix
-    //     is being bypassed.
-    // Note: OpenClaw ≥ 4.27 changed the log format from
-    //   "config change detected.*agents.list"
-    // to
-    //   "config change detected; evaluating reload (env, agents, ...)"
-    // so we match the common prefix + "agents" to cover both formats.
-    expect(logs, logs).toMatch(/\[reload\] config change detected.*agents/);
+    // (a) Positive: the config change reached OpenClaw's runtime. This is
+    //     ALREADY proven above by `waitForAgentDispatchable`, which polls OC's
+    //     live `agents.list` via `config.get` and THROWS if the agent never
+    //     appears — so reaching this line means the apply landed and we are
+    //     not vacuously satisfying (b).
+    //
+    //     We deliberately do NOT scrape a "[reload] config change detected"
+    //     log line here. That line is emitted only on OpenClaw's file-watcher
+    //     reload path, but Pinchy applies agent changes through the WS
+    //     `config.apply` RPC (which hot-reloads WITHOUT emitting it — see
+    //     write.ts `pushConfigInBackground`). On 2026.5.x that made the scrape
+    //     a flaky proxy: whenever the WS path was taken, `openClawLogsSince`
+    //     came back empty and the assertion failed even though the agent was
+    //     dispatchable and no restart occurred (#193 CI flake). The runtime
+    //     `agents.list` check is the stronger, path-independent signal.
 
     // (b) The bug fingerprint. With the bug present, OpenClaw logs:
     //     "[reload] config change requires gateway restart (...)"

--- a/packages/web/e2e/web/web-search.spec.ts
+++ b/packages/web/e2e/web/web-search.spec.ts
@@ -27,6 +27,7 @@ import {
   pollAuditForTool,
   seedDefaultProviderToOllama,
   waitForOpenClawStable,
+  waitForAgentDispatchable,
 } from "../shared/dispatch-probe";
 
 test.describe("pinchy-web — Brave Search E2E", () => {
@@ -182,6 +183,23 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
 
     // 7. Wait for OpenClaw to stabilise with the new Ollama config.
     await waitForOpenClawStable(() => pinchyGet("/api/health/openclaw", dispatchCookie));
+
+    // 8. Gate on the dispatch agent actually being in OC's hot-loaded
+    //    `agents.list` before any test dispatches to it. `waitForOpenClawStable`
+    //    above only proves the gateway is connected — NOT that the
+    //    fire-and-forget regenerate from the allowedTools PATCH (step 6) has
+    //    landed. On a cold-start run the regeneration storm can push the
+    //    agents.list apply past POST /api/agents' best-effort 5 s
+    //    `waitForAgentInRuntime`, so the first dispatch raced the apply and hit
+    //    `invalid agent params: unknown agent id` for longer than the chat
+    //    dispatch-race retry budget (CI flake on the 2026.5.28 bump). Polling
+    //    OC's live agents.list here closes that window deterministically — the
+    //    same gate the Odoo dispatch probe uses.
+    await waitForAgentDispatchable(
+      (agentId) => pinchyGet(`/api/health/openclaw?agentId=${agentId}`, dispatchCookie),
+      dispatchAgentId,
+      { deadlineMs: 120_000 }
+    );
   });
 
   test.afterAll(async () => {

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -89,7 +89,7 @@
     "eslint-config-next": "16.2.6",
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.5.20",
+    "openclaw": "2026.5.28",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",

--- a/packages/web/src/__tests__/api/version.test.ts
+++ b/packages/web/src/__tests__/api/version.test.ts
@@ -54,10 +54,10 @@ describe("GET /api/version", () => {
   });
 
   it("returns openclawVersion from NEXT_PUBLIC_OPENCLAW_VERSION", async () => {
-    process.env.NEXT_PUBLIC_OPENCLAW_VERSION = "2026.5.20";
+    process.env.NEXT_PUBLIC_OPENCLAW_VERSION = "2026.5.28";
     const response = await GET();
     const data = await response.json();
-    expect(data.openclawVersion).toBe("2026.5.20");
+    expect(data.openclawVersion).toBe("2026.5.28");
   });
 
   it("falls back to 'unknown' when NEXT_PUBLIC_OPENCLAW_VERSION is unset", async () => {

--- a/packages/web/src/__tests__/lib/fake-ollama-context-window.test.ts
+++ b/packages/web/src/__tests__/lib/fake-ollama-context-window.test.ts
@@ -1,0 +1,58 @@
+// @vitest-environment node
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import {
+  startFakeOllama,
+  stopFakeOllama,
+  FAKE_OLLAMA_PORT,
+} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+
+// Regression guard for the OpenClaw 2026.5.28 budget-triggered compaction
+// overflow that turned the "Integration Tests (OpenClaw + Fake Ollama)" suite
+// red when bumping the runtime from 2026.5.20.
+//
+// Chain: Pinchy reads each Ollama model's real context window from /api/show
+// `model_info.<arch>.context_length` (provider-models.ts extractOllamaContextLength)
+// and emits it as the model's `contextWindow` into openclaw.json. When the
+// fake server omits `model_info`, build.ts falls back to
+// OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW (32_768). The Smithers integration
+// session accumulates ~32k tokens across the dispatch-probe suite; once it
+// crosses a 32k window, OpenClaw 2026.5.28's cli_budget / overflow compaction
+// fires, the fake LLM cannot produce a real summary, and the agent run fails
+// with UNAVAILABLE — so the tool never dispatches and the audit assertion
+// times out. Real llama3.2 carries a 131072-token window, so advertising it
+// keeps the context window from ever being the bottleneck in these short
+// single-turn probes.
+describe("fake-ollama /api/show advertises a realistic context window", () => {
+  beforeAll(async () => {
+    await startFakeOllama();
+  });
+  afterAll(async () => {
+    await stopFakeOllama();
+  });
+
+  it("reports a real llama context_length so OpenClaw never triggers overflow compaction during probe tests", async () => {
+    const res = await fetch(`http://127.0.0.1:${FAKE_OLLAMA_PORT}/api/show`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "llama3.2" }),
+    });
+    expect(res.ok).toBe(true);
+
+    const data = (await res.json()) as { model_info?: Record<string, unknown> };
+    const contextLengthEntry = Object.entries(data.model_info ?? {}).find(([key]) =>
+      key.endsWith(".context_length")
+    );
+
+    expect(
+      contextLengthEntry,
+      "/api/show model_info must expose a *.context_length key"
+    ).toBeTruthy();
+
+    const contextLength = contextLengthEntry![1];
+    expect(typeof contextLength).toBe("number");
+    // 32_768 is build.ts's OLLAMA_LOCAL_DEFAULT_CONTEXT_WINDOW fallback — the
+    // value that triggered the 2026.5.28 overflow. Require a real, large
+    // window well above it.
+    expect(contextLength as number).toBeGreaterThanOrEqual(128_000);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -833,6 +833,40 @@ describe("regenerateOpenClawConfig", () => {
     );
   });
 
+  it("emits an explicit transport api for every built-in provider", async () => {
+    // OpenClaw 2026.5.28 changed default-api resolution: a provider with a
+    // baseUrl and no explicit `api` falls back to "openai-completions"
+    // (resolveConfiguredProviderDefaultApi in provider-policy). Earlier OC
+    // inferred the transport from the provider name. That silently broke the
+    // built-in google provider — OC POSTed `<baseUrl>/chat/completions`
+    // instead of native `:generateContent`, so Smithers replies failed with
+    // "provider returned an HTML error page" (FailoverError). anthropic/openai
+    // only survived because their model ids still matched OC's catalog
+    // discovery — the same latent landmine.
+    //
+    // Pinchy must emit each built-in provider's canonical transport `api`
+    // explicitly so the emitted openclaw.json is self-describing and never
+    // depends on OC's inference heuristics. Values mirror OpenClaw's own
+    // static provider catalog.
+    delete process.env.ANTHROPIC_BASE_URL;
+    delete process.env.OPENAI_BASE_URL;
+    delete process.env.GOOGLE_BASE_URL;
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-key";
+      if (key === "openai_api_key") return "sk-openai-key";
+      if (key === "google_api_key") return "AIza-test-key";
+      if (key === "default_provider") return "anthropic";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    expect(config?.models?.providers?.anthropic?.api).toBe("anthropic-messages");
+    expect(config?.models?.providers?.openai?.api).toBe("openai-responses");
+    expect(config?.models?.providers?.google?.api).toBe("google-generative-ai");
+  });
+
   describe("PINCHY_PROVIDER_BASEURL_* takes priority over SDK env vars", () => {
     // These env vars exist for E2E mock injection (Phase 1 of the setup-wizard
     // smoke tests). They override the *_BASE_URL SDK convention so the

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -916,7 +916,9 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
     expect(config?.models?.providers?.anthropic?.api).toBe("anthropic-messages");
-    expect(config?.models?.providers?.openai?.api).toBe("openai-responses");
+    // Chat Completions, not the Responses API — maximally compatible with
+    // OpenAI-compatible proxies behind OPENAI_BASE_URL (see BUILTIN_PROVIDER_API).
+    expect(config?.models?.providers?.openai?.api).toBe("openai-completions");
     expect(config?.models?.providers?.google?.api).toBe("google-generative-ai");
   });
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -306,6 +306,59 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.canvasHost?.enabled).toBe(false);
   });
 
+  it("emits gateway.controlUi.allowedOrigins so OpenClaw's in-memory seed never diffs", async () => {
+    // OpenClaw 2026.2.26+ seeds gateway.controlUi.allowedOrigins in memory for a
+    // bind:"lan" gateway but never writes it to openclaw.json. If Pinchy's
+    // regenerate omits it, OC's reload diff sees gateway.controlUi.allowedOrigins
+    // removed → restart-class change → SIGUSR1 cascade that delays agents.list
+    // hot-reload (the setup-wizard "unknown agent id" / #193 flake on 2026.5.28).
+    // Pinchy must always emit the same origins OC seeds.
+    mockedReadFileSync.mockReturnValue("" as unknown as Buffer); // cold start: no existing config
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-key";
+      if (key === "default_provider") return "anthropic";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      gateway?: { controlUi?: { enabled?: boolean; allowedOrigins?: string[] } };
+    };
+    expect(config.gateway?.controlUi?.enabled).toBe(false);
+    expect(config.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+  });
+
+  it("preserves an existing controlUi.allowedOrigins value emitted by OpenClaw", async () => {
+    // If OpenClaw enriched controlUi.allowedOrigins with a different value (e.g.
+    // a prior config.apply persisted it), Pinchy must round-trip that exact
+    // value rather than clobber it with the default — otherwise the round-trip
+    // itself becomes the restart-class diff.
+    const ocEnriched = JSON.stringify({
+      gateway: {
+        mode: "local",
+        bind: "lan",
+        controlUi: { enabled: false, allowedOrigins: ["http://oc-enriched.example:18789"] },
+      },
+    });
+    mockedReadFileSync.mockReturnValue(ocEnriched as unknown as Buffer);
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-key";
+      if (key === "default_provider") return "anthropic";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written) as {
+      gateway?: { controlUi?: { allowedOrigins?: string[] } };
+    };
+    expect(config.gateway?.controlUi?.allowedOrigins).toEqual(["http://oc-enriched.example:18789"]);
+  });
+
   it("disables OpenClaw's default daily session reset so chat history persists across days", async () => {
     // OpenClaw's default session reset (`session.reset.mode: "daily"`,
     // `atHour: 4` — confirmed in openclaw@2026.5.7
@@ -3651,19 +3704,29 @@ describe("seedRestartClassOverridesIfMissing", () => {
     expect(writtenAtomic).toBeDefined();
     const written = JSON.parse(String(writtenAtomic![1]));
     expect(written.gateway?.controlUi?.enabled).toBe(false);
+    // allowedOrigins must be seeded too: OpenClaw enriches it in memory only,
+    // so leaving it absent makes every later regenerate drop it and trigger a
+    // restart-class diff.
+    expect(written.gateway?.controlUi?.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
     expect(written.discovery?.mdns?.mode).toBe("off");
     expect(written.update?.checkOnStart).toBe(false);
     expect(written.canvasHost?.enabled).toBe(false);
   });
 
-  it("returns false (no write) when file already has all four overrides — production case", () => {
+  it("returns false (no write) when file already has all overrides — production case", () => {
     // Production case: Docker-managed named volume populated from the image's
     // baked-in `config/openclaw.json` already carries these. No write needed.
     const existing = {
       gateway: {
         mode: "local",
         bind: "lan",
-        controlUi: { enabled: false },
+        controlUi: {
+          enabled: false,
+          allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"],
+        },
       },
       discovery: { mdns: { mode: "off" } },
       update: { checkOnStart: false },
@@ -3678,6 +3741,33 @@ describe("seedRestartClassOverridesIfMissing", () => {
       (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json.tmp")
     );
     expect(writtenAtomic).toBeUndefined();
+  });
+
+  it("seeds controlUi.allowedOrigins when the file disables controlUi but omits it (upgrade case)", () => {
+    // Pre-2026.5.28 Pinchy wrote controlUi.enabled=false WITHOUT allowedOrigins.
+    // On upgrade, OpenClaw seeds allowedOrigins in memory only; if Pinchy never
+    // persists it, the next regenerate drops the field and OC restarts. The seed
+    // must add it even when the other four overrides are already correct.
+    const existing = {
+      gateway: { mode: "local", bind: "lan", controlUi: { enabled: false } },
+      discovery: { mdns: { mode: "off" } },
+      update: { checkOnStart: false },
+      canvasHost: { enabled: false },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+
+    const changed = seedRestartClassOverridesIfMissing();
+
+    expect(changed).toBe(true);
+    const writtenAtomic = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json.tmp")
+    );
+    const written = JSON.parse(String(writtenAtomic![1]));
+    expect(written.gateway.controlUi.enabled).toBe(false);
+    expect(written.gateway.controlUi.allowedOrigins).toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
   });
 
   it("preserves existing fields outside the four restart-class paths", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config/openclaw-baked-in-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/openclaw-baked-in-config.test.ts
@@ -47,6 +47,20 @@ describe("config/openclaw.json (baked-in config)", () => {
     expect(controlUi!.enabled).toBe(false);
   });
 
+  it("has gateway.controlUi.allowedOrigins — prevents OC's in-memory seed from diffing on reload", () => {
+    // OpenClaw 2026.2.26+ seeds gateway.controlUi.allowedOrigins in memory for a
+    // bind:"lan" gateway but never persists it. Baking it in keeps OC's reload
+    // diff empty for controlUi so an agents-only regenerate stays a hot reload
+    // instead of cascading into a SIGUSR1 restart (the setup-wizard "unknown
+    // agent id" / #193 flake on 2026.5.28).
+    const gateway = config.gateway as Record<string, unknown>;
+    const controlUi = gateway.controlUi as Record<string, unknown> | undefined;
+    expect(controlUi!.allowedOrigins, "controlUi.allowedOrigins must be baked in").toEqual([
+      "http://localhost:18789",
+      "http://127.0.0.1:18789",
+    ]);
+  });
+
   it("has discovery.mdns.mode: 'off' — prevents restart-triggering diff on first config.apply", () => {
     const discovery = config.discovery as Record<string, unknown> | undefined;
     expect(discovery, "config.discovery must exist").toBeDefined();

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -71,6 +71,25 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
   google: "GOOGLE_BASE_URL",
 };
 
+// OC's canonical transport `api` per built-in provider. We emit this
+// explicitly so the generated openclaw.json is self-describing and never
+// depends on OpenClaw's implicit api inference.
+//
+// OpenClaw 2026.5.28 changed `resolveConfiguredProviderDefaultApi`: a provider
+// with a `baseUrl` and no explicit `api` now falls back to "openai-completions"
+// instead of being inferred from the provider name. That silently broke the
+// built-in google provider — OC POSTed `<baseUrl>/chat/completions` instead of
+// the native Gemini `:generateContent`, so chat failed with a FailoverError
+// ("provider returned an HTML error page"). anthropic/openai only kept working
+// because their model ids still matched OC's catalog discovery, which is the
+// same latent fragility. Values mirror OpenClaw's static provider catalog
+// (extensions/{google,...}/provider-catalog.ts).
+const BUILTIN_PROVIDER_API: Record<"anthropic" | "openai" | "google", string> = {
+  anthropic: "anthropic-messages",
+  openai: "openai-responses",
+  google: "google-generative-ai",
+};
+
 /**
  * Public docs URL configuration for the bundled `pinchy-docs` plugin.
  *
@@ -1039,6 +1058,7 @@ export async function regenerateOpenClawConfig() {
       }
       modelProviders[providerName] = {
         apiKey: secretRef(`/providers/${providerName}/apiKey`),
+        api: BUILTIN_PROVIDER_API[providerName],
         baseUrl,
         models: getModelCatalogForProvider(providerName),
       };

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -23,7 +23,7 @@ import {
 } from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
 import { getOpenClawWorkspacePath } from "@/lib/workspace";
-import { CONFIG_PATH } from "./paths";
+import { CONFIG_PATH, OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS } from "./paths";
 import { configsAreEquivalentUpToOpenClawMetadata } from "./normalize";
 import { readExistingConfig, pushConfigInBackground } from "./write";
 import {
@@ -391,6 +391,14 @@ export async function regenerateOpenClawConfig() {
     controlUi: {
       ...existingControlUi,
       enabled: false,
+      // Always emit allowedOrigins so OC's reload diff never sees this
+      // restart-class field appear/disappear. Preserve OC's enriched value if
+      // the config already carries one (a prior config.apply persisted it);
+      // otherwise seed the same origins OC would. See
+      // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS for the full rationale.
+      allowedOrigins:
+        (existingControlUi.allowedOrigins as string[] | undefined) ??
+        OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
     },
   };
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -71,9 +71,9 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
   google: "GOOGLE_BASE_URL",
 };
 
-// OC's canonical transport `api` per built-in provider. We emit this
-// explicitly so the generated openclaw.json is self-describing and never
-// depends on OpenClaw's implicit api inference.
+// OC's transport `api` per built-in provider. We emit this explicitly so the
+// generated openclaw.json is self-describing and never depends on OpenClaw's
+// implicit api inference.
 //
 // OpenClaw 2026.5.28 changed `resolveConfiguredProviderDefaultApi`: a provider
 // with a `baseUrl` and no explicit `api` now falls back to "openai-completions"
@@ -82,11 +82,18 @@ const BUILTIN_PROVIDER_BASE_URL_ENV_VARS: Record<"anthropic" | "openai" | "googl
 // the native Gemini `:generateContent`, so chat failed with a FailoverError
 // ("provider returned an HTML error page"). anthropic/openai only kept working
 // because their model ids still matched OC's catalog discovery, which is the
-// same latent fragility. Values mirror OpenClaw's static provider catalog
-// (extensions/{google,...}/provider-catalog.ts).
+// same latent fragility.
+//
+// `openai` uses the Chat Completions API (`openai-completions`), NOT the newer
+// Responses API (`openai-responses`) that OC's own catalog defaults to. Reason:
+// the built-in `openai` provider accepts an `OPENAI_BASE_URL` override for
+// OpenAI-compatible proxy customers (vLLM, LiteLLM, gateways), and those
+// proxies broadly implement `/v1/chat/completions` but frequently NOT
+// `/v1/responses`. Chat Completions is the maximally-compatible surface and
+// fully covers Pinchy's chat + tools + vision needs against real OpenAI too.
 const BUILTIN_PROVIDER_API: Record<"anthropic" | "openai" | "google", string> = {
   anthropic: "anthropic-messages",
-  openai: "openai-responses",
+  openai: "openai-completions",
   google: "google-generative-ai",
 };
 
@@ -393,12 +400,12 @@ export async function regenerateOpenClawConfig() {
       enabled: false,
       // Always emit allowedOrigins so OC's reload diff never sees this
       // restart-class field appear/disappear. Preserve OC's enriched value if
-      // the config already carries one (a prior config.apply persisted it);
-      // otherwise seed the same origins OC would. See
-      // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS for the full rationale.
-      allowedOrigins:
-        (existingControlUi.allowedOrigins as string[] | undefined) ??
-        OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
+      // the config already carries a valid array (a prior config.apply
+      // persisted it); otherwise seed the same origins OC would. See
+      // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in paths.ts for the full rationale.
+      allowedOrigins: Array.isArray(existingControlUi.allowedOrigins)
+        ? existingControlUi.allowedOrigins
+        : OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
     },
   };
 

--- a/packages/web/src/lib/openclaw-config/paths.ts
+++ b/packages/web/src/lib/openclaw-config/paths.ts
@@ -1,3 +1,16 @@
 // Single source of truth for the openclaw.json file path. Lives in its own
 // module so both `write.ts` and `normalize.ts` can import it without a cycle.
 export const CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
+
+// Origins OpenClaw seeds into `gateway.controlUi.allowedOrigins` for a
+// non-loopback (`bind: "lan"`) gateway on its fixed port 18789. OpenClaw seeds
+// these in memory only (never persisted), so Pinchy must emit them explicitly
+// in every config write — otherwise the field appears/disappears between OC's
+// in-memory config and Pinchy's on-disk regenerate, and OC's reload diff
+// classifies the `gateway.controlUi` change as restart-class, triggering a
+// SIGUSR1 restart cascade. Lives here (alongside CONFIG_PATH) so build.ts and
+// targeted.ts can both import it without a module cycle.
+export const OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS = [
+  "http://localhost:18789",
+  "http://127.0.0.1:18789",
+];

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -332,7 +332,7 @@ export function seedRestartClassOverridesIfMissing(): boolean {
   // OpenClaw seeds controlUi.allowedOrigins in memory only (never persisted),
   // so an on-disk config that lacks it makes every later regenerate drop the
   // field and trigger a restart-class diff. Seed it up front. See
-  // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in build.ts for the full rationale.
+  // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in paths.ts for the full rationale.
   const needsAllowedOrigins = !Array.isArray(controlUi.allowedOrigins);
   const needsMdnsOff = mdns.mode !== "off";
   const needsUpdateCheck = update.checkOnStart !== false;

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -1,5 +1,5 @@
 import { readFileSync, existsSync } from "fs";
-import { CONFIG_PATH } from "./paths";
+import { CONFIG_PATH, OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS } from "./paths";
 import { writeConfigAtomic, readExistingConfig } from "./write";
 import { restartState } from "@/server/restart-state";
 import { getOrCreateGatewayToken } from "@/lib/gateway-token-source";
@@ -329,11 +329,22 @@ export function seedRestartClassOverridesIfMissing(): boolean {
   const canvasHost = (existing.canvasHost as Record<string, unknown>) || {};
 
   const needsControlUi = controlUi.enabled !== false;
+  // OpenClaw seeds controlUi.allowedOrigins in memory only (never persisted),
+  // so an on-disk config that lacks it makes every later regenerate drop the
+  // field and trigger a restart-class diff. Seed it up front. See
+  // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in build.ts for the full rationale.
+  const needsAllowedOrigins = !Array.isArray(controlUi.allowedOrigins);
   const needsMdnsOff = mdns.mode !== "off";
   const needsUpdateCheck = update.checkOnStart !== false;
   const needsCanvasHostOff = canvasHost.enabled !== false;
 
-  if (!needsControlUi && !needsMdnsOff && !needsUpdateCheck && !needsCanvasHostOff) {
+  if (
+    !needsControlUi &&
+    !needsAllowedOrigins &&
+    !needsMdnsOff &&
+    !needsUpdateCheck &&
+    !needsCanvasHostOff
+  ) {
     return false;
   }
 
@@ -341,7 +352,13 @@ export function seedRestartClassOverridesIfMissing(): boolean {
     ...existing,
     gateway: {
       ...gateway,
-      controlUi: { ...controlUi, enabled: false },
+      controlUi: {
+        ...controlUi,
+        enabled: false,
+        allowedOrigins: Array.isArray(controlUi.allowedOrigins)
+          ? controlUi.allowedOrigins
+          : OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
+      },
     },
     discovery: { ...discovery, mdns: { ...mdns, mode: "off" } },
     update: { ...update, checkOnStart: false },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -326,8 +326,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       openclaw:
-        specifier: 2026.5.20
-        version: 2026.5.20
+        specifier: 2026.5.28
+        version: 2026.5.28
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -367,8 +367,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.91.1':
-    resolution: {integrity: sha512-LAmu761tSN9r66ixvmciswUj/ZC+1Q4iAfpedTfSVLeswRwnY3n2Nb6Tsk+cLPP28aLOPWeMgIuTuCcMC6W/iw==}
+  '@anthropic-ai/sdk@0.98.0':
+    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -471,10 +471,6 @@ packages:
   '@aws-crypto/util@5.2.0':
     resolution: {integrity: sha512-4RkU9EsI6ZpBve5fseQlGNUWKMa1RLPQ1dnjnQoe07ldfIzcsGb5hC5W0Dm7u423KWzawlrpbjXBrXCEv9zazQ==}
 
-  '@aws-sdk/client-bedrock-runtime@3.1048.0':
-    resolution: {integrity: sha512-u+NT61JZEkRFtpL0CAw1N1dwxnaLgwVXQl/zjJxTGgLyS/jTIdg2SdoEoCTHxgDyCnqa1HEi9QOoE9/pYRNpOQ==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/client-cognito-identity@3.1045.0':
     resolution: {integrity: sha512-3OEn8zvtfJoN0jFfjVJ9jF2GVRDL3IjDfk6CAgVTAqjfCVjajiUD0iFAGQ4cOzdcv1LGsZ0b/snJDWalY3OePQ==}
     engines: {node: '>=20.0.0'}
@@ -523,14 +519,6 @@ packages:
     resolution: {integrity: sha512-J+it58HUGyMIAquB6pWtvmO4m0E/gQ/Tz9Xcoogk3Rety13likU5U8HioeIgE+aN1DDOAB//MARoIdLZS1Mpfw==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/eventstream-handler-node@3.972.17':
-    resolution: {integrity: sha512-WFwdNcjchKZr7jKYgGimUZO8sSKQF/le7GGqgeCzz/lHozInE6b0gFJ1YMr8NaIeAoWJwgtrF7RE4/qMgosAdQ==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/middleware-eventstream@3.972.13':
-    resolution: {integrity: sha512-ECfsw7mf6G/sxNbKbGE3/h1xeIArY/yRI1IjDGYkLgDIankh+aDOtDRSr40LVlIHGL9+jEH1cVuxmbJ8NLL/1A==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/middleware-host-header@3.972.10':
     resolution: {integrity: sha512-IJSsIMeVQ8MMCPbuh1AbltkFhLBLXn7aejzfX5YKT/VLDHn++Dcz8886tXckE+wQssyPUhaXrJhdakO2VilRhg==}
     engines: {node: '>=20.0.0'}
@@ -547,10 +535,6 @@ packages:
     resolution: {integrity: sha512-iz+B29TXcAZsJpwB+AwG/TTGA5l/VnmMZ2UxtiySOZjI6gCdmviXPwdgzcmuazMy16rXoPY4mYCGe7zdNKfx5A==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/middleware-websocket@3.972.21':
-    resolution: {integrity: sha512-yr+5+C7v9R55sAJ89A55Wrm7wIKPVn5cm6J3Hztnd5s/iwEUKxyJqCnIxJu4fVXgG9XBQD1Jc4rsWC1ozahJjA==}
-    engines: {node: '>= 14.0.0'}
-
   '@aws-sdk/nested-clients@3.997.11':
     resolution: {integrity: sha512-nWXXJ1r/r8N2Gw1pWolRgED38/A9A8DHR2ETWIv220zh4PZHcybbR4hUVWWktmNXTRHzDJwRluapHn0rZxuoqA==}
     engines: {node: '>=20.0.0'}
@@ -563,16 +547,8 @@ packages:
     resolution: {integrity: sha512-qs9z5LqXO/CZC2Lg9SGKpoLU8Rhi+m2pFKZqfO9pytX1clc0katqtsDNupJxFy0xT9wsZSPzM2v1y+/H/zfp5Q==}
     engines: {node: '>=20.0.0'}
 
-  '@aws-sdk/token-providers@3.1048.0':
-    resolution: {integrity: sha512-k0y/GcuesuSfWyUM0WamrGyeZmltRYaPbHO82UDA6mZ/doB+FOHKutikPAtSXMn/hDz970cF+iRuuiYO9VEbAA==}
-    engines: {node: '>=20.0.0'}
-
   '@aws-sdk/token-providers@3.1052.0':
     resolution: {integrity: sha512-QqZNB3so7UIDxZtroc85TQaLVxdZRFm0eWM1CSR2N+b06as9TOrilvrlTZuj3guYlxMs6yLOgGxnklJ5qMYtTw==}
-    engines: {node: '>=20.0.0'}
-
-  '@aws-sdk/types@3.973.8':
-    resolution: {integrity: sha512-gjlAdtHMbtR9X5iIhVUvbVcy55KnznpC6bkDUWW9z915bi0ckdUr5cjf16Kp6xq0bP5HBD2xzgbL9F9Quv5vUw==}
     engines: {node: '>=20.0.0'}
 
   '@aws-sdk/types@3.973.9':
@@ -825,22 +801,8 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-agent-core@0.75.4':
-    resolution: {integrity: sha512-cGYbysb4EqUf0B28OeqFq2ppm1XF3bYBOP71q9dv38yf/UJfzMjiXBeNelrcio+QWIoVrW+xzYm7sMzYIUc9Og==}
-    engines: {node: '>=22.19.0'}
-
-  '@earendil-works/pi-ai@0.75.4':
-    resolution: {integrity: sha512-m/w8Hh3vQ0rAycwJiJWdzkypkn4295f4eq/966lDRy8aX5sk6bgYXH8TQmL16TO7Uwc7MbJG0QoyFHgX8RqXUQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-coding-agent@0.75.4':
-    resolution: {integrity: sha512-Fb+FRo08b5H9pYKbQJ708/5OKL0+K/yclhfCMEhrBzSPTZZ4c85nY1YsBo4qwL20ohBMlBezHMRuHzcJ1ylEoQ==}
-    engines: {node: '>=22.19.0'}
-    hasBin: true
-
-  '@earendil-works/pi-tui@0.75.4':
-    resolution: {integrity: sha512-PDhKU7u6fmEcvHUFHzrRwGc/Ytokj/hO+X4RPf+MWKEGpvg3B1vHv88Ee+Dy33004tYkQF5YeXV4btJZcp5x1g==}
+  '@earendil-works/pi-tui@0.76.0':
+    resolution: {integrity: sha512-TWQEWqc38gVRYr/VTrlfePQPpJk938gNNLL1xuv0M+9cTkVr880/Q3baZQrxKoLrmN/MmVx7TyR8knYZGxTqqg==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -1390,17 +1352,8 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@google/genai@1.52.0':
-    resolution: {integrity: sha512-gwSvbpiN/17O9TbsqSsE/OzZcpv5Fo4RQjdngGgogtuB9RsyJ8ZHhX5KjHj1bp5N9snN2eK8LDGXSaWW2hof8Q==}
-    engines: {node: '>=20.0.0'}
-    peerDependencies:
-      '@modelcontextprotocol/sdk': ^1.25.2
-    peerDependenciesMeta:
-      '@modelcontextprotocol/sdk':
-        optional: true
-
-  '@google/genai@2.5.0':
-    resolution: {integrity: sha512-qDi3LLh9I3llJK0f9uV8kZ8EdT9oHPxGJJ9yOJ/i5YXYrVwRCs8jHo9x4e99uOeKYDvD3TZwT70p/H/LS3BixQ==}
+  '@google/genai@2.6.0':
+    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -1423,8 +1376,8 @@ packages:
   '@grammyjs/types@3.27.3':
     resolution: {integrity: sha512-yUKMLliGsGbnxu96YUJ7km7B0zy4PzeH/Jvti5705R/LeKDMqkDV4DckMSt+OrliWQpTwQljHE0QLol5zgxBkg==}
 
-  '@homebridge/ciao@1.3.8':
-    resolution: {integrity: sha512-lNhpCsZVbdbjz2trFjQdzQ3cUIMZQMIMksi7wd3ntTIYgdaGLqT1Ms97DfVIJYHzRuduf56ISvgU8RRLTpK/ng==}
+  '@homebridge/ciao@1.3.9':
+    resolution: {integrity: sha512-TMy9zy173jDOpnFXDqL3BPIQn5lfcAkSsivYQatCCakoHk4fLGd7QjfAaNGYE3Ox+/ZI6Lq0e1gGcz1qdw/IbA==}
     hasBin: true
 
   '@hono/node-server@1.19.14':
@@ -1660,76 +1613,8 @@ packages:
   '@lydell/node-pty@1.2.0-beta.12':
     resolution: {integrity: sha512-qIK890UwPupoj07osVvgOIa++1mxeHbcGry4PKRHhNVNs81V2SCG34eJr46GybiOmBtc8Sj5PB1/GGM5PL549g==}
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    resolution: {integrity: sha512-HjaisYCAbHi/1+N1yDAQHc8ZXGffufIUT5NSOSVR3f3AuMDusxTtnbK8tZ7JFDkShua1oNGZoNwQHsc8MPtE0Q==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    resolution: {integrity: sha512-8BWtPjOtJOJoykml3w0fx0zRrfWP31mXrJwfoA7xzNprkZw1uolCNfgmjDiVBseoKjp16EGITz7bN+61qn8dWA==}
-    engines: {node: '>= 10'}
-    os: [darwin]
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    resolution: {integrity: sha512-p9syiZD1kU4I+1ya7f7g+zD1GiUvR8fdlRlNmgsZNWlyjtc8rlV2EjTLd/35x1LsdBq020GVvtzp0ZmPgBI09Q==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [darwin]
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    resolution: {integrity: sha512-5JFf5rGofrm+V29HNF+wLthXphHdQpMbKDUYJ5tML6/Z5DLlLOV/9Ak4kDPtYyZ+Dzf+kAusE0VsFg4+tfP1IA==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    resolution: {integrity: sha512-JlVjxxw0GbGC0djXYWRIqyteO3J1KZ/QG3udlEFaOD5TLOM1FnmXXAPDQBqr+aBVr720ef9K00dirYnJ0LDCtw==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [linux]
-    libc: [musl]
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    resolution: {integrity: sha512-4t8BUi5zZ+L77otFQVnVSlaTyAX4TVk9EqQm4syMrEQp96trFEHEwwNHcNEBGzYv5+K7mxay50TthYkz47OWzQ==}
-    engines: {node: '>= 10'}
-    cpu: [riscv64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    resolution: {integrity: sha512-trtPwcNLW37irwQCJLtCxLw757jjJZk3TSnY/MU9bhtWtA3K9b/eLW0e4RGhUXDoFRds9opNWWaUDuFLa8dm0w==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [glibc]
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    resolution: {integrity: sha512-WfnzIvOCCWQiN0MmltCEo6cLceUDbYe+I7xyFZjaps5A+2Op/M2CY7Rey+C4ucQhrvmpoHmTSFgY9ODWk7snoA==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [linux]
-    libc: [musl]
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    resolution: {integrity: sha512-+8+1aHYsBPUjmW3otmWlg+Hijt0iJvoBBs5e0mxFeUd4gDaKMB8Bn6x7c6KVtscg7E5j5NFXnwQqNSIAO4p8zQ==}
-    engines: {node: '>= 10'}
-    cpu: [arm64]
-    os: [win32]
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    resolution: {integrity: sha512-S4xfPmERC8ZkiLHe3vekZCjdDwNEETCuvCgQK2kP6/TnvmUkq1y2Pk+DjM4t8uh9KMX9bH4zs5ePcKa8GTXmfg==}
-    engines: {node: '>= 10'}
-    cpu: [x64]
-    os: [win32]
-
-  '@mariozechner/clipboard@0.3.6':
-    resolution: {integrity: sha512-MXdtr+6+ntlIVHdrZYuZNQydu6o8yZswFJ2Ln81j2O/Y9B/LDHvEaIm95xWNPkjGTWriSOeLnQJRFs6dYb60bg==}
-    engines: {node: '>= 10'}
-
-  '@mistralai/mistralai@2.2.1':
-    resolution: {integrity: sha512-uKU8CZmL2RzYKmplsU01hii4p3pe4HqJefpWNRWXm1Tcm0Sm4xXfwSLIy4k7ZCPlbETCGcp69E7hZs+WOJ5itQ==}
+  '@mistralai/mistralai@2.2.5':
+    resolution: {integrity: sha512-ATbWzKkNzNAZ+gtw9MI/c/ULTMG80tKUiRNIbQFfg4OP0uEZZpTfXZeBCNfs5Dq0uqMQ/tQWc4o6RRJQtMrpDA==}
 
   '@modelcontextprotocol/sdk@1.29.0':
     resolution: {integrity: sha512-zo37mZA9hJWpULgkRpowewez1y6ML5GsXJPY8FI0tBBCd77HEvza4jDqRKOXgHNn867PVGCyTdzqpz0izu5ZjQ==}
@@ -2000,8 +1885,8 @@ packages:
     resolution: {integrity: sha512-nn5ozdjYQpUCZlWGuxcJY/KpxkWQs4DcbMCmKojjyrYDEAGy4Ce19NN4v5MduafTwJlbKc99UA8YhSVqq9yPZA==}
     engines: {node: '>=12.4.0'}
 
-  '@openclaw/fs-safe@0.2.7':
-    resolution: {integrity: sha512-l/Yj3K2ChR/gI+bZo1wIe7rjKyTFwGOAw120cTCMRT8LZbVhJhTbiZLGIRBMv0Gc9GQjYE8EjPBza3RdrSSbyQ==}
+  '@openclaw/fs-safe@0.3.0':
+    resolution: {integrity: sha512-uIBE441CIt1kIURoP9qRGKZ8LkGyfD9ZzeESjwAd29ZPWtghws/5GR3Pjb67jKdcJHP1I6roNXcvnhzAU7lHlA==}
     engines: {node: '>=20.11'}
 
   '@openclaw/proxyline@0.3.3':
@@ -2956,10 +2841,6 @@ packages:
     resolution: {integrity: sha512-y/Pcj1V9+qG98gyu1gvftHB7rDpdh+7kIBIggs55yGm3JdtBV8GT8IFF3a1qxZ79QnaJHX9GXzvBG6tAd+czJA==}
     engines: {node: '>=18.0.0'}
 
-  '@smithy/types@4.14.1':
-    resolution: {integrity: sha512-59b5HtSVrVR/eYNei3BUj3DCPKD/G7EtDDe7OEJE7i7FtQFugYo6MxbotS8mVJkLNVf8gYaAlEBwwtJ9HzhWSg==}
-    engines: {node: '>=18.0.0'}
-
   '@smithy/types@4.14.2':
     resolution: {integrity: sha512-P+otAxbV4CqBybp7EkcJCrig63yE2E7PuNVOmilVMRcx/O+QDzGULTrKsq4DV13gSfak9ObPrWaHl/9bL5YcWw==}
     engines: {node: '>=18.0.0'}
@@ -3031,6 +2912,9 @@ packages:
   '@smithy/uuid@1.1.2':
     resolution: {integrity: sha512-O/IEdcCUKkubz60tFbGA7ceITTAJsty+lBjNoorP4Z6XRqaFb/OjQjZODophEcuq68nKm6/0r+6/lLQ+XVpk8g==}
     engines: {node: '>=18.0.0'}
+
+  '@stablelib/base64@1.0.1':
+    resolution: {integrity: sha512-1bnPQqSxSuc3Ii6MhBysoWCg58j97aUjuCSZrGSmDxNqtytIi0k8utUenAwTZN4V5mXXYGsVUI9zeBqy+jBOSQ==}
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
@@ -3873,6 +3757,10 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
+  clawpdf@0.2.0:
+    resolution: {integrity: sha512-Za4HD3CMRHNqOXOOyVJiQLnEuezRZR/oXiBzraTwL5XEQZuBwFxnyC1UzN4AjQWV2JrLN3ItbzfPRGE0gGOVwg==}
+    engines: {node: '>=20'}
+
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
     engines: {node: '>=18'}
@@ -4119,8 +4007,8 @@ packages:
   diacritics@1.3.0:
     resolution: {integrity: sha512-wlwEkqcsaxvPJML+rDh/2iS824jbREk6DUMUKkEaSlxdYHeS43cClJtsWglvw2RfeXGm6ohKDqsXteJ5sP5enA==}
 
-  diff@8.0.4:
-    resolution: {integrity: sha512-DPi0FmjiSU5EvQV0++GFDOJ9ASQUVFh5kD+OzOnYdi7n3Wpm9hWWGfB/O2blfHcMVTL5WkQXSnRiK9makhrcnw==}
+  diff@9.0.0:
+    resolution: {integrity: sha512-svtcdpS8CgJyqAjEQIXdb3OjhFVVYjzGAPO8WGCmRbrml64SPw/jJD4GoE98aR7r25A0XcgrK3F02yw9R/vhQw==}
     engines: {node: '>=0.3.1'}
 
   dijkstrajs@1.0.3:
@@ -4559,6 +4447,9 @@ packages:
   fast-levenshtein@2.0.6:
     resolution: {integrity: sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw==}
 
+  fast-sha256@1.3.0:
+    resolution: {integrity: sha512-n11RGP/lrWEFI/bWdygLxhI+pVeo1ZYIVwvvPkW7azl/rOy+F3HYRZ2K5zeE9mmkhQppyv9sQFx0JM9UabnpPQ==}
+
   fast-string-truncated-width@3.0.3:
     resolution: {integrity: sha512-0jjjIEL6+0jag3l2XWWizO64/aZVtpiGE3t0Zgqxv0DPuxiMjvB3M24fCyhZUO4KomJQPj3LTSUnDP3GpdwC0g==}
 
@@ -4809,8 +4700,9 @@ packages:
   hermes-parser@0.25.1:
     resolution: {integrity: sha512-6pEjquH3rqaI6cYAXYPcz9MS4rY6R4ngRgrgfDshRptUZIc3lw0MCIJIGDj9++mfySOuPTHB4nrSW99BCvOPIA==}
 
-  highlight.js@10.7.3:
-    resolution: {integrity: sha512-tzcUFauisWKNHaRkN4Wjl/ZA07gENAjFl3J/c480dprkGTg5EQstgaNFqBfUqCq54kZRIEcreTsAgF/m2quD7A==}
+  highlight.js@11.11.1:
+    resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
+    engines: {node: '>=12.0.0'}
 
   hono@4.12.18:
     resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
@@ -4836,10 +4728,6 @@ packages:
   http-errors@2.0.1:
     resolution: {integrity: sha512-4FbRdAX+bSdmo4AUFuS0WNiPz8NgFt+r8ThgNWmlrjQjt1Q7ZR9+zTlce2859x4KSXrwIsaeTqDoKQmtP8pLmQ==}
     engines: {node: '>= 0.8'}
-
-  http-proxy-agent@7.0.2:
-    resolution: {integrity: sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==}
-    engines: {node: '>= 14'}
 
   http_ece@1.2.0:
     resolution: {integrity: sha512-JrF8SSLVmcvc5NducxgyOrKXe3EsyHMgBFgSaIUGmArKe+rwr0uphRkRXvwiom3I+fpIfoItveHrfudL8/rxuA==}
@@ -5155,9 +5043,6 @@ packages:
   keyv@4.5.4:
     resolution: {integrity: sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw==}
 
-  koffi@2.16.2:
-    resolution: {integrity: sha512-owU0MRwv6xkrVqCd+33uw6BaYppkTRXbO/rVdJNI2dvZG0gzyRhYwW25eWtc5pauwK8TGh3AbkFONSezdykfSA==}
-
   kysely@0.28.17:
     resolution: {integrity: sha512-nbD8lB9EB3wNdMhOCdx5Li8DxnLbvKByylRLcJ1h+4SkrowVeECAyZlyiKMThF7xFdRz0jSQ2MoJr+wXux2y0Q==}
     engines: {node: '>=20.0.0'}
@@ -5266,8 +5151,8 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.0:
-    resolution: {integrity: sha512-5aHCbzQRADcdP+ATqnDuhhJ/MRIqDkZX5pyjFHRRysS8vZ5AbqGEoFIb6pYHPZ+L/OC2Lc+xT8uHVVR5CAK/wQ==}
+  linkify-it@5.0.1:
+    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
 
   lint-staged@17.0.5:
     resolution: {integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==}
@@ -5330,8 +5215,8 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  markdown-it@14.1.1:
-    resolution: {integrity: sha512-BuU2qnTti9YKgK5N+IeMubp14ZUKUUw7yeJbkjtosvHiP0AZ5c8IAgEMk79D0eC8F23r4Ac/q8cAIFdm2FtyoA==}
+  markdown-it@14.2.0:
+    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
     hasBin: true
 
   markdown-table@3.0.4:
@@ -5738,20 +5623,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@6.26.0:
-    resolution: {integrity: sha512-zd23dbWTjiJ6sSAX6s0HrCZi41JwTA1bQVs0wLQPZ2/5o2gxOJA5wh7yOAUgwYybfhDXyhwlpeQf7Mlgx8EOCA==}
-    hasBin: true
-    peerDependencies:
-      ws: '>=8.20.1'
-      zod: ^3.25 || ^4.0
-    peerDependenciesMeta:
-      ws:
-        optional: true
-      zod:
-        optional: true
-
-  openai@6.38.0:
-    resolution: {integrity: sha512-AoMplt2UalrpgUDMh3L09QWjNRlgJPipclQvA6sYAaeF6nHNBMgmikAZGmcYLn8on4d9sQY9Q8bOLfrBS7Lc8g==}
+  openai@6.39.0:
+    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
     hasBin: true
     peerDependencies:
       ws: '>=8.20.1'
@@ -5766,8 +5639,8 @@ packages:
     resolution: {integrity: sha512-TCGlz+SPe8rvy0kQm4x39gDWO/bUlBxe6hFWvgV4g9O57/J8KQ686x4QYnR9FSGGHlmlIt6i0sJfMfNkQGB2lg==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.5.20:
-    resolution: {integrity: sha512-cgshS76CxS3Vp9NGtJR2UGtVZxVR5/4rvok8DKGGL19DugAftNabsXfYajyAEiJ3dC8QTXNqF62MdQNzUnQe8Q==}
+  openclaw@2026.5.28:
+    resolution: {integrity: sha512-p7jGN9wzCrqEvHNI6Y7+eh6DWoYDzJ1iQGKTm8xqQ2uQ9/2mY1CCf87WoZeb0+m3eHKSGchlI3tN33fE1lMtEA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -5983,8 +5856,8 @@ packages:
   queue-microtask@1.2.3:
     resolution: {integrity: sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A==}
 
-  quickjs-wasi@2.2.0:
-    resolution: {integrity: sha512-zQxXmQMrEoD3S+jQdYsloq4qAuaxKFHZj6hHqOYGwB2iQZH+q9e/lf5zQPXCKOk0WJuAjzRFbO4KwHIp2D05Iw==}
+  quickjs-wasi@3.0.0:
+    resolution: {integrity: sha512-X7ouKC4ZVf9bXQ8rsE7+L6TeBbesejAJH61x16xRaGAQGfBHHRcniWgzJZZVtHc8rS9yVsY+Tvk8/usAosg4bg==}
 
   radix-ui@1.4.3:
     resolution: {integrity: sha512-aWizCQiyeAenIdUbqEpXgRA1ya65P13NKn/W8rWkcN0OPkRDxdBVLWnIEDsS2RpwCK2nobI7oMUSmexzTDyAmA==}
@@ -6002,6 +5875,10 @@ packages:
   range-parser@1.2.1:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
+
+  rastermill@0.3.0:
+    resolution: {integrity: sha512-4g2i0I7M5sba//lFBh19Wi0hDGw8o+isnt/BtEyqQXIZaYclhcNBwL/Fw/6gDCp7aaLwQHADuUvyHCB0Oat5Vw==}
+    engines: {node: '>=20'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -6420,6 +6297,9 @@ packages:
   stackback@0.0.2:
     resolution: {integrity: sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==}
 
+  standardwebhooks@1.0.0:
+    resolution: {integrity: sha512-BbHGOQK9olHPMvQNHWul6MYlrRTAOKn03rOe4A8O3CLWhNf4YHBqq2HJKKC+sfqpxiBY52pNeesD6jIiLDz8jg==}
+
   statuses@2.0.2:
     resolution: {integrity: sha512-DvEy55V3DB7uknRo+4iOGT5fP1slR8wQohVdknigZPMpMstaKJQWhwiYBACJE3Ul2pTnATihhBYnRhZQHGBiRw==}
     engines: {node: '>= 0.8'}
@@ -6605,11 +6485,6 @@ packages:
   token-types@6.1.2:
     resolution: {integrity: sha512-dRXchy+C0IgK8WPC6xvCHFRIWYUbqqdEIKPaKo/AcTUNzwLTK6AH7RjdLWsEZcAN/TBdtfUw3PYEgPr5VPr6ww==}
     engines: {node: '>=14.16'}
-
-  tokenjuice@0.7.1:
-    resolution: {integrity: sha512-eO048hm9UcGHASjYkIWEij8QN68amGp+S1nJyo685qB1/ol+VGEYjPglcVPvCbJbZyFHvI+BBAMvOfnqYCtpsQ==}
-    engines: {node: '>=20'}
-    hasBin: true
 
   tough-cookie@6.0.1:
     resolution: {integrity: sha512-LktZQb3IeoUWB9lqR5EWTHgW/VTITCXg4D21M+lvybRVdylLrRMnqaIONLVb5mav8vM19m44HIcGq4qASeu2Qw==}
@@ -7037,18 +6912,6 @@ packages:
   wrappy@1.0.2:
     resolution: {integrity: sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==}
 
-  ws@8.20.1:
-    resolution: {integrity: sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==}
-    engines: {node: '>=10.0.0'}
-    peerDependencies:
-      bufferutil: ^4.0.1
-      utf-8-validate: '>=5.0.2'
-    peerDependenciesMeta:
-      bufferutil:
-        optional: true
-      utf-8-validate:
-        optional: true
-
   ws@8.21.0:
     resolution: {integrity: sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==}
     engines: {node: '>=10.0.0'}
@@ -7163,9 +7026,10 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.91.1(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.98.0(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
+      standardwebhooks: 1.0.0
     optionalDependencies:
       zod: 4.4.3
 
@@ -7265,51 +7129,39 @@ snapshots:
   '@aws-crypto/crc32@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/sha256-browser@5.2.0':
     dependencies:
       '@aws-crypto/sha256-js': 5.2.0
       '@aws-crypto/supports-web-crypto': 5.2.0
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@aws-sdk/util-locate-window': 3.965.5
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/sha256-js@5.2.0':
     dependencies:
       '@aws-crypto/util': 5.2.0
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/supports-web-crypto@5.2.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@aws-crypto/util@5.2.0':
     dependencies:
-      '@aws-sdk/types': 3.973.8
+      '@aws-sdk/types': 3.973.9
       '@smithy/util-utf8': 2.3.0
       tslib: 2.8.1
-
-  '@aws-sdk/client-bedrock-runtime@3.1048.0':
-    dependencies:
-      '@aws-crypto/sha256-browser': 5.2.0
-      '@aws-crypto/sha256-js': 5.2.0
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/credential-provider-node': 3.972.44
-      '@aws-sdk/eventstream-handler-node': 3.972.17
-      '@aws-sdk/middleware-eventstream': 3.972.13
-      '@aws-sdk/middleware-websocket': 3.972.21
-      '@aws-sdk/token-providers': 3.1048.0
-      '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/node-http-handler': 4.7.4
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/client-cognito-identity@3.1045.0':
     dependencies:
@@ -7366,6 +7218,7 @@ snapshots:
       '@smithy/types': 4.14.2
       bowser: 2.14.1
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-cognito-identity@3.972.31':
     dependencies:
@@ -7383,6 +7236,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-http@3.972.41':
     dependencies:
@@ -7393,6 +7247,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-ini@3.972.43':
     dependencies:
@@ -7409,6 +7264,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.3.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-login@3.972.43':
     dependencies:
@@ -7418,6 +7274,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-node@3.972.44':
     dependencies:
@@ -7432,6 +7289,7 @@ snapshots:
       '@smithy/credential-provider-imds': 4.3.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-process@3.972.39':
     dependencies:
@@ -7440,6 +7298,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-sso@3.972.43':
     dependencies:
@@ -7450,6 +7309,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-provider-web-identity@3.972.43':
     dependencies:
@@ -7459,6 +7319,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/credential-providers@3.1045.0':
     dependencies:
@@ -7485,20 +7346,6 @@ snapshots:
     transitivePeerDependencies:
       - aws-crt
     optional: true
-
-  '@aws-sdk/eventstream-handler-node@3.972.17':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
-  '@aws-sdk/middleware-eventstream@3.972.13':
-    dependencies:
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
 
   '@aws-sdk/middleware-host-header@3.972.10':
     dependencies:
@@ -7536,16 +7383,6 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@aws-sdk/middleware-websocket@3.972.21':
-    dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/types': 3.973.9
-      '@smithy/core': 3.24.4
-      '@smithy/fetch-http-handler': 5.4.4
-      '@smithy/signature-v4': 5.4.4
-      '@smithy/types': 4.14.2
-      tslib: 2.8.1
-
   '@aws-sdk/nested-clients@3.997.11':
     dependencies:
       '@aws-crypto/sha256-browser': 5.2.0
@@ -7558,6 +7395,7 @@ snapshots:
       '@smithy/node-http-handler': 4.7.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/region-config-resolver@3.972.13':
     dependencies:
@@ -7575,15 +7413,7 @@ snapshots:
       '@smithy/signature-v4': 5.4.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
-
-  '@aws-sdk/token-providers@3.1048.0':
-    dependencies:
-      '@aws-sdk/core': 3.974.13
-      '@aws-sdk/nested-clients': 3.997.11
-      '@aws-sdk/types': 3.973.8
-      '@smithy/core': 3.24.4
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/token-providers@3.1052.0':
     dependencies:
@@ -7593,16 +7423,13 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
-
-  '@aws-sdk/types@3.973.8':
-    dependencies:
-      '@smithy/types': 4.14.1
-      tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/types@3.973.9':
     dependencies:
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-endpoints@3.996.8':
     dependencies:
@@ -7616,6 +7443,7 @@ snapshots:
   '@aws-sdk/util-locate-window@3.965.5':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@aws-sdk/util-user-agent-browser@3.972.10':
     dependencies:
@@ -7641,8 +7469,10 @@ snapshots:
       '@smithy/types': 4.14.2
       fast-xml-parser: 5.7.3
       tslib: 2.8.1
+    optional: true
 
-  '@aws/lambda-invoke-store@0.2.4': {}
+  '@aws/lambda-invoke-store@0.2.4':
+    optional: true
 
   '@babel/code-frame@7.29.0':
     dependencies:
@@ -7857,74 +7687,10 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-agent-core@0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-ai': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      ignore: 7.0.5
-      typebox: 1.1.38
-      yaml: 2.9.0
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-ai@0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
-    dependencies:
-      '@anthropic-ai/sdk': 0.91.1(zod@4.4.3)
-      '@aws-sdk/client-bedrock-runtime': 3.1048.0
-      '@google/genai': 1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
-      '@mistralai/mistralai': 2.2.1
-      http-proxy-agent: 7.0.2
-      https-proxy-agent: 7.0.6
-      openai: 6.26.0(ws@8.20.1)(zod@4.4.3)
-      partial-json: 0.1.7
-      typebox: 1.1.38
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-coding-agent@0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)':
-    dependencies:
-      '@earendil-works/pi-agent-core': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.4
-      '@silvia-odwyer/photon-node': 0.3.4
-      chalk: 5.6.2
-      cross-spawn: 7.0.6
-      diff: 8.0.4
-      glob: 13.0.6
-      highlight.js: 10.7.3
-      hosted-git-info: 9.0.3
-      ignore: 7.0.5
-      jiti: 2.7.0
-      minimatch: 10.2.5
-      proper-lockfile: 4.1.2
-      typebox: 1.1.38
-      undici: 8.3.0
-      yaml: 2.9.0
-    optionalDependencies:
-      '@mariozechner/clipboard': 0.3.6
-    transitivePeerDependencies:
-      - '@modelcontextprotocol/sdk'
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-      - ws
-      - zod
-
-  '@earendil-works/pi-tui@0.75.4':
+  '@earendil-works/pi-tui@0.76.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
-    optionalDependencies:
-      koffi: 2.16.2
 
   '@emnapi/core@1.10.0':
     dependencies:
@@ -8253,20 +8019,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@google/genai@1.52.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
-    dependencies:
-      google-auth-library: 10.6.2
-      p-retry: 4.6.2
-      protobufjs: 8.4.0
-      ws: 8.21.0
-    optionalDependencies:
-      '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
-    transitivePeerDependencies:
-      - bufferutil
-      - supports-color
-      - utf-8-validate
-
-  '@google/genai@2.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -8291,7 +8044,7 @@ snapshots:
 
   '@grammyjs/types@3.27.3': {}
 
-  '@homebridge/ciao@1.3.8':
+  '@homebridge/ciao@1.3.9':
     dependencies:
       debug: 4.4.3
       fast-deep-equal: 3.1.3
@@ -8466,51 +8219,7 @@ snapshots:
       '@lydell/node-pty-win32-arm64': 1.2.0-beta.12
       '@lydell/node-pty-win32-x64': 1.2.0-beta.12
 
-  '@mariozechner/clipboard-darwin-arm64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-universal@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-darwin-x64@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-arm64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-riscv64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-gnu@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-linux-x64-musl@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-arm64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard-win32-x64-msvc@0.3.6':
-    optional: true
-
-  '@mariozechner/clipboard@0.3.6':
-    optionalDependencies:
-      '@mariozechner/clipboard-darwin-arm64': 0.3.6
-      '@mariozechner/clipboard-darwin-universal': 0.3.6
-      '@mariozechner/clipboard-darwin-x64': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-arm64-musl': 0.3.6
-      '@mariozechner/clipboard-linux-riscv64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-gnu': 0.3.6
-      '@mariozechner/clipboard-linux-x64-musl': 0.3.6
-      '@mariozechner/clipboard-win32-arm64-msvc': 0.3.6
-      '@mariozechner/clipboard-win32-x64-msvc': 0.3.6
-    optional: true
-
-  '@mistralai/mistralai@2.2.1':
+  '@mistralai/mistralai@2.2.5':
     dependencies:
       ws: 8.21.0
       zod: 4.4.3
@@ -8695,7 +8404,8 @@ snapshots:
 
   '@noble/hashes@2.0.1': {}
 
-  '@nodable/entities@2.1.0': {}
+  '@nodable/entities@2.1.0':
+    optional: true
 
   '@nodelib/fs.scandir@2.1.5':
     dependencies:
@@ -8711,7 +8421,7 @@ snapshots:
 
   '@nolyfill/is-core-module@1.0.39': {}
 
-  '@openclaw/fs-safe@0.2.7':
+  '@openclaw/fs-safe@0.3.0':
     optionalDependencies:
       jszip: 3.10.1
       tar: 7.5.13
@@ -9590,18 +9300,21 @@ snapshots:
       '@aws-crypto/crc32': 5.2.0
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/credential-provider-imds@4.3.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/fetch-http-handler@5.4.4':
     dependencies:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/hash-node@4.2.14':
     dependencies:
@@ -9620,6 +9333,7 @@ snapshots:
   '@smithy/is-array-buffer@2.2.0':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@smithy/is-array-buffer@4.2.2':
     dependencies:
@@ -9686,6 +9400,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/property-provider@4.2.14':
     dependencies:
@@ -9721,6 +9436,7 @@ snapshots:
       '@smithy/core': 3.24.4
       '@smithy/types': 4.14.2
       tslib: 2.8.1
+    optional: true
 
   '@smithy/smithy-client@4.12.13':
     dependencies:
@@ -9733,13 +9449,10 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
-  '@smithy/types@4.14.1':
-    dependencies:
-      tslib: 2.8.1
-
   '@smithy/types@4.14.2':
     dependencies:
       tslib: 2.8.1
+    optional: true
 
   '@smithy/url-parser@4.2.14':
     dependencies:
@@ -9769,6 +9482,7 @@ snapshots:
     dependencies:
       '@smithy/is-array-buffer': 2.2.0
       tslib: 2.8.1
+    optional: true
 
   '@smithy/util-buffer-from@4.2.2':
     dependencies:
@@ -9841,6 +9555,7 @@ snapshots:
     dependencies:
       '@smithy/util-buffer-from': 2.2.0
       tslib: 2.8.1
+    optional: true
 
   '@smithy/util-utf8@4.2.2':
     dependencies:
@@ -9852,6 +9567,8 @@ snapshots:
     dependencies:
       tslib: 2.8.1
     optional: true
+
+  '@stablelib/base64@1.0.1': {}
 
   '@standard-schema/spec@1.1.0': {}
 
@@ -10543,7 +10260,8 @@ snapshots:
 
   bottleneck@2.19.5: {}
 
-  bowser@2.14.1: {}
+  bowser@2.14.1:
+    optional: true
 
   brace-expansion@1.1.14:
     dependencies:
@@ -10647,6 +10365,8 @@ snapshots:
       clsx: 2.1.1
 
   classnames@2.5.1: {}
+
+  clawpdf@0.2.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -10868,7 +10588,7 @@ snapshots:
 
   diacritics@1.3.0: {}
 
-  diff@8.0.4: {}
+  diff@9.0.0: {}
 
   dijkstrajs@1.0.3: {}
 
@@ -11454,6 +11174,8 @@ snapshots:
 
   fast-levenshtein@2.0.6: {}
 
+  fast-sha256@1.3.0: {}
+
   fast-string-truncated-width@3.0.3: {}
 
   fast-string-width@3.0.2:
@@ -11469,6 +11191,7 @@ snapshots:
   fast-xml-builder@1.1.9:
     dependencies:
       path-expression-matcher: 1.5.0
+    optional: true
 
   fast-xml-parser@5.7.3:
     dependencies:
@@ -11476,6 +11199,7 @@ snapshots:
       fast-xml-builder: 1.1.9
       path-expression-matcher: 1.5.0
       strnum: 2.2.3
+    optional: true
 
   fastq@1.20.1:
     dependencies:
@@ -11762,7 +11486,7 @@ snapshots:
     dependencies:
       hermes-estree: 0.25.1
 
-  highlight.js@10.7.3: {}
+  highlight.js@11.11.1: {}
 
   hono@4.12.18: {}
 
@@ -11794,13 +11518,6 @@ snapshots:
       setprototypeof: 1.2.0
       statuses: 2.0.2
       toidentifier: 1.0.1
-
-  http-proxy-agent@7.0.2:
-    dependencies:
-      agent-base: 7.1.4
-      debug: 4.4.3
-    transitivePeerDependencies:
-      - supports-color
 
   http_ece@1.2.0: {}
 
@@ -12111,9 +11828,6 @@ snapshots:
     dependencies:
       json-buffer: 3.0.1
 
-  koffi@2.16.2:
-    optional: true
-
   kysely@0.28.17: {}
 
   kysely@0.29.2: {}
@@ -12195,7 +11909,7 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.0:
+  linkify-it@5.0.1:
     dependencies:
       uc.micro: 2.1.0
 
@@ -12277,11 +11991,11 @@ snapshots:
       underscore: 1.13.8
       xmlbuilder: 10.1.1
 
-  markdown-it@14.1.1:
+  markdown-it@14.2.0:
     dependencies:
       argparse: 2.0.1
       entities: 4.5.0
-      linkify-it: 5.0.0
+      linkify-it: 5.0.1
       mdurl: 2.0.0
       punycode.js: 2.3.1
       uc.micro: 2.1.0
@@ -12854,14 +12568,9 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.26.0(ws@8.20.1)(zod@4.4.3):
+  openai@6.39.0(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
-      ws: 8.20.1
-      zod: 4.4.3
-
-  openai@6.38.0(ws@8.20.1)(zod@4.4.3):
-    optionalDependencies:
-      ws: 8.20.1
+      ws: 8.21.0
       zod: 4.4.3
 
   openclaw-node@0.11.0:
@@ -12871,48 +12580,56 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.5.20:
+  openclaw@2026.5.28:
     dependencies:
       '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.98.0(zod@4.4.3)
       '@clack/core': 1.3.1
       '@clack/prompts': 1.4.0
-      '@earendil-works/pi-agent-core': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-ai': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-coding-agent': 0.75.4(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))(ws@8.20.1)(zod@4.4.3)
-      '@earendil-works/pi-tui': 0.75.4
-      '@google/genai': 2.5.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@earendil-works/pi-tui': 0.76.0
+      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@grammyjs/runner': 2.0.3(grammy@1.43.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
-      '@homebridge/ciao': 1.3.8
+      '@homebridge/ciao': 1.3.9
       '@lydell/node-pty': 1.2.0-beta.12
+      '@mistralai/mistralai': 2.2.5
       '@modelcontextprotocol/sdk': 1.29.0(zod@4.4.3)
       '@mozilla/readability': 0.6.0
-      '@openclaw/fs-safe': 0.2.7
+      '@openclaw/fs-safe': 0.3.0
       '@openclaw/proxyline': 0.3.3(undici@8.3.0)
-      ajv: 8.20.0
+      '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
+      clawpdf: 0.2.0
       commander: 14.0.3
       croner: 10.0.1
+      cross-spawn: 7.0.6
+      diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1
       file-type: 22.0.1
+      glob: 13.0.6
       grammy: 1.43.0
+      highlight.js: 11.11.1
+      hosted-git-info: 9.0.3
+      ignore: 7.0.5
       ipaddr.js: 2.4.0
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      markdown-it: 14.1.1
+      markdown-it: 14.2.0
+      minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.38.0(ws@8.20.1)(zod@4.4.3)
-      pdfjs-dist: 5.7.284
+      openai: 6.39.0(ws@8.21.0)(zod@4.4.3)
+      partial-json: 0.1.7
       playwright-core: 1.60.0
+      proper-lockfile: 4.1.2
       qrcode: 1.5.4
-      quickjs-wasi: 2.2.0
+      quickjs-wasi: 3.0.0
+      rastermill: 0.3.0
       tar: 7.5.15
-      tokenjuice: 0.7.1
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
       typebox: 1.1.38
@@ -12920,11 +12637,10 @@ snapshots:
       undici: 8.3.0
       web-push: 3.6.7
       web-tree-sitter: 0.26.9
-      ws: 8.20.1
+      ws: 8.21.0
       yaml: 2.9.0
       zod: 4.4.3
     optionalDependencies:
-      sharp: 0.34.5
       sqlite-vec: 0.1.9
     transitivePeerDependencies:
       - '@cfworker/json-schema'
@@ -13003,7 +12719,8 @@ snapshots:
 
   path-exists@4.0.0: {}
 
-  path-expression-matcher@1.5.0: {}
+  path-expression-matcher@1.5.0:
+    optional: true
 
   path-is-absolute@1.0.1: {}
 
@@ -13153,7 +12870,7 @@ snapshots:
 
   queue-microtask@1.2.3: {}
 
-  quickjs-wasi@2.2.0: {}
+  quickjs-wasi@3.0.0: {}
 
   radix-ui@1.4.3(@types/react-dom@19.2.3(@types/react@19.2.15))(@types/react@19.2.15)(react-dom@19.2.6(react@19.2.6))(react@19.2.6):
     dependencies:
@@ -13219,6 +12936,10 @@ snapshots:
       '@types/react-dom': 19.2.3(@types/react@19.2.15)
 
   range-parser@1.2.1: {}
+
+  rastermill@0.3.0:
+    dependencies:
+      '@silvia-odwyer/photon-node': 0.3.4
 
   raw-body@3.0.2:
     dependencies:
@@ -13752,6 +13473,11 @@ snapshots:
 
   stackback@0.0.2: {}
 
+  standardwebhooks@1.0.0:
+    dependencies:
+      '@stablelib/base64': 1.0.1
+      fast-sha256: 1.3.0
+
   statuses@2.0.2: {}
 
   std-env@4.0.0: {}
@@ -13857,7 +13583,8 @@ snapshots:
 
   strip-json-comments@3.1.1: {}
 
-  strnum@2.2.3: {}
+  strnum@2.2.3:
+    optional: true
 
   strtok3@10.3.5:
     dependencies:
@@ -13958,8 +13685,6 @@ snapshots:
       '@borewit/text-codec': 0.2.2
       '@tokenizer/token': 0.3.0
       ieee754: 1.2.1
-
-  tokenjuice@0.7.1: {}
 
   tough-cookie@6.0.1:
     dependencies:
@@ -14420,8 +14145,6 @@ snapshots:
       strip-ansi: 7.1.2
 
   wrappy@1.0.2: {}
-
-  ws@8.20.1: {}
 
   ws@8.21.0: {}
 


### PR DESCRIPTION
## Summary

Bumps the bundled OpenClaw runtime from **`2026.5.20`** to **`2026.5.28`** (latest stable; `2026.6.1` is beta-only). `openclaw-node` already sits at the latest `0.11.0`, so no client change is needed.

This is a patch-level step **within the same Gateway protocol v4 generation** — no protocol bump between `2026.5.20` and `2026.5.28`. `openclaw-node@0.11.0` advertises v4 and is compatible with OpenClaw ≥ `2026.5.12`.

## Compatibility check

- **No protocol cliff**: same v4 handshake on both ends.
- **Plugin-safe**: the SDK surfaces deprecated/removed across `2026.5.22…2026.5.28` (`channel turn runtime aliases`, sender-owner tool gating, `loadSessionStore`, `plugin-sdk/messaging-targets`) are **not imported** by any `pinchy-*` plugin — they only consume the runtime `api` object.
- Stable release range is gateway perf/caching, provider/auth hardening, and stability fixes.

## Changes

- `Dockerfile.openclaw` — pin `openclaw@2026.5.28`
- `packages/web/package.json` — `openclaw` devDep (drives `/api/version` via `next.config.ts`) → `2026.5.28`
- `packages/web/src/__tests__/api/version.test.ts` — representative version literals → `2026.5.28`
- `pnpm-lock.yaml` — regenerated (`@openclaw/fs-safe` 0.2.7 → 0.3.0)
- `docs/src/content/docs/architecture.mdx` — update current pin pair; also fixes pre-existing drift (docs still said `openclaw-node@0.10.0`; actual is `0.11.0`)

## Verification

- `version.test.ts`: 10/10 green
- Lockfile resolves cleanly, `package.json` valid, prettier/eslint pre-commit hooks pass
- Final integration/E2E gate against the real built OpenClaw image runs in CI (as with every prior OpenClaw bump)