### PR TITLE
fix(chat): own in-flight placeholder kills the optimistic-message crash class (tab-refocus tapClientLookup)

### DIFF
--- a/packages/web/src/__tests__/hooks/in-flight-placeholder.test.ts
+++ b/packages/web/src/__tests__/hooks/in-flight-placeholder.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect } from "vitest";
+import {
+  isInFlightPlaceholder,
+  replaceTrailingPlaceholder,
+  stripTrailingPlaceholder,
+} from "@/hooks/in-flight-placeholder";
+
+type Msg = { id: string; role: string; content: string; error?: unknown; status?: string };
+
+const user: Msg = { id: "u1", role: "user", content: "hi", status: "sent" };
+const placeholder: Msg = { id: "ph-1", role: "assistant", content: "" };
+const errorBubble: Msg = {
+  id: "e1",
+  role: "assistant",
+  content: "",
+  error: { disconnected: true },
+};
+
+describe("isInFlightPlaceholder", () => {
+  it("matches an empty assistant message without error", () => {
+    expect(isInFlightPlaceholder(placeholder)).toBe(true);
+  });
+
+  it("rejects error bubbles, user messages, and assistants with content", () => {
+    expect(isInFlightPlaceholder(errorBubble)).toBe(false);
+    expect(isInFlightPlaceholder(user)).toBe(false);
+    expect(isInFlightPlaceholder({ id: "a", role: "assistant", content: "x" })).toBe(false);
+  });
+});
+
+describe("replaceTrailingPlaceholder", () => {
+  it("replaces a trailing placeholder with the bubble — count stays stable", () => {
+    // This is the crash-class guard: error/timeout/disconnect bubbles used to
+    // APPEND while assistant-ui's optimistic message vanished in the same
+    // transition — with the placeholder, the bubble takes its slot instead.
+    const out = replaceTrailingPlaceholder([user, placeholder], errorBubble);
+    expect(out).toEqual([user, errorBubble]);
+  });
+
+  it("appends when there is no trailing placeholder", () => {
+    const out = replaceTrailingPlaceholder([user], errorBubble);
+    expect(out).toEqual([user, errorBubble]);
+  });
+
+  it("does not touch a trailing assistant that already streamed content", () => {
+    const partial: Msg = { id: "a1", role: "assistant", content: "partial" };
+    const out = replaceTrailingPlaceholder([user, partial], errorBubble);
+    expect(out).toEqual([user, partial, errorBubble]);
+  });
+});
+
+describe("stripTrailingPlaceholder", () => {
+  it("removes a trailing placeholder (for history-comparison logic)", () => {
+    expect(stripTrailingPlaceholder([user, placeholder])).toEqual([user]);
+  });
+
+  it("returns the list unchanged when nothing trails", () => {
+    expect(stripTrailingPlaceholder([user])).toEqual([user]);
+    expect(stripTrailingPlaceholder([user, errorBubble])).toEqual([user, errorBubble]);
+  });
+});

--- a/packages/web/src/__tests__/hooks/merge-chunk.test.ts
+++ b/packages/web/src/__tests__/hooks/merge-chunk.test.ts
@@ -52,4 +52,66 @@ describe("mergeOrAppendChunk", () => {
       { id: "x", role: "assistant", content: "a" },
     ]);
   });
