### PR TITLE
ci: guard against untracked test deletions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -116,6 +116,21 @@ jobs:
           # shellcheck disable=SC2086 -- word-split intentional: passes each migration path as a separate squawk arg
           npx --yes squawk-cli@2.48.0 $CHANGED
 
+      - name: Test removal guard (no untracked test deletions)
+        if: github.event_name == 'pull_request'
+        env:
+          # The `allow-test-deletion` PR label is the deliberate, visible override.
+          ALLOW_TEST_DELETION: ${{ contains(github.event.pull_request.labels.*.name, 'allow-test-deletion') }}
+          # Passed via env (not interpolated into the script) to avoid shell injection.
+          PR_BODY: ${{ github.event.pull_request.body }}
+        run: |
+          # Fail if the PR removes test cases on net — deleted test files or
+          # removed it()/test() blocks — without an explicit, tracked override.
+          # Closes the gap left by no-untracked-skips (which only catches
+          # .skip/.todo). See AGENTS.md § "No Untracked Test Removal".
+          git fetch --no-tags --depth=50 origin "${{ github.base_ref }}"
+          node scripts/check-test-deletions.mjs --base "origin/${{ github.base_ref }}"
+
       - name: Test
         run: pnpm test
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,8 +121,6 @@ jobs:
         env:
           # The `allow-test-deletion` PR label is the deliberate, visible override.
           ALLOW_TEST_DELETION: ${{ contains(github.event.pull_request.labels.*.name, 'allow-test-deletion') }}
-          # Passed via env (not interpolated into the script) to avoid shell injection.
-          PR_BODY: ${{ github.event.pull_request.body }}
         run: |
           # Fail if the PR removes test cases on net — deleted test files or
           # removed it()/test() blocks — without an explicit, tracked override.

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,7 +128,12 @@ jobs:
           # removed it()/test() blocks — without an explicit, tracked override.
           # Closes the gap left by no-untracked-skips (which only catches
           # .skip/.todo). See AGENTS.md § "No Untracked Test Removal".
-          git fetch --no-tags --depth=50 origin "${{ github.base_ref }}"
+          #
+          # Fetch base + deepen HEAD so a merge-base resolves (correct PR-diff
+          # semantics). The guard falls back to a tip-to-tip diff if it can't,
+          # so a shallow clone never crashes it.
+          git fetch --no-tags --depth=200 origin "${{ github.base_ref }}"
+          git fetch --no-tags --deepen=200 origin || true
           node scripts/check-test-deletions.mjs --base "origin/${{ github.base_ref }}"
 
       - name: Test

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -74,6 +74,11 @@ Removing tests must be a deliberate, tracked act — same contract as skips. Whe
 
 A bare reason without an issue reference is not enough, exactly as with skips. Moving a test between files is net-zero and never trips the guard. Do not weaken or delete a test to make reduced code pass — a failing test after a refactor signals lost coverage, not a wrong test.
 
