### PR TITLE
ci: retry GHCR pulls of pre-built images via composite action

### DIFF
--- a/.github/actions/pull-ci-images/action.yml
+++ b/.github/actions/pull-ci-images/action.yml
@@ -1,0 +1,26 @@
+name: Pull pre-built CI images
+description: >
+  Pulls the pre-built Pinchy and OpenClaw CI images from GHCR, retrying each
+  pull up to 3 times with 20s backoff instead of failing the job on the first
+  network blip. CI run 27339671342 (2026-06-11) lost two jobs to a brief
+  ghcr.io outage ("context deadline exceeded" / "Client.Timeout exceeded
+  while awaiting headers") before any test ran — same transient-5xx hardening
+  family as the ollama-install and link-check retries from PR #471.
+
+inputs:
+  pinchy-image:
+    description: Fully qualified ref of the pre-built Pinchy image
+    required: true
+  openclaw-image:
+    description: Fully qualified ref of the pre-built OpenClaw image
+    required: true
+
+runs:
+  using: composite
+  steps:
+    - name: Pull images with retry
+      shell: bash
+      env:
+        PINCHY_IMAGE: ${{ inputs.pinchy-image }}
+        OPENCLAW_IMAGE: ${{ inputs.openclaw-image }}
+      run: bash "$GITHUB_ACTION_PATH/pull-images-with-retry.sh" "$PINCHY_IMAGE" "$OPENCLAW_IMAGE"

--- a/.github/actions/pull-ci-images/pull-images-with-retry.sh
+++ b/.github/actions/pull-ci-images/pull-images-with-retry.sh
@@ -18,9 +18,33 @@ if [ "$#" -eq 0 ]; then
   exit 1
 fi
 
+# Composite actions do NOT enforce `required: true` on inputs: a dropped
+# `with:` field or a renamed build-image output arrives here as an empty
+# string. Validate all refs up front so that fails with a wiring hint
+# instead of burning retries on `docker pull ""`.
+for image in "$@"; do
+  if [ -z "$image" ]; then
+    echo "::error::pull-images-with-retry.sh received an empty image ref — check the with: wiring of the calling step and the build-image job outputs"
+    exit 1
+  fi
+done
+
+pull_log="$(mktemp)"
+
 for image in "$@"; do
   attempt=1
-  until docker pull "$image"; do
+  until docker pull "$image" 2>&1 | tee "$pull_log"; do
+    # Deterministic failures won't change on retry — fail immediately
+    # instead of sitting through the backoff twice. Same classification
+    # idea as the upgrade-sim compose pull in ci.yml. Errors that are
+    # merely *probably* deterministic (denied/unauthorized) stay
+    # retryable: GHCR hiccups have been seen wearing auth-shaped error
+    # messages, and a wasted retry costs 40s while a wrongly skipped one
+    # kills the job.
+    if grep -qE "manifest unknown|not found|invalid reference format|name unknown" "$pull_log"; then
+      echo "::error::docker pull ${image} failed for a non-transient reason (see output above) — retrying will not help."
+      exit 1
+    fi
     if [ "$attempt" -ge "$max_attempts" ]; then
       echo "::error::docker pull ${image} failed after ${max_attempts} attempts. GHCR is likely having an outage — re-run the job once it recovers."
       exit 1

--- a/.github/actions/pull-ci-images/pull-images-with-retry.sh
+++ b/.github/actions/pull-ci-images/pull-images-with-retry.sh
@@ -1,0 +1,32 @@
+#!/usr/bin/env bash
+# Pulls each given image ref, retrying transient registry failures.
+#
+# CI run 27339671342 (2026-06-11) lost two jobs to a brief ghcr.io outage
+# ("context deadline exceeded" / "Client.Timeout exceeded while awaiting
+# headers") before a single test ran. Same transient-5xx hardening family as
+# the ollama-install and link-check retries from PR #471.
+#
+# PULL_RETRY_DELAY_SECONDS overrides the backoff so tests don't sleep.
+# Covered by scripts/lib/pull-ci-images-retry.test.mjs against a stub docker.
+set -euo pipefail
+
+max_attempts=3
+retry_delay="${PULL_RETRY_DELAY_SECONDS:-20}"
+
+if [ "$#" -eq 0 ]; then
+  echo "::error::pull-images-with-retry.sh was called without image refs"
+  exit 1
+fi
+
+for image in "$@"; do
+  attempt=1
+  until docker pull "$image"; do
+    if [ "$attempt" -ge "$max_attempts" ]; then
+      echo "::error::docker pull ${image} failed after ${max_attempts} attempts. GHCR is likely having an outage — re-run the job once it recovers."
+      exit 1
+    fi
+    echo "::warning::docker pull ${image} failed (attempt ${attempt}/${max_attempts}). Retrying in ${retry_delay}s..."
+    sleep "$retry_delay"
+    attempt=$((attempt + 1))
+  done
+done

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -319,9 +319,14 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
+
+      - name: Tag pulled images as :latest for compose
+        if: needs.build-image.result == 'success'
         run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
           docker tag ${{ needs.build-image.outputs.pinchy-image }} ghcr.io/heypinchy/pinchy:latest
           docker tag ${{ needs.build-image.outputs.openclaw-image }} ghcr.io/heypinchy/pinchy-openclaw:latest
 
@@ -680,9 +685,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Build production images locally (fork PR fallback)
         if: needs.build-image.result == 'skipped'
@@ -842,9 +848,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: steps.prev.outputs.skip == 'false' && needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Build this PR's images locally (fork PR fallback)
         if: steps.prev.outputs.skip == 'false' && needs.build-image.result == 'skipped'
@@ -1079,9 +1086,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Start test stack with mock Odoo (CI — pre-built images)
         if: needs.build-image.result == 'success'
@@ -1198,9 +1206,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Start test stack with mock Brave (CI — pre-built images)
         if: needs.build-image.result == 'success'
@@ -1317,9 +1326,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Start test stack with mock Gmail (CI — pre-built images)
         if: needs.build-image.result == 'success'
@@ -1438,9 +1448,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Start test stack with mock LLM providers (CI — pre-built images)
         if: needs.build-image.result == 'success'
@@ -1573,9 +1584,10 @@ jobs:
 
       - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Start test stack with mock Telegram (CI — pre-built images)
         if: needs.build-image.result == 'success'
@@ -1737,9 +1749,10 @@ jobs:
 
       - name: Pull pre-built Pinchy and OpenClaw images (skip on fork PRs)
         if: needs.build-image.result == 'success'
-        run: |
-          docker pull ${{ needs.build-image.outputs.pinchy-image }}
-          docker pull ${{ needs.build-image.outputs.openclaw-image }}
+        uses: ./.github/actions/pull-ci-images
+        with:
+          pinchy-image: ${{ needs.build-image.outputs.pinchy-image }}
+          openclaw-image: ${{ needs.build-image.outputs.openclaw-image }}
 
       - name: Build Pinchy and OpenClaw images locally (fork PR fallback)
         if: needs.build-image.result == 'skipped'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1747,7 +1747,7 @@ jobs:
 
       - uses: ./.github/actions/setup-pnpm
 
-      - name: Pull pre-built Pinchy and OpenClaw images (skip on fork PRs)
+      - name: Pull pre-built CI images (skip on fork PRs)
         if: needs.build-image.result == 'success'
         uses: ./.github/actions/pull-ci-images
         with:

--- a/scripts/lib/pull-ci-images-retry.test.mjs
+++ b/scripts/lib/pull-ci-images-retry.test.mjs
@@ -1,0 +1,158 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { spawnSync } from "node:child_process";
+import {
+  chmodSync,
+  existsSync,
+  mkdtempSync,
+  readFileSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { join, dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+// Behavior tests + wiring guards for the GHCR pull-retry hardening (CI run
+// 27339671342: two jobs died on a transient ghcr.io outage before any test
+// ran). The retry logic lives in a standalone script inside the composite
+// action so it can be exercised here against a stub `docker` binary — same
+// transient-5xx hardening family as the ollama-install retry from PR #471.
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const ACTION_DIR = join(ROOT, ".github", "actions", "pull-ci-images");
+const SCRIPT = join(ACTION_DIR, "pull-images-with-retry.sh");
+const ACTION_YML = join(ACTION_DIR, "action.yml");
+const CI_YML = join(ROOT, ".github", "workflows", "ci.yml");
+
+/**
+ * Creates a stub `docker` on PATH that fails the first `failTimes` pulls of
+ * each image with a GHCR-outage-shaped error, then succeeds. Pull counts are
+ * recorded per image so tests can assert the retry cadence.
+ */
+function runScriptWithStub({ failTimes, images }) {
+  const stubDir = mkdtempSync(join(tmpdir(), "pull-ci-images-stub-"));
+  const stub = join(stubDir, "docker");
+  writeFileSync(
+    stub,
+    `#!/usr/bin/env bash
+[ "$1" = "pull" ] || { echo "stub docker: unexpected subcommand $1" >&2; exit 64; }
+image_key=$(printf '%s' "$2" | tr -c 'a-zA-Z0-9' '_')
+count_file="$STUB_DIR/count-$image_key"
+count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
+printf '%s' "$count" > "$count_file"
+if [ "$count" -le "$FAIL_TIMES" ]; then
+  echo 'Error response from daemon: Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)' >&2
+  exit 1
+fi
+exit 0
+`,
+  );
+  chmodSync(stub, 0o755);
+
+  const result = spawnSync("bash", [SCRIPT, ...images], {
+    encoding: "utf8",
+    env: {
+      ...process.env,
+      PATH: `${stubDir}:${process.env.PATH}`,
+      STUB_DIR: stubDir,
+      FAIL_TIMES: String(failTimes),
+      // Tests must not sit through the real backoff.
+      PULL_RETRY_DELAY_SECONDS: "0",
+    },
+  });
+
+  const pullCount = (image) => {
+    const key = image.replace(/[^a-zA-Z0-9]/g, "_");
+    const file = join(stubDir, `count-${key}`);
+    return existsSync(file) ? Number(readFileSync(file, "utf8")) : 0;
+  };
+
+  return { result, pullCount };
+}
+
+const PINCHY = "ghcr.io/heypinchy/pinchy:ci-abc123";
+const OPENCLAW = "ghcr.io/heypinchy/pinchy-openclaw:ci-abc123";
+
+test("pulls every image once and exits 0 when the registry is healthy", () => {
+  const { result, pullCount } = runScriptWithStub({
+    failTimes: 0,
+    images: [PINCHY, OPENCLAW],
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(pullCount(PINCHY), 1);
+  assert.equal(pullCount(OPENCLAW), 1);
+});
+
+test("retries transient failures and succeeds within 3 attempts", () => {
+  const { result, pullCount } = runScriptWithStub({
+    failTimes: 2,
+    images: [PINCHY, OPENCLAW],
+  });
+  assert.equal(result.status, 0, result.stderr);
+  assert.equal(pullCount(PINCHY), 3);
+  assert.equal(pullCount(OPENCLAW), 3);
+  assert.ok(
+    result.stdout.includes("::warning::"),
+    "retries must surface as ::warning:: annotations so transient blips stay visible",
+  );
+  assert.ok(
+    result.stdout.includes("attempt 1/3"),
+    "the warning must say which attempt failed",
+  );
+});
+
+test("fails with a ::error:: annotation after 3 exhausted attempts", () => {
+  const { result, pullCount } = runScriptWithStub({
+    failTimes: 99,
+    images: [PINCHY, OPENCLAW],
+  });
+  assert.equal(result.status, 1);
+  assert.equal(
+    pullCount(PINCHY),
+    3,
+    "must stop after 3 attempts, not loop forever",
+  );
+  assert.ok(
+    result.stdout.includes("::error::"),
+    "exhaustion must emit a ::error:: annotation",
+  );
+  assert.ok(
+    result.stdout.includes(PINCHY),
+    "the error must name the image that could not be pulled",
+  );
+});
+
+test("rejects a call without image refs instead of silently succeeding", () => {
+  const { result } = runScriptWithStub({ failTimes: 0, images: [] });
+  assert.equal(result.status, 1);
+  assert.ok(result.stdout.includes("::error::"));
+});
+
+// Wiring guards: the script only protects CI if the composite action invokes
+// it and ci.yml actually routes pulls through the action. Same textual-sweep
+// approach as release-version-guards.test.mjs.
+
+test("the composite action invokes the retry script", () => {
+  const action = readFileSync(ACTION_YML, "utf8");
+  assert.ok(
+    action.includes("pull-images-with-retry.sh"),
+    "action.yml must call pull-images-with-retry.sh — inline pulls would dodge the tested retry logic",
+  );
+});
+
+test("ci.yml has no bare docker pulls of the pre-built CI images", () => {
+  const ci = readFileSync(CI_YML, "utf8");
+  const bare = ci
+    .split("\n")
+    .filter((line) => line.includes("docker pull ${{ needs.build-image"));
+  assert.deepEqual(
+    bare,
+    [],
+    "pull pre-built images via ./.github/actions/pull-ci-images (retries transient GHCR outages); " +
+      "bare docker pull fails the job on the first network blip",
+  );
+  assert.ok(
+    ci.includes("uses: ./.github/actions/pull-ci-images"),
+    "ci.yml must pull the pre-built images through the pull-ci-images composite action",
+  );
+});

--- a/scripts/lib/pull-ci-images-retry.test.mjs
+++ b/scripts/lib/pull-ci-images-retry.test.mjs
@@ -5,6 +5,7 @@ import {
   chmodSync,
   existsSync,
   mkdtempSync,
+  readdirSync,
   readFileSync,
   writeFileSync,
 } from "node:fs";
@@ -22,14 +23,19 @@ const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const ACTION_DIR = join(ROOT, ".github", "actions", "pull-ci-images");
 const SCRIPT = join(ACTION_DIR, "pull-images-with-retry.sh");
 const ACTION_YML = join(ACTION_DIR, "action.yml");
-const CI_YML = join(ROOT, ".github", "workflows", "ci.yml");
+const WORKFLOWS_DIR = join(ROOT, ".github", "workflows");
+const CI_YML = join(WORKFLOWS_DIR, "ci.yml");
+
+const GHCR_OUTAGE_ERROR =
+  'Error response from daemon: Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)';
 
 /**
  * Creates a stub `docker` on PATH that fails the first `failTimes` pulls of
- * each image with a GHCR-outage-shaped error, then succeeds. Pull counts are
- * recorded per image so tests can assert the retry cadence.
+ * each image (with a GHCR-outage-shaped error unless `errorMessage` overrides
+ * it), then succeeds. Pull counts are recorded per image so tests can assert
+ * the retry cadence.
  */
-function runScriptWithStub({ failTimes, images }) {
+function runScriptWithStub({ failTimes, images, errorMessage }) {
   const stubDir = mkdtempSync(join(tmpdir(), "pull-ci-images-stub-"));
   const stub = join(stubDir, "docker");
   writeFileSync(
@@ -41,7 +47,7 @@ count_file="$STUB_DIR/count-$image_key"
 count=$(( $(cat "$count_file" 2>/dev/null || echo 0) + 1 ))
 printf '%s' "$count" > "$count_file"
 if [ "$count" -le "$FAIL_TIMES" ]; then
-  echo 'Error response from daemon: Get "https://ghcr.io/v2/": context deadline exceeded (Client.Timeout exceeded while awaiting headers)' >&2
+  echo "$STUB_ERROR_MESSAGE" >&2
   exit 1
 fi
 exit 0
@@ -56,6 +62,7 @@ exit 0
       PATH: `${stubDir}:${process.env.PATH}`,
       STUB_DIR: stubDir,
       FAIL_TIMES: String(failTimes),
+      STUB_ERROR_MESSAGE: errorMessage ?? GHCR_OUTAGE_ERROR,
       // Tests must not sit through the real backoff.
       PULL_RETRY_DELAY_SECONDS: "0",
     },
@@ -128,6 +135,45 @@ test("rejects a call without image refs instead of silently succeeding", () => {
   assert.ok(result.stdout.includes("::error::"));
 });
 
+// Composite actions do NOT enforce `required: true` on inputs: a dropped
+// `with:` field or a renamed build-image output arrives as an empty string.
+// That must fail fast with a wiring hint, not burn 40s retrying `docker
+// pull ""`.
+test("fails fast on an empty image ref instead of retrying docker pull ''", () => {
+  const { result, pullCount } = runScriptWithStub({
+    failTimes: 0,
+    images: [PINCHY, ""],
+  });
+  assert.equal(result.status, 1);
+  assert.ok(result.stdout.includes("::error::"));
+  assert.ok(
+    result.stdout.includes("empty image ref"),
+    "the error must point at the with:/outputs wiring, not at GHCR",
+  );
+  assert.equal(
+    pullCount(PINCHY),
+    0,
+    "all refs must be validated before any pull starts",
+  );
+});
+
+test("does not retry deterministic failures like a missing manifest", () => {
+  const { result, pullCount } = runScriptWithStub({
+    failTimes: 99,
+    images: [PINCHY, OPENCLAW],
+    errorMessage: "Error response from daemon: manifest unknown",
+  });
+  assert.equal(result.status, 1);
+  assert.equal(
+    pullCount(PINCHY),
+    1,
+    "a manifest-unknown failure is deterministic — retrying wastes 40s",
+  );
+  assert.equal(pullCount(OPENCLAW), 0);
+  assert.ok(result.stdout.includes("::error::"));
+  assert.ok(result.stdout.includes("non-transient"));
+});
+
 // Wiring guards: the script only protects CI if the composite action invokes
 // it and ci.yml actually routes pulls through the action. Same textual-sweep
 // approach as release-version-guards.test.mjs.
@@ -140,19 +186,27 @@ test("the composite action invokes the retry script", () => {
   );
 });
 
-test("ci.yml has no bare docker pulls of the pre-built CI images", () => {
-  const ci = readFileSync(CI_YML, "utf8");
-  const bare = ci
-    .split("\n")
-    .filter((line) => line.includes("docker pull ${{ needs.build-image"));
-  assert.deepEqual(
-    bare,
-    [],
-    "pull pre-built images via ./.github/actions/pull-ci-images (retries transient GHCR outages); " +
-      "bare docker pull fails the job on the first network blip",
+test("no workflow has bare docker pulls of the pre-built CI images", () => {
+  const workflows = readdirSync(WORKFLOWS_DIR).filter(
+    (file) => file.endsWith(".yml") || file.endsWith(".yaml"),
   );
+  assert.ok(workflows.length > 0, "no workflow files found — wrong path?");
+  for (const file of workflows) {
+    const bare = readFileSync(join(WORKFLOWS_DIR, file), "utf8")
+      .split("\n")
+      .filter((line) => line.includes("docker pull ${{ needs.build-image"));
+    assert.deepEqual(
+      bare,
+      [],
+      `${file}: pull pre-built images via ./.github/actions/pull-ci-images ` +
+        "(retries transient GHCR outages); bare docker pull fails the job " +
+        "on the first network blip",
+    );
+  }
   assert.ok(
-    ci.includes("uses: ./.github/actions/pull-ci-images"),
+    readFileSync(CI_YML, "utf8").includes(
+      "uses: ./.github/actions/pull-ci-images",
+    ),
     "ci.yml must pull the pre-built images through the pull-ci-images composite action",
   );
 });


### PR DESCRIPTION
## Why

CI run [27339671342](https://github.com/heypinchy/pinchy/actions/runs/27339671342) (2026-06-11) lost two jobs to a transient ghcr.io outage (`context deadline exceeded` / `Client.Timeout exceeded while awaiting headers`) during `docker pull` — before a single test ran. #471 already hardened the other transient-5xx surfaces (lychee link checks, ollama install) with retries; the image pulls were still bare.

## What

- New composite action `.github/actions/pull-ci-images` taking the two image refs as inputs. It retries each pull up to 3 times with 20s backoff (`::warning::` per failed attempt) and fails with a clear `::error::` after exhaustion — mirroring the retry style of the ollama-install hardening from #471.
- The retry logic lives in a standalone `pull-images-with-retry.sh` inside the action so it is unit-testable: `scripts/lib/pull-ci-images-retry.test.mjs` exercises it against a stub `docker` binary (healthy registry, transient failure recovered within 3 attempts, exhaustion, no-args misuse). Runs in `pnpm test:scripts`.
- All **nine** inline "Pull pre-built …" steps in `ci.yml` now use the action (the task description mentioned five, but the e2e-email/-web/-integration/-telegram jobs added since carry the same copy-pasted step — all hardened). The integration job's `docker tag` lines moved to a separate follow-up step.
- Wiring guard in the same test file: fails if anyone reintroduces a bare `docker pull ${{ needs.build-image.… }}` into `ci.yml` or drops the action — new E2E jobs are added by copy-paste regularly, so this is the drift surface.

## Verification

- TDD: tests written first and watched fail (script absent, 18 bare pull lines), then green after implementation.
- `pnpm test:scripts`: 98 tests pass (92 existing + 6 new).
- `ci.yml` and `action.yml` parse cleanly; behavior of the 9 steps is unchanged on the happy path (same images, same `if:` conditions, fork-PR fallbacks untouched).