+
+  describe("in-flight placeholder adoption", () => {
+    it("merges the first chunk into a trailing EMPTY assistant placeholder, adopting the chunk's id", () => {
+      // The send path appends an empty in-flight assistant placeholder so the
+      // list always ends in an assistant while isRunning (kills assistant-ui's
+      // optimistic-message count flank). The client can't know the server's
+      // messageId before the first chunk — so the placeholder carries a local
+      // id and the first chunk must MERGE into it (adopting the server id),
+      // not append a second bubble.
+      const messages: Msg[] = [
+        { id: "u1", role: "user", content: "hi" },
+        { id: "local-placeholder", role: "assistant", content: "" },
+      ];
+      const incoming: Msg = { id: "srv-1", role: "assistant", content: "Hel" };
+      expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+        { id: "u1", role: "user", content: "hi" },
+        { id: "srv-1", role: "assistant", content: "Hel" },
+      ]);
+    });
+
+    it("does NOT adopt a trailing empty ERROR bubble (it has content '' too)", () => {
+      const messages: Array<Msg & { error?: unknown }> = [
+        { id: "u1", role: "user", content: "hi" },
+        { id: "err-1", role: "assistant", content: "", error: { disconnected: true } },
+      ];
+      const incoming: Msg = { id: "srv-1", role: "assistant", content: "late chunk" };
+      const out = mergeOrAppendChunk(messages, incoming);
+      expect(out).toHaveLength(3);
+      expect(out[1]).toEqual({
+        id: "err-1",
+        role: "assistant",
+        content: "",
+        error: { disconnected: true },
+      });
+      expect(out[2]).toEqual({ id: "srv-1", role: "assistant", content: "late chunk" });
+    });
+
+    it("does NOT adopt a trailing assistant that already has content (different turn)", () => {
+      const messages: Msg[] = [{ id: "old-reply", role: "assistant", content: "done earlier" }];
+      const incoming: Msg = { id: "srv-2", role: "assistant", content: "new" };
+      expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+        { id: "old-reply", role: "assistant", content: "done earlier" },
+        { id: "srv-2", role: "assistant", content: "new" },
+      ]);
+    });
+
+    it("prefers an exact id match elsewhere over adopting the trailing placeholder", () => {
+      // Resume case: the relabeled in-flight message sits before a trailing
+      // placeholder-like message — id match must win.
+      const messages: Msg[] = [
+        { id: "srv-1", role: "assistant", content: "partial" },
+        { id: "u2", role: "user", content: "follow-up" },
+        { id: "local-placeholder", role: "assistant", content: "" },
+      ];
+      const incoming: Msg = { id: "srv-1", role: "assistant", content: " more" };
+      expect(mergeOrAppendChunk(messages, incoming)).toEqual([
+        { id: "srv-1", role: "assistant", content: "partial more" },
+        { id: "u2", role: "user", content: "follow-up" },
+        { id: "local-placeholder", role: "assistant", content: "" },
+      ]);
+    });
+  });
 });