+Known limitations (it's a tripwire, not a precise metric):
+
+- It counts test-case calls with a regex, so it does **not** catch a test that is _commented out_ rather than deleted, and it counts `it(`/`test(` that appear inside string literals (including the guard's own fixtures). Review still owns these cases.
+- In CI it diffs against the merge-base; if a shallow clone has no merge-base it falls back to a tip-to-tip diff and logs a `::warning::`. A branch far behind the base can then report false removals — rebase on the base (or use the override) if that happens.
+
 ## Commands
 
 Development should use Docker Compose because the app depends on PostgreSQL, OpenClaw, and migrations:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -61,6 +61,19 @@ Two patterns are explicitly allowed:
 
 If a check is in your way and you can't fix it in scope, **file the issue first**, link the number, then skip. Don't ship the skip with a promise to file the issue later — the 2026-05-22 audit found five clusters where exactly that happened, one of them hiding a production password-reset bug.
 
+## No Untracked Test Removal
+
+Skips are not the only way a test silently stops protecting you — **deleting** it does too, and the skip guards above cannot see a test that no longer exists. The 2026-06 `é`-dead-key regression shipped exactly this way: a refactor removed two composer composition tests (whole `it()` blocks from a surviving file), nothing flagged it, and the bug returned undetected on the next dependency bump.
+
+The `scripts/check-test-deletions.mjs` CI guard (PR-only, in the `quality` job) closes that gap. It diffs the PR against the base branch, counts test cases (`it`/`test`/`xit`/`fit`, including `.each`) across every changed test file, and **fails if the PR removes tests on net**. Pure logic lives in `scripts/lib/check-test-deletions.mjs` and is covered by `scripts/lib/check-test-deletions.test.mjs` (`pnpm test:scripts`).
+
+Removing tests must be a deliberate, tracked act — same contract as skips. When a removal is legitimate (dead-code cleanup, a deduplicated test, a removed feature), authorize it with **either**:
+
+- a commit trailer referencing an issue: `Allow-test-deletion: #NNN`, **or**
+- the `allow-test-deletion` label on the PR.
+
+A bare reason without an issue reference is not enough, exactly as with skips. Moving a test between files is net-zero and never trips the guard. Do not weaken or delete a test to make reduced code pass — a failing test after a refactor signals lost coverage, not a wrong test.
+
 ## Commands
 
 Development should use Docker Compose because the app depends on PostgreSQL, OpenClaw, and migrations:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -89,6 +89,8 @@ pnpm test:db
 
 All new features require tests. We practice TDD — write the failing test first, then the implementation.
 
+**Don't silently remove tests.** Two CI guards enforce this: `no-untracked-skips` blocks `.skip`/`.todo` without a tracking issue, and a test-removal guard fails any PR that deletes test cases on net (deleted files or removed `it()`/`test()` blocks). If a removal is genuinely intentional (dead code, a deduplicated test, a removed feature), authorize it explicitly — add a commit trailer `Allow-test-deletion: #<issue>` or apply the `allow-test-deletion` label. Never weaken or delete a test just to make changed code pass; a test that fails after a refactor signals lost coverage. See AGENTS.md § "No Untracked Test Removal".
+
 `pnpm test:db` provisions a `pinchy_test_vitest` database against the dev-stack Postgres on `localhost:5434`. Start it once with:
 
 ```bash

--- a/scripts/check-test-deletions.mjs
+++ b/scripts/check-test-deletions.mjs
@@ -27,6 +27,7 @@ import {
   TEST_FILE_RE,
   analyzeChanges,
   parseOverride,
+  diffArgs,
 } from "./lib/check-test-deletions.mjs";
 
 function git(args) {
@@ -87,19 +88,27 @@ function parseNameStatus(raw) {
 function main() {
   const { base } = parseArgs(process.argv.slice(2));
 
-  let mergeBaseRange;
-  try {
-    git(["rev-parse", "--verify", base]);
-    mergeBaseRange = `${base}...HEAD`;
-  } catch {
+  if (!gitSafe(["rev-parse", "--verify", base])) {
     console.error(
       `[test-removal-guard] base ref "${base}" not found. In CI, fetch it first ` +
-        `(git fetch --no-tags --depth=50 origin <base>). Skipping guard.`,
+        `(git fetch --no-tags --depth=200 origin <base>). Skipping guard.`,
     );
     process.exit(0);
   }
 
-  const changedRaw = git(["diff", "--name-status", "-M", mergeBaseRange]);
+  // Best-effort merge-base for correct PR-diff semantics; tip-to-tip fallback
+  // keeps the guard working in a shallow clone with no common ancestor.
+  const mergeBase = gitSafe(["merge-base", base, "HEAD"]);
+  const changedRaw = gitSafe(diffArgs(mergeBase, base));
+  if (changedRaw === null) {
+    // Could not compute a diff at all (unexpected). Fail open with a loud
+    // warning rather than blocking every PR on a guard-infrastructure error.
+    console.error(
+      `[test-removal-guard] could not compute a diff against "${base}" — skipping guard. ` +
+        `Check the CI checkout/fetch depth.`,
+    );
+    process.exit(0);
+  }
   const changed = parseNameStatus(changedRaw);
 
   if (changed.length === 0) {

--- a/scripts/check-test-deletions.mjs
+++ b/scripts/check-test-deletions.mjs
@@ -1,0 +1,163 @@
+#!/usr/bin/env node
+/**
+ * Test-removal guard (CI).
+ *
+ * Fails when a pull request removes automated tests on net, unless the removal
+ * is explicitly authorized. This closes the gap left by the no-untracked-skips
+ * guard: that guard catches `.skip`/`.todo`, but outright DELETION of a test
+ * file or an `it()`/`test()` block leaves nothing to match. A real regression
+ * shipped exactly this way (PR that deleted two composer composition tests),
+ * so deletion must be a conscious, tracked act — same philosophy as skips.
+ *
+ * Usage:
+ *   node scripts/check-test-deletions.mjs [--base <ref>]
+ *
+ * Base ref resolution: --base arg > $BASE_REF env > "origin/main".
+ *
+ * Override (either is sufficient):
+ *   - Apply the `allow-test-deletion` PR label (CI passes $ALLOW_TEST_DELETION).
+ *   - Add a commit trailer referencing an issue:
+ *       Allow-test-deletion: #1234
+ *
+ * See AGENTS.md § "No Untracked Test Removal".
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+  TEST_FILE_RE,
+  analyzeChanges,
+  parseOverride,
+} from "./lib/check-test-deletions.mjs";
+
+function git(args) {
+  return execFileSync("git", args, {
+    encoding: "utf8",
+    maxBuffer: 64 * 1024 * 1024,
+  });
+}
+
+function gitSafe(args) {
+  // For `git show <ref>:<path>` where the path may not exist at that ref.
+  try {
+    return git(args);
+  } catch {
+    return null;
+  }
+}
+
+function parseArgs(argv) {
+  let base = process.env.BASE_REF || "origin/main";
+  for (let i = 0; i < argv.length; i++) {
+    if (argv[i] === "--base") base = argv[++i];
+  }
+  return { base };
+}
+
+function isTestPath(path) {
+  return TEST_FILE_RE.test(path);
+}
+
+/**
+ * Parse `git diff --name-status -M` into changed test-file descriptors.
+ * Returns [{ path, status, oldPath }] for test files only.
+ */
+function parseNameStatus(raw) {
+  const out = [];
+  for (const line of raw.split("\n")) {
+    if (!line.trim()) continue;
+    const parts = line.split("\t");
+    const code = parts[0];
+    if (code.startsWith("R") || code.startsWith("C")) {
+      const oldPath = parts[1];
+      const newPath = parts[2];
+      if (isTestPath(newPath) || isTestPath(oldPath)) {
+        out.push({ path: newPath, oldPath, status: "renamed" });
+      }
+      continue;
+    }
+    const path = parts[1];
+    if (!isTestPath(path)) continue;
+    if (code === "A") out.push({ path, status: "added" });
+    else if (code === "D") out.push({ path, status: "deleted" });
+    else out.push({ path, status: "modified" }); // M, T, etc.
+  }
+  return out;
+}
+
+function main() {
+  const { base } = parseArgs(process.argv.slice(2));
+
+  let mergeBaseRange;
+  try {
+    git(["rev-parse", "--verify", base]);
+    mergeBaseRange = `${base}...HEAD`;
+  } catch {
+    console.error(
+      `[test-removal-guard] base ref "${base}" not found. In CI, fetch it first ` +
+        `(git fetch --no-tags --depth=50 origin <base>). Skipping guard.`,
+    );
+    process.exit(0);
+  }
+
+  const changedRaw = git(["diff", "--name-status", "-M", mergeBaseRange]);
+  const changed = parseNameStatus(changedRaw);
+
+  if (changed.length === 0) {
+    console.log("[test-removal-guard] no test files changed — OK");
+    process.exit(0);
+  }
+
+  const files = changed.map((c) => {
+    const oldPath = c.status === "renamed" ? c.oldPath : c.path;
+    const before =
+      c.status === "added" ? null : gitSafe(["show", `${base}:${oldPath}`]);
+    const after =
+      c.status === "deleted" ? null : gitSafe(["show", `HEAD:${c.path}`]);
+    return { path: c.path, status: c.status, before, after };
+  });
+
+  const { netRemoved, removals } = analyzeChanges(files);
+
+  if (netRemoved === 0) {
+    console.log(
+      `[test-removal-guard] ${changed.length} test file(s) changed, no net test removal — OK`,
+    );
+    process.exit(0);
+  }
+
+  const messages = (
+    gitSafe(["log", "--format=%B", `${base}..HEAD`]) || ""
+  ).split(/\n(?=commit |$)/);
+  const override = parseOverride({
+    envValue: process.env.ALLOW_TEST_DELETION,
+    messages: [messages.join("\n"), process.env.PR_BODY || ""],
+  });
+
+  const detail = removals
+    .map(
+      (r) =>
+        `  - ${r.path}: ${r.before} → ${r.after} test case(s) (${r.delta})`,
+    )
+    .join("\n");
+
+  if (override.allowed) {
+    console.log(
+      `[test-removal-guard] net removal of ${netRemoved} test case(s), allowed via ${override.reason}:\n${detail}`,
+    );
+    process.exit(0);
+  }
+
+  console.error(
+    `[test-removal-guard] This PR removes ${netRemoved} test case(s) on net:\n${detail}\n\n` +
+      `Removing tests must be a deliberate, tracked act. If this is intentional ` +
+      `(e.g. dead-code cleanup, a deduplicated test, a feature removal):\n` +
+      `  • file/locate the tracking issue, then add a commit trailer:\n` +
+      `        Allow-test-deletion: #<issue-number>\n` +
+      `    (amend the commit or add an empty commit with the trailer), OR\n` +
+      `  • apply the "allow-test-deletion" label to the PR.\n` +
+      `Otherwise, restore the tests. See AGENTS.md § "No Untracked Test Removal".`,
+  );
+  process.exit(1);
+}
+
+main();

