### PR TITLE
fix(chat): deterministic agent-readiness gate + reliable config-push across OC restart (de-flake dispatch E2E)

### DIFF
--- a/.github/actions/capture-e2e-diagnostics/action.yml
+++ b/.github/actions/capture-e2e-diagnostics/action.yml
@@ -53,10 +53,29 @@ runs:
           docker compose $COMPOSE_FILES_INPUT logs --no-color --timestamps "$MOCK_SERVICE" > "e2e-artifacts/${MOCK_SERVICE}.log" 2>&1
         fi
         # The OC config Pinchy wrote and OC reloaded against — definitive
-        # answer to "did the agent/tool propagate". `exec -T` falls back to
-        # an empty file if the container is gone, which is fine.
-        docker compose $COMPOSE_FILES_INPUT exec -T pinchy cat /openclaw-config/openclaw.json \
-          > e2e-artifacts/openclaw-config.json 2>/dev/null
+        # answer to "did the agent/tool propagate".
+        #
+        # SECURITY: this repo is public, so the uploaded artifact is downloadable
+        # by anyone for `retention-days`. openclaw.json carries plaintext
+        # bootstrap/provider secrets — `gateway.auth.token`,
+        # `models.providers.*.apiKey`, and `plugins.entries.*.config.gatewayToken`.
+        # In E2E these are ephemeral/mock today, but redact UNCONDITIONALLY as
+        # defense-in-depth so a future suite wired to a real CI-secret key can
+        # never leak it into a public artifact. We scrub on the host with jq
+        # (preinstalled on GitHub ubuntu runners). `exec -T` returns empty if the
+        # container is gone; if the snapshot is empty or not valid JSON we emit a
+        # note instead of risking an unscrubbed partial write.
+        raw_config="$(docker compose $COMPOSE_FILES_INPUT exec -T pinchy cat /openclaw-config/openclaw.json 2>/dev/null)"
+        if [ -n "$raw_config" ] && printf '%s' "$raw_config" | jq empty >/dev/null 2>&1; then
+          printf '%s' "$raw_config" | jq '
+            (if .gateway?.auth?.token then .gateway.auth.token = "***REDACTED***" else . end)
+            | (if .models?.providers then .models.providers |= map_values(if has("apiKey") then .apiKey = "***REDACTED***" else . end) else . end)
+            | (if .plugins?.entries then .plugins.entries |= map_values(if (.config|type) == "object" and (.config|has("gatewayToken")) then .config.gatewayToken = "***REDACTED***" else . end) else . end)
+          ' > e2e-artifacts/openclaw-config.json
+        else
+          echo "openclaw.json absent or non-JSON at capture time (container gone or mid-write)" \
+            > e2e-artifacts/openclaw-config.json
+        fi
 
         # Quick-glance tails in CI log so a maintainer doesn't always need to
         # download the artifact for the obvious cases.

--- a/.github/actions/capture-e2e-diagnostics/action.yml
+++ b/.github/actions/capture-e2e-diagnostics/action.yml
@@ -1,0 +1,87 @@
+name: "Capture E2E diagnostics on failure"
+description: >-
+  Collects full container logs, container state, and OC's live config
+  snapshot into ./e2e-artifacts/, prints a tail to the CI log for quick
+  triage, and uploads the directory plus Playwright's test-results/ as a
+  single named artifact. Designed for the `if: failure()` slot.
+
+  Without this, E2E flakes give zero new information (the previous
+  `tail -50` per service was truncated for tests that fail near the end of
+  the run). With this, every flake produces a downloadable bundle
+  containing Playwright traces, screenshots, and full container logs.
+
+inputs:
+  compose-files:
+    description: >-
+      Space-separated `-f <file>` arguments to apply to `docker compose`,
+      e.g. "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml".
+    required: true
+  mock-service:
+    description: >-
+      Mock service name (e.g. "odoo-mock", "brave-mock", "gmail-mock",
+      "telegram-mock", "llm-providers-mock"). Logs are captured per-service
+      so each suite's mock is isolated. Leave empty for suites with no
+      in-stack mock (e.g. integration tests that run fake-Ollama on the host).
+    required: false
+    default: ""
+  artifact-name:
+    description: >-
+      Name for the uploaded artifact. Should include the job slug and the
+      run attempt so re-runs don't collide (e.g. "odoo-e2e").
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Capture container state, logs, and OC config
+      shell: bash
+      env:
+        COMPOSE_FILES_INPUT: ${{ inputs.compose-files }}
+        MOCK_SERVICE: ${{ inputs.mock-service }}
+      run: |
+        set +e
+        mkdir -p e2e-artifacts
+        # shellcheck disable=SC2086
+        # Splitting COMPOSE_FILES_INPUT on whitespace is intentional — each
+        # element is a `-f <file>` pair that docker compose parses as separate
+        # arguments.
+        docker compose $COMPOSE_FILES_INPUT ps --all > e2e-artifacts/container-state.txt 2>&1
+        docker compose $COMPOSE_FILES_INPUT logs --no-color --timestamps pinchy > e2e-artifacts/pinchy.log 2>&1
+        docker compose $COMPOSE_FILES_INPUT logs --no-color --timestamps openclaw > e2e-artifacts/openclaw.log 2>&1
+        docker compose $COMPOSE_FILES_INPUT logs --no-color --timestamps db > e2e-artifacts/postgres.log 2>&1
+        if [ -n "$MOCK_SERVICE" ]; then
+          docker compose $COMPOSE_FILES_INPUT logs --no-color --timestamps "$MOCK_SERVICE" > "e2e-artifacts/${MOCK_SERVICE}.log" 2>&1
+        fi
+        # The OC config Pinchy wrote and OC reloaded against — definitive
+        # answer to "did the agent/tool propagate". `exec -T` falls back to
+        # an empty file if the container is gone, which is fine.
+        docker compose $COMPOSE_FILES_INPUT exec -T pinchy cat /openclaw-config/openclaw.json \
+          > e2e-artifacts/openclaw-config.json 2>/dev/null
+
+        # Quick-glance tails in CI log so a maintainer doesn't always need to
+        # download the artifact for the obvious cases.
+        echo "=== Container state ==="
+        cat e2e-artifacts/container-state.txt
+        echo
+        echo "=== Pinchy logs (last 80 lines) ==="
+        tail -80 e2e-artifacts/pinchy.log
+        echo
+        echo "=== OpenClaw logs (last 120 lines) ==="
+        tail -120 e2e-artifacts/openclaw.log
+        if [ -n "$MOCK_SERVICE" ]; then
+          echo
+          echo "=== ${MOCK_SERVICE} logs (last 60 lines) ==="
+          tail -60 "e2e-artifacts/${MOCK_SERVICE}.log"
+        fi
+
+    - name: Upload diagnostics artifact
+      uses: actions/upload-artifact@v4
+      with:
+        # Include run_attempt so a re-run uploads a fresh artifact instead of
+        # colliding with the previous attempt's bundle.
+        name: ${{ inputs.artifact-name }}-failure-${{ github.run_id }}-${{ github.run_attempt }}
+        path: |
+          packages/web/test-results/
+          e2e-artifacts/
+        if-no-files-found: ignore
+        retention-days: 14

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1148,15 +1148,13 @@ jobs:
         env:
           CI: true
 
-      - name: Show logs on failure
+      - name: Capture diagnostics on failure
         if: failure()
-        run: |
-          echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs pinchy 2>&1 | tail -50
-          echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs openclaw 2>&1 | tail -50
-          echo "=== Mock Odoo logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml logs odoo-mock 2>&1 | tail -30
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.odoo-test.yml"
+          mock-service: "odoo-mock"
+          artifact-name: "odoo-e2e"
 
       - name: Tear down
         if: always()
@@ -1269,15 +1267,13 @@ jobs:
         env:
           CI: true
 
-      - name: Show logs on failure
+      - name: Capture diagnostics on failure
         if: failure()
-        run: |
-          echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml logs pinchy 2>&1 | tail -50
-          echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml logs openclaw 2>&1 | tail -50
-          echo "=== Mock Brave logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml logs brave-mock 2>&1 | tail -30
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.web-test.yml"
+          mock-service: "brave-mock"
+          artifact-name: "web-e2e"
 
       - name: Tear down
         if: always()
@@ -1391,15 +1387,13 @@ jobs:
           CI: true
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
-      - name: Show logs on failure
+      - name: Capture diagnostics on failure
         if: failure()
-        run: |
-          echo "=== Pinchy logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml logs pinchy 2>&1 | tail -50
-          echo "=== OpenClaw logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml logs openclaw 2>&1 | tail -50
-          echo "=== Mock Gmail logs ==="
-          docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml logs gmail-mock 2>&1 | tail -30
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.email-test.yml"
+          mock-service: "gmail-mock"
+          artifact-name: "email-e2e"
 
       - name: Tear down
         if: always()
@@ -1514,15 +1508,13 @@ jobs:
           CI: true
           ENCRYPTION_KEY: 0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef
 
-      - name: Show logs on failure
+      - name: Capture diagnostics on failure
         if: failure()
-        run: |
-          echo "=== Pinchy logs ==="
-          docker compose $COMPOSE_FILES logs pinchy 2>&1 | tail -200
-          echo "=== OpenClaw logs ==="
-          docker compose $COMPOSE_FILES logs openclaw 2>&1 | tail -200
-          echo "=== Mock LLM providers logs ==="
-          docker compose $COMPOSE_FILES logs llm-providers-mock 2>&1 | tail -100
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: ${{ env.COMPOSE_FILES }}
+          mock-service: "llm-providers-mock"
+          artifact-name: "setup-wizard-e2e"
 
       - name: Tear down
         if: always()
@@ -1689,6 +1681,14 @@ jobs:
           echo "=== Pinchy logs ==="
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml logs pinchy 2>&1 | tail -500
 
+      - name: Capture full diagnostics on failure
+        if: failure()
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml"
+          mock-service: "telegram-mock"
+          artifact-name: "telegram-e2e"
+
       - name: Tear down
         if: always()
         run: docker compose -f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.test.yml down -v
@@ -1835,6 +1835,16 @@ jobs:
           echo "=== DB logs ==="
           docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
                          -f docker-compose.integration.yml logs db 2>&1 | tail -50
+
+      - name: Capture full diagnostics on failure
+        if: failure()
+        uses: ./.github/actions/capture-e2e-diagnostics
+        with:
+          compose-files: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.integration.yml"
+          # Integration suite runs fake-Ollama on the host, not as a compose
+          # service — no mock to capture, the globalTeardown-captured
+          # /tmp/openclaw-integration.log is already shown above.
+          artifact-name: "integration"
 
       - name: Tear down
         if: always()

--- a/package.json
+++ b/package.json
@@ -46,6 +46,7 @@
       "brace-expansion@<1.1.13": "^1.1.13",
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
       "flatted@<3.4.2": "^3.4.2",
+      "hono@>=4.0.0 <4.12.21": ">=4.12.21",
       "typescript-eslint@>=8.0.0 <8.58.2": ">=8.58.2",
       "@typescript-eslint/parser@>=8.0.0 <8.58.2": ">=8.58.2",
       "@typescript-eslint/eslint-plugin@>=8.0.0 <8.58.2": ">=8.58.2",

--- a/packages/web/e2e/email/email.spec.ts
+++ b/packages/web/e2e/email/email.spec.ts
@@ -228,7 +228,12 @@ test.describe("Email dispatch probe (pinchy-email plugin coverage)", () => {
     await stopFakeOllama();
   });
 
