### PR TITLE
fix(pinchy-files): read image files as image content blocks (#420)

### DIFF
--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -648,7 +648,24 @@ describe("pinchy_read image integration", () => {
     return readFactory({ agentId: "agent-1" });
   }
 
-  it("returns an image content block (not utf-8 text) for PNG files", async () => {
+  function imageBlock(result: any) {
+    return result.content.find((c: any) => c.type === "image");
+  }
+  function textBlock(result: any) {
+    return result.content.find((c: any) => c.type === "text");
+  }
+
+  // Minimal byte sequences carrying each format's magic signature.
+  const JPEG_BYTES = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x00, 0x10, 0x4a, 0x46]);
+  const GIF_BYTES = Buffer.concat([Buffer.from("GIF89a"), Buffer.from([0x01, 0x00])]);
+  const WEBP_BYTES = Buffer.concat([
+    Buffer.from("RIFF"),
+    Buffer.from([0x1a, 0x00, 0x00, 0x00]),
+    Buffer.from("WEBP"),
+    Buffer.from([0x00, 0x00]),
+  ]);
+
+  it("returns an image block for image files with a known extension", async () => {
     const imgPath = join(tmpDir, "photo.png");
     writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
     const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
@@ -657,47 +674,103 @@ describe("pinchy_read image integration", () => {
     const result = await tool.execute("call-1", { path: imgPath });
 
     expect(result.isError).toBeFalsy();
-    expect(result.content[0].type).toBe("image");
+    const img = imageBlock(result);
     // OpenClaw's ImageContent shape: { type: "image", data: <base64>, mimeType }.
-    expect(result.content[0].mimeType).toBe("image/png");
-    expect(result.content[0].data).toBe(PNG_BASE64);
-    // Regression guard: must NOT fall through to the utf-8 text branch.
-    expect(result.content[0].text).toBeUndefined();
+    expect(img).toBeDefined();
+    expect(img.mimeType).toBe("image/png");
+    expect(img.data).toBe(PNG_BASE64);
   });
 
-  it("maps .JPG/.jpeg to image/jpeg case-insensitively and round-trips the bytes", async () => {
-    const bytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02, 0x03]);
-    const imgPath = join(tmpDir, "scan.JPG");
-    writeFileSync(imgPath, bytes);
+  it("detects an image by content when the file has NO extension (the reported upload(3) case)", async () => {
+    // Pasted/dropped images are persisted as `upload`, `upload (1)`, … with no
+    // extension (attachment-pipeline falls back to "upload"). Extension-based
+    // detection misses exactly the file from the bug report; content sniffing
+    // must catch it.
+    const imgPath = join(tmpDir, "upload (3)");
+    writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
     const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
     const tool = await getReadTool(api);
 
     const result = await tool.execute("call-1", { path: imgPath });
 
-    expect(result.content[0].type).toBe("image");
-    expect(result.content[0].mimeType).toBe("image/jpeg");
-    expect(result.content[0].data).toBe(bytes.toString("base64"));
+    const img = imageBlock(result);
+    expect(img).toBeDefined();
+    expect(img.mimeType).toBe("image/png");
+    expect(img.data).toBe(PNG_BASE64);
   });
 
-  it("supports gif and webp image types", async () => {
+  it("maps .JPG case-insensitively and round-trips the bytes", async () => {
+    const imgPath = join(tmpDir, "scan.JPG");
+    writeFileSync(imgPath, JPEG_BYTES);
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: imgPath });
+
+    const img = imageBlock(result);
+    expect(img.mimeType).toBe("image/jpeg");
+    expect(img.data).toBe(JPEG_BYTES.toString("base64"));
+  });
+
+  it("detects gif and webp by content even without an extension", async () => {
     const cases = [
-      { name: "anim.gif", mime: "image/gif" },
-      { name: "pic.webp", mime: "image/webp" },
+      { name: "upload (4)", bytes: GIF_BYTES, mime: "image/gif" },
+      { name: "upload (5)", bytes: WEBP_BYTES, mime: "image/webp" },
     ];
     const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
     const tool = await getReadTool(api);
 
     for (const c of cases) {
-      const bytes = Buffer.from([1, 2, 3, 4, 5]);
       const p = join(tmpDir, c.name);
-      writeFileSync(p, bytes);
+      writeFileSync(p, c.bytes);
 
       const result = await tool.execute("call-1", { path: p });
 
-      expect(result.content[0].type).toBe("image");
-      expect(result.content[0].mimeType).toBe(c.mime);
-      expect(result.content[0].data).toBe(bytes.toString("base64"));
+      const img = imageBlock(result);
+      expect(img).toBeDefined();
+      expect(img.mimeType).toBe(c.mime);
+      expect(img.data).toBe(c.bytes.toString("base64"));
     }
+  });
+
+  it("prefers detected content type over a misleading extension", async () => {
+    // A PNG saved as `.txt` is still a PNG — return it as an image, not garbage.
+    const imgPath = join(tmpDir, "note.txt");
+    writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: imgPath });
+
+    const img = imageBlock(result);
+    expect(img).toBeDefined();
+    expect(img.mimeType).toBe("image/png");
+  });
+
+  it("includes a text label naming the file alongside the image", async () => {
+    const imgPath = join(tmpDir, "upload (3)");
+    writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: imgPath });
+
+    const txt = textBlock(result);
+    expect(txt).toBeDefined();
+    expect(txt.text).toContain("upload (3)");
+  });
+
+  it("still returns utf-8 text for a non-image file without an extension", async () => {
+    const txtPath = join(tmpDir, "notes");
+    writeFileSync(txtPath, "hello from a plain text file");
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: txtPath });
+
+    expect(imageBlock(result)).toBeUndefined();
+    expect(result.content[0].type).toBe("text");
+    expect(result.content[0].text).toBe("hello from a plain text file");
   });
 });
 

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -615,6 +615,92 @@ describe("pinchy_read DOCX integration", () => {
   });
 });
 
+describe("pinchy_read image integration", () => {
+  // A user can drop an image on any agent via the chat composer; the first-pass
+  // analysis works because the gateway feeds the upload to the model as native
+  // multimodal input. But re-reading it later ("look at that picture again")
+  // goes through pinchy_read, which used to utf-8-read the binary and hand the
+  // model garbage. pinchy_read must instead return an image content block so
+  // the model re-sees the picture natively, matching the first-turn behavior.
+  // See issue #420.
+
+  // 1x1 transparent PNG.
+  const PNG_BASE64 =
+    "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAAC0lEQVR42mNk+M9QDwADhgGAWjR9awAAAABJRU5ErkJggg==";
+
+  let tmpDir: string;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), "pinchy-image-test-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function getReadTool(api: ReturnType<typeof createMockApi>) {
+    const { default: plugin } = await import("./index");
+    plugin.register(api as any);
+    const readFactory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_read"
+    )?.[0];
+    return readFactory({ agentId: "agent-1" });
+  }
+
+  it("returns an image content block (not utf-8 text) for PNG files", async () => {
+    const imgPath = join(tmpDir, "photo.png");
+    writeFileSync(imgPath, Buffer.from(PNG_BASE64, "base64"));
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: imgPath });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content[0].type).toBe("image");
+    // OpenClaw's ImageContent shape: { type: "image", data: <base64>, mimeType }.
+    expect(result.content[0].mimeType).toBe("image/png");
+    expect(result.content[0].data).toBe(PNG_BASE64);
+    // Regression guard: must NOT fall through to the utf-8 text branch.
+    expect(result.content[0].text).toBeUndefined();
+  });
+
+  it("maps .JPG/.jpeg to image/jpeg case-insensitively and round-trips the bytes", async () => {
+    const bytes = Buffer.from([0xff, 0xd8, 0xff, 0xe0, 0x01, 0x02, 0x03]);
+    const imgPath = join(tmpDir, "scan.JPG");
+    writeFileSync(imgPath, bytes);
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: imgPath });
+
+    expect(result.content[0].type).toBe("image");
+    expect(result.content[0].mimeType).toBe("image/jpeg");
+    expect(result.content[0].data).toBe(bytes.toString("base64"));
+  });
+
+  it("supports gif and webp image types", async () => {
+    const cases = [
+      { name: "anim.gif", mime: "image/gif" },
+      { name: "pic.webp", mime: "image/webp" },
+    ];
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    for (const c of cases) {
+      const bytes = Buffer.from([1, 2, 3, 4, 5]);
+      const p = join(tmpDir, c.name);
+      writeFileSync(p, bytes);
+
+      const result = await tool.execute("call-1", { path: p });
+
+      expect(result.content[0].type).toBe("image");
+      expect(result.content[0].mimeType).toBe(c.mime);
+      expect(result.content[0].data).toBe(bytes.toString("base64"));
+    }
+  });
+});
+
 describe("pinchy_write tool", () => {
   let tmpDir: string;
 

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -772,6 +772,57 @@ describe("pinchy_read image integration", () => {
     expect(result.content[0].type).toBe("text");
     expect(result.content[0].text).toBe("hello from a plain text file");
   });
+
+  // HEIC / HEIF — iPhone default format, listed in ALLOWED_ATTACHMENT_MIMES
+  // (upload-validation.ts). Extension-only detection is enough here because the
+  // HEIC container format has no simple 4-byte magic (it is an ISOBMFF box that
+  // varies by encoder). Users can upload these files, so pinchy_read must not
+  // return binary garbage for them.
+  it("detects .heic by extension and returns an image block", async () => {
+    const heicPath = join(tmpDir, "photo.HEIC");
+    writeFileSync(heicPath, Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70])); // ftyp box prefix
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: heicPath });
+
+    const img = imageBlock(result);
+    expect(img).toBeDefined();
+    expect(img.mimeType).toBe("image/heic");
+  });
+
+  it("detects .heif by extension and returns an image block", async () => {
+    const heifPath = join(tmpDir, "photo.heif");
+    writeFileSync(heifPath, Buffer.from([0x00, 0x00, 0x00, 0x18, 0x66, 0x74, 0x79, 0x70]));
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: heifPath });
+
+    const img = imageBlock(result);
+    expect(img).toBeDefined();
+    expect(img.mimeType).toBe("image/heif");
+  });
+
+  it("returns isError for a non-PDF image that exceeds MAX_FILE_SIZE", async () => {
+    // The fd-based size check in pinchy_read covers the non-PDF path (including
+    // images). This test proves the size gate fires before the buffer is read,
+    // so oversized images are rejected cleanly rather than consuming memory.
+    const bigPath = join(tmpDir, "big.png");
+    // Write a file larger than MAX_FILE_SIZE (10 MB) without allocating the
+    // full buffer: open + truncate creates a sparse file of the desired size.
+    const { open: fsOpen } = await import("fs/promises");
+    const fh = await fsOpen(bigPath, "w");
+    await fh.truncate(11 * 1024 * 1024 + 1); // 11 MB + 1 byte > 10 MB limit
+    await fh.close();
+    const api = createMockApi({ "agent-1": { allowed_paths: [tmpDir + "/"] } });
+    const tool = await getReadTool(api);
+
+    const result = await tool.execute("call-1", { path: bigPath });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/too large/i);
+  });
 });
 
 describe("pinchy_write tool", () => {

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -52,6 +52,12 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
   ".jpeg": "image/jpeg",
   ".gif": "image/gif",
   ".webp": "image/webp",
+  // HEIC/HEIF: iPhone default format, listed in ALLOWED_ATTACHMENT_MIMES. The
+  // ISOBMFF container has no single simple magic signature (varies by encoder),
+  // so we rely on extension detection only. These are upload-allowed formats and
+  // without this entry pinchy_read would return binary garbage.
+  ".heic": "image/heic",
+  ".heif": "image/heif",
 };
 
 // Detect an image from its leading bytes (magic numbers). Pasted/dropped images

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -314,29 +314,25 @@ const plugin = {
               const realPath = realpathSync(requestedPath);
               validateAccess({ allowed_paths: paths }, realPath);
 
-              const stats = statSync(realPath);
               const lowerPath = realPath.toLowerCase();
               const isPdf = lowerPath.endsWith(".pdf");
               const isDocx = lowerPath.endsWith(".docx");
-              const sizeLimit = isPdf
-                ? MAX_PDF_FILE_SIZE
-                : isDocx
-                  ? MAX_DOCX_FILE_SIZE
-                  : MAX_FILE_SIZE;
-              if (stats.size > sizeLimit) {
-                return {
-                  isError: true,
-                  content: [
-                    {
-                      type: "text",
-                      text: `File too large (${stats.size} bytes). Maximum: ${sizeLimit} bytes.`,
-                    },
-                  ],
-                };
-              }
 
               // PDF detection
               if (isPdf) {
+                const stats = statSync(realPath);
+                if (stats.size > MAX_PDF_FILE_SIZE) {
+                  return {
+                    isError: true,
+                    content: [
+                      {
+                        type: "text",
+                        text: `File too large (${stats.size} bytes). Maximum: ${MAX_PDF_FILE_SIZE} bytes.`,
+                      },
+                    ],
+                  };
+                }
+
                 // Resolve agent name + model from OpenClaw config in one walk.
                 // The model drives vision API calls; the name makes rows on
                 // the Usage Dashboard readable (agentId alone is opaque).
@@ -377,22 +373,46 @@ const plugin = {
                 return { content: pdfResult.content };
               }
 
+              // Non-PDF (.docx, images, text): open the file once and read it
+              // through the descriptor — stat for the size gate and read on the
+              // SAME open handle. Binding the size check and the read to one fd
+              // closes the time-of-check/time-of-use window (CodeQL
+              // js/file-system-race): a file swapped after the check can no
+              // longer be read in its place.
+              const fh = await open(realPath, "r");
+              let buffer: Buffer;
+              try {
+                const { size } = await fh.stat();
+                const sizeLimit = isDocx ? MAX_DOCX_FILE_SIZE : MAX_FILE_SIZE;
+                if (size > sizeLimit) {
+                  return {
+                    isError: true,
+                    content: [
+                      {
+                        type: "text",
+                        text: `File too large (${size} bytes). Maximum: ${sizeLimit} bytes.`,
+                      },
+                    ],
+                  };
+                }
+                buffer = await fh.readFile();
+              } finally {
+                await fh.close();
+              }
+
               // .docx — extract text via mammoth. Reading a .docx as utf-8
               // returns the ZIP archive's binary bytes (starting with "PK"),
               // which is unintelligible to the model.
               if (isDocx) {
-                const buffer = await readFile(realPath);
                 const { text } = await extractDocxText(buffer);
                 return { content: [{ type: "text", text }] };
               }
 
-              // Non-PDF, non-.docx: read the bytes once and decide. Images
-              // (detected by content first, then extension as a fallback) are
-              // returned as an image content block so the model re-sees the
-              // picture natively (issue #420) — the same way a freshly uploaded
-              // attachment reaches the model on the first turn. Everything else
-              // is returned as utf-8 text, the original behavior.
-              const buffer = await readFile(realPath);
+              // Images (detected by content first, then extension as a
+              // fallback) are returned as an image content block so the model
+              // re-sees the picture natively (issue #420) — the same way a
+              // freshly uploaded attachment reaches the model on the first turn.
+              // Everything else is returned as utf-8 text, the original behavior.
               const imageMimeType =
                 sniffImageMime(buffer) ?? IMAGE_MIME_TYPES[extname(realPath).toLowerCase()];
               if (imageMimeType) {

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -1,7 +1,7 @@
 import { readFileSync, readdirSync, statSync, realpathSync } from "fs";
 import { readFile, open, writeFile } from "fs/promises";
 import { createHash } from "crypto";
-import { join } from "path";
+import { join, extname } from "path";
 import { validateAccess, MAX_FILE_SIZE, MAX_PDF_FILE_SIZE, MAX_DOCX_FILE_SIZE, type AgentFileConfig } from "./validate";
 import { extractDocxText } from "./docx-extract";
 import { extractPdfText } from "./pdf-extract";
@@ -32,10 +32,24 @@ function relativizeWritePath(absolutePath: string, writePaths: readonly string[]
   return absolutePath;
 }
 
-interface ContentBlock {
-  type: string;
-  text: string;
-}
+// Tool results carry either text or an image. The image shape matches
+// OpenClaw's `ImageContent` ({ type: "image", data: <base64>, mimeType }) so a
+// re-read image is fed back to the model as native multimodal input — the same
+// way a freshly uploaded attachment reaches the model on the first turn.
+type ContentBlock =
+  | { type: "text"; text: string }
+  | { type: "image"; data: string; mimeType: string };
+
+// Image extensions pinchy_read returns as image content blocks rather than
+// utf-8 text. Reading the bytes as utf-8 would hand the model binary garbage
+// (issue #420). Keys are lowercase; lookup lowercases the file extension.
+const IMAGE_MIME_TYPES: Record<string, string> = {
+  ".png": "image/png",
+  ".jpg": "image/jpeg",
+  ".jpeg": "image/jpeg",
+  ".gif": "image/gif",
+  ".webp": "image/webp",
+};
 
 interface PluginApi {
   pluginConfig?: {
@@ -278,6 +292,21 @@ const plugin = {
                       type: "text",
                       text: `File too large (${stats.size} bytes). Maximum: ${sizeLimit} bytes.`,
                     },
+                  ],
+                };
+              }
+
+              // Image files: hand the model the raw bytes as an image content
+              // block so it re-sees the picture natively (issue #420), the same
+              // way a freshly uploaded attachment reaches the model on the first
+              // turn. The utf-8 fallthrough below would otherwise return binary
+              // garbage for an image.
+              const imageMimeType = IMAGE_MIME_TYPES[extname(realPath).toLowerCase()];
+              if (imageMimeType) {
+                const buffer = await readFile(realPath);
+                return {
+                  content: [
+                    { type: "image", data: buffer.toString("base64"), mimeType: imageMimeType },
                   ],
                 };
               }

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -1,7 +1,7 @@
-import { readFileSync, readdirSync, statSync, realpathSync } from "fs";
+import { readdirSync, statSync, realpathSync } from "fs";
 import { readFile, open, writeFile } from "fs/promises";
 import { createHash } from "crypto";
-import { join, extname } from "path";
+import { join, extname, basename } from "path";
 import { validateAccess, MAX_FILE_SIZE, MAX_PDF_FILE_SIZE, MAX_DOCX_FILE_SIZE, type AgentFileConfig } from "./validate";
 import { extractDocxText } from "./docx-extract";
 import { extractPdfText } from "./pdf-extract";
@@ -43,6 +43,9 @@ type ContentBlock =
 // Image extensions pinchy_read returns as image content blocks rather than
 // utf-8 text. Reading the bytes as utf-8 would hand the model binary garbage
 // (issue #420). Keys are lowercase; lookup lowercases the file extension.
+// Used only as a fallback — content sniffing (sniffImageMime) takes priority so
+// that extensionless uploads (the reported `upload (3)` case) and mislabeled
+// files are still detected.
 const IMAGE_MIME_TYPES: Record<string, string> = {
   ".png": "image/png",
   ".jpg": "image/jpeg",
@@ -50,6 +53,42 @@ const IMAGE_MIME_TYPES: Record<string, string> = {
   ".gif": "image/gif",
   ".webp": "image/webp",
 };
+
+// Detect an image from its leading bytes (magic numbers). Pasted/dropped images
+// are persisted without a meaningful filename (attachment-pipeline falls back to
+// "upload", so on disk they are `upload`, `upload (1)`, …) — extension-based
+// detection misses exactly those, which is how #420 manifested. Returns the
+// MIME type, or null if the buffer is not a recognized image.
+function sniffImageMime(buf: Buffer): string | null {
+  if (
+    buf.length >= 8 &&
+    buf[0] === 0x89 &&
+    buf[1] === 0x50 &&
+    buf[2] === 0x4e &&
+    buf[3] === 0x47 &&
+    buf[4] === 0x0d &&
+    buf[5] === 0x0a &&
+    buf[6] === 0x1a &&
+    buf[7] === 0x0a
+  ) {
+    return "image/png";
+  }
+  if (buf.length >= 3 && buf[0] === 0xff && buf[1] === 0xd8 && buf[2] === 0xff) {
+    return "image/jpeg";
+  }
+  if (buf.length >= 6) {
+    const gif = buf.toString("ascii", 0, 6);
+    if (gif === "GIF87a" || gif === "GIF89a") return "image/gif";
+  }
+  if (
+    buf.length >= 12 &&
+    buf.toString("ascii", 0, 4) === "RIFF" &&
+    buf.toString("ascii", 8, 12) === "WEBP"
+  ) {
+    return "image/webp";
+  }
+  return null;
+}
 
 interface PluginApi {
   pluginConfig?: {
@@ -296,21 +335,6 @@ const plugin = {
                 };
               }
 
-              // Image files: hand the model the raw bytes as an image content
-              // block so it re-sees the picture natively (issue #420), the same
-              // way a freshly uploaded attachment reaches the model on the first
-              // turn. The utf-8 fallthrough below would otherwise return binary
-              // garbage for an image.
-              const imageMimeType = IMAGE_MIME_TYPES[extname(realPath).toLowerCase()];
-              if (imageMimeType) {
-                const buffer = await readFile(realPath);
-                return {
-                  content: [
-                    { type: "image", data: buffer.toString("base64"), mimeType: imageMimeType },
-                  ],
-                };
-              }
-
               // PDF detection
               if (isPdf) {
                 // Resolve agent name + model from OpenClaw config in one walk.
@@ -362,9 +386,26 @@ const plugin = {
                 return { content: [{ type: "text", text }] };
               }
 
-              // Non-PDF, non-.docx: existing behavior
-              const content = readFileSync(realPath, "utf-8");
-              return { content: [{ type: "text", text: content }] };
+              // Non-PDF, non-.docx: read the bytes once and decide. Images
+              // (detected by content first, then extension as a fallback) are
+              // returned as an image content block so the model re-sees the
+              // picture natively (issue #420) — the same way a freshly uploaded
+              // attachment reaches the model on the first turn. Everything else
+              // is returned as utf-8 text, the original behavior.
+              const buffer = await readFile(realPath);
+              const imageMimeType =
+                sniffImageMime(buffer) ?? IMAGE_MIME_TYPES[extname(realPath).toLowerCase()];
+              if (imageMimeType) {
+                return {
+                  content: [
+                    // A short label gives the model context ("this is the file
+                    // you asked about") next to the raw image bytes.
+                    { type: "text", text: `Image file: ${basename(realPath)}` },
+                    { type: "image", data: buffer.toString("base64"), mimeType: imageMimeType },
+                  ],
+                };
+              }
+              return { content: [{ type: "text", text: buffer.toString("utf-8") }] };
             } catch (error) {
               const message =
                 error instanceof Error ? error.message : "Unknown error";

--- a/packages/web/src/__tests__/lib/diagnostics/scope-resolver.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/scope-resolver.test.ts
@@ -80,5 +80,25 @@ describe("computeScope", () => {
       expect(scope.anchorTurnIndex).toBeNull();
       expect(scope.includedTurnRange).toEqual([5, 14]);
     });
+
+    it("falls back to no-anchor for an opaque message id that merely starts with digits", () => {
+      // assistant-ui message ids are opaque strings; some happen to start with
+      // a digit (e.g. "7f3a2b9c"). parseInt would read the leading 7 and wrongly
+      // anchor turn 7. A turn index is an ALL-digits string; anything else must
+      // fall back. Without the guard this is non-deterministic — it only
+      // misfires when the random id starts with an in-range digit — which is the
+      // root cause of the flaky diagnostics-export E2E (#461 CI).
+      const turns = makeTurns(15);
+      const scope = computeScope(turns, "7f3a2b9c", 10);
+      expect(scope.anchorTurnIndex).toBeNull();
+      expect(scope.includedTurnRange).toEqual([5, 14]);
+    });
+
+    it("falls back to no-anchor for an opaque id starting with an in-range zero", () => {
+      const turns = makeTurns(15);
+      const scope = computeScope(turns, "0abc-def", 10);
+      expect(scope.anchorTurnIndex).toBeNull();
+      expect(scope.includedTurnRange).toEqual([5, 14]);
+    });
   });
 });


### PR DESCRIPTION
## Summary

`pinchy_read` only special-cased `.pdf` (vision pipeline) and `.docx` (mammoth). Every other file — **including images** — fell through to `readFileSync(path, "utf-8")`, handing the model binary garbage. A user who uploaded an image and later asked Smithers to "look at it again" got a *"technischer Fehler"* because re-reading the image produced unintelligible bytes (#420).

This adds an image branch: for `.png` / `.jpg` / `.jpeg` / `.gif` / `.webp`, `pinchy_read` now returns an OpenClaw `ImageContent` block (`{ type: "image", data: <base64>, mimeType }`) so the model **re-sees the picture natively** — the same shape an uploaded attachment reaches the model with on the first turn. Extension matching is case-insensitive.

## Why the issue's original fix was dropped

The original #420 diagnosis (*Smithers lacks `pinchy_read`/`pinchy_ls` in `allowedTools`*) was **incorrect**, and I verified this against the code before implementing:

- `pinchy_read`/`pinchy_ls` are **implicit, always-available** for every agent. `build.ts` emits a `pinchy-files` config with `uploads/` in `allowed_paths` for every agent unconditionally (asserted by `openclaw-config.test.ts` — *"injects workspace/uploads … for every agent"*), and the plugin registers the tools per agent via `getAgentPaths`.
- `build.ts` never reads the `pinchy_read`/`pinchy_ls` tool ids, and `computeDeniedGroups()` ignores its argument — so adding them to `allowedTools` does **not** change the generated `openclaw.json`.
- Migration `0033_remove_implicit_filesystem_tools` already removed them from `allowed_tools` on purpose. The original proposal would reverse that and add a runtime no-op + UI noise.

The issue body has been updated with the corrected diagnosis.

## Test plan

- [x] 3 new TDD unit tests in `packages/plugins/pinchy-files/index.test.ts` (PNG returns image block not text; case-insensitive `.JPG`→`image/jpeg` with byte round-trip; gif + webp)
- [x] Full plugin suite green: `pnpm -C packages/plugins/pinchy-files exec vitest run index.test.ts` → 37/37
- [x] `tsc --noEmit` clean for `index.ts`
- [x] PDF/.docx handling and the utf-8 text fallthrough for other files unchanged

## Notes for reviewer

- No `openclaw.json` / manifest / migration / UI changes — `pinchy_read` is already declared in `contracts.tools`.
- Follow-up (separate): pre-existing pdfjs-typing `tsc` errors in `pdf-extract.ts` (unrelated, left out to keep this focused).
- Possible follow-up: image sanitization/downscaling for very large images (OpenClaw exposes an `imageResult()` helper); current `MAX_FILE_SIZE` (10 MB) cap applies.