### PR TITLE
fix(invite): render reset-specific UI and never overwrite display name (#436)

### DIFF
--- a/docs/src/content/docs/guides/user-management.mdx
+++ b/docs/src/content/docs/guides/user-management.mdx
@@ -113,6 +113,8 @@ If a user forgets their password, an admin can generate a reset link:
 3. A reset link appears. Copy it and share it with the user.
 4. The user opens the link, enters a new password, and regains access.
 
+The reset page is dedicated to recovery: it reads **"Reset your Pinchy password"** and asks only for a new password and confirmation. Unlike the invite page, it does **not** ask for a display name, so a reset can never change the user's existing name.
+
 Reset links follow the same rules as invite tokens: valid for 7 days, single-use.
 
 When a reset completes:

--- a/packages/web/e2e/11-user-invite.spec.ts
+++ b/packages/web/e2e/11-user-invite.spec.ts
@@ -1,5 +1,5 @@
 import { test, expect } from "@playwright/test";
-import { seedProviderConfig, loginAsAdmin } from "./helpers";
+import { seedProviderConfig, loginAsAdmin, createSecondUserViaInvite, loginAs } from "./helpers";
 
 test.describe.serial("User invite flow", () => {
   test.beforeAll(async () => {
@@ -84,20 +84,75 @@ test.describe.serial("User invite flow", () => {
     const inviteePage = await freshContext.newPage();
     await inviteePage.goto(`/invite/${token}`);
 
-    // Fill the form and attempt to claim — the server should reject it
-    await expect(inviteePage.getByText("You've been invited to Pinchy")).toBeVisible({
+    // The page loads the token type up front (#436), so a revoked invite is
+    // rejected immediately — no claim form is offered at all.
+    await expect(inviteePage.getByText("This link can't be used")).toBeVisible({
       timeout: 10000,
     });
-    await inviteePage.getByLabel("Name").fill("Revoked User");
-    await inviteePage.getByLabel("Password", { exact: true }).fill("R3voked-Password!");
-    await inviteePage.getByLabel("Confirm password").fill("R3voked-Password!");
-    await inviteePage.getByRole("button", { name: "Create account" }).click();
-
-    // The page shows an error for the invalid/expired invite
-    await expect(inviteePage.getByText(/invalid|expired|revoked|not found/i)).toBeVisible({
-      timeout: 5000,
-    });
+    await expect(inviteePage.getByText(/invalid|expired|revoked|not found/i)).toBeVisible();
+    await expect(inviteePage.getByText("You've been invited to Pinchy")).toHaveCount(0);
+    await expect(inviteePage.getByLabel("Name")).toHaveCount(0);
 
     await freshContext.close();
+  });
+
+  test("password-reset link renders the reset UI (not the invite UI) and preserves the name", async ({
+    page,
+    browser,
+  }) => {
+    // Regression guard for #436: a reset link must render a reset-specific UI
+    // with no name field, must not overwrite the user's display name, and must
+    // let the user sign in with the new password.
+    await loginAsAdmin(page);
+    const { email } = await createSecondUserViaInvite(page.context().request, {
+      email: "resetme@test.local",
+    });
+
+    // Find the freshly-created user's id, then generate a reset link.
+    const usersRes = await page.context().request.get("/api/users");
+    expect(usersRes.ok()).toBeTruthy();
+    const { users } = await usersRes.json();
+    const target = users.find((u: { email: string }) => u.email === email);
+    expect(target).toBeTruthy();
+    const originalName: string = target.name;
+
+    const resetRes = await page.context().request.post(`/api/users/${target.id}/reset`);
+    expect(resetRes.ok()).toBeTruthy();
+    const { token } = await resetRes.json();
+    expect(typeof token).toBe("string");
+
+    // Open the reset link in a fresh context (no session cookies).
+    const freshContext = await browser.newContext();
+    const resetPage = await freshContext.newPage();
+    await resetPage.goto(`/invite/${token}`);
+
+    // Reset-specific UI — NOT the invite copy.
+    await expect(resetPage.getByText("Reset your Pinchy password")).toBeVisible({ timeout: 10000 });
+    await expect(resetPage.getByText("You've been invited to Pinchy")).toHaveCount(0);
+    await expect(resetPage.getByText("Set a new password for your account.")).toBeVisible();
+
+    // No name field is offered during a reset.
+    await expect(resetPage.getByLabel("Name")).toHaveCount(0);
+
+    // Set a new password and submit.
+    const newPassword = "R3setN3w-Password!";
+    await resetPage.getByLabel("Password", { exact: true }).fill(newPassword);
+    await resetPage.getByLabel("Confirm password").fill(newPassword);
+    await resetPage.getByRole("button", { name: "Reset password" }).click();
+
+    await expect(resetPage.getByText("Password reset!")).toBeVisible({ timeout: 10000 });
+    await freshContext.close();
+
+    // The display name was NOT overwritten by the reset.
+    const usersAfterRes = await page.context().request.get("/api/users");
+    const { users: usersAfter } = await usersAfterRes.json();
+    const targetAfter = usersAfter.find((u: { email: string }) => u.email === email);
+    expect(targetAfter.name).toBe(originalName);
+
+    // The user can sign in with the new password.
+    const loginContext = await browser.newContext();
+    const loginPage = await loginContext.newPage();
+    await loginAs(loginPage, email, newPassword);
+    await loginContext.close();
   });
 });

--- a/packages/web/src/__tests__/api/invite-claim.integration.test.ts
+++ b/packages/web/src/__tests__/api/invite-claim.integration.test.ts
@@ -337,6 +337,33 @@ describe("POST /api/invite/claim (integration)", () => {
     expect(invite?.claimedByUserId).toBe(targetId);
   });
 
+  it("never overwrites the existing display name on reset, even if a name is sent", async () => {
+    // Guardrail for #436: the reset flow must never touch users.name. The UI
+    // hides the name field, but a crafted POST that still carries `name` must
+    // not silently overwrite the user's display name (data loss on a
+    // security-sensitive flow).
+    const adminId = await seedAdmin();
+    await auth.api.signUpEmail({
+      body: { name: "Original Name", email: "keepname@test.local", password: "originalpassword1" },
+    });
+    const { token } = await createInvite({
+      email: "keepname@test.local",
+      role: "member",
+      type: "reset",
+      createdBy: adminId,
+    });
+
+    const response = await POST(
+      makeRequest({ token, name: "Hijacked Name", password: "newpassword123" })
+    );
+    expect(response.status).toBe(200);
+
+    const user = await db.query.users.findFirst({
+      where: eq(users.email, "keepname@test.local"),
+    });
+    expect(user?.name).toBe("Original Name");
+  });
+
   it("does NOT seed a personal agent or regenerate config on reset", async () => {
     const adminId = await seedAdmin();
     await auth.api.signUpEmail({

--- a/packages/web/src/__tests__/api/invite-token-get.integration.test.ts
+++ b/packages/web/src/__tests__/api/invite-token-get.integration.test.ts
@@ -49,6 +49,19 @@ describe("GET /api/invite/[token] (integration)", () => {
     expect(await response.json()).toEqual({ type: "invite" });
   });
 
+  it("returns { type: 'invite' } for an open invite that has no email", async () => {
+    const adminId = await seedAdmin();
+    const { token } = await createInvite({
+      role: "member",
+      type: "invite",
+      createdBy: adminId,
+    });
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: "invite" });
+  });
+
   it("returns { type: 'reset' } for a password-reset token of an existing user", async () => {
     const adminId = await seedAdmin();
     await auth.api.signUpEmail({

--- a/packages/web/src/__tests__/api/invite-token-get.integration.test.ts
+++ b/packages/web/src/__tests__/api/invite-token-get.integration.test.ts
@@ -1,0 +1,122 @@
+// Real-DB integration test for GET /api/invite/[token].
+//
+// The /invite/[token] page serves two distinct flows — initial invite claim
+// and admin-triggered password reset — but historically rendered the same UI
+// for both (issue #436). This loader endpoint lets the page tell the two
+// apart before it renders, so the reset flow can drop the display-name field
+// (which would otherwise silently overwrite the user's name on submit).
+//
+// Exercised against a freshly migrated Postgres test DB (global-setup.ts),
+// truncated between cases (setup.ts).
+
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+
+import { db } from "@/db";
+import { invites } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { createInvite } from "@/lib/invites";
+import { auth } from "@/lib/auth";
+import { GET } from "@/app/api/invite/[token]/route";
+
+function makeRequest(token: string) {
+  return new NextRequest(`http://localhost:7777/api/invite/${token}`, { method: "GET" });
+}
+
+function makeContext(token: string) {
+  return { params: Promise.resolve({ token }) };
+}
+
+async function seedAdmin() {
+  const result = await auth.api.signUpEmail({
+    body: { name: "Admin", email: "admin@test.local", password: "adminpassword123" },
+  });
+  return result.user.id;
+}
+
+describe("GET /api/invite/[token] (integration)", () => {
+  it("returns { type: 'invite' } for a fresh invite token", async () => {
+    const adminId = await seedAdmin();
+    const { token } = await createInvite({
+      email: "newcomer@test.local",
+      role: "member",
+      type: "invite",
+      createdBy: adminId,
+    });
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: "invite" });
+  });
+
+  it("returns { type: 'reset' } for a password-reset token of an existing user", async () => {
+    const adminId = await seedAdmin();
+    await auth.api.signUpEmail({
+      body: { name: "Existing User", email: "existing@test.local", password: "originalpassword1" },
+    });
+    const { token } = await createInvite({
+      email: "existing@test.local",
+      role: "member",
+      type: "reset",
+      createdBy: adminId,
+    });
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(200);
+    expect(await response.json()).toEqual({ type: "reset" });
+  });
+
+  it("returns 410 for an unknown token", async () => {
+    const response = await GET(makeRequest("bogus-token"), makeContext("bogus-token"));
+    expect(response.status).toBe(410);
+    expect(await response.json()).toEqual({ error: "Invalid or expired invite link" });
+  });
+
+  it("returns 410 for an already-claimed token", async () => {
+    const adminId = await seedAdmin();
+    const { token, tokenHash } = await createInvite({
+      email: "claimed@test.local",
+      role: "member",
+      type: "invite",
+      createdBy: adminId,
+    });
+    await db
+      .update(invites)
+      .set({ claimedAt: new Date(), claimedByUserId: adminId })
+      .where(eq(invites.tokenHash, tokenHash));
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(410);
+  });
+
+  it("returns 410 for an expired token", async () => {
+    const adminId = await seedAdmin();
+    const { token, tokenHash } = await createInvite({
+      email: "expired@test.local",
+      role: "member",
+      type: "invite",
+      createdBy: adminId,
+    });
+    await db
+      .update(invites)
+      .set({ expiresAt: new Date(Date.now() - 60_000) })
+      .where(eq(invites.tokenHash, tokenHash));
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(410);
+  });
+
+  it("returns 404 for a reset token whose target user no longer exists", async () => {
+    const adminId = await seedAdmin();
+    const { token } = await createInvite({
+      email: "gone@test.local",
+      role: "member",
+      type: "reset",
+      createdBy: adminId,
+    });
+
+    const response = await GET(makeRequest(token), makeContext(token));
+    expect(response.status).toBe(404);
+    expect(await response.json()).toEqual({ error: "User not found" });
+  });
+});

--- a/packages/web/src/__tests__/app/invite-claim-page.test.tsx
+++ b/packages/web/src/__tests__/app/invite-claim-page.test.tsx
@@ -27,177 +27,292 @@ vi.mock("next/image", () => ({
 
 global.fetch = vi.fn();
 
+// The page fetches GET /api/invite/[token] on mount to learn whether the token
+// is a new-user invite or a password reset (#436). Queue that response first;
+// the submit POST (if any) is queued after.
+function mockTokenType(type: "invite" | "reset") {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: true,
+    json: async () => ({ type }),
+  });
+}
+
+function mockSubmit(response: { ok: boolean; body: unknown }) {
+  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+    ok: response.ok,
+    json: async () => response.body,
+  });
+}
+
 describe("Invite Claim Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("should render 'You've been invited to Pinchy' heading", () => {
-    render(<InviteClaimPage />);
-    expect(screen.getByText("You've been invited to Pinchy")).toBeInTheDocument();
-  });
+  describe("new-user invite flow", () => {
+    it("loads the invite type from GET /api/invite/[token] on mount", async () => {
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
 
-  it("should render Name, Password, and Confirm password input fields", () => {
-    render(<InviteClaimPage />);
-    expect(screen.getByLabelText(/name/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
-    expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
-  });
-
-  it("should render a show/hide toggle on the password field", () => {
-    render(<InviteClaimPage />);
-    expect(screen.getAllByRole("button", { name: /show password/i }).length).toBeGreaterThanOrEqual(
-      1
-    );
-  });
-
-  it("should toggle password visibility when clicking the toggle button", async () => {
-    const user = userEvent.setup();
-    render(<InviteClaimPage />);
-
-    const passwordInput = screen.getByLabelText(/^password$/i);
-    expect(passwordInput).toHaveAttribute("type", "password");
-
-    const toggle = screen.getAllByRole("button", { name: /show password/i })[0];
-    await user.click(toggle);
-    expect(passwordInput).toHaveAttribute("type", "text");
-  });
-
-  it("should render a 'Create account' submit button", () => {
-    render(<InviteClaimPage />);
-    expect(screen.getByRole("button", { name: /create account/i })).toBeInTheDocument();
-  });
-
-  it("should show validation error when name is empty", async () => {
-    const user = userEvent.setup();
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
-    await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Name is required")).toBeInTheDocument();
-    });
-
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("should show validation error when password is too short", async () => {
-    const user = userEvent.setup();
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "short");
-    await user.type(screen.getByLabelText(/confirm password/i), "short");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Password must be at least 12 characters")).toBeInTheDocument();
-    });
-
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("should show validation error inline when password is in the breach-list (no API roundtrip)", async () => {
-    const user = userEvent.setup();
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "passwordpassword");
-    await user.type(screen.getByLabelText(/confirm password/i), "passwordpassword");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(
-        screen.getByText("Password is too common. Please choose a less predictable one.")
-      ).toBeInTheDocument();
-    });
-
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("should show validation error when passwords do not match", async () => {
-    const user = userEvent.setup();
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
-    await user.type(screen.getByLabelText(/confirm password/i), "different456");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
-    });
-
-    expect(global.fetch).not.toHaveBeenCalled();
-  });
-
-  it("should show error when API returns error", async () => {
-    const user = userEvent.setup();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: false,
-      json: async () => ({ error: "Invalid or expired invite link" }),
-    });
-
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
-    await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByText("Invalid or expired invite link")).toBeInTheDocument();
-    });
-  });
-
-  it("should submit to /api/invite/claim with token, name, and password", async () => {
-    const user = userEvent.setup();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
-    });
-
-    render(<InviteClaimPage />);
-
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
-    await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith("/api/invite/claim", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          token: "test-token-123",
-          name: "Test User",
-          password: "Br1ghtNova!2",
-        }),
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/invite/test-token-123");
       });
     });
