### PR TITLE
fix(models): reconcile Ollama Cloud catalog with the live model list

### DIFF
--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -47,14 +47,75 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("qwen3.5:397b")).toBe(false);
   });
 
-  it("drops qwen3-next:80b — no working tool calls on Ollama Cloud", () => {
+  it("drops qwen3-next:80b — tool calls still flaky on Ollama Cloud", () => {
     // The model is still returned by /v1/models, but on the OpenAI-completions
-    // endpoint OpenClaw uses it never emits a structured tool_call: it returns
-    // empty content or leaks a malformed `<tools> {…} </tools>` text blob with
-    // a mangled tool name, even with tool_choice:"required". Every Pinchy agent
-    // uses tools (files/context/docs), so a tool-broken model must not be
+    // endpoint OpenClaw uses it originally never emitted a structured
+    // tool_call (empty content or a malformed `<tools> {…} </tools>` text
+    // blob, even with tool_choice:"required"). A 2026-06-12 re-probe after it
+    // reappeared in the live list showed the defect is now intermittent
+    // instead of permanent: 3/4 rounds emitted clean tool_calls, but one
+    // round returned empty content with no call — the original failure mode.
+    // Every Pinchy agent uses tools (files/context/docs), so a model that
+    // silently skips a requested tool call once in four requests must not be
     // surfaced as tool-capable.
     expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain("qwen3-next:80b");
+  });
+
+  it("includes nemotron-3-ultra with reasoning, text-only", () => {
+    // Library tags: "thinking tools cloud", input text-only, 256K context.
+    // Tools confirmed empirically 2026-06-11 against /v1/chat/completions:
+    // structured tool_calls in 4/4 single-turn rounds plus a clean multi-turn
+    // follow-up call after a tool result.
+    const m = byId("nemotron-3-ultra");
+    expect(m).toBeDefined();
+    expect(m!.reasoning).toBe(true);
+    expect(m!.vision).toBe(false);
+    expect(m!.contextWindow).toBe(262144);
+  });
+
+  it("includes kimi-k2:1t as tool-capable, non-reasoning, text-only", () => {
+    // Library tags: "tools cloud" (no thinking tag — the thinking variant is
+    // the separate kimi-k2-thinking, which stays out, see below), input
+    // text-only, 256K context. Tools confirmed empirically 2026-06-12:
+    // structured tool_calls in 4/4 single-turn rounds plus a clean multi-turn
+    // follow-up call after a tool result.
+    const m = byId("kimi-k2:1t");
+    expect(m).toBeDefined();
+    expect(m!.reasoning).toBe(false);
+    expect(m!.vision).toBe(false);
+    expect(m!.contextWindow).toBe(262144);
+  });
+
+  it("keeps cogito-2.1:671b out — leaks raw tool-call template text", () => {
+    // Probed 2026-06-11: in 1 of 4 rounds the model emitted a raw
+    // DeepSeek-style tool-call template (`<|tool▁calls▁begin|>…`) as plain
+    // assistant text instead of a structured tool_call. An agent on this
+    // model would intermittently print template gibberish into the chat
+    // instead of acting.
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain("cogito-2.1:671b");
+  });
+
+  it("keeps kimi-k2-thinking out — serving is broken (#305)", () => {
+    // Removed in #305 for HTTP 500s. Re-probed 2026-06-11: now every request
+    // fails HTTP 400 "prompt too long; exceeded max context length by 691
+    // tokens" — even for a ~1k-token prompt. The serving-side context
+    // accounting is broken, so the model is unusable regardless of tags.
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain("kimi-k2-thinking");
+  });
+
+  it("keeps the gemma3 family out — no usable tool path on Ollama Cloud", () => {
+    // Probed 2026-06-12. gemma3:4b leaks pseudo tool calls as a ```python
+    // text block in 4/4 rounds (no structured tool_calls). gemma3:12b
+    // returns HTTP 500 for every tools request, persisting across retries.
+    // gemma3:27b mostly emits clean single-turn tool_calls (4/4, then 3/4
+    // with one text leak on the confirmation re-run) but returns HTTP 500 as
+    // soon as the conversation history contains a tool result — reproduced
+    // across two independent runs, the same multi-turn failure mode that got
+    // kimi-k2-thinking removed in #305. Every Pinchy agent runs multi-turn
+    // tool loops, so all three stay out despite the library page's vision tag.
+    for (const id of ["gemma3:4b", "gemma3:12b", "gemma3:27b"]) {
+      expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain(id);
+    }
   });
 
   it("every model declares vision and carries no dead capability fields", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1741,6 +1741,7 @@ describe("regenerateOpenClawConfig", () => {
         "gpt-oss:20b",
         "kimi-k2.5",
         "kimi-k2.6",
+        "kimi-k2:1t",
         "minimax-m2",
         "minimax-m2.1",
         "minimax-m2.5",
@@ -1752,6 +1753,7 @@ describe("regenerateOpenClawConfig", () => {
         "mistral-large-3:675b",
         "nemotron-3-nano:30b",
         "nemotron-3-super",
+        "nemotron-3-ultra",
         "qwen3-coder-next",
         "qwen3-coder:480b",
         "qwen3-vl:235b",
@@ -1805,11 +1807,13 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["gemma4:31b"]).toBe(262144);
     expect(ctx["kimi-k2.5"]).toBe(262144);
     expect(ctx["kimi-k2.6"]).toBe(262144);
+    expect(ctx["kimi-k2:1t"]).toBe(262144);
     expect(ctx["ministral-3:3b"]).toBe(262144);
     expect(ctx["ministral-3:8b"]).toBe(262144);
     expect(ctx["ministral-3:14b"]).toBe(262144);
     expect(ctx["mistral-large-3:675b"]).toBe(262144);
     expect(ctx["nemotron-3-super"]).toBe(262144);
+    expect(ctx["nemotron-3-ultra"]).toBe(262144);
     expect(ctx["qwen3-coder-next"]).toBe(262144);
     expect(ctx["qwen3-coder:480b"]).toBe(262144);
     expect(ctx["qwen3-vl:235b"]).toBe(262144);
@@ -1880,6 +1884,10 @@ describe("regenerateOpenClawConfig", () => {
     expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
     expect(byId["devstral-small-2:24b"].input).toEqual(["text"]);
     expect(byId["qwen3.5:397b"].input).toEqual(["text"]);
+    // 2026-06 additions: both are text-only lines (no image input tag, and
+    // vision is never assumed without an empirical probe).
+    expect(byId["nemotron-3-ultra"].input).toEqual(["text"]);
+    expect(byId["kimi-k2:1t"].input).toEqual(["text"]);
 
     // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
     const reasoningModels = [
@@ -1903,6 +1911,7 @@ describe("regenerateOpenClawConfig", () => {
       "minimax-m3",
       "nemotron-3-nano:30b",
       "nemotron-3-super",
+      "nemotron-3-ultra",
       "qwen3-vl:235b",
       "qwen3-vl:235b-instruct",
       "qwen3.5:397b",
@@ -1912,10 +1921,13 @@ describe("regenerateOpenClawConfig", () => {
     }
     // Non-reasoning — qwen3-coder-next explicitly "Non-thinking mode only",
     // ministral-3 / mistral-large-3 / devstral-* and rnj-1 not tagged,
-    // minimax-m2.1 absent from Ollama's thinking tag list.
+    // minimax-m2.1 absent from Ollama's thinking tag list, kimi-k2:1t is the
+    // non-thinking kimi-k2 line (the thinking variant is the separate — and
+    // broken — kimi-k2-thinking).
     const nonReasoningModels = [
       "devstral-2:123b",
       "devstral-small-2:24b",
+      "kimi-k2:1t",
       "minimax-m2.1",
       "ministral-3:3b",
       "ministral-3:8b",

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -296,6 +296,7 @@ describe("fetchProviderModels", () => {
             { id: "kimi-k2-thinking" },
             { id: "kimi-k2.5" },
             { id: "kimi-k2.6" },
+            { id: "kimi-k2:1t" },
             { id: "minimax-m2" },
             { id: "minimax-m2.1" },
             { id: "minimax-m2.5" },
@@ -307,6 +308,7 @@ describe("fetchProviderModels", () => {
             { id: "mistral-large-3:675b" },
             { id: "nemotron-3-nano:30b" },
             { id: "nemotron-3-super" },
+            { id: "nemotron-3-ultra" },
             { id: "qwen3-coder-next" },
             { id: "qwen3-coder:480b" },
             { id: "qwen3-next:80b" },
@@ -314,12 +316,11 @@ describe("fetchProviderModels", () => {
             { id: "qwen3-vl:235b-instruct" },
             { id: "qwen3.5:397b" },
             { id: "rnj-1:8b" },
-            // Not tool-capable per ollama.com library pages — must be filtered out
+            // Tool-broken on the live chat/completions endpoint — must be filtered out
             { id: "cogito-2.1:671b" },
             { id: "gemma3:27b" },
             { id: "gemma3:12b" },
             { id: "gemma3:4b" },
-            { id: "kimi-k2:1t" },
           ],
         }),
         { status: 200 }
@@ -350,6 +351,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
+        "ollama-cloud/kimi-k2:1t",
         "ollama-cloud/minimax-m2",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
@@ -361,6 +363,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/mistral-large-3:675b",
         "ollama-cloud/nemotron-3-nano:30b",
         "ollama-cloud/nemotron-3-super",
+        "ollama-cloud/nemotron-3-ultra",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
         "ollama-cloud/qwen3-vl:235b",
@@ -372,14 +375,16 @@ describe("fetchProviderModels", () => {
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
     // qwen3-next:80b is still returned by /v1/models but no longer allow-listed:
-    // it emits no working tool calls on the OpenAI-completions endpoint.
+    // tool calls are still flaky on the OpenAI-completions endpoint (re-probed
+    // 2026-06-12: one of four rounds returned empty content with no call).
     expect(ids).not.toContain("ollama-cloud/qwen3-next:80b");
     // minimax-m3 was added to the allowlist (vision + tools confirmed live).
     expect(ids).toContain("ollama-cloud/minimax-m3");
-    expect(ids).toHaveLength(33);
+    expect(ids).toHaveLength(35);
 
-    // Non-tool-capable models are filtered out
-    expect(ids).not.toContain("ollama-cloud/kimi-k2:1t");
+    // Tool-broken models are filtered out (probed 2026-06-12: gemma3:4b leaks
+    // pseudo tool calls as text, gemma3:12b serves HTTP 500, gemma3:27b
+    // serves HTTP 500 on multi-turn tool loops, cogito leaks template text)
     expect(ids).not.toContain("ollama-cloud/gemma3:27b");
     expect(ids).not.toContain("ollama-cloud/gemma3:12b");
     expect(ids).not.toContain("ollama-cloud/gemma3:4b");
@@ -424,7 +429,7 @@ describe("fetchProviderModels", () => {
     const ids = ollama!.models.map((m) => m.id);
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
-    expect(ids).toHaveLength(33);
+    expect(ids).toHaveLength(35);
     expect(ids).toEqual(
       expect.arrayContaining([
         "ollama-cloud/deepseek-v3.1:671b",
@@ -443,6 +448,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
+        "ollama-cloud/kimi-k2:1t",
         "ollama-cloud/minimax-m2",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
@@ -454,6 +460,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/mistral-large-3:675b",
         "ollama-cloud/nemotron-3-nano:30b",
         "ollama-cloud/nemotron-3-super",
+        "ollama-cloud/nemotron-3-ultra",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
         "ollama-cloud/qwen3-vl:235b",

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -164,6 +164,21 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: true,
   },
   {
+    // Non-thinking kimi-k2 line (the thinking variant, kimi-k2-thinking, is
+    // NOT in this catalog: removed in #305 for HTTP 500s, and a 2026-06-11
+    // re-probe showed every request now fails HTTP 400 "prompt too long" even
+    // for ~1k-token prompts — its serving-side context accounting is broken).
+    // kimi-k2:1t itself probed clean against the live API on 2026-06-12:
+    // structured tool_calls in 4/4 single-turn rounds plus a clean multi-turn
+    // follow-up. Text-only input; library page: 256K context, "tools" tag
+    // without "thinking".
+    id: "kimi-k2:1t",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: false,
+    vision: false,
+  },
+  {
     id: "minimax-m2",
     contextWindow: 204800,
     maxTokens: 8192,
@@ -242,6 +257,16 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   },
   {
     id: "nemotron-3-super",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
+    // Probed clean against the live API on 2026-06-11: structured tool_calls
+    // in 4/4 single-turn rounds plus a clean multi-turn follow-up. Text-only
+    // input; library page: 256K context, "thinking" + "tools" tags.
+    id: "nemotron-3-ultra",
     contextWindow: 262144,
     maxTokens: 8192,
     reasoning: true,


### PR DESCRIPTION
## Summary

The curated Ollama Cloud catalog (`packages/web/src/lib/ollama-cloud-models.ts`) had drifted from the live `https://ollama.com/v1/models` listing: eight models were live but absent from the catalog. Following the established process, every candidate was probed empirically against the live `/v1/chat/completions` endpoint (tool-calling sweeps with production-shaped schemas, single-turn + multi-turn follow-up after a tool result; vision is never assumed without a probe) rather than trusting library-page tags.

### Added (probes clean: 4/4 structured tool_calls + clean multi-turn)

| Model | Flags | Context |
|---|---|---|
| `nemotron-3-ultra` | reasoning, text-only | 256K |
| `kimi-k2:1t` | non-reasoning, text-only | 256K |

### Kept out (each pinned by a regression test)

- **`qwen3-next:80b`** — re-probed after reappearing in the live list. The broken-tool-call defect is now intermittent instead of permanent: 3/4 rounds emit clean tool_calls, but 1/4 returns empty content with no call (the original failure mode). Still unusable for tool-dependent agents.
- **`gemma3:4b`** — leaks pseudo tool calls as a ```` ```python ```` text block in 4/4 rounds; no structured tool_calls.
- **`gemma3:12b`** — HTTP 500 on every tools request, persistent across retries.
- **`gemma3:27b`** — clean single-turn tool calls, but HTTP 500 as soon as the conversation history contains a tool result. Reproduced across two independent runs. Same multi-turn failure mode that removed `kimi-k2-thinking` in #305.
- **`cogito-2.1:671b`** — leaks a raw DeepSeek-style tool-call template (`<|tool▁calls▁begin|>…`) as plain text in 1/4 rounds.
- **`kimi-k2-thinking`** — serving rejects every request with HTTP 400 "prompt too long; exceeded max context length by 691 tokens", even for ~1k-token prompts.

All 33 existing catalog entries are still present in the live listing — this PR is additions-only (33 → 35).

### Cascades

- Resolver vision slots, `BALANCED_PATTERNS`/`BALANCED_ANCHORS`, and `providers.ts#defaultModel` are unchanged: both additions are text-only and the balanced default stays `glm-4.7`.
- The openclaw-config writer and the model-capabilities seed derive from the catalog; their tests were updated first (TDD) and cover the new entries (model list, context windows, reasoning flags, text-only input, zero cost, streaming-usage opt-in).
- The llm-providers mock is unchanged — `qwen3-next:80b` deliberately stays in its `/v1/models` response to keep exercising the allowlist filter.

## Test plan

- [x] TDD: updated `ollama-cloud-models.test.ts`, `provider-models.test.ts`, `openclaw-config.test.ts` first and watched them fail for the expected reason, then added the catalog entries.
- [x] Full unit suite: 5742 passed, 13 skipped (pre-existing `skipIf` gates).
- [x] `tsc --noEmit`, ESLint (0 errors), Prettier clean.
- [x] llm-providers mock tests: 15/15.
- [x] Net test count increases (+6), no skips added.