### PR TITLE
fix(pinchy-files): bound DOCX decompressed size against zip bombs

### DIFF
--- a/packages/plugins/pinchy-files/docx-extract.test.ts
+++ b/packages/plugins/pinchy-files/docx-extract.test.ts
@@ -49,12 +49,8 @@ describe("extractDocxText", () => {
     const buffer = readFileSync(join(FIXTURES, "simple.docx"));
     const result = await extractDocxText(buffer);
     // Header row + separator row + data row, all pipe-delimited.
-    expect(result.text).toMatch(
-      /\|\s*SKU\s*\|\s*Quantity\s*\|\s*Unit Price\s*\|/,
-    );
-    expect(result.text).toMatch(
-      /\|\s*WIDGET-BLUE-01\s*\|\s*20\s*\|\s*EUR 42\.50\s*\|/,
-    );
+    expect(result.text).toMatch(/\|\s*SKU\s*\|\s*Quantity\s*\|\s*Unit Price\s*\|/);
+    expect(result.text).toMatch(/\|\s*WIDGET-BLUE-01\s*\|\s*20\s*\|\s*EUR 42\.50\s*\|/);
   });
 
   it("replaces embedded images with a textual placeholder, not base64 data URLs", async () => {

--- a/packages/plugins/pinchy-files/docx-extract.test.ts
+++ b/packages/plugins/pinchy-files/docx-extract.test.ts
@@ -49,8 +49,12 @@ describe("extractDocxText", () => {
     const buffer = readFileSync(join(FIXTURES, "simple.docx"));
     const result = await extractDocxText(buffer);
     // Header row + separator row + data row, all pipe-delimited.
-    expect(result.text).toMatch(/\|\s*SKU\s*\|\s*Quantity\s*\|\s*Unit Price\s*\|/);
-    expect(result.text).toMatch(/\|\s*WIDGET-BLUE-01\s*\|\s*20\s*\|\s*EUR 42\.50\s*\|/);
+    expect(result.text).toMatch(
+      /\|\s*SKU\s*\|\s*Quantity\s*\|\s*Unit Price\s*\|/,
+    );
+    expect(result.text).toMatch(
+      /\|\s*WIDGET-BLUE-01\s*\|\s*20\s*\|\s*EUR 42\.50\s*\|/,
+    );
   });
 
   it("replaces embedded images with a textual placeholder, not base64 data URLs", async () => {
@@ -66,5 +70,27 @@ describe("extractDocxText", () => {
     expect(result.text).toContain("[image]");
     expect(result.text).not.toMatch(/!\[[^\]]*\]\(data:image\//);
     expect(result.text).not.toMatch(/<img[^>]/i);
+  });
+
+  // Issue #424: a 50 MB compressed DOCX may decompress to multiple GB (zip
+  // bomb). The declared-size guard must reject it BEFORE mammoth inflates.
+  it("rejects a zip bomb before inflating it", async () => {
+    const buffer = readFileSync(join(FIXTURES, "simple.docx"));
+    await expect(
+      extractDocxText(buffer, { maxDecompressedBytes: 10 }),
+    ).rejects.toThrow(/decompressed size .* exceeds/i);
+  });
+
+  it("caps the extracted text length as a second defense layer", async () => {
+    const buffer = readFileSync(join(FIXTURES, "simple.docx"));
+    await expect(extractDocxText(buffer, { maxTextBytes: 10 })).rejects.toThrow(
+      /extracted text .* exceeds/i,
+    );
+  });
+
+  it("extracts normally with default limits (regression guard)", async () => {
+    const buffer = readFileSync(join(FIXTURES, "simple.docx"));
+    const result = await extractDocxText(buffer);
+    expect(result.text.length).toBeGreaterThan(50);
   });
 });

--- a/packages/plugins/pinchy-files/docx-extract.ts
+++ b/packages/plugins/pinchy-files/docx-extract.ts
@@ -1,10 +1,25 @@
 import mammoth from "mammoth";
 import TurndownService from "turndown";
 import { gfm } from "turndown-plugin-gfm";
+import {
+  assertDocxDecompressedSizeWithinLimit,
+  MAX_DOCX_DECOMPRESSED_BYTES,
+} from "./docx-zip-guard";
 
 export interface DocxExtractionResult {
   text: string;
 }
+
+export interface DocxExtractOptions {
+  /** Cap on the archive's declared decompressed size (issue #424). */
+  maxDecompressedBytes?: number;
+  /** Cap on the extracted Markdown length — second defense layer. */
+  maxTextBytes?: number;
+}
+
+// Aligned with MAX_FILE_SIZE in validate.ts: a .docx may not hand the model
+// more text than the largest plain-text file pinchy_read would serve.
+export const MAX_DOCX_EXTRACTED_TEXT_BYTES = 10 * 1024 * 1024;
 
 const turndown = new TurndownService({
   headingStyle: "atx",
@@ -38,7 +53,10 @@ turndown.addRule("strip-image", {
  * bundle isolation; a shared package would complicate that.
  */
 function normalizeTableHtml(html: string): string {
-  let out = html.replace(/<(td|th)([^>]*)><p>([\s\S]*?)<\/p><\/(td|th)>/g, "<$1$2>$3</$1>");
+  let out = html.replace(
+    /<(td|th)([^>]*)><p>([\s\S]*?)<\/p><\/(td|th)>/g,
+    "<$1$2>$3</$1>",
+  );
 
   // Mammoth emits no <tbody>, so rows sit directly under <table>.
   out = out.replace(/<table>([\s\S]*?)<\/table>/g, (_, inner: string) => {
@@ -46,7 +64,9 @@ function normalizeTableHtml(html: string): string {
     if (!firstRowMatch) return `<table>${inner}</table>`;
     const firstRow = firstRowMatch[1];
     const rest = inner.slice(firstRow.length);
-    const headingRow = firstRow.replace(/<td([^>]*)>/g, "<th$1>").replace(/<\/td>/g, "</th>");
+    const headingRow = firstRow
+      .replace(/<td([^>]*)>/g, "<th$1>")
+      .replace(/<\/td>/g, "</th>");
     return `<table><thead>${headingRow}</thead><tbody>${rest}</tbody></table>`;
   });
 
@@ -66,18 +86,35 @@ function normalizeTableHtml(html: string): string {
  */
 export async function extractDocxText(
   buffer: Buffer,
+  options: DocxExtractOptions = {},
 ): Promise<DocxExtractionResult> {
+  // Issue #424: reject decompression bombs from the central directory's
+  // declared sizes before mammoth inflates anything.
+  assertDocxDecompressedSizeWithinLimit(
+    buffer,
+    options.maxDecompressedBytes ?? MAX_DOCX_DECOMPRESSED_BYTES,
+  );
+
   const { value: rawHtml } = await mammoth.convertToHtml(
     { buffer },
     {
       // Empty src skips mammoth's base64 encoding; the strip-image
       // turndown rule above replaces <img> with [image] downstream.
       convertImage: mammoth.images.imgElement(() =>
-        Promise.resolve({ src: "" })
+        Promise.resolve({ src: "" }),
       ),
-    }
+    },
   );
   const html = normalizeTableHtml(rawHtml);
   const text = turndown.turndown(html);
+
+  // Second defense layer: an archive that lied about its declared sizes
+  // still cannot hand the model an unbounded extraction result.
+  const maxTextBytes = options.maxTextBytes ?? MAX_DOCX_EXTRACTED_TEXT_BYTES;
+  if (Buffer.byteLength(text, "utf-8") > maxTextBytes) {
+    throw new Error(
+      `DOCX extracted text (${Buffer.byteLength(text, "utf-8")} bytes) exceeds the limit (${maxTextBytes} bytes).`,
+    );
+  }
   return { text };
 }

--- a/packages/plugins/pinchy-files/docx-extract.ts
+++ b/packages/plugins/pinchy-files/docx-extract.ts
@@ -53,10 +53,7 @@ turndown.addRule("strip-image", {
  * bundle isolation; a shared package would complicate that.
  */
 function normalizeTableHtml(html: string): string {
-  let out = html.replace(
-    /<(td|th)([^>]*)><p>([\s\S]*?)<\/p><\/(td|th)>/g,
-    "<$1$2>$3</$1>",
-  );
+  let out = html.replace(/<(td|th)([^>]*)><p>([\s\S]*?)<\/p><\/(td|th)>/g, "<$1$2>$3</$1>");
 
   // Mammoth emits no <tbody>, so rows sit directly under <table>.
   out = out.replace(/<table>([\s\S]*?)<\/table>/g, (_, inner: string) => {
@@ -64,9 +61,7 @@ function normalizeTableHtml(html: string): string {
     if (!firstRowMatch) return `<table>${inner}</table>`;
     const firstRow = firstRowMatch[1];
     const rest = inner.slice(firstRow.length);
-    const headingRow = firstRow
-      .replace(/<td([^>]*)>/g, "<th$1>")
-      .replace(/<\/td>/g, "</th>");
+    const headingRow = firstRow.replace(/<td([^>]*)>/g, "<th$1>").replace(/<\/td>/g, "</th>");
     return `<table><thead>${headingRow}</thead><tbody>${rest}</tbody></table>`;
   });
 

--- a/packages/plugins/pinchy-files/docx-extract.ts
+++ b/packages/plugins/pinchy-files/docx-extract.ts
@@ -5,11 +5,17 @@ import {
   assertDocxDecompressedSizeWithinLimit,
   MAX_DOCX_DECOMPRESSED_BYTES,
 } from "./docx-zip-guard";
+import { MAX_FILE_SIZE } from "./validate";
 
 export interface DocxExtractionResult {
   text: string;
 }
 
+/**
+ * Limits for extractDocxText. The defaults are the production values —
+ * the overrides exist so tests can exercise both guards without multi-GB
+ * fixtures, not as a runtime configuration surface.
+ */
 export interface DocxExtractOptions {
   /** Cap on the archive's declared decompressed size (issue #424). */
   maxDecompressedBytes?: number;
@@ -17,9 +23,9 @@ export interface DocxExtractOptions {
   maxTextBytes?: number;
 }
 
-// Aligned with MAX_FILE_SIZE in validate.ts: a .docx may not hand the model
-// more text than the largest plain-text file pinchy_read would serve.
-export const MAX_DOCX_EXTRACTED_TEXT_BYTES = 10 * 1024 * 1024;
+// A .docx may not hand the model more text than the largest plain-text file
+// pinchy_read would serve.
+export const MAX_DOCX_EXTRACTED_TEXT_BYTES = MAX_FILE_SIZE;
 
 const turndown = new TurndownService({
   headingStyle: "atx",
@@ -96,9 +102,9 @@ export async function extractDocxText(
       // Empty src skips mammoth's base64 encoding; the strip-image
       // turndown rule above replaces <img> with [image] downstream.
       convertImage: mammoth.images.imgElement(() =>
-        Promise.resolve({ src: "" }),
+        Promise.resolve({ src: "" })
       ),
-    },
+    }
   );
   const html = normalizeTableHtml(rawHtml);
   const text = turndown.turndown(html);

--- a/packages/plugins/pinchy-files/docx-zip-guard.test.ts
+++ b/packages/plugins/pinchy-files/docx-zip-guard.test.ts
@@ -149,6 +149,20 @@ describe("assertDocxDecompressedSizeWithinLimit", () => {
     );
   });
 
+  it("allows a declared size exactly at the limit and rejects one byte over", () => {
+    const zip = buildZip([
+      {
+        name: "word/document.xml",
+        data: Buffer.alloc(64),
+        declaredUncompressedSize: 1000,
+      },
+    ]);
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip, 1000)).not.toThrow();
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip, 999)).toThrow(
+      /decompressed size .* exceeds/i,
+    );
+  });
+
   it("honors a custom limit", () => {
     const zip = buildZip([
       { name: "word/document.xml", data: Buffer.alloc(2000) },

--- a/packages/plugins/pinchy-files/docx-zip-guard.test.ts
+++ b/packages/plugins/pinchy-files/docx-zip-guard.test.ts
@@ -1,0 +1,163 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { join } from "node:path";
+import { deflateRawSync } from "node:zlib";
+import {
+  readDeclaredDocxSize,
+  assertDocxDecompressedSizeWithinLimit,
+  MAX_DOCX_DECOMPRESSED_BYTES,
+} from "./docx-zip-guard";
+
+const FIXTURES = join(import.meta.dirname, "test-fixtures");
+
+/**
+ * Build a structurally valid ZIP buffer by hand so tests can control the
+ * DECLARED uncompressed size independently of the actual payload. A zip bomb
+ * declares its (huge) uncompressed size truthfully — the guard must reject it
+ * from the central directory alone, without inflating anything.
+ */
+function buildZip(
+  entries: Array<{
+    name: string;
+    data: Buffer;
+    declaredUncompressedSize?: number;
+  }>,
+): Buffer {
+  const localParts: Buffer[] = [];
+  const centralParts: Buffer[] = [];
+  let offset = 0;
+
+  for (const entry of entries) {
+    const nameBytes = Buffer.from(entry.name, "utf-8");
+    const compressed = deflateRawSync(entry.data);
+    const uncompressedSize =
+      entry.declaredUncompressedSize ?? entry.data.length;
+
+    const local = Buffer.alloc(30 + nameBytes.length);
+    local.writeUInt32LE(0x04034b50, 0); // local file header signature
+    local.writeUInt16LE(20, 4); // version needed
+    local.writeUInt16LE(8, 8); // compression: deflate
+    local.writeUInt32LE(compressed.length, 18);
+    local.writeUInt32LE(uncompressedSize, 22);
+    local.writeUInt16LE(nameBytes.length, 26);
+    nameBytes.copy(local, 30);
+
+    const central = Buffer.alloc(46 + nameBytes.length);
+    central.writeUInt32LE(0x02014b50, 0); // central directory signature
+    central.writeUInt16LE(20, 6); // version needed
+    central.writeUInt16LE(8, 10); // compression: deflate
+    central.writeUInt32LE(compressed.length, 20);
+    central.writeUInt32LE(uncompressedSize, 24);
+    central.writeUInt16LE(nameBytes.length, 28);
+    central.writeUInt32LE(offset, 42); // local header offset
+    nameBytes.copy(central, 46);
+
+    localParts.push(local, compressed);
+    centralParts.push(central);
+    offset += local.length + compressed.length;
+  }
+
+  const centralDir = Buffer.concat(centralParts);
+  const eocd = Buffer.alloc(22);
+  eocd.writeUInt32LE(0x06054b50, 0); // end-of-central-directory signature
+  eocd.writeUInt16LE(entries.length, 8); // entries on this disk
+  eocd.writeUInt16LE(entries.length, 10); // total entries
+  eocd.writeUInt32LE(centralDir.length, 12);
+  eocd.writeUInt32LE(offset, 16); // central directory offset
+
+  return Buffer.concat([...localParts, centralDir, eocd]);
+}
+
+describe("readDeclaredDocxSize", () => {
+  it("sums the declared uncompressed sizes from the central directory", () => {
+    const zip = buildZip([
+      { name: "word/document.xml", data: Buffer.alloc(1000, 0x41) },
+      { name: "word/styles.xml", data: Buffer.alloc(500, 0x42) },
+    ]);
+    expect(readDeclaredDocxSize(zip).totalUncompressedBytes).toBe(1500);
+  });
+
+  it("reads the declared size of a real .docx fixture", () => {
+    const buffer = readFileSync(join(FIXTURES, "simple.docx"));
+    const { totalUncompressedBytes } = readDeclaredDocxSize(buffer);
+    expect(totalUncompressedBytes).toBeGreaterThan(0);
+    expect(totalUncompressedBytes).toBeLessThan(MAX_DOCX_DECOMPRESSED_BYTES);
+  });
+
+  it("throws a clear error when the buffer has no central directory", () => {
+    const notZip = Buffer.from("this is not a zip archive", "utf-8");
+    expect(() => readDeclaredDocxSize(notZip)).toThrow(/not a valid \.docx/i);
+  });
+
+  it("throws when the central directory lies outside the buffer", () => {
+    const zip = buildZip([
+      { name: "word/document.xml", data: Buffer.alloc(100) },
+    ]);
+    // Corrupt the EOCD's central-directory offset to point past the end.
+    zip.writeUInt32LE(zip.length + 1000, zip.length - 22 + 16);
+    expect(() => readDeclaredDocxSize(zip)).toThrow(/not a valid \.docx/i);
+  });
+});
+
+describe("assertDocxDecompressedSizeWithinLimit", () => {
+  it("accepts an archive whose declared size is within the limit", () => {
+    const zip = buildZip([
+      { name: "word/document.xml", data: Buffer.alloc(1000) },
+    ]);
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip)).not.toThrow();
+  });
+
+  it("rejects a zip bomb that declares a decompressed size above the limit", () => {
+    // Tiny compressed payload, honestly-declared huge decompressed size —
+    // the classic high-ratio bomb shape. Must be rejected without inflating.
+    const zip = buildZip([
+      {
+        name: "word/document.xml",
+        data: Buffer.alloc(1024),
+        declaredUncompressedSize: 0xfffffffe, // ~4 GB, below the ZIP64 marker
+      },
+    ]);
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip)).toThrow(
+      /decompressed size .* exceeds/i,
+    );
+  });
+
+  it("rejects when many small entries sum past the limit", () => {
+    const entries = Array.from({ length: 20 }, (_, i) => ({
+      name: `word/part${i}.xml`,
+      data: Buffer.alloc(64),
+      declaredUncompressedSize: 30 * 1024 * 1024, // 20 × 30 MB = 600 MB
+    }));
+    expect(() =>
+      assertDocxDecompressedSizeWithinLimit(buildZip(entries)),
+    ).toThrow(/decompressed size .* exceeds/i);
+  });
+
+  it("rejects ZIP64 size markers fail-closed", () => {
+    // 0xFFFFFFFF means "real size is in the ZIP64 extra field". No mainstream
+    // DOCX writer emits ZIP64; treat it as over-limit rather than trusting it.
+    const zip = buildZip([
+      {
+        name: "word/document.xml",
+        data: Buffer.alloc(64),
+        declaredUncompressedSize: 0xffffffff,
+      },
+    ]);
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip)).toThrow(
+      /decompressed size|ZIP64/i,
+    );
+  });
+
+  it("honors a custom limit", () => {
+    const zip = buildZip([
+      { name: "word/document.xml", data: Buffer.alloc(2000) },
+    ]);
+    expect(() => assertDocxDecompressedSizeWithinLimit(zip, 1000)).toThrow(
+      /decompressed size .* exceeds/i,
+    );
+    expect(() =>
+      assertDocxDecompressedSizeWithinLimit(zip, 4000),
+    ).not.toThrow();
+  });
+});

--- a/packages/plugins/pinchy-files/docx-zip-guard.ts
+++ b/packages/plugins/pinchy-files/docx-zip-guard.ts
@@ -8,7 +8,10 @@
 // total uncompressed size exceeds the limit. A real bomb must declare its
 // sizes truthfully for ordinary readers to inflate it; a payload that lies
 // about its size is caught downstream by the extracted-text cap in
-// docx-extract.ts (second defense layer).
+// docx-extract.ts (second defense layer). Note the residual gap: that cap
+// bounds what reaches the model, not mammoth's peak memory while it inflates
+// a lying archive — accepted because lying archives are treated as corrupt
+// by mainstream ZIP readers, so their attack value is doubtful.
 
 const EOCD_SIGNATURE = 0x06054b50; // end of central directory
 const CENTRAL_DIR_SIGNATURE = 0x02014b50;

--- a/packages/plugins/pinchy-files/docx-zip-guard.ts
+++ b/packages/plugins/pinchy-files/docx-zip-guard.ts
@@ -1,0 +1,100 @@
+// Issue #424: DOCX is a ZIP archive, and mammoth materialises the full
+// decompressed content in memory. The 50 MB pre-extract cap on the COMPRESSED
+// file does not bound that — a high-ratio zip bomb within the cap can inflate
+// to multiple GB inside the OpenClaw container.
+//
+// This guard reads the archive's central directory (plain offset arithmetic,
+// no decompression, no new dependency) and rejects the file when the DECLARED
+// total uncompressed size exceeds the limit. A real bomb must declare its
+// sizes truthfully for ordinary readers to inflate it; a payload that lies
+// about its size is caught downstream by the extracted-text cap in
+// docx-extract.ts (second defense layer).
+
+const EOCD_SIGNATURE = 0x06054b50; // end of central directory
+const CENTRAL_DIR_SIGNATURE = 0x02014b50;
+const ZIP64_MARKER_16 = 0xffff;
+const ZIP64_MARKER_32 = 0xffffffff;
+// EOCD record (22 bytes) may be followed by a comment of up to 65535 bytes.
+const EOCD_SEARCH_WINDOW = 22 + 0xffff;
+
+// Generous for any legitimate DOCX: text XML rarely decompresses past a few
+// hundred MB, and embedded media (PNG/JPEG) is stored near ratio 1.
+export const MAX_DOCX_DECOMPRESSED_BYTES = 500 * 1024 * 1024;
+
+export interface DocxDeclaredSize {
+  totalUncompressedBytes: number;
+}
+
+function invalidDocx(detail: string): Error {
+  return new Error(`Not a valid .docx archive: ${detail}`);
+}
+
+/**
+ * Sum the declared uncompressed sizes of all entries in the archive's
+ * central directory. Throws on structurally invalid archives (fail closed —
+ * every mainstream DOCX writer emits a standard, non-ZIP64 central
+ * directory, so anything else is not a document we should inflate).
+ */
+export function readDeclaredDocxSize(buffer: Buffer): DocxDeclaredSize {
+  const searchStart = Math.max(0, buffer.length - EOCD_SEARCH_WINDOW);
+  let eocdOffset = -1;
+  for (let i = buffer.length - 22; i >= searchStart; i--) {
+    if (buffer.readUInt32LE(i) === EOCD_SIGNATURE) {
+      eocdOffset = i;
+      break;
+    }
+  }
+  if (eocdOffset < 0) {
+    throw invalidDocx("end-of-central-directory record not found");
+  }
+
+  const totalEntries = buffer.readUInt16LE(eocdOffset + 10);
+  const cdSize = buffer.readUInt32LE(eocdOffset + 12);
+  const cdOffset = buffer.readUInt32LE(eocdOffset + 16);
+
+  if (
+    totalEntries === ZIP64_MARKER_16 ||
+    cdSize === ZIP64_MARKER_32 ||
+    cdOffset === ZIP64_MARKER_32
+  ) {
+    throw invalidDocx("ZIP64 archives are not supported");
+  }
+  if (cdOffset + cdSize > eocdOffset) {
+    throw invalidDocx("central directory lies outside the file");
+  }
+
+  let totalUncompressedBytes = 0;
+  let pos = cdOffset;
+  for (let entry = 0; entry < totalEntries; entry++) {
+    if (
+      pos + 46 > eocdOffset ||
+      buffer.readUInt32LE(pos) !== CENTRAL_DIR_SIGNATURE
+    ) {
+      throw invalidDocx("malformed central directory entry");
+    }
+    const uncompressedSize = buffer.readUInt32LE(pos + 24);
+    // 0xFFFFFFFF defers the real size to a ZIP64 extra field. Rather than
+    // trusting that field, count the marker value itself (~4.3 GB) so the
+    // entry trips the limit check — fail closed.
+    totalUncompressedBytes += uncompressedSize;
+
+    const nameLength = buffer.readUInt16LE(pos + 28);
+    const extraLength = buffer.readUInt16LE(pos + 30);
+    const commentLength = buffer.readUInt16LE(pos + 32);
+    pos += 46 + nameLength + extraLength + commentLength;
+  }
+
+  return { totalUncompressedBytes };
+}
+
+export function assertDocxDecompressedSizeWithinLimit(
+  buffer: Buffer,
+  limit: number = MAX_DOCX_DECOMPRESSED_BYTES,
+): void {
+  const { totalUncompressedBytes } = readDeclaredDocxSize(buffer);
+  if (totalUncompressedBytes > limit) {
+    throw new Error(
+      `DOCX declared decompressed size (${totalUncompressedBytes} bytes) exceeds the limit (${limit} bytes). The file may be a decompression bomb.`,
+    );
+  }
+}


### PR DESCRIPTION
Closes #424.

## Problem

PR #406 raised the DOCX pre-extract cap to 50 MB — but DOCX is a ZIP archive, and nothing bounded the **decompressed** size mammoth materialises. A high-ratio decompression bomb within the 50 MB cap could inflate to multiple GB of memory inside the OpenClaw container.

## Fix (two defense layers)

1. **Pre-extract guard** (`docx-zip-guard.ts`, new): parses the archive's ZIP central directory — plain offset arithmetic, no decompression, no new dependency — and rejects the file when the **declared** total uncompressed size exceeds 500 MB. A real bomb must declare its sizes truthfully for ordinary readers to inflate it. Fail-closed handling for everything a mainstream DOCX writer never emits: ZIP64 markers, missing EOCD, central directory pointing outside the buffer.
2. **Post-extract cap** (`extractDocxText`): the extracted Markdown is capped at 10 MB (aligned with `MAX_FILE_SIZE` for plain-text reads), so an archive that **lied** about its declared sizes still cannot hand the model an unbounded result.

Worker-with-memory-limit (option 3 from the issue) is not viable: worker threads don't run in the plugin container (no tsx).

## Limits chosen

- **500 MB declared decompressed**: generous for legitimate files — text XML rarely decompresses past a few hundred MB and embedded media (PNG/JPEG) is stored near ratio 1. Chosen over the issue's 50× ratio idea because small, highly-compressible legitimate XML can legitimately exceed ratio 50, while real bombs exceed any absolute bound.
- **10 MB extracted text**: a .docx may not produce more text than the largest plain-text file `pinchy_read` would serve.

## Out of scope

The browser-side extraction path (`use-ws-runtime.ts`, composer uploads) runs client-side — a bomb there only affects the uploader's own tab, not the server. Can be hardened separately if desired.

## Tests

- 9 new unit tests for the guard (declared-size summation, real fixture, bomb rejection, multi-entry summation, ZIP64 fail-closed, corrupt EOCD/central directory, custom limit) — built on a hand-rolled ZIP writer so the declared size is controllable without multi-GB fixtures.
- 3 new integration tests through `extractDocxText` (bomb rejected before inflation, text cap, defaults regression guard).
- TDD: all written first and watched fail. Full plugin suite: 165 passed.