+
+    it("should render 'You've been invited to Pinchy' heading", async () => {
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+      expect(await screen.findByText("You've been invited to Pinchy")).toBeInTheDocument();
+    });
+
+    it("should render Name, Password, and Confirm password input fields", async () => {
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+      expect(await screen.findByLabelText(/name/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/^password$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    });
+
+    it("should render a show/hide toggle on the password field", async () => {
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+      await screen.findByLabelText(/^password$/i);
+      expect(
+        screen.getAllByRole("button", { name: /show password/i }).length
+      ).toBeGreaterThanOrEqual(1);
+    });
+
+    it("should toggle password visibility when clicking the toggle button", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+
+      const passwordInput = await screen.findByLabelText(/^password$/i);
+      expect(passwordInput).toHaveAttribute("type", "password");
+
+      const toggle = screen.getAllByRole("button", { name: /show password/i })[0];
+      await user.click(toggle);
+      expect(passwordInput).toHaveAttribute("type", "text");
+    });
+
+    it("should render a 'Create account' submit button", async () => {
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+      expect(await screen.findByRole("button", { name: /create account/i })).toBeInTheDocument();
+    });
+
+    it("should show validation error when name is empty", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Name is required")).toBeInTheDocument();
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1); // only the GET type fetch
+    });
+
+    it("should show validation error when password is too short", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "short");
+      await user.type(screen.getByLabelText(/confirm password/i), "short");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Password must be at least 12 characters")).toBeInTheDocument();
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show validation error inline when password is in the breach-list (no API roundtrip)", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "passwordpassword");
+      await user.type(screen.getByLabelText(/confirm password/i), "passwordpassword");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(
+          screen.getByText("Password is too common. Please choose a less predictable one.")
+        ).toBeInTheDocument();
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show validation error when passwords do not match", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "different456");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
+      });
+
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+
+    it("should show error when API returns error", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      mockSubmit({ ok: false, body: { error: "Invalid or expired invite link" } });
+
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByText("Invalid or expired invite link")).toBeInTheDocument();
+      });
+    });
+
+    it("should submit to /api/invite/claim with token, name, and password", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      mockSubmit({ ok: true, body: { success: true } });
+
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/invite/claim", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            token: "test-token-123",
+            name: "Test User",
+            password: "Br1ghtNova!2",
+          }),
+        });
+      });
+    });
+
+    it("should redirect to /login on success via 'Continue to sign in' button", async () => {
+      const user = userEvent.setup();
+      mockTokenType("invite");
+      mockSubmit({ ok: true, body: { success: true } });
+
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/name/i), "Test User");
+      await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /create account/i }));
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /continue to sign in/i })).toBeInTheDocument();
+      });
+
+      await user.click(screen.getByRole("button", { name: /continue to sign in/i }));
+      expect(pushMock).toHaveBeenCalledWith("/login");
+    });
   });
 
