### PR TITLE
fix(openclaw): bump runtime to 2026.6.5 and de-flake the E2E suite at root cause

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.5.28
+RUN npm install -g openclaw@2026.6.1
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.6.1
+RUN npm install -g openclaw@2026.6.5
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -221,7 +221,7 @@ For the full details, see [Audit Trail](/concepts/audit-trail/).
 
 OpenClaw runs as a separate Docker container. Pinchy communicates with it via `openclaw-node` (the official Node.js client) over WebSocket on port 18789. The browser never connects to OpenClaw directly.
 
-The current pin pair is **`openclaw@2026.6.1`** in `Dockerfile.openclaw` and **`openclaw-node@0.12.1`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
+The current pin pair is **`openclaw@2026.6.5`** in `Dockerfile.openclaw` and **`openclaw-node@0.12.1`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
 
 ### Config generation
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -221,7 +221,7 @@ For the full details, see [Audit Trail](/concepts/audit-trail/).
 
 OpenClaw runs as a separate Docker container. Pinchy communicates with it via `openclaw-node` (the official Node.js client) over WebSocket on port 18789. The browser never connects to OpenClaw directly.
 
-The current pin pair is **`openclaw@2026.5.28`** in `Dockerfile.openclaw` and **`openclaw-node@0.12.1`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
+The current pin pair is **`openclaw@2026.6.1`** in `Dockerfile.openclaw` and **`openclaw-node@0.12.1`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
 
 ### Config generation
 

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -25,6 +25,18 @@ OpenClaw gateway reachability check. **Public — no authentication required.**
 
 Useful for monitoring the WebSocket gateway separately from the web process.
 
