### PR TITLE
fix(db): correct out-of-order migration journal timestamps (v0.5.7 upload release blocker)

### DIFF
--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -173,7 +173,7 @@
     {
       "idx": 24,
       "version": "7",
-      "when": 1774530563587,
+      "when": 1774902510387,
       "tag": "0024_cuddly_vapor",
       "breakpoints": true
     },
@@ -250,7 +250,7 @@
     {
       "idx": 35,
       "version": "7",
-      "when": 1779219073816,
+      "when": 1779412860001,
       "tag": "0035_smart_misty_knight",
       "breakpoints": true
     },

--- a/packages/web/src/__tests__/db/migration-journal-order.test.ts
+++ b/packages/web/src/__tests__/db/migration-journal-order.test.ts
@@ -1,0 +1,53 @@
+/**
+ * Guard for the Drizzle migration journal ordering.
+ *
+ * Drizzle's migrator is timestamp-gated: on a non-empty database it applies a
+ * migration only when its `when` (from drizzle/meta/_journal.json) is greater
+ * than the most-recently-applied migration's timestamp. If an entry's `when`
+ * is out of order relative to its position, that migration is silently SKIPPED
+ * on every upgrade whose starting point is past the dip — the table/columns it
+ * creates never appear, and the failure surfaces far away (e.g. a 500 on first
+ * use of the feature), not at migrate time.
+ *
+ * This is exactly how `0035_smart_misty_knight` (uploaded_files) shipped broken:
+ * its `when` predated `0034`, so drizzle skipped it on every v0.5.6→v0.5.7
+ * upgrade. This guard makes that class of bug impossible to merge.
+ */
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+
+// vitest runs with cwd = packages/web (pnpm -C packages/web test).
+type JournalEntry = { idx: number; when: number; tag: string };
+const journal = JSON.parse(
+  readFileSync(join(process.cwd(), "drizzle/meta/_journal.json"), "utf-8")
+) as { entries: JournalEntry[] };
+
+describe("drizzle migration journal", () => {
+  it("lists entries in strictly ascending idx order", () => {
+    const idxs = journal.entries.map((e) => e.idx);
+    const violations = idxs
+      .map((idx, i) => ({ idx, prev: idxs[i - 1] }))
+      .filter((p, i) => i > 0 && p.idx <= p.prev!);
+    expect(violations).toEqual([]);
+  });
+
+  it("has strictly increasing 'when' timestamps in idx order", () => {
+    // Each migration's timestamp must be greater than every prior migration's,
+    // otherwise drizzle's timestamp-gated migrator skips it on upgrade.
+    const violations: string[] = [];
+    let runningMax = -Infinity;
+    let runningMaxTag = "(start)";
+    for (const e of journal.entries) {
+      if (e.when <= runningMax) {
+        violations.push(
+          `${e.tag} (when=${e.when}) is not after the preceding max ${runningMaxTag} (when=${runningMax}) — it would be skipped on upgrade`
+        );
+      } else {
+        runningMax = e.when;
+        runningMaxTag = e.tag;
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Release blocker for v0.5.7

File uploads are broken on **every upgrade** to v0.5.7: the first PDF/image upload fails with a 500 — `relation "uploaded_files" does not exist`. Found during staging click-through (Phase 2 of the staging test plan).

## Root cause

drizzle's migrator is **timestamp-gated**: on a non-empty DB it applies a migration only when its `when` (in `drizzle/meta/_journal.json`) is greater than the last-applied timestamp. Two journal entries had `when` values **earlier than their predecessors**, so drizzle silently skips them on upgrade:

| entry | creates | `when` problem | impact |
|---|---|---|---|
| `0035_smart_misty_knight` | `uploaded_files` | predates 0034 by ~2 days | **every v0.5.6→v0.5.7 upgrade skips it** → uploads 500 |
| `0024_cuddly_vapor` | `agent_connection_permissions` | predates 0023 | skippable on upgrades from certain older versions |

**Fresh installs were unaffected** — an empty DB applies every migration regardless of timestamp (the `!lastDbMigration` branch). That's why this escaped the fresh-migrate integration suite and only surfaces on a real upgrade.

Empirically confirmed on staging: `__drizzle_migrations` had 36/37 entries, with `0035` the only one missing (its hash absent), while `0036`/`models` and `0034`/`last_error` were present — exactly the skip pattern.

## Fix

- Bump the two out-of-order `when` timestamps just past their predecessor to restore **strict monotonicity**. No `.sql` change, no migration-hash change, **no-op for DBs that already applied these migrations**; upgraders from any prior version now apply the full pending tail in order.
- **Guard:** `src/__tests__/db/migration-journal-order.test.ts` asserts the journal is strictly increasing in idx order — written test-first (failed on exactly these two entries, now green). Makes this class of bug un-mergeable.

## Verification

- Guard test: RED on the two dips → GREEN after the timestamp fix.
- Cohort reasoning: a v0.5.6 DB (max `when` = 0033 = 1779412800000) now sees 0034/0035/0036 all > that → all apply.
- **Recommended pre-release validation:** once this is on `:next`, run a real v0.5.6→v0.5.7 upgrade on staging and confirm `uploaded_files` is created by the upgrade (the existing suite only covers fresh installs, which never had the bug).

Must merge before cutting v0.5.7.