### PR TITLE
fix(audit): keep numeric token counts readable in sanitized output

### DIFF
--- a/packages/plugins/pinchy-audit/index.test.ts
+++ b/packages/plugins/pinchy-audit/index.test.ts
@@ -254,6 +254,66 @@ describe("pinchy-audit plugin", () => {
   });
 
   describe("sensitive data sanitization", () => {
+    it("keeps numeric token counts readable while redacting real auth tokens (SYNC with web)", async () => {
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+
+      await afterHook(
+        {
+          toolName: "usage_probe",
+          params: { inputTokens: 240171, totalTokens: 35542, token: "tok-secret" },
+          result: "ok",
+          durationMs: 5,
+        },
+        {
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:user-user-1",
+          toolName: "usage_probe",
+        }
+      );
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body.params.inputTokens).toBe(240171);
+      expect(body.params.totalTokens).toBe(35542);
+      expect(body.params.token).toBe("[REDACTED]");
+    });
+
+    it("serializes Date values to ISO strings instead of destroying them (SYNC with web)", async () => {
+      const { default: plugin } = await import("./index");
+      plugin.register?.(
+        createMockApi({
+          apiBaseUrl: "http://pinchy:7777",
+          gatewayToken: "gw-token",
+        }) as any
+      );
+
+      const afterHook = mockOn.mock.calls.find((c) => c[0] === "after_tool_call")?.[1];
+
+      await afterHook(
+        {
+          toolName: "calendar_read",
+          params: { at: new Date("2026-06-09T16:48:57.441Z") },
+          result: "ok",
+          durationMs: 5,
+        },
+        {
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:user-user-1",
+          toolName: "calendar_read",
+        }
+      );
+
+      const body = JSON.parse((fetch as any).mock.calls[0][1].body);
+      expect(body.params.at).toBe("2026-06-09T16:48:57.441Z");
+    });
+
     it("redacts sensitive key names in params before posting", async () => {
       const { default: plugin } = await import("./index");
       plugin.register?.(

--- a/packages/plugins/pinchy-audit/index.ts
+++ b/packages/plugins/pinchy-audit/index.ts
@@ -97,6 +97,13 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEYS.some((pattern) => lower.includes(pattern));
 }
 
+// Numeric values under keys ending in "tokens" are token COUNTS (usage
+// counters like inputTokens/totalTokens), not credentials. Conservative on
+// purpose: only numbers are exempt — a string under such a key stays redacted.
+function isExemptTokenCount(key: string, value: unknown): boolean {
+  return typeof value === "number" && /tokens$/i.test(key);
+}
+
 function redactPatterns(value: string): string {
   if (value === REDACTED) return value;
   let result = value;
@@ -113,10 +120,13 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   if (value === null || value === undefined) return value;
   if (depth >= MAX_DEPTH) return value;
   if (Array.isArray(value)) return value.map((item) => sanitizeValue(item, depth + 1));
+  // Dates have no own enumerable properties — the generic object branch below
+  // would strip them to {}. Serialize like JSON.stringify would.
+  if (value instanceof Date) return value.toISOString();
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      if (isSensitiveKey(key) && val !== null && val !== undefined) {
+      if (isSensitiveKey(key) && val !== null && val !== undefined && !isExemptTokenCount(key, val)) {
         result[key] = REDACTED;
       } else {
         result[key] = sanitizeValue(val, depth + 1);

--- a/packages/web/src/__tests__/lib/audit-sanitize.test.ts
+++ b/packages/web/src/__tests__/lib/audit-sanitize.test.ts
@@ -26,6 +26,38 @@ describe("sanitizeDetail", () => {
     });
   });
 
+  describe("token-count exemption", () => {
+    it("does not redact numeric token COUNTS whose key ends in 'tokens'", () => {
+      // The diagnostics bundle carries OTel usage attributes like
+      // gen_ai.usage.input_tokens — numeric counters, not credentials. The
+      // blanket "token" key match redacted them all (v0.5.7 staging finding),
+      // destroying the usage data in every exported bug report.
+      const result = sanitizeDetail({
+        "gen_ai.usage.input_tokens": 240171,
+        "gen_ai.usage.output_tokens": 4300,
+        cacheReadTokens: 14404,
+        totalTokens: 35542,
+      });
+      expect(result).toEqual({
+        "gen_ai.usage.input_tokens": 240171,
+        "gen_ai.usage.output_tokens": 4300,
+        cacheReadTokens: 14404,
+        totalTokens: 35542,
+      });
+    });
+
+    it("still redacts string values under tokens-suffixed keys (conservative)", () => {
+      expect(sanitizeDetail({ refreshTokens: "abc" })).toEqual({ refreshTokens: "[REDACTED]" });
+    });
+
+    it("still redacts actual auth-token keys regardless of value type", () => {
+      expect(sanitizeDetail({ token: "tok-abc", botToken: "123:xyz" })).toEqual({
+        token: "[REDACTED]",
+        botToken: "[REDACTED]",
+      });
+    });
+  });
+
   describe("key-name redaction", () => {
     it("redacts values for known sensitive key names", () => {
       const input = {

--- a/packages/web/src/lib/audit-sanitize.ts
+++ b/packages/web/src/lib/audit-sanitize.ts
@@ -25,6 +25,17 @@ function isSensitiveKey(key: string): boolean {
   return SENSITIVE_KEY_PATTERNS.some((pattern) => lower.includes(pattern));
 }
 
+/**
+ * Numeric values under keys ending in "tokens" are token COUNTS (usage
+ * counters like `gen_ai.usage.input_tokens`, `cacheReadTokens`), not
+ * credentials — the blanket "token" key match redacted them all, destroying
+ * the usage data in every diagnostics bundle. Conservative on purpose: only
+ * numbers are exempt; a string under `refreshTokens` stays redacted.
+ */
+function isExemptTokenCount(key: string, value: unknown): boolean {
+  return typeof value === "number" && /tokens$/i.test(key);
+}
+
 const SECRET_PATTERNS: RegExp[] = [
   /sk-ant-[a-zA-Z0-9\-]{20,}/g, // Anthropic (must be before generic sk-)
   /sk-[a-zA-Z0-9]{20,}/g, // OpenAI
@@ -76,7 +87,12 @@ function sanitizeValue(value: unknown, depth: number): unknown {
   if (typeof value === "object") {
     const result: Record<string, unknown> = {};
     for (const [key, val] of Object.entries(value as Record<string, unknown>)) {
-      if (isSensitiveKey(key) && val !== null && val !== undefined) {
+      if (
+        isSensitiveKey(key) &&
+        val !== null &&
+        val !== undefined &&
+        !isExemptTokenCount(key, val)
+      ) {
         result[key] = REDACTED;
       } else {
         result[key] = sanitizeValue(val, depth + 1);


### PR DESCRIPTION
Staging finding while reviewing diagnostics bundles: `gen_ai.usage.input_tokens: [REDACTED]` — the blanket `token` key match redacts numeric **usage counters**, destroying the usage data in every exported bug report.

**Fix (conservative):** exempt values that are *numbers* under keys ending in `tokens` (`inputTokens`, `totalTokens`, `gen_ai.usage.*_tokens`). Strings under such keys (`refreshTokens: "abc"`) and real auth-token keys (`token`, `botToken`, `access_token`) stay redacted; pattern-based redaction is untouched.

**Sync repair:** the `pinchy-audit` plugin carries a duplicated copy of this sanitizer under an explicit SYNC contract — it had also missed the Date-serialization fix from #480. Both copies now serialize Dates to ISO strings and exempt token counts, with mirroring tests on both sides.

TDD red→green; web sanitize suites 40/40, plugin 17/17, typecheck clean.