### PR TITLE
fix(usage): record prompt-cache tokens and chart them as Cached Input

### DIFF
--- a/packages/web/src/__tests__/lib/usage-chart-data.test.ts
+++ b/packages/web/src/__tests__/lib/usage-chart-data.test.ts
@@ -1,0 +1,43 @@
+import { describe, it, expect } from "vitest";
+import { buildChartData } from "@/lib/usage-chart-data";
+
+describe("buildChartData", () => {
+  it("maps timeseries strings to numbers and sums cache read+write into cachedTokens", () => {
+    const rows = [
+      {
+        date: "2026-06-09",
+        inputTokens: "7",
+        outputTokens: "1474",
+        cacheReadTokens: "240171",
+        cacheWriteTokens: "163614",
+      },
+    ];
+    expect(buildChartData(rows)).toEqual([
+      {
+        date: "2026-06-09",
+        inputTokens: 7,
+        outputTokens: 1474,
+        cachedTokens: 403785,
+      },
+    ]);
+  });
+
+  it("treats null/missing cache fields as zero (rows from before the cache fix)", () => {
+    const rows = [
+      {
+        date: "2026-05-14",
+        inputTokens: "4000000",
+        outputTokens: "50000",
+        cacheReadTokens: null,
+        cacheWriteTokens: null,
+      },
+    ];
+    expect(buildChartData(rows)).toEqual([
+      { date: "2026-05-14", inputTokens: 4000000, outputTokens: 50000, cachedTokens: 0 },
+    ]);
+  });
+
+  it("returns an empty array for undefined input", () => {
+    expect(buildChartData(undefined)).toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -135,6 +135,77 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
+  it("maps OpenClaw's cacheRead/cacheWrite session fields into the snapshot", async () => {
+    // OpenClaw's session store (verified live on staging, OC 2026.5.28) names
+    // the cache counters `cacheRead` / `cacheWrite` — NOT `cacheReadTokens` /
+    // `cacheWriteTokens`. Reading the wrong names left every usage_record with
+    // cache=0 while Anthropic served ~97% of input from the prompt cache, so
+    // the dashboard showed "Input: 7" for a ~400k-token day.
+    const client = makeOpenClawClient([
+      {
+        key: "agent:agent-1:direct:user-1",
+        inputTokens: 3,
+        outputTokens: 80,
+        cacheRead: 14404,
+        cacheWrite: 21135,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionSnapshot: expect.objectContaining({
+          cacheReadTokens: 14404,
+          cacheWriteTokens: 21135,
+        }),
+      })
+    );
+  });
+
+  it("still accepts the cacheReadTokens/cacheWriteTokens spelling as fallback", async () => {
+    const client = makeOpenClawClient([
+      {
+        key: "agent:agent-1:direct:user-1",
+        inputTokens: 10,
+        outputTokens: 5,
+        cacheReadTokens: 111,
+        cacheWriteTokens: 222,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        sessionSnapshot: expect.objectContaining({
+          cacheReadTokens: 111,
+          cacheWriteTokens: 222,
+        }),
+      })
+    );
+  });
+
+  it("does not skip a session whose only activity is cache traffic", async () => {
+    // Last-turn gauges can show input=0/output=0 while cache counters moved.
+    const client = makeOpenClawClient([
+      {
+        key: "agent:agent-1:direct:user-1",
+        inputTokens: 0,
+        outputTokens: 0,
+        cacheRead: 5000,
+        cacheWrite: 100,
+        model: "claude-sonnet-4-6",
+      },
+    ]);
+
+    await pollAllSessions(client);
+
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+  });
+
   it("calls recordUsage for each session with tokens", async () => {
     mockFrom._agentResult = [
       { id: "agent-1", name: "Smithers" },

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -19,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
+import { buildChartData } from "@/lib/usage-chart-data";
 import {
   ResponsiveContainer,
   LineChart,
@@ -300,11 +301,7 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
   const systemBucket = bucketTotals(summary?.totals?.system);
   const pluginBucket = bucketTotals(summary?.totals?.plugin);
 
-  const chartData = (timeseries?.data ?? []).map((p) => ({
-    date: p.date,
-    inputTokens: Number(p.inputTokens ?? 0),
-    outputTokens: Number(p.outputTokens ?? 0),
-  }));
+  const chartData = buildChartData(timeseries?.data);
 
   const hasData = (summary?.agents?.length ?? 0) > 0;
 
@@ -498,6 +495,15 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                     strokeWidth={2}
                     dot={shouldShowDots(chartData.length)}
                     name="Output Tokens"
+                  />
+                  <Line
+                    type="monotone"
+                    dataKey="cachedTokens"
+                    stroke="oklch(0.6 0.12 140)"
+                    strokeWidth={2}
+                    strokeDasharray="4 3"
+                    dot={shouldShowDots(chartData.length)}
+                    name="Cached Input"
                   />
                 </LineChart>
               </ResponsiveContainer>

--- a/packages/web/src/lib/usage-chart-data.ts
+++ b/packages/web/src/lib/usage-chart-data.ts
@@ -1,0 +1,33 @@
+/**
+ * Maps the /api/usage/timeseries rows (numeric strings from SQL sum()) into
+ * the numeric points the Daily Token Usage chart renders.
+ *
+ * `cachedTokens` combines cache reads and writes into one series: both are
+ * input-class traffic the provider actually processed. With prompt caching
+ * (Anthropic et al.) the uncached `inputTokens` can be single digits per turn
+ * while the cache moves hundreds of thousands — without this series the chart
+ * suggested a near-idle day for heavy usage ("Input: 7" staging finding).
+ */
+export interface UsageTimeseriesRow {
+  date: string;
+  inputTokens: string | null;
+  outputTokens: string | null;
+  cacheReadTokens?: string | null;
+  cacheWriteTokens?: string | null;
+}
+
+export interface UsageChartPoint {
+  date: string;
+  inputTokens: number;
+  outputTokens: number;
+  cachedTokens: number;
+}
+
+export function buildChartData(rows: UsageTimeseriesRow[] | undefined): UsageChartPoint[] {
+  return (rows ?? []).map((p) => ({
+    date: p.date,
+    inputTokens: Number(p.inputTokens ?? 0),
+    outputTokens: Number(p.outputTokens ?? 0),
+    cachedTokens: Number(p.cacheReadTokens ?? 0) + Number(p.cacheWriteTokens ?? 0),
+  }));
+}

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -63,6 +63,13 @@ interface SessionListEntry {
   key: string;
   inputTokens?: number;
   outputTokens?: number;
+  // OpenClaw's session store names the cache counters `cacheRead`/`cacheWrite`
+  // (verified live against OC 2026.5.28). The `*Tokens` spellings are kept as
+  // fallback for other OC versions. Reading only the long names left every
+  // usage_record with cache=0 while Anthropic served ~97% of input from the
+  // prompt cache — the dashboard showed "Input: 7" for a ~400k-token day.
+  cacheRead?: number;
+  cacheWrite?: number;
   cacheReadTokens?: number;
   cacheWriteTokens?: number;
   model?: string;
@@ -99,7 +106,13 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
     const userIdMap = new Map(allUsers.map((u) => [u.id.toLowerCase(), u.id]));
 
     for (const session of sessions) {
-      const hasTokens = (session.inputTokens ?? 0) > 0 || (session.outputTokens ?? 0) > 0;
+      const cacheReadTokens = session.cacheRead ?? session.cacheReadTokens;
+      const cacheWriteTokens = session.cacheWrite ?? session.cacheWriteTokens;
+      const hasTokens =
+        (session.inputTokens ?? 0) > 0 ||
+        (session.outputTokens ?? 0) > 0 ||
+        (cacheReadTokens ?? 0) > 0 ||
+        (cacheWriteTokens ?? 0) > 0;
       if (!hasTokens) continue;
 
       const parsed = parseSessionKey(session.key);
@@ -120,8 +133,8 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
         sessionSnapshot: {
           inputTokens: session.inputTokens,
           outputTokens: session.outputTokens,
-          cacheReadTokens: session.cacheReadTokens,
-          cacheWriteTokens: session.cacheWriteTokens,
+          cacheReadTokens,
+          cacheWriteTokens,
           model: session.model,
         },
       });


### PR DESCRIPTION
Staging finding (usage dashboard, test-plan step 17): **\"Input Tokens: 7\"** for a day with a 9-turn tool-heavy session (~400k real input-class tokens).

## Root cause 1 (fixed here): OC field-name mismatch starves the cache counters
The poller read `session.cacheReadTokens`/`cacheWriteTokens`, but OpenClaw's session store names them **`cacheRead`/`cacheWrite`** (verified live on staging, OC 2026.5.28: `inputTokens=3, outputTokens=80, cacheRead=14404, cacheWrite=21135`). Every `usage_records` row stored cache=0 — and with Anthropic prompt caching serving ~97% of input, the visible uncached input is single digits per turn. Everything downstream (watermark deltas, cache columns, the 0.1×/1.25× cache-aware cost estimate) already existed and was simply starved of data. The fix maps the short names (long names kept as fallback) and stops skipping sessions whose only activity is cache traffic.

## Root cause 2 (tracked separately): gauge sampling loses turns
OC overwrites the session counters **per turn** (last-value gauge); the poller samples them on an interval and computes clamped deltas — turns between polls are lost (4 snapshots captured of 9 turns; the stored values decode exactly as deltas between unrelated turn gauges). Lossless per-turn accounting needs the trajectory events — architectural change, issue follows for v0.6.0.

## Dashboard
The timeseries API already aggregates the cache columns; the chart just never showed them. `buildChartData()` extracted (TDD) and a dashed **"Cached Input"** series added (cacheRead+cacheWrite — both input-class traffic).

## Verification
Usage suites + dashboard tests 93/93, typecheck clean. TDD red→green for the poller mapping (session fixture with OC's real field names) and the chart mapping.