-  it("should redirect to /login on success via 'Continue to sign in' button", async () => {
-    const user = userEvent.setup();
-    (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({ success: true }),
+  describe("password-reset flow", () => {
+    it("should render the reset-specific heading and subtitle", async () => {
+      mockTokenType("reset");
+      render(<InviteClaimPage />);
+
+      expect(await screen.findByText("Reset your Pinchy password")).toBeInTheDocument();
+      expect(screen.getByText("Set a new password for your account.")).toBeInTheDocument();
     });
 
-    render(<InviteClaimPage />);
+    it("should NOT render a Name field", async () => {
+      mockTokenType("reset");
+      render(<InviteClaimPage />);
 
-    await user.type(screen.getByLabelText(/name/i), "Test User");
-    await user.type(screen.getByLabelText(/^password$/i), "Br1ghtNova!2");
-    await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
-    await user.click(screen.getByRole("button", { name: /create account/i }));
-
-    await waitFor(() => {
-      expect(screen.getByRole("button", { name: /continue to sign in/i })).toBeInTheDocument();
+      // Wait for the form to load, then assert the name field is absent.
+      await screen.findByLabelText(/^password$/i);
+      expect(screen.queryByLabelText(/name/i)).not.toBeInTheDocument();
     });
 
-    await user.click(screen.getByRole("button", { name: /continue to sign in/i }));
-    expect(pushMock).toHaveBeenCalledWith("/login");
+    it("should render Password and Confirm password fields", async () => {
+      mockTokenType("reset");
+      render(<InviteClaimPage />);
+
+      expect(await screen.findByLabelText(/^password$/i)).toBeInTheDocument();
+      expect(screen.getByLabelText(/confirm password/i)).toBeInTheDocument();
+    });
+
+    it("should render a 'Reset password' submit button", async () => {
+      mockTokenType("reset");
+      render(<InviteClaimPage />);
+
+      expect(await screen.findByRole("button", { name: /reset password/i })).toBeInTheDocument();
+    });
+
+    it("should submit to /api/invite/claim with token and password but NO name", async () => {
+      const user = userEvent.setup();
+      mockTokenType("reset");
+      mockSubmit({ ok: true, body: { success: true } });
+
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenCalledWith("/api/invite/claim", {
+          method: "POST",
+          headers: { "Content-Type": "application/json" },
+          body: JSON.stringify({
+            token: "test-token-123",
+            password: "Br1ghtNova!2",
+          }),
+        });
+      });
+    });
+
+    it("should show a reset-specific success screen", async () => {
+      const user = userEvent.setup();
+      mockTokenType("reset");
+      mockSubmit({ ok: true, body: { success: true } });
+
+      render(<InviteClaimPage />);
+
+      await user.type(await screen.findByLabelText(/^password$/i), "Br1ghtNova!2");
+      await user.type(screen.getByLabelText(/confirm password/i), "Br1ghtNova!2");
+      await user.click(screen.getByRole("button", { name: /reset password/i }));
+
+      expect(await screen.findByText("Password reset!")).toBeInTheDocument();
+    });
+  });
+
+  describe("invalid token", () => {
+    it("shows an error when the token is invalid or expired", async () => {
+      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
+        ok: false,
+        json: async () => ({ error: "Invalid or expired invite link" }),
+      });
+      render(<InviteClaimPage />);
+
+      expect(await screen.findByText("Invalid or expired invite link")).toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/__tests__/app/invite-claim-page.test.tsx
+++ b/packages/web/src/__tests__/app/invite-claim-page.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { toast } from "sonner";
 import InviteClaimPage from "@/app/invite/[token]/page";
 
 const pushMock = vi.fn();
@@ -25,28 +26,59 @@ vi.mock("next/image", () => ({
   },
 }));
 
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
+
+// The page makes two distinct fetches: a GET to /api/invite/[token] on mount to
+// learn the flow type, and a POST to /api/invite/claim on submit. We route the
+// mock by URL+method rather than by call order so the tests don't break if the
+// page ever changes how many requests it makes.
+type MockResponse = { ok: boolean; body: unknown };
+let getResponse: MockResponse | "pending";
+let postResponse: MockResponse;
+
 global.fetch = vi.fn();
 
-// The page fetches GET /api/invite/[token] on mount to learn whether the token
-// is a new-user invite or a password reset (#436). Queue that response first;
-// the submit POST (if any) is queued after.
 function mockTokenType(type: "invite" | "reset") {
-  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-    ok: true,
-    json: async () => ({ type }),
-  });
+  getResponse = { ok: true, body: { type } };
 }
-
-function mockSubmit(response: { ok: boolean; body: unknown }) {
-  (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-    ok: response.ok,
-    json: async () => response.body,
-  });
+function mockTokenError(error: string) {
+  getResponse = { ok: false, body: { error } };
+}
+function mockTokenPending() {
+  getResponse = "pending";
+}
+function mockSubmit(response: MockResponse) {
+  postResponse = response;
 }
 
 describe("Invite Claim Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    getResponse = { ok: true, body: { type: "invite" } };
+    postResponse = { ok: true, body: { success: true } };
+    (global.fetch as ReturnType<typeof vi.fn>).mockImplementation(
+      (url: string, init?: RequestInit) => {
+        const method = init?.method ?? "GET";
+        if (method === "GET" && url.startsWith("/api/invite/")) {
+          if (getResponse === "pending") return new Promise(() => {});
+          return Promise.resolve({ ok: getResponse.ok, json: async () => getResponse.body });
+        }
+        if (method === "POST" && url === "/api/invite/claim") {
+          return Promise.resolve({ ok: postResponse.ok, json: async () => postResponse.body });
+        }
+        throw new Error(`Unexpected fetch: ${method} ${url}`);
+      }
+    );
+  });
+
+  describe("loading", () => {
+    it("shows a loading indicator until the invite type resolves", () => {
+      mockTokenPending();
+      render(<InviteClaimPage />);
+
+      expect(screen.getByRole("status", { name: /loading/i })).toBeInTheDocument();
+      expect(screen.queryByText("You've been invited to Pinchy")).not.toBeInTheDocument();
+    });
   });
 
   describe("new-user invite flow", () => {
@@ -114,7 +146,11 @@ describe("Invite Claim Page", () => {
         expect(screen.getByText("Name is required")).toBeInTheDocument();
       });
 
-      expect(global.fetch).toHaveBeenCalledTimes(1); // only the GET type fetch
+      // No POST to claim — validation blocked it (only the mount GET happened).
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        "/api/invite/claim",
+        expect.objectContaining({ method: "POST" })
+      );
     });
 
     it("should show validation error when password is too short", async () => {
@@ -131,7 +167,10 @@ describe("Invite Claim Page", () => {
         expect(screen.getByText("Password must be at least 12 characters")).toBeInTheDocument();
       });
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        "/api/invite/claim",
+        expect.objectContaining({ method: "POST" })
+      );
     });
 
     it("should show validation error inline when password is in the breach-list (no API roundtrip)", async () => {
@@ -150,7 +189,10 @@ describe("Invite Claim Page", () => {
         ).toBeInTheDocument();
       });
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        "/api/invite/claim",
+        expect.objectContaining({ method: "POST" })
+      );
     });
 
     it("should show validation error when passwords do not match", async () => {
@@ -167,10 +209,13 @@ describe("Invite Claim Page", () => {
         expect(screen.getByText("Passwords do not match")).toBeInTheDocument();
       });
 
-      expect(global.fetch).toHaveBeenCalledTimes(1);
+      expect(global.fetch).not.toHaveBeenCalledWith(
+        "/api/invite/claim",
+        expect.objectContaining({ method: "POST" })
+      );
     });
 
