### PR TITLE
fix(chat): streaming-resume duplicate message-id crash

### DIFF
--- a/packages/web/e2e/integration/17-reload-mid-stream-resume.spec.ts
+++ b/packages/web/e2e/integration/17-reload-mid-stream-resume.spec.ts
@@ -1,0 +1,75 @@
+// packages/web/e2e/integration/17-reload-mid-stream-resume.spec.ts
+//
+// Regression guard for the streaming-resume duplicate-message-id crash.
+//
+// Reloading the SAME tab while a reply is still streaming exercises the
+// `activeRun` resume path: the reconnecting client fetches history + an
+// activeRun signal and re-attaches to the in-flight run. A prior bug let the
+// in-flight assistant message be materialised twice with the same id, which
+// crashes assistant-ui's MessageRepository and replaces the chat with the
+// "Something went wrong" error boundary. (Fixed by dedupeById + mergeOrAppendChunk.)
+//
+// With the fix this is reliably green: whether the reload lands on the resume
+// path (run still in-flight) or the history path (run finished during reload),
+// the view must NOT crash and the reply must complete in a single bubble.
+import { test, expect } from "@playwright/test";
+import {
+  FAKE_OLLAMA_SLOW_STREAM_TRIGGER,
+  FAKE_OLLAMA_SLOW_STREAM_RESPONSE,
+} from "../shared/fake-ollama/fake-ollama-server";
+import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
+
+const RESPONSE_WORDS = FAKE_OLLAMA_SLOW_STREAM_RESPONSE.split(" ");
+const FIRST_WORD = RESPONSE_WORDS[0]!;
+const LAST_WORD = RESPONSE_WORDS[RESPONSE_WORDS.length - 1]!;
+
+test.describe("Streaming resume — reload mid-stream does not crash the chat view", () => {
+  test("reloading the tab while streaming resumes the reply without an error boundary", async ({
+    page,
+  }) => {
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+
+    await page.goto(`/chat/${agentId}`);
+    await waitForOpenClawConnected(page);
+
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10000 });
+
+    // This agent's chat history is shared across integration specs, so earlier
+    // slow-stream tests have already produced assistant bubbles containing the
+    // first word. Anchor on the bubble COUNT (and .last()) rather than text-
+    // filtering, which would match those stale bubbles in strict mode.
+    const assistantBubbles = page.locator('[data-role="assistant"]');
+    const before = await assistantBubbles.count();
+
+    await input.fill(`${FAKE_OLLAMA_SLOW_STREAM_TRIGGER}: list ${FIRST_WORD}..${LAST_WORD}`);
+    await input.press("Enter");
+
+    // Our reply opens a new bubble and starts streaming — the run is now
+    // in-flight and we're about to reload mid-stream (the resume path).
+    // Poll for "at least one more bubble" so a transient thinking indicator
+    // doesn't break an exact-count assertion.
+    await expect
+      .poll(async () => assistantBubbles.count(), { timeout: 30000 })
+      .toBeGreaterThan(before);
+    await expect(assistantBubbles.last()).toContainText(FIRST_WORD, { timeout: 30000 });
+
+    // Reload the SAME tab mid-stream — this is what previously crashed the view.
+    await page.reload();
+    await waitForOpenClawConnected(page);
+
+    // The error boundary must NOT have replaced the chat view.
+    await expect(page.getByText("Something went wrong")).toHaveCount(0);
+
+    // The reply resumes and completes in a single bubble (no orphan/duplicate).
+    const assistantMessage = page.locator('[data-role="assistant"]').last();
+    await expect(assistantMessage).toContainText(LAST_WORD, { timeout: 30000 });
+    await expect(assistantMessage).toContainText(FAKE_OLLAMA_SLOW_STREAM_RESPONSE, {
+      timeout: 5000,
+    });
+
+    // The composer is still interactive — a crashed view would have no input.
+    await expect(page.getByPlaceholder(/send a message/i)).toBeVisible();
+  });
+});

--- a/packages/web/src/__tests__/hooks/ensure-trailing-assistant.test.ts
+++ b/packages/web/src/__tests__/hooks/ensure-trailing-assistant.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { ensureTrailingAssistant } from "@/hooks/ensure-trailing-assistant";
+
+type Msg = { id: string; role: string; content: string };
+
+const anchor: Msg = { id: "run-1", role: "assistant", content: "" };
+
+describe("ensureTrailingAssistant", () => {
+  it("appends the anchor when history ends in a user message (unpersisted reply)", () => {
+    const messages: Msg[] = [{ id: "u1", role: "user", content: "hi" }];
+    expect(ensureTrailingAssistant(messages, anchor)).toEqual([
+      { id: "u1", role: "user", content: "hi" },
+      { id: "run-1", role: "assistant", content: "" },
+    ]);
+  });
+
+  it("re-anchors the trailing assistant's id in place, preserving its content", () => {
+    const messages: Msg[] = [
+      { id: "u1", role: "user", content: "hi" },
+      { id: "tmp", role: "assistant", content: "partial reply" },
+    ];
+    expect(ensureTrailingAssistant(messages, anchor)).toEqual([
+      { id: "u1", role: "user", content: "hi" },
+      { id: "run-1", role: "assistant", content: "partial reply" },
+    ]);
+  });
+
+  it("appends when an assistant exists but a newer user turn trails it", () => {
+    const messages: Msg[] = [
+      { id: "u1", role: "user", content: "first" },
+      { id: "a1", role: "assistant", content: "reply" },
+      { id: "u2", role: "user", content: "second" },
+    ];
+    const out = ensureTrailingAssistant(messages, anchor);
+    expect(out[out.length - 1]).toEqual({ id: "run-1", role: "assistant", content: "" });
+    // The earlier assistant keeps its own id — only the trailing anchor carries run-1.
+    expect(out.filter((m) => m.id === "run-1")).toHaveLength(1);
+    expect(out).toHaveLength(4);
+  });
+
+  it("appends the anchor for an empty history (run in flight, nothing persisted)", () => {
+    expect(ensureTrailingAssistant([] as Msg[], anchor)).toEqual([anchor]);
+  });
+
+  it("always yields an assistant as the last message", () => {
+    for (const messages of [
+      [] as Msg[],
+      [{ id: "u1", role: "user", content: "a" }],
+      [
+        { id: "u1", role: "user", content: "a" },
+        { id: "a1", role: "assistant", content: "b" },
+      ],
+    ]) {
+      const out = ensureTrailingAssistant(messages, anchor);
+      expect(out[out.length - 1]!.role).toBe("assistant");
+    }
+  });
+});