+**Response:**
+
+```json
+{
+  "status": "ok",
+  "connected": true,
+  "configPushesPending": 0
+}
+```
+
+`configPushesPending` is the number of configuration updates Pinchy has accepted but not yet confirmed inside the OpenClaw runtime (for example while OpenClaw's config-apply rate limit defers an update). A value of `0` means the runtime reflects every change you've made — useful for automation that needs to act right after a settings or permission change. While the gateway restarts, the response is `{ "status": "restarting", "connected": false, "since": <timestamp> }` instead.
+
 ## Setup (public)
 
 Setup endpoints handle the initial installation and first-admin account. They are accessible **only before setup has completed** — once an admin exists, they return `409 Conflict`.

--- a/packages/web/e2e/email/email.spec.ts
+++ b/packages/web/e2e/email/email.spec.ts
@@ -158,7 +158,11 @@ test.describe("Email dispatch probe (pinchy-email plugin coverage)", () => {
   let restoreSettings: (() => Promise<void>) | null = null;
 
   test.beforeAll(async ({}, testInfo) => {
-    testInfo.setTimeout(180_000);
+    // 240 s (was 180 s): waitForOpenClawStable now also waits for
+    // configPushesPending=0, whose worst case (a config.apply parked across
+    // rate-limit windows before the file fallback settles it) adds up to
+    // ~100 s before the 30 s stable streak can begin.
+    testInfo.setTimeout(240_000);
 
     // 1. Start fake-Ollama on the host (port 11435).
     await startFakeOllama();

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -276,7 +276,11 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
   let restoreSettings: (() => Promise<void>) | null = null;
 
   test.beforeAll(async ({}, testInfo) => {
-    testInfo.setTimeout(180_000);
+    // 240 s (was 180 s): waitForOpenClawStable now also waits for
+    // configPushesPending=0, whose worst case (a config.apply parked across
+    // rate-limit windows before the file fallback settles it) adds up to
+    // ~100 s before the 30 s stable streak can begin.
+    testInfo.setTimeout(240_000);
 
     // 1. Start fake-Ollama on the host (port 11435).
     await startFakeOllama();

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -159,8 +159,15 @@ export async function resetStack(): Promise<void> {
       const out = execSync(`curl -fsS http://localhost:7777/api/health/openclaw`, {
         stdio: "pipe",
       }).toString();
-      const health = JSON.parse(out) as { connected?: boolean; status?: string };
-      if (health.connected && health.status === "ok") {
+      const health = JSON.parse(out) as {
+        connected?: boolean;
+        status?: string;
+        configPushesPending?: number;
+      };
+      // Also require no config push in flight: a parked (rate-limited)
+      // config.apply means a change is NOT yet in OC's runtime even though
+      // `connected` is true — handing off to the wizard then races the apply.
+      if (health.connected && health.status === "ok" && (health.configPushesPending ?? 0) === 0) {
         connectedSince ??= Date.now();
         if (Date.now() - connectedSince >= 5000) return;
       } else {
@@ -196,8 +203,19 @@ async function waitForOpenClawSettledViaPage(
     try {
       const res = await page.request.get("/api/health/openclaw");
       if (res.ok()) {
-        const health = (await res.json()) as { connected?: boolean; status?: string };
-        if (health.connected && health.status === "ok") {
+        const health = (await res.json()) as {
+          connected?: boolean;
+          status?: string;
+          configPushesPending?: number;
+        };
+        // Require no config push in flight before the first chat: the wizard's
+        // provider save triggers a regenerate whose `models` block may be
+        // parked in OC's config.apply rate-limit window. Dispatching into that
+        // gap makes the run resolve the agent's model against a runtime that
+        // doesn't have the provider yet ("Unknown model: google/…", the google
+        // setup-wizard flake). The chat path's own model-race retry remains the
+        // production backstop; this keeps the test's common case fast & clean.
+        if (health.connected && health.status === "ok" && (health.configPushesPending ?? 0) === 0) {
           connectedSince ??= Date.now();
           if (Date.now() - connectedSince >= opts.stableForMs) return;
         } else {

--- a/packages/web/e2e/shared/dispatch-probe.ts
+++ b/packages/web/e2e/shared/dispatch-probe.ts
@@ -76,44 +76,57 @@ export async function seedDefaultProviderToOllama(
 }
 
 /**
- * Wait until `/api/health/openclaw` reports `connected=true` for `stableForMs`
- * consecutive milliseconds. A single transient `true` during a hot-reload
- * cycle is not enough — config-regen briefly tears down the bridge and a
- * naive poll catches the pre-reload state.
+ * Wait until `/api/health/openclaw` reports `connected=true` AND
+ * `configPushesPending=0` for `stableForMs` consecutive milliseconds. A single
+ * transient `true` during a hot-reload cycle is not enough — config-regen
+ * briefly tears down the bridge and a naive poll catches the pre-reload state.
  *
- * `stableForMs` defaults to 30 s because Pinchy's `pushConfigInBackground` is
- * fire-and-forget: `regenerateOpenClawConfig()` returns after the disk write
- * but the WebSocket `config.apply` can still be in-flight, and OC's
- * `config.apply` rate-limit (~3 calls / 45 s window) makes the second of two
- * rapid regens fall through to the inotify-debounced file-watcher reload.
- * 30 s of consecutive `connected=true` covers that worst case.
+ * Why `configPushesPending` is part of the predicate: Pinchy's
+ * `pushConfigInBackground` is fire-and-forget, and OC 5.3's `config.apply`
+ * rate-limit (~3 calls / 45 s window) can PARK a push coroutine for 33–53 s
+ * waiting out the window. OC stays connected the whole time, so a
+ * connection-only stability window passes while a config change this suite
+ * just made (e.g. the per-agent `pinchy-email` grant) is still NOT in OC's
+ * runtime. The next dispatch then snapshots a tool list without the grant and
+ * the agent answers "I can't use the tool … it isn't available" (the
+ * email/odoo/web/telegram dispatch-probe flake, sibling of #464). Requiring
+ * pending=0 makes the gate deterministic instead of probabilistic.
  */
 export async function waitForOpenClawStable(
-  fetchHealth: () => Promise<{ ok: boolean; json: () => Promise<{ connected?: boolean }> }>,
+  fetchHealth: () => Promise<{
+    ok: boolean;
+    json: () => Promise<{ connected?: boolean; configPushesPending?: number }>;
+  }>,
   opts: { deadlineMs?: number; stableForMs?: number; intervalMs?: number } = {}
 ): Promise<void> {
-  const deadline = Date.now() + (opts.deadlineMs ?? 90_000);
+  // 150 s default deadline (was 90 s): a parked config.apply can take one full
+  // rate-limit window (~53 s) — or two (~100 s) before the file-write fallback
+  // settles it — BEFORE the stableFor window can even begin. 90 s could expire
+  // mid-wait and turn the deterministic gate back into a flake.
+  const deadline = Date.now() + (opts.deadlineMs ?? 150_000);
   const stableFor = opts.stableForMs ?? 30_000;
   const interval = opts.intervalMs ?? 500;
-  let connectedSince: number | null = null;
+  let stableSince: number | null = null;
 
   while (Date.now() < deadline) {
     const res = await fetchHealth();
+    let stable = false;
     if (res.ok) {
       const body = await res.json();
-      if (body.connected) {
-        connectedSince ??= Date.now();
-        if (Date.now() - connectedSince >= stableFor) return;
-      } else {
-        connectedSince = null;
-      }
+      // Missing `configPushesPending` (older Pinchy build) counts as settled
+      // so the helper stays usable against both response shapes.
+      stable = Boolean(body.connected) && (body.configPushesPending ?? 0) === 0;
+    }
+    if (stable) {
+      stableSince ??= Date.now();
+      if (Date.now() - stableSince >= stableFor) return;
     } else {
-      connectedSince = null;
+      stableSince = null;
     }
     await new Promise((r) => setTimeout(r, interval));
   }
   throw new Error(
-    `OpenClaw did not stabilise (connected=true for ${String(stableFor)}ms) within deadline`
+    `OpenClaw did not stabilise (connected=true with configPushesPending=0 for ${String(stableFor)}ms) within deadline`
   );
 }
 

--- a/packages/web/e2e/web/web-search.spec.ts
+++ b/packages/web/e2e/web/web-search.spec.ts
@@ -114,7 +114,11 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
   let restoreSettings: (() => Promise<void>) | null = null;
 
   test.beforeAll(async ({}, testInfo) => {
-    testInfo.setTimeout(180_000);
+    // 240 s (was 180 s): waitForOpenClawStable now also waits for
+    // configPushesPending=0, whose worst case (a config.apply parked across
+    // rate-limit windows before the file fallback settles it) adds up to
+    // ~100 s before the 30 s stable streak can begin.
+    testInfo.setTimeout(240_000);
 
     // 1. Start fake-Ollama on the host (port 11435).
     await startFakeOllama();

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,7 +92,7 @@
     "eslint-config-next": "16.2.6",
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.5.28",
+    "openclaw": "2026.6.1",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,7 +92,7 @@
     "eslint-config-next": "16.2.6",
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.6.1",
+    "openclaw": "2026.6.5",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -8,6 +8,7 @@ import { SessionCache } from "./src/server/session-cache";
 import { validateWsSession } from "./src/server/ws-auth";
 import { restartState } from "./src/server/restart-state";
 import { openClawConnectionState } from "./src/server/openclaw-connection-state";
+import { applyKeepAliveTuning } from "./src/server/http-keepalive";
 import { setOpenClawClient } from "./src/server/openclaw-client";
 import { getActiveRunsSingleton } from "./src/server/active-runs-singleton";
 import {
@@ -251,6 +252,12 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   });
 
   const port = parseInt(process.env.PORT || "7777", 10);
+
+  // Hold idle keep-alive connections far longer than Node's 5s default so a
+  // connection-reusing client (browser, Playwright APIRequestContext, or a
+  // production reverse proxy) never reuses a socket the server is closing at
+  // that instant → no intermittent `socket hang up`. See http-keepalive.ts.
+  applyKeepAliveTuning(server);
 
   // Start listening BEFORE bootInits so the Docker Compose healthcheck can
   // reach /api/internal/openclaw-config-ready immediately. The endpoint returns

--- a/packages/web/src/__tests__/api/health-openclaw.test.ts
+++ b/packages/web/src/__tests__/api/health-openclaw.test.ts
@@ -25,6 +25,7 @@ function fakeRequest(url = "http://localhost/api/health/openclaw"): NextRequest 
 
 describe("GET /api/health/openclaw", () => {
   let GET: typeof import("@/app/api/health/openclaw/route").GET;
+  let pushState: typeof import("@/lib/openclaw-config/push-state");
 
   beforeEach(async () => {
     vi.resetModules();
@@ -33,6 +34,11 @@ describe("GET /api/health/openclaw", () => {
     mockRestartState.triggeredAt = null;
     mockConnectionState.connected = false;
     mockGetOpenClawClient.mockReturnValue({ config: { get: mockConfigGet } });
+    // The push-state tracker is globalThis-backed (NOT mocked here): the route
+    // must read the same counter `pushConfigInBackground` writes, across the
+    // Next-route vs custom-server module-graph split.
+    pushState = await import("@/lib/openclaw-config/push-state");
+    pushState._resetConfigPushState();
     const mod = await import("@/app/api/health/openclaw/route");
     GET = mod.GET;
   });
@@ -42,7 +48,7 @@ describe("GET /api/health/openclaw", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({ status: "ok", connected: false });
+    expect(body).toEqual({ status: "ok", connected: false, configPushesPending: 0 });
   });
 
   it("returns ok with connected: true when OpenClaw is connected", async () => {
@@ -52,7 +58,27 @@ describe("GET /api/health/openclaw", () => {
     const body = await response.json();
 
     expect(response.status).toBe(200);
-    expect(body).toEqual({ status: "ok", connected: true });
+    expect(body).toEqual({ status: "ok", connected: true, configPushesPending: 0 });
+  });
+
+  it("reports configPushesPending while a background config push is in flight", async () => {
+    // The email dispatch-probe flake: a rate-limited config.apply can park a
+    // push coroutine 33–53 s; health reported connected=true the whole time,
+    // so E2E stability gates dispatched into the gap and the agent ran without
+    // its freshly-granted tools. The gate needs this counter to wait it out.
+    mockConnectionState.connected = true;
+    pushState.trackConfigPushStarted();
+    pushState.trackConfigPushStarted();
+
+    const response = await GET(fakeRequest());
+    const body = await response.json();
+
+    expect(body).toEqual({ status: "ok", connected: true, configPushesPending: 2 });
+
+    pushState.trackConfigPushSettled();
+    pushState.trackConfigPushSettled();
+    const after = await (await GET(fakeRequest())).json();
+    expect(after.configPushesPending).toBe(0);
   });
 
   it("returns restarting with connected: false when restarting", async () => {
@@ -79,7 +105,12 @@ describe("GET /api/health/openclaw", () => {
       const body = await response.json();
 
       expect(response.status).toBe(200);
-      expect(body).toEqual({ status: "ok", connected: true, agentDispatchable: true });
+      expect(body).toEqual({
+        status: "ok",
+        connected: true,
+        configPushesPending: 0,
+        agentDispatchable: true,
+      });
     });
 
     it("returns agentDispatchable: false when the requested id is NOT in OC's list", async () => {

--- a/packages/web/src/__tests__/lib/dispatch-probe-stability.test.ts
+++ b/packages/web/src/__tests__/lib/dispatch-probe-stability.test.ts
@@ -1,0 +1,80 @@
+// Unit tests for the E2E dispatch-probe stability gate (e2e/shared/dispatch-probe.ts).
+//
+// The gate must wait not only for `connected=true` but also for
+// `configPushesPending === 0`: a rate-limited `config.apply` parks a push
+// coroutine for 33–53 s during which OC stays connected — so a connection-only
+// stability window passes while a freshly-granted per-agent plugin config is
+// still NOT in OC's runtime, and the suite dispatches a chat whose run lacks
+// the granted tools (the email dispatch-probe flake).
+
+import { describe, it, expect } from "vitest";
+import { waitForOpenClawStable } from "../../../e2e/shared/dispatch-probe";
+
+type HealthBody = { connected?: boolean; configPushesPending?: number };
+
+function healthSequence(bodies: HealthBody[]) {
+  let calls = 0;
+  let firstSettledAt: number | null = null;
+  const fetchHealth = async () => {
+    const body = bodies[Math.min(calls, bodies.length - 1)];
+    calls++;
+    if ((body.configPushesPending ?? 0) === 0 && body.connected) {
+      firstSettledAt ??= Date.now();
+    }
+    return { ok: true, json: async () => body };
+  };
+  return { fetchHealth, callCount: () => calls, firstSettledAt: () => firstSettledAt };
+}
+
+describe("waitForOpenClawStable", () => {
+  it("does not report stable while configPushesPending > 0, then settles once pushes drain", async () => {
+    // First 5 polls: connected but a push is parked (rate-limit window).
+    // Afterwards: pending drains to 0 → the stable window may start.
+    //
+    // Assertions are deliberately wall-clock-based, NOT poll-count-based: under
+    // CI load `setTimeout(intervalMs)` stretches, so the number of polls needed
+    // to span the stable window is unpredictable (a poll-count assertion here
+    // was itself flaky). The contract is: (a) every pending response is
+    // consumed before returning, and (b) the stable window only starts at the
+    // first settled response.
+    const pending: HealthBody = { connected: true, configPushesPending: 1 };
+    const settled: HealthBody = { connected: true, configPushesPending: 0 };
+    const { fetchHealth, callCount, firstSettledAt } = healthSequence([
+      pending,
+      pending,
+      pending,
+      pending,
+      pending,
+      settled,
+    ]);
+
+    await waitForOpenClawStable(fetchHealth, {
+      deadlineMs: 5_000,
+      stableForMs: 30,
+      intervalMs: 5,
+    });
+    const resolvedAt = Date.now();
+
+    // (a) It cannot have returned during the pending phase: all five pending
+    // responses (plus at least one settled) were consumed.
+    expect(callCount()).toBeGreaterThanOrEqual(6);
+    // (b) The stableFor window was measured from the FIRST settled poll — the
+    // pending polls did not count toward it.
+    expect(firstSettledAt()).not.toBeNull();
+    expect(resolvedAt - (firstSettledAt() as number)).toBeGreaterThanOrEqual(30);
+  });
+
+  it("treats a missing configPushesPending field as settled (backwards compatible)", async () => {
+    const { fetchHealth } = healthSequence([{ connected: true }]);
+    await expect(
+      waitForOpenClawStable(fetchHealth, { deadlineMs: 2_000, stableForMs: 20, intervalMs: 5 })
+    ).resolves.toBeUndefined();
+  });
+
+  it("throws at the deadline when pushes never settle (bounded, loud failure)", async () => {
+    const { fetchHealth } = healthSequence([{ connected: true, configPushesPending: 1 }]);
+    await expect(
+      waitForOpenClawStable(fetchHealth, { deadlineMs: 100, stableForMs: 20, intervalMs: 5 })
+    ).rejects.toThrow(/did not stabilise/);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -139,6 +139,7 @@ import {
   DOCS_PUBLIC_BASE_URL_SETTING_KEY,
 } from "@/lib/openclaw-config";
 import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
+import { getPendingConfigPushCount, _resetConfigPushState } from "@/lib/openclaw-config/push-state";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
 import { fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
@@ -3149,6 +3150,49 @@ describe("regenerateOpenClawConfig", () => {
       const appliedPayload = String(mockConfigApply.mock.calls[0][0]);
       expect(appliedPayload).toContain('"NEW"');
       expect(appliedPayload).not.toContain('"OLD"');
+    });
+
+    it("tracks pending state across the push lifecycle (applied, superseded, no-client)", async () => {
+      // Under OC 5.3's config.apply rate-limit a push coroutine can be parked
+      // 33–53 s; nothing observable said "a config change is still in flight",
+      // so E2E stability gates passed and dispatched into the gap (the email
+      // dispatch-probe flake). Contract: every pushConfigInBackground call is
+      // pending until its coroutine reaches ANY terminal state — applied,
+      // superseded, or file-write fallback — and the counter returns to 0.
+      _resetConfigPushState();
+
+      // Case 1: applied via WS — pending while config.apply is in flight.
+      let resolveApply!: () => void;
+      mockConfigGet.mockResolvedValue({ hash: "h1" });
+      mockConfigApply.mockImplementation(
+        () => new Promise<void>((resolve) => (resolveApply = resolve))
+      );
+      mockGetClient.mockImplementation(() => ({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      }));
+
+      pushConfigInBackground(JSON.stringify({ env: { A: "1" } }));
+      expect(getPendingConfigPushCount()).toBe(1);
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      // Still pending while the apply RPC is unresolved.
+      expect(getPendingConfigPushCount()).toBe(1);
+      resolveApply();
+      await vi.waitFor(() => expect(getPendingConfigPushCount()).toBe(0));
+
+      // Case 2: superseded — BOTH pushes settle (the older via the generation
+      // check, the newer via its apply), never leaving a stuck pending count.
+      mockConfigApply.mockResolvedValue(undefined);
+      pushConfigInBackground(JSON.stringify({ env: { OLD: "1" } }));
+      pushConfigInBackground(JSON.stringify({ env: { NEW: "2" } }));
+      expect(getPendingConfigPushCount()).toBe(2);
+      await vi.waitFor(() => expect(getPendingConfigPushCount()).toBe(0));
+
+      // Case 3: no WS client — synchronous file-write fallback still settles.
+      mockGetClient.mockImplementation(() => {
+        throw new Error("OpenClaw client not initialized");
+      });
+      pushConfigInBackground(JSON.stringify({ env: { B: "1" } }));
+      await vi.waitFor(() => expect(getPendingConfigPushCount()).toBe(0));
     });
 
     it("supplements channels.telegram fields absent from payload from OC in-memory config (OC 4.27+ channel diff prevention)", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config/push-state.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/push-state.test.ts
@@ -1,0 +1,66 @@
+// Unit tests for the config-push pending-state tracker.
+//
+// Why this exists: `pushConfigInBackground` is fire-and-forget, and under
+// OC 5.3's config.apply rate-limit (~3 calls / 45 s) a push coroutine can be
+// parked for 33–53 s waiting out the window. During that gap the config change
+// (e.g. a freshly-granted per-agent plugin config) is NOT in OC's runtime, but
+// nothing observable says so — `/api/health/openclaw` reports connected=true
+// throughout, so E2E stability gates pass and the test dispatches a chat whose
+// run snapshots its tool list WITHOUT the pending change (the email
+// dispatch-probe flake: "I can't use the tool email_list … it isn't available").
+//
+// The tracker makes "pushes still in flight" observable. It must live on
+// globalThis because Next.js API routes (which serve /api/health/openclaw) and
+// the custom server (which also triggers regenerates) can load SEPARATE module
+// instances — same reason as server/openclaw-client.ts.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  trackConfigPushStarted,
+  trackConfigPushSettled,
+  getPendingConfigPushCount,
+  _resetConfigPushState,
+} from "@/lib/openclaw-config/push-state";
+
+describe("config push pending-state tracker", () => {
+  beforeEach(() => {
+    _resetConfigPushState();
+  });
+
+  it("starts at zero pending", () => {
+    expect(getPendingConfigPushCount()).toBe(0);
+  });
+
+  it("counts started pushes and settles them back to zero", () => {
+    trackConfigPushStarted();
+    expect(getPendingConfigPushCount()).toBe(1);
+    trackConfigPushStarted();
+    expect(getPendingConfigPushCount()).toBe(2);
+    trackConfigPushSettled();
+    expect(getPendingConfigPushCount()).toBe(1);
+    trackConfigPushSettled();
+    expect(getPendingConfigPushCount()).toBe(0);
+  });
+
+  it("floors at zero on a spurious extra settle (never goes negative)", () => {
+    trackConfigPushSettled();
+    expect(getPendingConfigPushCount()).toBe(0);
+  });
+
+  it("is backed by globalThis so separate module instances share one counter", () => {
+    // The Next route bundle and the custom-server (tsx) bundle each get their
+    // own module instance of push-state. A plain module-level variable would
+    // give the health route a counter the server's pushes never touch. Pin the
+    // contract: the state lives under a well-known globalThis key.
+    trackConfigPushStarted();
+    const state = (globalThis as Record<string, unknown>).__pinchyConfigPushState as {
+      pending: number;
+    };
+    expect(state).toBeDefined();
+    expect(state.pending).toBe(1);
+    // And the reverse direction: a foreign module instance mutating the global
+    // is visible through our getter.
+    state.pending = 3;
+    expect(getPendingConfigPushCount()).toBe(3);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-version-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-version-pin-drift.test.ts
@@ -25,7 +25,7 @@ import { resolve } from "node:path";
 const REPO_ROOT = resolve(__dirname, "../../../../..");
 const DOCKERFILE_OPENCLAW = readFileSync(resolve(REPO_ROOT, "Dockerfile.openclaw"), "utf8");
 const WEB_PACKAGE_JSON = JSON.parse(
-  readFileSync(resolve(__dirname, "../../../package.json"), "utf8")
+  readFileSync(resolve(REPO_ROOT, "packages/web/package.json"), "utf8")
 ) as {
   dependencies?: Record<string, string>;
   devDependencies?: Record<string, string>;

--- a/packages/web/src/__tests__/lib/openclaw-version-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-version-pin-drift.test.ts
@@ -1,0 +1,63 @@
+/**
+ * Drift guard for the OpenClaw version pin.
+ *
+ * OpenClaw's version lives in two places that must stay in lockstep:
+ *
+ *   1. `Dockerfile.openclaw` — `RUN npm install -g openclaw@X.Y.Z` installs the
+ *      runtime that actually answers Gateway RPCs.
+ *   2. `packages/web/package.json` — `devDependencies.openclaw` is the SINGLE
+ *      source `next.config.ts` reads to populate `NEXT_PUBLIC_OPENCLAW_VERSION`,
+ *      which `/api/version` and the diagnostics bundle report to operators.
+ *
+ * If these drift, `/api/version` lies: it reports a version the container is not
+ * running. That is the exact failure class the release-version guards exist to
+ * stop for Pinchy's own version (assert-package-version.mjs) — this test extends
+ * the same contract to the OpenClaw pin, which has no other guard.
+ *
+ * Structural check so the drift trips here at `pnpm test` instead of in a
+ * post-release `/api/version` smoke test.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const DOCKERFILE_OPENCLAW = readFileSync(resolve(REPO_ROOT, "Dockerfile.openclaw"), "utf8");
+const WEB_PACKAGE_JSON = JSON.parse(
+  readFileSync(resolve(__dirname, "../../../package.json"), "utf8")
+) as {
+  dependencies?: Record<string, string>;
+  devDependencies?: Record<string, string>;
+};
+
+/**
+ * Extract the version from the canonical
+ * `RUN npm install -g openclaw@<version>` line in Dockerfile.openclaw.
+ * Intentionally narrow: a `@scope/openclaw` or a differently-named package
+ * must not match, so a refactor that renames the install can't silently
+ * defeat the guard.
+ */
+function dockerfileOpenclawVersion(dockerfile: string): string | undefined {
+  const match = dockerfile.match(/npm install -g openclaw@(\d[^\s"']*)/);
+  return match?.[1];
+}
+
+describe("OpenClaw version pin drift guard", () => {
+  it("Dockerfile.openclaw declares an openclaw@<version> install", () => {
+    expect(dockerfileOpenclawVersion(DOCKERFILE_OPENCLAW)).toBeDefined();
+  });
+
+  it("package.json declares an openclaw dependency", () => {
+    const pkgVersion =
+      WEB_PACKAGE_JSON.devDependencies?.openclaw ?? WEB_PACKAGE_JSON.dependencies?.openclaw;
+    expect(pkgVersion).toBeDefined();
+  });
+
+  it("Dockerfile install version matches package.json (so /api/version is truthful)", () => {
+    const dockerfileVersion = dockerfileOpenclawVersion(DOCKERFILE_OPENCLAW);
+    const pkgVersion =
+      WEB_PACKAGE_JSON.devDependencies?.openclaw ?? WEB_PACKAGE_JSON.dependencies?.openclaw;
+    expect(dockerfileVersion).toBe(pkgVersion);
+  });
+});

--- a/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
+++ b/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
@@ -11,7 +11,11 @@
 
 import { describe, it, expect, vi } from "vitest";
 import type { ChatChunk, ChatOptions } from "openclaw-node";
-import { chatWithDispatchRaceRetry, DISPATCH_RACE_PATTERN } from "@/server/chat-dispatch-retry";
+import {
+  chatWithDispatchRaceRetry,
+  DISPATCH_RACE_PATTERN,
+  MODEL_DISPATCH_RACE_PATTERN,
+} from "@/server/chat-dispatch-retry";
 
 function makeStream(chunks: ChatChunk[]) {
   return async function* () {
@@ -325,6 +329,162 @@ describe("chatWithDispatchRaceRetry", () => {
       expect(DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
       expect(clock.now()).toBeLessThanOrEqual(3000);
     });
+  });
+
+  // The cold-start config-apply storm can land the AGENT (`agents.list`) before
+  // its model's PROVIDER (`models`): OpenClaw accepts the dispatch (agent id is
+  // known) but the run immediately errors `FailoverError: Unknown model:
+  // <provider>/<model>` because the provider block isn't applied yet. Observed
+  // directly on the 2026.6.1 setup-wizard Google spec: agent applied 07:18:04,
+  // `models` applied 07:19:06, first chat dispatched 07:18:26 → "Unknown model".
+  // This is the SAME transient race as "unknown agent id", one config layer up,
+  // so the wrapper must retry it too — but via bounded backoff, NOT the
+  // agents.list gate (the agent is already present, so the gate would return
+  // true and hot-loop).
+  describe("model dispatch race (cold-start provider/models apply lag)", () => {
+    function modelRaceError(ref = "google/gemini-2.5-pro"): ChatChunk[] {
+      return [{ type: "error", text: `Unknown model: ${ref}`, runId: "r0" }];
+    }
+
+    it("retries the transient first-chunk 'Unknown model' race until the provider applies, swallowing it", async () => {
+      const successful: ChatChunk[] = [
+        { type: "text", text: "Sure, happy to help!", runId: "r1" },
+        { type: "done", text: "", runId: "r1" },
+      ];
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(modelRaceError()))
+        .mockImplementationOnce(makeStream(modelRaceError()))
+        .mockImplementationOnce(makeStream(modelRaceError()))
+        .mockImplementationOnce(makeStream(successful));
+
+      const clock = fakeClock();
+      const onDispatchRaceObserved = vi.fn();
+
+      const got = await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "596489fc-45c7-4113-8a82-b5f8d28861d7" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, onDispatchRaceObserved },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 150000 }
+        )
+      );
+
+      expect(got).toEqual(successful);
+      expect(chat).toHaveBeenCalledTimes(4);
+      // Bounded backoff governs the model race (no agents.list gate available
+      // for provider/models readiness): 500, 1000, 2000.
+      expect(clock.delay.mock.calls.map((c) => c[0])).toEqual([500, 1000, 2000]);
+      // Audited ONCE per raced dispatch, with the model-error text.
+      expect(onDispatchRaceObserved).toHaveBeenCalledTimes(1);
+      expect(onDispatchRaceObserved.mock.calls[0][0].providerError).toMatch(/unknown model/i);
+    });
+
+    it("retries when the model error follows the userMessagePersisted ack (the real OC chunk order)", async () => {
+      // Client-originated messages carry a clientMessageId, so OpenClaw ACKs the
+      // accepted dispatch with a leading `userMessagePersisted` chunk and only
+      // THEN fails resolving the model → the race error is the SECOND chunk. The
+      // ack must pass through (so the browser's ack-timeout clears) AND the
+      // error must still trigger a retry.
+      const ack: ChatChunk = {
+        type: "userMessagePersisted",
+        text: "",
+        runId: "r0",
+      } as unknown as ChatChunk;
+      const failedAttempt: ChatChunk[] = [ack, ...modelRaceError()];
+      const successfulAttempt: ChatChunk[] = [
+        ack,
+        { type: "text", text: "Sure, happy to help!", runId: "r1" },
+        { type: "done", text: "", runId: "r1" },
+      ];
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(failedAttempt))
+        .mockImplementationOnce(makeStream(successfulAttempt));
+
+      const clock = fakeClock();
+
+      const got = await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a", clientMessageId: "c-1" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 150000 }
+        )
+      );
+
+      // The failed attempt's ack passed through (ack-timeout safety); the model
+      // error was swallowed and retried; the successful attempt streamed.
+      expect(chat).toHaveBeenCalledTimes(2);
+      expect(got.map((c) => c.type)).toEqual([
+        "userMessagePersisted",
+        "userMessagePersisted",
+        "text",
+        "done",
+      ]);
+      // The "Unknown model" error never reached the caller.
+      expect(got.some((c) => c.type === "error")).toBe(false);
+    });
+
+    it("uses bounded backoff for the model race and does NOT consult the agents.list gate", async () => {
+      // The agent IS already present in the runtime (that's why OC accepted the
+      // dispatch before failing on the model), so gating on agents.list would
+      // return true and immediate-continue into a hot loop. The model race must
+      // therefore bypass the gate and rely on backoff.
+      const chat = vi
+        .fn()
+        .mockImplementationOnce(makeStream(modelRaceError()))
+        .mockImplementationOnce(makeStream([{ type: "done", text: "", runId: "r1" }]));
+
+      const clock = fakeClock();
+      const awaitAgentReady = vi.fn(async () => true);
+
+      await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now, awaitAgentReady },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 150000 }
+        )
+      );
+
+      // Gate NOT consulted for the model race; backoff used instead.
+      expect(awaitAgentReady).not.toHaveBeenCalled();
+      expect(clock.delay.mock.calls.map((c) => c[0])).toEqual([500]);
+    });
+
+    it("surfaces the 'Unknown model' error once the wall-clock budget is exhausted (bounded)", async () => {
+      const chat = vi.fn(makeStream(modelRaceError()));
+      const clock = fakeClock();
+
+      const got = await collect(
+        chatWithDispatchRaceRetry(
+          "hello",
+          { agentId: "a" } as ChatOptions,
+          { chat: chat as never, delay: clock.delay, now: clock.now },
+          { baseDelayMs: 500, maxDelayMs: 5000, maxTotalMs: 3000 }
+        )
+      );
+
+      expect(got).toHaveLength(1);
+      expect(got[0].type).toBe("error");
+      expect(MODEL_DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
+      expect(clock.now()).toBeLessThanOrEqual(3000);
+    });
+  });
+
+  it("MODEL_DISPATCH_RACE_PATTERN matches the OC FailoverError shape, not unrelated model errors", () => {
+    expect(MODEL_DISPATCH_RACE_PATTERN.test("Unknown model: google/gemini-2.5-pro")).toBe(true);
+    expect(MODEL_DISPATCH_RACE_PATTERN.test("FailoverError: Unknown model: openai/gpt-5.5")).toBe(
+      true
+    );
+    // A streaming/terminal failure that merely mentions "model" must NOT match.
+    expect(
+      MODEL_DISPATCH_RACE_PATTERN.test(
+        "FailoverError: provider/model ended with an incomplete terminal response"
+      )
+    ).toBe(false);
+    expect(MODEL_DISPATCH_RACE_PATTERN.test('unknown agent id "abc"')).toBe(false);
   });
 
   it("DISPATCH_RACE_PATTERN matches the exact OC 2026.5.x error message shape", () => {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -339,6 +339,54 @@ describe("ClientRouter", () => {
     expect(textChunks[1].content).toBe("there!");
   });
 
+  it("recovers from the cold-start 'Unknown model' dispatch race without surfacing an error", async () => {
+    // End-to-end guard for the OC 2026.6.1 setup-wizard flake: the cold-start
+    // config-apply storm lands the agent before its model's provider, so the
+    // first dispatch is ACCEPTED (emits the `userMessagePersisted` ack) and
+    // only THEN fails resolving the model. The chat path must retry and stream
+    // the recovered reply — never surface "Unknown model" to the browser.
+    const clientWs = createMockClientWs();
+    const clientMessageId = "client-msg-race";
+
+    async function* acceptedThenModelRace() {
+      yield { type: "userMessagePersisted" as const, clientMessageId, runId: "run-failed" };
+      yield {
+        type: "error" as const,
+        text: "Unknown model: google/gemini-2.5-pro",
+        runId: "run-failed",
+      };
+    }
+    async function* succeedsAfterProviderApplies() {
+      yield { type: "userMessagePersisted" as const, clientMessageId, runId: "run-ok" };
+      yield { type: "text" as const, text: "Sure, happy to help!" };
+      yield { type: "done" as const, text: "" };
+    }
+    mockChat
+      .mockReturnValueOnce(acceptedThenModelRace())
+      .mockReturnValueOnce(succeedsAfterProviderApplies());
+
+    await router.handleMessage(clientWs as any, {
+      type: "message",
+      content: "Hello, are you working?",
+      agentId: "agent-1",
+      clientMessageId,
+    });
+
+    // The race was retried (a second dispatch), not surfaced.
+    expect(mockChat).toHaveBeenCalledTimes(2);
+    const frames = clientWs.sent.map((s) => JSON.parse(s));
+    // The recovered reply reached the browser...
+    const chunks = frames.filter((m: { type: string }) => m.type === "chunk");
+    expect(chunks.map((c: { content: string }) => c.content).join("")).toContain(
+      "Sure, happy to help!"
+    );
+    // ...and the "Unknown model" error never did (no false "Smithers couldn't respond").
+    expect(frames.some((m: { type: string }) => m.type === "error")).toBe(false);
+    // The user's message was still acked immediately (ack-timeout safety), so the
+    // optimistic bubble isn't marked failed during the retry window.
+    expect(frames.some((m: { type: string }) => m.type === "ack")).toBe(true);
+  });
+
   it("should strip <final> tags from streamed chunks", async () => {
     const clientWs = createMockClientWs();
     async function* fakeStream() {

--- a/packages/web/src/__tests__/server/http-keepalive.test.ts
+++ b/packages/web/src/__tests__/server/http-keepalive.test.ts
@@ -1,0 +1,33 @@
+import { describe, it, expect } from "vitest";
+import {
+  KEEP_ALIVE_TIMEOUT_MS,
+  HEADERS_TIMEOUT_MS,
+  applyKeepAliveTuning,
+} from "@/server/http-keepalive";
+
+describe("HTTP keep-alive tuning", () => {
+  it("keepAliveTimeout is well above Node's 5s default so an idle socket isn't closed mid-reuse", () => {
+    // The flake this guards against: Node's default `keepAliveTimeout` (5s)
+    // closes an idle keep-alive socket exactly as a connection-reusing client
+    // (browser / Playwright APIRequestContext) sends its next request → the
+    // client observes ECONNRESET = "socket hang up". A timeout comfortably
+    // longer than any inter-request gap in a test or proxy keep-alive window
+    // removes the race.
+    expect(KEEP_ALIVE_TIMEOUT_MS).toBeGreaterThanOrEqual(60_000);
+  });
+
+  it("headersTimeout exceeds keepAliveTimeout (else Node kills long-kept-alive connections)", () => {
+    // Node requires headersTimeout > keepAliveTimeout: otherwise the
+    // headersTimeout can fire while the server is idly waiting for the next
+    // request on a kept-alive connection, re-introducing the very reset we're
+    // removing. Keeping them in one helper enforces the invariant.
+    expect(HEADERS_TIMEOUT_MS).toBeGreaterThan(KEEP_ALIVE_TIMEOUT_MS);
+  });
+
+  it("applyKeepAliveTuning sets both timeouts on the server instance", () => {
+    const server = {} as { keepAliveTimeout?: number; headersTimeout?: number };
+    applyKeepAliveTuning(server as unknown as import("http").Server);
+    expect(server.keepAliveTimeout).toBe(KEEP_ALIVE_TIMEOUT_MS);
+    expect(server.headersTimeout).toBe(HEADERS_TIMEOUT_MS);
+  });
+});

--- a/packages/web/src/__tests__/server/ws-frame-limit.test.ts
+++ b/packages/web/src/__tests__/server/ws-frame-limit.test.ts
@@ -14,6 +14,38 @@ import { SERVER_WS_MAX_PAYLOAD_BYTES } from "@/lib/limits";
  * a 5 MB JSON frame, and asserts the server delivers the message instead of
  * closing with code 1009 ("Message too big").
  */
+/**
+ * Open a WebSocket to the local test server, retrying the CONNECT phase on
+ * transient handshake failures (bounded, fresh socket per attempt).
+ *
+ * Why: under full-suite load (many vitest forks + local Docker stacks) a
+ * single-shot localhost TCP/WS handshake can fail with `socket hang up`
+ * (ECONNRESET during the HTTP upgrade) — pure environmental noise that has
+ * nothing to do with this file's contract, which is the server's `maxPayload`
+ * behaviour AFTER a connection exists. Retrying only the connect phase removes
+ * that noise without weakening the contract: every assertion still runs
+ * against a real connection, and a maxPayload regression fails exactly as
+ * before.
+ */
+async function connectWithRetry(port: number, attempts = 3): Promise<WebSocket> {
+  let lastError: unknown;
+  for (let i = 0; i < attempts; i++) {
+    const client = new WebSocket(`ws://127.0.0.1:${port}`);
+    try {
+      await new Promise<void>((resolve, reject) => {
+        client.once("open", () => resolve());
+        client.once("error", reject);
+      });
+      return client;
+    } catch (err) {
+      lastError = err;
+      client.terminate();
+      await new Promise((r) => setTimeout(r, 100 * (i + 1)));
+    }
+  }
+  throw lastError;
+}
+
 describe("WebSocket server frame limit (regression guard)", () => {
   let httpServer: HttpServer;
   let wss: WebSocketServer;
@@ -48,11 +80,7 @@ describe("WebSocket server frame limit (regression guard)", () => {
       });
     });
 
-    const client = new WebSocket(`ws://127.0.0.1:${port}`);
-    await new Promise<void>((resolve, reject) => {
-      client.once("open", () => resolve());
-      client.once("error", reject);
-    });
+    const client = await connectWithRetry(port);
 
     // 5 MB of base64-ish content, wrapped in a JSON message so it mirrors what
     // the real router parses.
@@ -86,11 +114,7 @@ describe("WebSocket server frame limit (regression guard)", () => {
       ws.on("error", () => {});
     });
 
-    const client = new WebSocket(`ws://127.0.0.1:${port}`);
-    await new Promise<void>((resolve, reject) => {
-      client.once("open", () => resolve());
-      client.once("error", reject);
-    });
+    const client = await connectWithRetry(port);
 
     const closeEvent = new Promise<{ code: number }>((resolve) => {
       client.once("close", (code) => resolve({ code }));

--- a/packages/web/src/app/api/health/openclaw/route.ts
+++ b/packages/web/src/app/api/health/openclaw/route.ts
@@ -3,6 +3,7 @@ import { restartState } from "@/server/restart-state";
 import { openClawConnectionState } from "@/server/openclaw-connection-state";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { getChannelHealthMonitor } from "@/server/channel-health-singleton";
+import { getPendingConfigPushCount } from "@/lib/openclaw-config/push-state";
 
 /**
  * GET `/api/health/openclaw[?agentId=<uuid>]`
@@ -36,7 +37,16 @@ export async function GET(request: NextRequest) {
     });
   }
 
-  const base = { status: "ok" as const, connected: openClawConnectionState.connected };
+  // `configPushesPending`: number of `pushConfigInBackground` coroutines still
+  // in flight. A rate-limited config.apply can park a push 33–53 s during which
+  // the change (e.g. a freshly-granted per-agent plugin config) is NOT in OC's
+  // runtime while `connected` stays true. E2E stability gates require this to
+  // be 0 before dispatching, so chats never race a parked config change.
+  const base = {
+    status: "ok" as const,
+    connected: openClawConnectionState.connected,
+    configPushesPending: getPendingConfigPushCount(),
+  };
 
   // With `?channelHealth=1`: the channel-health watchdog's per-account snapshot,
   // used by the admin Telegram settings UI to show a "degraded" badge. Reading

--- a/packages/web/src/lib/openclaw-config/push-state.ts
+++ b/packages/web/src/lib/openclaw-config/push-state.ts
@@ -1,0 +1,60 @@
+// Pending-state tracker for `pushConfigInBackground` coroutines.
+//
+// Why: config pushes are fire-and-forget, and under OC 5.3's `config.apply`
+// rate-limit (~3 calls / 45 s) a push coroutine can be PARKED for 33–53 s
+// waiting out the advertised window. During that gap the config change — e.g.
+// a freshly-granted `plugins.entries.pinchy-email.config.agents.<id>` block —
+// is not yet in OC's runtime, but nothing observable said so: OC stays
+// connected, `/api/health/openclaw` reports `connected: true`, the E2E
+// stability gates pass, and the suite dispatches a chat whose run snapshots
+// its tool list WITHOUT the pending change. The agent then answers
+// "I can't use the tool email_list … it isn't available" (the email/odoo/web/
+// telegram dispatch-probe flake class, sibling of heypinchy/pinchy#464).
+//
+// This tracker makes "a config push is still in flight" observable.
+// `/api/health/openclaw` reports it as `configPushesPending`, and the E2E
+// stability gates require it to be 0 before declaring OC stable.
+//
+// globalThis-backed for the same reason as `server/openclaw-client.ts`:
+// Next.js API routes (which serve the health endpoint) and the custom server
+// (which also triggers regenerates) can load SEPARATE instances of this
+// module, so a plain module-level counter would give the route a counter the
+// server's pushes never touch.
+
+interface ConfigPushState {
+  pending: number;
+}
+
+declare global {
+  var __pinchyConfigPushState: ConfigPushState | undefined;
+}
+
+function state(): ConfigPushState {
+  globalThis.__pinchyConfigPushState ??= { pending: 0 };
+  return globalThis.__pinchyConfigPushState;
+}
+
+/** Record that a `pushConfigInBackground` coroutine has started. */
+export function trackConfigPushStarted(): void {
+  state().pending++;
+}
+
+/**
+ * Record that a push coroutine reached a terminal state — applied via WS,
+ * superseded by a newer push, or file-write fallback. Floors at zero so a
+ * spurious double-settle can never wedge the counter negative.
+ */
+export function trackConfigPushSettled(): void {
+  const s = state();
+  s.pending = Math.max(0, s.pending - 1);
+}
+
+/** Number of push coroutines currently in flight (0 = config is settled). */
+export function getPendingConfigPushCount(): number {
+  return state().pending;
+}
+
+/** Test-only: reset between tests. Do not call in app code. */
+export function _resetConfigPushState(): void {
+  state().pending = 0;
+}

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -8,6 +8,7 @@ import {
   configsAreEquivalentUpToOpenClawMetadata,
 } from "./normalize";
 import { CONFIG_PATH } from "./paths";
+import { trackConfigPushStarted, trackConfigPushSettled } from "./push-state";
 
 /** Atomic write: tmp file + rename to prevent OpenClaw reading a truncated config */
 export function writeConfigAtomic(content: string) {
@@ -171,6 +172,13 @@ const NOT_CONNECTED_RETRY_DELAY_MS = 2_000;
 
 export function pushConfigInBackground(newContent: string): void {
   const generation = ++_pushGeneration;
+
+  // Make the in-flight push observable (health endpoint `configPushesPending`,
+  // consumed by the E2E stability gates): a rate-limited apply can park this
+  // coroutine 33–53 s, during which the change is NOT in OC's runtime while
+  // everything else looks healthy. `.finally` below settles on EVERY terminal
+  // exit — applied, no-op skip, superseded, or file-write fallback.
+  trackConfigPushStarted();
 
   void (async () => {
     let client;
@@ -394,5 +402,5 @@ export function pushConfigInBackground(newContent: string): void {
         await new Promise((resolve) => setTimeout(resolve, backoffsMs[i]));
       }
     }
-  })();
+  })().finally(trackConfigPushSettled);
 }

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -62,6 +62,42 @@ import type { ChatChunk, ChatOptions } from "openclaw-node";
  */
 export const DISPATCH_RACE_PATTERN = /unknown agent id/i;
 
+/**
+ * Second cold-start race shape: the config-apply storm can land an agent
+ * (`agents.list`) into OC's runtime BEFORE its model's provider (`models`).
+ * OC then ACCEPTS the dispatch (the agent id is known) but the run immediately
+ * errors `FailoverError: Unknown model: <provider>/<model>` because the
+ * provider block hasn't applied yet. Observed on the OC 2026.6.1 setup-wizard
+ * Google spec: agent applied at 07:18:04, `models` at 07:19:06, first chat
+ * dispatched at 07:18:26 → "Unknown model" (the provider landed ~40 s later).
+ *
+ * Anchored on `unknown model` (OC's internal phrase) so an unrelated provider
+ * error that merely contains the word "model" (e.g. "provider/model ended with
+ * an incomplete terminal response") cannot hijack the retry branch.
+ * Case-insensitive against an upstream message-casing tweak.
+ *
+ * Safety / why a bounded retry is correct here, mirroring the agent-id case:
+ * Pinchy OWNS the agent's model selection — the setup wizard picks a known
+ * provider default and `/settings` validates against the provider catalog — so
+ * "Unknown model" for a Pinchy-managed agent is the transient apply-lag, not a
+ * real misconfiguration. The `maxTotalMs` budget still bounds the loop, so even
+ * a genuinely-unknown model surfaces (never hangs forever). Unlike the agent
+ * race there is NO deterministic gate: `agents.list` only reports agent
+ * presence (already true here), and openclaw-node 0.12.1 exposes no runtime
+ * `models` view, so the model race relies on the bounded-backoff backstop.
+ */
+export const MODEL_DISPATCH_RACE_PATTERN = /unknown model/i;
+
+/**
+ * Chunk types that represent real model output the user would see (or that a
+ * retry would duplicate). Once one of these is yielded, the run is genuinely
+ * producing a response, so a later error is a downstream failure — never a
+ * cold-start dispatch race — and must NOT be retried. Everything else that can
+ * precede the model error (the `userMessagePersisted` accepted-dispatch ack,
+ * lifecycle frames) is replay-safe / idempotent on the client.
+ */
+const OUTPUT_CHUNK_TYPES: ReadonlySet<string> = new Set(["text", "tool_use", "tool_result"]);
+
 /** Backoff/budget policy for the dispatch-race retry loop. */
 export interface DispatchRetryPolicy {
   /** Delay before the first retry; doubles each attempt. Default 500 ms. */
@@ -125,16 +161,26 @@ export interface DispatchRetryDeps {
  * `unknown agent id` dispatch-race error.
  *
  * Contract:
- *   - Yields ALL chunks from the first attempt whose first chunk is NOT an
- *     unknown-agent-id error.
- *   - While the first chunk IS an unknown-agent-id error, swallows it, waits a
- *     backoff delay (exponential, capped at `maxDelayMs`), and restarts the
- *     chat — repeating until success or the `maxTotalMs` budget is exhausted.
+ *   - Yields ALL chunks from an attempt that produces real model output (or any
+ *     non-race error).
+ *   - While a race error arrives BEFORE any model-output chunk (text / tool
+ *     use / tool result), swallows it, waits/gates, and restarts the chat —
+ *     repeating until success or the `maxTotalMs` budget is exhausted.
  *   - On budget exhaustion, yields the final race error so the caller surfaces
  *     it (never loops forever).
- *   - Never retries on errors arriving AFTER the first chunk, or on any error
- *     not matching the dispatch-race pattern — those are real downstream
+ *   - Never retries on errors arriving AFTER model output has started, or on any
+ *     error not matching a dispatch-race pattern — those are real downstream
  *     failures the caller's error path must handle.
+ *
+ * Why "before model output" and not "first chunk": a client-originated message
+ * carries a `clientMessageId`, so OpenClaw ACKs an accepted dispatch with a
+ * leading `userMessagePersisted` chunk. In the provider/models apply-lag race
+ * the dispatch is ACCEPTED (ack emitted) and only THEN fails resolving the model
+ * → the race error is the SECOND chunk, after the ack. Gating on model output
+ * (not chunk position) catches that while still refusing to retry once real
+ * tokens have streamed. The leading ack is yielded immediately (not buffered) so
+ * the browser's ack-timeout clears and the user's message isn't marked failed;
+ * a retry re-emits it, which is idempotent on the client (ack dedupes by id).
  */
 export async function* chatWithDispatchRaceRetry(
   message: string,
@@ -149,17 +195,32 @@ export async function* chatWithDispatchRaceRetry(
   const start = now();
   for (let attempt = 0; ; attempt++) {
     const stream = deps.chat(message, options);
-    let isFirstChunk = true;
+    // Real model output yielded yet this attempt? Leading ack/lifecycle chunks
+    // (e.g. `userMessagePersisted`) are NOT output: the model race fails AFTER
+    // the accepted-dispatch ack, so we must still treat that error as a race.
+    // Once real output streams, a later error is a genuine downstream failure.
+    let sawOutput = false;
     let raceError: ChatChunk | null = null;
+    // Which cold-start race fired: "agent" has a deterministic agents.list gate;
+    // "model" (provider/models not applied yet) does not, so it backoff-only.
+    let raceKind: "agent" | "model" | null = null;
 
     for await (const chunk of stream) {
-      if (isFirstChunk && chunk.type === "error" && DISPATCH_RACE_PATTERN.test(chunk.text)) {
-        // Dispatch-race detected on the first chunk. Don't yield it; record the
+      if (!sawOutput && chunk.type === "error") {
+        // Race detected before any model output. Don't yield it; record the
         // observation and let the loop decide whether to retry or give up.
-        raceError = chunk;
-        break;
+        if (DISPATCH_RACE_PATTERN.test(chunk.text)) {
+          raceError = chunk;
+          raceKind = "agent";
+          break;
+        }
+        if (MODEL_DISPATCH_RACE_PATTERN.test(chunk.text)) {
+          raceError = chunk;
+          raceKind = "model";
+          break;
+        }
       }
-      isFirstChunk = false;
+      if (OUTPUT_CHUNK_TYPES.has(chunk.type)) sawOutput = true;
       yield chunk;
     }
 
@@ -184,11 +245,17 @@ export async function* chatWithDispatchRaceRetry(
       return;
     }
 
-    // Deterministic readiness gate (preferred): poll OC's runtime agents.list —
-    // the same view the dispatch handler checks — until the agent is present,
-    // bounded by the remaining budget. On success, re-dispatch immediately into
-    // a ready runtime instead of sleeping a backoff window and hoping.
-    if (deps.awaitAgentReady) {
+    // Deterministic readiness gate (preferred) — AGENT race only: poll OC's
+    // runtime agents.list (the same view the dispatch handler checks) until the
+    // agent is present, bounded by the remaining budget. On success, re-dispatch
+    // immediately into a ready runtime instead of sleeping a backoff window.
+    //
+    // The MODEL race deliberately skips this gate: the agent is ALREADY present
+    // (OC accepted the dispatch before failing on the model), so the gate would
+    // return true and immediate-continue into a hot loop while the provider is
+    // still unapplied. With no runtime-`models` introspection to gate on, the
+    // model race relies on the capped backoff below.
+    if (raceKind === "agent" && deps.awaitAgentReady) {
       const ready = await deps.awaitAgentReady(remaining);
       if (ready) continue;
       // Not confirmed within the window (timeout, or unobservable on an older

--- a/packages/web/src/server/chat-dispatch-retry.ts
+++ b/packages/web/src/server/chat-dispatch-retry.ts
@@ -77,14 +77,25 @@ export const DISPATCH_RACE_PATTERN = /unknown agent id/i;
  * Case-insensitive against an upstream message-casing tweak.
  *
  * Safety / why a bounded retry is correct here, mirroring the agent-id case:
- * Pinchy OWNS the agent's model selection — the setup wizard picks a known
- * provider default and `/settings` validates against the provider catalog — so
- * "Unknown model" for a Pinchy-managed agent is the transient apply-lag, not a
- * real misconfiguration. The `maxTotalMs` budget still bounds the loop, so even
- * a genuinely-unknown model surfaces (never hangs forever). Unlike the agent
- * race there is NO deterministic gate: `agents.list` only reports agent
- * presence (already true here), and openclaw-node 0.12.1 exposes no runtime
- * `models` view, so the model race relies on the bounded-backoff backstop.
+ * Pinchy OWNS the agent's model selection and keeps it consistent with the
+ * configured providers — the setup wizard picks a known provider default,
+ * `/settings` validates the model against the provider catalog on save, and
+ * deleting a provider MIGRATES its agents to a remaining provider's default
+ * (`settings/providers/route.ts`). So in steady state no agent references a
+ * model OC can't resolve, and "Unknown model" at dispatch is the transient
+ * apply-lag — exactly the case worth retrying.
+ *
+ * The trade-off: a model that IS genuinely unresolvable (only reachable via an
+ * inconsistent out-of-band state, e.g. a direct DB edit) now costs up to the
+ * full `maxTotalMs` budget before the error surfaces, instead of failing fast.
+ * That's an accepted cost — the loop is still BOUNDED (never hangs forever), and
+ * the alternative (every wizard user's first message failing on the race) is
+ * far worse and far more common. Unlike the agent race there is NO deterministic
+ * gate: `agents.list` only reports agent presence (already true here), and
+ * openclaw-node 0.12.1 exposes no runtime `models` view, so the model race
+ * relies on the bounded-backoff backstop. (If openclaw-node later wraps a
+ * runtime-`models` read, gate the model race on it to fail genuine misconfigs
+ * fast — same upgrade the agent race got from `agents.list`.)
  */
 export const MODEL_DISPATCH_RACE_PATTERN = /unknown model/i;
 
@@ -95,6 +106,12 @@ export const MODEL_DISPATCH_RACE_PATTERN = /unknown model/i;
  * cold-start dispatch race — and must NOT be retried. Everything else that can
  * precede the model error (the `userMessagePersisted` accepted-dispatch ack,
  * lifecycle frames) is replay-safe / idempotent on the client.
+ *
+ * KEEP IN SYNC with openclaw-node's output-bearing `ChatChunk` types (currently
+ * `text` / `tool_use` / `tool_result` in 0.12.1). If a future openclaw-node adds
+ * an output chunk type (e.g. an image/audio delta) and it's missing here, a race
+ * error arriving AFTER that output could be retried and duplicate the output.
+ * This list is the safe default precisely because it errs toward NOT retrying.
  */
 const OUTPUT_CHUNK_TYPES: ReadonlySet<string> = new Set(["text", "tool_use", "tool_result"]);
 

--- a/packages/web/src/server/http-keepalive.ts
+++ b/packages/web/src/server/http-keepalive.ts
@@ -1,0 +1,38 @@
+// HTTP keep-alive tuning for Pinchy's custom Node server (server.ts).
+//
+// Node's `http.Server` defaults `keepAliveTimeout` to 5s: it closes an idle
+// keep-alive connection 5s after the last response. A client that pools and
+// REUSES connections — the browser, and Playwright's APIRequestContext in our
+// E2E suite, but also a production reverse proxy (Caddy/nginx/Traefik) — can
+// pick a socket the server is closing at that exact moment and observe
+// ECONNRESET, surfaced as `socket hang up`. It's a race, so it's intermittent
+// (it flaked one unrelated E2E request, green on every prior run), but the
+// window is real whenever the server sets no timeout.
+//
+// Fix: hold idle connections far longer than any realistic inter-request gap
+// (test step, or proxy keep-alive). Node additionally requires
+// `headersTimeout > keepAliveTimeout` — otherwise `headersTimeout` can fire
+// while the server idly waits for the next request on a kept-alive socket and
+// re-introduces the reset. Both live here, applied together, so the invariant
+// can't drift.
+
+import type { Server } from "http";
+
+/**
+ * Idle keep-alive window. 65s clears Node's 5s default by a wide margin and
+ * sits just above the common 60s reverse-proxy idle timeout, so the proxy (or
+ * test client) never reuses a socket Pinchy is simultaneously closing.
+ */
+export const KEEP_ALIVE_TIMEOUT_MS = 65_000;
+
+/**
+ * Must exceed {@link KEEP_ALIVE_TIMEOUT_MS} (Node requirement). 1s of headroom
+ * is enough — its only job is to stay strictly greater.
+ */
+export const HEADERS_TIMEOUT_MS = 66_000;
+
+/** Apply the keep-alive tuning to a server instance. Idempotent. */
+export function applyKeepAliveTuning(server: Server): void {
+  server.keepAliveTimeout = KEEP_ALIVE_TIMEOUT_MS;
+  server.headersTimeout = HEADERS_TIMEOUT_MS;
+}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       openclaw:
-        specifier: 2026.5.28
-        version: 2026.5.28
+        specifier: 2026.6.1
+        version: 2026.6.1
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -386,8 +386,8 @@ packages:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
     engines: {node: '>=10'}
 
-  '@anthropic-ai/sdk@0.98.0':
-    resolution: {integrity: sha512-N7aXtCvC5g6T1Y4V29lJjceu/zTkVkIZF0jdBvagr0TRFHuKeImffalGWEfqZKrvjH+IQbzJWw6TmSmUzrlMgg==}
+  '@anthropic-ai/sdk@0.100.1':
+    resolution: {integrity: sha512-RANcEe7LpiLczkKGOwoXOTuFdPhuubS0i4xaAKOMpcqc55YO0mukgxppV7eygx3DXNjxWT6RYOLPyOy0aIAmwg==}
     hasBin: true
     peerDependencies:
       zod: ^3.25.0 || ^4.0.0
@@ -820,8 +820,8 @@ packages:
   '@drizzle-team/brocli@0.10.2':
     resolution: {integrity: sha512-z33Il7l5dKjUgGULTqBsQBQwckHh5AbIuxhdsIxDDiZAzBOrZO6q9ogcWC65kU382AfynTfgNumVcNIjuIua6w==}
 
-  '@earendil-works/pi-tui@0.76.0':
-    resolution: {integrity: sha512-TWQEWqc38gVRYr/VTrlfePQPpJk938gNNLL1xuv0M+9cTkVr880/Q3baZQrxKoLrmN/MmVx7TyR8knYZGxTqqg==}
+  '@earendil-works/pi-tui@0.78.0':
+    resolution: {integrity: sha512-3a705FnsVVUhAyceShNB3kS2rpxcxLcx+hqB0u6MMMpHwQGbW+m++MqA6r7eOzq/8FLx5e3vDh38h/SVTk2qzw==}
     engines: {node: '>=22.19.0'}
 
   '@emnapi/core@1.10.0':
@@ -1371,8 +1371,8 @@ packages:
   '@floating-ui/utils@0.2.10':
     resolution: {integrity: sha512-aGTxbpbg8/b5JfU1HXSrbH3wXZuLPJcNEcZQFMxLs3oSzgtVu6nFPkbbGGUvBcUjKV2YyB9Wxxabo+HEH9tcRQ==}
 
-  '@google/genai@2.6.0':
-    resolution: {integrity: sha512-HjoW3mPuEn7pnuKABJl9VbDoWDSF4nbwYKYvYYor7YjPeDxrrBxHzu2d1Prcd+BAuC4w+85UP6y7ZdcrQAoO7g==}
+  '@google/genai@2.7.0':
+    resolution: {integrity: sha512-tv0DRtcndt2oEhBYy+5mA0TaXH98+L1Gt0AP9unBfH7DP20KhB7+O3QqAN1Lz+laMARGTHS7BFQSNpLbl4gm1g==}
     engines: {node: '>=20.0.0'}
     peerDependencies:
       '@modelcontextprotocol/sdk': ^1.25.2
@@ -3782,9 +3782,10 @@ packages:
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
-  clawpdf@0.2.0:
-    resolution: {integrity: sha512-Za4HD3CMRHNqOXOOyVJiQLnEuezRZR/oXiBzraTwL5XEQZuBwFxnyC1UzN4AjQWV2JrLN3ItbzfPRGE0gGOVwg==}
+  clawpdf@0.3.0:
+    resolution: {integrity: sha512-41+3AnKk9yek2sm+/9XvUlDTN8Wi+ag7fmxZuqw+ySn4lqaf/fCgLeamqPLiXY4gVbizKEHGoTG/JrIIFNE2rw==}
     engines: {node: '>=20'}
+    hasBin: true
 
   cli-cursor@5.0.0:
     resolution: {integrity: sha512-aCj4O5wKyszjMmDT4tZj93kxyydN/K5zPWSCe6/0AV/AA1pqe5ZBIw0a2ZfPQV7lL5/yb5HsUreJ6UFAF1tEQw==}
@@ -4733,9 +4734,9 @@ packages:
     resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
     engines: {node: '>=16.9.0'}
 
-  hosted-git-info@9.0.3:
-    resolution: {integrity: sha512-Hc+ghLoSt6QaYZUv0WBiIvmMDZuZZ7oaDvdH8MbfOO4lOsxdXLEvuC6ePoGs9H1X9oCLyq6+NVN0MKqD+ydxyg==}
-    engines: {node: ^20.17.0 || >=22.9.0}
+  hosted-git-info@10.1.1:
+    resolution: {integrity: sha512-DeOnSPAvOndYKfw075gt8yZzQ7S2hNztw34zBTfhIzLhmBTswIBg5/y+pqu/VD5cYWm5goAFTusDmUEmKZ0PEQ==}
+    engines: {node: ^22.22.2 || ^24.15.0 || >=26.0.0}
 
   html-encoding-sniffer@6.0.0:
     resolution: {integrity: sha512-CV9TW3Y3f8/wT0BRFc1/KAVQ3TUHiXmaAb6VW9vtiMFf7SLoMd1PdAc4W3KFOFETBJUb90KatHqlsZMWV+R9Gg==}
@@ -4835,10 +4836,6 @@ packages:
   ipaddr.js@1.9.1:
     resolution: {integrity: sha512-0KI/607xoxSToH7GjN1FfSbLoU0+btTicjsQSWQlh/hZykN8KpmMf7uYwPW3R+akZ6R/w18ZlXSHBYXiYUPO3g==}
     engines: {node: '>= 0.10'}
-
-  ipaddr.js@2.4.0:
-    resolution: {integrity: sha512-9VGk3HGanVE6JoZXHiCpnGy5X0jYDnN4EA4lntFPj+1vIWlFhIylq2CrrCOJH9EAhc5CYhq18F2Av2tgoAPsYQ==}
-    engines: {node: '>= 10'}
 
   is-alphabetical@2.0.1:
     resolution: {integrity: sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ==}
@@ -5176,9 +5173,6 @@ packages:
       canvas:
         optional: true
 
-  linkify-it@5.0.1:
-    resolution: {integrity: sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg==}
-
   lint-staged@17.0.5:
     resolution: {integrity: sha512-d12yC+/e8RhBjZtaxZn71FyrgU/P5e+uAPifhCLwdosQZP/zamSdKRWDC30ocVIbzDKiFG1McHc/LUgB92GIPw==}
     engines: {node: '>=22.22.1'}
@@ -5240,10 +5234,6 @@ packages:
     engines: {node: '>=12.0.0'}
     hasBin: true
 
-  markdown-it@14.2.0:
-    resolution: {integrity: sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ==}
-    hasBin: true
-
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
 
@@ -5303,9 +5293,6 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
-
-  mdurl@2.0.0:
-    resolution: {integrity: sha512-Lf+9+2r+Tdp5wXDXC4PcIBjTDtq4UKjCPMQhKIuzpJNW0b96kVqSwW0bT7FhRSfmAiFYgP+SCRvdrDozfh0U5w==}
 
   media-typer@1.1.0:
     resolution: {integrity: sha512-aisnrDP4GNe06UcKFnV5bfMNPBUw4jsLGaWwWfnH3v02GnBuXX2MCVn5RbrWo0j3pczUilYblq7fQ7Nw2t5XKw==}
@@ -5648,8 +5635,8 @@ packages:
     resolution: {integrity: sha512-VXJjc87FScF88uafS3JllDgvAm+c/Slfz06lorj2uAY34rlUu0Nt+v8wreiImcrgAjjIHp1rXpTDlLOGw29WwQ==}
     engines: {node: '>=18'}
 
-  openai@6.39.0:
-    resolution: {integrity: sha512-O61LIsimY3acVabwvomwFhwrnN36yvHY2quIfy9keEcFytGgWeV35yLHQ6NVMLSBxRpHmcg2yuhCnlu2HT4pLQ==}
+  openai@6.39.1:
+    resolution: {integrity: sha512-z3dO9fEWOXBzlXynVb/xZ/tujzUjFWQWn3C0n0mw6Vo0zJTbEkaN4b2cLWjhJ6haJQx8LlREoafHRl+Gu/Hl+A==}
     hasBin: true
     peerDependencies:
       ws: '>=8.20.1'
@@ -5664,8 +5651,8 @@ packages:
     resolution: {integrity: sha512-aOPhmN7OKyut7DVs3/LitA+QU5tAtrEMY3gSQ/uJXpCN3Dy4JYeEkIjyYX0hViCdxsOJ9LWfCjtiaB3kTPCupw==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.5.28:
-    resolution: {integrity: sha512-p7jGN9wzCrqEvHNI6Y7+eh6DWoYDzJ1iQGKTm8xqQ2uQ9/2mY1CCf87WoZeb0+m3eHKSGchlI3tN33fE1lMtEA==}
+  openclaw@2026.6.1:
+    resolution: {integrity: sha512-rGSwhIo8N37cQQ5puG8vmWZESE8q/ych5VFpzOQNcf49TF/rvCYyxiNAyot11qbUZF5wfLh8bsvofapnOEh0BQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -5856,10 +5843,6 @@ packages:
   pump@3.0.4:
     resolution: {integrity: sha512-VS7sjc6KR7e1ukRFhQSY5LM2uBWAUPiOPa/A3mkKmiMwSmRFUITt0xuj+/lesgnCv+dPIEYlkzrcyXgquIHMcA==}
 
-  punycode.js@2.3.1:
-    resolution: {integrity: sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==}
-    engines: {node: '>=6'}
-
   punycode@2.3.1:
     resolution: {integrity: sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg==}
     engines: {node: '>=6'}
@@ -5901,9 +5884,9 @@ packages:
     resolution: {integrity: sha512-Hrgsx+orqoygnmhFbKaHE6c296J+HTAQXoxEF6gNupROmmGJRoyzfG3ccAveqCBrwr/2yxQ5BVd/GTl5agOwSg==}
     engines: {node: '>= 0.6'}
 
-  rastermill@0.3.0:
-    resolution: {integrity: sha512-4g2i0I7M5sba//lFBh19Wi0hDGw8o+isnt/BtEyqQXIZaYclhcNBwL/Fw/6gDCp7aaLwQHADuUvyHCB0Oat5Vw==}
-    engines: {node: '>=20'}
+  rastermill@0.3.1:
+    resolution: {integrity: sha512-CX4nij6+ZLHYIaojJNfLTr7W+AiH/IPJi6E9Aw1br2///1KZL2KBOHd68rkcLedc47MPvb4hhH+fzYeGFa4A/Q==}
+    engines: {node: '>=22'}
 
   raw-body@3.0.2:
     resolution: {integrity: sha512-K5zQjDllxWkf7Z5xJdV0/B0WTNqx6vxG70zJE4N0kBs4LovmEYWJzQGxC9bS9RAKu3bgM40lrd5zoLJ12MQ5BA==}
@@ -6588,8 +6571,8 @@ packages:
     resolution: {integrity: sha512-OZs6gsjF4vMp32qrCbiVSkrFmXtG/AZhY3t0iAMrMBiAZyV9oALtXO8hsrHbMXF9x6L3grlFuwW2oAz7cav+Gw==}
     engines: {node: '>= 0.6'}
 
-  typebox@1.1.38:
-    resolution: {integrity: sha512-pZ0aQPmMmXoUvSbeuWf/Hzsc+avNw/Zd6VeE8CFgkVGWyuHPJvqeJJDeJqLve+K70LvjYIoleGcoJHPT17cWoA==}
+  typebox@1.1.39:
+    resolution: {integrity: sha512-vj0afVtOfLQvv0GR0VxVagYxsXN64btL7Z9XoaG0ZggH3mruMMkOO6hXdgMsjCY3shZgEvooAWVeznQVs5c43w==}
 
   typed-array-buffer@1.0.3:
     resolution: {integrity: sha512-nAYYwfY3qnzX30IkA6AQZjVbtK6duGontcQm1WSG1MD94YLqK0515GNApXkoxKOWMusVssAHWLh9SeaoefYFGw==}
@@ -6618,9 +6601,6 @@ packages:
     resolution: {integrity: sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==}
     engines: {node: '>=14.17'}
     hasBin: true
-
-  uc.micro@2.1.0:
-    resolution: {integrity: sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==}
 
   uhyphen@0.2.0:
     resolution: {integrity: sha512-qz3o9CHXmJJPGBdqzab7qAYuW8kQGKNEuoHFYrBwV6hWIMcpAmxDLXojcHfFr9US1Pe6zUswEIJIbLI610fuqA==}
@@ -7058,7 +7038,7 @@ snapshots:
 
   '@alloc/quick-lru@5.2.0': {}
 
-  '@anthropic-ai/sdk@0.98.0(zod@4.4.3)':
+  '@anthropic-ai/sdk@0.100.1(zod@4.4.3)':
     dependencies:
       json-schema-to-ts: 3.1.1
       standardwebhooks: 1.0.0
@@ -7719,7 +7699,7 @@ snapshots:
 
   '@drizzle-team/brocli@0.10.2': {}
 
-  '@earendil-works/pi-tui@0.76.0':
+  '@earendil-works/pi-tui@0.78.0':
     dependencies:
       get-east-asian-width: 1.6.0
       marked: 15.0.12
@@ -8051,7 +8031,7 @@ snapshots:
 
   '@floating-ui/utils@0.2.10': {}
 
-  '@google/genai@2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
+  '@google/genai@2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))':
     dependencies:
       google-auth-library: 10.6.2
       p-retry: 4.6.2
@@ -10402,7 +10382,7 @@ snapshots:
 
   classnames@2.5.1: {}
 
-  clawpdf@0.2.0: {}
+  clawpdf@0.3.0: {}
 
   cli-cursor@5.0.0:
     dependencies:
@@ -11526,7 +11506,7 @@ snapshots:
 
   hono@4.12.23: {}
 
-  hosted-git-info@9.0.3:
+  hosted-git-info@10.1.1:
     dependencies:
       lru-cache: 11.3.5
 
@@ -11615,8 +11595,6 @@ snapshots:
     optional: true
 
   ipaddr.js@1.9.1: {}
-
-  ipaddr.js@2.4.0: {}
 
   is-alphabetical@2.0.1: {}
 
@@ -11945,10 +11923,6 @@ snapshots:
       htmlparser2: 10.1.0
       uhyphen: 0.2.0
 
-  linkify-it@5.0.1:
-    dependencies:
-      uc.micro: 2.1.0
-
   lint-staged@17.0.5:
     dependencies:
       listr2: 10.2.1
@@ -12026,15 +12000,6 @@ snapshots:
       path-is-absolute: 1.0.1
       underscore: 1.13.8
       xmlbuilder: 10.1.1
-
-  markdown-it@14.2.0:
-    dependencies:
-      argparse: 2.0.1
-      entities: 4.5.0
-      linkify-it: 5.0.1
-      mdurl: 2.0.0
-      punycode.js: 2.3.1
-      uc.micro: 2.1.0
 
   markdown-table@3.0.4: {}
 
@@ -12196,8 +12161,6 @@ snapshots:
       '@types/mdast': 4.0.4
 
   mdn-data@2.27.1: {}
-
-  mdurl@2.0.0: {}
 
   media-typer@1.1.0: {}
 
@@ -12604,7 +12567,7 @@ snapshots:
     dependencies:
       mimic-function: 5.0.1
 
-  openai@6.39.0(ws@8.21.0)(zod@4.4.3):
+  openai@6.39.1(ws@8.21.0)(zod@4.4.3):
     optionalDependencies:
       ws: 8.21.0
       zod: 4.4.3
@@ -12616,14 +12579,14 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.5.28:
+  openclaw@2026.6.1:
     dependencies:
       '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
-      '@anthropic-ai/sdk': 0.98.0(zod@4.4.3)
+      '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
       '@clack/core': 1.3.1
       '@clack/prompts': 1.4.0
-      '@earendil-works/pi-tui': 0.76.0
-      '@google/genai': 2.6.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
+      '@earendil-works/pi-tui': 0.78.0
+      '@google/genai': 2.7.0(@modelcontextprotocol/sdk@1.29.0(zod@4.4.3))
       '@grammyjs/runner': 2.0.3(grammy@1.43.0)
       '@grammyjs/transformer-throttler': 1.2.1(grammy@1.43.0)
       '@homebridge/ciao': 1.3.9
@@ -12633,10 +12596,9 @@ snapshots:
       '@mozilla/readability': 0.6.0
       '@openclaw/fs-safe': 0.3.0
       '@openclaw/proxyline': 0.3.3(undici@8.3.0)
-      '@silvia-odwyer/photon-node': 0.3.4
       chalk: 5.6.2
       chokidar: 5.0.0
-      clawpdf: 0.2.0
+      clawpdf: 0.3.0
       commander: 14.0.3
       croner: 10.0.1
       cross-spawn: 7.0.6
@@ -12647,28 +12609,26 @@ snapshots:
       glob: 13.0.6
       grammy: 1.43.0
       highlight.js: 11.11.1
-      hosted-git-info: 9.0.3
+      hosted-git-info: 10.1.1
       ignore: 7.0.5
-      ipaddr.js: 2.4.0
       jiti: 2.7.0
       json5: 2.2.3
       jszip: 3.10.1
       kysely: 0.29.2
       linkedom: 0.18.12
-      markdown-it: 14.2.0
       minimatch: 10.2.5
       node-edge-tts: 1.2.10
-      openai: 6.39.0(ws@8.21.0)(zod@4.4.3)
+      openai: 6.39.1(ws@8.21.0)(zod@4.4.3)
       partial-json: 0.1.7
       playwright-core: 1.60.0
       proper-lockfile: 4.1.2
       qrcode: 1.5.4
       quickjs-wasi: 3.0.0
-      rastermill: 0.3.0
+      rastermill: 0.3.1
       tar: 7.5.15
       tree-sitter-bash: 0.25.1
       tslog: 4.10.2
-      typebox: 1.1.38
+      typebox: 1.1.39
       typescript: 6.0.3
       undici: 8.3.0
       web-push: 3.6.7
@@ -12886,8 +12846,6 @@ snapshots:
       end-of-stream: 1.4.5
       once: 1.4.0
 
-  punycode.js@2.3.1: {}
-
   punycode@2.3.1: {}
 
   qrcode.react@4.2.0(react@19.2.6):
@@ -12973,7 +12931,7 @@ snapshots:
 
   range-parser@1.2.1: {}
 
-  rastermill@0.3.0:
+  rastermill@0.3.1:
     dependencies:
       '@silvia-odwyer/photon-node': 0.3.4
 
@@ -13793,7 +13751,7 @@ snapshots:
       media-typer: 1.1.0
       mime-types: 3.0.2
 
-  typebox@1.1.38: {}
+  typebox@1.1.39: {}
 
   typed-array-buffer@1.0.3:
     dependencies:
@@ -13840,8 +13798,6 @@ snapshots:
       - supports-color
 
   typescript@6.0.3: {}
-
-  uc.micro@2.1.0: {}
 
   uhyphen@0.2.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -345,8 +345,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       openclaw:
-        specifier: 2026.6.1
-        version: 2026.6.1
+        specifier: 2026.6.5
+        version: 2026.6.5
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -5651,8 +5651,8 @@ packages:
     resolution: {integrity: sha512-aOPhmN7OKyut7DVs3/LitA+QU5tAtrEMY3gSQ/uJXpCN3Dy4JYeEkIjyYX0hViCdxsOJ9LWfCjtiaB3kTPCupw==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.6.1:
-    resolution: {integrity: sha512-rGSwhIo8N37cQQ5puG8vmWZESE8q/ych5VFpzOQNcf49TF/rvCYyxiNAyot11qbUZF5wfLh8bsvofapnOEh0BQ==}
+  openclaw@2026.6.5:
+    resolution: {integrity: sha512-sRgF0TexfRcJX8Eg0lcL6Jj0YdZbSxUbbp8EbG+qo3v6TtVayE6tKPEs3oCKD7YfYe2C/8Qg26HUxTnycd44ZQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -12579,7 +12579,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.6.1:
+  openclaw@2026.6.5:
     dependencies:
       '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
       '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)


### PR DESCRIPTION
## What does this PR do?

Bumps the bundled OpenClaw runtime from **2026.5.28 → 2026.6.5** (the current npm `latest`; the train moved to monthly patch numbering with the June floor at 2026.6.5). `openclaw-node` stays at `0.12.1` (already latest).

The bump surfaced a family of latent cold-start race conditions, all fixed at root cause in this PR — plus guardrails so they can't silently return:

### 1. OpenClaw version drift guard
The version lives in `Dockerfile.openclaw` (installed runtime) and `packages/web/package.json` (the source `next.config.ts` reads for `/api/version`). A new test pins them in lockstep (TDD: red when only the Dockerfile was bumped).

### 2. Cold-start "Unknown model" dispatch race (chat path)
The config-apply storm can land an agent before its model's provider; OC accepts the dispatch (ack emitted) then fails resolving the model. `chatWithDispatchRaceRetry` now also retries `Unknown model` with bounded backoff; the trigger is "race error before any model output" because the error follows the `userMessagePersisted` ack. Deterministic `ClientRouter` integration test, verified red→green.

### 3. Intermittent `socket hang up` (server)
`server.ts` never set `keepAliveTimeout`, so Node's 5 s default closed idle keep-alive sockets exactly as clients reused them. New `http-keepalive.ts` helper: `keepAliveTimeout=65s`, `headersTimeout=66s` (Node requires headers > keepAlive; one helper keeps the invariant).

### 4. The dispatch-probe flake class, made deterministic (the big one)
OC 5.3's `config.apply` rate-limit can PARK a config push for 33–53 s. During that gap a change a test just made (e.g. the per-agent `pinchy-email` grant) is NOT in OC's runtime — but health said `connected: true` throughout, so every E2E stability gate passed and dispatched into the gap ("I can't use the tool email_list … it isn't available", CI run 27351361560).

Fix in three small layers:
- `openclaw-config/push-state.ts` — globalThis-backed pending-push counter (module-duality: Next routes vs custom server, same reason as `server/openclaw-client.ts`); `pushConfigInBackground` settles via `.finally()` on every terminal exit
- `/api/health/openclaw` reports **`configPushesPending`** (documented in `reference/api.mdx`)
- The E2E stability gates (shared `waitForOpenClawStable` + setup-wizard settle loops) require `configPushesPending === 0`, turning "hope the push landed" into a deterministic gate. Budgets raised accordingly (helper deadline 90→150 s, three dispatch `beforeAll`s 180→240 s) so the bounded worst case can't flip into a timeout.

### 5. Two unit-test flakes found by stress-running the suite
- `dispatch-probe-stability.test.ts` asserted a poll **count** that assumed exact `setTimeout` cadence → now asserts the wall-clock contract
- `ws-frame-limit.test.ts`: single-shot localhost WS handshake can hit transient ECONNRESET under load → bounded connect retry (the maxPayload contract assertions are unchanged)

## Type of change

- [x] 🐛 Bug fix
- [x] 🧪 Tests
- [x] 📝 Documentation

## Verification

- Full vitest suite **4× consecutive green** (5722 tests each) after the fixes; before them, repeat runs flaked ~1-in-3
- Integration E2E (protocol-real, locally built image): 20/20 green; protocol v4 handshake confirmed
- Full CI matrix **21/21 green** on the final commits — including all four channel suites (email/odoo/web/telegram), setup-wizard, and integration on the first run with the deterministic gate
- Drift guard + model-race retry + deterministic-gate tests all verified red→green

## Notes for reviewers

- The blind 60 s "drain the rate-limit window" sleeps in the odoo/web/email suites intentionally stay: they prevent those suites' own regens from being rate-limited (front-load), while the new gate confirms settledness (back-load). Removing them would be a separate change.
- Historical `// verified against OC 2026.5.28` comments are intentionally unchanged — they record real empirical verification at that version.
- `docs/architecture.mdx` updated to the new pin pair; `reference/api.mdx` documents the health response incl. `configPushesPending`.

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass