### PR TITLE
fix: oversize-attachment UX + model-picker capability icons (v0.5.7 staging findings)

### DIFF
--- a/packages/web/src/__tests__/components/agent-settings-general.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-general.test.tsx
@@ -3,11 +3,21 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentSettingsGeneral } from "@/components/agent-settings-general";
+import { useModelCapabilities } from "@/hooks/use-model-capabilities";
 
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: vi.fn(),
   }),
+}));
+
+vi.mock("@/hooks/use-model-capabilities", () => ({
+  useModelCapabilities: vi.fn(() => ({
+    data: undefined,
+    isLoading: false,
+    error: undefined,
+    refetch: vi.fn(),
+  })),
 }));
 
 describe("AgentSettingsGeneral", () => {
@@ -338,6 +348,47 @@ describe("AgentSettingsGeneral", () => {
           true
         );
       });
+    });
+  });
+
+  describe("capability icons in the model dropdown", () => {
+    const allCaps = {
+      vision: true,
+      documents: true,
+      audio: false,
+      video: false,
+      longContext: true,
+      tools: true,
+    };
+
+    it("merges the capability map into the picker so models show capability icons", async () => {
+      vi.mocked(useModelCapabilities).mockReturnValue({
+        data: {
+          "anthropic/claude-sonnet-4-6": allCaps,
+          "anthropic/claude-opus-4-20250514": allCaps,
+          "openai/gpt-5.4": { ...allCaps, vision: false, documents: false },
+        },
+        isLoading: false,
+        error: undefined,
+        refetch: vi.fn(),
+      });
+
+      // providers come in WITHOUT capabilities (as from /api/providers/models);
+      // the component must join them with the capability map.
+      render(
+        <AgentSettingsGeneral
+          agent={defaultAgent}
+          providers={defaultProviders}
+          onChange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole("combobox"));
+
+      // The two vision+document Anthropic models render the vision and document
+      // icons; the text-only GPT model does not add a vision icon.
+      expect(screen.getAllByLabelText("Supports image input").length).toBeGreaterThan(0);
+      expect(screen.getAllByLabelText("Supports document input").length).toBeGreaterThan(0);
     });
   });
 

--- a/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
+++ b/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
@@ -16,6 +16,7 @@ import { useWsRuntime, type PendingUpload } from "@/hooks/use-ws-runtime";
 import * as uploadModule from "@/lib/upload-attachment";
 import * as imageCompression from "@/lib/image-compression";
 import { CLIENT_IMAGE_COMPRESSION_TARGET_BYTES } from "@/lib/limits";
+import { toast } from "sonner";
 
 // ── Module mocks ──────────────────────────────────────────────────────────────
 
@@ -49,6 +50,10 @@ vi.mock("@assistant-ui/react", () => ({
       this.accept = adapters.map((a) => a.accept).join(",");
     }
   },
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn(), warning: vi.fn() },
 }));
 
 // ── WebSocket stub ────────────────────────────────────────────────────────────
@@ -129,6 +134,42 @@ describe("PendingUpload state machine", () => {
       /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/
     );
     expect(mockCreateObjectURL).toHaveBeenCalledWith(file);
+  });
+
+  it("client-side pre-check: an oversize non-image file is rejected with a toast and never uploaded", async () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+
+    const big = makeFile("huge.pdf", 1024);
+    // Spoof a 31 MB size without allocating 31 MB in the test.
+    Object.defineProperty(big, "size", { value: 31 * 1024 * 1024 });
+
+    await act(async () => {
+      result.current.addPendingUpload(big);
+    });
+
+    // No bytes leave the browser, no chip is created — just a clear toast that
+    // names the file and both sizes.
+    expect(uploadModule.uploadAttachment).not.toHaveBeenCalled();
+    expect(result.current.pendingUploads).toHaveLength(0);
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("huge.pdf"));
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("31 MB"));
+    expect(vi.mocked(toast.error)).toHaveBeenCalledWith(expect.stringContaining("15 MB"));
+  });
+
+  it("client-side pre-check does NOT reject images (they are compressed before upload)", async () => {
+    // Upload hangs so the chip stays in 'uploading' — proves the image path ran.
+    vi.mocked(uploadModule.uploadAttachment).mockReturnValue(new Promise(() => {}));
+
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const bigImage = new File([new Uint8Array(1024)], "photo.png", { type: "image/png" });
+    Object.defineProperty(bigImage, "size", { value: 40 * 1024 * 1024 });
+
+    await act(async () => {
+      result.current.addPendingUpload(bigImage);
+    });
+
+    expect(result.current.pendingUploads).toHaveLength(1);
+    expect(vi.mocked(toast.error)).not.toHaveBeenCalled();
   });
 
   it("progress callback updates the progress field", async () => {

--- a/packages/web/src/__tests__/lib/attach-capabilities.test.ts
+++ b/packages/web/src/__tests__/lib/attach-capabilities.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from "vitest";
+import { attachCapabilities } from "@/lib/model-capabilities/attach-capabilities";
+import type { ModelCapabilities } from "@/lib/model-capabilities/types";
+
+const caps = (over: Partial<ModelCapabilities> = {}): ModelCapabilities => ({
+  vision: false,
+  documents: false,
+  audio: false,
+  video: false,
+  longContext: false,
+  tools: false,
+  ...over,
+});
+
+describe("attachCapabilities", () => {
+  it("attaches capabilities to each model by qualified id, preserving other fields", () => {
+    const providers = [
+      {
+        id: "anthropic",
+        name: "Anthropic",
+        models: [{ id: "anthropic/claude-opus-4-7", name: "Claude Opus 4.7", compatible: true }],
+      },
+    ];
+    const map = {
+      "anthropic/claude-opus-4-7": caps({ vision: true, documents: true, tools: true }),
+    };
+
+    const out = attachCapabilities(providers, map);
+
+    expect(out[0].models[0]).toEqual({
+      id: "anthropic/claude-opus-4-7",
+      name: "Claude Opus 4.7",
+      compatible: true,
+      capabilities: caps({ vision: true, documents: true, tools: true }),
+    });
+  });
+
+  it("leaves capabilities undefined for models not present in the map", () => {
+    const providers = [{ id: "x", name: "X", models: [{ id: "x/unknown", name: "Unknown" }] }];
+
+    const out = attachCapabilities(providers, { "x/known": caps() });
+
+    expect(out[0].models[0].capabilities).toBeUndefined();
+  });
+
+  it("returns providers unchanged (capabilities undefined) when the map is still loading", () => {
+    const providers = [
+      { id: "x", name: "X", models: [{ id: "x/a", name: "A", compatible: false }] },
+    ];
+
+    const out = attachCapabilities(providers, undefined);
+
+    expect(out[0].models[0].capabilities).toBeUndefined();
+    expect(out[0].models[0].name).toBe("A");
+    expect(out[0].models[0].compatible).toBe(false);
+  });
+
+  it("maps capabilities across multiple providers and models", () => {
+    const providers = [
+      { id: "anthropic", name: "Anthropic", models: [{ id: "anthropic/claude", name: "Claude" }] },
+      { id: "openai", name: "OpenAI", models: [{ id: "openai/gpt-5.5", name: "GPT-5.5" }] },
+    ];
+    const map = {
+      "anthropic/claude": caps({ vision: true, longContext: true }),
+      "openai/gpt-5.5": caps({ vision: true, tools: true }),
+    };
+
+    const out = attachCapabilities(providers, map);
+
+    expect(out[0].models[0].capabilities).toEqual(caps({ vision: true, longContext: true }));
+    expect(out[1].models[0].capabilities).toEqual(caps({ vision: true, tools: true }));
+  });
+});

--- a/packages/web/src/__tests__/lib/attachment-size-check.test.ts
+++ b/packages/web/src/__tests__/lib/attachment-size-check.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import { oversizeAttachmentError } from "@/lib/attachment-size-check";
+import { CLIENT_MAX_ATTACHMENT_SIZE_BYTES } from "@/lib/limits";
+
+const MAX = CLIENT_MAX_ATTACHMENT_SIZE_BYTES; // 15 MB
+
+describe("oversizeAttachmentError", () => {
+  it("rejects a non-image file over the limit with a message naming the file and both sizes", () => {
+    const msg = oversizeAttachmentError({
+      name: "Noboarding.pdf",
+      type: "application/pdf",
+      size: 31 * 1024 * 1024,
+    });
+    expect(msg).not.toBeNull();
+    expect(msg).toContain("Noboarding.pdf");
+    expect(msg).toContain("31 MB"); // actual size
+    expect(msg).toContain("15 MB"); // limit
+  });
+
+  it("accepts a non-image file at or under the limit (returns null)", () => {
+    expect(
+      oversizeAttachmentError({ name: "a.pdf", type: "application/pdf", size: MAX })
+    ).toBeNull();
+    expect(
+      oversizeAttachmentError({ name: "a.pdf", type: "application/pdf", size: MAX - 1 })
+    ).toBeNull();
+  });
+
+  it("never rejects images by raw size — they are compressed client-side before upload", () => {
+    expect(
+      oversizeAttachmentError({ name: "photo.jpg", type: "image/jpeg", size: 50 * 1024 * 1024 })
+    ).toBeNull();
+    expect(
+      oversizeAttachmentError({ name: "shot.png", type: "image/png", size: 40 * 1024 * 1024 })
+    ).toBeNull();
+  });
+
+  it("rejects a large CSV/other non-image type too (not just PDFs)", () => {
+    const msg = oversizeAttachmentError({
+      name: "export.csv",
+      type: "text/csv",
+      size: 20 * 1024 * 1024,
+    });
+    expect(msg).toContain("export.csv");
+    expect(msg).toContain("20 MB");
+  });
+});

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect } from "react";
+import { useEffect, useMemo } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
@@ -15,6 +15,8 @@ import {
 } from "@/components/ui/form";
 import { DeleteAgentDialog } from "@/components/delete-agent-dialog";
 import { ModelPicker } from "@/components/model-picker";
+import { useModelCapabilities } from "@/hooks/use-model-capabilities";
+import { attachCapabilities } from "@/lib/model-capabilities/attach-capabilities";
 
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agent-constants";
 
@@ -61,6 +63,15 @@ export function AgentSettingsGeneral({
   });
 
   const values = useWatch({ control: form.control });
+
+  // Join the configured model list (from /api/providers/models, which carries no
+  // capability flags) with the capability map so the picker can render each
+  // model's capability icons. Undefined while the map loads → icon-free, no crash.
+  const { data: capabilities } = useModelCapabilities();
+  const providersWithCapabilities = useMemo(
+    () => attachCapabilities(providers, capabilities),
+    [providers, capabilities]
+  );
 
   useEffect(() => {
     onChange(
@@ -122,7 +133,7 @@ export function AgentSettingsGeneral({
                   <ModelPicker
                     value={field.value}
                     onChange={field.onChange}
-                    providers={providers}
+                    providers={providersWithCapabilities}
                     deprecatedModelId={agent.model}
                   />
                 </FormControl>

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -8,6 +8,7 @@ import { dedupeById } from "@/lib/dedupe-by-id";
 import { mergeOrAppendChunk } from "@/hooks/merge-chunk";
 import { ensureTrailingAssistant } from "@/hooks/ensure-trailing-assistant";
 import { uploadAttachment } from "@/lib/upload-attachment";
+import { oversizeAttachmentError } from "@/lib/attachment-size-check";
 import { useDraftId } from "@/hooks/use-draft-id";
 import {
   useExternalStoreRuntime,
@@ -1579,6 +1580,16 @@ export function useWsRuntime(agentId: string): {
       const activeCount = pendingUploadsRef.current.filter((u) => u.state !== "failed").length;
       if (activeCount >= MAX_ATTACHMENTS_PER_MESSAGE) {
         toast.error(`Too many attachments (max ${MAX_ATTACHMENTS_PER_MESSAGE})`);
+        return;
+      }
+
+      // Reject an oversize NON-image file up front — same rationale as the count
+      // check above: a clear toast immediately, instead of uploading the whole
+      // file just to surface a truncated 413 on a failed chip. Images are exempt
+      // (compressed below the cap before upload), so they fall through.
+      const sizeError = oversizeAttachmentError(file);
+      if (sizeError) {
+        toast.error(sizeError);
         return;
       }
 

--- a/packages/web/src/lib/attachment-size-check.ts
+++ b/packages/web/src/lib/attachment-size-check.ts
@@ -1,0 +1,22 @@
+import { CLIENT_MAX_ATTACHMENT_SIZE_BYTES } from "@/lib/limits";
+
+/**
+ * Decide, client-side and BEFORE any upload, whether a picked attachment is too
+ * large — returning a ready-to-toast message, or null if it's fine.
+ *
+ * Images are intentionally exempt: they are compressed client-side (to ~1.9 MB)
+ * before upload, so their raw size never reaches the cap. Non-image files (PDF,
+ * CSV, …) are sent untouched, so the raw size is what the server enforces — and
+ * checking it here lets us reject instantly with a clear message instead of
+ * uploading the whole file just to surface a truncated 413 on the chip.
+ */
+export function oversizeAttachmentError(
+  file: { name: string; type: string; size: number },
+  maxBytes: number = CLIENT_MAX_ATTACHMENT_SIZE_BYTES
+): string | null {
+  if (file.type.startsWith("image/")) return null;
+  if (file.size <= maxBytes) return null;
+  const limitMb = Math.round(maxBytes / 1024 / 1024);
+  const fileMb = Math.round(file.size / 1024 / 1024);
+  return `"${file.name}" is too large (${fileMb} MB). The maximum is ${limitMb} MB.`;
+}

--- a/packages/web/src/lib/model-capabilities/attach-capabilities.ts
+++ b/packages/web/src/lib/model-capabilities/attach-capabilities.ts
@@ -1,0 +1,27 @@
+import type { ModelCapabilities } from "@/lib/model-capabilities/types";
+import type { ModelCapabilityMap } from "@/hooks/use-model-capabilities";
+
+/**
+ * Merge the per-model capability map (from `useModelCapabilities`, i.e.
+ * `GET /api/models/capabilities`) into a provider list whose models are keyed by
+ * the same qualified id (`provider/model`). Each model gains a `capabilities`
+ * field so `ModelPicker` can render its capability icons; models absent from the
+ * map (or while it's still loading) keep `capabilities: undefined`, which the
+ * picker renders icon-free.
+ *
+ * `/api/providers/models` returns the configured/compatible model list WITHOUT
+ * capabilities; this is the client-side join that lights up the picker icons in
+ * the agent settings model dropdown.
+ */
+export function attachCapabilities<M extends { id: string }, P extends { models: M[] }>(
+  providers: P[],
+  capabilities: ModelCapabilityMap | undefined
+): Array<P & { models: Array<M & { capabilities?: ModelCapabilities }> }> {
+  return providers.map((provider) => ({
+    ...provider,
+    models: provider.models.map((model) => ({
+      ...model,
+      capabilities: capabilities?.[model.id],
+    })),
+  }));
+}


### PR DESCRIPTION
Two bugs found during the v0.5.7 staging click-through, each fixed TDD (separate commits).

## 1. Oversize attachments: reject client-side before upload (`193fa5be0`)
A >15 MB **non-image** file (PDF, CSV, …) was fully uploaded before the server's 413 surfaced — as a truncated `File exceed…` on a failed chip, no title, after a full progress bar. The size check only existed on the `.docx` adapter and server-side; the main image/PDF upload path had none.

- `oversizeAttachmentError()` + a call in `addPendingUpload` right after the existing max-attachments pre-check: a clear, full **toast** naming the file and both sizes, **before any bytes leave the browser** — no wasted upload, no chip to clean up.
- Images are exempt (compressed below the cap before upload). The server 413 stays as the backstop.
- The server already rejects *before* `persistStagedUpload`, so an oversize file was never persisted — verified on staging (no `uploaded_files` row, no staged file).

**Tests:** pure-helper (image/non-image, boundary) + PendingUpload behavior (oversize non-image → toast + no upload + no chip; oversize image → not pre-rejected).

## 2. Model-picker capability icons missing in agent settings (`0090be630`)
The capability-icons feature shipped its data layer (`models` table / `/api/models/capabilities` / `useModelCapabilities`) and its UI (`ModelPicker`'s `CapabilityBadges`) — but the **agent-settings picker was never wired to the data**. `AgentSettingsGeneral` passed the `/api/providers/models` list straight through, and that list has no capability flags, so `m.capabilities` was always undefined → no icons. (The recovery-panel path works only because `thread.tsx` enriches its providers.)

- `attachCapabilities(providers, capabilityMap)` joins the map (by qualified model id) into the provider list; `AgentSettingsGeneral` now calls `useModelCapabilities()` and passes enriched providers to `ModelPicker`. Undefined while loading → icon-free, no crash.

**Tests:** pure-merge unit tests + a component test that the settings dropdown renders the vision/document icons once the map is present (red before the wiring).

## Verification
Full web unit suite green (**5678 passed**), typecheck clean. Branched off current `main` (`7f3cfb27f`).