### PR TITLE
ci: harden link-check and ollama install against transient 5xx

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1862,7 +1862,17 @@ jobs:
       - uses: ./.github/actions/setup-pnpm
 
       - name: Install Ollama
-        run: curl -fsSL https://ollama.com/install.sh | sh
+        # Retry the whole install: ollama's installer downloads a binary from a
+        # CDN that intermittently returns a transient 504, which then feeds a
+        # partial body into zstd/tar and fails the step — not a real error.
+        run: |
+          for attempt in 1 2 3; do
+            if curl -fsSL https://ollama.com/install.sh | sh; then exit 0; fi
+            echo "Ollama install attempt ${attempt} failed; retrying in 10s..."
+            sleep 10
+          done
+          echo "::error::Ollama install failed after 3 attempts"
+          exit 1
 
       - name: Start Ollama
         run: |
@@ -1898,7 +1908,10 @@ jobs:
       - name: Check links
         uses: lycheeverse/lychee-action@v2
         with:
-          args: "--no-progress --max-retries 3 --retry-wait-time 5 '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org'"
+          # --accept treats transient server responses (rate-limit + 5xx, e.g.
+          # GitHub returning a 504 during a brief outage) as OK so they don't
+          # red-light unrelated PRs. Genuinely broken links (404/410) still fail.
+          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why
PR #469 (an unrelated DB-test PR) went red on a brief **GitHub 504 outage** — neither failure was caused by the change:

- **Check links (lychee):** `github.com/heypinchy/pinchy/issues` and `/discussions` returned **504 Gateway Timeout**; lychee's 3 retries (15s) didn't outlast the outage.
- **Ollama integration:** `curl … install.sh | sh` failed because the installer's CDN binary download hit a **504**, feeding a partial body into `zstd | tar` (`unexpected end of file`).

Per our 'fix flaky CI at the root, don't just rerun' rule, this hardens both against transient server responses.

## Changes
- **lychee:** add `--accept '200..=299,429,500..=599'` — transient rate-limit + 5xx responses are treated as OK; genuine broken links (404/410) still fail.
- **Ollama install:** wrap `curl … | sh` in a 3× retry loop that only fails the step after all attempts fail.

Repo-wide hardening — benefits every PR. (This PR self-validates: if the lychee args or retry logic were wrong, its own Check-links / Ollama jobs would fail.)