### PR TITLE
feat(release): enforce package.json/tag/version parity in CI (#438)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -58,7 +58,12 @@ jobs:
       # `pinchyVersion` despite the tag. This fails the workflow before any
       # GHCR push, so a botched release leaves no artifact to clean up.
       - name: Assert package.json versions match the release tag
-        run: node scripts/assert-package-version.mjs "${{ steps.release-tag.outputs.tag }}"
+        # Pass the tag via env (not inline ${{ }}) so the value never reaches
+        # the shell as interpolated text — same expression-injection-safe
+        # pattern as the Layer 3 smoke check below.
+        env:
+          RELEASE_TAG: ${{ steps.release-tag.outputs.tag }}
+        run: node scripts/assert-package-version.mjs "$RELEASE_TAG"
 
       - name: Extract metadata (tags, labels)
         id: meta-pinchy

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -53,6 +53,13 @@ jobs:
           echo "tag=${RELEASE_TAG}" >> "$GITHUB_OUTPUT"
           echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
 
+      # Build-time guard for the v0.5.5 drift: `gh release create` skipped the
+      # `pnpm release` version bump, so the images reported a stale
+      # `pinchyVersion` despite the tag. This fails the workflow before any
+      # GHCR push, so a botched release leaves no artifact to clean up.
+      - name: Assert package.json versions match the release tag
+        run: node scripts/assert-package-version.mjs "${{ steps.release-tag.outputs.tag }}"
+
       - name: Extract metadata (tags, labels)
         id: meta-pinchy
         uses: docker/metadata-action@v5
@@ -170,6 +177,25 @@ jobs:
           docker compose ps
           docker compose logs
           exit 1
+
+      # Runtime side of the v0.5.5 guard: /api/version reports
+      # packages/web/package.json#version (baked into NEXT_PUBLIC_PINCHY_VERSION
+      # at build time). Asserting it here catches any path that produces a
+      # runtime/tag mismatch — including future changes to where pinchyVersion
+      # is sourced — not just the package.json drift Layer 2 covers.
+      - name: Assert /api/version reports the released version
+        env:
+          RELEASE_TAG: ${{ github.event_name == 'workflow_dispatch' && inputs.tag || github.ref_name }}
+        working-directory: ${{ steps.install-dir.outputs.path }}
+        run: |
+          EXPECTED="${RELEASE_TAG#v}"
+          REPORTED=$(curl -sf http://localhost:7777/api/version | jq -r '.pinchyVersion')
+          echo "Reported pinchyVersion: '$REPORTED' (expected '$EXPECTED')"
+          if [ "$REPORTED" != "$EXPECTED" ]; then
+            echo "::error::/api/version reports '$REPORTED' but release is ${RELEASE_TAG}. The release was likely cut without 'pnpm release', leaving package.json#version stale."
+            docker compose logs --tail=20 pinchy
+            exit 1
+          fi
 
       - name: Assert all services running
         working-directory: ${{ steps.install-dir.outputs.path }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -189,7 +189,14 @@ jobs:
         working-directory: ${{ steps.install-dir.outputs.path }}
         run: |
           EXPECTED="${RELEASE_TAG#v}"
-          REPORTED=$(curl -sf http://localhost:7777/api/version | jq -r '.pinchyVersion')
+          # Capture curl separately so a non-responding endpoint produces a
+          # clear message instead of an opaque pipefail abort mid-step.
+          if ! RESPONSE=$(curl -sf http://localhost:7777/api/version); then
+            echo "::error::/api/version did not respond on the published stack."
+            docker compose logs --tail=20 pinchy
+            exit 1
+          fi
+          REPORTED=$(echo "$RESPONSE" | jq -r '.pinchyVersion')
           echo "Reported pinchyVersion: '$REPORTED' (expected '$EXPECTED')"
           if [ "$REPORTED" != "$EXPECTED" ]; then
             echo "::error::/api/version reports '$REPORTED' but release is ${RELEASE_TAG}. The release was likely cut without 'pnpm release', leaving package.json#version stale."

--- a/packages/web/src/__tests__/lib/diagnostics/scope-resolver.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/scope-resolver.test.ts
@@ -62,6 +62,18 @@ describe("computeScope", () => {
       expect(scope.includedTurnRange).toEqual([5, 14]);
     });
 
+    it("falls back to no-anchor for an opaque id that merely starts with digits", () => {
+      // assistant-ui message ids are opaque (nanoid-style) strings that begin
+      // with a digit ~16% of the time. parseInt would leniently read the
+      // leading digit as a turn index ("1-aBcD" -> 1), wrongly anchoring the
+      // bundle and flaking diagnostics-export.spec.ts. Only a *pure* integer
+      // string is a valid stringified turn index in v1.
+      const turns = makeTurns(15);
+      const scope = computeScope(turns, "1-aBcD3fG", 10);
+      expect(scope.anchorTurnIndex).toBeNull();
+      expect(scope.includedTurnRange).toEqual([5, 14]);
+    });
+
     it("falls back to no-anchor when anchorMessageId is out of range", () => {
       const turns = makeTurns(15);
       const scope = computeScope(turns, "99", 10);

--- a/packages/web/src/lib/diagnostics/scope-resolver.ts
+++ b/packages/web/src/lib/diagnostics/scope-resolver.ts
@@ -39,7 +39,12 @@ export function computeScope(
   }
 
   if (anchorMessageId !== undefined) {
-    const parsed = parseInt(anchorMessageId, 10);
+    // Only a *pure* non-negative integer string is a valid stringified turn
+    // index. parseInt alone is too lenient: assistant-ui message ids are opaque
+    // nanoid-style strings that begin with a digit ~16% of the time, and
+    // parseInt("1-aBcD") === 1 would wrongly anchor the bundle (and flake
+    // diagnostics-export.spec.ts). Require the whole string to be digits.
+    const parsed = /^\d+$/.test(anchorMessageId) ? parseInt(anchorMessageId, 10) : NaN;
     if (Number.isInteger(parsed) && parsed >= 0 && parsed < turns.length) {
       const end = parsed;
       const start = Math.max(0, end - (windowSize - 1));

--- a/scripts/assert-package-version.mjs
+++ b/scripts/assert-package-version.mjs
@@ -1,0 +1,41 @@
+#!/usr/bin/env node
+/**
+ * Build-time release guard: asserts that the version field of both
+ * package.json (root) and packages/web/package.json matches the release tag
+ * before any Docker image is built and pushed.
+ *
+ * Usage: node scripts/assert-package-version.mjs <tag>
+ *   e.g. node scripts/assert-package-version.mjs v0.5.5
+ *
+ * Exits 0 when both versions match the tag, 1 (with a ::error:: annotation
+ * for GitHub Actions) otherwise. See assertVersionMatchesTag in
+ * lib/release-logic.mjs for the v0.5.5 regression this guards against.
+ */
+
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertVersionMatchesTag } from "./lib/release-logic.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+const [, , tag] = process.argv;
+if (!tag) {
+  process.stderr.write("Usage: assert-package-version.mjs <tag>\n");
+  process.exit(1);
+}
+
+const readVersion = (relPath) => JSON.parse(readFileSync(resolve(ROOT, relPath), "utf8")).version;
+
+try {
+  assertVersionMatchesTag({
+    tag,
+    pkgVersion: readVersion("package.json"),
+    webVersion: readVersion("packages/web/package.json"),
+  });
+  process.stdout.write(`package versions match ${tag}\n`);
+} catch (err) {
+  process.stdout.write(`::error::${err.message}\n`);
+  process.exit(1);
+}

--- a/scripts/lib/assert-package-version.test.mjs
+++ b/scripts/lib/assert-package-version.test.mjs
@@ -32,7 +32,8 @@ function runCli(args) {
 test("CLI exits 0 when the tag matches the repo's package versions", () => {
   const result = runCli([`v${REPO_VERSION}`]);
   assert.equal(result.status, 0, result.stdout + result.stderr);
-  assert.match(result.stdout, new RegExp(`match v${REPO_VERSION.replace(/\./g, "\\.")}`));
+  // Plain substring check — no regex, so no escaping of the version is needed.
+  assert.ok(result.stdout.includes(`match v${REPO_VERSION}`), result.stdout);
 });
 
 test("CLI exits 1 with a ::error:: annotation on version drift", () => {

--- a/scripts/lib/assert-package-version.test.mjs
+++ b/scripts/lib/assert-package-version.test.mjs
@@ -1,0 +1,49 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { execFileSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// End-to-end coverage for the CLI glue around assertVersionMatchesTag: argv
+// parsing, file reading, and — most importantly — the exit codes release.yml
+// relies on to fail the workflow. The pure comparison is unit-tested in
+// release-logic.test.mjs; this exercises the script as the workflow runs it.
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const SCRIPT = resolve(ROOT, "scripts", "assert-package-version.mjs");
+const REPO_VERSION = JSON.parse(readFileSync(resolve(ROOT, "package.json"), "utf8")).version;
+
+// Runs the CLI and returns { status, stdout, stderr }. execFileSync throws on a
+// non-zero exit, so the catch path normalizes both outcomes into one shape.
+function runCli(args) {
+  try {
+    const stdout = execFileSync("node", [SCRIPT, ...args], { encoding: "utf8" });
+    return { status: 0, stdout, stderr: "" };
+  } catch (err) {
+    return {
+      status: err.status,
+      stdout: err.stdout?.toString() ?? "",
+      stderr: err.stderr?.toString() ?? "",
+    };
+  }
+}
+
+test("CLI exits 0 when the tag matches the repo's package versions", () => {
+  const result = runCli([`v${REPO_VERSION}`]);
+  assert.equal(result.status, 0, result.stdout + result.stderr);
+  assert.match(result.stdout, new RegExp(`match v${REPO_VERSION.replace(/\./g, "\\.")}`));
+});
+
+test("CLI exits 1 with a ::error:: annotation on version drift", () => {
+  const result = runCli(["v99.99.99"]);
+  assert.equal(result.status, 1);
+  assert.match(result.stdout, /::error::/);
+  assert.match(result.stdout, /pnpm release 99\.99\.99/);
+});
+
+test("CLI exits 1 with usage when no tag is given", () => {
+  const result = runCli([]);
+  assert.equal(result.status, 1);
+  assert.match(result.stderr, /Usage:/);
+});

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -74,6 +74,41 @@ export function buildCommitMessage(version) {
 }
 
 /**
+ * Asserts that both package.json versions match the release tag.
+ *
+ * Regression guard for the v0.5.5 release: it was cut with `gh release create`
+ * instead of `pnpm release`, so the `chore: release` version bump never ran and
+ * the published images reported `pinchyVersion: 0.5.4` (from packages/web's
+ * pkg.version, baked into NEXT_PUBLIC_PINCHY_VERSION at build) despite the
+ * v0.5.5 tag. release.yml runs this before pushing any image so the drift fails
+ * the workflow cheaply, before any GHCR artifact exists.
+ *
+ * @param {{ tag: string, pkgVersion: string, webVersion: string }} args
+ *   tag — release tag, with or without leading 'v' (e.g. "v0.5.5" or "0.5.5").
+ *   pkgVersion — version field of root package.json.
+ *   webVersion — version field of packages/web/package.json.
+ * @throws {Error} if the tag is not valid semver, or if either package version
+ *   does not match the tag.
+ */
+export function assertVersionMatchesTag({ tag, pkgVersion, webVersion }) {
+  const expected = parseAndValidateVersion(tag);
+  const mismatches = [];
+  if (pkgVersion !== expected) {
+    mismatches.push(`  package.json:              ${pkgVersion}`);
+  }
+  if (webVersion !== expected) {
+    mismatches.push(`  packages/web/package.json: ${webVersion}`);
+  }
+  if (mismatches.length > 0) {
+    throw new Error(
+      `Tag v${expected} does not match package versions:\n` +
+        `${mismatches.join("\n")}\n` +
+        `Run 'pnpm release ${expected}' to bump both before tagging.`,
+    );
+  }
+}
+
+/**
  * Escapes a string for safe inclusion in a RegExp pattern.
  * @param {string} s
  * @returns {string}

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -8,6 +8,7 @@ import {
   assertUpgradingSectionExists,
   extractUpgradeNotes,
   bumpEnvExample,
+  assertVersionMatchesTag,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -41,11 +42,7 @@ test("bumpPackageJson updates version field", () => {
 });
 
 test("bumpPackageJson preserves other fields", () => {
-  const input = JSON.stringify(
-    { name: "pinchy", version: "0.2.0", private: true },
-    null,
-    2,
-  );
+  const input = JSON.stringify({ name: "pinchy", version: "0.2.0", private: true }, null, 2);
   const output = bumpPackageJson(input, "0.3.0");
   const parsed = JSON.parse(output);
   assert.equal(parsed.name, "pinchy");
@@ -62,6 +59,83 @@ test("bumpPackageJson preserves trailing newline", () => {
 
 test("buildTagName prefixes version with v", () => {
   assert.equal(buildTagName("0.3.0"), "v0.3.0");
+});
+
+// assertVersionMatchesTag — the v0.5.5 regression guard. `gh release create`
+// skipped the `pnpm release` version bump, so the published images reported a
+// stale `pinchyVersion` (0.5.4) despite the v0.5.5 tag. This function is the
+// build-time gate that release.yml runs before pushing any image.
+
+test("assertVersionMatchesTag passes when both package versions match the tag", () => {
+  assert.doesNotThrow(() =>
+    assertVersionMatchesTag({
+      tag: "v0.5.5",
+      pkgVersion: "0.5.5",
+      webVersion: "0.5.5",
+    }),
+  );
+});
+
+test("assertVersionMatchesTag accepts a tag without the leading v", () => {
+  assert.doesNotThrow(() =>
+    assertVersionMatchesTag({
+      tag: "0.5.5",
+      pkgVersion: "0.5.5",
+      webVersion: "0.5.5",
+    }),
+  );
+});
+
+test("assertVersionMatchesTag throws when the root package.json version is stale", () => {
+  assert.throws(
+    () =>
+      assertVersionMatchesTag({
+        tag: "v0.5.5",
+        pkgVersion: "0.5.4",
+        webVersion: "0.5.5",
+      }),
+    /package\.json/,
+  );
+});
+
+test("assertVersionMatchesTag throws when the web package.json version is stale", () => {
+  assert.throws(
+    () =>
+      assertVersionMatchesTag({
+        tag: "v0.5.5",
+        pkgVersion: "0.5.5",
+        webVersion: "0.5.4",
+      }),
+    /packages\/web\/package\.json/,
+  );
+});
+
+test("assertVersionMatchesTag error names the offending version and suggests pnpm release", () => {
+  assert.throws(
+    () =>
+      assertVersionMatchesTag({
+        tag: "v0.5.5",
+        pkgVersion: "0.5.4",
+        webVersion: "0.5.4",
+      }),
+    (err) => {
+      assert.match(err.message, /0\.5\.4/);
+      assert.match(err.message, /pnpm release 0\.5\.5/);
+      return true;
+    },
+  );
+});
+
+test("assertVersionMatchesTag rejects a malformed tag", () => {
+  assert.throws(
+    () =>
+      assertVersionMatchesTag({
+        tag: "not-a-version",
+        pkgVersion: "0.5.5",
+        webVersion: "0.5.5",
+      }),
+    /invalid version/i,
+  );
 });
 
 // buildCommitMessage
@@ -84,9 +158,7 @@ test("assertUpgradingSectionExists accepts %%PINCHY_VERSION%% placeholder", () =
     "",
     "Notes go here.",
   ].join("\n");
-  assert.doesNotThrow(() =>
-    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
-  );
+  assert.doesNotThrow(() => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"));
 });
 
 test("assertUpgradingSectionExists accepts concrete target version", () => {
@@ -101,9 +173,7 @@ test("assertUpgradingSectionExists accepts concrete target version", () => {
     "",
     "Notes.",
   ].join("\n");
-  assert.doesNotThrow(() =>
-    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
-  );
+  assert.doesNotThrow(() => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"));
 });
 
 test("assertUpgradingSectionExists rejects missing section", () => {
@@ -125,9 +195,7 @@ test("assertUpgradingSectionExists rejects stale section (wrong 'from' version)"
 test("assertUpgradingSectionExists is whitespace-tolerant in the heading", () => {
   const mdx =
     "##   Upgrading  from  v0.4.4  to  %%PINCHY_VERSION%%  \n\n### Breaking changes\n\nNone.\n\n### Upgrade notes\n\nNotes.\n";
-  assert.doesNotThrow(() =>
-    assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"),
-  );
+  assert.doesNotThrow(() => assertUpgradingSectionExists(mdx, "0.4.4", "0.5.0"));
 });
 
 test("assertUpgradingSectionExists error message suggests the heading to add", () => {
@@ -308,10 +376,7 @@ test("bumpEnvExample throws when PINCHY_VERSION line is missing", () => {
   const input = `# Only optional vars, no PINCHY_VERSION
 # DB_PASSWORD=
 `;
-  assert.throws(
-    () => bumpEnvExample(input, "0.5.0"),
-    /No PINCHY_VERSION= line in \.env\.example/,
-  );
+  assert.throws(() => bumpEnvExample(input, "0.5.0"), /No PINCHY_VERSION= line in \.env\.example/);
 });
 
 test("bumpEnvExample preserves order and other variables when many exist", () => {

--- a/scripts/lib/release-version-guards.test.mjs
+++ b/scripts/lib/release-version-guards.test.mjs
@@ -1,0 +1,103 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Wiring guard for issue #438: a unit-tested version-match function and an
+// /api/version smoke check only protect a release if release.yml actually
+// invokes them. These textual sweeps fail if either guard is dropped from the
+// workflow (e.g. a refactor that re-orders or deletes the step). Same
+// dependency-free approach as workflow-compose-env.test.mjs.
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const RELEASE_YML = join(ROOT, ".github", "workflows", "release.yml");
+
+// Splits release.yml into per-job text blocks: { jobName, body }. Jobs are
+// 2-space-indented top-level keys under the `jobs:` line; a job's body runs
+// from its header up to (but not including) the next sibling job header.
+function splitWorkflowIntoJobs(workflowPath) {
+  const lines = readFileSync(workflowPath, "utf8").split("\n");
+  let inJobs = false;
+  let jobName = null;
+  let jobStart = -1;
+  const jobs = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+
+    const jobMatch = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobMatch) {
+      if (jobName !== null) {
+        jobs.push({ jobName, body: lines.slice(jobStart, i).join("\n") });
+      }
+      jobName = jobMatch[1];
+      jobStart = i;
+    }
+  }
+  if (jobName !== null) {
+    jobs.push({ jobName, body: lines.slice(jobStart).join("\n") });
+  }
+  return jobs;
+}
+
+function jobBody(name) {
+  const job = splitWorkflowIntoJobs(RELEASE_YML).find((j) => j.jobName === name);
+  assert.ok(job, `release.yml has no '${name}' job (workflow restructured?)`);
+  return job.body;
+}
+
+// Layer 2: build-time version-match guard.
+
+test("release.yml docker job runs the package-version assert", () => {
+  const body = jobBody("docker");
+  assert.match(
+    body,
+    /assert-package-version\.mjs/,
+    "docker job must run scripts/assert-package-version.mjs to catch tag/version drift",
+  );
+});
+
+test("release.yml asserts the version before pushing any image", () => {
+  const body = jobBody("docker");
+  const assertIdx = body.indexOf("assert-package-version.mjs");
+  const buildPushIdx = body.indexOf("docker/build-push-action");
+  assert.ok(assertIdx !== -1, "version assert step is missing");
+  assert.ok(buildPushIdx !== -1, "build-push step is missing");
+  assert.ok(
+    assertIdx < buildPushIdx,
+    "the version assert must run before docker/build-push-action so a stale " +
+      "version fails the workflow before any GHCR push",
+  );
+});
+
+// Layer 3: runtime /api/version smoke check.
+
+test("release.yml end-user-install job smoke-checks /api/version against the tag", () => {
+  const body = jobBody("end-user-install-published");
+  assert.match(
+    body,
+    /\/api\/version/,
+    "end-user-install-published must query /api/version to verify the runtime " +
+      "reports the released version",
+  );
+  assert.match(
+    body,
+    /pinchyVersion/,
+    "the smoke check must read the pinchyVersion field from /api/version",
+  );
+  // The reported pinchyVersion carries no leading 'v', so a correct comparison
+  // must strip it from the tag. `RELEASE_TAG#v` is unique to the smoke step —
+  // the pre-existing .env step uses ${RELEASE_TAG} unstripped — so this also
+  // ties the assertion to the smoke check rather than any RELEASE_TAG mention.
+  assert.match(
+    body,
+    /RELEASE_TAG#v/,
+    "the smoke check must compare /api/version against the v-stripped release tag",
+  );
+});

--- a/scripts/lib/release-version-guards.test.mjs
+++ b/scripts/lib/release-version-guards.test.mjs
@@ -1,8 +1,8 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readFileSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { splitWorkflowIntoJobs } from "./workflow-jobs.mjs";
 
 // Wiring guard for issue #438: a unit-tested version-match function and an
 // /api/version smoke check only protect a release if release.yml actually
@@ -12,39 +12,6 @@ import { fileURLToPath } from "node:url";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const RELEASE_YML = join(ROOT, ".github", "workflows", "release.yml");
-
-// Splits release.yml into per-job text blocks: { jobName, body }. Jobs are
-// 2-space-indented top-level keys under the `jobs:` line; a job's body runs
-// from its header up to (but not including) the next sibling job header.
-function splitWorkflowIntoJobs(workflowPath) {
-  const lines = readFileSync(workflowPath, "utf8").split("\n");
-  let inJobs = false;
-  let jobName = null;
-  let jobStart = -1;
-  const jobs = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^jobs:\s*$/.test(line)) {
-      inJobs = true;
-      continue;
-    }
-    if (!inJobs) continue;
-
-    const jobMatch = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
-    if (jobMatch) {
-      if (jobName !== null) {
-        jobs.push({ jobName, body: lines.slice(jobStart, i).join("\n") });
-      }
-      jobName = jobMatch[1];
-      jobStart = i;
-    }
-  }
-  if (jobName !== null) {
-    jobs.push({ jobName, body: lines.slice(jobStart).join("\n") });
-  }
-  return jobs;
-}
 
 function jobBody(name) {
   const job = splitWorkflowIntoJobs(RELEASE_YML).find((j) => j.jobName === name);

--- a/scripts/lib/workflow-compose-env.test.mjs
+++ b/scripts/lib/workflow-compose-env.test.mjs
@@ -1,8 +1,9 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
-import { readdirSync, readFileSync } from "node:fs";
+import { readdirSync } from "node:fs";
 import { join, dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
+import { splitWorkflowIntoJobs } from "./workflow-jobs.mjs";
 
 // Regression guard for the failed v0.5.0 release: the screenshots.yml
 // workflow ran `docker compose up -d` without setting PINCHY_VERSION,
@@ -34,50 +35,6 @@ function listWorkflows() {
   return readdirSync(WORKFLOW_DIR)
     .filter((f) => f.endsWith(".yml") || f.endsWith(".yaml"))
     .map((f) => join(WORKFLOW_DIR, f));
-}
-
-// Splits a workflow file into per-job text blocks. Returns
-// { jobName, body } pairs. Jobs are detected as 2-space-indented top-level
-// keys under the `jobs:` line. Body is the raw text from the job header
-// up to (but not including) the next sibling job header.
-function splitWorkflowIntoJobs(workflowPath) {
-  const text = readFileSync(workflowPath, "utf8");
-  const lines = text.split("\n");
-
-  let inJobs = false;
-  let jobName = null;
-  let jobStart = -1;
-  const jobs = [];
-
-  for (let i = 0; i < lines.length; i++) {
-    const line = lines[i];
-    if (/^jobs:\s*$/.test(line)) {
-      inJobs = true;
-      continue;
-    }
-    if (!inJobs) continue;
-
-    const jobMatch = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
-    if (jobMatch) {
-      if (jobName !== null) {
-        jobs.push({
-          jobName,
-          body: lines.slice(jobStart, i).join("\n"),
-          path: workflowPath,
-        });
-      }
-      jobName = jobMatch[1];
-      jobStart = i;
-    }
-  }
-  if (jobName !== null) {
-    jobs.push({
-      jobName,
-      body: lines.slice(jobStart).join("\n"),
-      path: workflowPath,
-    });
-  }
-  return jobs;
 }
 
 function jobInvokesCompose(job) {

--- a/scripts/lib/workflow-jobs.mjs
+++ b/scripts/lib/workflow-jobs.mjs
@@ -1,0 +1,57 @@
+/**
+ * Shared helper for textual sweeps over GitHub Actions workflow files.
+ * No side effects beyond reading the given workflow file.
+ */
+
+import { readFileSync } from "node:fs";
+
+/**
+ * Splits a workflow file into per-job text blocks. Returns
+ * { jobName, body, path } objects. Jobs are detected as 2-space-indented
+ * top-level keys under the `jobs:` line; a job's body runs from its header up
+ * to (but not including) the next sibling job header (or EOF for the last job).
+ *
+ * Kept deliberately dependency-free (no YAML parser): the textual sweep is
+ * precise enough because the assertions only look for literal step tokens.
+ *
+ * @param {string} workflowPath - absolute path to a .yml/.yaml workflow file
+ * @returns {Array<{ jobName: string, body: string, path: string }>}
+ */
+export function splitWorkflowIntoJobs(workflowPath) {
+  const lines = readFileSync(workflowPath, "utf8").split("\n");
+
+  let inJobs = false;
+  let jobName = null;
+  let jobStart = -1;
+  const jobs = [];
+
+  for (let i = 0; i < lines.length; i++) {
+    const line = lines[i];
+    if (/^jobs:\s*$/.test(line)) {
+      inJobs = true;
+      continue;
+    }
+    if (!inJobs) continue;
+
+    const jobMatch = /^ {2}([A-Za-z0-9_-]+):\s*$/.exec(line);
+    if (jobMatch) {
+      if (jobName !== null) {
+        jobs.push({
+          jobName,
+          body: lines.slice(jobStart, i).join("\n"),
+          path: workflowPath,
+        });
+      }
+      jobName = jobMatch[1];
+      jobStart = i;
+    }
+  }
+  if (jobName !== null) {
+    jobs.push({
+      jobName,
+      body: lines.slice(jobStart).join("\n"),
+      path: workflowPath,
+    });
+  }
+  return jobs;
+}


### PR DESCRIPTION
Closes #438.

## Problem

v0.5.5 was cut with `gh release create` instead of `pnpm release`, so the `chore: release` version bump never ran. The published images reported `pinchyVersion: 0.5.4` from `/api/version` despite the v0.5.5 tag, OCI labels, and runtime all being on v0.5.5. The only safeguard was a memory note — this lifts it to enforced code.

## What changed

**Layer 2 — build-time guard (`release.yml` `docker` job)**
A new step runs `scripts/assert-package-version.mjs <tag>` *before any image build*, so a stale `package.json` / `packages/web/package.json` version fails the workflow before any GHCR push (nothing to clean up). The comparison logic lives in `assertVersionMatchesTag` (`scripts/lib/release-logic.mjs`), unit-tested alongside the other release helpers.

**Layer 3 — runtime smoke check (`release.yml` `end-user-install-published` job)**
After the published-image stack is healthy, assert `/api/version` reports the v-stripped release tag. Catches any path producing a runtime/tag mismatch, not just `package.json` drift.

**Wiring guard**
`scripts/lib/release-version-guards.test.mjs` is a dependency-free textual sweep (same pattern as `workflow-compose-env.test.mjs`) that fails if either guard is dropped from `release.yml` or if Layer 2 is re-ordered after the image build.

## Note on the issue's framing

The issue described Layer 3 as catching `PINCHY_VERSION` build-arg drift. In practice that build-arg only feeds the OCI label — `/api/version` reports `pkg.version` via `next.config.ts` (`NEXT_PUBLIC_PINCHY_VERSION`). The guard therefore targets the *actual* v0.5.5 failure mode: `pkg.version` ↔ tag drift.

## Test plan

- [x] Layer 2 unit tests: passes on match, throws on stale root/web version, names the offender, suggests `pnpm release`, rejects malformed tags
- [x] CLI demonstrated: exit 0 on `v0.5.6` (current), exit 1 on `v0.5.7`
- [x] Workflow-sweep tests: both guards present, Layer 2 before `build-push`, Layer 3 compares `/api/version` to the tag (RED→GREEN verified)
- [x] `pnpm test:scripts` — 60/60 pass
- [x] Both guards pass on the current v0.5.6 release commit (sanity)
- [ ] Layer 3 runtime assertion runs only in CI against a published image (no local docker stack)

🤖 Generated with [Claude Code](https://claude.com/claude-code)