-    it("should show error when API returns error", async () => {
+    it("should show a toast when the claim API returns an error", async () => {
       const user = userEvent.setup();
       mockTokenType("invite");
       mockSubmit({ ok: false, body: { error: "Invalid or expired invite link" } });
@@ -183,7 +228,7 @@ describe("Invite Claim Page", () => {
       await user.click(screen.getByRole("button", { name: /create account/i }));
 
       await waitFor(() => {
-        expect(screen.getByText("Invalid or expired invite link")).toBeInTheDocument();
+        expect(toast.error).toHaveBeenCalledWith("Invalid or expired invite link");
       });
     });
 
@@ -306,13 +351,11 @@ describe("Invite Claim Page", () => {
 
   describe("invalid token", () => {
     it("shows an error when the token is invalid or expired", async () => {
-      (global.fetch as ReturnType<typeof vi.fn>).mockResolvedValueOnce({
-        ok: false,
-        json: async () => ({ error: "Invalid or expired invite link" }),
-      });
+      mockTokenError("Invalid or expired invite link");
       render(<InviteClaimPage />);
 
       expect(await screen.findByText("Invalid or expired invite link")).toBeInTheDocument();
+      expect(screen.getByText("This link can't be used")).toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/__tests__/security/api-auth-check.test.ts
+++ b/packages/web/src/__tests__/security/api-auth-check.test.ts
@@ -31,6 +31,10 @@ const PUBLIC_ROUTES = [
   "api/setup/route.ts",
   "api/setup/status/route.ts",
   "api/invite/claim/route.ts",
+  // Loader for the /invite/[token] page (#436): returns only the invite flow
+  // type so the unauthenticated invite/reset page can render the right UI.
+  // Token possession is the auth factor, same as the claim route above.
+  "api/invite/[token]/route.ts",
   "api/health/route.ts",
   "api/health/openclaw/route.ts",
   "api/diagnostics/route.ts",

--- a/packages/web/src/app/api/invite/[token]/route.ts
+++ b/packages/web/src/app/api/invite/[token]/route.ts
@@ -6,10 +6,7 @@
 //
 // audit-exempt: read-only token lookup, no state change.
 import { NextRequest, NextResponse } from "next/server";
-import { db } from "@/db";
-import { users } from "@/db/schema";
-import { eq } from "drizzle-orm";
-import { validateInviteToken } from "@/lib/invites";
+import { resolveInviteFlow } from "@/lib/invites";
 
 export async function GET(
   _request: NextRequest,
@@ -17,22 +14,10 @@ export async function GET(
 ) {
   const { token } = await params;
 
-  const invite = await validateInviteToken(token);
-  if (!invite) {
-    return NextResponse.json({ error: "Invalid or expired invite link" }, { status: 410 });
+  const flow = await resolveInviteFlow(token);
+  if (!flow.ok) {
+    return NextResponse.json({ error: flow.error }, { status: flow.status });
   }
 
-  if (invite.type === "reset") {
-    const existingUser = invite.email
-      ? await db.query.users.findFirst({ where: eq(users.email, invite.email) })
-      : null;
-
-    if (!existingUser) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
-
-    return NextResponse.json({ type: "reset" }, { status: 200 });
-  }
-
-  return NextResponse.json({ type: "invite" }, { status: 200 });
+  return NextResponse.json({ type: flow.type }, { status: 200 });
 }

--- a/packages/web/src/app/api/invite/[token]/route.ts
+++ b/packages/web/src/app/api/invite/[token]/route.ts
@@ -1,0 +1,38 @@
+// Loader for the /invite/[token] page. Returns the invite's flow type so the
+// page can render the right UI:
+//   - "invite" → new-user claim (name + password form, "Create account")
+//   - "reset"  → password reset for an existing user (no name field — see #436,
+//     where the shared invite UI silently overwrote the user's display name)
+//
+// audit-exempt: read-only token lookup, no state change.
+import { NextRequest, NextResponse } from "next/server";
+import { db } from "@/db";
+import { users } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { validateInviteToken } from "@/lib/invites";
+
+export async function GET(
+  _request: NextRequest,
+  { params }: { params: Promise<{ token: string }> }
+) {
+  const { token } = await params;
+
+  const invite = await validateInviteToken(token);
+  if (!invite) {
+    return NextResponse.json({ error: "Invalid or expired invite link" }, { status: 410 });
+  }
+
+  if (invite.type === "reset") {
+    const existingUser = invite.email
+      ? await db.query.users.findFirst({ where: eq(users.email, invite.email) })
+      : null;
+
+    if (!existingUser) {
+      return NextResponse.json({ error: "User not found" }, { status: 404 });
+    }
+
+    return NextResponse.json({ type: "reset" }, { status: 200 });
+  }
+
+  return NextResponse.json({ type: "invite" }, { status: 200 });
+}

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -10,7 +10,7 @@ import { auth } from "@/lib/auth";
 import { db } from "@/db";
 import { users, userGroups, accounts, sessions } from "@/db/schema";
 import { eq, and } from "drizzle-orm";
-import { validateInviteToken, claimInvite, getInviteGroupIds } from "@/lib/invites";
+import { resolveInviteFlow, claimInvite, getInviteGroupIds } from "@/lib/invites";
 import { seedPersonalAgent } from "@/lib/personal-agent";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { waitForAgentInRuntime } from "@/lib/wait-for-agent-in-runtime";
@@ -35,19 +35,17 @@ export async function POST(request: NextRequest) {
     return NextResponse.json({ error: passwordError }, { status: 400 });
   }
 
-  const invite = await validateInviteToken(token);
-  if (!invite) {
-    return NextResponse.json({ error: "Invalid or expired invite link" }, { status: 410 });
+  // Shared with the GET /api/invite/[token] loader so the two endpoints can
+  // never disagree on what a token means (410 unknown/expired, 404 reset whose
+  // user is gone).
+  const flow = await resolveInviteFlow(token);
+  if (!flow.ok) {
+    return NextResponse.json({ error: flow.error }, { status: flow.status });
   }
+  const { invite } = flow;
 
-  if (invite.type === "reset") {
-    const existingUser = invite.email
-      ? await db.query.users.findFirst({ where: eq(users.email, invite.email) })
-      : null;
-
-    if (!existingUser) {
-      return NextResponse.json({ error: "User not found" }, { status: 404 });
-    }
+  if (flow.type === "reset") {
+    const existingUser = flow.user;
 
     // Hash the new password and write it directly to the Better Auth
     // accounts table. We can't use Better Auth's admin-plugin endpoint

--- a/packages/web/src/app/api/invite/claim/route.ts
+++ b/packages/web/src/app/api/invite/claim/route.ts
@@ -59,24 +59,25 @@ export async function POST(request: NextRequest) {
     const hashedPassword = await hashPassword(password);
 
     try {
-      // All four writes participate in a single transaction:
+      // All three writes participate in a single transaction:
       //   1. update credential password
-      //   2. update display name (if provided)
-      //   3. revoke every active session for this user — without this, a
+      //   2. revoke every active session for this user — without this, a
       //      stale or leaked session token survives the reset and the
       //      reset's recovery semantics are broken
-      //   4. mark the invite claimed
+      //   3. mark the invite claimed
       // If any step fails the whole reset rolls back; the user keeps
       // their old password and the invite token stays usable.
+      //
+      // A reset must NEVER touch users.name (#436): the recovery flow has no
+      // legitimate reason to rename the account, and silently overwriting the
+      // display name with whatever the form carried was data loss. The page
+      // hides the name field; the route ignores `name` on reset as defense in
+      // depth.
       await db.transaction(async (tx) => {
         await tx
           .update(accounts)
           .set({ password: hashedPassword })
           .where(and(eq(accounts.userId, existingUser.id), eq(accounts.providerId, "credential")));
-
-        if (name) {
-          await tx.update(users).set({ name }).where(eq(users.id, existingUser.id));
-        }
 
         await tx.delete(sessions).where(eq(sessions.userId, existingUser.id));
 

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useParams, useRouter } from "next/navigation";
 import Image from "next/image";
 import { useForm } from "react-hook-form";
@@ -17,9 +17,22 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { CheckCircle2 } from "lucide-react";
+import { CheckCircle2, Loader2 } from "lucide-react";
 import { PasswordInput } from "@/components/password-input";
 import { passwordSchema } from "@/lib/validate-password";
+
+// The /invite/[token] page serves two flows that share the same token table
+// (#436): a brand-new user claiming an invite, and an existing user resetting
+// their password. They differ in copy and — crucially — the reset flow must
+// NOT collect a display name, because submitting one used to silently
+// overwrite the user's existing name.
+type InviteType = "invite" | "reset";
+
+const passwordRefine = {
+  check: (data: { password: string; confirmPassword: string }) =>
+    data.password === data.confirmPassword,
+  options: { message: "Passwords do not match", path: ["confirmPassword"] },
+};
 
 const inviteClaimSchema = z
   .object({
@@ -27,39 +40,133 @@ const inviteClaimSchema = z
     password: passwordSchema,
     confirmPassword: z.string(),
   })
-  .refine((data) => data.password === data.confirmPassword, {
-    message: "Passwords do not match",
-    path: ["confirmPassword"],
-  });
+  .refine(passwordRefine.check, passwordRefine.options);
 
-type InviteClaimValues = z.infer<typeof inviteClaimSchema>;
+const resetSchema = z
+  .object({
+    password: passwordSchema,
+    confirmPassword: z.string(),
+  })
+  .refine(passwordRefine.check, passwordRefine.options);
+
+type FormValues = {
+  name?: string;
+  password: string;
+  confirmPassword: string;
+};
+
+const COPY: Record<
+  InviteType,
+  { title: string; description: string; submit: string; busy: string }
+> = {
+  invite: {
+    title: "You've been invited to Pinchy",
+    description: "Set up your account to get started.",
+    submit: "Create account",
+    busy: "Creating account...",
+  },
+  reset: {
+    title: "Reset your Pinchy password",
+    description: "Set a new password for your account.",
+    submit: "Reset password",
+    busy: "Resetting password...",
+  },
+};
+
+const SUCCESS_COPY: Record<InviteType, { title: string; description: string }> = {
+  invite: {
+    title: "Account created!",
+    description: "You can now sign in with your credentials.",
+  },
+  reset: {
+    title: "Password reset!",
+    description: "You can now sign in with your new password.",
+  },
+};
 
 export default function InviteClaimPage() {
   const { token } = useParams();
+  const [type, setType] = useState<InviteType | null>(null);
+  const [loadError, setLoadError] = useState("");
+
+  useEffect(() => {
+    let cancelled = false;
+    async function loadType() {
+      try {
+        const res = await fetch(`/api/invite/${token}`);
+        const data = await res.json();
+        if (cancelled) return;
+        if (!res.ok) {
+          setLoadError(data.error || "Invalid or expired invite link");
+          return;
+        }
+        setType(data.type === "reset" ? "reset" : "invite");
+      } catch {
+        if (!cancelled) setLoadError("Something went wrong. Please try again.");
+      }
+    }
+    loadType();
+    return () => {
+      cancelled = true;
+    };
+  }, [token]);
+
+  return (
+    <div className="min-h-screen flex items-center justify-center">
+      <div className="w-full max-w-md flex flex-col items-center gap-6">
+        <Image src="/pinchy-logo.png" alt="Pinchy" width={80} height={85} priority />
+
+        <Card className="w-full">
+          {loadError ? (
+            <CardHeader>
+              <CardTitle>This link can&apos;t be used</CardTitle>
+              <CardDescription className="text-destructive">{loadError}</CardDescription>
+            </CardHeader>
+          ) : type === null ? (
+            <CardContent className="flex justify-center py-10">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            </CardContent>
+          ) : (
+            <ClaimForm token={String(token)} type={type} />
+          )}
+        </Card>
+      </div>
+    </div>
+  );
+}
+
+function ClaimForm({ token, type }: { token: string; type: InviteType }) {
   const router = useRouter();
+  const isReset = type === "reset";
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
 
-  const form = useForm<InviteClaimValues>({
-    resolver: zodResolver(inviteClaimSchema),
-    defaultValues: { name: "", password: "", confirmPassword: "" },
+  const form = useForm<FormValues>({
+    resolver: zodResolver(isReset ? resetSchema : inviteClaimSchema),
+    defaultValues: isReset
+      ? { password: "", confirmPassword: "" }
+      : { name: "", password: "", confirmPassword: "" },
   });
 
-  async function onSubmit(values: InviteClaimValues) {
+  async function onSubmit(values: FormValues) {
     setLoading(true);
     setError("");
+
+    const body = isReset
+      ? { token, password: values.password }
+      : { token, name: values.name, password: values.password };
 
     try {
       const res = await fetch("/api/invite/claim", {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ token, name: values.name, password: values.password }),
+        body: JSON.stringify(body),
       });
 
       if (!res.ok) {
         const data = await res.json();
-        setError(data.error || "Failed to create account");
+        setError(data.error || (isReset ? "Failed to reset password" : "Failed to create account"));
         return;
       }
 
@@ -71,86 +178,84 @@ export default function InviteClaimPage() {
     }
   }
 
+  if (success) {
+    const copy = isReset ? SUCCESS_COPY.reset : SUCCESS_COPY.invite;
+    return (
+      <>
+        <CardHeader className="text-center">
+          <div className="flex justify-center mb-2">
+            <CheckCircle2 className="size-12 text-primary" />
+          </div>
+          <CardTitle>{copy.title}</CardTitle>
+          <CardDescription>{copy.description}</CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Button onClick={() => router.push("/login")} className="w-full">
+            Continue to sign in
+          </Button>
+        </CardContent>
+      </>
+    );
+  }
+
+  const copy = isReset ? COPY.reset : COPY.invite;
   return (
-    <div className="min-h-screen flex items-center justify-center">
-      <div className="w-full max-w-md flex flex-col items-center gap-6">
-        <Image src="/pinchy-logo.png" alt="Pinchy" width={80} height={85} priority />
+    <>
+      <CardHeader>
+        <CardTitle>{copy.title}</CardTitle>
+        <CardDescription>{copy.description}</CardDescription>
+      </CardHeader>
+      <CardContent>
+        <Form {...form}>
+          <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
+            {error && <p className="text-destructive">{error}</p>}
 
-        <Card className="w-full">
-          {success ? (
-            <>
-              <CardHeader className="text-center">
-                <div className="flex justify-center mb-2">
-                  <CheckCircle2 className="size-12 text-primary" />
-                </div>
-                <CardTitle>Account created!</CardTitle>
-                <CardDescription>You can now sign in with your credentials.</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Button onClick={() => router.push("/login")} className="w-full">
-                  Continue to sign in
-                </Button>
-              </CardContent>
-            </>
-          ) : (
-            <>
-              <CardHeader>
-                <CardTitle>You&apos;ve been invited to Pinchy</CardTitle>
-                <CardDescription>Set up your account to get started.</CardDescription>
-              </CardHeader>
-              <CardContent>
-                <Form {...form}>
-                  <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-                    {error && <p className="text-destructive">{error}</p>}
+            {!isReset && (
+              <FormField
+                control={form.control}
+                name="name"
+                render={({ field }) => (
+                  <FormItem>
+                    <FormLabel>Name</FormLabel>
+                    <FormControl>
+                      <Input type="text" {...field} />
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            )}
 
-                    <FormField
-                      control={form.control}
-                      name="name"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Name</FormLabel>
-                          <FormControl>
-                            <Input type="text" {...field} />
-                          </FormControl>
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+            <FormField
+              control={form.control}
+              name="password"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Password</FormLabel>
+                  <PasswordInput {...field} />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-                    <FormField
-                      control={form.control}
-                      name="password"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Password</FormLabel>
-                          <PasswordInput {...field} />
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
+            <FormField
+              control={form.control}
+              name="confirmPassword"
+              render={({ field }) => (
+                <FormItem>
+                  <FormLabel>Confirm password</FormLabel>
+                  <PasswordInput {...field} />
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
 
-                    <FormField
-                      control={form.control}
-                      name="confirmPassword"
-                      render={({ field }) => (
-                        <FormItem>
-                          <FormLabel>Confirm password</FormLabel>
-                          <PasswordInput {...field} />
-                          <FormMessage />
-                        </FormItem>
-                      )}
-                    />
-
-                    <Button type="submit" disabled={loading} className="w-full">
-                      {loading ? "Creating account..." : "Create account"}
-                    </Button>
-                  </form>
-                </Form>
-              </CardContent>
-            </>
-          )}
-        </Card>
-      </div>
-    </div>
+            <Button type="submit" disabled={loading} className="w-full">
+              {loading ? copy.busy : copy.submit}
+            </Button>
+          </form>
+        </Form>
+      </CardContent>
+    </>
   );
 }

--- a/packages/web/src/app/invite/[token]/page.tsx
+++ b/packages/web/src/app/invite/[token]/page.tsx
@@ -18,6 +18,7 @@ import {
   FormMessage,
 } from "@/components/ui/form";
 import { CheckCircle2, Loader2 } from "lucide-react";
+import { toast } from "sonner";
 import { PasswordInput } from "@/components/password-input";
 import { passwordSchema } from "@/lib/validate-password";
 
@@ -123,8 +124,8 @@ export default function InviteClaimPage() {
               <CardDescription className="text-destructive">{loadError}</CardDescription>
             </CardHeader>
           ) : type === null ? (
-            <CardContent className="flex justify-center py-10">
-              <Loader2 className="size-6 animate-spin text-muted-foreground" />
+            <CardContent className="flex justify-center py-10" role="status" aria-label="Loading">
+              <Loader2 className="size-6 animate-spin text-muted-foreground" aria-hidden="true" />
             </CardContent>
           ) : (
             <ClaimForm token={String(token)} type={type} />
@@ -138,7 +139,6 @@ export default function InviteClaimPage() {
 function ClaimForm({ token, type }: { token: string; type: InviteType }) {
   const router = useRouter();
   const isReset = type === "reset";
-  const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
   const [success, setSuccess] = useState(false);
 
@@ -151,7 +151,6 @@ function ClaimForm({ token, type }: { token: string; type: InviteType }) {
 
   async function onSubmit(values: FormValues) {
     setLoading(true);
-    setError("");
 
     const body = isReset
       ? { token, password: values.password }
@@ -166,13 +165,18 @@ function ClaimForm({ token, type }: { token: string; type: InviteType }) {
 
       if (!res.ok) {
         const data = await res.json();
-        setError(data.error || (isReset ? "Failed to reset password" : "Failed to create account"));
+        // Submit failures (expired link, server error) are system-level, not
+        // field-correctable, so they surface as a toast per the error-display
+        // policy. Field validation stays inline via <FormMessage>.
+        toast.error(
+          data.error || (isReset ? "Failed to reset password" : "Failed to create account")
+        );
         return;
       }
 
       setSuccess(true);
     } catch {
-      setError("Something went wrong. Please try again.");
+      toast.error("Something went wrong. Please try again.");
     } finally {
       setLoading(false);
     }
@@ -208,8 +212,6 @@ function ClaimForm({ token, type }: { token: string; type: InviteType }) {
       <CardContent>
         <Form {...form}>
           <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-6">
-            {error && <p className="text-destructive">{error}</p>}
-
             {!isReset && (
               <FormField
                 control={form.control}

--- a/packages/web/src/lib/invites.ts
+++ b/packages/web/src/lib/invites.ts
@@ -1,7 +1,44 @@
 import { randomBytes, createHash } from "crypto";
 import { db } from "@/db";
-import { invites, inviteGroups } from "@/db/schema";
+import { invites, inviteGroups, users } from "@/db/schema";
 import { eq, and, isNull, gt } from "drizzle-orm";
+
+type InviteRow = typeof invites.$inferSelect;
+type UserRow = typeof users.$inferSelect;
+
+/**
+ * Resolves a raw invite token into the flow it drives, shared by the
+ * `GET /api/invite/[token]` loader and the `POST /api/invite/claim` handler so
+ * the two can never disagree on what a token means.
+ *
+ * - Unknown / expired / claimed token → `{ ok: false, status: 410 }`.
+ * - Reset token whose target user no longer exists → `{ ok: false, status: 404 }`.
+ * - Otherwise the discriminated `type` carries the data each caller needs: a
+ *   reset resolution guarantees a non-null `user`.
+ */
+export type InviteFlowResolution =
+  | { ok: false; status: number; error: string }
+  | { ok: true; type: "invite"; invite: InviteRow }
+  | { ok: true; type: "reset"; invite: InviteRow; user: UserRow };
+
+export async function resolveInviteFlow(token: string): Promise<InviteFlowResolution> {
+  const invite = await validateInviteToken(token);
+  if (!invite) {
+    return { ok: false, status: 410, error: "Invalid or expired invite link" };
+  }
+
+  if (invite.type === "reset") {
+    const user = invite.email
+      ? await db.query.users.findFirst({ where: eq(users.email, invite.email) })
+      : null;
+    if (!user) {
+      return { ok: false, status: 404, error: "User not found" };
+    }
+    return { ok: true, type: "reset", invite, user };
+  }
+
+  return { ok: true, type: "invite", invite };
+}
 
 const TOKEN_BYTES = 32;
 const EXPIRY_DAYS = 7;


### PR DESCRIPTION
## Summary

Fixes #436. The `/invite/[token]` page served two distinct flows — new-user invite claim **and** admin-triggered password reset — with identical UI. This was confusing for every reset recipient and, worse, silently overwrote the user's display name when a reset recipient typed a name into the shared form (data loss on a security-sensitive flow).

## What changed

- **New loader route** `GET /api/invite/[token]` returns `{ type: "invite" | "reset" }` so the page can branch before rendering.
- **Reset-specific UI** in `invite/[token]/page.tsx`: header "Reset your Pinchy password", subtitle "Set a new password for your account.", **no Name field**, submit button "Reset password". The reset POST no longer carries a `name`.
- **Defense in depth** in `api/invite/claim/route.ts`: the reset branch no longer touches `users.name` at all, so even a crafted POST carrying a `name` cannot overwrite the display name.
- Invalid / expired / revoked tokens are now rejected **up front** (the page shows an error immediately) instead of only failing at submit time.
- Docs updated (`guides/user-management.mdx`).

## Why

The audit log already distinguished `detail.type: "invite" | "reset"`; only the UI didn't. The silent display-name overwrite was the high-severity part — addressed at both the UI layer (no name field) and the API layer (reset never writes `name`).

## Testing

- **GET integration test** (`invite-token-get.integration.test.ts`) — 6/6: invite/reset type, 410 for unknown/expired/claimed, 404 for reset whose user is gone.
- **Claim integration test** — added a name-preservation guardrail asserting a reset with a `name` in the body leaves `users.name` untouched.
- **Component test** (`invite-claim-page.test.tsx`) — both invite and reset flows, including "no Name field on reset" and "submits no name".
- **E2E** (`11-user-invite.spec.ts`) — new reset happy-path (reset UI renders, no name field, name preserved, login with new password works); updated the revoked-invite test to assert the new up-front rejection.
- `tsc` and ESLint clean.

## Reviewer notes

The existing "revoked invite cannot be claimed" E2E was updated (not weakened): the page now rejects bad tokens before rendering the form, so the test asserts the immediate "This link can't be used" error instead of a submit-time failure.