--- a/packages/web/src/__tests__/hooks/ensure-trailing-assistant.test.ts
+++ b/packages/web/src/__tests__/hooks/ensure-trailing-assistant.test.ts
@@ -14,14 +14,27 @@ describe("ensureTrailingAssistant", () => {
     ]);
   });
 
-  it("re-anchors the trailing assistant's id in place, preserving its content", () => {
+  it("re-anchors the trailing assistant's id, keeping the longer persisted content when the resume buffer is empty", () => {
     const messages: Msg[] = [
       { id: "u1", role: "user", content: "hi" },
       { id: "tmp", role: "assistant", content: "partial reply" },
     ];
+    // anchor.content is "" (empty resume buffer) — must NOT shrink the reply.
     expect(ensureTrailingAssistant(messages, anchor)).toEqual([
       { id: "u1", role: "user", content: "hi" },
       { id: "run-1", role: "assistant", content: "partial reply" },
+    ]);
+  });
+
+  it("adopts the resume buffer when it is more complete than the persisted partial", () => {
+    const messages: Msg[] = [
+      { id: "u1", role: "user", content: "list one..ten" },
+      { id: "tmp", role: "assistant", content: "one two" },
+    ];
+    const fullerAnchor: Msg = { id: "run-1", role: "assistant", content: "one two three four" };
+    expect(ensureTrailingAssistant(messages, fullerAnchor)).toEqual([
+      { id: "u1", role: "user", content: "list one..ten" },
+      { id: "run-1", role: "assistant", content: "one two three four" },
     ]);
   });
 

--- a/packages/web/src/__tests__/hooks/merge-chunk.test.ts
+++ b/packages/web/src/__tests__/hooks/merge-chunk.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { mergeOrAppendChunk } from "@/hooks/merge-chunk";
+
+type Msg = { id: string; role: string; content: string };
+
+describe("mergeOrAppendChunk", () => {
+  it("appends a new assistant message when no message has the chunk's id", () => {
+    const messages: Msg[] = [{ id: "u1", role: "user", content: "hi" }];
+    const incoming: Msg = { id: "a1", role: "assistant", content: "Hel" };
+    expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+      { id: "u1", role: "user", content: "hi" },
+      { id: "a1", role: "assistant", content: "Hel" },
+    ]);
+  });
+
+  it("merges into the trailing assistant message (the common streaming case)", () => {
+    const messages: Msg[] = [
+      { id: "u1", role: "user", content: "hi" },
+      { id: "a1", role: "assistant", content: "Hel" },
+    ];
+    const incoming: Msg = { id: "a1", role: "assistant", content: "lo" };
+    expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+      { id: "u1", role: "user", content: "hi" },
+      { id: "a1", role: "assistant", content: "Hello" },
+    ]);
+  });
+
+  it("merges into an existing assistant message that is NOT last, instead of appending a duplicate id", () => {
+    // The streaming-resume case: after a reload the in-flight assistant message
+    // (relabeled to the run id) can sit before a trailing user/history message.
+    // The old "check only the last message" logic appended a SECOND message with
+    // the same id here, which crashes assistant-ui.
+    const messages: Msg[] = [
+      { id: "run-9", role: "assistant", content: "partial" },
+      { id: "u2", role: "user", content: "later question" },
+    ];
+    const incoming: Msg = { id: "run-9", role: "assistant", content: " continued" };
+    const out = mergeOrAppendChunk(messages, incoming);
+    expect(out).toEqual([
+      { id: "run-9", role: "assistant", content: "partial continued" },
+      { id: "u2", role: "user", content: "later question" },
+    ]);
+    // Critically: exactly one message carries run-9.
+    expect(out.filter((m) => m.id === "run-9")).toHaveLength(1);
+  });
+
+  it("does not merge a chunk into a user message that happens to share the id", () => {
+    const messages: Msg[] = [{ id: "x", role: "user", content: "u" }];
+    const incoming: Msg = { id: "x", role: "assistant", content: "a" };
+    expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+      { id: "x", role: "user", content: "u" },
+      { id: "x", role: "assistant", content: "a" },
+    ]);
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
@@ -92,6 +92,36 @@ describe("useWsRuntime — activeRun reconcile anchors a trailing assistant", ()
     expect(last?.id).toBe("srv-1");
   });
 
