### PR TITLE
feat(security): fail closed on default DB password + secret provenance in /api/health & Settings

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,10 +294,11 @@ jobs:
       packages: read
     # Dev-mode CI test: images are built locally and tagged :latest. Satisfy
     # the compose fail-loud check on ${PINCHY_VERSION:?} without depending on
-    # a .env file.
+    # a .env file. Deliberately NO DB_PASSWORD: this stack exercises the
+    # entrypoint's password auto-migration (#156) like a real install that
+    # never set one — asserted below via /api/health secrets provenance.
     env:
       PINCHY_VERSION: latest
-      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -403,6 +404,24 @@ jobs:
           echo "::error::Infrastructure not ready: database=$DB, openclaw=$OC"
           docker compose logs pinchy openclaw
           exit 1
+
+      - name: Verify DB password auto-migration (#156)
+        run: |
+          # The stack booted without DB_PASSWORD, so the entrypoint must have
+          # migrated the database off the public default and persisted the
+          # generated credential in the secrets volume.
+          PROV=$(curl -sf http://localhost:7777/api/health | jq -r '.secrets.db_password')
+          if [ "$PROV" != "generated" ]; then
+            echo "::error::expected secrets.db_password=generated after auto-migration, got: $PROV"
+            docker compose logs pinchy | grep -i -E "(db-password|password)" || true
+            exit 1
+          fi
+          docker compose logs pinchy | grep -q "Database is using a managed (non-default) password" || {
+            echo "::error::entrypoint migration log line missing"
+            docker compose logs pinchy | head -40
+            exit 1
+          }
+          echo "DB password auto-migration verified (provenance: generated)"
 
       - name: Run setup wizard (production)
         run: |
@@ -536,6 +555,16 @@ jobs:
           docker compose ps
           docker compose logs
           exit 1
+
+      - name: Verify generated DB password survives recreate (#156)
+        run: |
+          PROV=$(curl -sf http://localhost:7777/api/health | jq -r '.secrets.db_password')
+          if [ "$PROV" != "generated" ]; then
+            echo "::error::secrets.db_password should still be 'generated' after recreate, got: $PROV"
+            docker compose logs pinchy | grep -i "db-password" || true
+            exit 1
+          fi
+          echo "Generated DB password survived the recreate (steady state)"
 
       - name: Verify Pinchy reconnects to OpenClaw after recreate
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -297,6 +297,7 @@ jobs:
     # a .env file.
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -1062,6 +1063,7 @@ jobs:
     # in docker-compose.e2e.yml disables that limit only for this E2E stack.
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -1182,6 +1184,7 @@ jobs:
 
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -1302,6 +1305,7 @@ jobs:
 
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -1423,6 +1427,7 @@ jobs:
 
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
       COMPOSE_FILES: "-f docker-compose.yml -f docker-compose.e2e.yml -f docker-compose.setup-wizard-test.yml"
 
     steps:
@@ -1555,6 +1560,7 @@ jobs:
     # docker-compose.e2e.yml takes precedence and tags with that name.
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4
@@ -1725,6 +1731,7 @@ jobs:
     # takes precedence when PINCHY_IMAGE is not set.
     env:
       PINCHY_VERSION: latest
+      DB_PASSWORD: pinchy-ci-smoke-pass
 
     steps:
       - uses: actions/checkout@v4

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -19,16 +19,13 @@ mkdir -p pinchy && cd pinchy
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
 ```
 
-## 2. Pin the version and a database password
+## 2. Pin the version
 
 ```bash
-{
-  echo "PINCHY_VERSION=%%PINCHY_VERSION%%"
-  echo "DB_PASSWORD=$(openssl rand -hex 16)"
-} > .env
+echo "PINCHY_VERSION=%%PINCHY_VERSION%%" > .env
 ```
 
-The Compose file refuses to start without a pinned `PINCHY_VERSION`, and Pinchy refuses to run on the built-in database password — both checks exist so the stack you start today is still the one you expect after the next upgrade. The generated password stays on your machine; PostgreSQL is initialized with it on first start.
+The Compose file refuses to start without a pinned version, so the stack you start today is still the one you expect after the next upgrade. Everything else is zero-config: all secrets — including the database password — are generated on first start and persisted in Docker volumes. Prefer managing the database password yourself? Add `DB_PASSWORD=…` to the same `.env`; your value always wins.
 
 ## 3. Start the stack
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -19,7 +19,18 @@ mkdir -p pinchy && cd pinchy
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
 ```
 
-## 2. Start the stack
+## 2. Pin the version and a database password
+
+```bash
+{
+  echo "PINCHY_VERSION=%%PINCHY_VERSION%%"
+  echo "DB_PASSWORD=$(openssl rand -hex 16)"
+} > .env
+```
+
+The Compose file refuses to start without a pinned `PINCHY_VERSION`, and Pinchy refuses to run on the built-in database password — both checks exist so the stack you start today is still the one you expect after the next upgrade. The generated password stays on your machine; PostgreSQL is initialized with it on first start.
+
+## 3. Start the stack
 
 ```bash
 docker compose pull
@@ -34,13 +45,13 @@ This starts three services:
 
 Wait until `docker compose logs pinchy` shows `Pinchy ready on http://localhost:7777`.
 
-## 3. Create your admin account
+## 4. Create your admin account
 
 Open [http://localhost:7777](http://localhost:7777) in your browser. The setup wizard appears automatically on first run.
 
 Enter your name, email, and password. This creates the first admin user.
 
-## 4. Configure your AI provider
+## 5. Configure your AI provider
 
 After creating your account, Pinchy redirects you to the provider setup page. Choose your LLM provider and enter your API key:
 
@@ -55,7 +66,7 @@ Your API key is encrypted at rest using AES-256-GCM before being stored in the d
 
 If the provider you configure has no vision-capable model, the wizard shows an amber warning: **No vision-capable model configured.** Adding Anthropic, OpenAI, or Google as a provider enables image uploads and scanned-PDF support.
 
-## 5. Chat with Smithers
+## 6. Chat with Smithers
 
 Once your provider is configured, Pinchy redirects you to the chat interface. Your default agent — **Smithers** — greets you automatically and starts a short onboarding interview to learn about you (and your organization, if you're an admin). This builds context that every agent on the platform can use.
 
@@ -63,13 +74,13 @@ Once your provider is configured, Pinchy redirects you to the chat interface. Yo
 
 Type a message and hit Enter. Smithers responds in real time via WebSocket. See [Smithers Onboarding](/guides/smithers-onboarding/) for what Smithers asks and how the context is saved.
 
-## 6. Invite your team
+## 7. Invite your team
 
 Go to **Settings → Users** to invite team members. Enter their email address and Pinchy generates a one-time invite link.
 
 Each invited user gets their own personal **Smithers** agent, created automatically when they claim the invite. Invite links are valid for 7 days.
 
-## 7. Create a Knowledge Base Agent (optional)
+## 8. Create a Knowledge Base Agent (optional)
 
 You can create agents from templates. Creating an agent is simple: pick a template, give it a name, add an optional tagline, and click Create. Each agent gets a unique auto-generated avatar.
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -153,36 +153,26 @@ If you need to roll back after an upgrade:
 
 ### Breaking changes
 
-**Production now refuses to start on the default database password.** Until now, running without a custom `DB_PASSWORD` only logged a warning. Starting with %%PINCHY_VERSION%%, Pinchy exits at startup instead — the default password is public in our repository, so silently allowing it in production is not protection we can stand behind.
-
-If your `/opt/pinchy/.env` already sets `DB_PASSWORD`, no action is needed. If it doesn't, set one **before** bumping the version pin:
-
-1. Change the password inside PostgreSQL first (the `POSTGRES_PASSWORD` variable only applies on first initialization, so the running database keeps whatever password it was created with):
-
-   ```bash
-   cd /opt/pinchy
-   docker compose exec db psql -U pinchy -c "ALTER USER pinchy WITH PASSWORD 'your-secure-password';"
-   ```
-
-2. Add the same password to `/opt/pinchy/.env`:
-
-   ```bash
-   DB_PASSWORD=your-secure-password
-   ```
-
-3. Continue with the standard upgrade (`docker compose pull && docker compose up -d`).
-
-If Pinchy exits with `FATAL: Refusing to start in production with the default database password`, this is the check doing its job — complete the two steps above and start it again.
+None.
 
 ### Upgrade notes
 
-With `DB_PASSWORD` in place, the upgrade itself is the standard flow:
+The standard flow applies:
 
 ```bash
 cd /opt/pinchy
 sed -i 's/PINCHY_VERSION=v0.5.7/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
+
+#### Automatic migration off the default database password
+
+The default `pinchy_dev` database password is public in our repository, so running on it was never real protection. Starting with %%PINCHY_VERSION%%, installations that never set `DB_PASSWORD` are migrated automatically on their first boot after the upgrade: Pinchy generates a strong password, persists it in the `pinchy-secrets` Docker volume (the same place the encryption key already lives), and applies it to PostgreSQL — no action required, no downtime beyond the normal upgrade restart.
+
+- **If you set `DB_PASSWORD` in `.env`:** nothing changes. Your value always wins — and if you ever set it without updating PostgreSQL itself, Pinchy now applies it for you on the next boot instead of failing to connect.
+- **If you never set `DB_PASSWORD`:** the migration runs once, invisibly. Settings → Security shows the database password as _Auto-generated (Docker volume)_, and `GET /api/health` reports `"db_password": "generated"`.
+- **Backups keep working:** the documented `docker compose exec db pg_dump …` flow authenticates over the container's local socket and does not need the password.
+- **Heads-up for direct TCP access:** if you connect to the database from the host with the old default password (custom scripts, DB GUIs), switch them to the managed credential or pin your own `DB_PASSWORD` in `.env` — Pinchy will apply it on the next restart.
 
 #### See where your secrets come from
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -149,7 +149,46 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.5.6 to %%PINCHY_VERSION%%
+## Upgrading from v0.5.7 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+**Production now refuses to start on the default database password.** Until now, running without a custom `DB_PASSWORD` only logged a warning. Starting with %%PINCHY_VERSION%%, Pinchy exits at startup instead — the default password is public in our repository, so silently allowing it in production is not protection we can stand behind.
+
+If your `/opt/pinchy/.env` already sets `DB_PASSWORD`, no action is needed. If it doesn't, set one **before** bumping the version pin:
+
+1. Change the password inside PostgreSQL first (the `POSTGRES_PASSWORD` variable only applies on first initialization, so the running database keeps whatever password it was created with):
+
+   ```bash
+   cd /opt/pinchy
+   docker compose exec db psql -U pinchy -c "ALTER USER pinchy WITH PASSWORD 'your-secure-password';"
+   ```
+
+2. Add the same password to `/opt/pinchy/.env`:
+
+   ```bash
+   DB_PASSWORD=your-secure-password
+   ```
+
+3. Continue with the standard upgrade (`docker compose pull && docker compose up -d`).
+
+If Pinchy exits with `FATAL: Refusing to start in production with the default database password`, this is the check doing its job — complete the two steps above and start it again.
+
+### Upgrade notes
+
+With `DB_PASSWORD` in place, the upgrade itself is the standard flow:
+
+```bash
+cd /opt/pinchy
+sed -i 's/PINCHY_VERSION=v0.5.7/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+#### See where your secrets come from
+
+Settings → Security gains a **Secrets** card showing where each secret comes from — environment variable, persisted file in the Docker volume, or not created yet. The same information is available from the shell via `GET /api/health` (a new `secrets` object with provenance values only — never the secrets themselves). This makes the auto-generated file fallback visible from outside the container, so you can tell "secret loaded from the volume" apart from "no secret at all" before rotating anything.
+
+## Upgrading from v0.5.6 to v0.5.7
 
 ### Breaking changes
 
@@ -157,7 +196,7 @@ If you need to roll back after an upgrade:
 
 ### Upgrade notes
 
-%%PINCHY_VERSION%% is a large release. The headline changes are a new staged file-upload pipeline, capability-aware attachment handling with inline recovery, resumable streaming across reconnects, and a more reliable first chat on freshly-created agents. Everything below is picked up by the standard `docker compose pull && docker compose up -d` flow; three additive database migrations (`0034`–`0036`) run automatically on startup and require no manual steps.
+v0.5.7 is a large release. The headline changes are a new staged file-upload pipeline, capability-aware attachment handling with inline recovery, resumable streaming across reconnects, and a more reliable first chat on freshly-created agents. Everything below is picked up by the standard `docker compose pull && docker compose up -d` flow; three additive database migrations (`0034`–`0036`) run automatically on startup and require no manual steps.
 
 #### Resumable, staged file uploads
 
@@ -180,7 +219,7 @@ Pinchy now knows which capabilities (vision, documents, audio, video, long-conte
 - **Onboarding warning.** The setup wizard warns when no available model satisfies the default agent's required capabilities.
 - **`models` table — zero configuration.** A new `models` table records each model's capabilities. It is seeded from Pinchy's built-in catalog on every boot; for local Ollama, capabilities are detected from the Ollama API when you save the URL. No manual entry is required.
 
-> Earlier docs described this capability handling under the v0.5.4 notes; it actually ships in %%PINCHY_VERSION%%, and the v0.5.4 section has been corrected accordingly.
+> Earlier docs described this capability handling under the v0.5.4 notes; it actually ships in v0.5.7, and the v0.5.4 section has been corrected accordingly.
 
 #### Streaming resume across reconnect
 
@@ -221,7 +260,7 @@ Admins can now generate a downloadable bug-report bundle from **Settings → Sup
 
 #### Setup-wizard secrets fix
 
-%%PINCHY_VERSION%% also fixes the v0.5.6 setup-wizard regression where Smithers replied with `No API key found for provider '<name>'` on the very first chat message after a fresh install. The bug was provider-agnostic: OpenClaw's secrets-provider initialised at gateway boot with a "file missing" state because `secrets.json` was only written after the user completed the wizard. The provider never reinitialised when Pinchy hot-reloaded `openclaw.json` (the secrets-section diff was empty), so the gateway ran the rest of the session with no provider keys until a manual container restart.
+v0.5.7 also fixes the v0.5.6 setup-wizard regression where Smithers replied with `No API key found for provider '<name>'` on the very first chat message after a fresh install. The bug was provider-agnostic: OpenClaw's secrets-provider initialised at gateway boot with a "file missing" state because `secrets.json` was only written after the user completed the wizard. The provider never reinitialised when Pinchy hot-reloaded `openclaw.json` (the secrets-section diff was empty), so the gateway ran the rest of the session with no provider keys until a manual container restart.
 
 The fix is Pinchy-side: an `inotifywait` handler in `start-openclaw.sh` writes a `/openclaw-secrets/.bootstrap-applied` marker on the first appearance of `secrets.json` and SIGTERMs the gateway exactly once so the next boot picks up the file. The health-check loop respawns the gateway within ~10–40 s, and a build-time drift guard in `validateBuiltConfig` rejects emitted configs whose `SecretRef` pointers don't resolve in `secrets.json` — closing the related class of "config references a key that isn't there" bugs that would have produced the same symptom from the Pinchy side.
 
@@ -233,7 +272,7 @@ No manual steps beyond the standard upgrade flow:
 
 ```bash
 cd /opt/pinchy
-sed -i 's/PINCHY_VERSION=v0.5.6/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+sed -i 's/PINCHY_VERSION=v0.5.6/PINCHY_VERSION=v0.5.7/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -30,6 +30,7 @@ The simplest way to run Pinchy. One command starts the full stack.
 ```bash
 mkdir -p pinchy && cd pinchy
 curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/%%PINCHY_VERSION%%/docker-compose.yml -o docker-compose.yml
+echo "PINCHY_VERSION=%%PINCHY_VERSION%%" > .env
 docker compose pull && docker compose up -d
 ```
 
@@ -47,14 +48,14 @@ Only port **7777** is exposed to the host. OpenClaw and PostgreSQL are only reac
 
 ### Environment variables
 
-Almost no configuration is needed to get started: session key, encryption key, and HMAC signing key are auto-generated on first start and persisted in Docker volumes so they survive restarts. The two values you do set yourself are `PINCHY_VERSION` (the Compose file refuses to start without a pinned version) and `DB_PASSWORD` (Pinchy refuses to run on the built-in default — it's public in this repository). The [Getting Started](/getting-started/) guide generates both in one step.
+Almost no configuration is needed to get started: session key, encryption key, HMAC signing key, and the database password are auto-generated on first start and persisted in Docker volumes so they survive restarts. The one value you set yourself is `PINCHY_VERSION` — the Compose file refuses to start without a pinned version. See the [Getting Started](/getting-started/) guide.
 
 #### Optional: production hardening
 
-For production deployments, extend the `.env` file to pin the remaining secrets instead of relying on auto-generated ones:
+For production deployments, extend the `.env` file to pin your own secrets instead of relying on auto-generated ones:
 
 ```bash
-# Database password (required — Pinchy won't start in production on the default)
+# Database password (auto-generated and applied on first start if omitted)
 DB_PASSWORD=your-secure-password
 
 # Better Auth session secret (auto-generated if omitted)
@@ -70,7 +71,7 @@ AUDIT_HMAC_SECRET=
 PINCHY_ENTERPRISE_KEY=
 ```
 
-**`DB_PASSWORD`** — Password for the PostgreSQL `pinchy` user. Required in production: the default `pinchy_dev` value is public in this repository, so Pinchy exits at startup instead of running with it. Set it before the database is created for the first time (PostgreSQL only applies it on first initialization).
+**`DB_PASSWORD`** — Password for the PostgreSQL `pinchy` user. If omitted, Pinchy generates one on the first production start, persists it in the `pinchy-secrets` volume, and applies it to PostgreSQL automatically (the public `pinchy_dev` default never stays active). Set it explicitly if you want to manage the credential yourself — Pinchy applies your value on the next restart, even if the database still runs on an older one.
 
 **`BETTER_AUTH_SECRET`** — Used by Better Auth for session security. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 

--- a/docs/src/content/docs/installation.mdx
+++ b/docs/src/content/docs/installation.mdx
@@ -47,19 +47,14 @@ Only port **7777** is exposed to the host. OpenClaw and PostgreSQL are only reac
 
 ### Environment variables
 
-No configuration is needed to get started. All secrets (session key, encryption key, HMAC signing key) are auto-generated on first start and persisted in Docker volumes so they survive restarts.
-
-<Aside type="tip">
-  For a quick local trial, skip straight to the [Getting
-  Started](/getting-started/) guide — no `.env` file required.
-</Aside>
+Almost no configuration is needed to get started: session key, encryption key, and HMAC signing key are auto-generated on first start and persisted in Docker volumes so they survive restarts. The two values you do set yourself are `PINCHY_VERSION` (the Compose file refuses to start without a pinned version) and `DB_PASSWORD` (Pinchy refuses to run on the built-in default — it's public in this repository). The [Getting Started](/getting-started/) guide generates both in one step.
 
 #### Optional: production hardening
 
-For production deployments, create a `.env` file in the project root to pin your own secrets instead of relying on auto-generated ones:
+For production deployments, extend the `.env` file to pin the remaining secrets instead of relying on auto-generated ones:
 
 ```bash
-# Database password (default: pinchy_dev)
+# Database password (required — Pinchy won't start in production on the default)
 DB_PASSWORD=your-secure-password
 
 # Better Auth session secret (auto-generated if omitted)
@@ -75,7 +70,7 @@ AUDIT_HMAC_SECRET=
 PINCHY_ENTERPRISE_KEY=
 ```
 
-**`DB_PASSWORD`** — Password for the PostgreSQL `pinchy` user. Defaults to `pinchy_dev` in Docker Compose.
+**`DB_PASSWORD`** — Password for the PostgreSQL `pinchy` user. Required in production: the default `pinchy_dev` value is public in this repository, so Pinchy exits at startup instead of running with it. Set it before the database is created for the first time (PostgreSQL only applies it on first initialization).
 
 **`BETTER_AUTH_SECRET`** — Used by Better Auth for session security. Auto-generated and persisted in the `pinchy-secrets` volume if omitted. For production, set explicitly with `openssl rand -hex 32`.
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -66,6 +66,17 @@ if [ -n "$MISSING" ]; then
 fi
 echo "[entrypoint] all Pinchy plugins present in /openclaw-extensions/"
 
+# Issue #156: migrate the database off the public default password before
+# anything connects. The resolver prints the effective DATABASE_URL on stdout
+# (empty when unchanged, diagnostics on stderr) and never fails the boot —
+# drizzle-kit and the server below both consume the exported value.
+echo '[pinchy] Resolving database credentials...'
+RESOLVED_DATABASE_URL=$(su -s /bin/sh pinchy -c 'cd /app/packages/web && node scripts/resolve-db-password.mjs' || true)
+if [ -n "$RESOLVED_DATABASE_URL" ]; then
+  export DATABASE_URL="$RESOLVED_DATABASE_URL"
+  echo '[pinchy] Database is using a managed (non-default) password.'
+fi
+
 echo '[pinchy] Running database migrations...'
 su -s /bin/sh pinchy -c 'cd /app/packages/web && pnpm db:migrate'
 

--- a/packages/web/e2e/email/email.spec.ts
+++ b/packages/web/e2e/email/email.spec.ts
@@ -30,6 +30,7 @@ import {
   seedDefaultProviderToOllama,
   waitForOpenClawStable,
 } from "../shared/dispatch-probe";
+import { stackDbUrl } from "../shared/stack-db";
 
 test.describe("pinchy-email — Gmail E2E", () => {
   let cookie: string;
@@ -164,8 +165,7 @@ test.describe("Email dispatch probe (pinchy-email plugin coverage)", () => {
     await startFakeOllama();
 
     // 2. Swap default_provider to ollama-local and seed ollama_local_url.
-    const dbUrl =
-      process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+    const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
     restoreSettings = await seedDefaultProviderToOllama(dbUrl, FAKE_OLLAMA_PORT);
 
     // 3. Login (API cookie).

--- a/packages/web/e2e/email/helpers.ts
+++ b/packages/web/e2e/email/helpers.ts
@@ -1,4 +1,5 @@
 import { createCipheriv, randomBytes, randomUUID } from "crypto";
+import { stackDbUrl } from "../shared/stack-db";
 
 const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
 const GMAIL_MOCK_URL = process.env.GMAIL_MOCK_URL || "http://localhost:9004";
@@ -38,7 +39,7 @@ function encryptCredentials(plaintext: string): string {
  * Mirrors the web E2E seedSetup pattern.
  */
 export async function seedSetup(): Promise<void> {
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 
@@ -99,7 +100,7 @@ export async function seedSetup(): Promise<void> {
 export async function createGoogleConnectionInDb(
   name = "Test Gmail"
 ): Promise<{ id: string; type: string; name: string }> {
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 

--- a/packages/web/e2e/integration/global-setup.ts
+++ b/packages/web/e2e/integration/global-setup.ts
@@ -16,8 +16,9 @@ import { execSync, spawn } from "child_process";
 import path from "path";
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from "fs";
 import { FAKE_OLLAMA_PORT } from "../shared/fake-ollama/fake-ollama-server";
+import { stackDbUrl } from "../shared/stack-db";
 
-const INTEGRATION_DB_URL = "postgresql://pinchy:pinchy_dev@localhost:5435/pinchy";
+const INTEGRATION_DB_URL = stackDbUrl(5435);
 const FAKE_OLLAMA_PID_PATH = "/tmp/pinchy-fake-ollama.pid";
 const PROJECT_ROOT = path.resolve(__dirname, "../../../..");
 const PACKAGE_ROOT = path.resolve(__dirname, "../..");

--- a/packages/web/e2e/integration/usage-tracking.spec.ts
+++ b/packages/web/e2e/integration/usage-tracking.spec.ts
@@ -39,8 +39,9 @@ import {
   FAKE_OLLAMA_DEFAULT_COMPLETION_TOKENS,
 } from "../shared/fake-ollama/fake-ollama-server";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
+import { stackDbUrl } from "../shared/stack-db";
 
-const INTEGRATION_DB_URL = "postgresql://pinchy:pinchy_dev@localhost:5435/pinchy";
+const INTEGRATION_DB_URL = stackDbUrl(5435);
 const PROMPT = FAKE_OLLAMA_DEFAULT_PROMPT_TOKENS; // 42
 const COMPLETION = FAKE_OLLAMA_DEFAULT_COMPLETION_TOKENS; // 17
 

--- a/packages/web/e2e/odoo/helpers.ts
+++ b/packages/web/e2e/odoo/helpers.ts
@@ -1,4 +1,5 @@
 const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
+import { stackDbUrl } from "../shared/stack-db";
 const MOCK_ODOO_URL = process.env.MOCK_ODOO_URL || "http://localhost:9002";
 
 // Admin credentials — set by seedSetup, used by login and loginViaUI
@@ -18,7 +19,7 @@ export function getAdminPassword(): string {
  * Mirrors the Telegram E2E seedSetup pattern.
  */
 export async function seedSetup(): Promise<void> {
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -27,6 +27,7 @@ import {
   waitForOpenClawStable,
   waitForAgentDispatchable,
 } from "../shared/dispatch-probe";
+import { stackDbUrl } from "../shared/stack-db";
 
 const MOCK_ODOO_URL = process.env.MOCK_ODOO_URL || "http://localhost:9002";
 
@@ -301,8 +302,7 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
     // 3. Swap default_provider to ollama-local and seed ollama_local_url.
     //    Pinchy can reach ollama.local via the extra_hosts mapping added to the
     //    docker-compose.odoo-test.yml overlay. OpenClaw already has this mapping.
-    const dbUrl =
-      process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+    const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
     restoreSettings = await seedDefaultProviderToOllama(dbUrl, FAKE_OLLAMA_PORT);
 
     // 4. Login (API cookie).

--- a/packages/web/e2e/shared/stack-db.ts
+++ b/packages/web/e2e/shared/stack-db.ts
@@ -1,0 +1,11 @@
+// Host-side connection URL for a compose-stack PostgreSQL (the DB behind
+// docker-compose.yml's ${DB_PASSWORD:-pinchy_dev} interpolation).
+//
+// CI's production-image stack jobs set DB_PASSWORD because the server
+// fail-closes on the default password in production (#156) — helpers that
+// connect from the host must use the same value the stack was initialized
+// with. Local runs without DB_PASSWORD keep the dev default.
+export function stackDbUrl(port: number, db = "pinchy"): string {
+  const password = process.env.DB_PASSWORD || "pinchy_dev";
+  return `postgresql://pinchy:${encodeURIComponent(password)}@localhost:${port}/${db}`;
+}

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSync } from "child_process";
+import { stackDbUrl } from "../shared/stack-db";
 
 const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
 const MOCK_TELEGRAM_URL = process.env.MOCK_TELEGRAM_URL || "http://localhost:9001";
@@ -91,7 +92,7 @@ export async function createAgent(name: string): Promise<{ id: string; name: str
   // Create agent directly in DB — the POST /api/agents endpoint requires
   // template-specific fields (e.g. pluginConfig for knowledge-base) that
   // aren't needed for a basic agent used in multi-bot tests.
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
   const id = crypto.randomUUID();
@@ -279,7 +280,7 @@ export function extractPairingCode(botResponseText: string): string | null {
 export async function seedSetup(): Promise<void> {
   // Create admin account and provider config directly in DB.
   // Uses the same approach as existing E2E tests (03-provider.spec.ts).
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 

--- a/packages/web/e2e/web/helpers.ts
+++ b/packages/web/e2e/web/helpers.ts
@@ -1,4 +1,5 @@
 const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
+import { stackDbUrl } from "../shared/stack-db";
 const BRAVE_MOCK_URL = process.env.BRAVE_MOCK_URL || "http://localhost:9003";
 
 // Admin credentials — set by seedSetup, used by login
@@ -18,7 +19,7 @@ export function getAdminPassword(): string {
  * Mirrors the Odoo E2E seedSetup pattern.
  */
 export async function seedSetup(): Promise<void> {
-  const dbUrl = process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
   const { default: postgres } = await import("postgres");
   const sql = postgres(dbUrl);
 

--- a/packages/web/e2e/web/web-search.spec.ts
+++ b/packages/web/e2e/web/web-search.spec.ts
@@ -29,6 +29,7 @@ import {
   waitForOpenClawStable,
   waitForAgentDispatchable,
 } from "../shared/dispatch-probe";
+import { stackDbUrl } from "../shared/stack-db";
 
 test.describe("pinchy-web — Brave Search E2E", () => {
   let cookie: string;
@@ -136,8 +137,7 @@ test.describe("Web dispatch probe (pinchy-web plugin coverage)", () => {
     await new Promise((r) => setTimeout(r, 60_000));
 
     // 3. Swap default_provider to ollama-local and seed ollama_local_url.
-    const dbUrl =
-      process.env.DATABASE_URL || "postgresql://pinchy:pinchy_dev@localhost:5434/pinchy";
+    const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
     restoreSettings = await seedDefaultProviderToOllama(dbUrl, FAKE_OLLAMA_PORT);
 
     // 4. Login (API cookie).

--- a/packages/web/scripts/lib/db-password-deps.mjs
+++ b/packages/web/scripts/lib/db-password-deps.mjs
@@ -1,0 +1,67 @@
+// Real-world deps for db-password-resolver.mjs — separated so the unit tests
+// inject fakes while the integration test and the entrypoint runner share
+// these exact implementations.
+
+import { readFileSync, writeFileSync, unlinkSync, existsSync } from "node:fs";
+import postgres from "postgres";
+
+const IDENTIFIER = /^[a-zA-Z0-9_]+$/;
+
+async function withClient(url, fn) {
+  const sql = postgres(url, {
+    max: 1,
+    connect_timeout: 10,
+    onnotice: () => {},
+  });
+  try {
+    return await fn(sql);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+export function createDbPasswordDeps({ log } = {}) {
+  const emit = log ?? (() => {});
+  return {
+    probe: async (url) => {
+      try {
+        await withClient(url, (sql) => sql`SELECT 1`);
+        return true;
+      } catch (err) {
+        // 28P01 = invalid_password — the expected "wrong candidate" outcome.
+        // Anything else (db missing, network refused) is diagnostic gold for
+        // a failed migration, so surface it on stderr.
+        if (err?.code !== "28P01") {
+          emit(`probe failed (${err?.code ?? "?"}): ${err instanceof Error ? err.message : err}`);
+        }
+        return false;
+      }
+    },
+
+    alterPassword: async (url, username, newPassword) => {
+      if (!IDENTIFIER.test(username)) {
+        throw new Error(`refusing to alter unexpected database user "${username}"`);
+      }
+      await withClient(url, async (sql) => {
+        // ALTER USER is a utility statement and cannot take bind parameters.
+        // Let the server build the correctly-quoted statement via format()
+        // (with ordinary bind parameters), then execute that exact string.
+        const [{ statement }] = await sql`
+          SELECT format('ALTER USER %I WITH PASSWORD %L', ${username}::text, ${newPassword}::text) AS statement
+        `;
+        await sql.unsafe(statement);
+      });
+    },
+
+    readFile: (path) => (existsSync(path) ? readFileSync(path, "utf-8") : null),
+    writeFile: (path, content) => writeFileSync(path, content, { mode: 0o600 }),
+    deleteFile: (path) => {
+      try {
+        unlinkSync(path);
+      } catch {
+        // best effort — a stale file only costs one extra probe on later boots
+      }
+    },
+    log: emit,
+  };
+}

--- a/packages/web/scripts/lib/db-password-resolver.mjs
+++ b/packages/web/scripts/lib/db-password-resolver.mjs
@@ -1,0 +1,161 @@
+// Boot-time auto-migration away from the default database password (#156).
+//
+// docker-compose.yml interpolates DATABASE_URL with `${DB_PASSWORD:-pinchy_dev}`,
+// and the default value is public in this repository. Instead of refusing to
+// start (breaking every install that never set DB_PASSWORD), the entrypoint
+// resolves the real password before anything touches the database:
+//
+//   - Explicit DB_PASSWORD in .env always wins. If the database itself still
+//     runs on an older password (operator set .env but forgot ALTER USER),
+//     the resolver performs the ALTER USER automatically.
+//   - With the default password, a random one is generated, persisted to the
+//     secrets volume (same pattern as getOrCreateSecret), and applied via
+//     ALTER USER. Persist-before-alter makes every crash point recoverable.
+//   - When migration is impossible (db down, volume read-only), the resolver
+//     returns the original URL with a warning — never fail closed.
+//
+// Plain .mjs (no TypeScript, no path aliases): entrypoint.sh runs this with
+// plain `node` before drizzle-kit and the server start. All effectful deps
+// (probe/alter/fs) are injected — see db-password-deps.mjs for the real ones.
+
+import { randomBytes } from "node:crypto";
+import { join } from "node:path";
+
+export const DEFAULT_DB_PASSWORD = "pinchy_dev";
+export const DB_PASSWORD_FILE = ".db_password";
+
+export function replaceUrlPassword(databaseUrl, password) {
+  const url = new URL(databaseUrl);
+  url.password = password;
+  return url.toString();
+}
+
+export function generateDbPassword() {
+  // 64 hex chars — same shape as the other auto-generated secrets, and
+  // trivially safe inside a connection URL and a quoted SQL literal.
+  return randomBytes(32).toString("hex");
+}
+
+function urlPassword(databaseUrl) {
+  return decodeURIComponent(new URL(databaseUrl).password);
+}
+
+function urlUsername(databaseUrl) {
+  return decodeURIComponent(new URL(databaseUrl).username);
+}
+
+/**
+ * Resolve the effective DATABASE_URL, migrating the database off the default
+ * password when necessary.
+ *
+ * @returns {Promise<{url: string, source: "custom"|"generated"|"default", migrated?: boolean, warning?: string}>}
+ */
+export async function resolveDbPassword({ databaseUrl, secretsDir, deps }) {
+  const filePath = join(secretsDir, DB_PASSWORD_FILE);
+  const username = urlUsername(databaseUrl);
+  const envPassword = urlPassword(databaseUrl);
+  const filePassword = deps.readFile(filePath)?.trim() || null;
+
+  if (envPassword !== DEFAULT_DB_PASSWORD) {
+    // Operator-managed password. Normally it just works…
+    if (await deps.probe(databaseUrl)) {
+      return { url: databaseUrl, source: "custom" };
+    }
+    // …but if the database still runs on a previously generated or the
+    // default password, heal the mismatch instead of crashing later.
+    for (const candidate of [filePassword, DEFAULT_DB_PASSWORD]) {
+      if (!candidate) continue;
+      const candidateUrl = replaceUrlPassword(databaseUrl, candidate);
+      if (await deps.probe(candidateUrl)) {
+        try {
+          await deps.alterPassword(candidateUrl, username, envPassword);
+        } catch (err) {
+          return {
+            url: databaseUrl,
+            source: "custom",
+            warning: `failed to apply DB_PASSWORD via ALTER USER: ${message(err)}`,
+          };
+        }
+        if (candidate === filePassword) deps.deleteFile(filePath);
+        deps.log("applied DB_PASSWORD from the environment via ALTER USER");
+        return { url: databaseUrl, source: "custom", migrated: true };
+      }
+    }
+    return {
+      url: databaseUrl,
+      source: "custom",
+      warning: "could not connect with DB_PASSWORD, the persisted, or the default password",
+    };
+  }
+
+  // DATABASE_URL carries the public default password.
+  if (filePassword) {
+    const fileUrl = replaceUrlPassword(databaseUrl, filePassword);
+    if (await deps.probe(fileUrl)) {
+      // Steady state: migrated on an earlier boot.
+      return { url: fileUrl, source: "generated" };
+    }
+    if (await deps.probe(databaseUrl)) {
+      // Crash window recovery: the file was persisted but ALTER USER never
+      // ran. Finish the migration with the already-persisted password.
+      try {
+        await deps.alterPassword(databaseUrl, username, filePassword);
+      } catch (err) {
+        return {
+          url: databaseUrl,
+          source: "default",
+          warning: `password migration failed during recovery: ${message(err)}`,
+        };
+      }
+      deps.log("completed interrupted password migration");
+      return { url: fileUrl, source: "generated", migrated: true };
+    }
+    return {
+      url: databaseUrl,
+      source: "default",
+      warning: "could not connect with the persisted or the default password",
+    };
+  }
+
+  // First boot on the default password: migrate.
+  if (!(await deps.probe(databaseUrl))) {
+    return {
+      url: databaseUrl,
+      source: "default",
+      warning: "database unreachable — skipping password migration",
+    };
+  }
+  const newPassword = generateDbPassword();
+  try {
+    // Persist BEFORE altering: a crash after the write is recoverable (see
+    // above), a password change without the file would lock us out.
+    deps.writeFile(filePath, newPassword);
+    const readBack = deps.readFile(filePath)?.trim();
+    if (readBack !== newPassword) {
+      throw new Error("read-back of the persisted password does not match");
+    }
+  } catch (err) {
+    return {
+      url: databaseUrl,
+      source: "default",
+      warning: `cannot persist generated password (${message(err)}) — keeping the default`,
+    };
+  }
+  try {
+    await deps.alterPassword(databaseUrl, username, newPassword);
+  } catch (err) {
+    // The persisted file stays — the recovery path above finishes the job
+    // on the next boot.
+    return {
+      url: databaseUrl,
+      source: "default",
+      warning: `ALTER USER failed (${message(err)}) — will retry on next boot`,
+    };
+  }
+  deps.log("migrated the database off the default password (auto-generated credential persisted)");
+  return { url: replaceUrlPassword(databaseUrl, newPassword), source: "generated", migrated: true };
+}
+
+function message(err) {
+  return err instanceof Error ? err.message : String(err);
+}

--- a/packages/web/scripts/resolve-db-password.mjs
+++ b/packages/web/scripts/resolve-db-password.mjs
@@ -1,0 +1,45 @@
+#!/usr/bin/env node
+// Entrypoint runner for the DB password auto-migration (#156).
+//
+// Called by entrypoint.sh BEFORE drizzle-kit migrate and the server start,
+// because both consume DATABASE_URL. Prints the resolved URL to stdout
+// (nothing when the URL is unchanged); all diagnostics go to stderr so the
+// captured stdout never mixes with logs. Always exits 0 — a failed migration
+// must not block the boot (the server warns loudly instead).
+
+import { resolveDbPassword } from "./lib/db-password-resolver.mjs";
+import { createDbPasswordDeps } from "./lib/db-password-deps.mjs";
+
+const log = (msg) => process.stderr.write(`[db-password] ${msg}\n`);
+
+// Defense in depth: the production entrypoint is the only intended caller
+// (Dockerfile.pinchy sets NODE_ENV=production globally). Dev stacks keep the
+// well-known dev password so host-side tooling stays usable.
+if (process.env.NODE_ENV !== "production") {
+  process.exit(0);
+}
+
+const databaseUrl = process.env.DATABASE_URL;
+if (!databaseUrl) {
+  process.exit(0);
+}
+
+const secretsDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
+
+try {
+  const result = await resolveDbPassword({
+    databaseUrl,
+    secretsDir,
+    deps: createDbPasswordDeps({ log }),
+  });
+  if (result.warning) {
+    log(`WARNING: ${result.warning}`);
+  }
+  if (result.url !== databaseUrl) {
+    process.stdout.write(result.url);
+  }
+} catch (err) {
+  log(
+    `WARNING: unexpected error during password resolution: ${err instanceof Error ? err.message : err}`
+  );
+}

--- a/packages/web/server-preload.cjs
+++ b/packages/web/server-preload.cjs
@@ -13,10 +13,14 @@ if (!process.env.BETTER_AUTH_SECRET) {
   try {
     if (existsSync(secretPath)) {
       process.env.BETTER_AUTH_SECRET = readFileSync(secretPath, "utf-8").trim();
+      // Provenance marker for /api/health & Settings -> Security (#156):
+      // the env var now holds a file-backed value, not an operator-set one.
+      process.env.PINCHY_AUTH_SECRET_SOURCE = "file";
     } else if (existsSync(secretsDir)) {
       const secret = randomBytes(32).toString("hex");
       writeFileSync(secretPath, secret, { mode: 0o600 });
       process.env.BETTER_AUTH_SECRET = secret;
+      process.env.PINCHY_AUTH_SECRET_SOURCE = "file";
       console.log("Generated BETTER_AUTH_SECRET (persisted to secrets volume)");
     }
   } catch {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -40,6 +40,7 @@ import { seedSessionCache } from "./src/server/session-cache-seeder";
 import { readGatewayToken } from "./src/lib/gateway-token-reader";
 import { regenerateOpenClawConfig } from "./src/lib/openclaw-config";
 import { SERVER_WS_MAX_PAYLOAD_BYTES } from "./src/lib/limits";
+import { evaluateDbPasswordPolicy } from "./src/lib/secret-source";
 
 logCapture.install();
 
@@ -71,13 +72,17 @@ async function waitForGatewayToken(maxWaitMs = 30000): Promise<string | null> {
   return null;
 }
 
-if (process.env.NODE_ENV === "production") {
-  const dbUrl = process.env.DATABASE_URL || "";
-  if (dbUrl.includes(":pinchy_dev@")) {
-    console.warn(
-      "WARNING: Using default DB_PASSWORD. Set a secure password via .env for production."
-    );
-  }
+// Issue #156: production must not run on the default database password —
+// fail closed at startup instead of logging a warning nobody reads.
+const dbPasswordPolicy = evaluateDbPasswordPolicy({
+  nodeEnv: process.env.NODE_ENV,
+  databaseUrl: process.env.DATABASE_URL,
+});
+if (dbPasswordPolicy.action === "exit") {
+  console.error(dbPasswordPolicy.message);
+  process.exit(1);
+} else if (dbPasswordPolicy.action === "warn") {
+  console.warn(dbPasswordPolicy.message);
 }
 
 app.prepare().then(async () => {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -72,16 +72,15 @@ async function waitForGatewayToken(maxWaitMs = 30000): Promise<string | null> {
   return null;
 }
 
-// Issue #156: production must not run on the default database password —
-// fail closed at startup instead of logging a warning nobody reads.
+// Issue #156: the entrypoint auto-migrates installs off the default database
+// password before this process starts. Still seeing the default here means
+// that migration failed or was skipped — warn loudly (never exit; see
+// evaluateDbPasswordPolicy for the rationale).
 const dbPasswordPolicy = evaluateDbPasswordPolicy({
   nodeEnv: process.env.NODE_ENV,
   databaseUrl: process.env.DATABASE_URL,
 });
-if (dbPasswordPolicy.action === "exit") {
-  console.error(dbPasswordPolicy.message);
-  process.exit(1);
-} else if (dbPasswordPolicy.action === "warn") {
+if (dbPasswordPolicy.action === "warn") {
   console.warn(dbPasswordPolicy.message);
 }
 

--- a/packages/web/src/__tests__/api/health.test.ts
+++ b/packages/web/src/__tests__/api/health.test.ts
@@ -1,14 +1,16 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi, afterEach } from "vitest";
 import { GET } from "@/app/api/health/route";
 import { NextRequest } from "next/server";
 
 describe("GET /api/health", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
   it("should return 200 with status ok", async () => {
     const request = new NextRequest("http://localhost/api/health", { method: "GET" });
     const response = await GET(request);
     expect(response.status).toBe(200);
     const data = await response.json();
-    expect(data).toEqual({ status: "ok" });
+    expect(data).toMatchObject({ status: "ok" });
   });
 
   it("should return JSON content type", async () => {
@@ -16,5 +18,31 @@ describe("GET /api/health", () => {
     const response = await GET(request);
     const contentType = response.headers.get("content-type");
     expect(contentType).toContain("application/json");
+  });
+
+  // Issue #156: operators need to see WHERE secrets come from (provenance
+  // only — never values) to avoid rotating auto-generated secrets that
+  // didn't need rotating.
+  it("exposes secret provenance without leaking any secret values", async () => {
+    vi.stubEnv("ENCRYPTION_KEY", "a".repeat(64));
+    vi.stubEnv("BETTER_AUTH_SECRET", "super-secret-auth-value");
+    vi.stubEnv("DATABASE_URL", "postgresql://pinchy:pinchy_dev@db:5432/pinchy");
+
+    const request = new NextRequest("http://localhost/api/health", { method: "GET" });
+    const response = await GET(request);
+    const data = await response.json();
+
+    expect(data.secrets).toEqual({
+      encryption_key: "envvar",
+      auth_secret: "envvar",
+      audit_hmac_secret: expect.stringMatching(/^(envvar|file|unset)$/),
+      db_password: "default",
+    });
+
+    // Provenance only: no secret material may appear anywhere in the body.
+    const body = JSON.stringify(data);
+    expect(body).not.toContain("a".repeat(64));
+    expect(body).not.toContain("super-secret-auth-value");
+    expect(body).not.toContain("pinchy_dev");
   });
 });

--- a/packages/web/src/__tests__/components/secrets-provenance-card.test.tsx
+++ b/packages/web/src/__tests__/components/secrets-provenance-card.test.tsx
@@ -43,6 +43,25 @@ describe("SecretsProvenanceCard", () => {
     expect(screen.getByText(/custom password/i)).toBeInTheDocument();
   });
 
+  it("labels an auto-generated database password calmly", async () => {
+    fetchSpy.mockResolvedValue(
+      healthResponse({
+        encryption_key: "file",
+        auth_secret: "file",
+        audit_hmac_secret: "file",
+        db_password: "generated",
+      })
+    );
+
+    render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/auto-generated/i)).toBeInTheDocument();
+    });
+    // An auto-generated password is a managed, healthy state — no warning.
+    expect(screen.queryByText(/default password/i)).not.toBeInTheDocument();
+  });
+
   it("flags the default database password", async () => {
     fetchSpy.mockResolvedValue(
       healthResponse({

--- a/packages/web/src/__tests__/components/secrets-provenance-card.test.tsx
+++ b/packages/web/src/__tests__/components/secrets-provenance-card.test.tsx
@@ -1,0 +1,102 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import "@testing-library/jest-dom";
+
+import { SecretsProvenanceCard } from "@/components/secrets-provenance-card";
+
+function healthResponse(secrets: Record<string, string>) {
+  return new Response(JSON.stringify({ status: "ok", secrets }));
+}
+
+describe("SecretsProvenanceCard", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("shows where each secret comes from", async () => {
+    fetchSpy.mockResolvedValue(
+      healthResponse({
+        encryption_key: "file",
+        auth_secret: "envvar",
+        audit_hmac_secret: "file",
+        db_password: "custom",
+      })
+    );
+
+    render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/encryption key/i)).toBeInTheDocument();
+    });
+    expect(fetchSpy).toHaveBeenCalledWith("/api/health");
+    expect(screen.getAllByText("Persisted file (Docker volume)").length).toBe(2);
+    expect(screen.getByText("Environment variable")).toBeInTheDocument();
+    expect(screen.getByText(/auth secret/i)).toBeInTheDocument();
+    expect(screen.getByText(/audit signing secret/i)).toBeInTheDocument();
+    expect(screen.getByText(/database password/i)).toBeInTheDocument();
+    expect(screen.getByText(/custom password/i)).toBeInTheDocument();
+  });
+
+  it("flags the default database password", async () => {
+    fetchSpy.mockResolvedValue(
+      healthResponse({
+        encryption_key: "file",
+        auth_secret: "unset",
+        audit_hmac_secret: "unset",
+        db_password: "default",
+      })
+    );
+
+    render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/default password/i)).toBeInTheDocument();
+    });
+    expect(screen.getByText(/DB_PASSWORD/)).toBeInTheDocument();
+  });
+
+  it("explains not-yet-created secrets instead of alarming the user", async () => {
+    fetchSpy.mockResolvedValue(
+      healthResponse({
+        encryption_key: "unset",
+        auth_secret: "envvar",
+        audit_hmac_secret: "unset",
+        db_password: "custom",
+      })
+    );
+
+    render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(screen.getAllByText(/generated on first use/i).length).toBe(2);
+    });
+  });
+
+  it("renders nothing when the health endpoint has no secrets info", async () => {
+    fetchSpy.mockResolvedValue(new Response(JSON.stringify({ status: "ok" })));
+
+    const { container } = render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders nothing when the health fetch fails", async () => {
+    fetchSpy.mockRejectedValue(new Error("network down"));
+
+    const { container } = render(<SecretsProvenanceCard />);
+
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalled();
+    });
+    expect(container).toBeEmptyDOMElement();
+  });
+});

--- a/packages/web/src/__tests__/integration/db-password-resolver.integration.test.ts
+++ b/packages/web/src/__tests__/integration/db-password-resolver.integration.test.ts
@@ -1,0 +1,128 @@
+// Real-Postgres integration test for the DB password auto-migration (#156).
+// Uses the EXACT deps the entrypoint runner uses (db-password-deps.mjs), so a
+// behaviour change in probe/ALTER USER wiring fails here, not in production.
+//
+// The test creates its own login role so the suite's primary user (and the
+// other integration tests) are never affected.
+import { describe, it, expect, beforeEach, afterAll, beforeAll } from "vitest";
+import { mkdtempSync, rmSync, readFileSync, existsSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import postgres from "postgres";
+import {
+  resolveDbPassword,
+  replaceUrlPassword,
+  DB_PASSWORD_FILE,
+} from "../../../scripts/lib/db-password-resolver.mjs";
+import { createDbPasswordDeps } from "../../../scripts/lib/db-password-deps.mjs";
+
+const ADMIN_URL = process.env.DATABASE_URL!; // vitest.integration.config.ts sets this
+const ROLE = "pinchy_migtest";
+const DEFAULT_PW = "pinchy_dev";
+
+function roleUrl(password: string): string {
+  const url = new URL(ADMIN_URL);
+  url.username = ROLE;
+  url.password = password;
+  return url.toString();
+}
+
+async function adminSql<T>(fn: (sql: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
+  const sql = postgres(ADMIN_URL, { max: 1, onnotice: () => {} });
+  try {
+    return await fn(sql);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+describe("db password resolver (real Postgres)", () => {
+  let secretsDir: string;
+  const deps = createDbPasswordDeps();
+
+  beforeAll(async () => {
+    await adminSql(async (sql) => {
+      await sql.unsafe(`DROP ROLE IF EXISTS ${ROLE}`);
+      await sql.unsafe(`CREATE ROLE ${ROLE} LOGIN PASSWORD '${DEFAULT_PW}'`);
+    });
+  });
+
+  beforeEach(async () => {
+    secretsDir = mkdtempSync(join(tmpdir(), "pinchy-dbpw-"));
+    // Reset the role to the default password before each scenario.
+    await adminSql((sql) => sql.unsafe(`ALTER ROLE ${ROLE} WITH PASSWORD '${DEFAULT_PW}'`));
+  });
+
+  afterAll(async () => {
+    await adminSql((sql) => sql.unsafe(`DROP ROLE IF EXISTS ${ROLE}`));
+    rmSync(secretsDir, { recursive: true, force: true });
+  });
+
+  it("migrates a default-password role end to end and is idempotent", async () => {
+    const defaultUrl = roleUrl(DEFAULT_PW);
+
+    // First boot: generate + persist + ALTER USER.
+    const first = await resolveDbPassword({ databaseUrl: defaultUrl, secretsDir, deps });
+    expect(first.source).toBe("generated");
+    expect(first.migrated).toBe(true);
+
+    const persisted = readFileSync(join(secretsDir, DB_PASSWORD_FILE), "utf-8").trim();
+    expect(persisted).toMatch(/^[0-9a-f]{64}$/);
+
+    // The new password really is live: it connects, the default doesn't.
+    expect(await deps.probe(first.url)).toBe(true);
+    expect(await deps.probe(defaultUrl)).toBe(false);
+
+    // Second boot (steady state): same URL, no further migration.
+    const second = await resolveDbPassword({ databaseUrl: defaultUrl, secretsDir, deps });
+    expect(second.source).toBe("generated");
+    expect(second.migrated).toBeUndefined();
+    expect(second.url).toBe(first.url);
+  });
+
+  it("recovers when the file was persisted but ALTER USER never ran (crash window)", async () => {
+    const defaultUrl = roleUrl(DEFAULT_PW);
+    const orphanPassword = "ab".repeat(32);
+    writeFileSync(join(secretsDir, DB_PASSWORD_FILE), orphanPassword, { mode: 0o600 });
+
+    const result = await resolveDbPassword({ databaseUrl: defaultUrl, secretsDir, deps });
+    expect(result.source).toBe("generated");
+    expect(result.migrated).toBe(true);
+    expect(await deps.probe(roleUrl(orphanPassword))).toBe(true);
+    expect(await deps.probe(defaultUrl)).toBe(false);
+  });
+
+  it("applies an explicit DB_PASSWORD when the role still runs on the default (forgotten ALTER USER)", async () => {
+    const operatorUrl = roleUrl("operator-chosen-pw");
+
+    const result = await resolveDbPassword({ databaseUrl: operatorUrl, secretsDir, deps });
+    expect(result.source).toBe("custom");
+    expect(result.migrated).toBe(true);
+    expect(await deps.probe(operatorUrl)).toBe(true);
+    expect(await deps.probe(roleUrl(DEFAULT_PW))).toBe(false);
+  });
+
+  it("switches from a generated password to a later explicit DB_PASSWORD and removes the file", async () => {
+    const defaultUrl = roleUrl(DEFAULT_PW);
+    await resolveDbPassword({ databaseUrl: defaultUrl, secretsDir, deps });
+    expect(existsSync(join(secretsDir, DB_PASSWORD_FILE))).toBe(true);
+
+    // Operator later pins DB_PASSWORD in .env; the db still runs on the
+    // generated one. The resolver heals the mismatch and drops the file.
+    const operatorUrl = roleUrl("operator-chosen-pw");
+    const result = await resolveDbPassword({ databaseUrl: operatorUrl, secretsDir, deps });
+    expect(result.source).toBe("custom");
+    expect(result.migrated).toBe(true);
+    expect(await deps.probe(operatorUrl)).toBe(true);
+    expect(existsSync(join(secretsDir, DB_PASSWORD_FILE))).toBe(false);
+  });
+
+  it("quotes passwords with SQL metacharacters safely", async () => {
+    const trickyUrl = replaceUrlPassword(roleUrl("x"), "it's;DROP TABLE--\"quote");
+
+    const result = await resolveDbPassword({ databaseUrl: trickyUrl, secretsDir, deps });
+    expect(result.source).toBe("custom");
+    expect(result.migrated).toBe(true);
+    expect(await deps.probe(trickyUrl)).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/db-password-resolver.test.ts
+++ b/packages/web/src/__tests__/lib/db-password-resolver.test.ts
@@ -1,0 +1,242 @@
+// Unit tests for the boot-time DB password auto-migration (#156).
+// The resolver lives in scripts/lib as plain .mjs because entrypoint.sh runs
+// it with plain `node` before drizzle-kit and the server start — no tsx, no
+// path aliases. Tests inject fake deps; the real postgres/fs deps are
+// exercised by db-password-resolver.integration.test.ts.
+import { describe, it, expect, vi } from "vitest";
+import {
+  DEFAULT_DB_PASSWORD,
+  replaceUrlPassword,
+  generateDbPassword,
+  resolveDbPassword,
+} from "../../../scripts/lib/db-password-resolver.mjs";
+
+const DEFAULT_URL = `postgresql://pinchy:${DEFAULT_DB_PASSWORD}@db:5432/pinchy`;
+const CUSTOM_URL = "postgresql://pinchy:operator-pw@db:5432/pinchy";
+const SECRETS_DIR = "/app/secrets";
+const FILE_PATH = "/app/secrets/.db_password";
+const FILE_PW = "f".repeat(64);
+
+interface FakeDepsOptions {
+  probeOk?: (url: string) => boolean;
+  files?: Record<string, string>;
+  writeError?: Error;
+  alterError?: Error;
+}
+
+function fakeDeps(opts: FakeDepsOptions = {}) {
+  const files: Record<string, string> = { ...(opts.files ?? {}) };
+  const calls: string[] = [];
+  return {
+    files,
+    calls,
+    deps: {
+      probe: vi.fn(async (url: string) => (opts.probeOk ? opts.probeOk(url) : false)),
+      alterPassword: vi.fn(async (_url: string, _user: string, _pw: string) => {
+        calls.push("alter");
+        if (opts.alterError) throw opts.alterError;
+      }),
+      readFile: vi.fn((path: string) => files[path] ?? null),
+      writeFile: vi.fn((path: string, content: string) => {
+        calls.push("write");
+        if (opts.writeError) throw opts.writeError;
+        files[path] = content;
+      }),
+      deleteFile: vi.fn((path: string) => {
+        delete files[path];
+      }),
+      log: vi.fn(),
+    },
+  };
+}
+
+describe("replaceUrlPassword", () => {
+  it("replaces only the password, keeping user, host, port, db, and query", () => {
+    const url = "postgresql://pinchy:old@db:5432/pinchy?sslmode=disable";
+    const out = replaceUrlPassword(url, "newpw");
+    expect(out).toContain("pinchy:newpw@db:5432/pinchy");
+    expect(out).toContain("sslmode=disable");
+    expect(out).not.toContain("old");
+  });
+});
+
+describe("generateDbPassword", () => {
+  it("produces 64 hex characters", () => {
+    expect(generateDbPassword()).toMatch(/^[0-9a-f]{64}$/);
+  });
+});
+
+describe("resolveDbPassword", () => {
+  it("returns the URL untouched when a custom password connects", async () => {
+    const { deps } = fakeDeps({ probeOk: (u) => u === CUSTOM_URL });
+    const result = await resolveDbPassword({
+      databaseUrl: CUSTOM_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: CUSTOM_URL, source: "custom" });
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+
+  it("heals a custom password the operator set without ALTER USER (db still on default)", async () => {
+    const { deps } = fakeDeps({
+      probeOk: (u) => u.includes(`:${DEFAULT_DB_PASSWORD}@`),
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: CUSTOM_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: CUSTOM_URL, source: "custom", migrated: true });
+    expect(deps.alterPassword).toHaveBeenCalledWith(
+      expect.stringContaining(`:${DEFAULT_DB_PASSWORD}@`),
+      "pinchy",
+      "operator-pw"
+    );
+  });
+
+  it("heals a custom password when the db runs on a previously generated one, and removes the stale file", async () => {
+    const { deps, files } = fakeDeps({
+      probeOk: (u) => u.includes(`:${FILE_PW}@`),
+      files: { [FILE_PATH]: FILE_PW },
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: CUSTOM_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: CUSTOM_URL, source: "custom", migrated: true });
+    expect(deps.alterPassword).toHaveBeenCalledWith(
+      expect.stringContaining(`:${FILE_PW}@`),
+      "pinchy",
+      "operator-pw"
+    );
+    expect(files[FILE_PATH]).toBeUndefined();
+  });
+
+  it("returns a warning when a custom password matches nothing", async () => {
+    const { deps } = fakeDeps({ probeOk: () => false });
+    const result = await resolveDbPassword({
+      databaseUrl: CUSTOM_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result.url).toBe(CUSTOM_URL);
+    expect(result.source).toBe("custom");
+    expect(result.warning).toBeTruthy();
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+
+  it("migrates a default-password install: generate, persist, then ALTER USER", async () => {
+    const { deps, files, calls } = fakeDeps({
+      probeOk: (u) => u.includes(`:${DEFAULT_DB_PASSWORD}@`),
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result.source).toBe("generated");
+    expect(result.migrated).toBe(true);
+    const persisted = files[FILE_PATH];
+    expect(persisted).toMatch(/^[0-9a-f]{64}$/);
+    expect(result.url).toContain(`:${persisted}@`);
+    // Crash safety: the file must be persisted BEFORE the password changes.
+    expect(calls).toEqual(["write", "alter"]);
+  });
+
+  it("keeps the default password (with a warning) when the secrets dir is not writable", async () => {
+    const { deps } = fakeDeps({
+      probeOk: (u) => u.includes(`:${DEFAULT_DB_PASSWORD}@`),
+      writeError: new Error("EROFS: read-only file system"),
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: DEFAULT_URL, source: "default" });
+    expect(result.warning).toMatch(/EROFS/);
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+
+  it("keeps the default URL (with a warning) when the database is unreachable", async () => {
+    const { deps } = fakeDeps({ probeOk: () => false });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: DEFAULT_URL, source: "default" });
+    expect(result.warning).toBeTruthy();
+    expect(deps.writeFile).not.toHaveBeenCalled();
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+
+  it("uses the persisted password without ALTER USER on subsequent boots (steady state)", async () => {
+    const { deps } = fakeDeps({
+      probeOk: (u) => u.includes(`:${FILE_PW}@`),
+      files: { [FILE_PATH]: FILE_PW },
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result.source).toBe("generated");
+    expect(result.url).toContain(`:${FILE_PW}@`);
+    expect(result.migrated).toBeUndefined();
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+
+  it("recovers from a crash between persist and ALTER USER", async () => {
+    // File exists but the db still accepts the default password.
+    const { deps } = fakeDeps({
+      probeOk: (u) => u.includes(`:${DEFAULT_DB_PASSWORD}@`),
+      files: { [FILE_PATH]: FILE_PW },
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result.source).toBe("generated");
+    expect(result.migrated).toBe(true);
+    expect(result.url).toContain(`:${FILE_PW}@`);
+    expect(deps.alterPassword).toHaveBeenCalledWith(
+      expect.stringContaining(`:${DEFAULT_DB_PASSWORD}@`),
+      "pinchy",
+      FILE_PW
+    );
+  });
+
+  it("leaves the persisted file in place when ALTER USER fails, so the next boot can recover", async () => {
+    const { deps, files } = fakeDeps({
+      probeOk: (u) => u.includes(`:${DEFAULT_DB_PASSWORD}@`),
+      alterError: new Error("connection lost"),
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: DEFAULT_URL, source: "default" });
+    expect(result.warning).toMatch(/connection lost/);
+    expect(files[FILE_PATH]).toMatch(/^[0-9a-f]{64}$/);
+  });
+
+  it("returns a warning when neither the persisted nor the default password connects", async () => {
+    const { deps } = fakeDeps({
+      probeOk: () => false,
+      files: { [FILE_PATH]: FILE_PW },
+    });
+    const result = await resolveDbPassword({
+      databaseUrl: DEFAULT_URL,
+      secretsDir: SECRETS_DIR,
+      deps,
+    });
+    expect(result).toMatchObject({ url: DEFAULT_URL, source: "default" });
+    expect(result.warning).toBeTruthy();
+    expect(deps.alterPassword).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/lib/secret-source.test.ts
+++ b/packages/web/src/__tests__/lib/secret-source.test.ts
@@ -1,0 +1,150 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const existsSyncMock = vi.fn(() => false);
+  const readFileSyncMock = vi.fn();
+  const writeFileSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      existsSync: existsSyncMock,
+      readFileSync: readFileSyncMock,
+      writeFileSync: writeFileSyncMock,
+    },
+    existsSync: existsSyncMock,
+    readFileSync: readFileSyncMock,
+    writeFileSync: writeFileSyncMock,
+  };
+});
+
+import { existsSync } from "fs";
+import { getSecretSource } from "@/lib/encryption";
+import {
+  getAuthSecretSource,
+  getDbPasswordSource,
+  getSecretsProvenance,
+  evaluateDbPasswordPolicy,
+} from "@/lib/secret-source";
+
+const mockedExistsSync = vi.mocked(existsSync);
+const VALID_KEY = "a".repeat(64);
+
+describe("getSecretSource", () => {
+  beforeEach(() => {
+    mockedExistsSync.mockReturnValue(false);
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+  });
+
+  it("returns 'envvar' when the env var holds a valid 64-hex key", () => {
+    vi.stubEnv("ENCRYPTION_KEY", VALID_KEY);
+    expect(getSecretSource("encryption_key")).toBe("envvar");
+  });
+
+  it("falls through to 'file' when the env var is set but invalid", () => {
+    vi.stubEnv("ENCRYPTION_KEY", "not-a-valid-key");
+    mockedExistsSync.mockImplementation((p) => String(p).endsWith(".encryption_key"));
+    expect(getSecretSource("encryption_key")).toBe("file");
+  });
+
+  it("returns 'file' when no env var is set and the key file exists", () => {
+    vi.stubEnv("ENCRYPTION_KEY", "");
+    mockedExistsSync.mockImplementation((p) => String(p).endsWith(".encryption_key"));
+    expect(getSecretSource("encryption_key")).toBe("file");
+  });
+
+  it("returns 'unset' when neither env var nor file is present", () => {
+    vi.stubEnv("ENCRYPTION_KEY", "");
+    expect(getSecretSource("encryption_key")).toBe("unset");
+  });
+
+  it("resolves per-secret names (audit_hmac_secret)", () => {
+    vi.stubEnv("AUDIT_HMAC_SECRET", VALID_KEY);
+    expect(getSecretSource("audit_hmac_secret")).toBe("envvar");
+  });
+});
+
+describe("getAuthSecretSource", () => {
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("returns 'envvar' when BETTER_AUTH_SECRET is set", () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "some-long-secret-value");
+    expect(getAuthSecretSource()).toBe("envvar");
+  });
+
+  it("returns 'unset' when BETTER_AUTH_SECRET is empty or whitespace", () => {
+    vi.stubEnv("BETTER_AUTH_SECRET", "");
+    expect(getAuthSecretSource()).toBe("unset");
+    vi.stubEnv("BETTER_AUTH_SECRET", "   ");
+    expect(getAuthSecretSource()).toBe("unset");
+  });
+});
+
+describe("getDbPasswordSource", () => {
+  it("returns 'default' when the URL carries the default dev password", () => {
+    expect(getDbPasswordSource("postgresql://pinchy:pinchy_dev@db:5432/pinchy")).toBe("default");
+  });
+
+  it("returns 'custom' for any other password", () => {
+    expect(getDbPasswordSource("postgresql://pinchy:s3cure-pw@db:5432/pinchy")).toBe("custom");
+  });
+});
+
+describe("getSecretsProvenance", () => {
+  beforeEach(() => {
+    mockedExistsSync.mockReturnValue(false);
+    vi.unstubAllEnvs();
+  });
+
+  afterEach(() => vi.unstubAllEnvs());
+
+  it("reports provenance for all four secrets with issue-#156 keys", () => {
+    vi.stubEnv("ENCRYPTION_KEY", VALID_KEY);
+    vi.stubEnv("BETTER_AUTH_SECRET", "auth-secret");
+    vi.stubEnv("DATABASE_URL", "postgresql://pinchy:pinchy_dev@db:5432/pinchy");
+
+    expect(getSecretsProvenance()).toEqual({
+      encryption_key: "envvar",
+      auth_secret: "envvar",
+      audit_hmac_secret: "unset",
+      db_password: "default",
+    });
+  });
+});
+
+describe("evaluateDbPasswordPolicy", () => {
+  const DEFAULT_URL = "postgresql://pinchy:pinchy_dev@db:5432/pinchy";
+  const CUSTOM_URL = "postgresql://pinchy:s3cure-pw@db:5432/pinchy";
+
+  it("demands exit in production with the default password", () => {
+    const result = evaluateDbPasswordPolicy({
+      nodeEnv: "production",
+      databaseUrl: DEFAULT_URL,
+    });
+    expect(result.action).toBe("exit");
+    expect(result.message).toMatch(/DB_PASSWORD/);
+  });
+
+  it("only warns outside production with the default password", () => {
+    const result = evaluateDbPasswordPolicy({
+      nodeEnv: "development",
+      databaseUrl: DEFAULT_URL,
+    });
+    expect(result.action).toBe("warn");
+    expect(result.message).toMatch(/DB_PASSWORD/);
+  });
+
+  it("is silent with a custom password", () => {
+    expect(
+      evaluateDbPasswordPolicy({ nodeEnv: "production", databaseUrl: CUSTOM_URL }).action
+    ).toBe("none");
+    expect(
+      evaluateDbPasswordPolicy({ nodeEnv: "development", databaseUrl: CUSTOM_URL }).action
+    ).toBe("none");
+  });
+});

--- a/packages/web/src/__tests__/lib/secret-source.test.ts
+++ b/packages/web/src/__tests__/lib/secret-source.test.ts
@@ -19,7 +19,7 @@ vi.mock("fs", async (importOriginal) => {
   };
 });
 
-import { existsSync } from "fs";
+import { existsSync, readFileSync } from "fs";
 import { getSecretSource } from "@/lib/encryption";
 import {
   getAuthSecretSource,
@@ -29,6 +29,7 @@ import {
 } from "@/lib/secret-source";
 
 const mockedExistsSync = vi.mocked(existsSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
 const VALID_KEY = "a".repeat(64);
 
 describe("getSecretSource", () => {
@@ -77,6 +78,14 @@ describe("getAuthSecretSource", () => {
     expect(getAuthSecretSource()).toBe("envvar");
   });
 
+  it("returns 'file' when the preload loaded the secret from the secrets volume", () => {
+    // server-preload.cjs copies the file-backed secret into the env and marks
+    // the provenance — without the marker we could not tell the sources apart.
+    vi.stubEnv("BETTER_AUTH_SECRET", "loaded-from-file");
+    vi.stubEnv("PINCHY_AUTH_SECRET_SOURCE", "file");
+    expect(getAuthSecretSource()).toBe("file");
+  });
+
   it("returns 'unset' when BETTER_AUTH_SECRET is empty or whitespace", () => {
     vi.stubEnv("BETTER_AUTH_SECRET", "");
     expect(getAuthSecretSource()).toBe("unset");
@@ -86,12 +95,31 @@ describe("getAuthSecretSource", () => {
 });
 
 describe("getDbPasswordSource", () => {
+  beforeEach(() => {
+    mockedExistsSync.mockReturnValue(false);
+  });
+
   it("returns 'default' when the URL carries the default dev password", () => {
     expect(getDbPasswordSource("postgresql://pinchy:pinchy_dev@db:5432/pinchy")).toBe("default");
   });
 
   it("returns 'custom' for any other password", () => {
     expect(getDbPasswordSource("postgresql://pinchy:s3cure-pw@db:5432/pinchy")).toBe("custom");
+  });
+
+  it("returns 'generated' when the URL password matches the persisted .db_password file", () => {
+    const generated = "c".repeat(64);
+    mockedExistsSync.mockImplementation((p) => String(p).endsWith(".db_password"));
+    mockedReadFileSync.mockReturnValue(`${generated}\n`);
+    expect(getDbPasswordSource(`postgresql://pinchy:${generated}@db:5432/pinchy`)).toBe(
+      "generated"
+    );
+  });
+
+  it("returns 'custom' when the URL password differs from the persisted file", () => {
+    mockedExistsSync.mockImplementation((p) => String(p).endsWith(".db_password"));
+    mockedReadFileSync.mockReturnValue(`${"c".repeat(64)}\n`);
+    expect(getDbPasswordSource("postgresql://pinchy:operator-pw@db:5432/pinchy")).toBe("custom");
   });
 });
 
@@ -121,16 +149,25 @@ describe("evaluateDbPasswordPolicy", () => {
   const DEFAULT_URL = "postgresql://pinchy:pinchy_dev@db:5432/pinchy";
   const CUSTOM_URL = "postgresql://pinchy:s3cure-pw@db:5432/pinchy";
 
-  it("demands exit in production with the default password", () => {
+  beforeEach(() => {
+    mockedExistsSync.mockReturnValue(false);
+  });
+
+  // Deliberately warn-only: the entrypoint's auto-migration (issue #156,
+  // scripts/resolve-db-password.mjs) moves installs off the default password
+  // automatically. Reaching the server with the default URL means that
+  // migration failed or was skipped — warn loudly, never refuse to start.
+  it("warns loudly in production when the default password survived boot resolution", () => {
     const result = evaluateDbPasswordPolicy({
       nodeEnv: "production",
       databaseUrl: DEFAULT_URL,
     });
-    expect(result.action).toBe("exit");
+    expect(result.action).toBe("warn");
     expect(result.message).toMatch(/DB_PASSWORD/);
+    expect(result.message).toMatch(/migration/i);
   });
 
-  it("only warns outside production with the default password", () => {
+  it("warns outside production with the default password", () => {
     const result = evaluateDbPasswordPolicy({
       nodeEnv: "development",
       databaseUrl: DEFAULT_URL,
@@ -145,6 +182,18 @@ describe("evaluateDbPasswordPolicy", () => {
     ).toBe("none");
     expect(
       evaluateDbPasswordPolicy({ nodeEnv: "development", databaseUrl: CUSTOM_URL }).action
+    ).toBe("none");
+  });
+
+  it("is silent with an auto-generated password", () => {
+    const generated = "c".repeat(64);
+    mockedExistsSync.mockImplementation((p) => String(p).endsWith(".db_password"));
+    mockedReadFileSync.mockReturnValue(generated);
+    expect(
+      evaluateDbPasswordPolicy({
+        nodeEnv: "production",
+        databaseUrl: `postgresql://pinchy:${generated}@db:5432/pinchy`,
+      }).action
     ).toBe("none");
   });
 });

--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,5 +1,13 @@
 import { NextResponse } from "next/server";
+import { getSecretsProvenance } from "@/lib/secret-source";
 
 export async function GET() {
-  return NextResponse.json({ status: "ok" });
+  return NextResponse.json({
+    status: "ok",
+    // Issue #156: provenance only ("envvar" | "file" | "unset" /
+    // "custom" | "default") — never secret values. Lets operators see from
+    // the shell whether the file fallback is active before rotating
+    // anything (rotating an auto-generated encryption key loses data).
+    secrets: getSecretsProvenance(),
+  });
 }

--- a/packages/web/src/components/secrets-provenance-card.tsx
+++ b/packages/web/src/components/secrets-provenance-card.tsx
@@ -1,0 +1,93 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { KeyRound, TriangleAlert } from "lucide-react";
+
+// Keep in sync with SecretsProvenance in @/lib/secret-source — duplicated
+// here because the server lib must not be bundled into a client component.
+interface SecretsInfo {
+  encryption_key: "envvar" | "file" | "unset";
+  auth_secret: "envvar" | "unset";
+  audit_hmac_secret: "envvar" | "file" | "unset";
+  db_password: "custom" | "default";
+}
+
+const SOURCE_LABELS: Record<string, string> = {
+  envvar: "Environment variable",
+  file: "Persisted file (Docker volume)",
+  unset: "Not created yet — generated on first use",
+};
+
+function SecretRow({ name, label }: { name: string; label: string }) {
+  return (
+    <div className="flex items-center justify-between gap-4 text-sm">
+      <span>{name}</span>
+      <span className="text-muted-foreground">{label}</span>
+    </div>
+  );
+}
+
+/**
+ * Shows where this instance's secrets come from (issue #156) — provenance
+ * only, values never leave the server. Renders nothing when /api/health
+ * doesn't expose the info (older server during a rolling upgrade).
+ */
+export function SecretsProvenanceCard() {
+  const [secrets, setSecrets] = useState<SecretsInfo | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    (async () => {
+      try {
+        const res = await fetch("/api/health");
+        if (!res.ok || cancelled) return;
+        const data = await res.json();
+        if (!cancelled && data.secrets) setSecrets(data.secrets);
+      } catch {
+        // Health endpoint unreachable — simply don't render the card.
+      }
+    })();
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  if (!secrets) return null;
+
+  const defaultDbPassword = secrets.db_password === "default";
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle className="flex items-center gap-2">
+          <KeyRound className="size-5" />
+          Secrets
+        </CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-3">
+        <p className="text-sm text-muted-foreground">
+          Where this instance&apos;s secrets come from. Environment variables override persisted
+          files. Values never leave the server.
+        </p>
+        <SecretRow name="Encryption key" label={SOURCE_LABELS[secrets.encryption_key]} />
+        <SecretRow
+          name="Auth secret"
+          label={secrets.auth_secret === "envvar" ? SOURCE_LABELS.envvar : "Not set"}
+        />
+        <SecretRow name="Audit signing secret" label={SOURCE_LABELS[secrets.audit_hmac_secret]} />
+        <div className="flex items-center justify-between gap-4 text-sm">
+          <span>Database password</span>
+          {defaultDbPassword ? (
+            <span className="flex items-center gap-1.5 text-amber-600">
+              <TriangleAlert className="size-4" />
+              Default password — set DB_PASSWORD in your .env
+            </span>
+          ) : (
+            <span className="text-muted-foreground">Custom password</span>
+          )}
+        </div>
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/components/secrets-provenance-card.tsx
+++ b/packages/web/src/components/secrets-provenance-card.tsx
@@ -8,9 +8,9 @@ import { KeyRound, TriangleAlert } from "lucide-react";
 // here because the server lib must not be bundled into a client component.
 interface SecretsInfo {
   encryption_key: "envvar" | "file" | "unset";
-  auth_secret: "envvar" | "unset";
+  auth_secret: "envvar" | "file" | "unset";
   audit_hmac_secret: "envvar" | "file" | "unset";
-  db_password: "custom" | "default";
+  db_password: "custom" | "default" | "generated";
 }
 
 const SOURCE_LABELS: Record<string, string> = {
@@ -73,7 +73,7 @@ export function SecretsProvenanceCard() {
         <SecretRow name="Encryption key" label={SOURCE_LABELS[secrets.encryption_key]} />
         <SecretRow
           name="Auth secret"
-          label={secrets.auth_secret === "envvar" ? SOURCE_LABELS.envvar : "Not set"}
+          label={secrets.auth_secret === "unset" ? "Not set" : SOURCE_LABELS[secrets.auth_secret]}
         />
         <SecretRow name="Audit signing secret" label={SOURCE_LABELS[secrets.audit_hmac_secret]} />
         <div className="flex items-center justify-between gap-4 text-sm">
@@ -84,7 +84,11 @@ export function SecretsProvenanceCard() {
               Default password — set DB_PASSWORD in your .env
             </span>
           ) : (
-            <span className="text-muted-foreground">Custom password</span>
+            <span className="text-muted-foreground">
+              {secrets.db_password === "generated"
+                ? "Auto-generated (Docker volume)"
+                : "Custom password"}
+            </span>
           )}
         </div>
       </CardContent>

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -15,6 +15,7 @@ import { SettingsIntegrations } from "@/components/settings-integrations";
 import { SettingsLicense } from "@/components/settings-license";
 import { TelegramLinkSettings } from "@/components/telegram-link-settings";
 import { SettingsSecurity } from "@/components/settings-security";
+import { SecretsProvenanceCard } from "@/components/secrets-provenance-card";
 import { SettingsSupport } from "@/components/settings-support";
 import type { LicenseInfo } from "@/lib/enterprise";
 
@@ -162,7 +163,10 @@ export function SettingsPageContent({
 
           {isAdmin && (
             <TabsContent value="security">
-              <SettingsSecurity />
+              <div className="space-y-6">
+                <SettingsSecurity />
+                <SecretsProvenanceCard />
+              </div>
             </TabsContent>
           )}
 

--- a/packages/web/src/lib/encryption.ts
+++ b/packages/web/src/lib/encryption.ts
@@ -5,39 +5,60 @@ import { join } from "path";
 const ALGORITHM = "aes-256-gcm";
 const IV_LENGTH = 12;
 
+/** Where a file-backed secret currently comes from (issue #156). */
+export type SecretSource = "envvar" | "file" | "unset";
+
+function secretPaths(name: string) {
+  const keyFileDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
+  return { keyFileDir, keyFilePath: join(keyFileDir, `.${name}`) };
+}
+
+/**
+ * Resolve the provenance of a secret WITHOUT creating it. Mirrors the
+ * priority order of getOrCreateSecret below — keep both in sync by having
+ * getOrCreateSecret dispatch on this function.
+ */
+export function getSecretSource(name: string): SecretSource {
+  const envKey = process.env[name.toUpperCase()];
+  if (envKey && envKey.length === 64 && /^[0-9a-fA-F]+$/.test(envKey)) {
+    return "envvar";
+  }
+  if (existsSync(secretPaths(name).keyFilePath)) {
+    return "file";
+  }
+  return "unset";
+}
+
 export function getOrCreateSecret(name: string): Buffer {
   const envVarName = name.toUpperCase();
-  const fileName = `.${name}`;
-  const keyFileDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
-  const keyFilePath = join(keyFileDir, fileName);
+  const { keyFileDir, keyFilePath } = secretPaths(name);
 
-  // Priority 1: Environment variable
-  const envKey = process.env[envVarName];
-  if (envKey && envKey.length === 64 && /^[0-9a-fA-F]+$/.test(envKey)) {
-    return Buffer.from(envKey, "hex");
-  }
+  switch (getSecretSource(name)) {
+    case "envvar":
+      return Buffer.from(process.env[envVarName]!, "hex");
 
-  // Priority 2: Existing key file
-  if (existsSync(keyFilePath)) {
-    const fileKey = readFileSync(keyFilePath, "utf-8").trim();
-    if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
-      throw new Error(`Invalid secret in ${keyFilePath}: expected 64 hex characters`);
+    case "file": {
+      const fileKey = readFileSync(keyFilePath, "utf-8").trim();
+      if (fileKey.length !== 64 || !/^[0-9a-fA-F]+$/.test(fileKey)) {
+        throw new Error(`Invalid secret in ${keyFilePath}: expected 64 hex characters`);
+      }
+      return Buffer.from(fileKey, "hex");
     }
-    return Buffer.from(fileKey, "hex");
-  }
 
-  // Priority 3: Auto-generate and persist
-  if (existsSync(keyFileDir)) {
-    const newKey = randomBytes(32).toString("hex");
-    writeFileSync(keyFilePath, newKey, { mode: 0o600 });
-    return Buffer.from(newKey, "hex");
+    case "unset": {
+      // Auto-generate and persist
+      if (existsSync(keyFileDir)) {
+        const newKey = randomBytes(32).toString("hex");
+        writeFileSync(keyFilePath, newKey, { mode: 0o600 });
+        return Buffer.from(newKey, "hex");
+      }
+      throw new Error(
+        `${envVarName} environment variable is required (64 hex characters) ` +
+          "or a writable directory at " +
+          keyFileDir
+      );
+    }
   }
-
-  throw new Error(
-    `${envVarName} environment variable is required (64 hex characters) ` +
-      "or a writable directory at " +
-      keyFileDir
-  );
 }
 
 export function getEncryptionKey(): Buffer {

--- a/packages/web/src/lib/secret-source.ts
+++ b/packages/web/src/lib/secret-source.ts
@@ -6,31 +6,54 @@
 // rotating, losing encrypted data. Provenance makes the file fallback
 // visible from outside the container.
 
+import { existsSync, readFileSync } from "fs";
+import { join } from "path";
 import { getSecretSource, type SecretSource } from "@/lib/encryption";
 
-export type DbPasswordSource = "custom" | "default";
+export type DbPasswordSource = "custom" | "default" | "generated";
 
 /** Default password baked into docker-compose.yml (`DB_PASSWORD:-pinchy_dev`). */
 const DEFAULT_DB_PASSWORD_MARKER = ":pinchy_dev@";
 
+/** Written by scripts/resolve-db-password.mjs during the entrypoint. */
+const DB_PASSWORD_FILE = ".db_password";
+
 export interface SecretsProvenance {
   encryption_key: SecretSource;
-  auth_secret: "envvar" | "unset";
+  auth_secret: SecretSource;
   audit_hmac_secret: SecretSource;
   db_password: DbPasswordSource;
 }
 
 /**
- * Better Auth reads BETTER_AUTH_SECRET from the environment directly —
- * there is no file fallback for it, so the only sources are env or unset.
+ * Better Auth reads BETTER_AUTH_SECRET from the environment. The preload
+ * (server-preload.cjs) may have filled that env var from the secrets-volume
+ * file — it marks that via PINCHY_AUTH_SECRET_SOURCE so the provenance can
+ * tell the two apart.
  */
-export function getAuthSecretSource(): "envvar" | "unset" {
+export function getAuthSecretSource(): SecretSource {
   const value = process.env.BETTER_AUTH_SECRET;
-  return value && value.trim().length > 0 ? "envvar" : "unset";
+  if (!value || value.trim().length === 0) return "unset";
+  return process.env.PINCHY_AUTH_SECRET_SOURCE === "file" ? "file" : "envvar";
 }
 
 export function getDbPasswordSource(databaseUrl: string | undefined): DbPasswordSource {
-  return (databaseUrl ?? "").includes(DEFAULT_DB_PASSWORD_MARKER) ? "default" : "custom";
+  const url = databaseUrl ?? "";
+  if (!url || url.includes(DEFAULT_DB_PASSWORD_MARKER)) return "default";
+
+  // The entrypoint's auto-migration (#156) rewrites the URL with the password
+  // persisted in the secrets volume. When the URL password matches that file,
+  // the credential is ours, not the operator's.
+  const filePath = join(process.env.ENCRYPTION_KEY_DIR || "/app/secrets", DB_PASSWORD_FILE);
+  try {
+    if (existsSync(filePath)) {
+      const persisted = readFileSync(filePath, "utf-8").trim();
+      if (persisted && new URL(url).password === persisted) return "generated";
+    }
+  } catch {
+    // Unparseable URL or unreadable file — fall through to "custom".
+  }
+  return "custom";
 }
 
 export function getSecretsProvenance(): SecretsProvenance {
@@ -43,29 +66,32 @@ export function getSecretsProvenance(): SecretsProvenance {
 }
 
 export interface DbPasswordPolicyResult {
-  action: "exit" | "warn" | "none";
+  action: "warn" | "none";
   message?: string;
 }
 
 /**
- * Issue #156: running production on the default database password must be
- * fail-closed, not a log line nobody reads. Pure so server.ts wiring stays
- * a one-liner and the decision table is unit-testable.
+ * Issue #156: the entrypoint auto-migrates installs off the default database
+ * password (scripts/resolve-db-password.mjs). If the server still sees the
+ * default URL, that migration failed or was skipped — warn loudly, but never
+ * refuse to start: a hard exit would break exactly the unattended installs
+ * the auto-migration exists to protect.
  */
 export function evaluateDbPasswordPolicy(opts: {
   nodeEnv: string | undefined;
   databaseUrl: string | undefined;
 }): DbPasswordPolicyResult {
-  if (getDbPasswordSource(opts.databaseUrl) === "custom") {
+  if (getDbPasswordSource(opts.databaseUrl) !== "default") {
     return { action: "none" };
   }
   if (opts.nodeEnv === "production") {
     return {
-      action: "exit",
+      action: "warn",
       message:
-        "FATAL: Refusing to start in production with the default database password. " +
-        "Set DB_PASSWORD in your .env (next to docker-compose.yml) and run " +
-        "`docker compose up -d` again.",
+        "WARNING: Running on the default database password — the boot-time " +
+        "password migration failed or was skipped (see [db-password] log lines " +
+        "above). Set DB_PASSWORD in your .env, or fix the secrets volume so the " +
+        "migration can run.",
     };
   }
   return {

--- a/packages/web/src/lib/secret-source.ts
+++ b/packages/web/src/lib/secret-source.ts
@@ -1,0 +1,75 @@
+// Issue #156: surface WHERE each secret comes from — never its value.
+//
+// `docker inspect` shows env vars as empty strings when only the file
+// fallback is active (auto-generated secret under /app/secrets). That made
+// an operator misread "no secret" and rotate secrets that didn't need
+// rotating, losing encrypted data. Provenance makes the file fallback
+// visible from outside the container.
+
+import { getSecretSource, type SecretSource } from "@/lib/encryption";
+
+export type DbPasswordSource = "custom" | "default";
+
+/** Default password baked into docker-compose.yml (`DB_PASSWORD:-pinchy_dev`). */
+const DEFAULT_DB_PASSWORD_MARKER = ":pinchy_dev@";
+
+export interface SecretsProvenance {
+  encryption_key: SecretSource;
+  auth_secret: "envvar" | "unset";
+  audit_hmac_secret: SecretSource;
+  db_password: DbPasswordSource;
+}
+
+/**
+ * Better Auth reads BETTER_AUTH_SECRET from the environment directly —
+ * there is no file fallback for it, so the only sources are env or unset.
+ */
+export function getAuthSecretSource(): "envvar" | "unset" {
+  const value = process.env.BETTER_AUTH_SECRET;
+  return value && value.trim().length > 0 ? "envvar" : "unset";
+}
+
+export function getDbPasswordSource(databaseUrl: string | undefined): DbPasswordSource {
+  return (databaseUrl ?? "").includes(DEFAULT_DB_PASSWORD_MARKER) ? "default" : "custom";
+}
+
+export function getSecretsProvenance(): SecretsProvenance {
+  return {
+    encryption_key: getSecretSource("encryption_key"),
+    auth_secret: getAuthSecretSource(),
+    audit_hmac_secret: getSecretSource("audit_hmac_secret"),
+    db_password: getDbPasswordSource(process.env.DATABASE_URL),
+  };
+}
+
+export interface DbPasswordPolicyResult {
+  action: "exit" | "warn" | "none";
+  message?: string;
+}
+
+/**
+ * Issue #156: running production on the default database password must be
+ * fail-closed, not a log line nobody reads. Pure so server.ts wiring stays
+ * a one-liner and the decision table is unit-testable.
+ */
+export function evaluateDbPasswordPolicy(opts: {
+  nodeEnv: string | undefined;
+  databaseUrl: string | undefined;
+}): DbPasswordPolicyResult {
+  if (getDbPasswordSource(opts.databaseUrl) === "custom") {
+    return { action: "none" };
+  }
+  if (opts.nodeEnv === "production") {
+    return {
+      action: "exit",
+      message:
+        "FATAL: Refusing to start in production with the default database password. " +
+        "Set DB_PASSWORD in your .env (next to docker-compose.yml) and run " +
+        "`docker compose up -d` again.",
+    };
+  }
+  return {
+    action: "warn",
+    message: "WARNING: Using default DB_PASSWORD. Set a secure password via .env for production.",
+  };
+}


### PR DESCRIPTION
Closes #156.

## What

Two hardening steps from the issue, sharing the same surface (startup config validation + operator-facing observability):

### 1. Fail-closed on default DB_PASSWORD in production

`server.ts` previously only logged `WARNING: Using default DB_PASSWORD` and started anyway. Now:

- **production + default password → `console.error` + `process.exit(1)`** with a message that says exactly what to do.
- **dev + default password → warning** (unchanged behavior for dev-compose smoke tests).

The decision table is a pure function (`evaluateDbPasswordPolicy` in `src/lib/secret-source.ts`) so the policy is unit-tested and the server wiring stays a one-liner.

### 2. Secret provenance in /api/health and Settings → Security

`GET /api/health` now returns:

```json
{ "status": "ok", "secrets": { "encryption_key": "envvar|file|unset", "auth_secret": "envvar|unset", "audit_hmac_secret": "envvar|file|unset", "db_password": "custom|default" } }
```

Provenance only — no values. Settings → Security shows the same as a new **Secrets** card (own component, so the existing `SettingsSecurity` fetch-sequence tests stay untouched), with an amber flag on the default DB password. `audit_hmac_secret` is included beyond the issue's list since it's the third file-backed secret with the same operator-confusion potential.

To keep provenance and actual secret resolution from drifting, `getOrCreateSecret()` was refactored to dispatch on the new `getSecretSource()` — one priority order, two consumers.

## Deployment impact (please read)

This is a **breaking change for production deployments that never set `DB_PASSWORD`** — they will refuse to start after upgrading. `docs/guides/upgrading.mdx` has a new section with the recovery recipe (ALTER USER first — `POSTGRES_PASSWORD` only applies on first init — then `.env`, then upgrade). **Check demo.heypinchy.com and pinchy.heypinchy.com before tagging the next release.**

Security trade-off note: `/api/health` is unauthenticated; the provenance object reveals config posture (e.g. `db_password: default`) but no secret material. The issue explicitly wants the shell-curl use case; the default password is public in the repo anyway, and the DB is not network-exposed. Flagging it in case you'd rather gate the field on an admin session.

Also pins the v0.5.6→v0.5.7 `upgrading.mdx` heading/placeholders to v0.5.7 — they were left unpinned by the release, and the docs build resolves `%%PINCHY_VERSION%%` with the *current* version, which would have mislabeled that section after the next release.

## Tests

TDD throughout (all watched red first):
- `secret-source.test.ts` — source resolution incl. invalid-env fallthrough, auth-secret whitespace handling, policy decision table.
- `health.test.ts` — provenance shape + an assert that no secret values appear anywhere in the response body.
- `secrets-provenance-card.test.tsx` — provenance rendering, default-password flag, calm copy for not-yet-created secrets, renders nothing on older servers/fetch failure.
- Full suite: 5720 passed. Docs build clean (incl. the #370 prune guard on the new upgrade section).