-  test("email_list dispatches via fake-LLM and writes audit entry", async ({ page }) => {
+  test("email_list dispatches via fake-LLM and writes audit entry", async ({ page }, testInfo) => {
+    // 160 s poll past the 150 s chatWithDispatchRaceRetry budget; 180 s per-test
+    // timeout to outlast it. See odoo-agent-chat.spec.ts for the measured
+    // ~104 s agent-apply delay this covers.
+    testInfo.setTimeout(180_000);
+
     await loginViaUI(page, getAdminEmail(), getAdminPassword());
 
     await page.goto(`/chat/${dispatchAgentId}`);
@@ -242,6 +247,7 @@ test.describe("Email dispatch probe (pinchy-email plugin coverage)", () => {
     const found = await pollAuditForTool(page, {
       toolName: "email_list",
       agentId: dispatchAgentId,
+      deadlineMs: 160_000,
     });
     expect(found).toBe(true);
   });

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -365,7 +365,17 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
     await stopFakeOllama();
   });
 
-  test("odoo_list_models dispatches via fake-LLM and writes audit entry", async ({ page }) => {
+  test("odoo_list_models dispatches via fake-LLM and writes audit entry", async ({
+    page,
+  }, testInfo) => {
+    // The chat path's chatWithDispatchRaceRetry retries `unknown agent id` for
+    // up to 150 s while OC's runtime catches up to a freshly-created agent
+    // (measured: a coalesced file-watcher reload landed ~104 s after dispatch).
+    // The audit lands shortly after the dispatch succeeds, so the poll must
+    // outlast the retry budget, and the per-test timeout must outlast the poll
+    // + login + nav. Default Playwright 120 s would cut this off mid-poll.
+    testInfo.setTimeout(180_000);
+
     await loginViaUI(page, getAdminEmail(), getAdminPassword());
 
     await page.goto(`/chat/${dispatchAgentId}`);
@@ -376,9 +386,15 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
     await input.fill(`${FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_TRIGGER}: list Odoo models`);
     await input.press("Enter");
 
+    // 160 s deadline: just past chatWithDispatchRaceRetry's 150 s budget so the
+    // poll is still running when a late dispatch finally writes its audit. No
+    // chat re-send (the earlier probe's aggressive re-send measurably worsened
+    // this flake — re-sending chat doesn't trigger an agents reload and floods
+    // OC with agent RPCs; CI run 26843343975).
     const found = await pollAuditForTool(page, {
       toolName: "odoo_list_models",
       agentId: dispatchAgentId,
+      deadlineMs: 160_000,
     });
     expect(found).toBe(true);
   });

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -67,6 +67,19 @@ export async function resetStack(): Promise<void> {
   // for the remainder of the test suite. Deleting both files (plus the
   // bootstrap marker) means the next Pinchy regenerate sees no existing
   // file, skips the size-drop comparison, and writes a clean baseline.
+  //
+  // This rm runs while OpenClaw is still up (exec needs a running container).
+  // OpenClaw's file-watcher sees the deletion as "config file not found" and
+  // skips the reload — harmless. The DANGEROUS event is the next one: Pinchy's
+  // entrypoint.sh re-seeds a 42-byte `{"gateway":{"mode":"local","bind":"lan"}}`
+  // when it finds openclaw.json missing on restart. If OpenClaw's OLD process
+  // is still running when that 42-byte seed lands, its file-watcher sees a
+  // size-drop (4.9 KB → 42 B) whose diff is missing every restart-class field
+  // (gateway.controlUi/auth, discovery, update, canvasHost) → OpenClaw fires a
+  // SIGUSR1 gateway restart, and the cascade (compounded by the first-time
+  // secrets.json bootstrap pkill) keeps the freshly-created Smithers agent out
+  // of OC's runtime `agents.list` for >90 s → the wizard's first chat times out
+  // with `unknown agent id` (the google.spec.ts flake; CI run 26840320245).
   execSync(
     `docker compose ${COMPOSE_ARGS} exec -T openclaw rm -f ` +
       `/root/.openclaw/openclaw.json ` +
@@ -75,13 +88,28 @@ export async function resetStack(): Promise<void> {
     { stdio: "pipe", cwd: REPO_ROOT }
   );
 
-  execSync(`docker compose ${COMPOSE_ARGS} restart pinchy openclaw`, {
+  // Stop OpenClaw BEFORE restarting Pinchy so OC's file-watcher is dead while
+  // the config transitions through the 42-byte entrypoint seed and Pinchy's
+  // bootInits re-seed. OC only comes back up (further below) once Pinchy has
+  // regenerated a complete, restart-class-consistent config — so OC never
+  // observes the intermediate size-drop and never enters the SIGUSR1 cascade.
+  // `restart: unless-stopped` honours a manual `stop`, so OC stays down until
+  // the explicit `start`.
+  execSync(`docker compose ${COMPOSE_ARGS} stop openclaw`, {
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
+
+  execSync(`docker compose ${COMPOSE_ARGS} restart pinchy`, {
     stdio: "pipe",
     cwd: REPO_ROOT,
   });
 
   // Poll /api/setup/status until Pinchy answers — this proves the regenerated
   // openclaw.json has been picked up and the wizard route is reachable.
+  // (Pinchy boots with OC down: its WS connect fails and it falls back to
+  // writing openclaw.json directly via writeConfigAtomic — exactly the
+  // complete baseline we want on disk before OC starts.)
   // 60 s budget: container restart + Next.js cold compile can run ~30 s.
   const deadline = Date.now() + 60000;
   let pinchyReady = false;
@@ -96,6 +124,15 @@ export async function resetStack(): Promise<void> {
     await sleep(1000);
   }
   if (!pinchyReady) throw new Error("Pinchy did not become ready within 60s after reset");
+
+  // Now bring OpenClaw back up. It reads the complete config Pinchy just wrote
+  // (restart-class fields present, no agents/providers yet — those arrive via
+  // hot-reload when the wizard runs), so its first load is clean and no
+  // restart-class diff fires.
+  execSync(`docker compose ${COMPOSE_ARGS} start openclaw`, {
+    stdio: "pipe",
+    cwd: REPO_ROOT,
+  });
 
   // Then wait for OpenClaw to fully SETTLE before handing off to the wizard.
   //
@@ -135,6 +172,47 @@ export async function resetStack(): Promise<void> {
     await sleep(1000);
   }
   throw new Error("OpenClaw did not settle within 60s after reset");
+}
+
+/**
+ * Poll `/api/health/openclaw` via the Playwright page's request context until
+ * OpenClaw reports `connected` continuously for `stableForMs` (a transient
+ * reload/restart resets the streak), or `deadlineMs` elapses. Used to wait out
+ * the secrets-bootstrap gateway restart before dispatching the first chat.
+ *
+ * Mirrors the settle loop in `resetStack` but runs in a page context (uses
+ * `page.request` instead of `execSync`) and takes a configurable, longer
+ * stability window — the post-provider-save restart can start a few seconds
+ * after the save, so a short streak could otherwise pass on the pre-restart
+ * connected state.
+ */
+async function waitForOpenClawSettledViaPage(
+  page: Page,
+  opts: { stableForMs: number; deadlineMs: number }
+): Promise<void> {
+  const deadline = Date.now() + opts.deadlineMs;
+  let connectedSince: number | null = null;
+  while (Date.now() < deadline) {
+    try {
+      const res = await page.request.get("/api/health/openclaw");
+      if (res.ok()) {
+        const health = (await res.json()) as { connected?: boolean; status?: string };
+        if (health.connected && health.status === "ok") {
+          connectedSince ??= Date.now();
+          if (Date.now() - connectedSince >= opts.stableForMs) return;
+        } else {
+          connectedSince = null;
+        }
+      } else {
+        connectedSince = null;
+      }
+    } catch {
+      connectedSince = null;
+    }
+    await sleep(1000);
+  }
+  // Don't throw — fall through and let the chat assertion's own retry budget
+  // run. A failure here would mask the real assertion's diagnostic.
 }
 
 export interface ProviderSmokeTestSpec {
@@ -208,6 +286,22 @@ export async function runProviderSmokeTest(page: Page, spec: ProviderSmokeTestSp
   // "No API key found for provider '<provider>'" and Pinchy renders an error.
   await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
   await expect(page.getByText(/i'm smithers/i)).toBeVisible({ timeout: 30000 });
+
+  // Wait for OpenClaw to SETTLE past the provider-save's secrets-bootstrap
+  // restart BEFORE sending the first chat. Saving the provider key writes the
+  // first-ever secrets.json, which trips start-openclaw.sh's secrets-watcher
+  // → a one-shot gateway pkill+respawn (~40 s). If we dispatch into that
+  // window, OC rejects with `unknown agent id` until the restart applies the
+  // agent — and the chat path's own bounded retry (chatWithDispatchRaceRetry,
+  // ~90 s) sometimes can't outlast a slow-CI restart, so the assert below
+  // times out (the google/anthropic ~33 % flake, CI run 26843343975 + reruns).
+  // Settling here means the dispatch lands on a ready runtime and the response
+  // is fast — without masking the actual regression (the "No API key" /
+  // "couldn't respond" content assertions below still fire if secrets didn't
+  // flush). "Settled" = connected continuously for 12 s; the restart breaks
+  // the streak, so a 12 s streak proves we're past it. 90 s deadline covers a
+  // worst-case respawn; happy path exits in ~12 s.
+  await waitForOpenClawSettledViaPage(page, { stableForMs: 12000, deadlineMs: 90000 });
 
   const composer = page.getByPlaceholder(/send a message/i);
   await composer.fill("Hello, are you working?");

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -313,14 +313,17 @@ export async function runProviderSmokeTest(page: Page, spec: ProviderSmokeTestSp
   // ("Sure, happy to help! What would you like to work on?") and that
   // NO error UI is shown.
   //
-  // 90 s budget: the wizard's "Continue" click triggers regenerateOpenClawConfig
-  // which writes openclaw.json + secrets.json. OpenClaw's secrets-watcher then
-  // pkills the gateway on first-time secrets.json appearance (config/start-openclaw.sh
-  // bootstrap-marker logic), and the health-loop respawn cycle is ~40 s.
-  // 30 s was too tight on a cold E2E stack — the test would assert before OC
-  // finished its first-real-config restart. 90 s covers the worst case
-  // (one full restart cycle + chat round-trip).
-  await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 90000 });
+  // 160 s budget: must outlast the chat path's server-side
+  // chatWithDispatchRaceRetry (150 s — see chat-dispatch-retry.ts). The
+  // wizard's "Continue" triggers regenerateOpenClawConfig + the first-ever
+  // secrets.json, so OC pkills+respawns the gateway (~40 s) and the new
+  // Smithers agent's apply can lag; on the FIRST provider spec (cold initial
+  // stack) the apply was measured ~108 s after the chat. A 90 s client-side
+  // assertion gave up before the 150 s server-side retry could land the
+  // dispatch — the residual setup-wizard flake (CI run 26868364630, the
+  // anthropic spec; the warmer later specs settle in ~20 s). 160 s sits just
+  // past the server budget. The settle above keeps the common case fast.
+  await expect(page.getByText(/sure, happy to help/i)).toBeVisible({ timeout: 160000 });
   await expect(page.getByText(/smithers couldn't respond/i)).not.toBeVisible();
   await expect(page.getByText(/no api key found/i)).not.toBeVisible();
 }

--- a/packages/web/e2e/web/web-search.spec.ts
+++ b/packages/web/e2e/web/web-search.spec.ts
@@ -215,7 +215,14 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
     await stopFakeOllama();
   });
 
-  test("pinchy_web_search dispatches via fake-LLM and writes audit entry", async ({ page }) => {
+  test("pinchy_web_search dispatches via fake-LLM and writes audit entry", async ({
+    page,
+  }, testInfo) => {
+    // 160 s poll past the 150 s chatWithDispatchRaceRetry budget; 180 s per-test
+    // timeout to outlast it. See odoo-agent-chat.spec.ts for the measured
+    // ~104 s agent-apply delay this covers.
+    testInfo.setTimeout(180_000);
+
     await loginViaUI(page, getAdminEmail(), getAdminPassword());
 
     await page.goto(`/chat/${dispatchAgentId}`);
@@ -229,6 +236,7 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
     const found = await pollAuditForTool(page, {
       toolName: "pinchy_web_search",
       agentId: dispatchAgentId,
+      deadlineMs: 160_000,
     });
     expect(found).toBe(true);
   });

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -54,7 +54,7 @@
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
-    "openclaw-node": "0.12.0",
+    "openclaw-node": "0.12.1",
     "pdfkit": "^0.18.0",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -54,7 +54,7 @@
     "next": "16.2.6",
     "next-themes": "^0.4.6",
     "odoo-node": "0.2.0",
-    "openclaw-node": "0.11.0",
+    "openclaw-node": "0.12.0",
     "pdfkit": "^0.18.0",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",

--- a/packages/web/playwright.email.config.ts
+++ b/packages/web/playwright.email.config.ts
@@ -14,5 +14,10 @@ export default defineConfig({
   timeout: 120000,
   use: {
     baseURL: process.env.PINCHY_URL || "http://localhost:7777",
+    // Capture diagnostics on failure so flakes surface ground truth rather
+    // than another guessing round. `retain-on-failure` writes the artifact
+    // only when a test fails — zero cost on green runs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 });

--- a/packages/web/playwright.odoo.config.ts
+++ b/packages/web/playwright.odoo.config.ts
@@ -15,5 +15,10 @@ export default defineConfig({
   timeout: 120000,
   use: {
     baseURL: process.env.PINCHY_URL || "http://localhost:7777",
+    // Capture diagnostics on failure so flakes surface ground truth rather
+    // than another guessing round. `retain-on-failure` writes the artifact
+    // only when a test fails — zero cost on green runs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 });

--- a/packages/web/playwright.setup-wizard.config.ts
+++ b/packages/web/playwright.setup-wizard.config.ts
@@ -11,7 +11,13 @@ export default defineConfig({
   retries: 0,
   workers: 1,
   reporter: "list",
-  timeout: 120000,
+  // 240 s per test: the first provider spec runs against a cold initial stack
+  // where the new Smithers agent's apply after the secrets-bootstrap restart
+  // can lag ~108 s, so the chat assertion now waits 160 s (matching the
+  // server-side dispatch budget). Add the ~30 s wizard flow + 12 s OC settle on
+  // top and the default 120 s would cut the test off mid-wait. The warm later
+  // specs still finish in ~20 s; this is only a ceiling.
+  timeout: 240000,
   use: {
     baseURL: process.env.PINCHY_URL || "http://localhost:7777",
     // Capture diagnostics on failure so flakes surface ground truth rather

--- a/packages/web/playwright.setup-wizard.config.ts
+++ b/packages/web/playwright.setup-wizard.config.ts
@@ -14,5 +14,10 @@ export default defineConfig({
   timeout: 120000,
   use: {
     baseURL: process.env.PINCHY_URL || "http://localhost:7777",
+    // Capture diagnostics on failure so flakes surface ground truth rather
+    // than another guessing round. `retain-on-failure` writes the artifact
+    // only when a test fails — zero cost on green runs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 });

--- a/packages/web/playwright.telegram.config.ts
+++ b/packages/web/playwright.telegram.config.ts
@@ -23,6 +23,11 @@ export default defineConfig({
   grepInvert: process.env.CI ? /@llm|@channel-restart/ : undefined,
   use: {
     baseURL: "http://localhost:7777",
+    // Capture diagnostics on failure so flakes surface ground truth rather
+    // than another guessing round. `retain-on-failure` writes the artifact
+    // only when a test fails — zero cost on green runs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
   // No webServer — tests run against the Docker Compose stack
   // No globalSetup/teardown — Docker Compose handles lifecycle

--- a/packages/web/playwright.web.config.ts
+++ b/packages/web/playwright.web.config.ts
@@ -14,5 +14,10 @@ export default defineConfig({
   timeout: 120000,
   use: {
     baseURL: process.env.PINCHY_URL || "http://localhost:7777",
+    // Capture diagnostics on failure so flakes surface ground truth rather
+    // than another guessing round. `retain-on-failure` writes the artifact
+    // only when a test fails — zero cost on green runs.
+    trace: "retain-on-failure",
+    screenshot: "only-on-failure",
   },
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3258,17 +3258,20 @@ describe("regenerateOpenClawConfig", () => {
       expect(mockConfigApply).not.toHaveBeenCalled();
     });
 
-    it("skips config.apply when OC in-memory config and file both lack meta (missing-meta-before-write cascade guard)", async () => {
-      // Scenario: OC just restarted (in-memory config has no meta) AND the
-      // previous config.apply already wrote a meta-less file. Neither source
-      // can supply meta, so supplementation leaves the payload without it.
-      // Sending that payload via config.apply triggers OC's
-      // "missing-meta-before-write" anomaly → SIGUSR1 restart cascade.
+    it("applies config via config.apply even when OC in-memory config and file both lack meta (no obsolete meta-guard)", async () => {
+      // Scenario: first-install secrets-bootstrap window — OC's in-memory config
+      // has no meta AND the fresh-install file seed has none either, so the
+      // supplemented payload lacks meta.
       //
-      // The guard must detect this and return early, relying on inotify
-      // (from the writeConfigAtomic call above) instead of config.apply.
-      // The guard only fires when current.config IS defined (OC is running
-      // and has a config) — cold-start (current.config absent) still proceeds.
+      // The OLD meta-guard returned early to a `writeConfigAtomic` file write
+      // here, to dodge OpenClaw 4.27's "missing-meta-before-write" restart
+      // cascade. That anomaly is GONE in the pinned OC 2026.5.28 — verified
+      // empirically (a meta-less config.apply adding an agent is accepted and
+      // hot-reloaded, no restart, agent lands in runtime). The guard was also
+      // actively harmful: it shunted every agent-create push onto the file-write
+      // path, whose atomic-rename OC's post-restart watcher does not reliably
+      // reload, so the agent never reached runtime (#464). So config.apply MUST
+      // be used even without meta.
       const ocConfigWithoutMeta = {
         gateway: { mode: "local" },
         plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
@@ -3278,7 +3281,7 @@ describe("regenerateOpenClawConfig", () => {
       mockGetClient.mockReturnValue({
         config: { get: mockConfigGet, apply: mockConfigApply },
       });
-      // File also has no meta (written by a previous meta-less config.apply)
+      // File also has no meta (fresh-install seed / previous meta-less write).
       mockedReadFileSync.mockReturnValue(
         JSON.stringify({
           gateway: { mode: "local" },
@@ -3288,8 +3291,9 @@ describe("regenerateOpenClawConfig", () => {
       await regenerateOpenClawConfig();
       await drainBackgroundCoroutine();
 
-      // config.apply must NOT be called — guard returns early when payload lacks meta
-      expect(mockConfigApply).not.toHaveBeenCalled();
+      // config.apply IS called — the meta-less payload applies in-process
+      // (reliable) instead of falling back to the watcher-lagged file write.
+      expect(mockConfigApply).toHaveBeenCalledTimes(1);
     });
 
     it("retries config.apply IMMEDIATELY (no backoff) when OC reports stale hash", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3549,48 +3549,140 @@ describe("regenerateOpenClawConfig", () => {
       }
     });
 
-    it("skips the file write immediately when OC rate-limits config.apply", async () => {
-      // Scenario: OC 5.3 rejects the apply call with "rate limit exceeded for
-      // config.apply; retry after 45s". Consuming backoff slots would delay
-      // the eventual inotify fallback by up to 3.85 s with no benefit.
-      // More importantly, OC already has the correct config in memory from
-      // the last successful config.apply — writing to disk would trigger an
-      // inotify hot-reload that causes OC to add built-in plugins (e.g.
-      // memory-core) and reorder meta, producing spurious config drift.
-      // The fix: skip the write entirely. The next config.apply (after the
-      // 45 s window resets) will deliver any pending changes.
+    it("retries config.apply via WS after the rate-limit window instead of dropping the change", async () => {
+      // Scenario: OC 5.3 rejects the apply with "rate limit exceeded for
+      // config.apply; retry after Ns" (e.g. several back-to-back regens piled
+      // into one window). The OLD behaviour returned immediately on rate-limit
+      // ("OC already has the correct config in memory"), but that assumption is
+      // false for a GENUINE pending change: the no-op guard above already
+      // returns for semantically-equivalent configs, so a rate-limited apply
+      // ALWAYS carries a real diff. Dropping it silently lost newly-created
+      // agents — OC's runtime never learned about them and rejected chat
+      // dispatch with `unknown agent id` indefinitely (the Odoo/email/web
+      // dispatch-probe flake; CI run 26837712634).
+      //
+      // The fix: wait out the advertised window, then RETRY the same clean WS
+      // config.apply path. No file write on this path → no inotify drift (the
+      // original reason for skipping the write is preserved).
       vi.useFakeTimers();
       try {
-        const existingOcConfig = {
-          meta: { version: "5.3.0", lastTouchedAt: "2026-01-01T00:00:00Z" },
-          gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
-        };
         mockConfigGet.mockResolvedValue({ hash: "h1" });
+        mockConfigApply
+          .mockRejectedValueOnce(new Error("rate limit exceeded for config.apply; retry after 2s"))
+          .mockResolvedValueOnce(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
+
+        // First apply fires and is rate-limited.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mockConfigApply).toHaveBeenCalledTimes(1);
+
+        // No file write yet — we wait out the window on the clean WS path,
+        // we do NOT fall back to disk (which would cause inotify drift).
+        let openclawWrite = mockedWriteFileSync.mock.calls.find(
+          (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+        );
+        expect(
+          openclawWrite,
+          "must NOT file-write before the WS retry budget is exhausted"
+        ).toBeUndefined();
+
+        // Advance past the advertised 2 s window (plus the buffer). The retry
+        // fires a fresh config.get + config.apply, which now succeeds.
+        await vi.advanceTimersByTimeAsync(4_000);
+
+        expect(mockConfigApply).toHaveBeenCalledTimes(2);
+        // Still no file write — the change was delivered cleanly over WS.
+        openclawWrite = mockedWriteFileSync.mock.calls.find(
+          (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+        );
+        expect(
+          openclawWrite,
+          "writeFileSync must NOT be called when the WS retry succeeds"
+        ).toBeUndefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("falls back to a file write only after the rate-limit retry budget is exhausted", async () => {
+      // If OC keeps rate-limiting us across multiple windows, the pending
+      // change must STILL reach OC's runtime — a late, slightly-drifted config
+      // (inotify reload adds built-in plugin entries / reorders keys) is
+      // strictly better than a permanently-lost agent. After the bounded WS
+      // retry budget, fall back to writeConfigAtomic so OC's file-watcher picks
+      // the change up. This is the safety net the old "drop and hope the next
+      // apply delivers it" code lacked — there is no guaranteed next apply.
+      vi.useFakeTimers();
+      try {
+        mockConfigGet.mockResolvedValue({ hash: "h1" });
+        // Always rate-limited — exhaust the retry budget.
         mockConfigApply.mockRejectedValue(
-          new Error("rate limit exceeded for config.apply; retry after 45s")
+          new Error("rate limit exceeded for config.apply; retry after 1s")
         );
         mockGetClient.mockReturnValue({
           config: { get: mockConfigGet, apply: mockConfigApply },
         });
-        mockedReadFileSync.mockReturnValue(JSON.stringify(existingOcConfig) as unknown as Buffer);
 
         pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
 
-        // Drain microtasks — the rate-limit path must NOT hit any setTimeout.
+        // Drive through the initial apply + all bounded rate-limit retries.
+        // Generous advance covers every window-wait plus buffer.
         for (let i = 0; i < 10; i++) {
-          await vi.advanceTimersByTimeAsync(0);
+          await vi.advanceTimersByTimeAsync(5_000);
         }
 
-        // config.apply was called once (first attempt), then we gave up immediately.
-        expect(mockConfigApply).toHaveBeenCalledTimes(1);
-        // No file write — OC already has the correct config in memory.
+        // The change was NOT lost — it landed on disk for the file-watcher.
         const openclawWrite = mockedWriteFileSync.mock.calls.find(
           (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
         );
         expect(
           openclawWrite,
-          "writeFileSync must NOT be called for openclaw.json on rate-limit"
-        ).toBeUndefined();
+          "writeConfigAtomic must run as the last-resort fallback so the change is not lost"
+        ).toBeDefined();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("cancels a pending rate-limit retry when a newer push starts", async () => {
+      // The retry sleeps out the rate-limit window. If a newer
+      // pushConfigInBackground call starts during that sleep, the stale retry
+      // must abort at the generation check rather than firing config.apply
+      // with an outdated payload on top of the newer one.
+      vi.useFakeTimers();
+      try {
+        mockConfigGet.mockResolvedValue({ hash: "h1" });
+        mockConfigApply.mockRejectedValue(
+          new Error("rate limit exceeded for config.apply; retry after 2s")
+        );
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+
+        pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+        // First apply fires and is rate-limited; the coroutine now sleeps.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mockConfigApply).toHaveBeenCalledTimes(1);
+
+        // A newer push bumps the generation while the first is mid-sleep.
+        mockConfigApply.mockReset();
+        mockConfigApply.mockResolvedValue(undefined);
+        pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+
+        // Advance past the first push's retry window. Its retry must NOT fire
+        // — it returns at the generation check. Only the NEW push's apply runs.
+        await vi.advanceTimersByTimeAsync(4_000);
+
+        const oldPayloadApplied = mockConfigApply.mock.calls.some((c) =>
+          String(c[0]).includes('"OLD"')
+        );
+        expect(oldPayloadApplied, "stale OLD payload must not be applied after a newer push").toBe(
+          false
+        );
       } finally {
         vi.useRealTimers();
       }

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3258,105 +3258,38 @@ describe("regenerateOpenClawConfig", () => {
       expect(mockConfigApply).not.toHaveBeenCalled();
     });
 
-    it("never sends a meta-less config.apply; when meta stays missing it waits then falls back to a file write (cascade guard preserved)", async () => {
-      // Scenario: OC restarted (in-memory config has no meta) AND the file is a
-      // meta-less seed. Neither source can supply meta. A meta-less config.apply
-      // would trip OC's "missing-meta-before-write" cascade, so the guard must
-      // NEVER send one. With the meta-retry fix it waits for OC to stamp meta
-      // (re-running config.get); only after the bounded budget does it fall back
-      // to a file write so the change is never lost.
-      vi.useFakeTimers();
-      try {
-        const ocConfigWithoutMeta = {
+    it("skips config.apply when OC in-memory config and file both lack meta (missing-meta-before-write cascade guard)", async () => {
+      // Scenario: OC just restarted (in-memory config has no meta) AND the
+      // previous config.apply already wrote a meta-less file. Neither source
+      // can supply meta, so supplementation leaves the payload without it.
+      // Sending that payload via config.apply triggers OC's
+      // "missing-meta-before-write" anomaly → SIGUSR1 restart cascade.
+      //
+      // The guard must detect this and return early, relying on inotify
+      // (from the writeConfigAtomic call above) instead of config.apply.
+      // The guard only fires when current.config IS defined (OC is running
+      // and has a config) — cold-start (current.config absent) still proceeds.
+      const ocConfigWithoutMeta = {
+        gateway: { mode: "local" },
+        plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+      };
+      mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      // File also has no meta (written by a previous meta-less config.apply)
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({
           gateway: { mode: "local" },
-          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
-        };
-        // Meta never appears (OC stays meta-less for the whole window).
-        mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
-        mockConfigApply.mockResolvedValue(undefined);
-        mockGetClient.mockReturnValue({
-          config: { get: mockConfigGet, apply: mockConfigApply },
-        });
-        // File also has no meta (fresh-install seed / previous meta-less write).
-        mockedReadFileSync.mockReturnValue(
-          JSON.stringify({ gateway: { mode: "local" } }) as unknown as Buffer
-        );
+        }) as unknown as Buffer
+      );
 
-        pushConfigInBackground(JSON.stringify({ agents: { list: [{ id: "agent-new" }] } }));
+      await regenerateOpenClawConfig();
+      await drainBackgroundCoroutine();
 
-        // Mid-wait: config.apply has not been called (cascade guard holds).
-        await vi.advanceTimersByTimeAsync(2500);
-        expect(mockConfigApply).not.toHaveBeenCalled();
-
-        // Advance past the meta-missing budget → file-write fallback fires.
-        await vi.advanceTimersByTimeAsync(65_000);
-        for (let i = 0; i < 20; i++) await Promise.resolve();
-
-        // Cascade guard preserved: a meta-less payload was NEVER applied.
-        expect(mockConfigApply).not.toHaveBeenCalled();
-        // Safety net: the change was persisted to disk after the budget.
-        expect(mockedWriteFileSync).toHaveBeenCalled();
-      } finally {
-        vi.useRealTimers();
-      }
-    });
-
-    it("retries config.get when OC config transiently lacks meta (post-restart), then applies WITH meta once OC stamps it — no silent meta-less file write", async () => {
-      // Root fix for the #464 secrets-restart-window flake: during OC's
-      // first-install secrets-bootstrap restart, OC's in-memory config briefly
-      // has no `meta` AND the fresh-install file seed has none either. The old
-      // meta-guard silently `writeConfigAtomic`'d the meta-less payload, which
-      // OC's reload mishandled — the freshly-created agent never reached OC's
-      // runtime and dispatch stuck on `unknown agent id`. The fix waits for OC
-      // to stamp meta (retrying config.get) so the eventual config.apply carries
-      // meta and applies IN-PROCESS (no file-watcher dependency), keeping the
-      // agent on the reliable path while still never sending a meta-less apply.
-      vi.useFakeTimers();
-      try {
-        const ocNoMeta = {
-          gateway: { mode: "local" },
-          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
-        };
-        const ocWithMeta = {
-          meta: { schemaVersion: 1 },
-          gateway: { mode: "local" },
-          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
-        };
-        // First get: post-restart, no meta. Subsequent gets: OC has stamped meta.
-        mockConfigGet
-          .mockResolvedValueOnce({ hash: "h1", config: ocNoMeta })
-          .mockResolvedValue({ hash: "h2", config: ocWithMeta });
-        mockConfigApply.mockResolvedValue(undefined);
-        mockGetClient.mockReturnValue({
-          config: { get: mockConfigGet, apply: mockConfigApply },
-        });
-        // File seed also lacks meta (fresh install), so the file-fallback can't
-        // supply it on the first attempt.
-        mockedReadFileSync.mockReturnValue(
-          JSON.stringify({ gateway: { mode: "local" } }) as unknown as Buffer
-        );
-
-        pushConfigInBackground(JSON.stringify({ agents: { list: [{ id: "agent-new" }] } }));
-
-        // First config.get returns no-meta → meta-wait scheduled, no apply yet.
-        await vi.advanceTimersByTimeAsync(0);
-        expect(mockConfigApply).not.toHaveBeenCalled();
-
-        // Advance one meta-retry delay → second config.get returns meta → apply.
-        await vi.advanceTimersByTimeAsync(2500);
-        for (let i = 0; i < 20; i++) await Promise.resolve();
-
-        // The agent config applied via WS config.apply WITH meta — not a silent
-        // meta-less file write.
-        expect(mockConfigApply).toHaveBeenCalledTimes(1);
-        const appliedPayload = JSON.parse(mockConfigApply.mock.calls[0][0] as string) as Record<
-          string,
-          unknown
-        >;
-        expect(appliedPayload).toHaveProperty("meta");
-      } finally {
-        vi.useRealTimers();
-      }
+      // config.apply must NOT be called — guard returns early when payload lacks meta
+      expect(mockConfigApply).not.toHaveBeenCalled();
     });
 
     it("retries config.apply IMMEDIATELY (no backoff) when OC reports stale hash", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -3258,38 +3258,105 @@ describe("regenerateOpenClawConfig", () => {
       expect(mockConfigApply).not.toHaveBeenCalled();
     });
 
-    it("skips config.apply when OC in-memory config and file both lack meta (missing-meta-before-write cascade guard)", async () => {
-      // Scenario: OC just restarted (in-memory config has no meta) AND the
-      // previous config.apply already wrote a meta-less file. Neither source
-      // can supply meta, so supplementation leaves the payload without it.
-      // Sending that payload via config.apply triggers OC's
-      // "missing-meta-before-write" anomaly → SIGUSR1 restart cascade.
-      //
-      // The guard must detect this and return early, relying on inotify
-      // (from the writeConfigAtomic call above) instead of config.apply.
-      // The guard only fires when current.config IS defined (OC is running
-      // and has a config) — cold-start (current.config absent) still proceeds.
-      const ocConfigWithoutMeta = {
-        gateway: { mode: "local" },
-        plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
-      };
-      mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
-      mockConfigApply.mockResolvedValue(undefined);
-      mockGetClient.mockReturnValue({
-        config: { get: mockConfigGet, apply: mockConfigApply },
-      });
-      // File also has no meta (written by a previous meta-less config.apply)
-      mockedReadFileSync.mockReturnValue(
-        JSON.stringify({
+    it("never sends a meta-less config.apply; when meta stays missing it waits then falls back to a file write (cascade guard preserved)", async () => {
+      // Scenario: OC restarted (in-memory config has no meta) AND the file is a
+      // meta-less seed. Neither source can supply meta. A meta-less config.apply
+      // would trip OC's "missing-meta-before-write" cascade, so the guard must
+      // NEVER send one. With the meta-retry fix it waits for OC to stamp meta
+      // (re-running config.get); only after the bounded budget does it fall back
+      // to a file write so the change is never lost.
+      vi.useFakeTimers();
+      try {
+        const ocConfigWithoutMeta = {
           gateway: { mode: "local" },
-        }) as unknown as Buffer
-      );
+          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+        };
+        // Meta never appears (OC stays meta-less for the whole window).
+        mockConfigGet.mockResolvedValue({ hash: "h1", config: ocConfigWithoutMeta });
+        mockConfigApply.mockResolvedValue(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+        // File also has no meta (fresh-install seed / previous meta-less write).
+        mockedReadFileSync.mockReturnValue(
+          JSON.stringify({ gateway: { mode: "local" } }) as unknown as Buffer
+        );
 
-      await regenerateOpenClawConfig();
-      await drainBackgroundCoroutine();
+        pushConfigInBackground(JSON.stringify({ agents: { list: [{ id: "agent-new" }] } }));
 
-      // config.apply must NOT be called — guard returns early when payload lacks meta
-      expect(mockConfigApply).not.toHaveBeenCalled();
+        // Mid-wait: config.apply has not been called (cascade guard holds).
+        await vi.advanceTimersByTimeAsync(2500);
+        expect(mockConfigApply).not.toHaveBeenCalled();
+
+        // Advance past the meta-missing budget → file-write fallback fires.
+        await vi.advanceTimersByTimeAsync(65_000);
+        for (let i = 0; i < 20; i++) await Promise.resolve();
+
+        // Cascade guard preserved: a meta-less payload was NEVER applied.
+        expect(mockConfigApply).not.toHaveBeenCalled();
+        // Safety net: the change was persisted to disk after the budget.
+        expect(mockedWriteFileSync).toHaveBeenCalled();
+      } finally {
+        vi.useRealTimers();
+      }
+    });
+
+    it("retries config.get when OC config transiently lacks meta (post-restart), then applies WITH meta once OC stamps it — no silent meta-less file write", async () => {
+      // Root fix for the #464 secrets-restart-window flake: during OC's
+      // first-install secrets-bootstrap restart, OC's in-memory config briefly
+      // has no `meta` AND the fresh-install file seed has none either. The old
+      // meta-guard silently `writeConfigAtomic`'d the meta-less payload, which
+      // OC's reload mishandled — the freshly-created agent never reached OC's
+      // runtime and dispatch stuck on `unknown agent id`. The fix waits for OC
+      // to stamp meta (retrying config.get) so the eventual config.apply carries
+      // meta and applies IN-PROCESS (no file-watcher dependency), keeping the
+      // agent on the reliable path while still never sending a meta-less apply.
+      vi.useFakeTimers();
+      try {
+        const ocNoMeta = {
+          gateway: { mode: "local" },
+          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+        };
+        const ocWithMeta = {
+          meta: { schemaVersion: 1 },
+          gateway: { mode: "local" },
+          plugins: { allow: ["anthropic"], entries: { anthropic: { enabled: true } } },
+        };
+        // First get: post-restart, no meta. Subsequent gets: OC has stamped meta.
+        mockConfigGet
+          .mockResolvedValueOnce({ hash: "h1", config: ocNoMeta })
+          .mockResolvedValue({ hash: "h2", config: ocWithMeta });
+        mockConfigApply.mockResolvedValue(undefined);
+        mockGetClient.mockReturnValue({
+          config: { get: mockConfigGet, apply: mockConfigApply },
+        });
+        // File seed also lacks meta (fresh install), so the file-fallback can't
+        // supply it on the first attempt.
+        mockedReadFileSync.mockReturnValue(
+          JSON.stringify({ gateway: { mode: "local" } }) as unknown as Buffer
+        );
+
+        pushConfigInBackground(JSON.stringify({ agents: { list: [{ id: "agent-new" }] } }));
+
+        // First config.get returns no-meta → meta-wait scheduled, no apply yet.
+        await vi.advanceTimersByTimeAsync(0);
+        expect(mockConfigApply).not.toHaveBeenCalled();
+
+        // Advance one meta-retry delay → second config.get returns meta → apply.
+        await vi.advanceTimersByTimeAsync(2500);
+        for (let i = 0; i < 20; i++) await Promise.resolve();
+
+        // The agent config applied via WS config.apply WITH meta — not a silent
+        // meta-less file write.
+        expect(mockConfigApply).toHaveBeenCalledTimes(1);
+        const appliedPayload = JSON.parse(mockConfigApply.mock.calls[0][0] as string) as Record<
+          string,
+          unknown
+        >;
+        expect(appliedPayload).toHaveProperty("meta");
+      } finally {
+        vi.useRealTimers();
+      }
     });
 
     it("retries config.apply IMMEDIATELY (no backoff) when OC reports stale hash", async () => {

--- a/packages/web/src/__tests__/server/agent-readiness.test.ts
+++ b/packages/web/src/__tests__/server/agent-readiness.test.ts
@@ -1,0 +1,172 @@
+// Tests for the runtime-readiness gate that waits for a freshly (re)created
+// agent to appear in OpenClaw's RUNTIME agents.list before Pinchy dispatches a
+// chat to it.
+//
+// Why this gate exists and why it is reliable: OC's `agents.list` RPC
+// (openclaw-node >= 0.12.0) reads `getRuntimeConfig()` — the SAME runtime view
+// the chat-dispatch handler checks before accepting a message. So polling it
+// until the agent appears is an authoritative, deterministic readiness signal,
+// unlike `config.get` which reads the config FILE and leads the applied runtime
+// by seconds-to-minutes while a write propagates. See agent-readiness.ts.
+//
+// The helper is decoupled from openclaw-node via injected deps so these unit
+// tests pin the polling/deadline/graceful-degradation logic with a fake clock
+// and need no Gateway. The real agents.list() wire shape is verified by the
+// Docker E2E dispatch probes.
+
+import { describe, it, expect, vi } from "vitest";
+import { waitForAgentInRuntime } from "@/server/agent-readiness";
+
+/**
+ * Fake clock: `delay(ms)` advances `now` by `ms` synchronously so the
+ * poll-interval / deadline logic runs deterministically without real timers.
+ */
+function fakeClock() {
+  let t = 0;
+  return {
+    now: () => t,
+    delay: vi.fn(async (ms: number) => {
+      t += ms;
+    }),
+  };
+}
+
+describe("waitForAgentInRuntime", () => {
+  it("resolves true immediately when the agent is already in the runtime list", async () => {
+    const clock = fakeClock();
+    const listRuntimeAgentIds = vi.fn(async () => ["smithers", "agent-1"]);
+
+    const ready = await waitForAgentInRuntime(
+      "agent-1",
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds,
+        delay: clock.delay,
+        now: clock.now,
+      },
+      { deadlineMs: 30_000 }
+    );
+
+    expect(ready).toBe(true);
+    expect(listRuntimeAgentIds).toHaveBeenCalledTimes(1);
+    expect(clock.delay).not.toHaveBeenCalled(); // fast path: no sleeping
+  });
+
+  it("polls until the agent appears, swallowing its initial absence", async () => {
+    const clock = fakeClock();
+    let calls = 0;
+    const listRuntimeAgentIds = vi.fn(async () => {
+      calls++;
+      // Absent for the first two polls, present on the third.
+      return calls >= 3 ? ["smithers", "late-agent"] : ["smithers"];
+    });
+    const onWaitObserved = vi.fn();
+
+    const ready = await waitForAgentInRuntime(
+      "late-agent",
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds,
+        delay: clock.delay,
+        now: clock.now,
+        onWaitObserved,
+      },
+      { deadlineMs: 30_000, intervalMs: 500 }
+    );
+
+    expect(ready).toBe(true);
+    expect(listRuntimeAgentIds).toHaveBeenCalledTimes(3);
+    expect(clock.delay).toHaveBeenCalledTimes(2);
+    expect(clock.now()).toBe(1000); // two 500 ms sleeps
+    expect(onWaitObserved).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "late-agent", ready: true, polls: 3 })
+    );
+  });
+
+  it("resolves false when the agent never appears within the deadline", async () => {
+    const clock = fakeClock();
+    const listRuntimeAgentIds = vi.fn(async () => ["smithers"]);
+    const onWaitObserved = vi.fn();
+
+    const ready = await waitForAgentInRuntime(
+      "never-shows",
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds,
+        delay: clock.delay,
+        now: clock.now,
+        onWaitObserved,
+      },
+      { deadlineMs: 2_000, intervalMs: 500 }
+    );
+
+    expect(ready).toBe(false);
+    expect(clock.now()).toBe(2_000); // stopped exactly at the deadline
+    expect(onWaitObserved).toHaveBeenCalledWith(
+      expect.objectContaining({ agentId: "never-shows", ready: false })
+    );
+  });
+
+  it("resolves false immediately, without polling, when the Gateway lacks agents.list", async () => {
+    const clock = fakeClock();
+    const listRuntimeAgentIds = vi.fn(async () => ["smithers"]);
+
+    const ready = await waitForAgentInRuntime(
+      "agent-1",
+      {
+        hasAgentsListRpc: () => false,
+        listRuntimeAgentIds,
+        delay: clock.delay,
+        now: clock.now,
+      },
+      { deadlineMs: 30_000 }
+    );
+
+    expect(ready).toBe(false);
+    expect(listRuntimeAgentIds).not.toHaveBeenCalled();
+    expect(clock.delay).not.toHaveBeenCalled();
+  });
+
+  it("tolerates transient agents.list errors and keeps polling until the agent appears", async () => {
+    const clock = fakeClock();
+    let calls = 0;
+    const listRuntimeAgentIds = vi.fn(async () => {
+      calls++;
+      if (calls === 1) throw new Error("ECONNRESET");
+      return calls >= 2 ? ["smithers", "agent-x"] : ["smithers"];
+    });
+
+    const ready = await waitForAgentInRuntime(
+      "agent-x",
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds,
+        delay: clock.delay,
+        now: clock.now,
+      },
+      { deadlineMs: 30_000, intervalMs: 500 }
+    );
+
+    expect(ready).toBe(true);
+    expect(listRuntimeAgentIds).toHaveBeenCalledTimes(2);
+  });
+
+  it("never reports a fast-path hit through onWaitObserved (only actual waits)", async () => {
+    const clock = fakeClock();
+    const onWaitObserved = vi.fn();
+
+    await waitForAgentInRuntime(
+      "agent-1",
+      {
+        hasAgentsListRpc: () => true,
+        listRuntimeAgentIds: async () => ["agent-1"],
+        delay: clock.delay,
+        now: clock.now,
+        onWaitObserved,
+      },
+      { deadlineMs: 30_000 }
+    );
+
+    expect(onWaitObserved).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
+++ b/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
@@ -220,6 +220,113 @@ describe("chatWithDispatchRaceRetry", () => {
     expect(chat).toHaveBeenNthCalledWith(2, "hello", opts);
   });
 
+  describe("runtime-readiness gate (awaitAgentReady)", () => {
+    it("polls runtime readiness instead of blind backoff, re-dispatching as soon as the agent is ready", async () => {
+      const successful: ChatChunk[] = [{ type: "done", text: "", runId: "r1" }];
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(raceError()))
+        .mockImplementationOnce(makeStream(raceError()))
+        .mockImplementationOnce(makeStream(successful));
+
+      const clock = fakeClock();
+      // The gate confirms readiness each time (the agent is present in the
+      // runtime agents.list). It models the deterministic poll: no need for the
+      // wrapper's blind backoff.
+      const awaitAgentReady = vi.fn(async () => true);
+
+      const got = await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, awaitAgentReady },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 90000 }
+        )
+      );
+
+      expect(got).toEqual(successful);
+      expect(chat).toHaveBeenCalledTimes(3);
+      // Gate consulted once per race; blind backoff NOT used.
+      expect(awaitAgentReady).toHaveBeenCalledTimes(2);
+      expect(clock.delay).not.toHaveBeenCalled();
+    });
+
+    it("passes the REMAINING wall-clock budget to the readiness gate", async () => {
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(raceError()))
+        .mockImplementationOnce(makeStream([{ type: "done", text: "", runId: "r1" }]));
+
+      const clock = fakeClock();
+      const awaitAgentReady = vi.fn(async () => true);
+
+      await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, awaitAgentReady },
+          { maxTotalMs: 90000 }
+        )
+      );
+
+      // First (and only) race fires at t=0, so the full budget is available.
+      expect(awaitAgentReady).toHaveBeenCalledWith(90000);
+    });
+
+    it("falls back to capped blind backoff when the gate reports not-ready (unobservable / timeout)", async () => {
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(raceError()))
+        .mockImplementationOnce(makeStream([{ type: "done", text: "", runId: "r1" }]));
+
+      const clock = fakeClock();
+      // Gate cannot confirm readiness (e.g. older Gateway without agents.list →
+      // helper returns false immediately). Wrapper must still make progress via
+      // its blind backoff so the bounded retry is preserved.
+      const awaitAgentReady = vi.fn(async () => false);
+
+      await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, awaitAgentReady },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 90000 }
+        )
+      );
+
+      expect(awaitAgentReady).toHaveBeenCalledTimes(1);
+      // Blind backoff applied exactly once (the first attempt's 500 ms) before
+      // the successful re-dispatch.
+      expect(clock.delay.mock.calls.map((c) => c[0])).toEqual([500]);
+    });
+
+    it("stays bounded by the budget even when the gate keeps consuming time without readiness", async () => {
+      const chat = vi.fn(makeStream(raceError("a")));
+      const clock = fakeClock();
+      // Gate burns the whole window it is given and never confirms readiness,
+      // mirroring an agent that genuinely never applies (a Pinchy-side bad id).
+      const awaitAgentReady = vi.fn(async (budgetMs: number) => {
+        clock.delay(budgetMs); // advance the clock as a real poll would
+        return false;
+      });
+
+      const got = await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, awaitAgentReady },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 3000 }
+        )
+      );
+
+      // Terminates and surfaces the race error rather than looping forever.
+      expect(got).toHaveLength(1);
+      expect(got[0].type).toBe("error");
+      expect(DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
+      expect(clock.now()).toBeLessThanOrEqual(3000);
+    });
+  });
+
   it("DISPATCH_RACE_PATTERN matches the exact OC 2026.5.x error message shape", () => {
     expect(DISPATCH_RACE_PATTERN.test('invalid agent params: unknown agent id "abc-123"')).toBe(
       true

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -5,6 +5,7 @@ const {
   mockChat,
   mockSessionsHistory,
   mockSessionsList,
+  mockAgentsList,
   mockFindFirst,
   mockUserFindFirst,
   mockAppendAuditLog,
@@ -18,6 +19,7 @@ const {
   mockChat: vi.fn(),
   mockSessionsHistory: vi.fn(),
   mockSessionsList: vi.fn(),
+  mockAgentsList: vi.fn(),
   mockFindFirst: vi.fn(),
   mockUserFindFirst: vi.fn(),
   mockAppendAuditLog: vi.fn().mockResolvedValue(undefined),
@@ -164,6 +166,11 @@ function createMockOpenClawClient(connected = true) {
   const client = Object.assign(emitter, {
     chat: mockChat,
     sessions: { history: mockSessionsHistory, list: mockSessionsList },
+    // Mirrors openclaw-node >= 0.12.0: the dispatch-race readiness gate calls
+    // hasMethod("agents.list") then agents.list() to confirm the agent is in
+    // OC's runtime before re-dispatching.
+    hasMethod: (method: string) => method === "agents.list",
+    agents: { list: mockAgentsList },
     isConnected: connected,
   });
   return client;
@@ -188,6 +195,9 @@ describe("ClientRouter", () => {
     mockUserFindFirst.mockResolvedValue({ id: "user-1", context: null });
     // Default: empty history for history-mode requests
     mockSessionsHistory.mockResolvedValue({ messages: [] });
+    // Default: the agent is present in OC's runtime agents.list, so the
+    // dispatch-race readiness gate confirms readiness on the first poll.
+    mockAgentsList.mockResolvedValue({ defaultId: "agent-1", agents: [{ id: "agent-1" }] });
   });
 
   it("should return error when agent not found", async () => {
@@ -749,8 +759,9 @@ describe("ClientRouter", () => {
         agentId: "agent-1",
       });
 
-      // Initial thinking + consume the race error (starts the keep-alive) +
-      // drain the 500 ms backoff into the hanging retry attempt.
+      // Initial thinking + consume the race error (starts the keep-alive). The
+      // readiness gate then confirms the agent is present (default mock
+      // agents.list) and re-dispatches into the hanging retry attempt.
       await vi.advanceTimersByTimeAsync(0);
       await vi.advanceTimersByTimeAsync(600);
 

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -368,8 +368,9 @@ export function pushConfigInBackground(newContent: string): void {
 
         // WS-disconnected extended wait: see WS_DISCONNECTED_ERROR_FRAGMENT
         // commentary above. Sleep 2 s without consuming a backoff slot, up to
-        // 30 s total, so the WS reconnect during OC's restart lands the next
-        // config.apply via WS instead of via writeConfigAtomic-into-restart.
+        // NOT_CONNECTED_MAX_WAIT_MS (60 s) total, so the WS reconnect during
+        // OC's restart lands the next config.apply via WS instead of via
+        // writeConfigAtomic-into-restart.
         if (
           message.includes(WS_DISCONNECTED_ERROR_FRAGMENT) &&
           notConnectedWaitMs < NOT_CONNECTED_MAX_WAIT_MS

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -266,6 +266,9 @@ export function pushConfigInBackground(newContent: string): void {
         if (current.config) {
           const parsed = JSON.parse(supplemented) as Record<string, unknown>;
           if (!("meta" in parsed)) {
+            console.log(
+              `[openclaw-config] push gen=${String(generation)}: OC config and file both lack meta → file write (cascade guard; inotify reload)`
+            );
             writeConfigAtomic(newContent);
             return;
           }

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -176,6 +176,9 @@ export function pushConfigInBackground(newContent: string): void {
       // No WS client — write directly to file so inotify picks up the change.
       // This path runs synchronously (no await before writeConfigAtomic), so the
       // file is on disk before regenerateOpenClawConfig() returns to its caller.
+      console.log(
+        `[openclaw-config] push gen=${String(generation)}: no WS client → file write (inotify; reload may lag)`
+      );
       writeConfigAtomic(newContent);
       return;
     }
@@ -212,7 +215,12 @@ export function pushConfigInBackground(newContent: string): void {
     for (let i = 0; i < backoffsMs.length; i++) {
       // Check before each attempt — a newer pushConfigInBackground call
       // may have started while we were sleeping.
-      if (generation !== _pushGeneration) return;
+      if (generation !== _pushGeneration) {
+        console.log(
+          `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(_pushGeneration)}) before attempt ${String(i)}`
+        );
+        return;
+      }
       try {
         const current = (await client.config.get()) as {
           hash: string;
@@ -220,7 +228,12 @@ export function pushConfigInBackground(newContent: string): void {
         };
 
         // Newer call started while we were awaiting config.get()
-        if (generation !== _pushGeneration) return;
+        if (generation !== _pushGeneration) {
+          console.log(
+            `[openclaw-config] push gen=${String(generation)}: superseded by newer push (gen=${String(_pushGeneration)}) during config.get`
+          );
+          return;
+        }
 
         // Supplement OC-managed fields (meta, non-pinchy plugins, controlUi,
         // channels.telegram OC-specific fields, models.providers baseUrl).
@@ -273,6 +286,9 @@ export function pushConfigInBackground(newContent: string): void {
               JSON.stringify(supplementedConfig, null, 2)
             )
           ) {
+            console.log(
+              `[openclaw-config] push gen=${String(generation)}: no-op skip (supplemented payload ≡ OC runtime)`
+            );
             return;
           }
         }
@@ -284,6 +300,9 @@ export function pushConfigInBackground(newContent: string): void {
         // config.apply's inner writeConfigFile persists the config to disk.
         // A newer call's payload will overwrite via its own config.apply or
         // writeConfigAtomic fallback.
+        console.log(
+          `[openclaw-config] push gen=${String(generation)}: applied via WS config.apply (in-process, synchronous runtime refresh)${rateLimitAttempts > 0 ? ` after ${String(rateLimitAttempts)} rate-limit wait(s)` : ""}`
+        );
         return;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -316,7 +335,7 @@ export function pushConfigInBackground(newContent: string): void {
           // OC's file-watcher reloads the change. Accept the inotify drift;
           // losing the change entirely is worse.
           console.warn(
-            "[openclaw-config] config.apply rate-limited past retry budget; writing file for inotify fallback:",
+            `[openclaw-config] push gen=${String(generation)}: config.apply rate-limited past retry budget; writing file for inotify fallback (reload may lag):`,
             message
           );
           writeConfigAtomic(lastSupplemented ?? supplementPayloadWithFileFields(newContent));
@@ -352,7 +371,7 @@ export function pushConfigInBackground(newContent: string): void {
 
         if (i === backoffsMs.length - 1) {
           console.warn(
-            "[openclaw-config] background config.apply failed; writing to file for inotify:",
+            `[openclaw-config] push gen=${String(generation)}: background config.apply failed; writing to file for inotify (reload may lag):`,
             message
           );
           // All retries exhausted — fall back to file write so inotify picks up

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -250,8 +250,8 @@ export function pushConfigInBackground(newContent: string): void {
           : supplementPayloadWithFileFields(newContent);
 
         // Meta-fallback: OC's in-memory config may lack meta immediately after a
-        // SIGUSR1 restart (before OC stamps it). The previous file still has meta;
-        // read it as a fallback so config.apply doesn't trigger a cascade restart.
+        // SIGUSR1 restart (before OC stamps it). The previous file may still have
+        // meta; fold it in so the applied config keeps OC's metadata intact.
         if (current.config) {
           const parsed = JSON.parse(supplemented) as Record<string, unknown>;
           if (!("meta" in parsed)) {
@@ -259,20 +259,21 @@ export function pushConfigInBackground(newContent: string): void {
           }
         }
 
-        // Meta-guard: if OC is running (current.config defined) but neither the
-        // in-memory config nor the file could supply meta, skip config.apply.
-        // A meta-less payload triggers OC's "missing-meta-before-write" anomaly
-        // → SIGUSR1 restart cascade. Fall back to inotify via file write.
-        if (current.config) {
-          const parsed = JSON.parse(supplemented) as Record<string, unknown>;
-          if (!("meta" in parsed)) {
-            console.log(
-              `[openclaw-config] push gen=${String(generation)}: OC config and file both lack meta → file write (cascade guard; inotify reload)`
-            );
-            writeConfigAtomic(newContent);
-            return;
-          }
-        }
+        // NOTE: there is deliberately NO meta-guard here any more. The old guard
+        // returned early to a `writeConfigAtomic` file write whenever the payload
+        // lacked `meta`, to dodge OpenClaw 4.27's "missing-meta-before-write"
+        // restart-cascade anomaly. That anomaly is GONE in the pinned OC
+        // 2026.5.28 — verified empirically: a meta-less `config.apply` that adds
+        // an agent is accepted and HOT-RELOADED (`reload applied (agents.list)`,
+        // no restart), and the agent lands in OC's runtime. Worse, the guard was
+        // actively harmful: during the first-install secrets-bootstrap restart
+        // window OC's config (and the fresh-install file seed) both lack meta, so
+        // the guard fired on every agent-create push and shunted it onto the
+        // file-write path — whose atomic-rename OC's post-restart watcher does
+        // NOT reliably reload, leaving the freshly-created agent absent from
+        // runtime and dispatch stuck on `unknown agent id` (#464). Letting the
+        // meta-less payload go through `config.apply` applies it in-process,
+        // reliably, with no file-watcher dependency.
 
         // No-op guard: skip config.apply entirely if the supplemented payload
         // is semantically equivalent to OC's current in-memory config. OC 5.3

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -153,13 +153,20 @@ function parseRetryAfterMs(message: string): number | null {
 // load` (Telegram E2E `agent-create-no-restart.spec.ts` cascade — the spec's
 // own header explicitly names this failure mode). Extending the retry budget
 // here lets the WS reconnect so the next iteration's config.apply lands
-// cleanly — both the in-process SIGUSR1 case (~5–15 s) and the integration-
-// test `docker compose restart openclaw` case (~10 s) finish well inside the
-// 30 s budget. After the budget exhausts the file-write fallback runs as
-// before; by that point any normal restart has completed and the write is
-// safe (OC is genuinely down, not racing its own startup).
+// cleanly — the in-process SIGUSR1 case (~5–15 s) and the integration-test
+// `docker compose restart openclaw` case (~10 s) finish quickly, but the
+// FIRST-INSTALL secrets-bootstrap restart (config/start-openclaw.sh pkills and
+// respawns the gateway, ~40 s) does NOT fit the old 30 s budget — that's the
+// window the dispatch-probe agent-create config storm lands in
+// (heypinchy/pinchy#464). With openclaw-node >= 0.12.1 rejecting in-flight
+// requests immediately on close (instead of stalling to the 30 s request
+// timeout), this wait is ACTIVE: it re-attempts config.get every ~2 s and lands
+// the apply the instant OC is back, so a 60 s budget covers the ~40 s secrets
+// restart with margin while staying bounded. After the budget exhausts the
+// file-write fallback runs as before; by then any normal restart has completed
+// and the write is safe (OC is genuinely down, not racing its own startup).
 const WS_DISCONNECTED_ERROR_FRAGMENT = "Not connected to OpenClaw Gateway";
-const NOT_CONNECTED_MAX_WAIT_MS = 30_000;
+const NOT_CONNECTED_MAX_WAIT_MS = 60_000;
 const NOT_CONNECTED_RETRY_DELAY_MS = 2_000;
 
 export function pushConfigInBackground(newContent: string): void {

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -111,11 +111,37 @@ export function _resetPushGeneration() {
 const STALE_HASH_ERROR_FRAGMENT = "config changed since last load";
 const MAX_STALE_HASH_RETRIES = 3;
 
-// OC 5.3 rate-limits config.apply (~3 calls per 45 s window). Consuming
-// backoff slots on each rejection just delays the eventual file-write
-// fallback by up to 3.85 s for no benefit — fall through to inotify
-// immediately instead.
+// OC 5.3 rate-limits config.apply (~3 calls per 45 s window). The error
+// carries an explicit "retry after Ns" hint. A rate-limited apply ALWAYS
+// carries a genuine diff (the no-op guard above already returns for
+// semantically-equivalent configs), so dropping it silently loses real
+// changes — most visibly a freshly-created agent that then never enters OC's
+// runtime, so chat dispatch fails with `unknown agent id` indefinitely (the
+// Odoo/email/web dispatch-probe flake; CI run 26837712634). Instead we wait
+// out the advertised window and RETRY the same clean WS config.apply path —
+// no file write, so no inotify drift. Only after a bounded retry budget do we
+// fall back to a file write (accepting the drift) so the change is never lost.
 const RATE_LIMIT_ERROR_FRAGMENT = "rate limit exceeded";
+// Buffer added past OC's advertised reset so the window is actually clear when
+// we retry (clock skew + the apply's own processing time).
+const RATE_LIMIT_BUFFER_MS = 1_000;
+// Used when the error has no parseable "retry after Ns" (defensive — every
+// observed OC 5.3 rate-limit message includes it).
+const RATE_LIMIT_FALLBACK_WAIT_MS = 10_000;
+// Cap a single wait so a malformed/huge "retry after" can't park the coroutine
+// for minutes. OC's window is ~45 s; 50 s covers it with headroom.
+const RATE_LIMIT_MAX_WAIT_MS = 50_000;
+// At most this many window-waits before the file-write fallback. Two covers
+// the realistic worst case (our apply lands in a maxed window, waits it out,
+// and a second batch of regens maxed the next one too) without parking the
+// coroutine across more than ~100 s.
+const MAX_RATE_LIMIT_RETRIES = 2;
+
+/** Parse OC's "retry after Ns" hint into milliseconds, or null if absent. */
+function parseRetryAfterMs(message: string): number | null {
+  const match = /retry after (\d+)\s*s/i.exec(message);
+  return match ? Number(match[1]) * 1000 : null;
+}
 
 // Pinchy's WS client throws this when config.get()/apply() runs while OC is
 // mid-restart (a successful config.apply triggered SIGUSR1, OC is relaunching
@@ -176,6 +202,7 @@ export function pushConfigInBackground(newContent: string): void {
     const backoffsMs = [100, 250, 500, 1000, 2000];
     let staleHashAttempts = 0;
     let notConnectedWaitMs = 0;
+    let rateLimitAttempts = 0;
     // Holds the OC-supplemented payload from the most recent successful
     // config.get(). Used when inotify file-write is the fallback so we
     // write content WITH meta and OC-managed fields — raw `newContent`
@@ -261,14 +288,38 @@ export function pushConfigInBackground(newContent: string): void {
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
 
-        // Rate-limit bypass: OC 5.3 rejects apply calls over the budget.
-        // OC already has the correct config in memory from the last successful
-        // config.apply — no file write needed. Writing to disk (even with meta)
-        // triggers an inotify hot-reload that causes OC to add built-in plugin
-        // entries (e.g. memory-core) and reorder keys, producing spurious drift
-        // in the config file. The next config.apply (after the 45 s window
-        // resets) will deliver any pending changes.
+        // Rate-limit handling: OC 5.3 rejects apply calls over the budget with
+        // an explicit "retry after Ns" hint. Because the no-op guard above
+        // already returned for equivalent configs, a rate-limited apply always
+        // carries a genuine pending change. Wait out the advertised window and
+        // retry the SAME clean WS path — no file write, so no inotify drift
+        // (the original reason for skipping the disk write). Only after the
+        // bounded retry budget do we fall back to a file write so the change is
+        // never permanently lost (a late, slightly-drifted config beats a
+        // dropped agent that dispatch then rejects with `unknown agent id`).
         if (message.includes(RATE_LIMIT_ERROR_FRAGMENT)) {
+          if (rateLimitAttempts < MAX_RATE_LIMIT_RETRIES) {
+            rateLimitAttempts++;
+            const waitMs = Math.min(
+              (parseRetryAfterMs(message) ?? RATE_LIMIT_FALLBACK_WAIT_MS) + RATE_LIMIT_BUFFER_MS,
+              RATE_LIMIT_MAX_WAIT_MS
+            );
+            console.warn(
+              `[openclaw-config] config.apply rate-limited; retrying via WS in ${String(waitMs)}ms (attempt ${String(rateLimitAttempts)}/${String(MAX_RATE_LIMIT_RETRIES)}):`,
+              message
+            );
+            i--; // OC's reset hint, not a transient failure — don't burn a backoff slot
+            await new Promise((resolve) => setTimeout(resolve, waitMs));
+            continue;
+          }
+          // Budget exhausted across multiple windows — disk-write fallback so
+          // OC's file-watcher reloads the change. Accept the inotify drift;
+          // losing the change entirely is worse.
+          console.warn(
+            "[openclaw-config] config.apply rate-limited past retry budget; writing file for inotify fallback:",
+            message
+          );
+          writeConfigAtomic(lastSupplemented ?? supplementPayloadWithFileFields(newContent));
           return;
         }
 

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -169,19 +169,6 @@ const WS_DISCONNECTED_ERROR_FRAGMENT = "Not connected to OpenClaw Gateway";
 const NOT_CONNECTED_MAX_WAIT_MS = 60_000;
 const NOT_CONNECTED_RETRY_DELAY_MS = 2_000;
 
-// OC's in-memory config briefly lacks `meta` right after a restart (before OC
-// re-stamps it) — most visibly during the FIRST-INSTALL secrets-bootstrap
-// restart, when the file is still a minimal seed with no meta either. A
-// meta-less config.apply trips OC's "missing-meta-before-write" cascade, and a
-// meta-less FILE WRITE is silently mishandled by OC's reload (the freshly
-// created agent never reaches runtime → `unknown agent id`, the #464
-// dispatch-probe flake). So instead of either, we WAIT for OC to stamp meta
-// (re-running config.get) so the eventual config.apply carries meta and applies
-// in-process. ~40 s covers the secrets-bootstrap respawn; 60 s gives margin.
-// After the budget we fall back to a file write so the change is never lost.
-const META_MISSING_MAX_WAIT_MS = 60_000;
-const META_MISSING_RETRY_DELAY_MS = 2_000;
-
 export function pushConfigInBackground(newContent: string): void {
   const generation = ++_pushGeneration;
 
@@ -225,7 +212,6 @@ export function pushConfigInBackground(newContent: string): void {
     const backoffsMs = [100, 250, 500, 1000, 2000];
     let staleHashAttempts = 0;
     let notConnectedWaitMs = 0;
-    let metaMissingWaitMs = 0;
     let rateLimitAttempts = 0;
     // Holds the OC-supplemented payload from the most recent successful
     // config.get(). Used when inotify file-write is the fallback so we
@@ -274,31 +260,12 @@ export function pushConfigInBackground(newContent: string): void {
         }
 
         // Meta-guard: if OC is running (current.config defined) but neither the
-        // in-memory config nor the file could supply meta, do NOT proceed —
-        // a meta-less config.apply trips OC's "missing-meta-before-write"
-        // cascade, and a meta-less FILE WRITE is silently mishandled by OC's
-        // reload so the change (e.g. a freshly-created agent) never reaches
-        // runtime (#464 secrets-restart-window flake). This is a TRANSIENT
-        // post-restart state: OC re-stamps meta once it settles. So wait and
-        // re-run config.get (i--, no backoff slot) until meta reappears, after
-        // which the normal config.apply path carries meta and applies
-        // in-process. Only after a bounded budget do we fall back to a file
-        // write so the change is never permanently lost.
+        // in-memory config nor the file could supply meta, skip config.apply.
+        // A meta-less payload triggers OC's "missing-meta-before-write" anomaly
+        // → SIGUSR1 restart cascade. Fall back to inotify via file write.
         if (current.config) {
           const parsed = JSON.parse(supplemented) as Record<string, unknown>;
           if (!("meta" in parsed)) {
-            if (metaMissingWaitMs < META_MISSING_MAX_WAIT_MS) {
-              metaMissingWaitMs += META_MISSING_RETRY_DELAY_MS;
-              console.log(
-                `[openclaw-config] push gen=${String(generation)}: OC config lacks meta (transient post-restart); waiting ${String(META_MISSING_RETRY_DELAY_MS)}ms for OC to stamp it, then retrying config.get (${String(metaMissingWaitMs)}/${String(META_MISSING_MAX_WAIT_MS)}ms)`
-              );
-              i--; // OC-settle wait, not a transient failure — don't burn a backoff slot
-              await new Promise((resolve) => setTimeout(resolve, META_MISSING_RETRY_DELAY_MS));
-              continue;
-            }
-            console.warn(
-              `[openclaw-config] push gen=${String(generation)}: meta still missing after ${String(metaMissingWaitMs)}ms; writing file fallback (reload may lag):`
-            );
             writeConfigAtomic(newContent);
             return;
           }

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -169,6 +169,19 @@ const WS_DISCONNECTED_ERROR_FRAGMENT = "Not connected to OpenClaw Gateway";
 const NOT_CONNECTED_MAX_WAIT_MS = 60_000;
 const NOT_CONNECTED_RETRY_DELAY_MS = 2_000;
 
+// OC's in-memory config briefly lacks `meta` right after a restart (before OC
+// re-stamps it) — most visibly during the FIRST-INSTALL secrets-bootstrap
+// restart, when the file is still a minimal seed with no meta either. A
+// meta-less config.apply trips OC's "missing-meta-before-write" cascade, and a
+// meta-less FILE WRITE is silently mishandled by OC's reload (the freshly
+// created agent never reaches runtime → `unknown agent id`, the #464
+// dispatch-probe flake). So instead of either, we WAIT for OC to stamp meta
+// (re-running config.get) so the eventual config.apply carries meta and applies
+// in-process. ~40 s covers the secrets-bootstrap respawn; 60 s gives margin.
+// After the budget we fall back to a file write so the change is never lost.
+const META_MISSING_MAX_WAIT_MS = 60_000;
+const META_MISSING_RETRY_DELAY_MS = 2_000;
+
 export function pushConfigInBackground(newContent: string): void {
   const generation = ++_pushGeneration;
 
@@ -212,6 +225,7 @@ export function pushConfigInBackground(newContent: string): void {
     const backoffsMs = [100, 250, 500, 1000, 2000];
     let staleHashAttempts = 0;
     let notConnectedWaitMs = 0;
+    let metaMissingWaitMs = 0;
     let rateLimitAttempts = 0;
     // Holds the OC-supplemented payload from the most recent successful
     // config.get(). Used when inotify file-write is the fallback so we
@@ -260,12 +274,31 @@ export function pushConfigInBackground(newContent: string): void {
         }
 
         // Meta-guard: if OC is running (current.config defined) but neither the
-        // in-memory config nor the file could supply meta, skip config.apply.
-        // A meta-less payload triggers OC's "missing-meta-before-write" anomaly
-        // → SIGUSR1 restart cascade. Fall back to inotify via file write.
+        // in-memory config nor the file could supply meta, do NOT proceed —
+        // a meta-less config.apply trips OC's "missing-meta-before-write"
+        // cascade, and a meta-less FILE WRITE is silently mishandled by OC's
+        // reload so the change (e.g. a freshly-created agent) never reaches
+        // runtime (#464 secrets-restart-window flake). This is a TRANSIENT
+        // post-restart state: OC re-stamps meta once it settles. So wait and
+        // re-run config.get (i--, no backoff slot) until meta reappears, after
+        // which the normal config.apply path carries meta and applies
+        // in-process. Only after a bounded budget do we fall back to a file
+        // write so the change is never permanently lost.
         if (current.config) {
           const parsed = JSON.parse(supplemented) as Record<string, unknown>;
           if (!("meta" in parsed)) {
+            if (metaMissingWaitMs < META_MISSING_MAX_WAIT_MS) {
+              metaMissingWaitMs += META_MISSING_RETRY_DELAY_MS;
+              console.log(
+                `[openclaw-config] push gen=${String(generation)}: OC config lacks meta (transient post-restart); waiting ${String(META_MISSING_RETRY_DELAY_MS)}ms for OC to stamp it, then retrying config.get (${String(metaMissingWaitMs)}/${String(META_MISSING_MAX_WAIT_MS)}ms)`
+              );
+              i--; // OC-settle wait, not a transient failure — don't burn a backoff slot
+              await new Promise((resolve) => setTimeout(resolve, META_MISSING_RETRY_DELAY_MS));
+              continue;
+            }
+            console.warn(
+              `[openclaw-config] push gen=${String(generation)}: meta still missing after ${String(metaMissingWaitMs)}ms; writing file fallback (reload may lag):`
+            );
             writeConfigAtomic(newContent);
             return;
           }

--- a/packages/web/src/server/agent-readiness.ts
+++ b/packages/web/src/server/agent-readiness.ts
@@ -1,0 +1,111 @@
+// packages/web/src/server/agent-readiness.ts
+//
+// Runtime-readiness gate for a freshly (re)created agent.
+//
+// OpenClaw applies a config change to its runtime ASYNCHRONOUSLY: after Pinchy
+// writes/applies a new agent, OC's chat-dispatch handler keeps rejecting the id
+// with `unknown agent id` until the runtime `agents.list` reflects the change.
+// That lag is normally 1–2 s, but on a cold start or under OC 5.3's
+// `config.apply` rate-limit it can balloon to ~100 s (see chat-dispatch-retry.ts
+// and reference_config_apply_rate_limit_drop in project memory).
+//
+// `agents.list` (openclaw-node >= 0.12.0) is backed by the SAME runtime view
+// (`getRuntimeConfig()`) that OC's chat-dispatch handler checks before accepting
+// a message. Verified against OC 2026.5.28: both the `agent` dispatch handler
+// (`knownAgents = listAgentIds(getRuntimeConfig())`) and the `agents.list`
+// handler (`listAgentsForGateway(getRuntimeConfig())`) read that one view. So
+// polling `agents.list` until the agent id appears is an AUTHORITATIVE,
+// deterministic readiness signal — the gate `config.get` could never be, because
+// `config.get` reads the config FILE, which leads the applied runtime.
+//
+// Contract: this helper NEVER throws and NEVER blocks chat outright.
+//   - Gateway without agents.list (older OC)  → returns false immediately.
+//   - agents.list RPC errors transiently      → treated as "not yet present".
+//   - agent never appears within the deadline  → returns false.
+// In every false case the caller dispatches anyway; `chatWithDispatchRaceRetry`
+// remains the backstop, so a readiness-probe miss can only ever cost a little
+// latency, never a dropped message.
+
+export interface AgentRuntimeReadinessDeps {
+  /** Whether the connected Gateway advertises the `agents.list` RPC. */
+  hasAgentsListRpc: () => boolean;
+  /**
+   * Resolve the agent ids currently present in OC's RUNTIME config (i.e. the
+   * `id`s returned by `agents.list`). Rejections are caught by the caller and
+   * treated as "agent not yet present".
+   */
+  listRuntimeAgentIds: () => Promise<string[]>;
+  /** Sleep helper, injectable so tests don't wait real time. */
+  delay?: (ms: number) => Promise<void>;
+  /** Clock, injectable so tests drive the deadline deterministically. */
+  now?: () => number;
+  /**
+   * Observability hook, invoked once per wait that ACTUALLY had to poll (i.e.
+   * the agent was not already present on the first check). Skipped on the
+   * zero-wait fast path so it does not flood with no-op observations.
+   */
+  onWaitObserved?: (info: {
+    agentId: string;
+    waitedMs: number;
+    ready: boolean;
+    polls: number;
+  }) => void;
+}
+
+export interface AgentRuntimeReadinessOptions {
+  /** Total wall-clock budget to wait for the agent to appear in the runtime. */
+  deadlineMs: number;
+  /** Delay between polls. Default 500 ms. */
+  intervalMs?: number;
+}
+
+const DEFAULT_INTERVAL_MS = 500;
+
+/**
+ * Resolves `true` once `agentId` is present in OC's runtime `agents.list`, or
+ * `false` if it never appears within `deadlineMs` (or readiness is
+ * unobservable on this Gateway). Mirrors the dispatch handler's own predicate:
+ * a direct membership check on the runtime agent-id list.
+ */
+export async function waitForAgentInRuntime(
+  agentId: string,
+  deps: AgentRuntimeReadinessDeps,
+  opts: AgentRuntimeReadinessOptions
+): Promise<boolean> {
+  // Unobservable on this Gateway → don't burn the deadline polling something
+  // that will never answer; let the dispatch-race backstop handle it.
+  if (!deps.hasAgentsListRpc()) return false;
+
+  const intervalMs = opts.intervalMs ?? DEFAULT_INTERVAL_MS;
+  const delay = deps.delay ?? ((ms: number) => new Promise<void>((r) => setTimeout(r, ms)));
+  const now = deps.now ?? Date.now;
+
+  const start = now();
+  let polls = 0;
+  for (;;) {
+    polls++;
+    let present = false;
+    try {
+      present = (await deps.listRuntimeAgentIds()).includes(agentId);
+    } catch {
+      // Transient agents.list error — treat as "not yet present" and keep
+      // polling within the deadline rather than giving up early.
+      present = false;
+    }
+
+    if (present) {
+      // Only report waits that actually had to poll past the first check, so
+      // the hot path (agent already ready) stays observation-free.
+      if (polls > 1)
+        deps.onWaitObserved?.({ agentId, waitedMs: now() - start, ready: true, polls });
+      return true;
+    }
+
+    const remaining = opts.deadlineMs - (now() - start);
+    if (remaining <= 0) {
+      deps.onWaitObserved?.({ agentId, waitedMs: now() - start, ready: false, polls });
+      return false;
+    }
+    await delay(Math.min(intervalMs, remaining));
+  }
+}

--- a/packages/web/src/server/agent-readiness.ts
+++ b/packages/web/src/server/agent-readiness.ts
@@ -18,6 +18,13 @@
 // deterministic readiness signal — the gate `config.get` could never be, because
 // `config.get` reads the config FILE, which leads the applied runtime.
 //
+// Polling cost is safe under contention: `agents.list` is a READ. Verified
+// against OC 2026.5.28's method descriptors — `config.apply` carries
+// `controlPlaneWrite: true` (the ~3-per-45s write rate-limit bucket that
+// motivated this whole gate), but `agents.list` does NOT, so polling it cannot
+// consume a write slot or contend with the very apply we're waiting on. The
+// default 500 ms interval is therefore a cheap read even across the full budget.
+//
 // Contract: this helper NEVER throws and NEVER blocks chat outright.
 //   - Gateway without agents.list (older OC)  → returns false immediately.
 //   - agents.list RPC errors transiently      → treated as "not yet present".

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -20,11 +20,23 @@
 // a 114 s gap that a single 500 ms retry could never bridge, surfacing
 // "Smithers couldn't respond" on a brand-new user's first message.
 //
-// `config.get`-based readiness gates (waitForAgentInRuntime, the
-// `agentDispatchable` health probe) CANNOT close this race: they poll the same
-// file-vs-runtime-divergent path. The only reliable readiness signal is a
-// dispatch that actually succeeds — so we retry the real dispatch with
-// exponential backoff until it lands or a wall-clock budget elapses.
+// `config.get`-based readiness gates CANNOT close this race: `config.get` reads
+// the FILE, which leads the applied runtime, so a file-based gate reports
+// "ready" while the dispatch handler still rejects. The reliable signal is OC's
+// `agents.list` RPC (openclaw-node >= 0.12.0): verified against OC 2026.5.28,
+// it reads the SAME `getRuntimeConfig()` view the dispatch handler checks, so
+// once an id appears there a dispatch will not be rejected. We therefore prefer
+// a DETERMINISTIC GATE — poll `agents.list` until the agent is present (the
+// injected `awaitAgentReady` dep, backed by `agent-readiness.ts`) — and only
+// fall back to blind exponential backoff when the gate is absent or
+// unobservable (older Gateway). Either way the loop stays bounded by the
+// wall-clock budget and re-dispatches the real chat once readiness lands.
+//
+// Historical note: before the gate existed this loop relied purely on blind
+// backoff-retry of the real dispatch (the "only a successful dispatch is a
+// reliable signal" era — true while `config.get` was the only introspection
+// openclaw-node wrapped). The gate makes the common case deterministic instead
+// of probabilistic; the backoff retry remains the backstop.
 //
 // Safety: this ONLY retries the literal `unknown agent id` shape, and ONLY
 // when it is the FIRST chunk. For an agent Pinchy just created and confirmed,
@@ -88,6 +100,24 @@ export interface DispatchRetryDeps {
    * loop would be invisible.
    */
   onDispatchRaceObserved?: (info: { providerError: string; attempt: number }) => void;
+  /**
+   * Optional runtime-readiness gate. When provided, on a dispatch-race error the
+   * wrapper awaits this — bounded by the REMAINING budget — INSTEAD of a blind
+   * backoff sleep, then re-dispatches. It should resolve:
+   *   - `true`  → the target agent is now present in OpenClaw's RUNTIME
+   *               `agents.list` (the same view the dispatch handler checks), so
+   *               the next dispatch will land; retry immediately, no sleep.
+   *   - `false` → readiness could not be confirmed within the window (timeout,
+   *               or unobservable on an older Gateway without `agents.list`); the
+   *               wrapper falls back to its capped blind backoff so the bounded
+   *               retry is preserved.
+   *
+   * This turns the blind "sleep and hope" retry into a deterministic gate.
+   * Absent → pure exponential backoff (the original behaviour), which remains
+   * the backstop. See `agent-readiness.ts` for why `agents.list` is reliable
+   * where `config.get` is not.
+   */
+  awaitAgentReady?: (budgetMs: number) => Promise<boolean>;
 }
 
 /**
@@ -154,9 +184,27 @@ export async function* chatWithDispatchRaceRetry(
       return;
     }
 
+    // Deterministic readiness gate (preferred): poll OC's runtime agents.list —
+    // the same view the dispatch handler checks — until the agent is present,
+    // bounded by the remaining budget. On success, re-dispatch immediately into
+    // a ready runtime instead of sleeping a backoff window and hoping.
+    if (deps.awaitAgentReady) {
+      const ready = await deps.awaitAgentReady(remaining);
+      if (ready) continue;
+      // Not confirmed within the window (timeout, or unobservable on an older
+      // Gateway). Fall through to the capped backoff so we keep making bounded
+      // progress rather than hot-looping on a still-unready runtime.
+    }
+
     // Exponential backoff capped at maxDelayMs, and never sleeping past the
-    // remaining budget.
+    // remaining budget. Recompute the budget: a readiness gate above may have
+    // consumed part of it.
+    const remainingAfterGate = maxTotalMs - (now() - start);
+    if (remainingAfterGate <= 0) {
+      yield raceError;
+      return;
+    }
     const backoff = Math.min(baseDelayMs * 2 ** attempt, maxDelayMs);
-    await delay(Math.min(backoff, remaining));
+    await delay(Math.min(backoff, remainingAfterGate));
   }
 }

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -58,9 +58,14 @@ export interface DispatchRetryPolicy {
   maxDelayMs?: number;
   /**
    * Total wall-clock budget for retrying. Once exceeded, the last race error is
-   * yielded so the caller surfaces it. Default 90 s — comfortably covers one
-   * gateway restart + a `config.apply` rate-limit window; bounded so a
-   * genuinely-unknown agent can't hang the chat forever.
+   * yielded so the caller surfaces it. Default 150 s — the original 90 s was
+   * actually SHORTER than this file's own documented worst case (the #448
+   * fresh-install gap was 114 s; the Odoo/email/web dispatch-probe E2E measured
+   * an OpenClaw agents-reload landing ~104 s after the first dispatch when
+   * rapid config writes coalesce in OC's file-watcher debounce, so the agent
+   * applied 14 s AFTER the 90 s budget gave up — the residual dispatch-probe
+   * flake). 150 s covers both with margin while staying bounded so a
+   * genuinely-unknown agent (a Pinchy-side bug) can't hang the chat forever.
    */
   maxTotalMs?: number;
 }
@@ -68,7 +73,7 @@ export interface DispatchRetryPolicy {
 const DEFAULT_POLICY: Required<DispatchRetryPolicy> = {
   baseDelayMs: 500,
   maxDelayMs: 5000,
-  maxTotalMs: 90000,
+  maxTotalMs: 150000,
 };
 
 export interface DispatchRetryDeps {

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -368,7 +368,7 @@ export class ClientRouter {
         chat: (m, o) => this.openclawClient.chat(m, o),
         onDispatchRaceObserved: async ({ providerError }) => {
           // The resilient retry (chat-dispatch-retry.ts) can stay silent for up
-          // to ~90 s while OpenClaw applies the agent into its runtime. The
+          // to ~150 s while OpenClaw applies the agent into its runtime. The
           // browser's stuck-timer (STUCK_TIMEOUT_MS, use-ws-runtime.ts) fires
           // after 60 s of silence and falsely times the run out — so once we
           // KNOW we're in a dispatch-race, re-emit `thinking` every 20 s to keep

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -1,5 +1,6 @@
 import type { OpenClawClient, ChatAttachment, ChatChunk, ChatOptions } from "openclaw-node";
 import { chatWithDispatchRaceRetry } from "@/server/chat-dispatch-retry";
+import { waitForAgentInRuntime } from "@/server/agent-readiness";
 import type { WebSocket } from "ws";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
@@ -366,6 +367,32 @@ export class ClientRouter {
 
       const stream = chatWithDispatchRaceRetry(text, chatOptions as ChatOptions, {
         chat: (m, o) => this.openclawClient.chat(m, o),
+        // Deterministic readiness gate: on a dispatch-race, poll OC's RUNTIME
+        // `agents.list` (the same `getRuntimeConfig()` view the dispatch handler
+        // checks) until this agent is present, instead of blind-sleeping a
+        // backoff window. Reading the runtime list — not `config.get` (the FILE,
+        // which leads the runtime) — is what makes this reliable. Bounded by the
+        // remaining retry budget; never throws, so a probe miss only costs a
+        // little latency (the backoff retry remains the backstop). Requires
+        // openclaw-node >= 0.12.0; `hasMethod` guards older Gateways.
+        awaitAgentReady: (budgetMs) =>
+          waitForAgentInRuntime(
+            message.agentId,
+            {
+              hasAgentsListRpc: () => this.openclawClient.hasMethod("agents.list"),
+              listRuntimeAgentIds: async () =>
+                (await this.openclawClient.agents.list()).agents.map((a) => a.id),
+              onWaitObserved: ({ waitedMs, ready, polls }) => {
+                if (process.env.PINCHY_E2E_CHAT_TRACE === "1") {
+                  console.log(
+                    `[trace:chat] readiness-gate agent=${message.agentId} ` +
+                      `ready=${ready} waitedMs=${waitedMs} polls=${polls}`
+                  );
+                }
+              },
+            },
+            { deadlineMs: budgetMs }
+          ),
         onDispatchRaceObserved: async ({ providerError }) => {
           // The resilient retry (chat-dispatch-retry.ts) can stay silent for up
           // to ~150 s while OpenClaw applies the agent into its runtime. The

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,7 @@ overrides:
   brace-expansion@<1.1.13: ^1.1.13
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   flatted@<3.4.2: ^3.4.2
+  hono@>=4.0.0 <4.12.21: '>=4.12.21'
   typescript-eslint@>=8.0.0 <8.58.2: '>=8.58.2'
   '@typescript-eslint/parser@>=8.0.0 <8.58.2': '>=8.58.2'
   '@typescript-eslint/eslint-plugin@>=8.0.0 <8.58.2': '>=8.58.2'
@@ -1402,7 +1403,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: ^4
+      hono: '>=4.12.21'
 
   '@hookform/resolvers@5.4.0':
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
@@ -4728,8 +4729,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.18:
-    resolution: {integrity: sha512-RWzP96k/yv0PQfyXnWjs6zot20TqfpfsNXhOnev8d1InAxubW93L11/oNUc3tQqn2G0bSdAOBpX+2uDFHV7kdQ==}
+  hono@4.12.23:
+    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@9.0.3:
@@ -8084,9 +8085,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.14(hono@4.12.18)':
+  '@hono/node-server@1.19.14(hono@4.12.23)':
     dependencies:
-      hono: 4.12.18
+      hono: 4.12.23
 
   '@hookform/resolvers@5.4.0(react-hook-form@7.76.1(react@19.2.6))':
     dependencies:
@@ -8263,7 +8264,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.18)
+      '@hono/node-server': 1.19.14(hono@4.12.23)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -8273,7 +8274,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.0(express@5.2.1)
-      hono: 4.12.18
+      hono: 4.12.23
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10929,8 +10930,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -10952,7 +10953,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10963,22 +10964,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10989,7 +10990,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -11523,7 +11524,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.18: {}
+  hono@4.12.23: {}
 
   hosted-git-info@9.0.3:
     dependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       openclaw-node:
-        specifier: 0.11.0
-        version: 0.11.0
+        specifier: 0.12.0
+        version: 0.12.0
       pdfkit:
         specifier: ^0.18.0
         version: 0.18.0
@@ -5659,8 +5659,8 @@ packages:
       zod:
         optional: true
 
-  openclaw-node@0.11.0:
-    resolution: {integrity: sha512-TCGlz+SPe8rvy0kQm4x39gDWO/bUlBxe6hFWvgV4g9O57/J8KQ686x4QYnR9FSGGHlmlIt6i0sJfMfNkQGB2lg==}
+  openclaw-node@0.12.0:
+    resolution: {integrity: sha512-RJ7ynB4jLHS1K97EhihRVbz3fUJLOf6J16QY5dNJYCdGTAHfPW2leg6QBtOwcy6t+K5Rzbcf2VdEewhken2K2A==}
     engines: {node: '>=20.0.0'}
 
   openclaw@2026.5.28:
@@ -10929,8 +10929,8 @@ snapshots:
       '@next/eslint-plugin-next': 16.2.6
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-jsx-a11y: 6.10.2(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react: 7.37.5(eslint@9.39.4(jiti@2.7.0))
       eslint-plugin-react-hooks: 7.0.1(eslint@9.39.4(jiti@2.7.0))
@@ -10952,7 +10952,7 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@nolyfill/is-core-module': 1.0.39
       debug: 4.4.3
@@ -10963,22 +10963,22 @@ snapshots:
       tinyglobby: 0.2.16
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-module-utils@2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       debug: 3.2.7
     optionalDependencies:
       '@typescript-eslint/parser': 8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3)
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0)(eslint@9.39.4(jiti@2.7.0))
     transitivePeerDependencies:
       - supports-color
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0)):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10989,7 +10989,7 @@ snapshots:
       doctrine: 2.1.0
       eslint: 9.39.4(jiti@2.7.0)
       eslint-import-resolver-node: 0.3.9
-      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0)))(eslint@9.39.4(jiti@2.7.0))
+      eslint-module-utils: 2.12.1(@typescript-eslint/parser@8.58.2(eslint@9.39.4(jiti@2.7.0))(typescript@6.0.3))(eslint-import-resolver-node@0.3.9)(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.4(jiti@2.7.0))
       hasown: 2.0.2
       is-core-module: 2.16.1
       is-glob: 4.0.3
@@ -12608,7 +12608,7 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
-  openclaw-node@0.11.0:
+  openclaw-node@0.12.0:
     optionalDependencies:
       ws: 8.21.0
     transitivePeerDependencies:

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -235,8 +235,8 @@ importers:
         specifier: 0.2.0
         version: 0.2.0
       openclaw-node:
-        specifier: 0.12.0
-        version: 0.12.0
+        specifier: 0.12.1
+        version: 0.12.1
       pdfkit:
         specifier: ^0.18.0
         version: 0.18.0
@@ -5659,8 +5659,8 @@ packages:
       zod:
         optional: true
 
-  openclaw-node@0.12.0:
-    resolution: {integrity: sha512-RJ7ynB4jLHS1K97EhihRVbz3fUJLOf6J16QY5dNJYCdGTAHfPW2leg6QBtOwcy6t+K5Rzbcf2VdEewhken2K2A==}
+  openclaw-node@0.12.1:
+    resolution: {integrity: sha512-aOPhmN7OKyut7DVs3/LitA+QU5tAtrEMY3gSQ/uJXpCN3Dy4JYeEkIjyYX0hViCdxsOJ9LWfCjtiaB3kTPCupw==}
     engines: {node: '>=20.0.0'}
 
   openclaw@2026.5.28:
@@ -12608,7 +12608,7 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
-  openclaw-node@0.12.0:
+  openclaw-node@0.12.1:
     optionalDependencies:
       ws: 8.21.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

De-flakes the Odoo / email / web / telegram dispatch-probe and setup-wizard E2E suites (previously ~33%, rotating between jobs). **Confirmed fixed:** with the root fix applied, all six dispatch-probe + setup-wizard E2E suites pass green ([CI run 27017808881](https://github.com/heypinchy/pinchy/actions/runs/27017808881) — every prior run had 1–2 suites rotating-failing).

## Root cause — an obsolete guard × OC's restart window

Pinned by the CI diagnostics added here, then verified empirically against the pinned OC 2026.5.28:

- During OC's **first-install secrets-bootstrap restart**, OC's in-memory config AND the fresh-install file seed both lack `meta`.
- Pinchy's **meta-guard** — added long ago to dodge OpenClaw **4.27**'s "missing-meta-before-write" restart cascade — fired on every agent-create push in that window and shunted it onto `writeConfigAtomic` (file write).
- OC's **post-restart file-watcher does not reliably reload that atomic-rename write**, so the freshly-created agent never reached runtime → chat dispatch stuck on `unknown agent id`. CI logs showed `config.get` + `agents.list` succeeding over WS but **zero `config.apply`** and no agent reload after the restart.

**The 4.27 anomaly is gone in OC 2026.5.28** — verified with a probe against the real gateway: a meta-less `config.apply` adding an agent returns `ok=true`, OC **hot-reloads it** (`reload applied (agents.list)`, no restart, no cascade), and the agent lands in runtime. So the guard is obsolete *and* was the lynchpin causing the flake.

**Fix:** remove the meta-guard so meta-less payloads apply via `config.apply` (in-process, reliable, no file-watcher dependency). The cascade test is repurposed to assert `config.apply` IS called without meta.

## Supporting robustness (all verified)

- **`agents.list` readiness gate** (openclaw-node 0.12.0): polls OC's runtime agent list — the same `getRuntimeConfig()` view the dispatch handler checks — for deterministic readiness instead of blind backoff.
- **openclaw-node 0.12.1**: reject in-flight requests on disconnect (no 30s stall when OC restarts mid-`config.apply`); Pinchy's WS-reconnect wait sized to 60s to cover the ~40s secrets respawn.
- **rate-limit-drop prod fix**: `config.apply` rate-limited by OC is retried (was silently dropped).
- **setup-wizard restart-window races**: stop OC before reseed; settle before first chat.
- **CI diagnostics** (`capture-e2e-diagnostics` + `[openclaw-config] push gen=…` tracing): made every root cause measurable rather than guessed.
- **security**: `hono` override to >=4.12.21 clears 4 newly-disclosed CVEs (transitive devDep via openclaw; not in production build).

## Test plan

- [x] Empirical: meta-less `config.apply` against real OC 2026.5.28 → agent hot-reloaded into runtime, no cascade
- [x] Unit: full suite 5585 pass; `tsc` + prettier + lint clean
- [x] openclaw-node: 136 pass; `agents.list` + pending-request-rejection tests; 0.12.0 & 0.12.1 published
- [x] **CI: all 6 dispatch-probe + setup-wizard E2E suites green with the root fix** (run 27017808881)
- [x] osv-scan: green (`No issues found`)
- [ ] CI: confirming all-green sweep with the osv fix folded in (in progress)

## Note on history

Includes an honest mistake+revert pair: an intermediate "wait for OC to stamp meta" attempt (e82618b38) wrongly assumed the meta-absence was transient; it regressed suites and was reverted (13b950f76). The diagnostics caught it, and the correct fix (the meta-guard is simply obsolete) followed.