+  it("seeds the in-flight bubble with the server's resume buffer (partialContent)", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+    // Reload mid-stream: the words "one two three" already streamed before the
+    // reload. History has only the user turn; the server replays the accumulated
+    // text via activeRun.partialContent so it isn't lost.
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        activeRun: {
+          runId: "run-1",
+          messageId: "srv-1",
+          startedAt: 1000,
+          partialContent: "one two three",
+        },
+      })
+    );
+
+    const msgs = (
+      result.current.runtime as { messages?: { id: string; role: string; content?: unknown }[] }
+    ).messages!;
+    const last = msgs[msgs.length - 1]!;
+    expect(last.role).toBe("assistant");
+    expect(last.id).toBe("srv-1");
+    // The pre-reload content is recovered, not lost.
+    expect(JSON.stringify(last.content)).toContain("one two three");
+  });
+
   it("anchors the trailing assistant in place when the reply IS in history", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0]!;

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Regression guard (#470): on the streaming-resume path, the reconciled message
+ * list handed to assistant-ui must ALWAYS end with an assistant message while
+ * the run is in flight. Otherwise assistant-ui appends its own optimistic
+ * assistant (isRunning && last !== assistant), whose count leads its per-message
+ * resource list by one and crashes ThreadPrimitive.Messages with a
+ * tapClientLookup out-of-bounds index ("Something went wrong").
+ *
+ * This file mocks @assistant-ui/react to the identity function so
+ * `runtime.messages` exposes the exact convertedMessages array that would be fed
+ * to the real runtime — we assert its trailing message directly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: vi.fn() }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+vi.mock("@assistant-ui/react", () => ({
+  useExternalStoreRuntime: (config: any) => config,
+  SimpleImageAttachmentAdapter: class {
+    accept = "image/*";
+  },
+  SimpleTextAttachmentAdapter: class {
+    accept = "text/plain";
+  },
+  CompositeAttachmentAdapter: class {
+    accept = "";
+    constructor() {}
+  },
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+type Converted = { id: string; role: string };
+function messagesOf(runtime: unknown): Converted[] {
+  return ((runtime as { messages?: Converted[] }).messages ?? []) as Converted[];
+}
+
+describe("useWsRuntime — activeRun reconcile anchors a trailing assistant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("appends a trailing assistant when history ends in the user turn (unpersisted reply)", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+
+    const msgs = messagesOf(result.current.runtime);
+    const last = msgs[msgs.length - 1];
+    expect(last?.role).toBe("assistant");
+    expect(last?.id).toBe("srv-1");
+  });
+
+  it("anchors the trailing assistant in place when the reply IS in history", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "list one..ten" },
+          { role: "assistant", content: "one two" },
+        ],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+
+    const msgs = messagesOf(result.current.runtime);
+    const last = msgs[msgs.length - 1];
+    expect(last?.role).toBe("assistant");
+    expect(last?.id).toBe("srv-1");
+    // Exactly one message carries the run id — no duplicate bubble.
+    expect(msgs.filter((m) => m.id === "srv-1")).toHaveLength(1);
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-resume-crash.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-resume-crash.test.tsx
@@ -1,0 +1,199 @@
+/**
+ * Hook-layer regression guard for the streaming-resume crashes (#470).
+ * Reloading the tab mid-stream lands on the `activeRun` resume path:
+ * the fresh client fetches history + an activeRun signal and re-attaches to the
+ * in-flight run, then chunks stream in. A bug let assistant-ui's MessageRepository
+ * end up with the same message id at two positions in the parent chain, which
+ * throws ("A message with the same id already exists in the parent tree") and
+ * replaces the chat with the app's error boundary ("Something went wrong").
+ *
+ * Unlike `use-ws-runtime.test.ts` (which mocks @assistant-ui/react to the
+ * identity function and so never exercises the repository sync), this test uses
+ * the REAL assistant-ui runtime: useWsRuntime feeds its convertedMessages into a
+ * real <AssistantRuntimeProvider>/<Thread>, whose repository sync runs in a
+ * useEffect on every render. The MessageRepository duplicate-id relink cycle
+ * therefore throws here exactly as it does in the browser. (jsdom renders
+ * synchronously, so it does NOT reproduce the concurrent-mode tapClientLookup
+ * desync — the reload-mid-stream E2E is authoritative for that; the invariant
+ * is pinned by use-ws-runtime-active-run-anchor.test.ts.) The error boundary
+ * below mirrors app/error.tsx so a crash flips `errored` to true.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, act } from "@testing-library/react";
+import { Component, type ReactNode } from "react";
+import { AssistantRuntimeProvider, ThreadPrimitive, MessagePrimitive } from "@assistant-ui/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+// --- unrelated dependency mocks (NOT @assistant-ui/react — we want the real one) ---
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: vi.fn() }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((event: Event) => void) | null = null;
+  onmessage: ((event: MessageEvent) => void) | null = null;
+  onclose: ((event: CloseEvent) => void) | null = null;
+  onerror: ((event: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+function latestWs(): MockWebSocket {
+  const ws = wsInstances[wsInstances.length - 1];
+  if (!ws) throw new Error("No MockWebSocket instance created yet");
+  return ws;
+}
+
+// Error boundary mirroring app/error.tsx — flips to the fallback on any throw.
+class CrashBoundary extends Component<{ children: ReactNode }, { errored: boolean }> {
+  state = { errored: false };
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+  componentDidCatch() {}
+  render() {
+    if (this.state.errored) return <div data-testid="crashed">Something went wrong</div>;
+    return this.props.children;
+  }
+}
+
+const ThreadView = () => (
+  <ThreadPrimitive.Root>
+    <ThreadPrimitive.Viewport>
+      <ThreadPrimitive.Messages
+        components={{
+          UserMessage: () => (
+            <div data-role="user">
+              <MessagePrimitive.Parts />
+            </div>
+          ),
+          AssistantMessage: () => (
+            <div data-role="assistant">
+              <MessagePrimitive.Parts />
+            </div>
+          ),
+        }}
+      />
+    </ThreadPrimitive.Viewport>
+  </ThreadPrimitive.Root>
+);
+
+function Harness() {
+  const { runtime } = useWsRuntime("agent-1");
+  return (
+    <CrashBoundary>
+      <AssistantRuntimeProvider runtime={runtime}>
+        <ThreadView />
+      </AssistantRuntimeProvider>
+    </CrashBoundary>
+  );
+}
+
+describe("useWsRuntime — reload mid-stream resume does not crash assistant-ui", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("A: history[user,assistant]+activeRun then chunks", () => {
+    render(<Harness />);
+    const ws = latestWs();
+    act(() => ws.simulateOpen());
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "list one..ten" },
+          { role: "assistant", content: "one two" },
+        ],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+    act(() => ws.simulateMessage({ type: "chunk", content: " three", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "chunk", content: " ten", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "complete" }));
+    expect(screen.queryByTestId("crashed")).toBeNull();
+  });
+
+  it("B: history[user]-only +activeRun (optimistic path) then chunks", () => {
+    render(<Harness />);
+    const ws = latestWs();
+    act(() => ws.simulateOpen());
+    // In-flight run: the assistant message is not yet persisted, so history
+    // returns only the user turn while activeRun points at the live message.
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+    act(() => ws.simulateMessage({ type: "chunk", content: "one two", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "chunk", content: " ten", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "complete" }));
+    expect(screen.queryByTestId("crashed")).toBeNull();
+  });
+
+  it("C: chunk buffered BEFORE history[user]+activeRun (Tier 2b drain)", () => {
+    render(<Harness />);
+    const ws = latestWs();
+    act(() => ws.simulateOpen());
+    // Chunk arrives before the history frame — buffered until reconcile drains it.
+    act(() => ws.simulateMessage({ type: "chunk", content: "one two", messageId: "srv-1" }));
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+    act(() => ws.simulateMessage({ type: "chunk", content: " ten", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "complete" }));
+    expect(screen.queryByTestId("crashed")).toBeNull();
+  });
+
+  it("D: chunk buffered BEFORE history[user,assistant]+activeRun", () => {
+    render(<Harness />);
+    const ws = latestWs();
+    act(() => ws.simulateOpen());
+    act(() => ws.simulateMessage({ type: "chunk", content: " three", messageId: "srv-1" }));
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "list one..ten" },
+          { role: "assistant", content: "one two" },
+        ],
+        activeRun: { runId: "run-1", messageId: "srv-1", startedAt: 1000 },
+      })
+    );
+    act(() => ws.simulateMessage({ type: "chunk", content: " ten", messageId: "srv-1" }));
+    act(() => ws.simulateMessage({ type: "complete" }));
+    expect(screen.queryByTestId("crashed")).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/dedupe-by-id.test.ts
+++ b/packages/web/src/__tests__/lib/dedupe-by-id.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect } from "vitest";
+import { dedupeById } from "@/lib/dedupe-by-id";
+
+describe("dedupeById", () => {
+  it("returns the array unchanged when all ids are unique", () => {
+    const input = [
+      { id: "a", v: 1 },
+      { id: "b", v: 2 },
+      { id: "c", v: 3 },
+    ];
+    expect(dedupeById(input)).toEqual(input);
+  });
+
+  it("keeps the last occurrence of a duplicated id, at its last position", () => {
+    // This is the streaming-resume case: the in-flight assistant message can
+    // appear twice (history relabel + resumed stream), both with the same id.
+    // assistant-ui's MessageRepository throws on a duplicate id and crashes the
+    // whole chat view — so the array handed to it must never contain one.
+    const input = [
+      { id: "user-1", v: "hi" },
+      { id: "run-7", v: "partial" }, // history-relabeled in-flight message
+      { id: "run-7", v: "streamed" }, // same id from the resumed stream
+    ];
+    expect(dedupeById(input)).toEqual([
+      { id: "user-1", v: "hi" },
+      { id: "run-7", v: "streamed" },
+    ]);
+  });
+
+  it("collapses every duplicate id to a single entry", () => {
+    const input = [
+      { id: "x", n: 1 },
+      { id: "y", n: 2 },
+      { id: "x", n: 3 },
+      { id: "y", n: 4 },
+      { id: "x", n: 5 },
+    ];
+    const out = dedupeById(input);
+    expect(out).toEqual([
+      { id: "y", n: 4 },
+      { id: "x", n: 5 },
+    ]);
+    expect(out.map((o) => o.id)).toEqual([...new Set(out.map((o) => o.id))]);
+  });
+
+  it("handles an empty array", () => {
+    expect(dedupeById([])).toEqual([]);
+  });
+
+  it("keeps every item whose id is undefined (no id to collide on)", () => {
+    // assistant-ui's ThreadMessageLike types `id` as optional, so the guard
+    // must tolerate undefined ids without collapsing them together.
+    const input = [
+      { id: undefined, v: 1 },
+      { id: "x", v: 2 },
+      { id: undefined, v: 3 },
+      { id: "x", v: 4 },
+    ];
+    expect(dedupeById(input)).toEqual([
+      { id: undefined, v: 1 },
+      { id: undefined, v: 3 },
+      { id: "x", v: 4 },
+    ]);
+  });
+});

--- a/packages/web/src/__tests__/server/active-runs.test.ts
+++ b/packages/web/src/__tests__/server/active-runs.test.ts
@@ -92,6 +92,41 @@ describe("ActiveRuns", () => {
     });
   });
 
+  describe("currentContent (Tier 2b: resume buffer for the in-flight reply)", () => {
+    it("defaults to an empty string when register omits it", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, ws });
+      expect(runs.get(baseRun.sessionKey)?.currentContent).toBe("");
+    });
+
+    it("seeds from register input (text emitted before the registering chunk)", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, currentContent: "one ", ws });
+      expect(runs.get(baseRun.sessionKey)?.currentContent).toBe("one ");
+    });
+
+    it("setContent mirrors the pipe's accumulated emitted text", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, ws });
+      runs.setContent(baseRun.sessionKey, "one two");
+      expect(runs.get(baseRun.sessionKey)?.currentContent).toBe("one two");
+      runs.setContent(baseRun.sessionKey, "one two three");
+      expect(runs.get(baseRun.sessionKey)?.currentContent).toBe("one two three");
+    });
+
+    it("setContent is a no-op for an unknown sessionKey", () => {
+      expect(() => runs.setContent("agent:gone:direct:u1", "x")).not.toThrow();
+    });
+
+    it("updateMessageId resets currentContent — the finished turn is now in history", () => {
+      const ws = fakeWs();
+      runs.register({ ...baseRun, ws });
+      runs.setContent(baseRun.sessionKey, "first turn reply");
+      runs.updateMessageId(baseRun.sessionKey, "msg-turn-2");
+      expect(runs.get(baseRun.sessionKey)?.currentContent).toBe("");
+    });
+  });
+
   describe("touch", () => {
     it("updates lastChunkAt on every chunk so the watchdog measures inactivity, not absolute age", () => {
       const ws = fakeWs();

--- a/packages/web/src/__tests__/server/client-router-active-runs.test.ts
+++ b/packages/web/src/__tests__/server/client-router-active-runs.test.ts
@@ -184,6 +184,48 @@ describe("ClientRouter ↔ ActiveRuns wiring (#310 Tier 2a)", () => {
     expect(activeRuns.size()).toBe(0);
   });
 
+  it("accumulates emitted text into the ActiveRun resume buffer for reconnect replay (Tier 2b)", async () => {
+    const chunks: ChatChunk[] = [
+      { type: "text", text: "one ", runId: "run-acc" },
+      { type: "text", text: "two ", runId: "run-acc" },
+      { type: "text", text: "three", runId: "run-acc" },
+      { type: "done", text: "", runId: "run-acc" },
+    ];
+    mockChat.mockReturnValue(makeChunkStream(chunks));
+    const router = new ClientRouter(
+      buildClient() as never,
+      "user-1",
+      "member",
+      sessionCache,
+      activeRuns
+    );
+    const ws = createMockWs();
+    const sessionKey = "agent:agent-1:direct:user-1";
+
+    // Sample the resume buffer on every broadcast so we can prove it grows as
+    // the stream progresses and reaches the full emitted reply — this is what a
+    // reconnecting client is re-seeded with via activeRun.partialContent.
+    const contentSamples: string[] = [];
+    (ws.send as unknown as ReturnType<typeof vi.fn>).mockImplementation(() => {
+      const run = activeRuns.get(sessionKey);
+      if (run) contentSamples.push(run.currentContent);
+    });
+
+    await router.handleMessage(ws, {
+      type: "message",
+      content: "hi",
+      agentId: "agent-1",
+    });
+
+    // The buffer reached the full reply mid-stream.
+    expect(contentSamples).toContain("one two three");
+    // And it only ever grew (prefix chain) while in-flight — never shrank.
+    const nonEmpty = contentSamples.filter((s) => s.length > 0);
+    for (let i = 1; i < nonEmpty.length; i++) {
+      expect(nonEmpty[i]!.startsWith(nonEmpty[i - 1]!)).toBe(true);
+    }
+  });
+
   it("touches lastChunkAt as new chunks arrive (watchdog distinguishes 'progressing' from 'silent')", async () => {
     const chunks: ChatChunk[] = [
       { type: "text", text: "Hi ", runId: "run-touch" },

--- a/packages/web/src/__tests__/server/client-router-history-resume.test.ts
+++ b/packages/web/src/__tests__/server/client-router-history-resume.test.ts
@@ -148,8 +148,12 @@ describe("ClientRouter handleHistory ↔ ActiveRuns resume (#310 Tier 2b)", () =
       currentMessageId: "msg-inflight",
       ws: wsOriginal,
     });
+    // The server has emitted more of the reply than OpenClaw has persisted —
+    // this is the resume buffer the reconnecting client must be re-seeded with.
+    activeRuns.setContent(sessionKey, "We're checking the vacation policy for you");
 
-    // OC history returns a partial assistant turn (typical for in-flight).
+    // OC history returns a shorter (or no) partial assistant turn (typical for
+    // in-flight — persistence lags the live stream).
     mockSessionsHistory.mockResolvedValue({
       messages: [
         { role: "user", content: "What's the vacation policy?" },
@@ -174,6 +178,10 @@ describe("ClientRouter handleHistory ↔ ActiveRuns resume (#310 Tier 2b)", () =
       runId: "run-active",
       messageId: "msg-inflight",
       startedAt: 1000,
+      // Resume completeness: the server replays its accumulated emitted text so
+      // the client recovers words streamed before the reload, even though OC
+      // history only has the shorter persisted "We're checking...".
+      partialContent: "We're checking the vacation policy for you",
     });
     // The reconnecting ws joined the listener set so future chunks
     // broadcast to it.

--- a/packages/web/src/hooks/ensure-trailing-assistant.ts
+++ b/packages/web/src/hooks/ensure-trailing-assistant.ts
@@ -17,21 +17,28 @@
  *
  * On reload mid-stream the server sends history + an `activeRun` signal, but the
  * in-flight assistant reply may not be persisted yet (history ends in the user
- * turn) — exactly the `isRunning && last !== assistant` shape. By appending an
- * empty assistant bubble anchored to the run id (or re-anchoring the existing
- * trailing assistant), we keep the list ending in an assistant: assistant-ui
- * never injects its optimistic message, and streaming chunks MERGE into this id
- * via `mergeOrAppendChunk` instead of appending a fresh bubble (another count
- * lead). The empty bubble is the in-flight reply the user is already watching.
+ * turn) — exactly the `isRunning && last !== assistant` shape. The `anchor`
+ * carries the run id and the server's resume buffer (`partialContent`) as its
+ * content. By appending it (or re-anchoring the existing trailing assistant), we
+ * keep the list ending in an assistant: assistant-ui never injects its optimistic
+ * message, and future streaming chunks MERGE into this id via `mergeOrAppendChunk`
+ * instead of appending a fresh bubble (another count lead).
+ *
+ * Content: when re-anchoring an assistant that's already in history, we adopt
+ * whichever is MORE complete — the server's `partialContent` (authoritative,
+ * up-to-the-millisecond) or the persisted history content — so a lagging or
+ * empty resume buffer can never shrink a reply the user already saw.
  */
-export function ensureTrailingAssistant<T extends { id: string; role: string }>(
+export function ensureTrailingAssistant<T extends { id: string; role: string; content: string }>(
   messages: T[],
   anchor: T
 ): T[] {
   const last = messages[messages.length - 1];
   if (last && last.role === "assistant") {
-    // The in-flight reply is already trailing — re-anchor its id, keep content.
-    return [...messages.slice(0, -1), { ...last, id: anchor.id }];
+    // The in-flight reply is already trailing — re-anchor its id and adopt the
+    // more complete content (resume buffer vs persisted partial).
+    const content = anchor.content.length >= last.content.length ? anchor.content : last.content;
+    return [...messages.slice(0, -1), { ...last, id: anchor.id, content }];
   }
   // No trailing assistant (unpersisted reply, or a newer user turn trails it):
   // append the anchor so the list ends with an assistant.

--- a/packages/web/src/hooks/ensure-trailing-assistant.ts
+++ b/packages/web/src/hooks/ensure-trailing-assistant.ts
@@ -1,0 +1,39 @@
+/**
+ * Anchor an in-flight run's assistant reply as the TRAILING message of the
+ * reconciled history, so the list always ends with an assistant while the run
+ * is running.
+ *
+ * Why this matters: assistant-ui's external store appends its own *optimistic*
+ * assistant message whenever `isRunning && lastMessage.role !== "assistant"`
+ * (see external-store-thread-runtime-core: `hasUpcomingMessage`). That extra
+ * message lands in assistant-ui's message COUNT
+ * (`ThreadPrimitive.Messages` renders `thread.messages.length` items) one render
+ * before its internal per-message resource list catches up — so
+ * `aui.thread().message({ index }).getState()` is called with an index one past
+ * the resource list and throws `tapClientLookup: Index N out of bounds
+ * (length: N)`, which the app's error boundary turns into "Something went
+ * wrong". This is the streaming-resume crash that survives the dedupeById /
+ * mergeOrAppendChunk guards (#470).
+ *
+ * On reload mid-stream the server sends history + an `activeRun` signal, but the
+ * in-flight assistant reply may not be persisted yet (history ends in the user
+ * turn) — exactly the `isRunning && last !== assistant` shape. By appending an
+ * empty assistant bubble anchored to the run id (or re-anchoring the existing
+ * trailing assistant), we keep the list ending in an assistant: assistant-ui
+ * never injects its optimistic message, and streaming chunks MERGE into this id
+ * via `mergeOrAppendChunk` instead of appending a fresh bubble (another count
+ * lead). The empty bubble is the in-flight reply the user is already watching.
+ */
+export function ensureTrailingAssistant<T extends { id: string; role: string }>(
+  messages: T[],
+  anchor: T
+): T[] {
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant") {
+    // The in-flight reply is already trailing — re-anchor its id, keep content.
+    return [...messages.slice(0, -1), { ...last, id: anchor.id }];
+  }
+  // No trailing assistant (unpersisted reply, or a newer user turn trails it):
+  // append the anchor so the list ends with an assistant.
+  return [...messages, anchor];
+}

--- a/packages/web/src/hooks/merge-chunk.ts
+++ b/packages/web/src/hooks/merge-chunk.ts
@@ -1,0 +1,40 @@
+/**
+ * Apply a streaming content chunk to the message list: merge it into the
+ * assistant message that already carries the chunk's id, or append a new
+ * assistant message if none exists.
+ *
+ * The match is by id ANYWHERE in the list, not just the trailing message. The
+ * old "only look at the last message" logic appended a second message with the
+ * same id whenever the in-flight assistant message wasn't last — which happens
+ * on streaming-resume: after a reload the relabeled in-flight message can sit
+ * before a trailing user/history message. Two messages with the same id crash
+ * assistant-ui's MessageRepository (and the whole chat view). Merging by id
+ * makes that duplicate impossible at its source.
+ *
+ * `incoming.content` is the delta: it is concatenated onto an existing message,
+ * or used as the initial content of an appended one.
+ */
+export function mergeOrAppendChunk<T extends { id: string; role: string; content: string }>(
+  messages: T[],
+  incoming: T
+): T[] {
+  // Fast path: the common case streams into the trailing assistant message.
+  const last = messages[messages.length - 1];
+  if (last && last.role === "assistant" && last.id === incoming.id) {
+    return [...messages.slice(0, -1), { ...last, content: last.content + incoming.content }];
+  }
+
+  // Resume path: a message with this id already exists but isn't last — merge
+  // into it in place rather than appending a duplicate id.
+  const existingIdx = messages.findIndex((m) => m.role === "assistant" && m.id === incoming.id);
+  if (existingIdx !== -1) {
+    const updated = messages.slice();
+    updated[existingIdx] = {
+      ...updated[existingIdx],
+      content: updated[existingIdx].content + incoming.content,
+    };
+    return updated;
+  }
+
+  return [...messages, incoming];
+}

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -6,6 +6,7 @@ import { useRestart } from "@/components/restart-provider";
 import { uuid } from "@/lib/uuid";
 import { dedupeById } from "@/lib/dedupe-by-id";
 import { mergeOrAppendChunk } from "@/hooks/merge-chunk";
+import { ensureTrailingAssistant } from "@/hooks/ensure-trailing-assistant";
 import { uploadAttachment } from "@/lib/upload-attachment";
 import { useDraftId } from "@/hooks/use-draft-id";
 import {
@@ -966,12 +967,23 @@ export function useWsRuntime(agentId: string): {
             }
           ).activeRun;
           if (activeRun) {
-            for (let i = historyMessages.length - 1; i >= 0; i--) {
-              if (historyMessages[i].role === "assistant") {
-                historyMessages[i].id = activeRun.messageId;
-                break;
-              }
-            }
+            // Anchor the in-flight reply as the TRAILING assistant message. If
+            // the reply isn't persisted in history yet (history ends in the user
+            // turn), this appends an empty assistant bubble for it. Keeping the
+            // list ending in an assistant while isRunning stops assistant-ui from
+            // injecting its own optimistic message, which would lead its message
+            // count past its per-message resource list and crash
+            // ThreadPrimitive.Messages (tapClientLookup index out of bounds).
+            // Chunks merge into this id via mergeOrAppendChunk. See
+            // ensure-trailing-assistant.ts (#470).
+            const anchored = ensureTrailingAssistant(historyMessages, {
+              id: activeRun.messageId,
+              role: "assistant",
+              content: "",
+              timestamp: new Date().toISOString(),
+            });
+            historyMessages.length = 0;
+            historyMessages.push(...anchored);
             isRunningRef.current = true;
             setIsRunning(true);
             inflightRunIdRef.current = activeRun.runId;

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -963,23 +963,31 @@ export function useWsRuntime(agentId: string): {
           // the spinner doesn't flicker.
           const activeRun = (
             data as {
-              activeRun?: { runId: string; messageId: string; startedAt: number };
+              activeRun?: {
+                runId: string;
+                messageId: string;
+                startedAt: number;
+                partialContent?: string;
+              };
             }
           ).activeRun;
           if (activeRun) {
-            // Anchor the in-flight reply as the TRAILING assistant message. If
-            // the reply isn't persisted in history yet (history ends in the user
-            // turn), this appends an empty assistant bubble for it. Keeping the
-            // list ending in an assistant while isRunning stops assistant-ui from
+            // Anchor the in-flight reply as the TRAILING assistant message, seeded
+            // with the server's resume buffer (`partialContent`) — the text
+            // already streamed before this reload, which the server won't replay
+            // as deltas and OpenClaw may not have persisted into history yet. If
+            // the reply isn't in history, this appends a bubble for it; if it is,
+            // it adopts whichever content is more complete. Keeping the list
+            // ending in an assistant while isRunning also stops assistant-ui from
             // injecting its own optimistic message, which would lead its message
             // count past its per-message resource list and crash
             // ThreadPrimitive.Messages (tapClientLookup index out of bounds).
-            // Chunks merge into this id via mergeOrAppendChunk. See
+            // Future chunks merge into this id via mergeOrAppendChunk. See
             // ensure-trailing-assistant.ts (#470).
             const anchored = ensureTrailingAssistant(historyMessages, {
               id: activeRun.messageId,
               role: "assistant",
-              content: "",
+              content: activeRun.partialContent ?? "",
               timestamp: new Date().toISOString(),
             });
             historyMessages.length = 0;

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -4,6 +4,7 @@ import { useState, useEffect, useRef, useCallback, useMemo } from "react";
 import { toast } from "sonner";
 import { useRestart } from "@/components/restart-provider";
 import { uuid } from "@/lib/uuid";
+import { dedupeById } from "@/lib/dedupe-by-id";
 import { uploadAttachment } from "@/lib/upload-attachment";
 import { useDraftId } from "@/hooks/use-draft-id";
 import {
@@ -1767,7 +1768,12 @@ export function useWsRuntime(agentId: string): {
   const hasInitialContent = messages.length > 0 || knownEmptyHistory;
 
   const convertedMessages = useMemo(() => {
-    const base = messages.map(convertMessage);
+    // Defense-in-depth: a duplicate message id crashes assistant-ui's
+    // MessageRepository (and the whole chat view via the error boundary). The
+    // streaming-resume reconcile can transiently produce one — never let it
+    // reach assistant-ui. See dedupe-by-id.ts and the root-cause fix in the
+    // history `activeRun` reconcile below.
+    const base = dedupeById(messages.map(convertMessage));
     if (isOrphaned) {
       return [
         ...base,

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -5,6 +5,7 @@ import { toast } from "sonner";
 import { useRestart } from "@/components/restart-provider";
 import { uuid } from "@/lib/uuid";
 import { dedupeById } from "@/lib/dedupe-by-id";
+import { mergeOrAppendChunk } from "@/hooks/merge-chunk";
 import { uploadAttachment } from "@/lib/upload-attachment";
 import { useDraftId } from "@/hooks/use-draft-id";
 import {
@@ -1118,22 +1119,20 @@ export function useWsRuntime(agentId: string): {
                 filtered = filtered.slice(0, lastUserIdx + 1);
               }
             }
-            const last = filtered[filtered.length - 1];
-            if (last?.role === "assistant" && last.id === data.messageId) {
-              return capMessages([
-                ...filtered.slice(0, -1),
-                { ...last, content: last.content + data.content },
-              ]);
-            }
-            return capMessages([
-              ...filtered,
-              {
+            // Merge the chunk into the assistant message with this id wherever
+            // it sits (not just the trailing one) — see merge-chunk.ts. On
+            // streaming-resume the relabeled in-flight message can be non-last,
+            // and appending a second message with the same id crashes
+            // assistant-ui. This is the root-cause complement to the dedupeById
+            // guard applied before the runtime.
+            return capMessages(
+              mergeOrAppendChunk(filtered, {
                 id: data.messageId,
                 role: "assistant",
                 content: data.content,
                 timestamp: new Date().toISOString(),
-              },
-            ]);
+              })
+            );
           });
         }
 

--- a/packages/web/src/lib/dedupe-by-id.ts
+++ b/packages/web/src/lib/dedupe-by-id.ts
@@ -1,0 +1,25 @@
+/**
+ * Collapse items that share an `id`, keeping the LAST occurrence at its
+ * position and dropping earlier duplicates.
+ *
+ * Used as a defense-in-depth guard right before the message list is handed to
+ * assistant-ui's `useExternalStoreRuntime`. assistant-ui's MessageRepository
+ * throws ("a message with the same id already exists in the parent tree") and
+ * crashes the entire chat view via the error boundary if it ever receives two
+ * messages with the same id. The streaming-resume reconcile can transiently
+ * produce such a duplicate (the in-flight assistant message arrives both from
+ * the relabeled history and from the resumed stream); this keeps a duplicate
+ * from ever reaching assistant-ui, regardless of reconcile timing.
+ *
+ * Keeping the last occurrence means the freshest version of a streaming message
+ * wins.
+ */
+export function dedupeById<T extends { id?: string }>(items: T[]): T[] {
+  const lastIndexById = new Map<string, number>();
+  items.forEach((item, index) => {
+    if (item.id !== undefined) lastIndexById.set(item.id, index);
+  });
+  return items.filter(
+    (item, index) => item.id === undefined || lastIndexById.get(item.id) === index
+  );
+}

--- a/packages/web/src/server/active-runs.ts
+++ b/packages/web/src/server/active-runs.ts
@@ -53,6 +53,20 @@ export interface ActiveRun {
    * matching message after reconcile.
    */
   currentMessageId: string;
+  /**
+   * The assistant text Pinchy has emitted to clients for `currentMessageId` so
+   * far (Tier 2b resume completeness). Streaming chunks are DELTAS: after a
+   * reload the server resumes broadcasting from the current position and never
+   * replays earlier deltas, and OpenClaw may not have persisted the in-flight
+   * partial into history yet — so without this buffer the words streamed before
+   * the reload are lost. On reconnect the server hands this back as
+   * `activeRun.partialContent`; the client seeds the anchored assistant bubble
+   * with it, then appends future deltas. Reset to "" on each per-turn messageId
+   * rotation (the completed turn is now in OpenClaw history). Kept in sync via
+   * `setContent` against the pipe's local accumulator, so it stays correct even
+   * if early text streamed before the run was registered.
+   */
+  currentContent: string;
   listeners: Set<WebSocket>;
 }
 
@@ -75,10 +89,16 @@ export class ActiveRuns {
    * the old entry is discarded — its listeners are no longer reached, which
    * matches the user expectation that the new turn replaces the old one.
    */
-  register(input: Omit<ActiveRun, "lastChunkAt" | "listeners"> & { ws: WebSocket }): ActiveRun {
-    const { ws, ...rest } = input;
+  register(
+    input: Omit<ActiveRun, "lastChunkAt" | "listeners" | "currentContent"> & {
+      ws: WebSocket;
+      currentContent?: string;
+    }
+  ): ActiveRun {
+    const { ws, currentContent, ...rest } = input;
     const run: ActiveRun = {
       ...rest,
+      currentContent: currentContent ?? "",
       lastChunkAt: rest.startedAt,
       listeners: new Set<WebSocket>([ws]),
     };
@@ -110,6 +130,22 @@ export class ActiveRuns {
     const run = this.runs.get(sessionKey);
     if (!run) return;
     run.currentMessageId = messageId;
+    // A new per-turn message starts with no emitted text. The just-finished
+    // turn is now persisted in OpenClaw history, so a reconnecting client gets
+    // it from history rather than from the resume buffer.
+    run.currentContent = "";
+  }
+
+  /**
+   * Sync the accumulated emitted text for the current message. Called from the
+   * stream pipe against its local accumulator on every emitted chunk, so the
+   * registry mirrors exactly what clients have received — the source of truth
+   * for `activeRun.partialContent` on reconnect.
+   */
+  setContent(sessionKey: string, content: string): void {
+    const run = this.runs.get(sessionKey);
+    if (!run) return;
+    run.currentContent = content;
   }
 
   get(sessionKey: string): ActiveRun | undefined {

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -471,6 +471,12 @@ export class ClientRouter {
           runId: activeRun.runId,
           messageId: activeRun.currentMessageId,
           startedAt: activeRun.startedAt,
+          // Tier 2b resume completeness: the text emitted for the in-flight
+          // message so far. Snapshotted here in the SAME synchronous block as
+          // `addListener` above (no await between) so it can't double-count a
+          // chunk that also arrives as a live delta. The client seeds the
+          // anchored assistant bubble with this, then appends future deltas.
+          partialContent: activeRun.currentContent,
         }
       : undefined;
 
@@ -715,6 +721,13 @@ export class ClientRouter {
     let activeRunRegistered = false;
     let activeRunId: string | undefined;
     let sawTerminalError = false;
+    // Tier 2b resume buffer: the assistant text emitted to clients for the
+    // current `messageId` so far. Mirrored into the ActiveRun registry on every
+    // emit so a reconnecting client can be re-seeded with the words it streamed
+    // before the reload (chunks are deltas; the server never replays them and
+    // OpenClaw may not have persisted the partial yet). Reset on each per-turn
+    // `done` rotation.
+    let emittedContent = "";
 
     try {
       for await (const chunk of stream) {
@@ -754,6 +767,9 @@ export class ClientRouter {
             agentName: agent.name,
             startedAt: Date.now(),
             currentMessageId: messageId,
+            // Seed with any text already emitted before this registering chunk
+            // so the resume buffer never starts behind what clients have seen.
+            currentContent: emittedContent,
             ws: clientWs,
           });
           activeRunRegistered = true;
@@ -838,6 +854,13 @@ export class ClientRouter {
             if (safeLen > 0) {
               const emit = textBuffer.slice(0, safeLen);
               textBuffer = textBuffer.slice(safeLen);
+              // Accumulate then mirror into the registry in the SAME synchronous
+              // block as the broadcast: a reconnect's atomic snapshot+addListener
+              // means any chunk is either fully before the snapshot (counted in
+              // partialContent, not re-broadcast to the new ws) or fully after
+              // (not in the snapshot, delivered as a live delta) — never both.
+              emittedContent += emit;
+              this.activeRuns.setContent(sessionKey, emittedContent);
               this.broadcastForRun(sessionKey, clientWs, {
                 type: "chunk",
                 content: emit,
@@ -926,6 +949,8 @@ export class ClientRouter {
             // resolved to the silent-reply sentinel, suppress it; otherwise
             // emit whatever text was held back.
             if (textBuffer && textBuffer !== SILENT_REPLY_TOKEN) {
+              emittedContent += textBuffer;
+              this.activeRuns.setContent(sessionKey, emittedContent);
               this.broadcastForRun(sessionKey, clientWs, {
                 type: "chunk",
                 content: textBuffer,
@@ -942,6 +967,9 @@ export class ClientRouter {
         // stores them in history).
         if (chunk.type === "done") {
           textBuffer = "";
+          // The completed turn is now in OpenClaw history; the next turn starts
+          // with an empty resume buffer (updateMessageId clears the registry's).
+          emittedContent = "";
           messageId = crypto.randomUUID();
           // Tier 2b: keep the registry's view of the current messageId in
           // sync with the per-turn rotation so a reconnecting client gets


### PR DESCRIPTION
Fixes the streaming-resume duplicate-message-id crash found in the staging click-through (Phase 3).

## Bug
Reloading the page **during** a streaming reply hard-crashes the whole chat view: assistant-ui's MessageRepository throws `a message with the same id already exists in the parent tree` and the app error boundary shows `Something went wrong`. A second reload (stream finished) shows the full reply.

## Root cause
On reload-mid-stream the history frame carries an `activeRun` signal and the reconcile relabels the last history assistant message to `activeRun.messageId`. When the in-flight assistant isn't in history yet (OpenClaw hasn't persisted it), the relabel lands on a prior assistant and the **chunk handler — which only checked the trailing message — appended a SECOND message with the run id**, the duplicate that crashes assistant-ui.

## Layered fix
- **Layer 1 — crash guard:** `dedupeById()` collapses duplicate ids right before `useExternalStoreRuntime`, so a transient duplicate can never crash the view. Pure, unit-tested (5 cases).
- **Layer 2 — root cause:** `mergeOrAppendChunk()` merges a chunk into the assistant message carrying its id **anywhere** in the list (not just the tail), so the duplicate is never created. Pure, unit-tested (4 cases incl. the non-last resume case). 219 hook tests green, no streaming regression.
- **Layer 3 — E2E:** Playwright reload-mid-stream regression — reload the same tab while streaming, assert no error boundary and that the reply resumes in one bubble.

Deterministic red/green proof is at the unit layer (Layers 1+2); the E2E is the end-to-end behavior guard (reliably green with the fix). Build/typecheck green.