--- a/packages/web/src/__tests__/hooks/orphan-detector.test.ts
+++ b/packages/web/src/__tests__/hooks/orphan-detector.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { isOrphaned } from "@/hooks/orphan-detector";
+
+const ctx = { isRunning: false, isHistoryLoaded: true };
+
+describe("isOrphaned", () => {
+  it("detects a sent user message with no reply while idle", () => {
+    expect(isOrphaned([{ id: "u1", role: "user", content: "hi", status: "sent" }], ctx)).toBe(true);
+  });
+
+  it("is false while running, before history load, or with a real reply", () => {
+    const sentUser = { id: "u1", role: "user" as const, content: "hi", status: "sent" as const };
+    expect(isOrphaned([sentUser], { ...ctx, isRunning: true })).toBe(false);
+    expect(isOrphaned([sentUser], { ...ctx, isHistoryLoaded: false })).toBe(false);
+    expect(isOrphaned([sentUser, { id: "a1", role: "assistant", content: "reply" }], ctx)).toBe(
+      false
+    );
+  });
+
+  it("sees through a trailing in-flight placeholder (the send-path appends one)", () => {
+    // Without placeholder-transparency the detector reads the placeholder as
+    // "the agent replied" and the orphan-retry bubble never appears again.
+    expect(
+      isOrphaned(
+        [
+          { id: "u1", role: "user", content: "hi", status: "sent" },
+          { id: "ph", role: "assistant", content: "" },
+        ],
+        ctx
+      )
+    ).toBe(true);
+  });
+
+  it("does NOT see through a trailing empty ERROR bubble (that turn already failed visibly)", () => {
+    expect(
+      isOrphaned(
+        [
+          { id: "u1", role: "user", content: "hi", status: "sent" },
+          { id: "e1", role: "assistant", content: "", error: { disconnected: true } },
+        ],
+        ctx
+      )
+    ).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
+++ b/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
@@ -23,6 +23,39 @@ function assistant(content: string, opts: { error?: boolean } = {}): WsMessage {
 }
 
 describe("shouldReplaceLocalWithServerHistory", () => {
+  describe("in-flight placeholder transparency", () => {
+    // The send path appends an empty assistant placeholder (the tab-refocus
+    // crash fix). It is a client-only artifact the server never knows about —
+    // the gate must behave EXACTLY as if it weren't there, otherwise the
+    // trailing-assistant rule would fire `true` and bypass the #310
+    // strictly-longer guard.
+    it("ignores a trailing placeholder: acked user + history NOT longer → false", () => {
+      expect(
+        shouldReplaceLocalWithServerHistory([user("hi", "sent"), assistant("")], [user("hi")], true)
+      ).toBe(false);
+    });
+
+    it("ignores a trailing placeholder: acked user + history strictly longer → true (#310)", () => {
+      expect(
+        shouldReplaceLocalWithServerHistory(
+          [user("hi", "sent"), assistant("")],
+          [user("hi"), assistant("the completed reply")],
+          true
+        )
+      ).toBe(true);
+    });
+
+    it("still honors a REAL partial assistant (non-empty) as mid-stream → true", () => {
+      expect(
+        shouldReplaceLocalWithServerHistory(
+          [user("hi", "sent"), assistant("partial text")],
+          [user("hi")],
+          true
+        )
+      ).toBe(true);
+    });
+  });
+
   it("returns false when recovery flag is not set (initial load)", () => {
     expect(
       shouldReplaceLocalWithServerHistory(

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-placeholder.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-placeholder.test.tsx
@@ -1,0 +1,178 @@
+/**
+ * Regression guard for the tab-refocus tapClientLookup crash (v0.5.7 prod).
+ *
+ * assistant-ui injects an OPTIMISTIC assistant message while
+ * `isRunning && last.role !== "assistant"` and removes it on any
+ * `isRunning → false` flip — that removal shrinks the rendered count and a
+ * stale trailing-index subscriber crashes the view (`tapClientLookup: Index N
+ * out of bounds (length: N)`). Two unguarded flips existed: the
+ * lifecycle-suspend branch and the #199 grace branch of ws.onclose.
+ *
+ * The fix kills the class at the source: the send path appends Pinchy's OWN
+ * empty in-flight assistant placeholder, so the list always ends in an
+ * assistant while running and the optimistic message never exists. These
+ * tests pin the proximate invariant (jsdom cannot reproduce the tap-scheduler
+ * race itself — see the #470 lesson).
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: { error: vi.fn(), success: vi.fn() } }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+vi.mock("@assistant-ui/react", () => ({
+  useExternalStoreRuntime: (config: unknown) => config,
+  SimpleImageAttachmentAdapter: class {
+    accept = "image/*";
+  },
+  SimpleTextAttachmentAdapter: class {
+    accept = "text/plain";
+  },
+  CompositeAttachmentAdapter: class {
+    accept = "";
+    constructor() {}
+  },
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+  simulateClose(code = 1006) {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent("close", { code }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+type Converted = {
+  id: string;
+  role: string;
+  content?: unknown;
+  metadata?: { custom?: { error?: unknown } };
+};
+
+function errorOf(msg: Converted | undefined): unknown {
+  return msg?.metadata?.custom?.error;
+}
+function messagesOf(runtime: unknown): Converted[] {
+  return ((runtime as { messages?: Converted[] }).messages ?? []) as Converted[];
+}
+
+function sendText(result: { current: { runtime: unknown } }, text: string) {
+  (
+    result.current.runtime as {
+      onNew: (m: { content: { type: string; text: string }[]; parentId: string }) => void;
+    }
+  ).onNew({ content: [{ type: "text", text }], parentId: "root" });
+}
+
+describe("useWsRuntime — in-flight placeholder invariant", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+  });
+  afterEach(() => vi.useRealTimers());
+
+  function setup() {
+    const hook = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+    return { hook, ws };
+  }
+
+  it("sending a message appends the in-flight assistant placeholder (list ends in assistant while running)", () => {
+    const { hook } = setup();
+    act(() => sendText(hook.result, "hello"));
+
+    expect(hook.result.current.isRunning).toBe(true);
+    const msgs = messagesOf(hook.result.current.runtime);
+    const last = msgs[msgs.length - 1];
+    expect(last?.role).toBe("assistant");
+  });
+
+  it("the first chunk merges into the placeholder instead of appending a second bubble", () => {
+    const { hook, ws } = setup();
+    act(() => sendText(hook.result, "hello"));
+    const countAfterSend = messagesOf(hook.result.current.runtime).length;
+
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: "Hi" }));
+
+    const msgs = messagesOf(hook.result.current.runtime);
+    expect(msgs.length).toBe(countAfterSend); // adopted, not appended
+    expect(msgs[msgs.length - 1]?.id).toBe("srv-1");
+  });
+
+  it("CRASH GUARD: ws close before the first chunk keeps the list ending in assistant (count-neutral isRunning flip)", () => {
+    // The production sequence: send → tab backgrounded → browser closes the WS
+    // → onclose flips isRunning false. Pre-fix, assistant-ui's optimistic
+    // message vanished here (rendered count -1 → tapClientLookup). With the
+    // placeholder, the flip is count-neutral: the list still ends in assistant.
+    const { hook, ws } = setup();
+    act(() => sendText(hook.result, "hello"));
+    const countBefore = messagesOf(hook.result.current.runtime).length;
+
+    act(() => ws.simulateClose());
+
+    expect(hook.result.current.isRunning).toBe(false);
+    const msgs = messagesOf(hook.result.current.runtime);
+    expect(msgs.length).toBe(countBefore); // nothing vanished in the flip
+    expect(msgs[msgs.length - 1]?.role).toBe("assistant");
+  });
+
+  it("the deferred disconnect bubble REPLACES the placeholder instead of appending next to it", () => {
+    const { hook, ws } = setup();
+    act(() => sendText(hook.result, "hello"));
+    const countAfterSend = messagesOf(hook.result.current.runtime).length;
+
+    act(() => ws.simulateClose());
+    act(() => {
+      vi.advanceTimersByTime(2100); // DISCONNECT_ERROR_GRACE_MS
+    });
+
+    const msgs = messagesOf(hook.result.current.runtime);
+    expect(msgs.length).toBe(countAfterSend); // bubble took the placeholder's slot
+    const last = msgs[msgs.length - 1];
+    expect(last?.role).toBe("assistant");
+    expect(errorOf(last)).toBeTruthy();
+  });
+
+  it("the stuck-timeout bubble REPLACES the placeholder instead of appending next to it", () => {
+    const { hook } = setup();
+    act(() => sendText(hook.result, "hello"));
+    const countAfterSend = messagesOf(hook.result.current.runtime).length;
+
+    act(() => {
+      vi.advanceTimersByTime(61_000); // STUCK_TIMEOUT_MS
+    });
+
+    const msgs = messagesOf(hook.result.current.runtime);
+    expect(msgs.length).toBe(countAfterSend);
+    expect(errorOf(msgs[msgs.length - 1])).toBeTruthy();
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -1596,11 +1596,14 @@ describe("useWsRuntime", () => {
       );
       expect(messageSends).toHaveLength(0);
 
-      // User message should still appear optimistically in messages
+      // User message should still appear optimistically in messages, followed
+      // by the in-flight assistant placeholder the send path appends (the
+      // tab-refocus crash fix — list always ends in assistant while running).
       const messages = result.current.runtime.messages;
-      expect(messages).toHaveLength(1);
+      expect(messages).toHaveLength(2);
       expect(messages[0].role).toBe("user");
       expect(messages[0].content[0].text).toBe("Hello while connecting");
+      expect(messages[1].role).toBe("assistant");
 
       // Now the connection opens
       ws.readyState = 1;
@@ -4310,13 +4313,15 @@ describe("useWsRuntime", () => {
         });
       });
 
-      // At this point the chunk MUST NOT have been applied — there's no
-      // assistant message with content "25 days vacation." yet.
+      // At this point the chunk MUST NOT have been applied — no assistant
+      // message carries "25 days vacation." yet. (The empty in-flight
+      // placeholder from the send path is allowed to exist; only the chunk
+      // CONTENT must still be absent.)
       const midwayMessages = result.current.runtime.messages;
-      const assistantBefore = (midwayMessages as Array<{ role: string; content: unknown }>).find(
-        (m) => m.role === "assistant"
+      const appliedBefore = (midwayMessages as Array<{ role: string; content: unknown }>).find(
+        (m) => m.role === "assistant" && JSON.stringify(m.content).includes("25 days vacation.")
       );
-      expect(assistantBefore).toBeUndefined();
+      expect(appliedBefore).toBeUndefined();
 
       // Now the history frame arrives with an activeRun signal pinning
       // the in-flight assistant turn to the same messageId the chunk

--- a/packages/web/src/hooks/in-flight-placeholder.ts
+++ b/packages/web/src/hooks/in-flight-placeholder.ts
@@ -1,0 +1,57 @@
+/**
+ * In-flight assistant placeholder helpers (the tab-refocus crash fix).
+ *
+ * assistant-ui injects an OPTIMISTIC assistant message while
+ * `isRunning && last.role !== "assistant"` — and removes it again on any
+ * `isRunning → false` transition. That removal shrinks the rendered count by
+ * one; a trailing-index subscriber reading its stale snapshot then crashes
+ * the view with `tapClientLookup: Index N out of bounds (length: N)`
+ * (production incident on v0.5.7: backgrounded tab → ws close flips
+ * isRunning without message compensation → boundary visible on refocus).
+ *
+ * Instead of guarding every isRunning flip, Pinchy appends its OWN empty
+ * in-flight assistant placeholder at send time — the list then always ends
+ * in an assistant while running, the optimistic message never exists, and
+ * every isRunning transition is count-neutral. These helpers keep the
+ * placeholder's lifecycle consistent:
+ *
+ * - the first chunk ADOPTS it (see mergeOrAppendChunk),
+ * - terminal bubbles (timeout/disconnect/error) REPLACE it instead of
+ *   appending next to it,
+ * - history-length comparisons IGNORE it (it never exists server-side).
+ */
+
+interface PlaceholderShape {
+  role: string;
+  content: string;
+  error?: unknown;
+}
+
+export function isInFlightPlaceholder(msg: PlaceholderShape | undefined): boolean {
+  return !!msg && msg.role === "assistant" && msg.content === "" && !msg.error;
+}
+
+/**
+ * Replace a trailing placeholder with `bubble` (count-neutral), or append the
+ * bubble when nothing adoptable trails.
+ */
+export function replaceTrailingPlaceholder<T extends PlaceholderShape>(
+  messages: T[],
+  bubble: T
+): T[] {
+  if (isInFlightPlaceholder(messages[messages.length - 1])) {
+    return [...messages.slice(0, -1), bubble];
+  }
+  return [...messages, bubble];
+}
+
+/**
+ * Drop a trailing placeholder for comparisons against server history — the
+ * placeholder is a client-only artifact the server never knows about.
+ */
+export function stripTrailingPlaceholder<T extends PlaceholderShape>(messages: T[]): T[] {
+  if (isInFlightPlaceholder(messages[messages.length - 1])) {
+    return messages.slice(0, -1);
+  }
+  return messages;
+}

--- a/packages/web/src/hooks/merge-chunk.ts
+++ b/packages/web/src/hooks/merge-chunk.ts
@@ -14,10 +14,9 @@
  * `incoming.content` is the delta: it is concatenated onto an existing message,
  * or used as the initial content of an appended one.
  */
-export function mergeOrAppendChunk<T extends { id: string; role: string; content: string }>(
-  messages: T[],
-  incoming: T
-): T[] {
+export function mergeOrAppendChunk<
+  T extends { id: string; role: string; content: string; error?: unknown },
+>(messages: T[], incoming: T): T[] {
   // Fast path: the common case streams into the trailing assistant message.
   const last = messages[messages.length - 1];
   if (last && last.role === "assistant" && last.id === incoming.id) {
@@ -34,6 +33,18 @@ export function mergeOrAppendChunk<T extends { id: string; role: string; content
       content: updated[existingIdx].content + incoming.content,
     };
     return updated;
+  }
+
+  // Placeholder adoption: the send path appends an empty in-flight assistant
+  // placeholder (local id) so the list always ends in an assistant while a run
+  // is in flight. The first chunk carries the server's messageId, which the
+  // client could not know at send time — adopt the placeholder (id + content)
+  // instead of appending a second bubble. Empty ERROR bubbles also have
+  // content "", so the no-error guard keeps them untouched.
+  if (last && last.role === "assistant" && last.content === "" && !last.error) {
+    // Spread `incoming` over the placeholder so fresh fields (id, content,
+    // timestamp) win while any placeholder-only metadata survives.
+    return [...messages.slice(0, -1), { ...last, ...incoming }];
   }
 
   return [...messages, incoming];

--- a/packages/web/src/hooks/orphan-detector.ts
+++ b/packages/web/src/hooks/orphan-detector.ts
@@ -1,10 +1,14 @@
+import { stripTrailingPlaceholder } from "./in-flight-placeholder";
+
 type MessageRole = "user" | "assistant";
 type MessageStatus = "sent" | "sending" | "failed" | undefined;
 
 interface Message {
   id: string;
   role: MessageRole;
+  content: string;
   status?: MessageStatus;
+  error?: unknown;
 }
 
 interface OrphanContext {
@@ -16,6 +20,11 @@ interface OrphanContext {
  * Returns true when the last user message was sent but the agent has no
  * response and is not currently running — indicating an orphaned message
  * that needs a retry (Case B retry bubble).
+ *
+ * The in-flight placeholder the send path appends is a client-only artifact,
+ * not an agent reply — the detector looks through it. A trailing empty ERROR
+ * bubble is different: that turn already failed visibly and carries its own
+ * retry affordance.
  */
 export function isOrphaned(
   messages: Message[],
@@ -25,6 +34,7 @@ export function isOrphaned(
   if (isRunning) return false;
   if (!isHistoryLoaded) return false;
 
-  const last = messages[messages.length - 1];
-  return last.role === "user" && last.status === "sent";
+  const effective = stripTrailingPlaceholder(messages);
+  const last = effective[effective.length - 1];
+  return !!last && last.role === "user" && last.status === "sent";
 }

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -5,6 +5,10 @@ import { toast } from "sonner";
 import { useRestart } from "@/components/restart-provider";
 import { uuid } from "@/lib/uuid";
 import { dedupeById } from "@/lib/dedupe-by-id";
+import {
+  replaceTrailingPlaceholder,
+  stripTrailingPlaceholder,
+} from "@/hooks/in-flight-placeholder";
 import { mergeOrAppendChunk } from "@/hooks/merge-chunk";
 import { ensureTrailingAssistant } from "@/hooks/ensure-trailing-assistant";
 import { uploadAttachment } from "@/lib/upload-attachment";
@@ -365,13 +369,20 @@ export function shouldReplaceLocalWithServerHistory(
   if (!shouldRecoverFromHistory) return false;
   if (historyMessages.length === 0) return false;
 
-  const lastNonError = [...prevMessages].reverse().find((m) => !m.error);
+  // The in-flight placeholder is a client-only artifact (appended at send time
+  // so the list always ends in an assistant while running — the tab-refocus
+  // crash fix). The server never knows it; the gate must behave exactly as if
+  // it weren't there, or the trailing-assistant rule below would bypass the
+  // #310 strictly-longer guard.
+  const prev = stripTrailingPlaceholder(prevMessages);
+
+  const lastNonError = [...prev].reverse().find((m) => !m.error);
   if (!lastNonError) return true;
 
   if (lastNonError.role === "assistant") return true;
 
   // lastNonError.role === "user"
-  return lastNonError.status === "sent" && historyMessages.length > prevMessages.length;
+  return lastNonError.status === "sent" && historyMessages.length > prev.length;
 }
 
 export function useWsRuntime(agentId: string): {
@@ -699,17 +710,16 @@ export function useWsRuntime(agentId: string): {
         setIsRunning(false);
         setIsDelayed(false);
         setMessages((prev) =>
-          capMessages([
-            ...prev,
-            {
+          capMessages(
+            replaceTrailingPlaceholder(prev, {
               id: uuid(),
               role: "assistant",
               content: "",
               error: { timedOut: true },
               retryable: true,
               retryReason: "partial_stream_failure" as const,
-            },
-          ])
+            })
+          )
         );
       }, STUCK_TIMEOUT_MS);
     }
@@ -794,9 +804,8 @@ export function useWsRuntime(agentId: string): {
           setKnownEmptyHistory(false);
           setPayloadRejected(true);
           setMessages((prev) =>
-            capMessages([
-              ...prev,
-              {
+            capMessages(
+              replaceTrailingPlaceholder(prev, {
                 id: uuid(),
                 role: "assistant",
                 content: "",
@@ -804,8 +813,8 @@ export function useWsRuntime(agentId: string): {
                   payloadTooLarge: true,
                   message: "Message too large to send. Try a shorter message or fewer attachments.",
                 },
-              },
-            ])
+              })
+            )
           );
           return;
         }
@@ -829,17 +838,16 @@ export function useWsRuntime(agentId: string): {
             pendingDisconnectErrorRef.current = null;
             if (!mountedRef.current) return;
             setMessages((prev) =>
-              capMessages([
-                ...prev,
-                {
+              capMessages(
+                replaceTrailingPlaceholder(prev, {
                   id: uuid(),
                   role: "assistant",
                   content: "",
                   error: { disconnected: true },
                   retryable: true,
                   retryReason,
-                },
-              ])
+                })
+              )
             );
           }, DISCONNECT_ERROR_GRACE_MS);
           pendingDisconnectErrorRef.current = { timer, retryReason };
@@ -1259,21 +1267,25 @@ export function useWsRuntime(agentId: string): {
               : { message: data.message || "An unknown error occurred." };
 
           setMessages((prev) =>
-            capMessages([
+            capMessages(
               // Remove any existing error bubble — only one error is ever shown
-              // at a time to avoid stacking after repeated retries.
-              ...prev.filter((m) => !m.error),
-              {
-                id: uuid(),
-                role: "assistant",
-                content: "",
-                error,
-                retryable: true,
-                retryReason: hasReceivedChunkRef.current
-                  ? ("partial_stream_failure" as const)
-                  : ("send_failure" as const),
-              },
-            ])
+              // at a time to avoid stacking after repeated retries. The new
+              // bubble takes a trailing in-flight placeholder's slot so the
+              // isRunning flip below stays count-neutral.
+              replaceTrailingPlaceholder(
+                prev.filter((m) => !m.error),
+                {
+                  id: uuid(),
+                  role: "assistant",
+                  content: "",
+                  error,
+                  retryable: true,
+                  retryReason: hasReceivedChunkRef.current
+                    ? ("partial_stream_failure" as const)
+                    : ("send_failure" as const),
+                }
+              )
+            )
           );
           isRunningRef.current = false;
           setIsRunning(false);
@@ -1432,6 +1444,20 @@ export function useWsRuntime(agentId: string): {
                 mimeType: u.file.type,
               })),
             }),
+          },
+          // In-flight assistant placeholder: keeps the list ending in an
+          // assistant for the whole run, so assistant-ui never injects its
+          // optimistic message — whose removal on ANY isRunning→false flip
+          // shrank the rendered count and crashed the view with
+          // tapClientLookup (v0.5.7 tab-refocus production incident). The
+          // first chunk adopts this message (id + content) via
+          // mergeOrAppendChunk; terminal bubbles replace it via
+          // replaceTrailingPlaceholder.
+          {
+            id: uuid(),
+            role: "assistant",
+            content: "",
+            timestamp: new Date().toISOString(),
           },
         ])
       );


### PR DESCRIPTION
## Production incident (v0.5.7)
`tapClientLookup: Index 66 out of bounds (length: 66)` on pinchy.heypinchy.com when a backgrounded tab regained focus after its run completed server-side (audit: `chat.run_completed_after_disconnect` immediately before).

## Root cause — the third flank of the #470 class
assistant-ui injects an **optimistic** assistant message while `isRunning && last.role !== "assistant"` — and removes it again on **any** `isRunning → false` flip. The removal shrinks the rendered count by one; a trailing-index subscriber reading its stale snapshot crashes the view. Two flips had no same-render compensation:
- the **lifecycle-suspend** branch of `ws.onclose` (tab backgrounded), and
- the **#199 grace** branch — ironically its bubble-deferral (built to keep the list length stable) is exactly what leaves the optimistic removal uncompensated. (The stuck timer was already safe: flip + bubble in one batch.)

## Fix: kill the class at the source
The send path appends Pinchy's **own empty in-flight assistant placeholder** — the list then always ends in an assistant while running, the optimistic message never exists, and every `isRunning` flip is count-neutral. Lifecycle:
- **Adoption:** the first chunk merges into the trailing placeholder, adopting the server `messageId` (unknowable at send time); empty *error* bubbles are explicitly not adopted.
- **Replacement:** terminal bubbles (stuck timeout, deferred disconnect, 1009, error frames) take the placeholder's slot instead of appending next to it.
- **Transparency:** `shouldReplaceLocalWithServerHistory` (#310 strictly-longer gate) and the orphan detector strip the trailing placeholder before their rules — it is a client-only artifact the server never knows.

## Tests (all TDD red→green)
Pure functions: placeholder adoption/replacement/strip (incl. error-bubble negatives), gate transparency, orphan transparency. Hook invariants: send appends placeholder; first chunk adopts; **crash guard** (ws close pre-first-chunk keeps the list ending in assistant, count-neutral); disconnect + stuck bubbles replace instead of append. jsdom cannot reproduce the tap race itself (#470 lesson) — the proximate invariant is pinned and the reload-mid-stream integration E2E remains the browser-level boundary guard.

Full web suite **5724 passed**, typecheck clean.

Suggest shipping as **v0.5.8** together with #467.