--- a/scripts/check-test-deletions.mjs
+++ b/scripts/check-test-deletions.mjs
@@ -99,6 +99,17 @@ function main() {
   // Best-effort merge-base for correct PR-diff semantics; tip-to-tip fallback
   // keeps the guard working in a shallow clone with no common ancestor.
   const mergeBase = gitSafe(["merge-base", base, "HEAD"]);
+  if (!mergeBase) {
+    // Without a merge-base we compare tip-to-tip, which can attribute tests
+    // that advanced on the base branch to this PR (false positives) if the
+    // branch is far behind. Surface it so a confusing failure is diagnosable;
+    // rebasing on the base or the override resolves it.
+    console.error(
+      `::warning::[test-removal-guard] no merge-base with "${base}" (shallow clone) — ` +
+        `using a tip-to-tip diff. A branch far behind "${base}" may report false ` +
+        `removals; rebase on "${base}" or use the override if that happens.`,
+    );
+  }
   const changedRaw = gitSafe(diffArgs(mergeBase, base));
   if (changedRaw === null) {
     // Could not compute a diff at all (unexpected). Fail open with a loud
@@ -134,12 +145,10 @@ function main() {
     process.exit(0);
   }
 
-  const messages = (
-    gitSafe(["log", "--format=%B", `${base}..HEAD`]) || ""
-  ).split(/\n(?=commit |$)/);
+  const commitLog = gitSafe(["log", "--format=%B", `${base}..HEAD`]) || "";
   const override = parseOverride({
     envValue: process.env.ALLOW_TEST_DELETION,
-    messages: [messages.join("\n"), process.env.PR_BODY || ""],
+    messages: [commitLog],
   });
 
   const detail = removals

--- a/scripts/lib/check-test-deletions.mjs
+++ b/scripts/lib/check-test-deletions.mjs
@@ -1,0 +1,84 @@
+/**
+ * Pure logic for the test-removal guard (see scripts/check-test-deletions.mjs
+ * for the CLI/CI wrapper and AGENTS.md § "No Untracked Test Removal").
+ *
+ * The guard is a tripwire, not a precise metric: it counts test-case
+ * invocations with a regex and fails CI when a PR removes tests on net,
+ * unless an explicit, tracked override is present. Mirrors the philosophy of
+ * the no-untracked-skips guard — deletion must be a conscious, greppable act.
+ */
+
+// Same matcher the no-untracked-skips drift-guard uses, kept in sync on purpose.
+export const TEST_FILE_RE = /\.(test|spec)\.(?:c|m)?[jt]sx?$/;
+
+// Match test *cases* — it / test / xit / fit, including modifier chains
+// (.skip/.only/.todo/.each/...) — terminated by "(" or a "`" (for
+// `it.each`table``). `describe` is intentionally excluded: it is a group, not
+// a case (removing a describe still removes the it()s inside it, which are
+// counted). The leading look-behind rejects keywords embedded in identifiers
+// (commit, submit, latest, audit) and method calls (obj.it(...)).
+const TEST_CASE_RE =
+  /(?<![\w$.])(?:it|test|xit|fit)(?:\.(?:skip|only|todo|fails|failing|concurrent|sequential|each|runIf|skipIf))*\s*[(`]/g;
+
+/**
+ * Count test cases in a source string.
+ * @param {string} source
+ * @returns {number}
+ */
+export function countTestCases(source) {
+  if (!source) return 0;
+  const matches = source.match(TEST_CASE_RE);
+  return matches ? matches.length : 0;
+}
+
+/**
+ * Analyze a set of changed test files.
+ * @param {Array<{path: string, status: string, before: string|null, after: string|null}>} files
+ * @returns {{ netRemoved: number, removals: Array<{path: string, before: number, after: number, delta: number}> }}
+ */
+export function analyzeChanges(files) {
+  let totalBefore = 0;
+  let totalAfter = 0;
+  const removals = [];
+
+  for (const file of files) {
+    const before = file.before == null ? 0 : countTestCases(file.before);
+    const after = file.after == null ? 0 : countTestCases(file.after);
+    totalBefore += before;
+    totalAfter += after;
+    if (after < before) {
+      removals.push({ path: file.path, before, after, delta: after - before });
+    }
+  }
+
+  removals.sort((a, b) => a.delta - b.delta);
+  return { netRemoved: Math.max(0, totalBefore - totalAfter), removals };
+}
+
+// An override must be a deliberate, tracked act — either a maintainer applied
+// the PR label (passed in via env) or a commit trailer references an issue.
+// A bare "Allow-test-deletion: because reasons" is rejected, mirroring the
+// no-untracked-skips contract where "tracked separately" is not tracking.
+const ISSUE_REF_RE =
+  /#\d+|https:\/\/github\.com\/[^/\s]+\/[^/\s]+\/issues\/\d+/;
+const TRAILER_RE = /Allow-test-deletion:\s*(.+)/i;
+
+/**
+ * Decide whether removing tests is explicitly authorized.
+ * @param {{ envValue?: string, messages?: string[] }} input
+ * @returns {{ allowed: boolean, reason: string }}
+ */
+export function parseOverride({ envValue, messages = [] } = {}) {
+  const env = (envValue ?? "").trim().toLowerCase();
+  if (env === "true" || env === "1" || env === "yes") {
+    return { allowed: true, reason: "allow-test-deletion label" };
+  }
+  for (const message of messages) {
+    const match = message.match(TRAILER_RE);
+    if (match && ISSUE_REF_RE.test(match[1])) {
+      const ref = match[1].match(ISSUE_REF_RE)[0];
+      return { allowed: true, reason: `Allow-test-deletion trailer (${ref})` };
+    }
+  }
+  return { allowed: false, reason: "" };
+}

--- a/scripts/lib/check-test-deletions.mjs
+++ b/scripts/lib/check-test-deletions.mjs
@@ -82,3 +82,25 @@ export function parseOverride({ envValue, messages = [] } = {}) {
   }
   return { allowed: false, reason: "" };
 }
+
+/**
+ * Build the `git diff` argument list for the PR's changed test files.
+ *
+ * Prefers a two-dot range from the merge-base (`<merge-base>..HEAD`), which is
+ * the correct "changes introduced by this branch" semantics. Falls back to a
+ * tip-to-tip two-dot range (`<base> HEAD`) when no merge-base is known — e.g. a
+ * shallow CI checkout with no common ancestor. We deliberately never use the
+ * three-dot form (`<base>...HEAD`): it requires a merge-base and throws in a
+ * shallow clone, which is exactly what crashed the guard.
+ *
+ * @param {string|null|undefined} mergeBase
+ * @param {string} base
+ * @returns {string[]}
+ */
+export function diffArgs(mergeBase, base) {
+  const head = ["diff", "--name-status", "-M"];
+  if (mergeBase && mergeBase.trim()) {
+    return [...head, `${mergeBase.trim()}..HEAD`];
+  }
+  return [...head, base, "HEAD"];
+}

--- a/scripts/lib/check-test-deletions.test.mjs
+++ b/scripts/lib/check-test-deletions.test.mjs
@@ -4,7 +4,40 @@ import {
   countTestCases,
   analyzeChanges,
   parseOverride,
+  diffArgs,
 } from "./check-test-deletions.mjs";
+
+test("diffArgs uses merge-base two-dot range when a merge-base is known", () => {
+  // Correct PR semantics: only changes introduced by the branch.
+  assert.deepEqual(diffArgs("abc123", "origin/main"), [
+    "diff",
+    "--name-status",
+    "-M",
+    "abc123..HEAD",
+  ]);
+});
+
+test("diffArgs falls back to tip-to-tip two-dot when no merge-base (shallow CI)", () => {
+  // Never uses three-dot (origin/main...HEAD), which throws in a shallow clone
+  // with no common ancestor. Tip-to-tip always resolves once base is fetched.
+  assert.deepEqual(diffArgs(null, "origin/main"), [
+    "diff",
+    "--name-status",
+    "-M",
+    "origin/main",
+    "HEAD",
+  ]);
+});
+
+test("diffArgs treats an empty merge-base string as no merge-base", () => {
+  assert.deepEqual(diffArgs("", "origin/main"), [
+    "diff",
+    "--name-status",
+    "-M",
+    "origin/main",
+    "HEAD",
+  ]);
+});
 
 test("countTestCases counts it/test/xit/fit invocations", () => {
   const src = `

--- a/scripts/lib/check-test-deletions.test.mjs
+++ b/scripts/lib/check-test-deletions.test.mjs
@@ -1,0 +1,136 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import {
+  countTestCases,
+  analyzeChanges,
+  parseOverride,
+} from "./check-test-deletions.mjs";
+
+test("countTestCases counts it/test/xit/fit invocations", () => {
+  const src = `
+    describe("group", () => {
+      it("a", () => {});
+      test("b", () => {});
+      xit("c", () => {});
+      fit("d", () => {});
+    });
+  `;
+  // describe is a group, not a case — only the four cases count.
+  assert.equal(countTestCases(src), 4);
+});
+
+test("countTestCases counts modifier and .each forms", () => {
+  const src = `
+    it.skip("a", () => {});
+    it.only("b", () => {});
+    test.concurrent("c", () => {});
+    it.each([1, 2])("d %s", () => {});
+    test.each\`
+      x
+    \`("e", () => {});
+  `;
+  assert.equal(countTestCases(src), 5);
+});
+
+test("countTestCases does not count identifiers that merely contain a keyword", () => {
+  const src = `
+    commit("not a test");
+    submit("nope");
+    const latest = compute();
+    obj.it("method call, not a test case");
+    audit("x");
+  `;
+  assert.equal(countTestCases(src), 0);
+});
+
+test("analyzeChanges reports all cases removed when a test file is deleted", () => {
+  const before = `it("a", () => {}); it("b", () => {});`;
+  const result = analyzeChanges([
+    { path: "a.test.ts", status: "deleted", before, after: null },
+  ]);
+  assert.equal(result.netRemoved, 2);
+  assert.deepEqual(result.removals, [
+    { path: "a.test.ts", before: 2, after: 0, delta: -2 },
+  ]);
+});
+
+test("analyzeChanges flags net removal inside a modified file", () => {
+  const before = `it("a",()=>{}); it("b",()=>{}); it("c",()=>{});`;
+  const after = `it("a",()=>{});`;
+  const result = analyzeChanges([
+    { path: "x.test.ts", status: "modified", before, after },
+  ]);
+  assert.equal(result.netRemoved, 2);
+  assert.equal(result.removals.length, 1);
+  assert.equal(result.removals[0].delta, -2);
+});
+
+test("analyzeChanges treats moving a test between files as net zero", () => {
+  const result = analyzeChanges([
+    {
+      path: "a.test.ts",
+      status: "modified",
+      before: `it("x",()=>{}); it("y",()=>{});`,
+      after: `it("x",()=>{});`,
+    },
+    {
+      path: "b.test.ts",
+      status: "modified",
+      before: `it("z",()=>{});`,
+      after: `it("z",()=>{}); it("y",()=>{});`,
+    },
+  ]);
+  assert.equal(result.netRemoved, 0);
+});
+
+test("analyzeChanges returns netRemoved 0 when tests are only added", () => {
+  const result = analyzeChanges([
+    {
+      path: "n.test.ts",
+      status: "added",
+      before: null,
+      after: `it("a",()=>{}); it("b",()=>{});`,
+    },
+  ]);
+  assert.equal(result.netRemoved, 0);
+  assert.deepEqual(result.removals, []);
+});
+
+test("parseOverride allows when the CI label env is set", () => {
+  assert.equal(parseOverride({ envValue: "true", messages: [] }).allowed, true);
+  assert.equal(parseOverride({ envValue: "1", messages: [] }).allowed, true);
+});
+
+test("parseOverride ignores falsey/empty env values", () => {
+  assert.equal(parseOverride({ envValue: "", messages: [] }).allowed, false);
+  assert.equal(
+    parseOverride({ envValue: "false", messages: [] }).allowed,
+    false,
+  );
+  assert.equal(
+    parseOverride({ envValue: undefined, messages: [] }).allowed,
+    false,
+  );
+});
+
+test("parseOverride allows a commit trailer that references an issue", () => {
+  const messages = ["fix: dedup tests\n\nAllow-test-deletion: #449"];
+  const result = parseOverride({ envValue: "", messages });
+  assert.equal(result.allowed, true);
+  assert.match(result.reason, /#449/);
+});
+
+test("parseOverride accepts a full issue URL in the trailer", () => {
+  const messages = [
+    "Allow-test-deletion: https://github.com/heypinchy/pinchy/issues/12",
+  ];
+  assert.equal(parseOverride({ envValue: "", messages }).allowed, true);
+});
+
+test("parseOverride rejects a trailer without an issue reference", () => {
+  // Mirrors no-untracked-skips: a bare promise is not tracking.
+  const messages = [
+    "chore: cleanup\n\nAllow-test-deletion: yes because reasons",
+  ];
+  assert.equal(parseOverride({ envValue: "", messages }).allowed, false);
+});


### PR DESCRIPTION
## What does this PR do?

Adds a CI guard that fails any PR which **deletes automated tests on net** without an explicit, tracked override. This closes a real gap in our test-integrity guarantees.

### Why

The `no-untracked-skips` guards (ESLint rule + vitest drift-guard) catch `.skip`/`.todo`/`xit`, but they cannot see a test that was **outright deleted** — a whole test file, or one or more `it()`/`test()` blocks removed from a surviving file. A real regression shipped exactly this way: PR #450's root cause was that an earlier refactor (`26bb31a2b`) removed two composer IME-composition tests, nothing flagged it, and the `é` dead-key freeze returned undetected on the next `@assistant-ui/react` bump.

### How

`scripts/check-test-deletions.mjs` runs PR-only in the `quality` job. It diffs against the base branch, counts test cases (`it`/`test`/`xit`/`fit`, including `.each`) across every changed test file, and fails when the net count drops. Same philosophy as `no-untracked-skips`: removing a test must be a deliberate, tracked act.

**Override (either is sufficient):**
- apply the `allow-test-deletion` label to the PR, or
- add a commit trailer `Allow-test-deletion: #<issue>`.

A bare reason without an issue reference is rejected (mirrors the skip contract). **Moving** a test between files is net-zero and never trips the guard.

Pure logic lives in `scripts/lib/check-test-deletions.mjs`, TDD-covered by `scripts/lib/check-test-deletions.test.mjs` (runs in `pnpm test:scripts`). Documented in `AGENTS.md` § "No Untracked Test Removal" and `CONTRIBUTING.md`.

### Verified

- Unit suite: 12 new tests, green (`pnpm test:scripts` → 63 pass).
- End-to-end on a scratch branch: removing 2 `test()` blocks → guard exits 1 with a clear message; `ALLOW_TEST_DELETION=true` → exits 0; `Allow-test-deletion: #449` trailer → exits 0.
- This PR only adds tests, so the new guard passes on itself.

### Deliberately not included (documented as optional next layers)

- **CODEOWNERS + required review on test paths** — for the current solo/small-maintainer flow (commits land on `main` directly) this would block the author from merging their own test changes (no self-approval). Worth enabling if the team grows.
- **Mutation testing (Stryker)** — the right tool against test *weakening* (not just deletion), but a meaningful monorepo run is slow and would need careful scoping to avoid a flaky/long CI job; better as its own initiative than bolted on here.

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [x] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass
