### PR TITLE
fix(diagnostics): per-turn span startTime from prompt.submitted pairing

### DIFF
--- a/packages/web/src/__tests__/lib/diagnostics/turn-extractor.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/turn-extractor.test.ts
@@ -15,6 +15,40 @@ describe("extractTurns", () => {
     expect(turns[0].assistantResponse).toBeDefined();
   });
 
+  it("takes each turn's userMessage timestamp from its paired prompt.submitted event", () => {
+    // Real staging finding (bundle 2026-06-11): every span carried the SAME
+    // startTime because the extractor read the FIRST snapshot message's
+    // timestamp — i.e. the session's first message — for every turn. The
+    // trajectory's prompt.submitted events carry the true per-turn submit
+    // time and pair with model.completed via runId.
+    const events = parseJsonlLines(FIXTURE);
+    const turns = extractTurns(events);
+
+    const expected = [
+      "2026-05-19T12:00:51.761Z",
+      "2026-05-19T12:31:37.955Z",
+      "2026-05-19T12:33:04.267Z",
+      "2026-05-19T12:42:20.201Z",
+      "2026-05-19T13:02:36.041Z",
+    ].map((iso) => Date.parse(iso));
+
+    expect(turns.map((t) => t.userMessage?.timestamp)).toEqual(expected);
+    // And crucially: the timestamps are per-turn distinct, not all identical.
+    expect(new Set(expected).size).toBe(expected.length);
+  });
+
+  it("falls back to the latest preceding prompt.submitted when runIds are absent", () => {
+    const events = [
+      { type: "prompt.submitted", ts: "2026-01-01T10:00:00.000Z" },
+      { type: "model.completed", ts: "2026-01-01T10:00:05.000Z", data: {} },
+      { type: "prompt.submitted", ts: "2026-01-01T11:00:00.000Z" },
+      { type: "model.completed", ts: "2026-01-01T11:00:09.000Z", data: {} },
+    ];
+    const turns = extractTurns(events);
+    expect(turns[0].userMessage?.timestamp).toBe(Date.parse("2026-01-01T10:00:00.000Z"));
+    expect(turns[1].userMessage?.timestamp).toBe(Date.parse("2026-01-01T11:00:00.000Z"));
+  });
+
   it("populates finish_reason, usage, and model on the assistantResponse", () => {
     const events = parseJsonlLines(FIXTURE);
     const turns = extractTurns(events);

--- a/packages/web/src/lib/diagnostics/turn-extractor.ts
+++ b/packages/web/src/lib/diagnostics/turn-extractor.ts
@@ -117,7 +117,11 @@ function collectToolCalls(snapshot: SnapshotMessage[]): ToolCall[] {
   return calls;
 }
 
-function buildTurn(event: Record<string, unknown>, index: number): Turn {
+function buildTurn(
+  event: Record<string, unknown>,
+  index: number,
+  promptTimestamp: number | undefined
+): Turn {
   const data = asRecord(event.data) ?? {};
   const timestamp = parseTimestamp(event.ts);
   const finalPromptText = asString(data.finalPromptText) ?? "";
@@ -147,20 +151,47 @@ function buildTurn(event: Record<string, unknown>, index: number): Turn {
   if (usage) assistantResponse.usage = usage;
   if (toolCalls.length > 0) assistantResponse.toolCalls = toolCalls;
 
+  // Per-turn submit time comes from the paired prompt.submitted event (see
+  // extractTurns). Fallback: the first snapshot message — which in practice is
+  // the SESSION's first message, so it only approximates the first turn. It
+  // exists for old transcripts without prompt.submitted events.
   const firstSnapshotMessage = snapshot[0];
-  const userMessageTimestamp =
+  const snapshotFallbackTimestamp =
     firstSnapshotMessage?.role === "user" ? asNumber(firstSnapshotMessage.timestamp) : undefined;
 
   return {
     index,
     role: "user",
-    userMessage: { text: finalPromptText, timestamp: userMessageTimestamp },
+    userMessage: { text: finalPromptText, timestamp: promptTimestamp ?? snapshotFallbackTimestamp },
     assistantResponse,
   };
 }
 
 export function extractTurns(events: JsonlEvent[]): Turn[] {
-  return events
-    .filter((event) => event.type === "model.completed")
-    .map((event, index) => buildTurn(event, index));
+  // Pair each model.completed with its prompt.submitted: by runId when both
+  // carry one, otherwise by the latest prompt.submitted seen before it in
+  // event order. The prompt event's `ts` is the turn's true submit time —
+  // reading the first snapshot message instead gave every turn the SESSION
+  // start time (staging finding, 2026-06-11 bundle).
+  const promptTsByRunId = new Map<string, number>();
+  for (const event of events) {
+    if (event.type !== "prompt.submitted") continue;
+    const runId = asString(event.runId);
+    const ts = parseTimestamp(event.ts);
+    if (runId && ts !== undefined) promptTsByRunId.set(runId, ts);
+  }
+
+  const turns: Turn[] = [];
+  let lastPromptTs: number | undefined;
+  for (const event of events) {
+    if (event.type === "prompt.submitted") {
+      lastPromptTs = parseTimestamp(event.ts) ?? lastPromptTs;
+      continue;
+    }
+    if (event.type !== "model.completed") continue;
+    const runId = asString(event.runId);
+    const promptTs = (runId ? promptTsByRunId.get(runId) : undefined) ?? lastPromptTs;
+    turns.push(buildTurn(event, turns.length, promptTs));
+  }
+  return turns;
 }


### PR DESCRIPTION
Follow-up to #480, found while verifying the fix against a real staging bundle (`pinchy-bugreport-ada-20260611-0900.json`): `endTime` was correct per turn, but **every span carried the same `startTime`** — the turn extractor read the *first* snapshot message's timestamp (the session's first message) for every turn.

The trajectory already records the true per-turn submit time: each `prompt.submitted` event's `ts`, pairing 1:1 with `model.completed` via `runId` (verified against the live staging trajectory: 9 prompts / 9 completions with distinct timestamps). The extractor now pairs by `runId`, falls back to the latest preceding `prompt.submitted` in event order, and keeps the snapshot-based value only as a last resort for old transcripts.

TDD: fixture-based test asserting all five turns get their distinct paired timestamps (red: all came back identical/`undefined`), plus a no-runId fallback test. Diagnostics suite 68/68, typecheck clean.