### PR TITLE
fix(models): refresh Ollama Cloud catalog against the live API

### DIFF
--- a/config/llm-providers-mock/server.js
+++ b/config/llm-providers-mock/server.js
@@ -282,6 +282,12 @@ app.get("/ollama-cloud/v1/models", (req, res) => {
   res.json({
     object: "list",
     data: [
+      // glm-4.7 is the balanced-tier default; minimax-m3 is the vision/
+      // reasoning addition. qwen3-next:80b is still returned by the real API
+      // but Pinchy filters it out (no working tool calls), so it stays here to
+      // exercise the allowlist filter.
+      { id: "glm-4.7", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
+      { id: "minimax-m3", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
       { id: "qwen3-next:80b", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
       { id: "qwen3-coder:480b", object: "model", created: MOCK_CREATED_AT, owned_by: "ollama" },
     ],
@@ -301,7 +307,7 @@ app.post("/ollama-cloud/v1/chat/completions", (req, res) => {
     id: "chatcmpl-mock-ollama-1",
     object: "chat.completion",
     created: MOCK_CREATED_AT,
-    model: req.body?.model ?? "qwen3-next:80b",
+    model: req.body?.model ?? "glm-4.7",
     choices: [
       { index: 0, message: { role: "assistant", content: MOCK_ASSISTANT_REPLY }, finish_reason: "stop" },
     ],

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -202,6 +202,16 @@ Pinchy no longer reads `BETTER_AUTH_URL`. An investigation ([#352](https://githu
 
 The variable is gone from `docker-compose.yml`, `.env.example`, and the startup warning that previously told Domain-Locked deployments to set it (added in v0.5.4 — see below). **If you set `BETTER_AUTH_URL` in your `.env` or a `docker-compose.override.yml`, you can drop it.** Leaving it in place is harmless — it is simply ignored — but the line is now dead config. Domain Lock remains the single source of truth for your public origin; HTTPS, secure cookies, and origin enforcement are unchanged.
 
+#### Ollama Cloud model catalog refreshed against the live API
+
+The Ollama Cloud library pages over-promise: some models advertise capabilities the live API doesn't actually honor. We re-probed every cloud model against the real `/v1/chat/completions` endpoint — sending image payloads with non-guessable content for vision and a function schema for tools — and corrected the catalog to match what the API does, not what the library page claims.
+
+- **MiniMax M3 added.** `minimax-m3` joins the picker as a vision + reasoning + tools model (512K context). Vision and tool calling were both confirmed against the live API. It is now the reasoning-tier vision default.
+- **`qwen3.5:397b` is now text-only.** Its library page lists image input, but the live endpoint accepts image payloads and then hallucinates their contents rather than rejecting them — it does not actually see images. It stays available as a text/reasoning model and is no longer offered as a vision choice. Image work that previously could route here now uses the canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`).
+- **`qwen3-next:80b` removed.** On Ollama Cloud's OpenAI-completions endpoint it never emits a structured tool call — it returns empty content or a malformed tool-call blob, even when tools are required. Every Pinchy agent uses tools, so a tool-broken model has no place in the picker. The Ollama Cloud balanced default moves to `glm-4.7`.
+
+No action is required for agents created the normal way: their model comes from the capability resolver (which never selected `qwen3-next:80b`), and the global default is recomputed on the upgrade's config regeneration. The only agents affected are ones where someone **manually** pinned `ollama-cloud/qwen3-next:80b` — those couldn't call tools before this release either, so switch them to `ollama-cloud/glm-4.7` (or another model) in the agent's settings.
+
 ## Upgrading from v0.5.5 to v0.5.6
 
 ### Breaking changes

--- a/packages/web/src/__tests__/lib/model-vision.integration.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.integration.test.ts
@@ -52,8 +52,16 @@ describe("Ollama cloud vision models (from DB seed)", () => {
     expect(isModelVisionCapable("ollama-cloud/mistral-large-3:675b")).toBe(true);
   });
 
-  it("returns true for qwen3.5:397b", () => {
-    expect(isModelVisionCapable("ollama-cloud/qwen3.5:397b")).toBe(true);
+  it("returns true for minimax-m3", () => {
+    expect(isModelVisionCapable("ollama-cloud/minimax-m3")).toBe(true);
+  });
+
+  it("returns FALSE for qwen3.5:397b (claims vision, hallucinates)", () => {
+    // The library page lists image input, but the live `/v1/chat/completions`
+    // endpoint hallucinates image contents rather than rejecting them — it
+    // does not actually see images. qwen3.5 is a text/reasoning model, not a
+    // VL model (contrast qwen3-vl). Flagged vision:false in the catalog.
+    expect(isModelVisionCapable("ollama-cloud/qwen3.5:397b")).toBe(false);
   });
 
   it("returns true for every ministral-3 variant", () => {

--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -1,10 +1,68 @@
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS } from "@/lib/ollama-cloud-models";
+import { describe, it, expect } from "vitest";
+import {
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS,
+  VISION_OLLAMA_CLOUD_MODEL_IDS,
+} from "@/lib/ollama-cloud-models";
 
-it("every model declares all capability fields", () => {
-  for (const m of TOOL_CAPABLE_OLLAMA_CLOUD_MODELS) {
-    expect(typeof m.vision).toBe("boolean");
-    expect(m.documents).toBe(false);
-    expect(m.audio).toBe(false);
-    expect(m.video).toBe(false);
-  }
+/**
+ * These assertions pin the capability flags that Pinchy curates for Ollama
+ * Cloud models to what the live API actually does — not to what the
+ * ollama.com/library/<name> pages claim. The pages are documented as
+ * unreliable (see the file header), so each non-obvious flag below was
+ * verified empirically against https://ollama.com/v1/chat/completions:
+ *
+ *  - Vision was probed by sending base64 image payloads carrying a random,
+ *    non-guessable 4-digit number plus a colored circle and checking the
+ *    reply against the ground truth across several distinct images. A model
+ *    that returns the correct number/color sees the image; one that returns
+ *    HTTP 400 ("does not support image input") or hallucinates wrong content
+ *    on a 200 does not.
+ *  - Tools were probed by offering a function schema and checking for a
+ *    structured `tool_calls` response.
+ */
+const byId = (id: string) => TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === id);
+
+describe("Ollama Cloud model catalog — empirically verified capabilities", () => {
+  it("includes minimax-m3 with vision and reasoning", () => {
+    // Library tags: "vision tools thinking cloud". Empirically confirmed:
+    // read a random 4-digit number AND the circle color correctly across 4
+    // distinct images (3/3 + 3/3), and emits structured tool_calls.
+    const m = byId("minimax-m3");
+    expect(m).toBeDefined();
+    expect(m!.vision).toBe(true);
+    expect(m!.reasoning).toBe(true);
+  });
+
+  it("flags qwen3.5:397b as text-only despite its library page", () => {
+    // The /v1/chat/completions endpoint returns HTTP 200 on image payloads
+    // for this model but hallucinates the contents (colors 1/3, numbers 0/3
+    // across distinct test images) — it does not actually see the image.
+    // Unlike qwen3-vl, qwen3.5 is a text/reasoning model, not a VL model.
+    // Flagged vision:false so it is never picked as an image model and is
+    // not offered as a vision-capable choice.
+    const m = byId("qwen3.5:397b");
+    expect(m).toBeDefined();
+    expect(m!.vision).toBe(false);
+    expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("qwen3.5:397b")).toBe(false);
+  });
+
+  it("drops qwen3-next:80b — no working tool calls on Ollama Cloud", () => {
+    // The model is still returned by /v1/models, but on the OpenAI-completions
+    // endpoint OpenClaw uses it never emits a structured tool_call: it returns
+    // empty content or leaks a malformed `<tools> {…} </tools>` text blob with
+    // a mangled tool name, even with tool_choice:"required". Every Pinchy agent
+    // uses tools (files/context/docs), so a tool-broken model must not be
+    // surfaced as tool-capable.
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain("qwen3-next:80b");
+  });
+
+  it("every model declares all capability fields", () => {
+    for (const m of TOOL_CAPABLE_OLLAMA_CLOUD_MODELS) {
+      expect(typeof m.vision).toBe("boolean");
+      expect(m.documents).toBe(false);
+      expect(m.audio).toBe(false);
+      expect(m.video).toBe(false);
+    }
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1744,6 +1744,7 @@ describe("regenerateOpenClawConfig", () => {
         "minimax-m2.1",
         "minimax-m2.5",
         "minimax-m2.7",
+        "minimax-m3",
         "ministral-3:14b",
         "ministral-3:3b",
         "ministral-3:8b",
@@ -1752,7 +1753,6 @@ describe("regenerateOpenClawConfig", () => {
         "nemotron-3-super",
         "qwen3-coder-next",
         "qwen3-coder:480b",
-        "qwen3-next:80b",
         "qwen3-vl:235b",
         "qwen3-vl:235b-instruct",
         "qwen3.5:397b",
@@ -1811,12 +1811,13 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["nemotron-3-super"]).toBe(262144);
     expect(ctx["qwen3-coder-next"]).toBe(262144);
     expect(ctx["qwen3-coder:480b"]).toBe(262144);
-    expect(ctx["qwen3-next:80b"]).toBe(262144);
     expect(ctx["qwen3-vl:235b"]).toBe(262144);
     expect(ctx["qwen3-vl:235b-instruct"]).toBe(262144);
     expect(ctx["qwen3.5:397b"]).toBe(262144);
     // 384K
     expect(ctx["devstral-small-2:24b"]).toBe(393216);
+    // 512K — minimax-m3's guaranteed minimum (library page: "up to 1M")
+    expect(ctx["minimax-m3"]).toBe(524288);
     // 1M
     expect(ctx["deepseek-v4-flash"]).toBe(1048576);
     expect(ctx["deepseek-v4-pro"]).toBe(1048576);
@@ -1857,13 +1858,13 @@ describe("regenerateOpenClawConfig", () => {
       "gemma4:31b",
       "kimi-k2.5",
       "kimi-k2.6",
+      "minimax-m3",
       "ministral-3:3b",
       "ministral-3:8b",
       "ministral-3:14b",
       "mistral-large-3:675b",
       "qwen3-vl:235b",
       "qwen3-vl:235b-instruct",
-      "qwen3.5:397b",
     ];
     for (const id of visionModels) {
       expect(byId[id].input).toEqual(["text", "image"]);
@@ -1871,10 +1872,13 @@ describe("regenerateOpenClawConfig", () => {
     // Spot-check that text-only models stay text-only (gemma4 was the
     // specific counter-example the user flagged during review). devstral-
     // small-2:24b joined this list after the #416 smoke test demoted it.
+    // qwen3.5:397b joined it too: its library page claims image input but the
+    // live endpoint hallucinates image contents, so it is flagged text-only.
     expect(byId["rnj-1:8b"].input).toEqual(["text"]);
     expect(byId["qwen3-coder:480b"].input).toEqual(["text"]);
     expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
     expect(byId["devstral-small-2:24b"].input).toEqual(["text"]);
+    expect(byId["qwen3.5:397b"].input).toEqual(["text"]);
 
     // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
     const reasoningModels = [
@@ -1895,9 +1899,9 @@ describe("regenerateOpenClawConfig", () => {
       "minimax-m2",
       "minimax-m2.5",
       "minimax-m2.7",
+      "minimax-m3",
       "nemotron-3-nano:30b",
       "nemotron-3-super",
-      "qwen3-next:80b",
       "qwen3-vl:235b",
       "qwen3-vl:235b-instruct",
       "qwen3.5:397b",
@@ -6731,10 +6735,11 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
   });
 
   it("picks the canonical-vision ollama-cloud model when only ollama-cloud is configured", async () => {
-    // The provider's general balanced default is `qwen3-next:80b` (text-only)
-    // and several other ollama-cloud models accept image input but mislabel
-    // colors (mistral-large-3, qwen3.5:397b, kimi-k2.5/k2.6 — see the #416
-    // empirical smoke test). The image-default picker explicitly prefers the
+    // The provider's general balanced default is `glm-4.7` (text-only) and
+    // several other ollama-cloud models are weaker on images: mistral-large-3
+    // and kimi-k2.5/k2.6 accept image input but occasionally misread digits,
+    // and qwen3.5:397b only claims vision (it hallucinates image contents and
+    // is flagged text-only). The image-default picker explicitly prefers the
     // "canonical vision line" — qwen3-vl > gemini-3-flash > gemma4 — over
     // those weaker models.
     mockedGetSetting.mockImplementation(async (key: string) =>

--- a/packages/web/src/__tests__/lib/provider-models-drift.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-drift.test.ts
@@ -72,7 +72,7 @@ describe("balanced default — drift resistance", () => {
       ["anthropic", "anthropic/claude-sonnet-4-6"],
       ["openai", "openai/gpt-5.5"],
       ["google", "google/gemini-2.5-pro"],
-      ["ollama-cloud", "ollama-cloud/qwen3-next:80b"],
+      ["ollama-cloud", "ollama-cloud/glm-4.7"],
     ] as const)("%s: empty candidate list → anchor %s", (provider, anchor) => {
       const noMatch = [{ id: `${provider}/something-totally-unexpected`, name: "x" }];
       expect(selectDefaultModel(provider, noMatch)).toBe(anchor);

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/providers", () => ({
       name: "Ollama Cloud",
       settingsKey: "ollama_cloud_api_key",
       envVar: "OLLAMA_CLOUD_API_KEY",
-      defaultModel: "ollama-cloud/qwen3-next:80b",
+      defaultModel: "ollama-cloud/glm-4.7",
       placeholder: "sk-...",
     },
     "ollama-local": {
@@ -300,6 +300,7 @@ describe("fetchProviderModels", () => {
             { id: "minimax-m2.1" },
             { id: "minimax-m2.5" },
             { id: "minimax-m2.7" },
+            { id: "minimax-m3" },
             { id: "ministral-3:3b" },
             { id: "ministral-3:8b" },
             { id: "ministral-3:14b" },
@@ -353,6 +354,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
+        "ollama-cloud/minimax-m3",
         "ollama-cloud/ministral-3:3b",
         "ollama-cloud/ministral-3:8b",
         "ollama-cloud/ministral-3:14b",
@@ -361,7 +363,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/nemotron-3-super",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
-        "ollama-cloud/qwen3-next:80b",
         "ollama-cloud/qwen3-vl:235b",
         "ollama-cloud/qwen3-vl:235b-instruct",
         "ollama-cloud/qwen3.5:397b",
@@ -370,6 +371,11 @@ describe("fetchProviderModels", () => {
     );
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
+    // qwen3-next:80b is still returned by /v1/models but no longer allow-listed:
+    // it emits no working tool calls on the OpenAI-completions endpoint.
+    expect(ids).not.toContain("ollama-cloud/qwen3-next:80b");
+    // minimax-m3 was added to the allowlist (vision + tools confirmed live).
+    expect(ids).toContain("ollama-cloud/minimax-m3");
     expect(ids).toHaveLength(33);
 
     // Non-tool-capable models are filtered out
@@ -441,6 +447,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
+        "ollama-cloud/minimax-m3",
         "ollama-cloud/ministral-3:3b",
         "ollama-cloud/ministral-3:8b",
         "ollama-cloud/ministral-3:14b",
@@ -449,7 +456,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/nemotron-3-super",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
-        "ollama-cloud/qwen3-next:80b",
         "ollama-cloud/qwen3-vl:235b",
         "ollama-cloud/qwen3-vl:235b-instruct",
         "ollama-cloud/qwen3.5:397b",
@@ -772,7 +778,7 @@ describe("selectDefaultModel", () => {
       { id: "ollama-cloud/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
       { id: "ollama-cloud/qwen3.5:397b", name: "Qwen 3.5 397B" },
     ];
-    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/qwen3-next:80b");
+    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/glm-4.7");
   });
 
   it("prefers stable versions over preview versions", async () => {

--- a/packages/web/src/__tests__/lib/providers.test.ts
+++ b/packages/web/src/__tests__/lib/providers.test.ts
@@ -132,7 +132,7 @@ describe("PROVIDERS", () => {
     expect(PROVIDERS.anthropic.defaultModel).toBe("anthropic/claude-sonnet-4-6");
     expect(PROVIDERS.openai.defaultModel).toBe("openai/gpt-5.5");
     expect(PROVIDERS.google.defaultModel).toBe("google/gemini-2.5-pro");
-    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/qwen3-next:80b");
+    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/glm-4.7");
   });
 
   it("should have settings keys for all providers", () => {

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -34,13 +34,14 @@ const BY_TIER_FAMILY: Record<
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",
-    // Largest non-preview reasoning+vision+tools model (262K context).
-    // gemini-3-flash-preview was the previous pick (1M context) but is blocked
-    // by the tools-blocklist as of pinchy#344 (silent hang + schema rejection on
-    // the tools+vision path). Kimi family also avoided: v0.5.3 silent-500 incident.
-    // Restore gemini-3-flash-preview here once upstream openclaw#72879 ships and
-    // the silent-hang variant is fixed (track in pinchy#344).
-    vision: "ollama-cloud/qwen3.5:397b",
+    // reasoning+vision+tools, 512K context. qwen3.5:397b was the previous pick
+    // but only claims vision — the live endpoint hallucinates image contents
+    // (see ollama-cloud-models.ts), so it is now flagged vision:false and can
+    // no longer fill a vision slot. minimax-m3's vision was confirmed against
+    // the live API (reads a random number + circle color correctly across
+    // distinct images). gemini-3-flash-preview is still blocked by the
+    // tools-blocklist (pinchy#344); kimi family avoided (v0.5.3 silent-500).
+    vision: "ollama-cloud/minimax-m3",
   },
 };
 

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -258,6 +258,23 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     video: false,
   },
   {
+    // ollama.com/library/minimax-m3 tags: "vision tools thinking cloud",
+    // input "Text, Image", context "up to 1M with a guaranteed minimum of
+    // 512K". Vision and tools were both confirmed against the live
+    // /v1/chat/completions endpoint (reads a random 4-digit number and the
+    // circle color correctly across distinct images; emits structured
+    // tool_calls). We use the guaranteed 512K floor as the pruning hint so
+    // context trimming kicks in before the smallest promised limit.
+    id: "minimax-m3",
+    contextWindow: 524288,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: true,
+    documents: false,
+    audio: false,
+    video: false,
+  },
+  {
     id: "ministral-3:3b",
     contextWindow: 262144,
     maxTokens: 8192,
@@ -338,16 +355,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     video: false,
   },
   {
-    id: "qwen3-next:80b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-    documents: false,
-    audio: false,
-    video: false,
-  },
-  {
     id: "qwen3-vl:235b",
     contextWindow: 262144,
     maxTokens: 8192,
@@ -368,11 +375,17 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     video: false,
   },
   {
+    // The ollama.com/library/qwen3.5 page lists image input, but the live
+    // /v1/chat/completions endpoint hallucinates image contents (wrong number
+    // AND wrong color across distinct test images) rather than rejecting them
+    // — it does not actually see images. qwen3.5 is a text/reasoning model,
+    // not a VL model (contrast qwen3-vl). Flagged vision:false so it is never
+    // picked as an image model or offered as a vision-capable choice.
     id: "qwen3.5:397b",
     contextWindow: 262144,
     maxTokens: 8192,
     reasoning: true,
-    vision: true,
+    vision: false,
     documents: false,
     audio: false,
     video: false,

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -252,15 +252,17 @@ async function resolveDefaultPdfModel(): Promise<string | null> {
  * images for that model with HTTP 400 (#416). Pinning the choice removes
  * that fragility.
  *
- * For `ollama-cloud`, the empirical smoke test in #416 showed several
- * vision-flagged models (`mistral-large-3:675b`, `qwen3.5:397b`,
- * `kimi-k2.5`/`k2.6`) accept image input but mislabel colors. We pin the
- * choice to the canonical vision line (`qwen3-vl` >
- * `gemini-3-flash-preview` > `gemma4`) via the typed
- * `OLLAMA_CLOUD_IMAGE_PREFERENCE` list. The TypeScript constraint on that
- * list (must be `OllamaCloudModelId`) means an unknown ID fails to
- * compile, so a runtime fallback to `getDefaultModel("ollama-cloud")`
- * would only fire if every preference entry were removed from the curated
+ * For `ollama-cloud`, empirical API probing showed the vision-flagged line
+ * is uneven: some models (`mistral-large-3:675b`, `kimi-k2.5`/`k2.6`) accept
+ * image input but occasionally misread digits, and `qwen3.5:397b` only
+ * claims vision — it hallucinates image contents and is now flagged
+ * vision:false (see ollama-cloud-models.ts). We pin the choice to the
+ * canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`)
+ * via the typed `OLLAMA_CLOUD_IMAGE_PREFERENCE` list. The TypeScript
+ * constraint on that list (must be `OllamaCloudModelId`) means an unknown
+ * ID fails to compile, so a runtime fallback to
+ * `getDefaultModel("ollama-cloud")` would only fire if every preference
+ * entry were removed from the curated
  * list — at which point the right action is to update the preference list,
  * not silently route to the provider's balanced text-only default. So we
  * skip the provider in that case and continue down the preference order.

--- a/packages/web/src/lib/provider-model-constants.ts
+++ b/packages/web/src/lib/provider-model-constants.ts
@@ -17,6 +17,6 @@ export const BALANCED_ANCHORS: Record<ProviderName, string> = {
   anthropic: "anthropic/claude-sonnet-4-6",
   openai: "openai/gpt-5.5",
   google: "google/gemini-2.5-pro",
-  "ollama-cloud": "ollama-cloud/qwen3-next:80b",
+  "ollama-cloud": "ollama-cloud/glm-4.7",
   "ollama-local": "",
 };

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -170,7 +170,7 @@ export const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   anthropic: /^anthropic\/claude-sonnet-\d+-\d+(?:-\d{8})?$/,
   openai: /^openai\/gpt-([5-9]|\d{2,})(\.\d+)?(?:-\d{4}-\d{2}-\d{2})?$/,
   google: /^google\/gemini-[2-9](?:\.\d+)?-pro(?:-\d{3})?$/,
-  "ollama-cloud": /^ollama-cloud\/qwen3-next:\d+b$/,
+  "ollama-cloud": /^ollama-cloud\/glm-4\.7$/,
   "ollama-local": /.*/,
 };
 

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -41,7 +41,11 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "ollama_cloud_api_key",
     envVar: "OLLAMA_CLOUD_API_KEY",
-    defaultModel: "ollama-cloud/qwen3-next:80b",
+    // glm-4.7 is the balanced-tier general pick in the resolver and emits
+    // working tool calls on Ollama Cloud. qwen3-next:80b (the previous
+    // default) was dropped from the catalog — it cannot tool-call on the
+    // OpenAI-completions endpoint (see ollama-cloud-models.ts).
+    defaultModel: "ollama-cloud/glm-4.7",
     placeholder: "sk-...",
   },
   "ollama-local": {


### PR DESCRIPTION
## Summary

Ollama Cloud's `ollama.com/library/<name>` capability tags and its `/v1/models` listing over-promise. Probing **every** cloud model against the live `/v1/chat/completions` endpoint — image payloads with non-guessable content (a random 4-digit number + a colored circle) for vision, a function schema for tools — surfaced two capability claims the API does **not** honor, plus one genuinely new model worth adding.

## What changed

- **Add `minimax-m3`** — vision + reasoning + tools, 512K context. Both vision and tool calling confirmed against the live API (read a random number + circle color correctly across 4 distinct images; emits structured `tool_calls`). It becomes the reasoning-tier vision default.
- **`qwen3.5:397b` → `vision: false`** — its library page lists image input, but the live endpoint returns HTTP 200 and then **hallucinates** the image contents (wrong number *and* wrong color across distinct test images). It is a text/reasoning model, not a VL model. It was wired as the **reasoning-tier vision slot**, so reasoning agents handed an image were routed to a model that makes the contents up. Stays available as a text/reasoning model; vision work now uses the canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`).
- **Remove `qwen3-next:80b`** — on Ollama Cloud's OpenAI-completions endpoint it never emits a structured tool call (empty content or a malformed `<tools>{…}</tools>` text blob, `finish_reason=stop`, even with `tool_choice:"required"`). Every Pinchy agent uses tools, so a tool-broken model has no place in the picker. It was the **provider default**; the default moves to `glm-4.7` (the resolver's balanced-general pick, tool calls confirmed).

## Why

Two of these are correctness bugs for the enterprise audience: a reasoning agent silently hallucinating image contents, and the provider's default model unable to call tools. Both were masked by unreliable upstream capability metadata — exactly why we verify empirically rather than trusting the library tags.

## Migration

**None required.** The capability resolver never auto-selected `qwen3-next:80b` (tiers use deepseek/glm/qwen3-coder), and the global `agents.defaults.model.primary` is recomputed on the upgrade's config regeneration. The only affected agents are ones where someone **manually** pinned `ollama-cloud/qwen3-next:80b` — those couldn't call tools before this release either; switch them to `ollama-cloud/glm-4.7` in agent settings. Documented in the upgrade notes.

## Tests

TDD throughout. New `ollama-cloud-models.test.ts` pins the empirically-verified flags; updated the cascading drift guards (resolver vision slot, `BALANCED_PATTERNS`/`BALANCED_ANCHORS`, `providers.ts#defaultModel`, the openclaw-config writer, the llm-providers mock). Model suite + drift guards (367 tests) green, mock tests (15) green, `tsc` clean, ESLint 0 errors, Prettier clean, `next build` passed (pre-push hook).

## Reviewer notes

- The empirical probe methodology (distinguishing API-rejection vs. real-vision vs. hallucinated-vision) follows the existing `devstral-small-2:24b` precedent in `ollama-cloud-models.ts`.
- `minimax-m3` context window uses the **guaranteed 512K minimum** (`524288`) as the pruning hint rather than the "up to 1M" ceiling, to stay conservative.