### PR TITLE
fix(diagnostics): correct bundle timestamps, openclaw-node version, span timing

### DIFF
--- a/packages/web/src/__tests__/lib/audit-sanitize.test.ts
+++ b/packages/web/src/__tests__/lib/audit-sanitize.test.ts
@@ -2,6 +2,30 @@ import { describe, expect, it } from "vitest";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
 
 describe("sanitizeDetail", () => {
+  describe("Date serialization", () => {
+    it("serializes Date values to ISO strings instead of destroying them", () => {
+      // A Date has no own enumerable properties, so the generic object
+      // recursion turned it into {} — which shipped empty `timestamp: {}`
+      // fields in diagnostics bundles (v0.5.7 staging finding).
+      const ts = new Date("2026-06-09T16:48:57.441Z");
+      const result = sanitizeDetail({ timestamp: ts, note: "ok" });
+      expect(result).toEqual({ timestamp: "2026-06-09T16:48:57.441Z", note: "ok" });
+    });
+
+    it("serializes Dates nested in arrays and objects", () => {
+      const result = sanitizeDetail({
+        entries: [{ at: new Date("2026-01-02T03:04:05.000Z") }],
+      });
+      expect(result).toEqual({ entries: [{ at: "2026-01-02T03:04:05.000Z" }] });
+    });
+
+    it("still redacts a Date stored under a sensitive key", () => {
+      const result = sanitizeDetail({ tokenExpiry: new Date("2026-01-01T00:00:00.000Z") });
+      // Key-based redaction wins over serialization, same as for strings.
+      expect(result).toEqual({ tokenExpiry: "[REDACTED]" });
+    });
+  });
+
   describe("key-name redaction", () => {
     it("redacts values for known sensitive key names", () => {
       const input = {

--- a/packages/web/src/__tests__/lib/diagnostics/otel-builder.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/otel-builder.test.ts
@@ -56,6 +56,21 @@ describe("buildOtelSpans", () => {
     ]);
   });
 
+  it("carries turn timing into the span as ISO startTime/endTime", () => {
+    // Without timestamps an analyst cannot correlate spans with audit entries
+    // or wall-clock logs (v0.5.7 staging finding: spans had no timing at all).
+    const spans = buildOtelSpans([sampleTurn]);
+    expect(spans[0].startTime).toBe(new Date(1716000000000).toISOString()); // userMessage.timestamp
+    expect(spans[0].endTime).toBe(new Date(1716000001000).toISOString()); // assistantResponse.timestamp
+  });
+
+  it("omits startTime/endTime when no timestamps are known", () => {
+    const minimal: Turn = { index: 0, role: "user", assistantResponse: { text: "hi" } };
+    const spans = buildOtelSpans([minimal]);
+    expect(spans[0].startTime).toBeUndefined();
+    expect(spans[0].endTime).toBeUndefined();
+  });
+
   it("skips turns without an assistant response", () => {
     const userOnly: Turn = { index: 0, role: "user", userMessage: { text: "hi" } };
     expect(buildOtelSpans([userOnly])).toHaveLength(0);

--- a/packages/web/src/__tests__/lib/diagnostics/versions.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/versions.test.ts
@@ -1,5 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
-import { getDiagnosticsVersions } from "@/lib/diagnostics/versions";
+import { mkdtempSync, mkdirSync, writeFileSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { getDiagnosticsVersions, readOpenclawNodeVersionFrom } from "@/lib/diagnostics/versions";
 
 const ENV_KEYS = ["NEXT_PUBLIC_PINCHY_VERSION", "NEXT_PUBLIC_OPENCLAW_VERSION"] as const;
 const original: Partial<Record<(typeof ENV_KEYS)[number], string>> = {};
@@ -40,5 +43,54 @@ describe("getDiagnosticsVersions", () => {
     // the lockfile; if the package can't be resolved at all we'd see
     // "unknown", which would also be a failure here.
     expect(versions.openclawNode).toMatch(/^\d+\.\d+\.\d+/);
+  });
+});
+
+describe("readOpenclawNodeVersionFrom (bundler-proof path strategy)", () => {
+  // The createRequire-based resolution silently broke in the production
+  // bundle: webpack statically rewrites `require.resolve("openclaw-node")`
+  // (the local was named `require`), so dirname() threw and the route
+  // degraded to "unknown" — the v0.5.7 staging finding. This strategy reads
+  // <baseDir>/node_modules/openclaw-node/package.json directly off the
+  // filesystem, which no bundler can interfere with.
+  let dir: string;
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), "pinchy-versions-"));
+  });
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true });
+  });
+
+  function writePkg(content: unknown) {
+    const pkgDir = join(dir, "node_modules", "openclaw-node");
+    mkdirSync(pkgDir, { recursive: true });
+    writeFileSync(join(pkgDir, "package.json"), JSON.stringify(content));
+  }
+
+  it("reads the version from <baseDir>/node_modules/openclaw-node/package.json", () => {
+    writePkg({ name: "openclaw-node", version: "0.12.1" });
+    expect(readOpenclawNodeVersionFrom(dir)).toBe("0.12.1");
+  });
+
+  it("returns null when the package.json is missing", () => {
+    expect(readOpenclawNodeVersionFrom(dir)).toBeNull();
+  });
+
+  it("returns null when the package.json belongs to a different package", () => {
+    writePkg({ name: "something-else", version: "9.9.9" });
+    expect(readOpenclawNodeVersionFrom(dir)).toBeNull();
+  });
+
+  it("returns null when the version field is missing or not a string", () => {
+    writePkg({ name: "openclaw-node", version: 42 });
+    expect(readOpenclawNodeVersionFrom(dir)).toBeNull();
+  });
+
+  it("is used by getDiagnosticsVersions: the real package resolves from cwd", () => {
+    // process.cwd() in vitest is packages/web — the same layout the
+    // production container has (/app/packages/web), verified on staging.
+    expect(readOpenclawNodeVersionFrom(process.cwd())).toMatch(/^\d+\.\d+\.\d+/);
   });
 });

--- a/packages/web/src/lib/audit-sanitize.ts
+++ b/packages/web/src/lib/audit-sanitize.ts
@@ -66,6 +66,13 @@ function sanitizeValue(value: unknown, depth: number): unknown {
     return value.map((item) => sanitizeValue(item, depth + 1));
   }
 
+  // Dates have no own enumerable properties — the generic object branch below
+  // would strip them to {} (which shipped empty timestamps in diagnostics
+  // bundles). Serialize them like JSON.stringify would.
+  if (value instanceof Date) {
+    return value.toISOString();
+  }
+
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {

--- a/packages/web/src/lib/diagnostics/otel-builder.ts
+++ b/packages/web/src/lib/diagnostics/otel-builder.ts
@@ -2,7 +2,19 @@ import type { Turn } from "./turn-extractor";
 
 export interface OtelSpan {
   name: string;
+  /**
+   * ISO timestamps from the turn's JSONL events (user message → start, model
+   * completion → end). Optional: older transcripts may lack `ts` fields.
+   * Without these an analyst cannot correlate spans with audit entries or
+   * wall-clock logs.
+   */
+  startTime?: string;
+  endTime?: string;
   attributes: Record<string, unknown>;
+}
+
+function toIso(epochMs: number | undefined): string | undefined {
+  return epochMs === undefined ? undefined : new Date(epochMs).toISOString();
 }
 
 export function buildOtelSpans(turns: Turn[]): OtelSpan[] {
@@ -32,9 +44,13 @@ export function buildOtelSpans(turns: Turn[]): OtelSpan[] {
         result: tc.result,
       }));
     }
+    const startTime = toIso(turn.userMessage?.timestamp);
+    const endTime = toIso(r.timestamp);
     return [
       {
         name: "agent.turn",
+        ...(startTime !== undefined ? { startTime } : {}),
+        ...(endTime !== undefined ? { endTime } : {}),
         attributes: Object.fromEntries(Object.entries(attrs).filter(([, v]) => v !== undefined)),
       },
     ];

--- a/packages/web/src/lib/diagnostics/versions.ts
+++ b/packages/web/src/lib/diagnostics/versions.ts
@@ -4,33 +4,71 @@
 //   - `openclaw`     — injected at build time via NEXT_PUBLIC_OPENCLAW_VERSION
 //                       (the OC gateway version Pinchy is paired with).
 //   - `openclawNode` — read from the openclaw-node npm package's own
-//                       package.json. The package's `exports` map doesn't
-//                       expose `./package.json`, so neither a static
-//                       `import "openclaw-node/package.json"` nor
-//                       `require("openclaw-node/package.json")` work. Instead
-//                       we resolve the package's main entry and walk up to
-//                       find the enclosing package.json — this never touches
-//                       the exports map. If anything goes wrong (e.g. the
-//                       package is unresolvable in a stripped image) we
-//                       degrade to "unknown" rather than crashing the route.
+//                       package.json, via two strategies (see below). If both
+//                       fail we degrade to "unknown" rather than crashing the
+//                       route.
 import { createRequire } from "node:module";
 import { readFileSync } from "node:fs";
 import { dirname, join } from "node:path";
 
-function readOpenclawNodeVersion(): string {
+/**
+ * Strategy 1 (bundler-proof): read
+ * `<baseDir>/node_modules/openclaw-node/package.json` directly off the
+ * filesystem. `readFileSync` follows the pnpm symlink to the real package and
+ * no bundler can interfere with a plain path read.
+ *
+ * This exists because strategy 2 silently broke in the production bundle:
+ * webpack statically rewrites `require.resolve("openclaw-node")` when the
+ * local is named `require`, returning a module id instead of a path —
+ * `dirname()` threw, the catch swallowed it, and every bundle shipped
+ * `openclawNodeVersion: "unknown"` (v0.5.7 staging finding). In all our
+ * runtime layouts (dev compose, production image) the server's cwd is
+ * `packages/web`, which has `node_modules/openclaw-node` — verified on
+ * staging.
+ *
+ * Exported for tests. Returns null when the package.json is missing,
+ * belongs to a different package, or has no usable version.
+ */
+export function readOpenclawNodeVersionFrom(baseDir: string): string | null {
   try {
-    const require = createRequire(import.meta.url);
-    const mainPath = require.resolve("openclaw-node");
+    const raw = readFileSync(
+      join(baseDir, "node_modules", "openclaw-node", "package.json"),
+      "utf8"
+    );
+    const pkg = JSON.parse(raw) as { name?: unknown; version?: unknown };
+    if (pkg.name === "openclaw-node" && typeof pkg.version === "string" && pkg.version) {
+      return pkg.version;
+    }
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Strategy 2 (fallback): resolve the package's main entry and walk up to the
+ * enclosing package.json. The package's `exports` map doesn't expose
+ * `./package.json`, so a direct `require("openclaw-node/package.json")` would
+ * not work — the walk-up never touches the exports map.
+ *
+ * The createRequire local is deliberately NOT named `require`: webpack
+ * special-cases the bare identifier `require` and statically rewrites
+ * `require.resolve(...)`, which is exactly what broke this path in the
+ * production bundle.
+ */
+function readOpenclawNodeVersionViaResolver(): string | null {
+  try {
+    const nodeRequire = createRequire(import.meta.url);
+    const mainPath = nodeRequire.resolve("openclaw-node");
+    if (typeof mainPath !== "string") return null;
     // Expected resolutions across our layouts:
     //   pnpm hoisted (root install): node_modules/openclaw-node/dist/index.js
     //     → ../package.json (1 level up)
     //   pnpm non-hoisted (default):  node_modules/.pnpm/openclaw-node@<v>/
     //                                 node_modules/openclaw-node/dist/index.js
-    //     → ../package.json (1 level up — `.pnpm/<pkg>@<v>/node_modules/<pkg>/`
-    //       still ends at the package root one level above main)
+    //     → ../package.json (1 level up)
     // We tolerate up to 5 levels in case the package ever nests its main
-    // file deeper (e.g. dist/cjs/index.js or dist/esm/node/index.js). On
-    // any failure we degrade to "unknown" rather than crashing the route.
+    // file deeper (e.g. dist/cjs/index.js).
     let dir = dirname(mainPath);
     for (let i = 0; i < 5; i++) {
       try {
@@ -46,10 +84,16 @@ function readOpenclawNodeVersion(): string {
       if (parent === dir) break;
       dir = parent;
     }
-    return "unknown";
+    return null;
   } catch {
-    return "unknown";
+    return null;
   }
+}
+
+function readOpenclawNodeVersion(): string {
+  return (
+    readOpenclawNodeVersionFrom(process.cwd()) ?? readOpenclawNodeVersionViaResolver() ?? "unknown"
+  );
 }
 
 export function getDiagnosticsVersions(): {


### PR DESCRIPTION
Three defects in the v0.5.7 diagnostics export, found while reviewing a real staging bundle (`pinchy-bugreport-ada-20260611-0801.json`). Each fixed TDD (red→green, separate commits).

## 1. `auditEntries[].timestamp` was `{}` (`78562956b`)
`sanitizeValue` in `audit-sanitize.ts` recursed into objects via `Object.entries` — a `Date` has no own enumerable properties, so **every Date in the bundle became `{}`**. All audit timestamps in every exported bundle were destroyed. Fix: `instanceof Date → toISOString()` (key-based redaction still wins for sensitive keys). Benefits every `sanitizeDetail` consumer.

## 2. `openclawNodeVersion: "unknown"` (`1fd42a47e`)
Verified empirically on staging: plain-Node resolution finds `openclaw-node@0.12.1` in-container just fine. The route still reported "unknown" because the `createRequire` local was named `require` — **webpack statically rewrites `require.resolve("openclaw-node")`** to a module id, `dirname()` throws, the catch degrades to "unknown". Fix: strategy 1 reads `<cwd>/node_modules/openclaw-node/package.json` directly off the filesystem (bundler-proof, follows the pnpm symlink; cwd is `packages/web` in all layouts — staging-verified); the resolver walk-up remains as fallback with a non-`require` local.

## 3. Spans carried no timing (`1d27bd8bb`)
`OtelSpan` was `{name, attributes}` only — analysts couldn't correlate spans with audit entries or wall-clock logs. The turn extractor already parses the timestamps; now `startTime` (user message) and `endTime` (model completion) are emitted as ISO strings, omitted when the transcript lacks `ts`. Additive — `schemaVersion` stays `pinchy.bugreport.v1`.

## Verification
Diagnostics + sanitize suites 98/98; broader lib+api sweep 2715 passed; typecheck clean.