### PR TITLE
feat: in-app conversion CTAs, seat grace, and fail-closed license expiry (pricing Phase A)

### DIFF
--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -9,12 +9,10 @@ Pinchy Enterprise unlocks features like [Groups](/concepts/groups/), agent acces
 
 ## Getting a license key
 
-Contact us to get a license key:
+- **Trial key** — 30 days, all Pro features, no credit card. Start at [heypinchy.com/pricing](https://heypinchy.com/pricing#trial); the key arrives by email.
+- **Paid key (Pinchy Pro)** — Annual license, renewable. Buy at [heypinchy.com/pricing](https://heypinchy.com/pricing). Need more seats than the published plan? Email [sales@heypinchy.com](mailto:sales@heypinchy.com) for a quote you can accept online.
 
-- **Trial key** — 14 days, all enterprise features. [Book a call](https://calendly.com/clemenshelm/pinchy-demo) or email [hey@clemenshelm.com](mailto:hey@clemenshelm.com).
-- **Paid key** — Annual license, renewable. Same contact.
-
-No credit card required for trials. No per-agent or per-message fees.
+No per-agent or per-message fees. Activation works fully offline — your instance never contacts us.
 
 ## Activating your key
 
@@ -63,29 +61,29 @@ The enterprise features (Groups tab, agent access control) should now be availab
 
 ## Seat cap enforcement
 
-Enterprise license tokens include a `maxUsers` field that limits how many seats your organisation can use. A seat counts as either an **active user** or a **valid pending invitation** — both consume a seat.
+License tokens include a `maxUsers` field that limits how many seats your organisation can use. A seat counts as either an **active user** or a **valid pending invitation** — both consume a seat.
 
-### What "at cap" means
+### Soft cap with a grace window
 
-When `seatsUsed >= maxUsers`:
+The seat cap is a soft cap. Invites keep working up to **120 % of your licensed seats** (`floor(1.2 × maxUsers)` — 12 seats on a 10-seat license), so a new hire never waits on procurement:
 
-- The **Invite User** button in **Settings → Users** is disabled and a banner explains why.
-- The **Settings → License** page shows the current seat count next to the cap (`7 / 10 seats used`).
-- Attempting to create an invite via the API returns `403 Forbidden` with `{ "error": "Seat limit reached" }`.
-- **No existing users are locked out.** Pinchy never deactivates an account to enforce a cap. Only new invitations are blocked.
+- **Up to 100 %** — everything works normally. The user list shows a permanent counter (`7 of 10 seats used`).
+- **100–120 % (grace)** — invites still work. Admins see a factual notice in the invite flow and a dismissible banner pointing at the quote path. Nothing turns red, nothing is blocked.
+- **Beyond 120 %** — new invites are paused. The API returns `403 Forbidden` with `{ "error": "Seat limit reached", "graceCap": 12 }`, and the UI offers to email [sales@heypinchy.com](mailto:sales@heypinchy.com) for a quote.
+- **No existing users are locked out.** Pinchy never deactivates an account to enforce a cap. Only new invitations pause.
 
 ### Freeing up a seat
 
-To invite someone new when you are at cap, you can:
+To invite someone new when invites are paused, you can:
 
 1. **Revoke a pending invitation** — if an invite was sent but not yet claimed, revoking it frees the seat immediately.
 2. **Deactivate an existing user** — deactivated users no longer count toward the seat total.
 
-Both actions take effect immediately — the invite button re-enables without a page reload.
+Both actions take effect immediately.
 
 ### Trials and unlimited licenses
 
-A `maxUsers` value of **0** means unlimited seats. Trial keys issued by Pinchy carry `maxUsers: 0`, so seat enforcement does not apply during a trial. Paid keys include the seat count negotiated with your order.
+A `maxUsers` value of **0** means unlimited seats. Trial keys include up to 50 seats — enough to evaluate Groups and access control with a realistic team. Paid keys include the seat count of your order.
 
 <Aside type="note">
   The seat count shown in **Settings → License** includes both active users and
@@ -93,20 +91,26 @@ A `maxUsers` value of **0** means unlimited seats. Trial keys issued by Pinchy c
   unclaimed invites in **Settings → Users**.
 </Aside>
 
-## What happens when a key expires
+## What happens when a license expires
 
-Pinchy degrades gracefully. Nothing breaks:
+Pinchy fails closed: **an expired license never silently widens access.** Your access restrictions exist to protect you — they don't disappear because a renewal slipped.
 
-- Agents with **Restricted** visibility fall back to **All users** — everyone can access them.
-- Group assignments stay in the database but are not enforced.
-- The audit trail continues to work.
-- All data, agents, and configuration remain intact.
+Paid keys carry a paid-until date plus a **30-day grace window** (the key stays fully valid during grace). After the grace window:
 
-Renew your key and permissions are restored instantly.
+- **Existing restrictions stay enforced.** Agents with **Restricted** visibility stay restricted; group-based access keeps working exactly as configured.
+- **Management locks.** Creating or editing groups, adding users to groups, changing agent visibility, analytics, and CSV export pause until a new key is entered.
+- **Restriction-tightening operations always work**, even without a license: removing a user from a group and deactivating a user. An admin must be able to revoke a leaving contractor's access at any time — a license that blocked that would itself be the security risk.
+- **Nothing is lost.** All data, agents, groups, and configuration stay intact. Enter a new key and everything reactivates instantly.
+
+### Returning to community semantics
+
+If you decide not to renew, you don't have to keep the restrictions: **Settings → License** offers **Remove all license-gated configuration**. It deletes all groups and makes restricted agents visible to all users — an explicit, audited admin action, never something an expiry does on its own.
 
 <Aside type="note">
-  Admins see a warning banner when the key is close to expiring: 30 days before
-  for paid keys, 7 days for trial keys.
+  Admins see a factual banner during the lifecycle: trial keys show the
+  remaining days throughout the trial, paid keys show a renewal reminder from 14
+  days before the paid period ends, and expired keys state that restrictions
+  remain enforced. All banners are dismissible per session.
 </Aside>
 
 ## Enterprise features

--- a/docs/src/content/docs/guides/enterprise-setup.mdx
+++ b/docs/src/content/docs/guides/enterprise-setup.mdx
@@ -83,7 +83,7 @@ Both actions take effect immediately.
 
 ### Trials and unlimited licenses
 
-A `maxUsers` value of **0** means unlimited seats. Trial keys include up to 50 seats — enough to evaluate Groups and access control with a realistic team. Paid keys include the seat count of your order.
+A `maxUsers` value of **0** means unlimited seats. Newly issued trial keys include up to 50 seats — enough to evaluate Groups and access control with a realistic team; older trial keys may carry unlimited seats. Paid keys include the seat count of your order.
 
 <Aside type="note">
   The seat count shown in **Settings → License** includes both active users and

--- a/packages/web/src/__tests__/api/agents-delete.test.ts
+++ b/packages/web/src/__tests__/api/agents-delete.test.ts
@@ -18,6 +18,7 @@ vi.mock("@/lib/groups", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 vi.mock("@/lib/auth", () => {

--- a/packages/web/src/__tests__/api/agents-patch-validation.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-validation.test.ts
@@ -30,7 +30,10 @@ vi.mock("@/lib/workspace", () => ({
 vi.mock("@/lib/telegram-allow-store", () => ({
   recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
 }));
-vi.mock("@/lib/enterprise", () => ({ isEnterprise: vi.fn().mockResolvedValue(false) }));
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
+}));
 vi.mock("@/lib/provider-models", () => ({
   fetchProviderModels: vi.fn().mockResolvedValue([
     {

--- a/packages/web/src/__tests__/api/agents-visibility.test.ts
+++ b/packages/web/src/__tests__/api/agents-visibility.test.ts
@@ -100,6 +100,7 @@ vi.mock("@/lib/settings", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 import { auth } from "@/lib/auth";

--- a/packages/web/src/__tests__/api/enterprise-gated-config.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-gated-config.test.ts
@@ -77,6 +77,18 @@ describe("DELETE /api/enterprise/gated-config", () => {
     );
   });
 
+  it("writes the audit entry BEFORE the telegram recalc — a recalc failure must not lose the trail", async () => {
+    vi.mocked(recalculateTelegramAllowStores).mockRejectedValueOnce(new Error("recalc boom"));
+
+    await expect(DELETE()).rejects.toThrow("recalc boom");
+
+    // The mutation happened, so the audit entry must exist even though the
+    // request failed afterwards.
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({ eventType: "config.gated_config_removed", outcome: "success" })
+    );
+  });
+
   it("caps audit list snapshots to keep detail under the size budget", async () => {
     const manyGroups = Array.from({ length: 50 }, (_, i) => ({ id: `g${i}`, name: `Group ${i}` }));
     vi.mocked(removeGatedConfig).mockResolvedValue({ groups: manyGroups, agents: [] });

--- a/packages/web/src/__tests__/api/enterprise-gated-config.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-gated-config.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextResponse } from "next/server";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/api-auth", () => ({
+  requireAdmin: vi.fn(),
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn(),
+}));
+
+vi.mock("@/lib/gated-config", () => ({
+  hasGatedConfig: vi.fn(),
+  removeGatedConfig: vi.fn(),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/telegram-allow-store", () => ({
+  recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { requireAdmin } from "@/lib/api-auth";
+import { isEnterprise } from "@/lib/enterprise";
+import { removeGatedConfig } from "@/lib/gated-config";
+import { appendAuditLog } from "@/lib/audit";
+import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+
+describe("DELETE /api/enterprise/gated-config", () => {
+  let DELETE: typeof import("@/app/api/enterprise/gated-config/route").DELETE;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    vi.mocked(requireAdmin).mockResolvedValue({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as never);
+    vi.mocked(isEnterprise).mockResolvedValue(false);
+    vi.mocked(removeGatedConfig).mockResolvedValue({
+      groups: [{ id: "g1", name: "Engineering" }],
+      agents: [{ id: "a1", name: "Sales Bot" }],
+    });
+    const mod = await import("@/app/api/enterprise/gated-config/route");
+    DELETE = mod.DELETE;
+  });
+
+  it("removes gated config and reports counts", async () => {
+    const res = await DELETE();
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toEqual({ groupsRemoved: 1, agentsReset: 1 });
+    expect(removeGatedConfig).toHaveBeenCalled();
+    expect(recalculateTelegramAllowStores).toHaveBeenCalled();
+  });
+
+  it("writes an audit entry with name snapshots (deleted rows are gone)", async () => {
+    await DELETE();
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        actorType: "user",
+        actorId: "admin-1",
+        eventType: "config.gated_config_removed",
+        outcome: "success",
+        detail: expect.objectContaining({
+          groupsRemoved: 1,
+          agentsReset: 1,
+          groups: [{ id: "g1", name: "Engineering" }],
+          agents: [{ id: "a1", name: "Sales Bot" }],
+        }),
+      })
+    );
+  });
+
+  it("caps audit list snapshots to keep detail under the size budget", async () => {
+    const manyGroups = Array.from({ length: 50 }, (_, i) => ({ id: `g${i}`, name: `Group ${i}` }));
+    vi.mocked(removeGatedConfig).mockResolvedValue({ groups: manyGroups, agents: [] });
+
+    await DELETE();
+
+    const call = vi.mocked(appendAuditLog).mock.calls[0][0];
+    const detail = call.detail as { groups: unknown[]; groupsRemoved: number; truncated: boolean };
+    expect(detail.groupsRemoved).toBe(50);
+    expect(detail.groups).toHaveLength(20);
+    expect(detail.truncated).toBe(true);
+  });
+
+  it("refuses while a license is active (this is an escape hatch, not management)", async () => {
+    vi.mocked(isEnterprise).mockResolvedValue(true);
+    const res = await DELETE();
+    expect(res.status).toBe(409);
+    expect(removeGatedConfig).not.toHaveBeenCalled();
+  });
+
+  it("requires admin", async () => {
+    vi.mocked(requireAdmin).mockResolvedValue(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 }) as never
+    );
+    const res = await DELETE();
+    expect(res.status).toBe(403);
+    expect(removeGatedConfig).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/api/enterprise-status.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-status.test.ts
@@ -13,10 +13,14 @@ vi.mock("@/lib/enterprise", () => ({
 vi.mock("@/lib/seat-usage", () => ({
   getSeatUsage: vi.fn(),
 }));
+vi.mock("@/lib/gated-config", () => ({
+  hasGatedConfig: vi.fn(),
+}));
 
 const { getSession } = await import("@/lib/auth");
 const { getLicenseStatus, isKeyFromEnv } = await import("@/lib/enterprise");
 const { getSeatUsage } = await import("@/lib/seat-usage");
+const { hasGatedConfig } = await import("@/lib/gated-config");
 
 describe("GET /api/enterprise/status", () => {
   beforeEach(() => {
@@ -87,5 +91,115 @@ describe("GET /api/enterprise/status", () => {
     expect(body.seatsUsed).toBe(0);
     expect(body.maxUsers).toBe(0);
     expect(getSeatUsage).not.toHaveBeenCalled();
+  });
+
+  it("reports state=community without a key and does not query gated config eagerly for active licenses", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: false,
+      ver: 1,
+      maxUsers: 0,
+      features: [],
+    });
+    (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.state).toBe("community");
+    expect(body.paidUntil).toBeNull();
+    expect(body.hasGatedConfig).toBe(false);
+  });
+
+  it("reports state=paid with paidUntil for a valid paid key", async () => {
+    const paidUntilAt = new Date(Date.now() + 100 * 86400000);
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+      type: "paid",
+      org: "TestCo",
+      paidUntilAt,
+      expiresAt: new Date(paidUntilAt.getTime() + 30 * 86400000),
+    });
+    (getSeatUsage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      used: 7,
+      max: 10,
+      available: 3,
+      unlimited: false,
+      activeUsers: 5,
+      pendingInvites: 2,
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.state).toBe("paid");
+    expect(body.paidUntil).toBe(paidUntilAt.toISOString());
+    expect(hasGatedConfig).not.toHaveBeenCalled();
+  });
+
+  it("reports state=grace when paidUntil has passed but exp has not", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+      type: "paid",
+      paidUntilAt: new Date(Date.now() - 86400000),
+      expiresAt: new Date(Date.now() + 29 * 86400000),
+    });
+    (getSeatUsage as ReturnType<typeof vi.fn>).mockResolvedValue({
+      used: 7,
+      max: 10,
+      available: 3,
+      unlimited: false,
+      activeUsers: 7,
+      pendingInvites: 0,
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.state).toBe("grace");
+  });
+
+  it("reports state=expired with claims and gated-config flag for an expired paid key", async () => {
+    const paidUntilAt = new Date(Date.now() - 40 * 86400000);
+    const expiresAt = new Date(Date.now() - 10 * 86400000);
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: false,
+      expired: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+      type: "paid",
+      org: "TestCo",
+      paidUntilAt,
+      expiresAt,
+    });
+    (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(true);
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.enterprise).toBe(false);
+    expect(body.state).toBe("expired");
+    expect(body.paidUntil).toBe(paidUntilAt.toISOString());
+    expect(body.expiresAt).toBe(expiresAt.toISOString());
+    expect(body.hasGatedConfig).toBe(true);
+  });
+
+  it("reports state=trial-expired for an expired trial key", async () => {
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: false,
+      expired: true,
+      ver: 1,
+      maxUsers: 50,
+      features: ["enterprise"],
+      type: "trial",
+      expiresAt: new Date(Date.now() - 86400000),
+    });
+    (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(false);
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.state).toBe("trial-expired");
   });
 });

--- a/packages/web/src/__tests__/api/enterprise-status.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-status.test.ts
@@ -26,7 +26,7 @@ describe("GET /api/enterprise/status", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     (getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
-      user: { id: "u1" },
+      user: { id: "u1", role: "admin" },
     });
     (isKeyFromEnv as ReturnType<typeof vi.fn>).mockReturnValue(false);
   });
@@ -184,6 +184,26 @@ describe("GET /api/enterprise/status", () => {
     expect(body.paidUntil).toBe(paidUntilAt.toISOString());
     expect(body.expiresAt).toBe(expiresAt.toISOString());
     expect(body.hasGatedConfig).toBe(true);
+  });
+
+  it("does not query gated config for non-admins (only the escape hatch needs it)", async () => {
+    (getSession as ReturnType<typeof vi.fn>).mockResolvedValue({
+      user: { id: "u2", role: "member" },
+    });
+    (getLicenseStatus as ReturnType<typeof vi.fn>).mockResolvedValue({
+      active: false,
+      expired: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+      type: "paid",
+      expiresAt: new Date(Date.now() - 86400000),
+    });
+    const { GET } = await import("@/app/api/enterprise/status/route");
+    const res = await GET();
+    const body = await res.json();
+    expect(body.hasGatedConfig).toBe(false);
+    expect(hasGatedConfig).not.toHaveBeenCalled();
   });
 
   it("reports state=trial-expired for an expired trial key", async () => {

--- a/packages/web/src/__tests__/api/groups.test.ts
+++ b/packages/web/src/__tests__/api/groups.test.ts
@@ -68,6 +68,7 @@ vi.mock("@/db/schema", async (importOriginal) => {
 
 import { auth } from "@/lib/auth";
 import { appendAuditLog } from "@/lib/audit";
+import { isEnterprise } from "@/lib/enterprise";
 
 // ── GET /api/groups ──────────────────────────────────────────────────────
 
@@ -750,5 +751,89 @@ describe("PUT /api/groups/[groupId]/members", () => {
         },
       })
     );
+  });
+
+  it("returns a structured 403 when adding members without an active license", async () => {
+    vi.mocked(isEnterprise).mockResolvedValue(false);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockSelectWhere.mockResolvedValueOnce([{ id: "group-1" }]); // group exists
+    mockSelectWhere.mockResolvedValueOnce([]); // existing members: none
+    // No names select queued — the route returns 403 before resolving names.
+
+    const request = new NextRequest("http://localhost:7777/api/groups/group-1/members", {
+      method: "PUT",
+      body: JSON.stringify({ userIds: ["user-1"] }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ groupId: "group-1" }) });
+    expect(response.status).toBe(403);
+    const body = await response.json();
+    expect(body.error).toBe("License required");
+    expect(body.message).toMatch(/Removing users from groups always works/);
+    expect(mockDelete).not.toHaveBeenCalled();
+  });
+
+  it("allows removal-only member updates without an active license (carve-out, § 5)", async () => {
+    vi.mocked(isEnterprise).mockResolvedValue(false);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockSelectWhere.mockResolvedValueOnce([{ id: "group-1" }]); // group exists
+    mockSelectWhere.mockResolvedValueOnce([
+      { userId: "user-1", groupId: "group-1" },
+      { userId: "user-2", groupId: "group-1" },
+    ]); // existing members
+    mockSelectWhere.mockResolvedValueOnce([{ id: "user-2", name: "User Two" }]); // names
+
+    const request = new NextRequest("http://localhost:7777/api/groups/group-1/members", {
+      method: "PUT",
+      body: JSON.stringify({ userIds: ["user-1"] }),
+    });
+
+    const response = await PUT(request, { params: Promise.resolve({ groupId: "group-1" }) });
+    expect(response.status).toBe(200);
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith([{ userId: "user-1", groupId: "group-1" }]);
+  });
+});
+
+describe("group reads stay available without an active license (removal UI needs them)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.mocked(isEnterprise).mockResolvedValue(false);
+  });
+
+  it("GET /api/groups responds 200 without an active license", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockSelectGroupBy.mockResolvedValueOnce([]);
+
+    const { GET } = await import("@/app/api/groups/route");
+    const response = await GET();
+    expect(response.status).toBe(200);
+  });
+
+  it("GET /api/groups/[groupId]/members responds 200 without an active license", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockSelectWhere.mockResolvedValueOnce([{ id: "group-1" }]); // group exists
+    mockSelectWhere.mockResolvedValueOnce([]); // members
+
+    const { GET } = await import("@/app/api/groups/[groupId]/members/route");
+    const response = await GET(
+      new NextRequest("http://localhost:7777/api/groups/group-1/members"),
+      { params: Promise.resolve({ groupId: "group-1" }) }
+    );
+    expect(response.status).toBe(200);
   });
 });

--- a/packages/web/src/__tests__/api/uploads-post.integration.test.ts
+++ b/packages/web/src/__tests__/api/uploads-post.integration.test.ts
@@ -42,6 +42,7 @@ vi.mock("@/lib/auth", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
 }));
 
 vi.mock("@/lib/groups", () => ({

--- a/packages/web/src/__tests__/api/user-groups.test.ts
+++ b/packages/web/src/__tests__/api/user-groups.test.ts
@@ -77,13 +77,15 @@ describe("PUT /api/users/[userId]/groups", () => {
     PUT = mod.PUT;
   });
 
-  it("returns 403 when not enterprise", async () => {
+  it("returns a structured 403 when adding groups without an active license", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "admin-1", role: "admin" },
       expires: "",
     } as any);
     mockIsEnterprise.mockResolvedValueOnce(false);
 
+    // user-1 currently has no groups — adding g1 would widen nothing but
+    // creates a new restriction-bearing membership, which is gated.
     const request = new NextRequest("http://localhost:7777/api/users/user-1/groups", {
       method: "PUT",
       body: JSON.stringify({ groupIds: ["g1"] }),
@@ -94,7 +96,63 @@ describe("PUT /api/users/[userId]/groups", () => {
     });
     expect(response.status).toBe(403);
     const body = await response.json();
-    expect(body.error).toBe("Enterprise feature");
+    expect(body.error).toBe("License required");
+    expect(body.message).toMatch(/Removing users from groups always works/);
+  });
+
+  it("allows removal-only updates without an active license (carve-out, § 5)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockIsEnterprise.mockResolvedValue(false);
+
+    mockSelectWhere.mockReset();
+    mockSelectWhere
+      .mockResolvedValueOnce([{ id: "user-1", name: "Max Müller" }]) // user lookup
+      .mockResolvedValueOnce([{ groupId: "g1" }, { groupId: "g2" }]) // previous memberships
+      .mockResolvedValueOnce([
+        { id: "g1", name: "Engineering" },
+        { id: "g2", name: "Marketing" },
+      ]); // group names
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1/groups", {
+      method: "PUT",
+      body: JSON.stringify({ groupIds: ["g1"] }),
+    });
+
+    const response = await PUT(request, {
+      params: Promise.resolve({ userId: "user-1" }),
+    });
+    expect(response.status).toBe(200);
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockValues).toHaveBeenCalledWith([{ userId: "user-1", groupId: "g1" }]);
+  });
+
+  it("allows removing all groups without an active license", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockIsEnterprise.mockResolvedValue(false);
+
+    mockSelectWhere.mockReset();
+    mockSelectWhere
+      .mockResolvedValueOnce([{ id: "user-1", name: "Max Müller" }]) // user lookup
+      .mockResolvedValueOnce([{ groupId: "g1" }]) // previous memberships
+      .mockResolvedValueOnce([{ id: "g1", name: "Engineering" }]); // group names
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1/groups", {
+      method: "PUT",
+      body: JSON.stringify({ groupIds: [] }),
+    });
+
+    const response = await PUT(request, {
+      params: Promise.resolve({ userId: "user-1" }),
+    });
+    expect(response.status).toBe(200);
+    expect(mockDelete).toHaveBeenCalled();
+    expect(mockInsert).not.toHaveBeenCalled();
   });
 
   it("returns 401 when not authenticated", async () => {

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -79,7 +79,7 @@ describe("POST /api/users/invite — seat cap", () => {
     POST = mod.POST;
   });
 
-  it("returns 403 when seat cap is reached", async () => {
+  it("still creates invites at 100% (first grace seat — § 5 soft cap)", async () => {
     vi.mocked(getLicenseStatus).mockResolvedValue({
       active: true,
       ver: 1,
@@ -95,11 +95,53 @@ describe("POST /api/users/invite — seat cap", () => {
       pendingInvites: 2,
     });
     const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(201);
+    expect(createInvite).toHaveBeenCalled();
+  });
+
+  it("still creates invites inside the grace window (11 of 10 seats)", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+    });
+    vi.mocked(getSeatUsage).mockResolvedValue({
+      used: 11,
+      max: 10,
+      available: 0,
+      unlimited: false,
+      activeUsers: 11,
+      pendingInvites: 0,
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
+    expect(res.status).toBe(201);
+    expect(createInvite).toHaveBeenCalled();
+  });
+
+  it("returns a structured 403 beyond the grace cap (12 of 10 seats)", async () => {
+    vi.mocked(getLicenseStatus).mockResolvedValue({
+      active: true,
+      ver: 1,
+      maxUsers: 10,
+      features: ["enterprise"],
+    });
+    vi.mocked(getSeatUsage).mockResolvedValue({
+      used: 12,
+      max: 10,
+      available: 0,
+      unlimited: false,
+      activeUsers: 12,
+      pendingInvites: 0,
+    });
+    const res = await POST(makeRequest({ email: "new@test.com", role: "member" }));
     expect(res.status).toBe(403);
     const body = await res.json();
     expect(body.error).toBe("Seat limit reached");
-    expect(body.seatsUsed).toBe(10);
+    expect(body.seatsUsed).toBe(12);
     expect(body.maxUsers).toBe(10);
+    expect(body.graceCap).toBe(12);
+    expect(body.message).toContain("sales@heypinchy.com");
     expect(createInvite).not.toHaveBeenCalled();
   });
 
@@ -111,11 +153,11 @@ describe("POST /api/users/invite — seat cap", () => {
       features: ["enterprise"],
     });
     vi.mocked(getSeatUsage).mockResolvedValue({
-      used: 5,
+      used: 6,
       max: 5,
       available: 0,
       unlimited: false,
-      activeUsers: 5,
+      activeUsers: 6,
       pendingInvites: 0,
     });
     vi.stubEnv("AUDIT_HMAC_SECRET", "f".repeat(64));
@@ -133,8 +175,9 @@ describe("POST /api/users/invite — seat cap", () => {
           emailPreview: "new@test.com",
           role: "member",
           reason: "seat_cap",
-          seatsUsed: 5,
+          seatsUsed: 6,
           maxUsers: 5,
+          graceCap: 6,
         }),
       })
     );

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -3,6 +3,15 @@ import { NextRequest } from "next/server";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
+// Pins the § 5 carve-out: deactivating a user is a restriction-tightening
+// operation and must work in EVERY license state. If the route ever grows a
+// license gate, this inactive-license mock makes the pin test below fail.
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("expired"),
+  getLicenseStatus: vi.fn().mockResolvedValue({ active: false, features: [], ver: 1, maxUsers: 0 }),
+}));
+
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
 }));
@@ -315,6 +324,38 @@ describe("DELETE /api/users/[userId]", () => {
         detail: { name: "Test User" },
       })
     );
+  });
+
+  it("deactivates users without an active license (restriction-tightening carve-out, § 5)", async () => {
+    // The enterprise mock at the top of this file reports an EXPIRED license.
+    // An admin must always be able to revoke access — a license that blocked
+    // this would itself be the security risk.
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as never);
+
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([]),
+      }),
+    } as never);
+
+    const mockUpdate = {
+      set: vi.fn().mockReturnThis(),
+      where: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue([{ id: "user-1", name: "Test User", email: "u@test.com" }]),
+      }),
+    };
+    vi.mocked(db.update).mockReturnValueOnce(mockUpdate as never);
+
+    const request = new NextRequest("http://localhost:7777/api/users/user-1", { method: "DELETE" });
+    const response = await DELETE(request, { params: Promise.resolve({ userId: "user-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(mockUpdate.set).toHaveBeenCalledWith(expect.objectContaining({ banned: true }));
   });
 
   it("does not record the user's email in the user.deleted audit detail (GDPR Art. 17)", async () => {

--- a/packages/web/src/__tests__/app/chat-page.test.tsx
+++ b/packages/web/src/__tests__/app/chat-page.test.tsx
@@ -49,6 +49,7 @@ vi.mock("@/lib/groups", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 vi.mock("@/lib/avatar", () => ({
@@ -119,7 +120,7 @@ describe("ChatPage", () => {
       "member",
       [],
       [],
-      true
+      "paid"
     );
     expect(mockNotFound).toHaveBeenCalled();
   });
@@ -151,7 +152,7 @@ describe("ChatPage", () => {
       "member",
       ["g1", "g2"],
       ["g2", "g3"],
-      true
+      "paid"
     );
   });
 
@@ -186,7 +187,7 @@ describe("ChatPage", () => {
       "member",
       [],
       [],
-      true
+      "paid"
     );
   });
 
@@ -221,7 +222,7 @@ describe("ChatPage", () => {
       "admin",
       [],
       [],
-      true
+      "paid"
     );
   });
 

--- a/packages/web/src/__tests__/app/usage-page.test.tsx
+++ b/packages/web/src/__tests__/app/usage-page.test.tsx
@@ -21,6 +21,7 @@ vi.mock("@/components/usage-dashboard", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseStatus: vi.fn().mockResolvedValue({ active: false, features: [], ver: 1, maxUsers: 0 }),
 }));
 
 import UsagePage from "@/app/(app)/usage/page";

--- a/packages/web/src/__tests__/components/agent-settings-access.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-access.test.tsx
@@ -177,7 +177,7 @@ describe("AgentSettingsAccess", () => {
       expect(screen.getByText("Access Control")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Enterprise")).toBeInTheDocument();
+    expect(screen.getByText("Pro")).toBeInTheDocument();
     expect(
       screen.getByText(/Control which users and groups can access this agent/)
     ).toBeInTheDocument();

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -134,6 +134,22 @@ describe("EnterpriseBanner", () => {
     );
   });
 
+  it("anchors the renewal banner on exp for legacy keys without paidUntil", async () => {
+    // Keys issued before the paidUntil claim existed encode no grace —
+    // exp IS the period end. Losing the reminder for those keys would be a
+    // regression for every existing paid customer.
+    await renderWithStatus(
+      statusJson({
+        paidUntil: null,
+        expiresAt: new Date(Date.now() + 10 * DAY).toISOString(),
+        daysRemaining: 10,
+      })
+    );
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/Your license period ends on/);
+    expect(screen.getByRole("link", { name: /renew/i })).toBeInTheDocument();
+  });
+
   it("shows the grace banner with the canonical copy", async () => {
     const paidUntil = new Date("2026-06-01T00:00:00.000Z");
     const exp = new Date("2026-07-01T00:00:00.000Z");

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { act, render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
 const mockFetch = vi.fn();
@@ -7,12 +8,20 @@ global.fetch = mockFetch;
 
 import { EnterpriseBanner } from "@/components/enterprise-banner";
 
+const DAY = 86400000;
+
 function statusJson(overrides: Record<string, unknown> = {}) {
   return {
     enterprise: true,
+    state: "paid",
     type: "paid",
+    org: "TestCo",
     daysRemaining: 200,
-    expiresAt: new Date(Date.now() + 200 * 86400000).toISOString(),
+    expiresAt: new Date(Date.now() + 200 * DAY).toISOString(),
+    paidUntil: null,
+    seatsUsed: 3,
+    maxUsers: 10,
+    hasGatedConfig: false,
     ...overrides,
   };
 }
@@ -21,143 +30,244 @@ function mockStatusResponse(data: object) {
   return { ok: true, json: async () => data } as Response;
 }
 
+async function renderWithStatus(data: object) {
+  mockFetch.mockResolvedValue(mockStatusResponse(data));
+  render(<EnterpriseBanner isAdmin={true} />);
+  await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+}
+
 describe("EnterpriseBanner", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    sessionStorage.clear();
   });
 
   it("renders nothing when not admin", () => {
     const { container } = render(<EnterpriseBanner isAdmin={false} />);
     expect(container.innerHTML).toBe("");
+    expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("renders nothing when license is active with plenty of time", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        enterprise: true,
-        type: "paid",
-        daysRemaining: 200,
-        expiresAt: new Date(Date.now() + 200 * 86400000).toISOString(),
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled();
-    });
-    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
-  });
-
-  it("renders nothing when no license (no banner, handled by Settings)", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+  it("renders nothing for community (no permanent banner — § 6)", async () => {
+    await renderWithStatus(
+      statusJson({
         enterprise: false,
+        state: "community",
         type: null,
-        daysRemaining: null,
         expiresAt: null,
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(mockFetch).toHaveBeenCalled();
-    });
+        daysRemaining: null,
+        maxUsers: 0,
+      })
+    );
     expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("renders yellow banner for trial with 7 days remaining", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        enterprise: true,
-        type: "trial",
-        daysRemaining: 7,
-        expiresAt: new Date(Date.now() + 7 * 86400000).toISOString(),
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/trial expires in 7 days/i)).toBeInTheDocument();
-    expect(screen.getByText(/upgrade/i)).toBeInTheDocument();
+  it("renders nothing for a paid license outside the renewal window", async () => {
+    await renderWithStatus(
+      statusJson({ paidUntil: new Date(Date.now() + 100 * DAY).toISOString() })
+    );
+    expect(screen.queryByRole("alert")).not.toBeInTheDocument();
   });
 
-  it("renders red banner for trial with 2 days remaining", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        enterprise: true,
-        type: "trial",
-        daysRemaining: 2,
-        expiresAt: new Date(Date.now() + 2 * 86400000).toISOString(),
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/trial expires in 2 days/i)).toBeInTheDocument();
+  it("shows a subtle trial banner with a buy CTA during the trial", async () => {
+    await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 23 }));
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent("Trial: 23 days remaining.");
+    expect(banner.className).not.toContain("bg-amber");
+    const buy = screen.getByRole("link", { name: /buy pinchy pro/i });
+    expect(buy).toHaveAttribute(
+      "href",
+      "https://buy.heypinchy.com/shop/pinchy-pro-5?utm_source=pinchy-app&utm_medium=trial-banner&utm_campaign=pro-10"
+    );
+    const compare = screen.getByRole("link", { name: /compare plans/i });
+    expect(compare).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=trial-banner&utm_campaign=pro-10"
+    );
   });
 
-  it("renders yellow banner for paid with 25 days remaining", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        enterprise: true,
-        type: "paid",
-        daysRemaining: 25,
-        expiresAt: new Date(Date.now() + 25 * 86400000).toISOString(),
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/license expires in 25 days/i)).toBeInTheDocument();
-    expect(screen.getByText(/renew/i)).toBeInTheDocument();
+  it("emphasizes the trial banner from 7 days remaining", async () => {
+    await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 7 }));
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent("Trial: 7 days remaining.");
+    expect(banner.className).toContain("bg-amber");
   });
 
-  it("renders red banner for paid with 5 days remaining", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        enterprise: true,
-        type: "paid",
-        daysRemaining: 5,
-        expiresAt: new Date(Date.now() + 5 * 86400000).toISOString(),
-      }),
-    });
-
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
-      expect(screen.getByRole("alert")).toBeInTheDocument();
-    });
-    expect(screen.getByText(/license expires in 5 days/i)).toBeInTheDocument();
+  it("uses the singular for one remaining day", async () => {
+    await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 1 }));
+    expect(screen.getByRole("alert")).toHaveTextContent("Trial: 1 day remaining.");
   });
 
-  it("renders red banner when expired", async () => {
-    mockFetch.mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
+  it("shows the trial-expired banner with a pricing CTA and no re-trial button", async () => {
+    const expiresAt = new Date("2026-06-01T00:00:00.000Z");
+    await renderWithStatus(
+      statusJson({
         enterprise: false,
+        state: "trial-expired",
         type: "trial",
         daysRemaining: 0,
-        expiresAt: new Date(Date.now() - 86400000).toISOString(),
-      }),
+        expiresAt: expiresAt.toISOString(),
+      })
+    );
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(
+      "Your trial ended on Jun 1, 2026. Your configuration is preserved."
+    );
+    const pricing = screen.getByRole("link", { name: /see pricing/i });
+    expect(pricing).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=expired-banner&utm_campaign=pro-10"
+    );
+    expect(screen.queryByText(/start free/i)).not.toBeInTheDocument();
+  });
+
+  it("shows the renewal banner from 14 days before paidUntil", async () => {
+    const paidUntil = new Date(Date.now() + 10 * DAY);
+    await renderWithStatus(statusJson({ paidUntil: paidUntil.toISOString() }));
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(/Your license period ends on/);
+    expect(banner).toHaveTextContent("Your renewal key arrives by email after payment.");
+    const renew = screen.getByRole("link", { name: /renew/i });
+    expect(renew).toHaveAttribute(
+      "href",
+      "https://buy.heypinchy.com/my?utm_source=pinchy-app&utm_medium=expired-banner&utm_campaign=pro-10"
+    );
+  });
+
+  it("shows the grace banner with the canonical copy", async () => {
+    const paidUntil = new Date("2026-06-01T00:00:00.000Z");
+    const exp = new Date("2026-07-01T00:00:00.000Z");
+    await renderWithStatus(
+      statusJson({
+        state: "grace",
+        paidUntil: paidUntil.toISOString(),
+        expiresAt: exp.toISOString(),
+        daysRemaining: 19,
+      })
+    );
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent("License period ended Jun 1, 2026. Grace until Jul 1, 2026.");
+    expect(screen.getByRole("link", { name: /renew/i })).toBeInTheDocument();
+  });
+
+  it("shows the expired banner stating that restrictions remain enforced", async () => {
+    const paidUntil = new Date("2026-05-01T00:00:00.000Z");
+    await renderWithStatus(
+      statusJson({
+        enterprise: false,
+        state: "expired",
+        paidUntil: paidUntil.toISOString(),
+        expiresAt: new Date("2026-05-31T00:00:00.000Z").toISOString(),
+        daysRemaining: 0,
+      })
+    );
+    const banner = screen.getByRole("alert");
+    expect(banner).toHaveTextContent(
+      "Your license period ended on May 1, 2026. Existing access restrictions remain enforced; management features are locked."
+    );
+    expect(screen.getByRole("link", { name: /renew/i })).toBeInTheDocument();
+  });
+
+  it("falls back to expiresAt as the period end when the key has no paidUntil", async () => {
+    await renderWithStatus(
+      statusJson({
+        enterprise: false,
+        state: "expired",
+        paidUntil: null,
+        expiresAt: new Date("2026-05-31T00:00:00.000Z").toISOString(),
+        daysRemaining: 0,
+      })
+    );
+    expect(screen.getByRole("alert")).toHaveTextContent(
+      "Your license period ended on May 31, 2026."
+    );
+  });
+
+  describe("seat-pressure banner", () => {
+    it("shows a factual over-cap banner with quote CTAs and no red styling", async () => {
+      await renderWithStatus(statusJson({ seatsUsed: 11, maxUsers: 10 }));
+      const banner = screen.getByRole("alert");
+      expect(banner).toHaveTextContent("You're using 11 of 10 licensed seats.");
+      expect(banner).toHaveTextContent("Grace seats keep a new hire from waiting on procurement.");
+      expect(banner.className).not.toContain("destructive");
+      expect(banner.className).not.toContain("bg-amber");
+      expect(screen.getByRole("link", { name: /email us for a quote/i })).toHaveAttribute(
+        "href",
+        "mailto:sales@heypinchy.com?subject=Pinchy%20seats%20quote%20request"
+      );
+      expect(screen.getByRole("link", { name: /book a call/i })).toHaveAttribute(
+        "href",
+        "https://calendly.com/clemenshelm/pinchy-demo"
+      );
     });
 
-    render(<EnterpriseBanner isAdmin={true} />);
-    await waitFor(() => {
+    it("does not show the seat banner at exactly 100%", async () => {
+      await renderWithStatus(statusJson({ seatsUsed: 10, maxUsers: 10 }));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("does not show the seat banner when the license is inactive", async () => {
+      await renderWithStatus(
+        statusJson({ enterprise: false, state: "expired", seatsUsed: 11, maxUsers: 10 })
+      );
+      // The expired banner shows, but no seat banner on top.
+      expect(screen.queryByText(/licensed seats/i)).not.toBeInTheDocument();
+    });
+  });
+
+  describe("session dismissal", () => {
+    it("hides the banner for the session when dismissed", async () => {
+      const user = userEvent.setup();
+      await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 23 }));
+      expect(screen.getByRole("alert")).toBeInTheDocument();
+
+      await user.click(screen.getByRole("button", { name: /dismiss/i }));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+      expect(sessionStorage.getItem("pinchy-banner-dismissed:license:trial")).toBe("1");
+    });
+
+    it("stays hidden on re-render within the same session", async () => {
+      sessionStorage.setItem("pinchy-banner-dismissed:license:trial", "1");
+      await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 23 }));
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
+    });
+
+    it("re-appears when the license state changes", async () => {
+      sessionStorage.setItem("pinchy-banner-dismissed:license:trial", "1");
+      await renderWithStatus(
+        statusJson({
+          enterprise: false,
+          state: "trial-expired",
+          type: "trial",
+          daysRemaining: 0,
+          expiresAt: new Date("2026-06-01T00:00:00.000Z").toISOString(),
+        })
+      );
       expect(screen.getByRole("alert")).toBeInTheDocument();
     });
-    expect(screen.getByText(/license has expired/i)).toBeInTheDocument();
-    expect(screen.getByText(/enter new key/i)).toBeInTheDocument();
+
+    it("dismisses the seat banner independently of the license banner", async () => {
+      const user = userEvent.setup();
+      await renderWithStatus(
+        statusJson({
+          state: "trial",
+          type: "trial",
+          daysRemaining: 23,
+          seatsUsed: 11,
+          maxUsers: 10,
+        })
+      );
+      const alerts = screen.getAllByRole("alert");
+      expect(alerts).toHaveLength(2);
+
+      const seatBanner = alerts.find((a) => a.textContent?.includes("licensed seats"))!;
+      const dismiss = seatBanner.querySelector("button")!;
+      await user.click(dismiss);
+
+      expect(screen.getAllByRole("alert")).toHaveLength(1);
+      expect(screen.getByRole("alert")).toHaveTextContent(/Trial:/);
+      expect(sessionStorage.getItem("pinchy-banner-dismissed:seats")).toBe("1");
+    });
   });
 
   describe("re-fetch triggers", () => {

--- a/packages/web/src/__tests__/components/enterprise-feature-card.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-feature-card.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 
@@ -8,26 +8,12 @@ global.fetch = mockFetch;
 
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
 
-function mockStatus(overrides: Record<string, unknown> = {}) {
-  mockFetch.mockResolvedValue({
-    ok: true,
-    json: async () => ({
-      enterprise: false,
-      state: "community",
-      type: null,
-      expiresAt: null,
-      paidUntil: null,
-      ...overrides,
-    }),
-  } as Response);
-}
-
 describe("EnterpriseFeatureCard", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("shows only a factual notice to non-admins (no sales copy, no fetch)", () => {
+  it("shows only a factual notice to non-admins (no sales copy)", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
@@ -41,53 +27,62 @@ describe("EnterpriseFeatureCard", () => {
     ).toBeInTheDocument();
     expect(screen.queryByRole("link")).not.toBeInTheDocument();
     expect(screen.queryByRole("button")).not.toBeInTheDocument();
+  });
+
+  it("never fetches — license info comes from the parent via props", () => {
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+        licenseState="community"
+      />
+    );
     expect(mockFetch).not.toHaveBeenCalled();
   });
 
-  it("renders feature name, description, and Pro badge for admins", async () => {
-    mockStatus();
+  it("renders feature name, description, and Pro badge for admins", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
         description="Manage team groups for access control."
         campaign="groups"
         isAdmin={true}
+        licenseState="community"
       />
     );
     expect(screen.getByText("Groups")).toBeInTheDocument();
     expect(screen.getByText("Manage team groups for access control.")).toBeInTheDocument();
     expect(screen.getByText("Pro")).toBeInTheDocument();
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   });
 
-  it("keeps the how-to-enable instructions for admins", async () => {
-    mockStatus();
+  it("keeps the how-to-enable instructions for admins", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
         description="Description here."
         campaign="groups"
         isAdmin={true}
+        licenseState="community"
       />
     );
     expect(screen.getByText(/Settings → License/)).toBeInTheDocument();
     expect(screen.getByText("PINCHY_ENTERPRISE_KEY")).toBeInTheDocument();
-    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   });
 
   it("opens the cliff dialog from the trial CTA on community instances", async () => {
     const user = userEvent.setup();
-    mockStatus();
     render(
       <EnterpriseFeatureCard
         feature="Groups"
         description="Description here."
         campaign="groups"
         isAdmin={true}
+        licenseState="community"
       />
     );
-    const cta = await screen.findByRole("button", { name: /start free 30-day trial/i });
-    await user.click(cta);
+    await user.click(screen.getByRole("button", { name: /start free 30-day trial/i }));
 
     expect(screen.getByText(/Groups is included in Pinchy Pro/i)).toBeInTheDocument();
     expect(screen.getByRole("link", { name: /start free 30-day trial/i })).toHaveAttribute(
@@ -99,27 +94,36 @@ describe("EnterpriseFeatureCard", () => {
     expect(screen.queryByText(/included in Pinchy Pro/i)).not.toBeInTheDocument();
   });
 
-  it("labels the CTA 'See pricing' after an expired trial", async () => {
-    mockStatus({ state: "trial-expired", type: "trial", expiresAt: "2026-06-01T00:00:00.000Z" });
+  it("labels the CTA 'See pricing' after an expired trial", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
         description="Description here."
         campaign="groups"
         isAdmin={true}
+        licenseState="trial-expired"
+        periodEnd="2026-06-01T00:00:00.000Z"
       />
     );
-    expect(await screen.findByRole("button", { name: /see pricing/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /see pricing/i })).toBeInTheDocument();
     expect(screen.queryByRole("button", { name: /start free/i })).not.toBeInTheDocument();
   });
 
-  it("labels the CTA 'Renew' for an expired paid license", async () => {
-    mockStatus({
-      state: "expired",
-      type: "paid",
-      paidUntil: "2026-05-01T00:00:00.000Z",
-      expiresAt: "2026-05-31T00:00:00.000Z",
-    });
+  it("labels the CTA 'Renew' for an expired paid license", () => {
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+        licenseState="expired"
+        periodEnd="2026-05-01T00:00:00.000Z"
+      />
+    );
+    expect(screen.getByRole("button", { name: /renew/i })).toBeInTheDocument();
+  });
+
+  it("defaults to the community CTA when the parent provides no state", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
@@ -128,6 +132,6 @@ describe("EnterpriseFeatureCard", () => {
         isAdmin={true}
       />
     );
-    expect(await screen.findByRole("button", { name: /renew/i })).toBeInTheDocument();
+    expect(screen.getByRole("button", { name: /start free 30-day trial/i })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/enterprise-feature-card.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-feature-card.test.tsx
@@ -1,36 +1,133 @@
-import { describe, it, expect } from "vitest";
-import { render, screen } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+
+const mockFetch = vi.fn();
+global.fetch = mockFetch;
+
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
 
+function mockStatus(overrides: Record<string, unknown> = {}) {
+  mockFetch.mockResolvedValue({
+    ok: true,
+    json: async () => ({
+      enterprise: false,
+      state: "community",
+      type: null,
+      expiresAt: null,
+      paidUntil: null,
+      ...overrides,
+    }),
+  } as Response);
+}
+
 describe("EnterpriseFeatureCard", () => {
-  it("renders feature name and description", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows only a factual notice to non-admins (no sales copy, no fetch)", () => {
     render(
       <EnterpriseFeatureCard
         feature="Groups"
         description="Manage team groups for access control."
+        campaign="groups"
+        isAdmin={false}
       />
     );
+    expect(
+      screen.getByText("This feature requires a Pro license. Ask your administrator.")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link")).not.toBeInTheDocument();
+    expect(screen.queryByRole("button")).not.toBeInTheDocument();
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
 
+  it("renders feature name, description, and Pro badge for admins", async () => {
+    mockStatus();
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Manage team groups for access control."
+        campaign="groups"
+        isAdmin={true}
+      />
+    );
     expect(screen.getByText("Groups")).toBeInTheDocument();
     expect(screen.getByText("Manage team groups for access control.")).toBeInTheDocument();
+    expect(screen.getByText("Pro")).toBeInTheDocument();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
   });
 
-  it("shows Enterprise badge", () => {
-    render(<EnterpriseFeatureCard feature="Groups" description="Description here." />);
-
-    expect(screen.getByText("Enterprise")).toBeInTheDocument();
-  });
-
-  it("shows Learn more link to enterprise page", () => {
-    render(<EnterpriseFeatureCard feature="Groups" description="Description here." />);
-
-    const link = screen.getByRole("link", { name: /learn more/i });
-    expect(link).toHaveAttribute(
-      "href",
-      "https://heypinchy.com/enterprise?utm_source=app&utm_medium=feature-card"
+  it("keeps the how-to-enable instructions for admins", async () => {
+    mockStatus();
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+      />
     );
-    expect(link).toHaveAttribute("target", "_blank");
-    expect(link).toHaveAttribute("rel", "noopener noreferrer");
+    expect(screen.getByText(/Settings → License/)).toBeInTheDocument();
+    expect(screen.getByText("PINCHY_ENTERPRISE_KEY")).toBeInTheDocument();
+    await waitFor(() => expect(mockFetch).toHaveBeenCalled());
+  });
+
+  it("opens the cliff dialog from the trial CTA on community instances", async () => {
+    const user = userEvent.setup();
+    mockStatus();
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+      />
+    );
+    const cta = await screen.findByRole("button", { name: /start free 30-day trial/i });
+    await user.click(cta);
+
+    expect(screen.getByText(/Groups is included in Pinchy Pro/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /start free 30-day trial/i })).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups#trial"
+    );
+
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    expect(screen.queryByText(/included in Pinchy Pro/i)).not.toBeInTheDocument();
+  });
+
+  it("labels the CTA 'See pricing' after an expired trial", async () => {
+    mockStatus({ state: "trial-expired", type: "trial", expiresAt: "2026-06-01T00:00:00.000Z" });
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+      />
+    );
+    expect(await screen.findByRole("button", { name: /see pricing/i })).toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /start free/i })).not.toBeInTheDocument();
+  });
+
+  it("labels the CTA 'Renew' for an expired paid license", async () => {
+    mockStatus({
+      state: "expired",
+      type: "paid",
+      paidUntil: "2026-05-01T00:00:00.000Z",
+      expiresAt: "2026-05-31T00:00:00.000Z",
+    });
+    render(
+      <EnterpriseFeatureCard
+        feature="Groups"
+        description="Description here."
+        campaign="groups"
+        isAdmin={true}
+      />
+    );
+    expect(await screen.findByRole("button", { name: /renew/i })).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/invite-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/invite-dialog.test.tsx
@@ -16,16 +16,23 @@ function resolveUrl(url: string | URL | Request): string {
 
 function mockFetchForInvite(
   inviteResponse: { ok: boolean; json: () => Promise<unknown> },
-  options?: { enterprise?: boolean; groups?: { id: string; name: string }[] }
+  options?: {
+    enterprise?: boolean;
+    groups?: { id: string; name: string }[];
+    maxUsers?: number;
+    seatsUsed?: number;
+  }
 ) {
   const enterprise = options?.enterprise ?? false;
   const groups = options?.groups ?? [];
+  const maxUsers = options?.maxUsers ?? 0;
+  const seatsUsed = options?.seatsUsed ?? 0;
   return (url: string | URL | Request) => {
     const urlStr = resolveUrl(url);
     if (urlStr.includes("/api/enterprise/status")) {
       return Promise.resolve({
         ok: true,
-        json: async () => ({ enterprise }),
+        json: async () => ({ enterprise, maxUsers, seatsUsed }),
       } as Response);
     }
     if (urlStr.includes("/api/groups")) {
@@ -142,6 +149,60 @@ describe("InviteDialog", () => {
 
     await waitFor(() => {
       expect(screen.getByText("Invite limit reached")).toBeInTheDocument();
+    });
+  });
+
+  it("shows a factual notice inside the grace window (§ 5)", async () => {
+    fetchSpy.mockImplementation(
+      mockFetchForInvite(
+        { ok: true, json: async () => ({}) },
+        { enterprise: true, maxUsers: 10, seatsUsed: 11 }
+      )
+    );
+    render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByText(/You're using 11 of 10 licensed seats\./)).toBeInTheDocument();
+    });
+    expect(
+      screen.getByText(/Grace seats keep a new hire from waiting on procurement\./)
+    ).toBeInTheDocument();
+    // The form still works inside the grace window.
+    expect(screen.getByRole("button", { name: "Create Invite" })).toBeEnabled();
+  });
+
+  it("shows no seat notice at or below 100%", async () => {
+    fetchSpy.mockImplementation(
+      mockFetchForInvite(
+        { ok: true, json: async () => ({}) },
+        { enterprise: true, maxUsers: 10, seatsUsed: 10 }
+      )
+    );
+    render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Create Invite" })).toBeInTheDocument();
+    });
+    expect(screen.queryByText(/licensed seats/)).not.toBeInTheDocument();
+  });
+
+  it("prefers the structured message of a seat-cap 403", async () => {
+    const user = userEvent.setup();
+    fetchSpy.mockImplementation(
+      mockFetchForInvite({
+        ok: false,
+        json: async () => ({
+          error: "Seat limit reached",
+          message:
+            "Your license includes 10 seats with grace up to 12. Remove an existing user or pending invitation, or email sales@heypinchy.com for a quote you can accept online.",
+          seatsUsed: 12,
+          maxUsers: 10,
+          graceCap: 12,
+        }),
+      })
+    );
+    render(<InviteDialog open={true} onOpenChange={vi.fn()} />);
+    await user.click(screen.getByRole("button", { name: "Create Invite" }));
+    await waitFor(() => {
+      expect(screen.getByText(/grace up to 12/)).toBeInTheDocument();
     });
   });
 

--- a/packages/web/src/__tests__/components/license-cliff-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/license-cliff-dialog.test.tsx
@@ -1,0 +1,88 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { LicenseCliffDialog } from "@/components/license-cliff-dialog";
+
+function renderDialog(props: Partial<Parameters<typeof LicenseCliffDialog>[0]> = {}) {
+  const onOpenChange = vi.fn();
+  render(
+    <LicenseCliffDialog
+      open={true}
+      onOpenChange={onOpenChange}
+      feature="Groups"
+      description="Control which users can access which agents."
+      campaign="groups"
+      licenseState="community"
+      periodEnd={null}
+      {...props}
+    />
+  );
+  return { onOpenChange };
+}
+
+describe("LicenseCliffDialog", () => {
+  it("offers the free trial first for community instances", () => {
+    renderDialog();
+    expect(screen.getByText(/Groups is included in Pinchy Pro/i)).toBeInTheDocument();
+    expect(screen.getByText("Control which users can access which agents.")).toBeInTheDocument();
+    expect(screen.getByText("30 days, no credit card, key by email.")).toBeInTheDocument();
+
+    const trial = screen.getByRole("link", { name: /start free 30-day trial/i });
+    expect(trial).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups#trial"
+    );
+    const pricing = screen.getByRole("link", { name: /see pricing/i });
+    expect(pricing).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups"
+    );
+  });
+
+  it("uses the visibility campaign for the access-control cliff", () => {
+    renderDialog({ feature: "Access Control", campaign: "visibility" });
+    expect(screen.getByRole("link", { name: /start free 30-day trial/i })).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=visibility#trial"
+    );
+  });
+
+  it("shows pricing without a re-trial offer after an expired trial", () => {
+    renderDialog({
+      licenseState: "trial-expired",
+      periodEnd: "2026-06-01T00:00:00.000Z",
+    });
+    expect(
+      screen.getByText("Your trial ended on Jun 1, 2026. Your configuration is preserved.")
+    ).toBeInTheDocument();
+    expect(screen.queryByRole("link", { name: /start free/i })).not.toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /see pricing/i })).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups"
+    );
+  });
+
+  it("points an expired paid license at the customer portal", () => {
+    renderDialog({
+      licenseState: "expired",
+      periodEnd: "2026-05-01T00:00:00.000Z",
+    });
+    expect(
+      screen.getByText(
+        "Your license period ended on May 1, 2026. Existing access restrictions remain enforced; management features are locked."
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /renew/i })).toHaveAttribute(
+      "href",
+      "https://buy.heypinchy.com/my?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups"
+    );
+  });
+
+  it("dismisses with a plain 'Not now'", async () => {
+    const user = userEvent.setup();
+    const { onOpenChange } = renderDialog();
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    expect(onOpenChange).toHaveBeenCalledWith(false);
+  });
+});

--- a/packages/web/src/__tests__/components/settings-groups.test.tsx
+++ b/packages/web/src/__tests__/components/settings-groups.test.tsx
@@ -215,7 +215,7 @@ describe("SettingsGroups", () => {
       expect(screen.getByText("Groups")).toBeInTheDocument();
     });
 
-    expect(screen.getByText("Enterprise")).toBeInTheDocument();
+    expect(screen.getByText("Pro")).toBeInTheDocument();
     expect(
       screen.getByText(/Create groups to control which users can access which agents/)
     ).toBeInTheDocument();

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -174,6 +174,92 @@ describe("SettingsLicense", () => {
     expect(screen.getByLabelText(/license key/i)).toBeInTheDocument();
   });
 
+  it("offers the audited escape hatch when the license is inactive and gated config exists", async () => {
+    const user = userEvent.setup();
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: false,
+          state: "expired",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2026-05-31T00:00:00Z",
+          paidUntil: "2026-05-01T00:00:00Z",
+          daysRemaining: 0,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: true,
+        }}
+      />
+    );
+    const button = screen.getByRole("button", { name: /remove all license-gated configuration/i });
+    await user.click(button);
+
+    // Confirmation explains exactly what happens — this deliberately widens access.
+    expect(screen.getByText(/deletes all groups/i)).toBeInTheDocument();
+    expect(screen.getByText(/recorded in the audit log/i)).toBeInTheDocument();
+
+    fetchSpy.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ groupsRemoved: 2, agentsReset: 1 }),
+    } as Response);
+
+    await user.click(screen.getByRole("button", { name: /remove configuration/i }));
+    await waitFor(() => {
+      expect(fetchSpy).toHaveBeenCalledWith(
+        "/api/enterprise/gated-config",
+        expect.objectContaining({ method: "DELETE" })
+      );
+    });
+  });
+
+  it("hides the escape hatch when no gated config exists", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: false,
+          state: "expired",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2026-05-31T00:00:00Z",
+          paidUntil: "2026-05-01T00:00:00Z",
+          daysRemaining: 0,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: false,
+        }}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /remove all license-gated configuration/i })
+    ).not.toBeInTheDocument();
+  });
+
+  it("hides the escape hatch while the license is active", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: true,
+          state: "paid",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2027-02-01T00:00:00Z",
+          paidUntil: "2027-01-01T00:00:00Z",
+          daysRemaining: 235,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: true,
+        }}
+      />
+    );
+    expect(
+      screen.queryByRole("button", { name: /remove all license-gated configuration/i })
+    ).not.toBeInTheDocument();
+  });
+
   it("shows the trial-expired copy with a pricing link", () => {
     render(
       <SettingsLicense

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -71,6 +71,136 @@ describe("SettingsLicense", () => {
     expect(screen.getByLabelText(/license key/i)).toBeInTheDocument();
   });
 
+  it("links community instances to the pricing page with settings UTM", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: false,
+          state: "community",
+          type: null,
+          org: null,
+          expiresAt: null,
+          paidUntil: null,
+          daysRemaining: null,
+          managedByEnv: false,
+          maxUsers: 0,
+          seatsUsed: 0,
+          hasGatedConfig: false,
+        }}
+      />
+    );
+    const link = screen.getByRole("link", { name: /see pricing/i });
+    expect(link).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=settings-license&utm_campaign=pro-10"
+    );
+  });
+
+  it("shows the license period end for paid keys with paidUntil", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: true,
+          state: "paid",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2027-02-01T00:00:00Z",
+          paidUntil: "2027-01-01T00:00:00Z",
+          daysRemaining: 235,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: false,
+        }}
+      />
+    );
+    expect(
+      screen.getByText(/License period ends Jan 1, 2027\. Grace until Feb 1, 2027\./)
+    ).toBeInTheDocument();
+  });
+
+  it("shows the grace copy and a renew link during grace", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: true,
+          state: "grace",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2026-07-01T00:00:00Z",
+          paidUntil: "2026-06-01T00:00:00Z",
+          daysRemaining: 19,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: false,
+        }}
+      />
+    );
+    expect(
+      screen.getByText(/License period ended Jun 1, 2026\. Grace until Jul 1, 2026\./)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /renew/i })).toHaveAttribute(
+      "href",
+      "https://buy.heypinchy.com/my?utm_source=pinchy-app&utm_medium=settings-license&utm_campaign=pro-10"
+    );
+  });
+
+  it("shows the expired copy with a renew link for an expired paid key", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: false,
+          state: "expired",
+          type: "paid",
+          org: "Acme Corp",
+          expiresAt: "2026-05-31T00:00:00Z",
+          paidUntil: "2026-05-01T00:00:00Z",
+          daysRemaining: 0,
+          managedByEnv: false,
+          maxUsers: 10,
+          seatsUsed: 3,
+          hasGatedConfig: true,
+        }}
+      />
+    );
+    expect(
+      screen.getByText(
+        /Your license period ended on May 1, 2026\. Existing access restrictions remain enforced; management features are locked\./
+      )
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /renew/i })).toBeInTheDocument();
+    // A new key can be entered right here.
+    expect(screen.getByLabelText(/license key/i)).toBeInTheDocument();
+  });
+
+  it("shows the trial-expired copy with a pricing link", () => {
+    render(
+      <SettingsLicense
+        initialLicense={{
+          enterprise: false,
+          state: "trial-expired",
+          type: "trial",
+          org: "Acme Corp",
+          expiresAt: "2026-06-01T00:00:00Z",
+          paidUntil: null,
+          daysRemaining: 0,
+          managedByEnv: false,
+          maxUsers: 50,
+          seatsUsed: 3,
+          hasGatedConfig: false,
+        }}
+      />
+    );
+    expect(
+      screen.getByText(/Your trial ended on Jun 1, 2026\. Your configuration is preserved\./)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /see pricing/i })).toHaveAttribute(
+      "href",
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=settings-license&utm_campaign=pro-10"
+    );
+  });
+
   it("shows license info when enterprise is true", async () => {
     render(
       <SettingsLicense

--- a/packages/web/src/__tests__/components/settings-users.test.tsx
+++ b/packages/web/src/__tests__/components/settings-users.test.tsx
@@ -745,11 +745,51 @@ describe("SettingsUsers", () => {
     expect(await screen.findByText(/7 of 10 seats used/i)).toBeInTheDocument();
   });
 
-  it("disables the invite button when at the cap", async () => {
+  it("keeps the invite button enabled at 100% (grace window, § 5)", async () => {
     mockFetchForUsers([], [], { enterprise: true, maxUsers: 10, seatsUsed: 10 });
     render(<SettingsUsers currentUserId="u1" />);
     const inviteBtn = await screen.findByRole("button", { name: /invite user/i });
-    expect(inviteBtn).toBeDisabled();
+    expect(inviteBtn).toBeEnabled();
+  });
+
+  it("shows a factual grace notice with quote CTAs when over the cap — never red", async () => {
+    mockFetchForUsers([], [], { enterprise: true, maxUsers: 10, seatsUsed: 11 });
+    render(<SettingsUsers currentUserId="u1" />);
+    const counter = await screen.findByText(/11 of 10 seats used/i);
+    expect(counter.closest("div")!.className).not.toContain("destructive");
+    expect(
+      screen.getByText(/Grace seats keep a new hire from waiting on procurement/i)
+    ).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /email us for a quote/i })).toHaveAttribute(
+      "href",
+      "mailto:sales@heypinchy.com?subject=Pinchy%20seats%20quote%20request"
+    );
+    expect(await screen.findByRole("button", { name: /invite user/i })).toBeEnabled();
+  });
+
+  it("opens the quote dialog instead of the invite dialog beyond the grace cap", async () => {
+    const user = userEvent.setup();
+    mockFetchForUsers([], [], { enterprise: true, maxUsers: 10, seatsUsed: 12 });
+    render(<SettingsUsers currentUserId="u1" />);
+    const inviteBtn = await screen.findByRole("button", { name: /invite user/i });
+    expect(inviteBtn).toBeEnabled();
+    await user.click(inviteBtn);
+
+    expect(screen.getByText(/Need more than 10 seats\?/)).toBeInTheDocument();
+    expect(screen.getByText(/Email us for a quote you can accept online/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /email sales@heypinchy.com/i })).toHaveAttribute(
+      "href",
+      "mailto:sales@heypinchy.com?subject=Pinchy%20seats%20quote%20request"
+    );
+    expect(screen.getByRole("link", { name: /book a call/i })).toHaveAttribute(
+      "href",
+      "https://calendly.com/clemenshelm/pinchy-demo"
+    );
+    // The invite form did not open.
+    expect(screen.queryByLabelText(/email \(optional\)/i)).not.toBeInTheDocument();
+
+    await user.click(screen.getByRole("button", { name: "Not now" }));
+    expect(screen.queryByText(/Need more than 10 seats\?/)).not.toBeInTheDocument();
   });
 
   it("hides banner when license is unlimited", async () => {

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -692,7 +692,7 @@ describe("UsageDashboard", () => {
       await user.click(screen.getByRole("tab", { name: "By User" }));
 
       await waitFor(() => {
-        expect(screen.getByText("Enterprise")).toBeInTheDocument();
+        expect(screen.getByText("Pro")).toBeInTheDocument();
       });
     });
 

--- a/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
+++ b/packages/web/src/__tests__/components/user-detail-sheet.test.tsx
@@ -111,7 +111,22 @@ describe("UserDetailSheet", () => {
     expect(marketingCheckbox).not.toBeChecked();
   });
 
-  it("should hide groups section when not enterprise", () => {
+  it("should hide groups section without a license when the user has no groups", () => {
+    render(
+      <UserDetailSheet
+        user={{ ...mockUser, groups: [] }}
+        allGroups={allGroups}
+        isEnterprise={false}
+        currentUserId="admin-1"
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+    expect(screen.queryByRole("checkbox", { name: /engineering/i })).not.toBeInTheDocument();
+  });
+
+  it("allows removing existing memberships without a license, but not adding (carve-out, § 5)", () => {
     render(
       <UserDetailSheet
         user={mockUser}
@@ -123,7 +138,38 @@ describe("UserDetailSheet", () => {
         onSaved={vi.fn()}
       />
     );
-    expect(screen.queryByRole("checkbox", { name: /engineering/i })).not.toBeInTheDocument();
+    // Existing membership can be removed…
+    const engCheckbox = screen.getByRole("checkbox", { name: /engineering/i });
+    expect(engCheckbox).toBeChecked();
+    expect(engCheckbox).toBeEnabled();
+    // …but new memberships require an active license.
+    expect(screen.getByRole("checkbox", { name: /marketing/i })).toBeDisabled();
+    expect(screen.getByRole("checkbox", { name: /sales/i })).toBeDisabled();
+    expect(
+      screen.getByText(/Adding to groups requires an active license\. Removing always works\./)
+    ).toBeInTheDocument();
+  });
+
+  it("does not allow re-checking a membership that was unchecked without a license", async () => {
+    const user = userEvent.setup();
+    render(
+      <UserDetailSheet
+        user={mockUser}
+        allGroups={allGroups}
+        isEnterprise={false}
+        currentUserId="admin-1"
+        open={true}
+        onOpenChange={vi.fn()}
+        onSaved={vi.fn()}
+      />
+    );
+    const engCheckbox = screen.getByRole("checkbox", { name: /engineering/i });
+    await user.click(engCheckbox);
+    expect(engCheckbox).not.toBeChecked();
+    // Re-checking would ADD a membership server-side relative to nothing —
+    // but the original membership still exists in the DB until saved, so
+    // restoring it stays within the original set and remains allowed.
+    expect(engCheckbox).toBeEnabled();
   });
 
   it("should hide groups section when no groups exist", () => {

--- a/packages/web/src/__tests__/lib/agent-access.test.ts
+++ b/packages/web/src/__tests__/lib/agent-access.test.ts
@@ -28,12 +28,12 @@ vi.mock("@/lib/groups", () => ({
 }));
 
 vi.mock("@/lib/enterprise", () => ({
-  isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 import { db } from "@/db";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
 
 function mockSelectChain(resolvedValue: unknown) {
   vi.mocked(db.select).mockReturnValueOnce({
@@ -264,8 +264,8 @@ describe("getAgentWithAccess", () => {
     expect(res.status).toBe(404);
   });
 
-  it("treats restricted as all when enterprise is false", async () => {
-    vi.mocked(isEnterprise).mockResolvedValueOnce(false);
+  it("treats restricted as all on community instances (never licensed)", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("community");
     const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
     mockSelectChain([agent]);
 
@@ -275,8 +275,8 @@ describe("getAgentWithAccess", () => {
     expect(result).toEqual(agent);
   });
 
-  it("skips group loading when enterprise is false", async () => {
-    vi.mocked(isEnterprise).mockResolvedValueOnce(false);
+  it("skips group loading on community instances", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("community");
     const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
     mockSelectChain([agent]);
 
@@ -285,42 +285,87 @@ describe("getAgentWithAccess", () => {
     expect(getUserGroupIds).not.toHaveBeenCalled();
     expect(getAgentGroupIds).not.toHaveBeenCalled();
   });
+
+  it("keeps restrictions enforced when the license is expired (fail closed, § 5)", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("expired");
+    const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
+    mockSelectChain([agent]);
+
+    const result = await getAgentWithAccess("a1", "user-1", "member");
+
+    expect(result).toBeInstanceOf(NextResponse);
+    expect((result as NextResponse).status).toBe(403);
+    expect(getUserGroupIds).toHaveBeenCalled();
+  });
+
+  it("grants group members access while the license is expired", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("expired");
+    vi.mocked(getUserGroupIds).mockResolvedValueOnce(["g1"]);
+    vi.mocked(getAgentGroupIds).mockResolvedValueOnce(["g1"]);
+    const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
+    mockSelectChain([agent]);
+
+    const result = await getAgentWithAccess("a1", "user-1", "member");
+
+    expect(result).toEqual(agent);
+  });
 });
 
 describe("effectiveVisibility", () => {
-  it("returns 'all' when not enterprise and visibility is 'restricted'", () => {
-    expect(effectiveVisibility("restricted", false)).toBe("all");
+  it("keeps 'restricted' for all licensed states", () => {
+    expect(effectiveVisibility("restricted", "paid")).toBe("restricted");
+    expect(effectiveVisibility("restricted", "trial")).toBe("restricted");
+    expect(effectiveVisibility("restricted", "grace")).toBe("restricted");
   });
 
-  it("returns 'restricted' when enterprise and visibility is 'restricted'", () => {
-    expect(effectiveVisibility("restricted", true)).toBe("restricted");
+  it("keeps 'restricted' after expiry — expiry never widens access (fail closed, § 5)", () => {
+    expect(effectiveVisibility("restricted", "expired")).toBe("restricted");
+    expect(effectiveVisibility("restricted", "trial-expired")).toBe("restricted");
   });
 
-  it("returns 'all' when visibility is 'all' regardless of enterprise", () => {
-    expect(effectiveVisibility("all", false)).toBe("all");
-    expect(effectiveVisibility("all", true)).toBe("all");
+  it("treats 'restricted' as 'all' only on community instances", () => {
+    // Shared agents default to visibility "restricted" in the DB. On an
+    // instance that never had a license, that default was never a deliberate
+    // restriction — mapping it to "all" keeps community instances usable.
+    expect(effectiveVisibility("restricted", "community")).toBe("all");
+  });
+
+  it("returns 'all' when visibility is 'all' regardless of state", () => {
+    expect(effectiveVisibility("all", "community")).toBe("all");
+    expect(effectiveVisibility("all", "paid")).toBe("all");
+    expect(effectiveVisibility("all", "expired")).toBe("all");
   });
 
   it("defaults to 'all' when visibility undefined", () => {
-    expect(effectiveVisibility(undefined, true)).toBe("all");
-    expect(effectiveVisibility(undefined, false)).toBe("all");
+    expect(effectiveVisibility(undefined, "paid")).toBe("all");
+    expect(effectiveVisibility(undefined, "community")).toBe("all");
   });
 });
 
-describe("assertAgentAccess with enterprise=false", () => {
-  it("treats restricted as all when enterprise is false", () => {
+describe("assertAgentAccess license states", () => {
+  it("treats restricted as all on community instances", () => {
     const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
-    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], false)).not.toThrow();
+    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], "community")).not.toThrow();
   });
 
-  it("still restricts when enterprise is true", () => {
+  it("restricts while licensed", () => {
     const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
-    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], true)).toThrow(
+    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], "paid")).toThrow(
       "Access denied"
     );
   });
 
-  it("defaults enterprise to true (backward compat)", () => {
+  it("keeps restricting after expiry (fail closed)", () => {
+    const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
+    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], "expired")).toThrow(
+      "Access denied"
+    );
+    expect(() => assertAgentAccess(agent, "user-1", "member", [], [], "trial-expired")).toThrow(
+      "Access denied"
+    );
+  });
+
+  it("defaults to enforcing restrictions (backward compat)", () => {
     const agent = { id: "a1", ownerId: null, isPersonal: false, visibility: "restricted" };
     expect(() => assertAgentAccess(agent, "user-1", "member", [], [])).toThrow("Access denied");
   });

--- a/packages/web/src/__tests__/lib/conversion-links.test.ts
+++ b/packages/web/src/__tests__/lib/conversion-links.test.ts
@@ -1,0 +1,56 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import {
+  PRICING_URL,
+  PRICING_TRIAL_URL,
+  BUY_PRO_URL,
+  PORTAL_URL,
+  SALES_MAILTO,
+  CALENDLY_URL,
+  conversionLink,
+} from "@/lib/conversion-links";
+
+describe("conversion link constants", () => {
+  it("point at the public funnel surfaces", () => {
+    expect(PRICING_URL).toBe("https://heypinchy.com/pricing");
+    expect(PRICING_TRIAL_URL).toBe("https://heypinchy.com/pricing#trial");
+    expect(BUY_PRO_URL).toBe("https://buy.heypinchy.com/shop/pinchy-pro-5");
+    expect(PORTAL_URL).toBe("https://buy.heypinchy.com/my");
+    expect(CALENDLY_URL).toBe("https://calendly.com/clemenshelm/pinchy-demo");
+  });
+
+  it("sales mailto has a static prefilled subject and no body", () => {
+    expect(SALES_MAILTO).toBe(
+      "mailto:sales@heypinchy.com?subject=Pinchy%20seats%20quote%20request"
+    );
+  });
+});
+
+describe("conversionLink", () => {
+  it("appends the static UTM triple", () => {
+    expect(conversionLink(PRICING_URL, "settings-license", "pro-10")).toBe(
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=settings-license&utm_campaign=pro-10"
+    );
+  });
+
+  it("keeps a #fragment after the UTM params", () => {
+    expect(conversionLink(PRICING_TRIAL_URL, "cliff-modal", "groups")).toBe(
+      "https://heypinchy.com/pricing?utm_source=pinchy-app&utm_medium=cliff-modal&utm_campaign=groups#trial"
+    );
+  });
+
+  it("builds buy links for the trial banner", () => {
+    expect(conversionLink(BUY_PRO_URL, "trial-banner", "pro-10")).toBe(
+      "https://buy.heypinchy.com/shop/pinchy-pro-5?utm_source=pinchy-app&utm_medium=trial-banner&utm_campaign=pro-10"
+    );
+  });
+
+  // D-011 zero-telemetry: links must be fully static. No instance or user
+  // identifiers may ever reach a URL — the only variable parts are the
+  // vocabulary-typed medium and campaign.
+  it("produces no characters outside the static URL alphabet (D-011)", () => {
+    const url = conversionLink(BUY_PRO_URL, "expired-banner", "pro-10");
+    expect(url).not.toMatch(/%[0-9A-F]{2}/i);
+    expect(new URL(url).searchParams.size).toBe(3);
+  });
+});

--- a/packages/web/src/__tests__/lib/license-state.test.ts
+++ b/packages/web/src/__tests__/lib/license-state.test.ts
@@ -1,0 +1,82 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { deriveLicenseState } from "@/lib/license-state";
+import { makeLicense } from "../helpers/license-fixtures";
+
+const NOW = new Date("2026-06-12T12:00:00.000Z");
+const DAYS = 86400000;
+
+describe("deriveLicenseState", () => {
+  it("returns community when there is no valid key", () => {
+    const status = { active: false, features: [], ver: 1, maxUsers: 0 };
+    expect(deriveLicenseState(status, NOW)).toBe("community");
+  });
+
+  it("returns trial for a valid trial key", () => {
+    const status = makeLicense({ type: "trial" });
+    expect(deriveLicenseState(status, NOW)).toBe("trial");
+  });
+
+  it("returns trial-expired for an expired trial key", () => {
+    const status = makeLicense({
+      active: false,
+      expired: true,
+      type: "trial",
+      expiresAt: new Date(NOW.getTime() - 1 * DAYS),
+    });
+    expect(deriveLicenseState(status, NOW)).toBe("trial-expired");
+  });
+
+  it("returns paid for a valid paid key without paidUntil", () => {
+    const status = makeLicense({ type: "paid" });
+    expect(deriveLicenseState(status, NOW)).toBe("paid");
+  });
+
+  it("returns paid while now is before paidUntil", () => {
+    const status = makeLicense({
+      type: "paid",
+      paidUntilAt: new Date(NOW.getTime() + 10 * DAYS),
+    });
+    expect(deriveLicenseState(status, NOW)).toBe("paid");
+  });
+
+  it("returns grace between paidUntil and exp", () => {
+    const status = makeLicense({
+      type: "paid",
+      paidUntilAt: new Date(NOW.getTime() - 1 * DAYS),
+      expiresAt: new Date(NOW.getTime() + 29 * DAYS),
+    });
+    expect(deriveLicenseState(status, NOW)).toBe("grace");
+  });
+
+  it("returns expired for a paid key past exp", () => {
+    const status = makeLicense({
+      active: false,
+      expired: true,
+      type: "paid",
+      paidUntilAt: new Date(NOW.getTime() - 31 * DAYS),
+      expiresAt: new Date(NOW.getTime() - 1 * DAYS),
+    });
+    expect(deriveLicenseState(status, NOW)).toBe("expired");
+  });
+
+  it("treats an active key without type as paid", () => {
+    const status = makeLicense({ type: undefined });
+    expect(deriveLicenseState(status, NOW)).toBe("paid");
+  });
+
+  it("treats an expired key without type as expired (not trial-expired)", () => {
+    const status = makeLicense({ active: false, expired: true, type: undefined });
+    expect(deriveLicenseState(status, NOW)).toBe("expired");
+  });
+
+  it("isLicenseActive reflects the gate-unlocking states", async () => {
+    const { isLicenseActive } = await import("@/lib/license-state");
+    expect(isLicenseActive("paid")).toBe(true);
+    expect(isLicenseActive("trial")).toBe(true);
+    expect(isLicenseActive("grace")).toBe(true);
+    expect(isLicenseActive("community")).toBe(false);
+    expect(isLicenseActive("trial-expired")).toBe(false);
+    expect(isLicenseActive("expired")).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/license.test.ts
+++ b/packages/web/src/__tests__/lib/license.test.ts
@@ -40,17 +40,82 @@ describe("validateLicense", () => {
     expect(status.daysRemaining).toBeGreaterThan(0);
   });
 
-  it("returns active=false for an expired token", async () => {
+  it("returns active=false but preserves claims for an expired token", async () => {
     const { validateLicense } = await import("@/lib/license");
     // jose checks exp against the current clock — advance the system clock
     // past the token's expiry instead of waiting in real time.
     vi.useFakeTimers();
     try {
-      const token = await createTestToken({}, "1s");
+      const token = await createTestToken({ type: "paid", maxUsers: 10 }, "1s");
       vi.setSystemTime(Date.now() + 1500);
       const status = await validateLicense(token, testPublicKeyPem);
       expect(status.active).toBe(false);
+      // The signature was valid — only exp has passed. The app needs the
+      // claims to tell "expired" apart from "community" (pricing concept § 6).
+      expect(status.expired).toBe(true);
+      expect(status.type).toBe("paid");
+      expect(status.org).toBe("test-org");
+      expect(status.maxUsers).toBe(10);
+      expect(status.expiresAt).toBeInstanceOf(Date);
+      expect(status.features).toEqual(["enterprise"]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("does not set expired for an expired token with an invalid signature", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const { privateKey: wrongKey } = await jose.generateKeyPair("ES256", {
+      extractable: true,
+    });
+    vi.useFakeTimers();
+    try {
+      const token = await new jose.SignJWT({ type: "paid", features: ["enterprise"] })
+        .setProtectedHeader({ alg: "ES256" })
+        .setIssuer("heypinchy.com")
+        .setSubject("test-org")
+        .setIssuedAt()
+        .setExpirationTime("1s")
+        .sign(wrongKey);
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.active).toBe(false);
+      expect(status.expired).toBeUndefined();
       expect(status.features).toEqual([]);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats an expired token with wrong issuer as inactive, not expired", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    vi.useFakeTimers();
+    try {
+      const token = await new jose.SignJWT({ type: "paid", features: ["enterprise"] })
+        .setProtectedHeader({ alg: "ES256" })
+        .setIssuer("evil.example.com")
+        .setSubject("test-org")
+        .setIssuedAt()
+        .setExpirationTime("1s")
+        .sign(testPrivateKey);
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.active).toBe(false);
+      expect(status.expired).toBeUndefined();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("treats an expired token without the enterprise feature as inactive, not expired", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    vi.useFakeTimers();
+    try {
+      const token = await createTestToken({ features: ["something-else"] }, "1s");
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.active).toBe(false);
+      expect(status.expired).toBeUndefined();
     } finally {
       vi.useRealTimers();
     }
@@ -156,5 +221,44 @@ describe("validateLicense", () => {
     expect(status.active).toBe(false);
     expect(status.ver).toBe(1);
     expect(status.maxUsers).toBe(0);
+  });
+
+  it("reads a numeric paidUntil claim as paidUntilAt", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const paidUntilSeconds = Math.floor(Date.now() / 1000) + 30 * 86400;
+    const token = await createTestToken({ type: "paid", paidUntil: paidUntilSeconds }, "60d");
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.paidUntilAt).toBeInstanceOf(Date);
+    expect(status.paidUntilAt!.getTime()).toBe(paidUntilSeconds * 1000);
+  });
+
+  it("leaves paidUntilAt undefined when the claim is missing", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({ type: "paid" }, "60d");
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.paidUntilAt).toBeUndefined();
+  });
+
+  it("ignores a non-numeric paidUntil claim (additive tolerance)", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    const token = await createTestToken({ type: "paid", paidUntil: "2027-01-01" }, "60d");
+    const status = await validateLicense(token, testPublicKeyPem);
+    expect(status.active).toBe(true);
+    expect(status.paidUntilAt).toBeUndefined();
+  });
+
+  it("preserves paidUntilAt on an expired token", async () => {
+    const { validateLicense } = await import("@/lib/license");
+    vi.useFakeTimers();
+    try {
+      const paidUntilSeconds = Math.floor(Date.now() / 1000) - 86400;
+      const token = await createTestToken({ type: "paid", paidUntil: paidUntilSeconds }, "1s");
+      vi.setSystemTime(Date.now() + 1500);
+      const status = await validateLicense(token, testPublicKeyPem);
+      expect(status.expired).toBe(true);
+      expect(status.paidUntilAt!.getTime()).toBe(paidUntilSeconds * 1000);
+    } finally {
+      vi.useRealTimers();
+    }
   });
 });

--- a/packages/web/src/__tests__/lib/seat-grace.test.ts
+++ b/packages/web/src/__tests__/lib/seat-grace.test.ts
@@ -1,0 +1,48 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { evaluateSeatPressure } from "@/lib/seat-grace";
+
+describe("evaluateSeatPressure", () => {
+  it("is unlimited when maxUsers is 0 (community / no cap)", () => {
+    const p = evaluateSeatPressure(42, 0);
+    expect(p.unlimited).toBe(true);
+    expect(p.overCap).toBe(false);
+    expect(p.inviteAllowed).toBe(true);
+    expect(p.graceCap).toBeNull();
+  });
+
+  it("computes the grace cap as floor(1.2 * maxUsers)", () => {
+    expect(evaluateSeatPressure(0, 10).graceCap).toBe(12);
+    expect(evaluateSeatPressure(0, 50).graceCap).toBe(60);
+    expect(evaluateSeatPressure(0, 7).graceCap).toBe(8);
+  });
+
+  it("is normal up to and including 100%", () => {
+    const p = evaluateSeatPressure(10, 10);
+    expect(p.overCap).toBe(false);
+    expect(p.inviteAllowed).toBe(true);
+  });
+
+  it("flags over-cap inside the grace window and still allows invites", () => {
+    const at11 = evaluateSeatPressure(11, 10);
+    expect(at11.overCap).toBe(true);
+    expect(at11.inviteAllowed).toBe(true);
+
+    // Seat 12 is the last grace seat — it exists, but no further invite.
+    const at12 = evaluateSeatPressure(12, 10);
+    expect(at12.overCap).toBe(true);
+    expect(at12.inviteAllowed).toBe(false);
+  });
+
+  it("blocks invites beyond the grace cap", () => {
+    const p = evaluateSeatPressure(13, 10);
+    expect(p.overCap).toBe(true);
+    expect(p.inviteAllowed).toBe(false);
+  });
+
+  it("never reports over-cap for negative or zero usage", () => {
+    const p = evaluateSeatPressure(0, 10);
+    expect(p.overCap).toBe(false);
+    expect(p.inviteAllowed).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/visible-agents.test.ts
+++ b/packages/web/src/__tests__/lib/visible-agents.test.ts
@@ -22,12 +22,12 @@ vi.mock("@/lib/groups", () => ({
 }));
 
 vi.mock("@/lib/enterprise", () => ({
-  isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 import { db } from "@/db";
 import { getUserGroupIds, getAgentGroupIds, getAllAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
 
 function mockSelectChain(resolvedValue: unknown) {
   vi.mocked(db.select).mockReturnValueOnce({
@@ -157,8 +157,8 @@ describe("getVisibleAgents", () => {
     expect(getAgentGroupIds).not.toHaveBeenCalled();
   });
 
-  it("member sees restricted agents when enterprise is false (graceful degradation)", async () => {
-    vi.mocked(isEnterprise).mockResolvedValueOnce(false);
+  it("member sees restricted agents on community instances (never licensed)", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("community");
     vi.mocked(getUserGroupIds).mockResolvedValue([]);
     vi.mocked(getAllAgentGroupIds).mockResolvedValue(new Map());
     mockSelectChain(allAgents);
@@ -168,8 +168,8 @@ describe("getVisibleAgents", () => {
     expect(result).toContainEqual(sharedAgentRestricted);
   });
 
-  it("skips group loading for member when enterprise is false", async () => {
-    vi.mocked(isEnterprise).mockResolvedValueOnce(false);
+  it("skips group loading for member on community instances", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("community");
     vi.mocked(getUserGroupIds).mockResolvedValue([]);
     vi.mocked(getAllAgentGroupIds).mockResolvedValue(new Map());
     mockSelectChain(allAgents);
@@ -178,5 +178,27 @@ describe("getVisibleAgents", () => {
 
     expect(getUserGroupIds).not.toHaveBeenCalled();
     expect(getAllAgentGroupIds).not.toHaveBeenCalled();
+  });
+
+  it("keeps restricted agents hidden when the license is expired (fail closed, § 5)", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("expired");
+    vi.mocked(getUserGroupIds).mockResolvedValue([]);
+    vi.mocked(getAllAgentGroupIds).mockResolvedValue(new Map());
+    mockSelectChain(allAgents);
+
+    const result = await getVisibleAgents("user-1", "member");
+
+    expect(result).not.toContainEqual(sharedAgentRestricted);
+  });
+
+  it("keeps group-based access working when the license is expired", async () => {
+    vi.mocked(getLicenseState).mockResolvedValueOnce("expired");
+    vi.mocked(getUserGroupIds).mockResolvedValue(["g1"]);
+    vi.mocked(getAllAgentGroupIds).mockResolvedValue(new Map([[sharedAgentRestricted.id, ["g1"]]]));
+    mockSelectChain(allAgents);
+
+    const result = await getVisibleAgents("user-1", "member");
+
+    expect(result).toContainEqual(sharedAgentRestricted);
   });
 });

--- a/packages/web/src/__tests__/security/groups-auth-check.test.ts
+++ b/packages/web/src/__tests__/security/groups-auth-check.test.ts
@@ -3,6 +3,27 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 vi.mock("@/lib/api-auth");
 vi.mock("@/lib/enterprise");
 
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/telegram-allow-store", () => ({
+  recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
+}));
+
+const mockSelectGroupBy = vi.fn().mockResolvedValue([]);
+const mockSelectLeftJoin = vi.fn().mockReturnValue({ groupBy: mockSelectGroupBy });
+const mockSelectWhere = vi.fn().mockResolvedValue([]);
+const mockSelectFrom = vi
+  .fn()
+  .mockReturnValue({ leftJoin: mockSelectLeftJoin, where: mockSelectWhere });
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => ({ from: mockSelectFrom })),
+  },
+}));
+
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { NextResponse } from "next/server";
@@ -78,12 +99,10 @@ describe("groups API enterprise gate", () => {
     (isEnterprise as any).mockResolvedValue(false);
   });
 
-  it("GET /api/groups returns 403 without enterprise", async () => {
+  it("GET /api/groups stays readable without enterprise (removal carve-out needs it, § 5)", async () => {
     const { GET } = await import("@/app/api/groups/route");
     const res = await GET();
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error).toBe("Enterprise feature");
+    expect(res.status).toBe(200);
   });
 
   it("POST /api/groups returns 403 without enterprise", async () => {
@@ -121,25 +140,27 @@ describe("groups API enterprise gate", () => {
     expect(body.error).toBe("Enterprise feature");
   });
 
-  it("GET /api/groups/:id/members returns 403 without enterprise", async () => {
+  it("GET /api/groups/:id/members stays readable without enterprise (removal carve-out, § 5)", async () => {
+    mockSelectWhere.mockResolvedValueOnce([{ id: "g1" }]); // group exists
+    mockSelectWhere.mockResolvedValueOnce([]); // members
     const { GET } = await import("@/app/api/groups/[groupId]/members/route");
     const req = new Request("http://localhost", { method: "GET" });
     const res = await GET(req as any, { params: Promise.resolve({ groupId: "g1" }) });
-    expect(res.status).toBe(403);
-    const body = await res.json();
-    expect(body.error).toBe("Enterprise feature");
+    expect(res.status).toBe(200);
   });
 
-  it("PUT /api/groups/:id/members returns 403 without enterprise", async () => {
+  it("PUT /api/groups/:id/members returns 403 when ADDING members without enterprise", async () => {
+    mockSelectWhere.mockResolvedValueOnce([{ id: "g1" }]); // group exists
+    mockSelectWhere.mockResolvedValueOnce([]); // existing members: none
     const { PUT } = await import("@/app/api/groups/[groupId]/members/route");
     const req = new Request("http://localhost", {
       method: "PUT",
-      body: JSON.stringify({ userIds: [] }),
+      body: JSON.stringify({ userIds: ["u1"] }),
       headers: { "Content-Type": "application/json" },
     });
     const res = await PUT(req as any, { params: Promise.resolve({ groupId: "g1" }) });
     expect(res.status).toBe(403);
     const body = await res.json();
-    expect(body.error).toBe("Enterprise feature");
+    expect(body.error).toBe("License required");
   });
 });

--- a/packages/web/src/__tests__/server/client-router-active-runs.test.ts
+++ b/packages/web/src/__tests__/server/client-router-active-runs.test.ts
@@ -60,6 +60,7 @@ vi.mock("@/lib/agent-access", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
 }));
 
 vi.mock("@/lib/groups", () => ({

--- a/packages/web/src/__tests__/server/client-router-broadcast.test.ts
+++ b/packages/web/src/__tests__/server/client-router-broadcast.test.ts
@@ -64,6 +64,7 @@ vi.mock("@/lib/agent-access", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
 }));
 
 vi.mock("@/lib/groups", () => ({

--- a/packages/web/src/__tests__/server/client-router-heartbeat.test.ts
+++ b/packages/web/src/__tests__/server/client-router-heartbeat.test.ts
@@ -76,6 +76,7 @@ vi.mock("@/lib/agent-access", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
 }));
 
 vi.mock("@/lib/groups", () => ({

--- a/packages/web/src/__tests__/server/client-router-history-resume.test.ts
+++ b/packages/web/src/__tests__/server/client-router-history-resume.test.ts
@@ -55,6 +55,7 @@ vi.mock("@/lib/agent-access", () => ({
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(false),
+  getLicenseState: vi.fn().mockResolvedValue("community"),
 }));
 
 vi.mock("@/lib/groups", () => ({

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -61,6 +61,7 @@ vi.mock("@/lib/agent-access", async (importOriginal) => {
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 vi.mock("@/db", () => ({

--- a/packages/web/src/__tests__/server/ws-protocol-outdated.test.ts
+++ b/packages/web/src/__tests__/server/ws-protocol-outdated.test.ts
@@ -40,6 +40,7 @@ vi.mock("@/lib/agent-access", async (importOriginal) => {
 
 vi.mock("@/lib/enterprise", () => ({
   isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
 }));
 
 vi.mock("@/db", () => ({

--- a/packages/web/src/app/(app)/chat/[agentId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/page.tsx
@@ -7,7 +7,7 @@ import { Chat } from "@/components/chat";
 import { requireAuth } from "@/lib/require-auth";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
 import { getAgentAvatarSvg } from "@/lib/avatar";
 
 export async function generateMetadata({
@@ -39,8 +39,8 @@ export default async function ChatPage({ params }: { params: Promise<{ agentId: 
 
   if (!agent) notFound();
 
-  const enterprise = await isEnterprise();
-  const effVis = effectiveVisibility(agent.visibility, enterprise);
+  const licenseState = await getLicenseState();
+  const effVis = effectiveVisibility(agent.visibility, licenseState);
   const needsGroups = userRole !== "admin" && effVis === "restricted";
 
   const [userGroupIds, agentGroupIds] = await Promise.all([
@@ -49,7 +49,7 @@ export default async function ChatPage({ params }: { params: Promise<{ agentId: 
   ]);
 
   try {
-    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, enterprise);
+    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
   } catch {
     notFound();
   }

--- a/packages/web/src/app/(app)/settings/page.tsx
+++ b/packages/web/src/app/(app)/settings/page.tsx
@@ -2,7 +2,9 @@ import type { Metadata } from "next";
 import { headers } from "next/headers";
 import { getSession } from "@/lib/auth";
 import { getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
+import { deriveLicenseState, isLicenseActive } from "@/lib/license-state";
 import { getSeatUsage } from "@/lib/seat-usage";
+import { hasGatedConfig } from "@/lib/gated-config";
 import { SettingsPageContent } from "@/components/settings-page-content";
 
 export const metadata: Metadata = {
@@ -22,6 +24,8 @@ export default async function SettingsPage({
   ]);
   const isAdmin = session?.user?.role === "admin";
   const usage = isAdmin ? await getSeatUsage(licenseStatus) : null;
+  const state = deriveLicenseState(licenseStatus, new Date());
+  const gatedConfig = isAdmin && !isLicenseActive(state) ? await hasGatedConfig() : false;
   return (
     <SettingsPageContent
       initialTab={tab}
@@ -30,13 +34,16 @@ export default async function SettingsPage({
         isAdmin
           ? {
               enterprise: licenseStatus.active,
+              state,
               type: licenseStatus.type ?? null,
               org: licenseStatus.org ?? null,
               expiresAt: licenseStatus.expiresAt?.toISOString() ?? null,
+              paidUntil: licenseStatus.paidUntilAt?.toISOString() ?? null,
               daysRemaining: licenseStatus.daysRemaining ?? null,
               managedByEnv: isKeyFromEnv(),
               maxUsers: licenseStatus.maxUsers,
               seatsUsed: usage?.used ?? 0,
+              hasGatedConfig: gatedConfig,
             }
           : undefined
       }

--- a/packages/web/src/app/(app)/usage/page.tsx
+++ b/packages/web/src/app/(app)/usage/page.tsx
@@ -3,7 +3,8 @@ import { getSession } from "@/lib/auth";
 import { headers } from "next/headers";
 import { redirect } from "next/navigation";
 import { UsageDashboard } from "@/components/usage-dashboard";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseStatus } from "@/lib/enterprise";
+import { deriveLicenseState } from "@/lib/license-state";
 
 export const metadata: Metadata = {
   title: "Usage & Costs",
@@ -15,11 +16,18 @@ export default async function UsagePage() {
     redirect("/");
   }
 
-  const enterprise = await isEnterprise();
+  const licenseStatus = await getLicenseStatus();
+  const licenseState = deriveLicenseState(licenseStatus, new Date());
 
   return (
     <div className="flex-1 overflow-auto p-6">
-      <UsageDashboard isEnterprise={enterprise} />
+      <UsageDashboard
+        isEnterprise={licenseStatus.active}
+        licenseState={licenseState}
+        licensePeriodEnd={
+          licenseStatus.paidUntilAt?.toISOString() ?? licenseStatus.expiresAt?.toISOString() ?? null
+        }
+      />
     </div>
   );
 }

--- a/packages/web/src/app/api/enterprise/gated-config/route.ts
+++ b/packages/web/src/app/api/enterprise/gated-config/route.ts
@@ -30,8 +30,10 @@ export async function DELETE() {
   }
 
   const removed = await removeGatedConfig();
-  await recalculateTelegramAllowStores();
 
+  // Audit immediately after the mutation, BEFORE any follow-up plumbing —
+  // a telegram-recalc failure must not leave an access-widening action
+  // without a trail.
   const truncated = removed.groups.length > SNAPSHOT_CAP || removed.agents.length > SNAPSHOT_CAP;
   await appendAuditLog({
     actorType: "user",
@@ -46,6 +48,8 @@ export async function DELETE() {
     },
     outcome: "success",
   });
+
+  await recalculateTelegramAllowStores();
 
   return NextResponse.json({
     groupsRemoved: removed.groups.length,

--- a/packages/web/src/app/api/enterprise/gated-config/route.ts
+++ b/packages/web/src/app/api/enterprise/gated-config/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+import { requireAdmin } from "@/lib/api-auth";
+import { isEnterprise } from "@/lib/enterprise";
+import { removeGatedConfig } from "@/lib/gated-config";
+import { appendAuditLog } from "@/lib/audit";
+import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
+
+/** Cap list snapshots so the audit detail stays under the 2048-byte budget. */
+const SNAPSHOT_CAP = 20;
+
+/**
+ * "Remove all license-gated configuration" — the audited escape hatch back
+ * to community semantics (pricing concept § 5, carve-out 2). Only available
+ * while no license is active: with an active license this would just be
+ * regular (gated) management.
+ */
+export async function DELETE() {
+  const sessionOrError = await requireAdmin();
+  if (sessionOrError instanceof NextResponse) return sessionOrError;
+  const session = sessionOrError;
+
+  if (await isEnterprise()) {
+    return NextResponse.json(
+      {
+        error: "License is active",
+        message: "Gated configuration can be managed normally while a license is active.",
+      },
+      { status: 409 }
+    );
+  }
+
+  const removed = await removeGatedConfig();
+  await recalculateTelegramAllowStores();
+
+  const truncated = removed.groups.length > SNAPSHOT_CAP || removed.agents.length > SNAPSHOT_CAP;
+  await appendAuditLog({
+    actorType: "user",
+    actorId: session.user.id!,
+    eventType: "config.gated_config_removed",
+    detail: {
+      groupsRemoved: removed.groups.length,
+      agentsReset: removed.agents.length,
+      groups: removed.groups.slice(0, SNAPSHOT_CAP),
+      agents: removed.agents.slice(0, SNAPSHOT_CAP),
+      truncated,
+    },
+    outcome: "success",
+  });
+
+  return NextResponse.json({
+    groupsRemoved: removed.groups.length,
+    agentsReset: removed.agents.length,
+  });
+}

--- a/packages/web/src/app/api/enterprise/status/route.ts
+++ b/packages/web/src/app/api/enterprise/status/route.ts
@@ -1,19 +1,28 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-auth";
 import { getLicenseStatus, isKeyFromEnv } from "@/lib/enterprise";
+import { deriveLicenseState, isLicenseActive } from "@/lib/license-state";
 import { getSeatUsage } from "@/lib/seat-usage";
+import { hasGatedConfig } from "@/lib/gated-config";
 
 export const GET = withAuth(async () => {
   const status = await getLicenseStatus();
+  const state = deriveLicenseState(status, new Date());
   const usage = status.active ? await getSeatUsage(status) : null;
+  // Only relevant for the "Remove all license-gated configuration" escape
+  // hatch, which exists for instances without an active license.
+  const gatedConfig = isLicenseActive(state) ? false : await hasGatedConfig();
   return NextResponse.json({
     enterprise: status.active,
+    state,
     type: status.type ?? null,
     org: status.org ?? null,
     expiresAt: status.expiresAt?.toISOString() ?? null,
+    paidUntil: status.paidUntilAt?.toISOString() ?? null,
     daysRemaining: status.daysRemaining ?? null,
     managedByEnv: isKeyFromEnv(),
     seatsUsed: usage?.used ?? 0,
     maxUsers: status.maxUsers,
+    hasGatedConfig: gatedConfig,
   });
 });

--- a/packages/web/src/app/api/enterprise/status/route.ts
+++ b/packages/web/src/app/api/enterprise/status/route.ts
@@ -5,13 +5,16 @@ import { deriveLicenseState, isLicenseActive } from "@/lib/license-state";
 import { getSeatUsage } from "@/lib/seat-usage";
 import { hasGatedConfig } from "@/lib/gated-config";
 
-export const GET = withAuth(async () => {
+export const GET = withAuth(async (_req, _ctx, session) => {
   const status = await getLicenseStatus();
   const state = deriveLicenseState(status, new Date());
   const usage = status.active ? await getSeatUsage(status) : null;
   // Only relevant for the "Remove all license-gated configuration" escape
-  // hatch, which exists for instances without an active license.
-  const gatedConfig = isLicenseActive(state) ? false : await hasGatedConfig();
+  // hatch — an admin-only surface on instances without an active license.
+  // Skipping it everywhere else keeps the frequently polled status endpoint
+  // free of extra DB work.
+  const gatedConfig =
+    session.user.role === "admin" && !isLicenseActive(state) ? await hasGatedConfig() : false;
   return NextResponse.json({
     enterprise: status.active,
     state,

--- a/packages/web/src/app/api/groups/[groupId]/members/route.ts
+++ b/packages/web/src/app/api/groups/[groupId]/members/route.ts
@@ -21,10 +21,8 @@ export async function GET(
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  if (!(await isEnterprise())) {
-    return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
-  }
-
+  // No license gate: admins need to see memberships to REMOVE users from
+  // groups, which must always work (fail-closed carve-out, § 5).
   const { groupId } = await params;
 
   if (!(await groupExists(groupId))) {
@@ -47,10 +45,6 @@ export async function PUT(
   if (sessionOrError instanceof NextResponse) return sessionOrError;
   const session = sessionOrError;
 
-  if (!(await isEnterprise())) {
-    return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
-  }
-
   const { groupId } = await params;
   const parsed = await parseRequestBody(setMembersSchema, request);
   if ("error" in parsed) return parsed.error;
@@ -70,6 +64,21 @@ export async function PUT(
 
   const addedIds = [...newIds].filter((id) => !existingIds.has(id));
   const removedIds = [...existingIds].filter((id) => !newIds.has(id));
+
+  // Fail closed with a carve-out (pricing concept § 5): without an active
+  // license, group management is locked — but restriction-TIGHTENING
+  // operations must always work. Removing members tightens; adding members
+  // requires a license.
+  if (addedIds.length > 0 && !(await isEnterprise())) {
+    return NextResponse.json(
+      {
+        error: "License required",
+        message:
+          "Adding users to groups requires an active license. Removing users from groups always works.",
+      },
+      { status: 403 }
+    );
+  }
 
   // Resolve names for changed users
   const changedIds = [...addedIds, ...removedIds];

--- a/packages/web/src/app/api/groups/route.ts
+++ b/packages/web/src/app/api/groups/route.ts
@@ -12,10 +12,8 @@ export async function GET() {
   const sessionOrError = await requireAdmin();
   if (sessionOrError instanceof NextResponse) return sessionOrError;
 
-  if (!(await isEnterprise())) {
-    return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
-  }
-
+  // No license gate: admins need to list groups to REMOVE users from them,
+  // which must always work (fail-closed carve-out, § 5).
   const allGroups = await db
     .select({
       id: groups.id,

--- a/packages/web/src/app/api/users/[userId]/groups/route.ts
+++ b/packages/web/src/app/api/users/[userId]/groups/route.ts
@@ -21,10 +21,6 @@ export async function PUT(
   if (sessionOrError instanceof NextResponse) return sessionOrError;
   const session = sessionOrError;
 
-  if (!(await isEnterprise())) {
-    return NextResponse.json({ error: "Enterprise feature" }, { status: 403 });
-  }
-
   const { userId } = await params;
   const parsed = await parseRequestBody(updateUserGroupsSchema, request);
   if ("error" in parsed) return parsed.error;
@@ -70,6 +66,21 @@ export async function PUT(
   const removed = [...previousGroupIds]
     .filter((id) => !newGroupIdSet.has(id))
     .map((id) => ({ id, name: nameMap.get(id) ?? id }));
+
+  // Fail closed with a carve-out (pricing concept § 5): without an active
+  // license, group management is locked — but restriction-TIGHTENING
+  // operations must always work. Removing a user from a group tightens;
+  // adding one requires a license.
+  if (added.length > 0 && !(await isEnterprise())) {
+    return NextResponse.json(
+      {
+        error: "License required",
+        message:
+          "Adding users to groups requires an active license. Removing users from groups always works.",
+      },
+      { status: 403 }
+    );
+  }
 
   // 5. Delete all existing userGroups for this userId
   await db.delete(userGroups).where(eq(userGroups.userId, userId));

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -5,6 +5,7 @@ import { createInvite } from "@/lib/invites";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
 import { getLicenseStatus } from "@/lib/enterprise";
 import { getSeatUsage } from "@/lib/seat-usage";
+import { evaluateSeatPressure } from "@/lib/seat-grace";
 import { db } from "@/db";
 import { groups } from "@/db/schema";
 import { inArray } from "drizzle-orm";
@@ -28,7 +29,11 @@ export async function POST(request: NextRequest) {
   const license = await getLicenseStatus();
   if (license.active && license.maxUsers > 0) {
     const usage = await getSeatUsage(license);
-    if (usage.used >= license.maxUsers) {
+    // Soft cap with a 20% grace window (pricing concept § 5): invites keep
+    // working up to floor(1.2 * maxUsers) seats so a new hire never waits on
+    // procurement. Existing users are never deactivated or degraded.
+    const pressure = evaluateSeatPressure(usage.used, license.maxUsers);
+    if (!pressure.inviteAllowed) {
       after(() =>
         appendAuditLog({
           actorType: "user",
@@ -40,6 +45,7 @@ export async function POST(request: NextRequest) {
             reason: "seat_cap",
             seatsUsed: usage.used,
             maxUsers: license.maxUsers,
+            graceCap: pressure.graceCap,
           },
           outcome: "failure",
           error: { message: "Seat cap reached" },
@@ -48,9 +54,10 @@ export async function POST(request: NextRequest) {
       return NextResponse.json(
         {
           error: "Seat limit reached",
-          message: `Your license allows ${license.maxUsers} seats, all are in use. Remove an existing user or pending invitation, or upgrade your subscription.`,
+          message: `Your license includes ${license.maxUsers} seats with grace up to ${pressure.graceCap}. Remove an existing user or pending invitation, or email sales@heypinchy.com for a quote you can accept online.`,
           seatsUsed: usage.used,
           maxUsers: license.maxUsers,
+          graceCap: pressure.graceCap,
         },
         { status: 403 }
       );

--- a/packages/web/src/components/agent-settings-access.tsx
+++ b/packages/web/src/components/agent-settings-access.tsx
@@ -26,6 +26,7 @@ interface AgentSettingsAccessProps {
   agent: { visibility: string };
   currentGroupIds: string[];
   onChange: (values: AccessValues, isDirty: boolean) => void;
+  isAdmin?: boolean;
 }
 
 function sortedJson(arr: string[]) {
@@ -36,6 +37,7 @@ export function AgentSettingsAccess({
   agent,
   currentGroupIds,
   onChange,
+  isAdmin = true,
 }: AgentSettingsAccessProps) {
   const [visibility, setVisibility] = useState(agent.visibility || "restricted");
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>(currentGroupIds);
@@ -105,6 +107,8 @@ export function AgentSettingsAccess({
       <EnterpriseFeatureCard
         feature="Access Control"
         description="Control which users and groups can access this agent. Set visibility to specific groups or make agents available to everyone."
+        campaign="visibility"
+        isAdmin={isAdmin}
       />
     );
   }

--- a/packages/web/src/components/agent-settings-access.tsx
+++ b/packages/web/src/components/agent-settings-access.tsx
@@ -11,6 +11,7 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
+import type { LicenseState } from "@/lib/license-state";
 
 interface AccessValues {
   visibility: string;
@@ -43,6 +44,8 @@ export function AgentSettingsAccess({
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>(currentGroupIds);
   const [groups, setGroups] = useState<Group[]>([]);
   const [isEnterprise, setIsEnterprise] = useState<boolean | null>(null);
+  const [licenseState, setLicenseState] = useState<LicenseState>("community");
+  const [licensePeriodEnd, setLicensePeriodEnd] = useState<string | null>(null);
 
   // Baseline tracks the last saved server state (updates when props change after save + refetch)
   const [baselineVisibility, setBaselineVisibility] = useState(agent.visibility || "restricted");
@@ -66,7 +69,11 @@ export function AgentSettingsAccess({
   useEffect(() => {
     fetch("/api/enterprise/status")
       .then((res) => (res.ok ? res.json() : { enterprise: false }))
-      .then((data) => setIsEnterprise(data.enterprise))
+      .then((data) => {
+        setIsEnterprise(data.enterprise);
+        if (data.state) setLicenseState(data.state);
+        setLicensePeriodEnd(data.paidUntil ?? data.expiresAt ?? null);
+      })
       .catch(() => setIsEnterprise(false));
   }, []);
 
@@ -109,6 +116,8 @@ export function AgentSettingsAccess({
         description="Control which users and groups can access this agent. Set visibility to specific groups or make agents available to everyone."
         campaign="visibility"
         isAdmin={isAdmin}
+        licenseState={licenseState}
+        periodEnd={licensePeriodEnd}
       />
     );
   }

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -473,6 +473,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
                 agent={{ visibility: agent.visibility }}
                 currentGroupIds={agent.groupIds || []}
                 onChange={handleAccessChange}
+                isAdmin={isAdmin}
               />
             </TabsContent>
           )}

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -1,101 +1,177 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import Link from "next/link";
+import { X } from "lucide-react";
+import type { LicenseState } from "@/lib/license-state";
+import { evaluateSeatPressure } from "@/lib/seat-grace";
+import {
+  BUY_PRO_URL,
+  PRICING_URL,
+  PORTAL_URL,
+  SALES_MAILTO,
+  CALENDLY_URL,
+  conversionLink,
+} from "@/lib/conversion-links";
 
 const REFETCH_INTERVAL_MS = 15 * 60 * 1000;
+const RENEWAL_WINDOW_MS = 14 * 86400000;
+const DISMISS_PREFIX = "pinchy-banner-dismissed:";
 
 interface LicenseInfo {
   enterprise: boolean;
+  state: LicenseState;
   type: string | null;
   daysRemaining: number | null;
   expiresAt: string | null;
+  paidUntil: string | null;
+  seatsUsed: number;
+  maxUsers: number;
 }
 
-function shouldShowBanner(license: LicenseInfo): {
-  show: boolean;
-  variant: "warning" | "destructive";
+interface BannerLink {
+  label: string;
+  href: string;
+}
+
+interface Banner {
+  /** Dismissal scope — a new state shows the banner again. */
+  key: string;
+  tone: "info" | "warn";
   message: string;
-  linkText: string;
-  linkHref: string;
-} {
-  const { enterprise, type, daysRemaining, expiresAt } = license;
-  const noShow = {
-    show: false,
-    variant: "warning" as const,
-    message: "",
-    linkText: "",
-    linkHref: "",
+  links: BannerLink[];
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * License-lifecycle banner per the pricing concept's § 6 state table.
+ * Factual copy, no countdowns, no guilt — and never red: an expired
+ * license is a renewal task, not an emergency.
+ */
+function licenseBanner(license: LicenseInfo, now: Date): Banner | null {
+  const { state, daysRemaining, expiresAt, paidUntil } = license;
+  const periodEnd = paidUntil ?? expiresAt;
+
+  switch (state) {
+    case "trial": {
+      if (daysRemaining === null) return null;
+      const days = `${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}`;
+      return {
+        key: "license:trial",
+        tone: daysRemaining <= 7 ? "warn" : "info",
+        message: `Trial: ${days} remaining.`,
+        links: [
+          { label: "Buy Pinchy Pro", href: conversionLink(BUY_PRO_URL, "trial-banner", "pro-10") },
+          { label: "Compare plans", href: conversionLink(PRICING_URL, "trial-banner", "pro-10") },
+        ],
+      };
+    }
+    case "trial-expired":
+      return {
+        key: "license:trial-expired",
+        tone: "warn",
+        message: `Your trial ended${expiresAt ? ` on ${formatDate(expiresAt)}` : ""}. Your configuration is preserved.`,
+        links: [
+          { label: "See pricing", href: conversionLink(PRICING_URL, "expired-banner", "pro-10") },
+        ],
+      };
+    case "paid": {
+      // Renewal reminder from paidUntil − 14d (§ 4.7) — keys without a
+      // paidUntil claim have no renewal window we could anchor on.
+      if (!paidUntil) return null;
+      const ends = new Date(paidUntil).getTime();
+      if (now.getTime() < ends - RENEWAL_WINDOW_MS) return null;
+      return {
+        key: "license:renewal",
+        tone: "info",
+        message: `Your license period ends on ${formatDate(paidUntil)}. Your renewal key arrives by email after payment.`,
+        links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
+      };
+    }
+    case "grace":
+      return {
+        key: "license:grace",
+        tone: "warn",
+        message: `License period ended${periodEnd ? ` ${formatDate(periodEnd)}` : ""}.${expiresAt ? ` Grace until ${formatDate(expiresAt)}.` : ""}`,
+        links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
+      };
+    case "expired":
+      return {
+        key: "license:expired",
+        tone: "warn",
+        message: `Your license period ended${periodEnd ? ` on ${formatDate(periodEnd)}` : ""}. Existing access restrictions remain enforced; management features are locked.`,
+        links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
+      };
+    case "community":
+      return null;
+  }
+}
+
+/**
+ * Seat-pressure banner (§ 5): factual, never red, dismissible. Phase A has
+ * a single SKU, so more seats go through the quote path — no checkout links.
+ */
+function seatBanner(license: LicenseInfo): Banner | null {
+  if (!license.enterprise) return null;
+  const pressure = evaluateSeatPressure(license.seatsUsed, license.maxUsers);
+  if (!pressure.overCap) return null;
+  return {
+    key: "seats",
+    tone: "info",
+    message: `You're using ${license.seatsUsed} of ${license.maxUsers} licensed seats. Grace seats keep a new hire from waiting on procurement.`,
+    links: [
+      { label: "Email us for a quote", href: SALES_MAILTO },
+      { label: "Book a call", href: CALENDLY_URL },
+    ],
   };
+}
 
-  // Expired (had a license but it's no longer active, and we have expiry info)
-  if (!enterprise && expiresAt && daysRemaining !== null && daysRemaining <= 0) {
-    return {
-      show: true,
-      variant: "destructive",
-      message: "Your enterprise license has expired. Enterprise features are deactivated.",
-      linkText: "Enter new key \u2192",
-      linkHref: "/settings?tab=license",
-    };
-  }
-
-  if (!enterprise) return noShow;
-
-  if (type === "trial") {
-    if (daysRemaining !== null && daysRemaining <= 3) {
-      return {
-        show: true,
-        variant: "destructive",
-        message: `Your trial expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}.`,
-        linkText: "Upgrade \u2192",
-        linkHref: "https://heypinchy.com/enterprise?utm_source=app&utm_medium=banner",
-      };
-    }
-    if (daysRemaining !== null && daysRemaining <= 7) {
-      return {
-        show: true,
-        variant: "warning",
-        message: `Your trial expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}.`,
-        linkText: "Upgrade \u2192",
-        linkHref: "https://heypinchy.com/enterprise?utm_source=app&utm_medium=banner",
-      };
-    }
-  }
-
-  if (type === "paid") {
-    if (daysRemaining !== null && daysRemaining <= 7) {
-      return {
-        show: true,
-        variant: "destructive",
-        message: `Your license expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}.`,
-        linkText: "Renew \u2192",
-        linkHref: "https://heypinchy.com/enterprise?utm_source=app&utm_medium=banner",
-      };
-    }
-    if (daysRemaining !== null && daysRemaining <= 30) {
-      return {
-        show: true,
-        variant: "warning",
-        message: `Your license expires in ${daysRemaining} day${daysRemaining !== 1 ? "s" : ""}.`,
-        linkText: "Renew \u2192",
-        linkHref: "https://heypinchy.com/enterprise?utm_source=app&utm_medium=banner",
-      };
-    }
-  }
-
-  return noShow;
+function BannerBar({ banner, onDismiss }: { banner: Banner; onDismiss: (key: string) => void }) {
+  const toneClass =
+    banner.tone === "warn" ? "bg-amber-500 text-white" : "bg-muted text-foreground border-b";
+  return (
+    <div role="alert" className={`relative px-8 py-2 text-sm text-center ${toneClass}`}>
+      {banner.message}{" "}
+      {banner.links.map((link, i) => (
+        <span key={link.href}>
+          {i > 0 && <span className="mx-1 opacity-60">·</span>}
+          <a
+            href={link.href}
+            target={link.href.startsWith("mailto:") ? undefined : "_blank"}
+            rel="noopener noreferrer"
+            className="underline font-medium"
+          >
+            {link.label}
+          </a>
+        </span>
+      ))}
+      <button
+        type="button"
+        aria-label="Dismiss"
+        onClick={() => onDismiss(banner.key)}
+        className="absolute right-2 top-1/2 -translate-y-1/2 p-1 opacity-70 hover:opacity-100"
+      >
+        <X className="h-4 w-4" />
+      </button>
+    </div>
+  );
 }
 
 export function EnterpriseBanner({ isAdmin }: { isAdmin: boolean }) {
-  const [banner, setBanner] = useState<ReturnType<typeof shouldShowBanner> | null>(null);
+  const [license, setLicense] = useState<LicenseInfo | null>(null);
+  const [, setDismissTick] = useState(0);
 
   const fetchStatus = useCallback(() => {
     fetch("/api/enterprise/status")
       .then((res) => (res.ok ? res.json() : null))
       .then((data) => {
-        if (data) {
-          setBanner(shouldShowBanner(data));
-        }
+        if (data) setLicense(data);
       })
       .catch(() => {});
   }, []);
@@ -120,29 +196,25 @@ export function EnterpriseBanner({ isAdmin }: { isAdmin: boolean }) {
     };
   }, [isAdmin, fetchStatus]);
 
-  if (!isAdmin || !banner?.show) return null;
+  if (!isAdmin || !license) return null;
 
-  const isExternal = banner.linkHref.startsWith("http");
-  const bgClass =
-    banner.variant === "destructive" ? "bg-destructive text-white" : "bg-amber-500 text-white";
+  const dismiss = (key: string) => {
+    sessionStorage.setItem(`${DISMISS_PREFIX}${key}`, "1");
+    setDismissTick((t) => t + 1);
+  };
+  const isDismissed = (key: string) => sessionStorage.getItem(`${DISMISS_PREFIX}${key}`) === "1";
+
+  const banners = [licenseBanner(license, new Date()), seatBanner(license)].filter(
+    (b): b is Banner => b !== null && !isDismissed(b.key)
+  );
+
+  if (banners.length === 0) return null;
 
   return (
-    <div role="alert" className={`px-4 py-2 text-sm text-center ${bgClass}`}>
-      {banner.message}{" "}
-      {isExternal ? (
-        <a
-          href={banner.linkHref}
-          target="_blank"
-          rel="noopener noreferrer"
-          className="underline font-medium"
-        >
-          {banner.linkText}
-        </a>
-      ) : (
-        <Link href={banner.linkHref} className="underline font-medium">
-          {banner.linkText}
-        </Link>
-      )}
-    </div>
+    <>
+      {banners.map((banner) => (
+        <BannerBar key={banner.key} banner={banner} onDismiss={dismiss} />
+      ))}
+    </>
   );
 }

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -82,15 +82,16 @@ function licenseBanner(license: LicenseInfo, now: Date): Banner | null {
         ],
       };
     case "paid": {
-      // Renewal reminder from paidUntil − 14d (§ 4.7) — keys without a
-      // paidUntil claim have no renewal window we could anchor on.
-      if (!paidUntil) return null;
-      const ends = new Date(paidUntil).getTime();
+      // Renewal reminder from paidUntil − 14d (§ 4.7). Keys issued before
+      // the paidUntil claim existed encode no grace — there, exp IS the
+      // period end, so the window anchors on exp instead.
+      if (!periodEnd) return null;
+      const ends = new Date(periodEnd).getTime();
       if (now.getTime() < ends - RENEWAL_WINDOW_MS) return null;
       return {
         key: "license:renewal",
         tone: "info",
-        message: `Your license period ends on ${formatDate(paidUntil)}. Your renewal key arrives by email after payment.`,
+        message: `Your license period ends on ${formatDate(periodEnd)}. Your renewal key arrives by email after payment.`,
         links: [{ label: "Renew", href: conversionLink(PORTAL_URL, "expired-banner", "pro-10") }],
       };
     }

--- a/packages/web/src/components/enterprise-feature-card.tsx
+++ b/packages/web/src/components/enterprise-feature-card.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { LicenseCliffDialog } from "@/components/license-cliff-dialog";
@@ -12,11 +12,14 @@ interface EnterpriseFeatureCardProps {
   description: string;
   campaign: UtmCampaign;
   isAdmin: boolean;
-}
-
-interface CliffStatus {
-  state: LicenseState;
-  periodEnd: string | null;
+  /**
+   * Provided by the parent (which already fetched /api/enterprise/status) —
+   * the card itself never fetches. Defaults to community, the only state in
+   * which a gated surface renders without any license info.
+   */
+  licenseState?: LicenseState;
+  /** ISO date the license period ended (paidUntil, or exp as fallback). */
+  periodEnd?: string | null;
 }
 
 function ctaLabel(state: LicenseState): string {
@@ -40,21 +43,10 @@ export function EnterpriseFeatureCard({
   description,
   campaign,
   isAdmin,
+  licenseState = "community",
+  periodEnd = null,
 }: EnterpriseFeatureCardProps) {
-  const [status, setStatus] = useState<CliffStatus | null>(null);
   const [cliffOpen, setCliffOpen] = useState(false);
-
-  useEffect(() => {
-    if (!isAdmin) return;
-    fetch("/api/enterprise/status")
-      .then((res) => (res.ok ? res.json() : null))
-      .then((data) => {
-        if (data) {
-          setStatus({ state: data.state, periodEnd: data.paidUntil ?? data.expiresAt ?? null });
-        }
-      })
-      .catch(() => {});
-  }, [isAdmin]);
 
   if (!isAdmin) {
     return (
@@ -80,7 +72,7 @@ export function EnterpriseFeatureCard({
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-muted-foreground">{description}</p>
-        {status && <Button onClick={() => setCliffOpen(true)}>{ctaLabel(status.state)}</Button>}
+        <Button onClick={() => setCliffOpen(true)}>{ctaLabel(licenseState)}</Button>
         <div className="rounded-lg border bg-muted/50 p-4 space-y-2">
           <p className="text-sm font-medium">How to enable</p>
           <p className="text-sm text-muted-foreground">
@@ -94,17 +86,15 @@ export function EnterpriseFeatureCard({
           </p>
         </div>
       </CardContent>
-      {status && (
-        <LicenseCliffDialog
-          open={cliffOpen}
-          onOpenChange={setCliffOpen}
-          feature={feature}
-          description={description}
-          campaign={campaign}
-          licenseState={status.state}
-          periodEnd={status.periodEnd}
-        />
-      )}
+      <LicenseCliffDialog
+        open={cliffOpen}
+        onOpenChange={setCliffOpen}
+        feature={feature}
+        description={description}
+        campaign={campaign}
+        licenseState={licenseState}
+        periodEnd={periodEnd}
+      />
     </Card>
   );
 }

--- a/packages/web/src/components/enterprise-feature-card.tsx
+++ b/packages/web/src/components/enterprise-feature-card.tsx
@@ -1,26 +1,86 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
+import { LicenseCliffDialog } from "@/components/license-cliff-dialog";
+import type { LicenseState } from "@/lib/license-state";
+import type { UtmCampaign } from "@/lib/conversion-links";
 
 interface EnterpriseFeatureCardProps {
   feature: string;
   description: string;
+  campaign: UtmCampaign;
+  isAdmin: boolean;
 }
 
-export function EnterpriseFeatureCard({ feature, description }: EnterpriseFeatureCardProps) {
+interface CliffStatus {
+  state: LicenseState;
+  periodEnd: string | null;
+}
+
+function ctaLabel(state: LicenseState): string {
+  switch (state) {
+    case "trial-expired":
+      return "See pricing";
+    case "expired":
+      return "Renew";
+    default:
+      return "Start free 30-day trial";
+  }
+}
+
+/**
+ * Replacement surface for a license-gated feature. Admins get the feature
+ * pitch and the cliff modal (§ 6); non-admins only get a factual pointer —
+ * employees of a customer are not a marketing audience.
+ */
+export function EnterpriseFeatureCard({
+  feature,
+  description,
+  campaign,
+  isAdmin,
+}: EnterpriseFeatureCardProps) {
+  const [status, setStatus] = useState<CliffStatus | null>(null);
+  const [cliffOpen, setCliffOpen] = useState(false);
+
+  useEffect(() => {
+    if (!isAdmin) return;
+    fetch("/api/enterprise/status")
+      .then((res) => (res.ok ? res.json() : null))
+      .then((data) => {
+        if (data) {
+          setStatus({ state: data.state, periodEnd: data.paidUntil ?? data.expiresAt ?? null });
+        }
+      })
+      .catch(() => {});
+  }, [isAdmin]);
+
+  if (!isAdmin) {
+    return (
+      <Card>
+        <CardContent className="pt-6">
+          <p className="text-sm text-muted-foreground">
+            This feature requires a Pro license. Ask your administrator.
+          </p>
+        </CardContent>
+      </Card>
+    );
+  }
+
   return (
     <Card>
       <CardHeader>
         <CardTitle className="flex items-center gap-2">
           {feature}
           <span className="text-xs font-normal bg-primary/10 text-primary px-2 py-0.5 rounded-full">
-            Enterprise
+            Pro
           </span>
         </CardTitle>
       </CardHeader>
       <CardContent className="space-y-4">
         <p className="text-muted-foreground">{description}</p>
+        {status && <Button onClick={() => setCliffOpen(true)}>{ctaLabel(status.state)}</Button>}
         <div className="rounded-lg border bg-muted/50 p-4 space-y-2">
           <p className="text-sm font-medium">How to enable</p>
           <p className="text-sm text-muted-foreground">
@@ -32,17 +92,19 @@ export function EnterpriseFeatureCard({ feature, description }: EnterpriseFeatur
             <code className="bg-muted px-1 py-0.5 rounded text-xs">PINCHY_ENTERPRISE_KEY</code>{" "}
             environment variable.
           </p>
-          <a
-            href="https://heypinchy.com/enterprise?utm_source=app&utm_medium=feature-card"
-            target="_blank"
-            rel="noopener noreferrer"
-          >
-            <Button variant="outline" size="sm" className="mt-2">
-              Learn more
-            </Button>
-          </a>
         </div>
       </CardContent>
+      {status && (
+        <LicenseCliffDialog
+          open={cliffOpen}
+          onOpenChange={setCliffOpen}
+          feature={feature}
+          description={description}
+          campaign={campaign}
+          licenseState={status.state}
+          periodEnd={status.periodEnd}
+        />
+      )}
     </Card>
   );
 }

--- a/packages/web/src/components/invite-dialog.tsx
+++ b/packages/web/src/components/invite-dialog.tsx
@@ -51,6 +51,7 @@ export function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
   const [creating, setCreating] = useState(false);
   const { isCopied: copied, copy: copyInviteLink } = useCopyToClipboard();
   const [isEnterprise, setIsEnterprise] = useState<boolean | null>(null);
+  const [seatInfo, setSeatInfo] = useState<{ maxUsers: number; seatsUsed: number } | null>(null);
   const [groups, setGroups] = useState<{ id: string; name: string }[]>([]);
   const [selectedGroupIds, setSelectedGroupIds] = useState<string[]>([]);
 
@@ -79,7 +80,12 @@ export function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
     if (!open) return;
     fetch("/api/enterprise/status")
       .then((r) => r.json())
-      .then((d) => setIsEnterprise(d.enterprise))
+      .then((d) => {
+        setIsEnterprise(d.enterprise);
+        if (typeof d.maxUsers === "number" && typeof d.seatsUsed === "number") {
+          setSeatInfo({ maxUsers: d.maxUsers, seatsUsed: d.seatsUsed });
+        }
+      })
       .catch(() => setIsEnterprise(false));
   }, [open]);
 
@@ -108,7 +114,9 @@ export function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
         setInviteLink(buildInviteUrl(window.location.origin, data.token));
       } else {
         const data = await res.json();
-        setError(data.error || "Failed to create invite");
+        // Seat-cap 403s carry an actionable message (quote path, § 5) —
+        // prefer it over the terse error code.
+        setError(data.message || data.error || "Failed to create invite");
       }
     } catch {
       setError("Failed to create invite");
@@ -147,6 +155,16 @@ export function InviteDialog({ open, onOpenChange }: InviteDialogProps) {
           <DialogTitle>Invite User</DialogTitle>
           <DialogDescription>Create an invite link to add a new user.</DialogDescription>
         </DialogHeader>
+
+        {!inviteLink &&
+          seatInfo &&
+          seatInfo.maxUsers > 0 &&
+          seatInfo.seatsUsed > seatInfo.maxUsers && (
+            <div className="rounded-md border bg-muted p-3 text-sm text-muted-foreground">
+              You&apos;re using {seatInfo.seatsUsed} of {seatInfo.maxUsers} licensed seats. Grace
+              seats keep a new hire from waiting on procurement.
+            </div>
+          )}
 
         {inviteLink ? (
           <div className="space-y-4">

--- a/packages/web/src/components/license-cliff-dialog.tsx
+++ b/packages/web/src/components/license-cliff-dialog.tsx
@@ -1,0 +1,123 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import type { LicenseState } from "@/lib/license-state";
+import {
+  PRICING_URL,
+  PRICING_TRIAL_URL,
+  PORTAL_URL,
+  conversionLink,
+  type UtmCampaign,
+} from "@/lib/conversion-links";
+
+interface LicenseCliffDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Display name of the gated feature, e.g. "Groups". */
+  feature: string;
+  /** Two sentences of benefit, shared with the feature card. */
+  description: string;
+  campaign: UtmCampaign;
+  licenseState: LicenseState;
+  /** ISO date the license period ended (paidUntil, or exp as fallback). */
+  periodEnd: string | null;
+}
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
+
+/**
+ * The cliff modal from pricing concept § 6: shown when an admin reaches a
+ * license-gated feature. Factual copy per license state, a plain "Not now"
+ * to dismiss — no guilt copy, no countdowns.
+ */
+export function LicenseCliffDialog({
+  open,
+  onOpenChange,
+  feature,
+  description,
+  campaign,
+  licenseState,
+  periodEnd,
+}: LicenseCliffDialogProps) {
+  const ended = periodEnd ? ` on ${formatDate(periodEnd)}` : "";
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>{feature} is included in Pinchy Pro</DialogTitle>
+          <DialogDescription>{description}</DialogDescription>
+        </DialogHeader>
+
+        {licenseState === "trial-expired" && (
+          <p className="text-sm">Your trial ended{ended}. Your configuration is preserved.</p>
+        )}
+        {licenseState === "expired" && (
+          <p className="text-sm">
+            Your license period ended{ended}. Existing access restrictions remain enforced;
+            management features are locked.
+          </p>
+        )}
+        {licenseState === "community" && (
+          <p className="text-sm text-muted-foreground">30 days, no credit card, key by email.</p>
+        )}
+
+        <DialogFooter className="sm:justify-start gap-2">
+          {licenseState === "community" && (
+            <>
+              <a
+                href={conversionLink(PRICING_TRIAL_URL, "cliff-modal", campaign)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button>Start free 30-day trial</Button>
+              </a>
+              <a
+                href={conversionLink(PRICING_URL, "cliff-modal", campaign)}
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                <Button variant="outline">See pricing</Button>
+              </a>
+            </>
+          )}
+          {licenseState === "trial-expired" && (
+            <a
+              href={conversionLink(PRICING_URL, "cliff-modal", campaign)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button>See pricing</Button>
+            </a>
+          )}
+          {licenseState === "expired" && (
+            <a
+              href={conversionLink(PORTAL_URL, "cliff-modal", campaign)}
+              target="_blank"
+              rel="noopener noreferrer"
+            >
+              <Button>Renew</Button>
+            </a>
+          )}
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Not now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/seat-limit-dialog.tsx
+++ b/packages/web/src/components/seat-limit-dialog.tsx
@@ -1,0 +1,52 @@
+"use client";
+
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from "@/components/ui/dialog";
+import { Button } from "@/components/ui/button";
+import { SALES_MAILTO, CALENDLY_URL } from "@/lib/conversion-links";
+
+interface SeatLimitDialogProps {
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  maxUsers: number;
+  graceCap: number;
+}
+
+/**
+ * Shown when an invite would exceed the seat grace cap (§ 5). Phase A has a
+ * single SKU, so more seats go through the quote path — factual tone, no
+ * countdowns, no red. Existing users always keep their access.
+ */
+export function SeatLimitDialog({ open, onOpenChange, maxUsers, graceCap }: SeatLimitDialogProps) {
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent>
+        <DialogHeader>
+          <DialogTitle>Need more than {maxUsers} seats?</DialogTitle>
+          <DialogDescription>
+            Your license includes {maxUsers} seats with grace up to {graceCap}. Email us for a quote
+            you can accept online — no call needed. Existing users keep their access; only new
+            invites are paused.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="sm:justify-start gap-2">
+          <a href={SALES_MAILTO}>
+            <Button>Email sales@heypinchy.com</Button>
+          </a>
+          <a href={CALENDLY_URL} target="_blank" rel="noopener noreferrer">
+            <Button variant="outline">Book a call</Button>
+          </a>
+          <Button variant="ghost" onClick={() => onOpenChange(false)}>
+            Not now
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/packages/web/src/components/settings-groups.tsx
+++ b/packages/web/src/components/settings-groups.tsx
@@ -36,6 +36,7 @@ import { Checkbox } from "@/components/ui/checkbox";
 import { toast } from "sonner";
 import { apiPost, apiPatch, apiPut, apiDelete, ApiError } from "@/lib/api-client";
 import type { CreateGroupInput } from "@/lib/schemas/groups";
+import type { LicenseState } from "@/lib/license-state";
 
 interface Group {
   id: string;
@@ -70,6 +71,8 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
   const [editGroup, setEditGroup] = useState<Group | null>(null);
   const [deleteGroupId, setDeleteGroupId] = useState<string | null>(null);
   const [isEnterprise, setIsEnterprise] = useState<boolean | null>(null);
+  const [licenseState, setLicenseState] = useState<LicenseState>("community");
+  const [licensePeriodEnd, setLicensePeriodEnd] = useState<string | null>(null);
 
   // Form state
   const [formName, setFormName] = useState("");
@@ -83,7 +86,11 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
   useEffect(() => {
     fetch("/api/enterprise/status")
       .then((res) => (res.ok ? res.json() : { enterprise: false }))
-      .then((data) => setIsEnterprise(data.enterprise))
+      .then((data) => {
+        setIsEnterprise(data.enterprise);
+        if (data.state) setLicenseState(data.state);
+        setLicensePeriodEnd(data.paidUntil ?? data.expiresAt ?? null);
+      })
       .catch(() => setIsEnterprise(false));
   }, [refreshKey]);
 
@@ -268,6 +275,8 @@ export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsPro
         description="Create groups to control which users can access which agents. Organize your team into departments like Engineering, Marketing, or HR, and assign agent access per group."
         campaign="groups"
         isAdmin={isAdmin}
+        licenseState={licenseState}
+        periodEnd={licensePeriodEnd}
       />
     );
   }

--- a/packages/web/src/components/settings-groups.tsx
+++ b/packages/web/src/components/settings-groups.tsx
@@ -59,9 +59,10 @@ interface GroupMember {
 
 interface SettingsGroupsProps {
   refreshKey?: number;
+  isAdmin?: boolean;
 }
 
-export function SettingsGroups({ refreshKey }: SettingsGroupsProps) {
+export function SettingsGroups({ refreshKey, isAdmin = true }: SettingsGroupsProps) {
   const [groups, setGroups] = useState<Group[]>([]);
   const [users, setUsers] = useState<User[]>([]);
   const [loading, setLoading] = useState(true);
@@ -265,6 +266,8 @@ export function SettingsGroups({ refreshKey }: SettingsGroupsProps) {
       <EnterpriseFeatureCard
         feature="Groups"
         description="Create groups to control which users can access which agents. Organize your team into departments like Engineering, Marketing, or HR, and assign agent access per group."
+        campaign="groups"
+        isAdmin={isAdmin}
       />
     );
   }

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -6,6 +6,18 @@ import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from "@/components/ui/alert-dialog";
+import { toast } from "sonner";
+import { apiDelete, ApiError } from "@/lib/api-client";
 import type { LicenseInfo } from "@/lib/enterprise";
 import { PRICING_URL, PORTAL_URL, conversionLink } from "@/lib/conversion-links";
 
@@ -29,6 +41,8 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
   const [saving, setSaving] = useState(false);
   const [error, setError] = useState<string | null>(null);
   const [showInput, setShowInput] = useState(false);
+  const [confirmRemoveGated, setConfirmRemoveGated] = useState(false);
+  const [removingGated, setRemovingGated] = useState(false);
 
   const fetchStatus = useCallback(async () => {
     try {
@@ -46,6 +60,24 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
     if (initialLicense) return;
     fetchStatus();
   }, [fetchStatus, initialLicense]);
+
+  const handleRemoveGatedConfig = async () => {
+    setRemovingGated(true);
+    try {
+      const result = await apiDelete<{ groupsRemoved: number; agentsReset: number }>(
+        "/api/enterprise/gated-config"
+      );
+      setConfirmRemoveGated(false);
+      toast(
+        `Removed ${result.groupsRemoved} group${result.groupsRemoved !== 1 ? "s" : ""} and reset ${result.agentsReset} agent${result.agentsReset !== 1 ? "s" : ""} to community semantics.`
+      );
+      await fetchStatus();
+    } catch (e) {
+      toast.error(e instanceof ApiError ? e.message : "Failed to remove gated configuration");
+    } finally {
+      setRemovingGated(false);
+    }
+  };
 
   const handleSave = async () => {
     setSaving(true);
@@ -189,6 +221,45 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
             </p>
           </div>
         )}
+
+        {!license?.enterprise && license?.hasGatedConfig && (
+          <div className="space-y-2 rounded-lg border bg-muted/50 p-4">
+            <p className="text-sm font-medium">License-gated configuration</p>
+            <p className="text-sm text-muted-foreground">
+              Groups and agent visibility restrictions stay enforced without a license. To return
+              this instance to community semantics, you can remove them.
+            </p>
+            <Button variant="outline" size="sm" onClick={() => setConfirmRemoveGated(true)}>
+              Remove all license-gated configuration
+            </Button>
+          </div>
+        )}
+
+        <AlertDialog
+          open={confirmRemoveGated}
+          onOpenChange={(open) => !open && setConfirmRemoveGated(false)}
+        >
+          <AlertDialogContent>
+            <AlertDialogHeader>
+              <AlertDialogTitle>Remove all license-gated configuration?</AlertDialogTitle>
+              <AlertDialogDescription>
+                This deletes all groups and makes restricted agents visible to all users. Existing
+                users keep their accounts. This action is recorded in the audit log and cannot be
+                undone.
+              </AlertDialogDescription>
+            </AlertDialogHeader>
+            <AlertDialogFooter>
+              <AlertDialogCancel>Cancel</AlertDialogCancel>
+              <AlertDialogAction
+                variant="destructive"
+                disabled={removingGated}
+                onClick={handleRemoveGatedConfig}
+              >
+                {removingGated ? "Removing..." : "Remove configuration"}
+              </AlertDialogAction>
+            </AlertDialogFooter>
+          </AlertDialogContent>
+        </AlertDialog>
 
         {(showInput || !license?.enterprise) && !license?.managedByEnv && (
           <div className="space-y-2">

--- a/packages/web/src/components/settings-license.tsx
+++ b/packages/web/src/components/settings-license.tsx
@@ -7,6 +7,15 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Badge } from "@/components/ui/badge";
 import type { LicenseInfo } from "@/lib/enterprise";
+import { PRICING_URL, PORTAL_URL, conversionLink } from "@/lib/conversion-links";
+
+function formatDate(iso: string): string {
+  return new Date(iso).toLocaleDateString("en-US", {
+    year: "numeric",
+    month: "short",
+    day: "numeric",
+  });
+}
 
 interface SettingsLicenseProps {
   onEnterpriseActivated?: () => void;
@@ -95,15 +104,30 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
               </Badge>
               {license.org && <span className="text-sm text-muted-foreground">{license.org}</span>}
             </div>
-            {license.expiresAt && (
+            {license.paidUntil && license.expiresAt ? (
+              // Paid keys carry paidUntil; all copy reckons from it (§ 1):
+              // exp is paidUntil plus the 30-day grace window.
               <p className="text-sm">
-                Expires:{" "}
-                {new Date(license.expiresAt).toLocaleDateString("en-US", {
-                  year: "numeric",
-                  month: "short",
-                  day: "numeric",
-                })}{" "}
-                ({license.daysRemaining} days remaining)
+                License period {license.state === "grace" ? "ended" : "ends"}{" "}
+                {formatDate(license.paidUntil)}. Grace until {formatDate(license.expiresAt)}.
+              </p>
+            ) : (
+              license.expiresAt && (
+                <p className="text-sm">
+                  Expires: {formatDate(license.expiresAt)} ({license.daysRemaining} days remaining)
+                </p>
+              )
+            )}
+            {license.state === "grace" && (
+              <p className="text-sm">
+                <a
+                  href={conversionLink(PORTAL_URL, "settings-license", "pro-10")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Renew
+                </a>
               </p>
             )}
             {license.maxUsers > 0 && (
@@ -125,18 +149,43 @@ export function SettingsLicense({ onEnterpriseActivated, initialLicense }: Setti
           </>
         ) : (
           <div className="space-y-2">
+            {license?.state === "expired" && (
+              <p className="text-sm">
+                Your license period ended
+                {(license.paidUntil ?? license.expiresAt) &&
+                  ` on ${formatDate(license.paidUntil ?? license.expiresAt!)}`}
+                . Existing access restrictions remain enforced; management features are locked.
+              </p>
+            )}
+            {license?.state === "trial-expired" && (
+              <p className="text-sm">
+                Your trial ended{license.expiresAt && ` on ${formatDate(license.expiresAt)}`}. Your
+                configuration is preserved.
+              </p>
+            )}
             <p className="text-sm text-muted-foreground">
-              No active license key. Enter a key to enable Enterprise features.
+              No active license key. Enter a key to enable Pro features.
             </p>
             <p className="text-sm">
-              <a
-                href="https://heypinchy.com/enterprise?utm_source=app&utm_medium=settings"
-                target="_blank"
-                rel="noopener noreferrer"
-                className="text-primary underline"
-              >
-                Learn more about Enterprise
-              </a>
+              {license?.state === "expired" ? (
+                <a
+                  href={conversionLink(PORTAL_URL, "settings-license", "pro-10")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  Renew
+                </a>
+              ) : (
+                <a
+                  href={conversionLink(PRICING_URL, "settings-license", "pro-10")}
+                  target="_blank"
+                  rel="noopener noreferrer"
+                  className="text-primary underline"
+                >
+                  See pricing
+                </a>
+              )}
             </p>
           </div>
         )}

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -228,7 +228,7 @@ export function SettingsPageContent({
 
           {isAdmin && (
             <TabsContent value="groups" keepMounted>
-              <SettingsGroups refreshKey={enterpriseRefreshKey} />
+              <SettingsGroups refreshKey={enterpriseRefreshKey} isAdmin={isAdmin} />
             </TabsContent>
           )}
 

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -334,7 +334,7 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
         }}
       />
 
-      {seatInfo && pressure?.graceCap !== null && pressure !== null && (
+      {seatInfo !== null && pressure !== null && pressure.graceCap !== null && (
         <SeatLimitDialog
           open={seatLimitOpen}
           onOpenChange={setSeatLimitOpen}

--- a/packages/web/src/components/settings-users.tsx
+++ b/packages/web/src/components/settings-users.tsx
@@ -14,13 +14,15 @@ import {
   TableRow,
 } from "@/components/ui/table";
 import { InviteDialog } from "@/components/invite-dialog";
+import { SeatLimitDialog } from "@/components/seat-limit-dialog";
 import { UserDetailSheet } from "@/components/user-detail-sheet";
 import { StatusBadge } from "@/components/status-badge";
 import { toast } from "sonner";
 import { mergeUserList, type UserListItem, type UserGroup } from "@/lib/user-list";
 import { useCopyToClipboard } from "@/hooks/use-copy-to-clipboard";
 import { buildInviteUrl } from "@/lib/invite-url";
-import { cn } from "@/lib/utils";
+import { evaluateSeatPressure } from "@/lib/seat-grace";
+import { SALES_MAILTO, CALENDLY_URL } from "@/lib/conversion-links";
 
 interface SettingsUsersProps {
   currentUserId: string;
@@ -76,6 +78,7 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
   });
   const [loading, setLoading] = useState(true);
   const [inviteOpen, setInviteOpen] = useState(false);
+  const [seatLimitOpen, setSeatLimitOpen] = useState(false);
   const [resetLink, setResetLink] = useState<string | null>(null);
   const { isCopied: isResetLinkCopied, copy: copyResetLink } = useCopyToClipboard();
   const [selectedUser, setSelectedUser] = useState<(UserListItem & { kind: "user" }) | null>(null);
@@ -83,9 +86,8 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
   const [isEnterprise, setIsEnterprise] = useState(false);
   const [seatInfo, setSeatInfo] = useState<{ maxUsers: number; seatsUsed: number } | null>(null);
 
-  const atCap =
-    seatInfo !== null && seatInfo.maxUsers > 0 && seatInfo.seatsUsed >= seatInfo.maxUsers;
-  const showBanner = seatInfo !== null && seatInfo.maxUsers > 0;
+  const pressure = seatInfo ? evaluateSeatPressure(seatInfo.seatsUsed, seatInfo.maxUsers) : null;
+  const showCounter = seatInfo !== null && seatInfo.maxUsers > 0;
 
   const fetchUsers = useCallback(async () => {
     try {
@@ -165,13 +167,15 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Users</CardTitle>
           <Button
-            onClick={() => setInviteOpen(true)}
-            disabled={atCap}
-            title={
-              atCap
-                ? "Seat limit reached — remove an existing user or pending invitation first."
-                : undefined
-            }
+            onClick={() => {
+              // Beyond the grace cap the endpoint would reject the invite —
+              // surface the quote path instead of a doomed form (§ 5).
+              if (pressure && !pressure.inviteAllowed) {
+                setSeatLimitOpen(true);
+              } else {
+                setInviteOpen(true);
+              }
+            }}
           >
             Invite User
           </Button>
@@ -192,18 +196,27 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
             </div>
           )}
 
-          {showBanner && (
-            <div
-              className={cn(
-                "mb-4 rounded-md border p-3 text-sm",
-                atCap
-                  ? "border-destructive/50 bg-destructive/5 text-destructive-foreground"
-                  : "bg-muted text-muted-foreground"
+          {showCounter && (
+            <div className="mb-4 rounded-md border p-3 text-sm bg-muted text-muted-foreground">
+              {`${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used.`}
+              {pressure?.overCap && (
+                <>
+                  {" "}
+                  Grace seats keep a new hire from waiting on procurement.{" "}
+                  <a href={SALES_MAILTO} className="underline">
+                    Email us for a quote
+                  </a>{" "}
+                  <span className="opacity-60">·</span>{" "}
+                  <a
+                    href={CALENDLY_URL}
+                    target="_blank"
+                    rel="noopener noreferrer"
+                    className="underline"
+                  >
+                    Book a call
+                  </a>
+                </>
               )}
-            >
-              {atCap
-                ? `${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used. Remove a user or pending invitation to invite someone new, or upgrade your subscription.`
-                : `${seatInfo!.seatsUsed} of ${seatInfo!.maxUsers} seats used.`}
             </div>
           )}
 
@@ -320,6 +333,15 @@ export function SettingsUsers({ currentUserId, refreshKey }: SettingsUsersProps)
           if (!open) fetchUsers();
         }}
       />
+
+      {seatInfo && pressure?.graceCap !== null && pressure !== null && (
+        <SeatLimitDialog
+          open={seatLimitOpen}
+          onOpenChange={setSeatLimitOpen}
+          maxUsers={seatInfo.maxUsers}
+          graceCap={pressure.graceCap}
+        />
+      )}
 
       {selectedUser && (
         <UserDetailSheet

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -651,6 +651,8 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                 <EnterpriseFeatureCard
                   feature="Per-User Breakdown"
                   description="See which team members use the most tokens and which agents they prefer. Identify power users and optimize costs per person."
+                  campaign="analytics"
+                  isAdmin
                 />
               )}
             </TabsContent>

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -19,6 +19,7 @@ import {
   TooltipTrigger,
 } from "@/components/ui/tooltip";
 import { EnterpriseFeatureCard } from "@/components/enterprise-feature-card";
+import type { LicenseState } from "@/lib/license-state";
 import { buildChartData } from "@/lib/usage-chart-data";
 import {
   ResponsiveContainer,
@@ -89,6 +90,8 @@ interface TimeseriesResponse {
 
 interface UsageDashboardProps {
   isEnterprise?: boolean;
+  licenseState?: LicenseState;
+  licensePeriodEnd?: string | null;
 }
 
 function formatTokens(n: number): string {
@@ -142,7 +145,11 @@ function StatCard({
   );
 }
 
-export function UsageDashboard({ isEnterprise: initialEnterprise = false }: UsageDashboardProps) {
+export function UsageDashboard({
+  isEnterprise: initialEnterprise = false,
+  licenseState = "community",
+  licensePeriodEnd = null,
+}: UsageDashboardProps) {
   const [enterprise, setEnterprise] = useState(initialEnterprise);
   const [days, setDays] = useState<DaysOption>(30);
   const [selectedAgent, setSelectedAgent] = useState("all");
@@ -653,6 +660,8 @@ export function UsageDashboard({ isEnterprise: initialEnterprise = false }: Usag
                   description="See which team members use the most tokens and which agents they prefer. Identify power users and optimize costs per person."
                   campaign="analytics"
                   isAdmin
+                  licenseState={licenseState}
+                  periodEnd={licensePeriodEnd}
                 />
               )}
             </TabsContent>

--- a/packages/web/src/components/user-detail-sheet.tsx
+++ b/packages/web/src/components/user-detail-sheet.tsx
@@ -66,7 +66,13 @@ export function UserDetailSheet({
   const isOwnAccount = user.id === currentUserId;
   const isDeactivated = user.status === "deactivated";
 
-  const showGroups = isEnterprise && allGroups.length > 0;
+  // Without an active license, group management is locked EXCEPT removing
+  // existing memberships (restriction-tightening carve-out, § 5). Members
+  // originally in a group can be unchecked (and re-checked before saving);
+  // new memberships need a license.
+  const originalGroupIds = new Set(user.groups.map((g) => g.id));
+  const showGroups = allGroups.length > 0 && (isEnterprise || originalGroupIds.size > 0);
+  const canAddToGroup = (groupId: string) => isEnterprise || originalGroupIds.has(groupId);
 
   const isDirty = useMemo(() => {
     if (selectedRole !== user.role) return true;
@@ -209,12 +215,17 @@ export function UserDetailSheet({
                     <Checkbox
                       checked={selectedGroupIds.has(group.id)}
                       onCheckedChange={() => handleGroupToggle(group.id)}
-                      disabled={isDeactivated}
+                      disabled={isDeactivated || !canAddToGroup(group.id)}
                     />
                     {group.name}
                   </label>
                 ))}
               </div>
+              {!isEnterprise && (
+                <p className="text-xs text-muted-foreground">
+                  Adding to groups requires an active license. Removing always works.
+                </p>
+              )}
             </div>
           )}
         </div>

--- a/packages/web/src/lib/agent-access.ts
+++ b/packages/web/src/lib/agent-access.ts
@@ -3,7 +3,8 @@ import { db } from "@/db";
 import { activeAgents } from "@/db/schema";
 import { eq } from "drizzle-orm";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
+import type { LicenseState } from "@/lib/license-state";
 
 interface AgentForAccess {
   id: string;
@@ -14,12 +15,19 @@ interface AgentForAccess {
 
 /**
  * Return the effective visibility for an agent.
- * When enterprise features are disabled, "restricted" falls back to "all"
- * so no users lose access after an enterprise key expires.
+ *
+ * Fail closed (pricing concept § 5): a license expiry NEVER widens access —
+ * "restricted" stays enforced in every licensed and expired state. The single
+ * exception is a community instance (never licensed): shared agents default
+ * to visibility "restricted" in the DB without anyone having restricted them,
+ * so community maps that default to "all" to stay usable.
  */
-export function effectiveVisibility(dbVisibility: string | undefined, enterprise: boolean): string {
+export function effectiveVisibility(
+  dbVisibility: string | undefined,
+  licenseState: LicenseState
+): string {
   const vis = dbVisibility ?? "all";
-  if (!enterprise && vis === "restricted") return "all";
+  if (licenseState === "community" && vis === "restricted") return "all";
   return vis;
 }
 
@@ -31,7 +39,8 @@ export function effectiveVisibility(dbVisibility: string | undefined, enterprise
  * - Personal agents are only accessible to their owner
  * - Shared agents check visibility: "all" (everyone), "restricted" (only users
  *   who share a group with the agent; if no groups assigned, admins only)
- * - When enterprise=false, "restricted" is treated as "all" (graceful degradation)
+ * - Restrictions stay enforced after license expiry (fail closed, § 5);
+ *   only community instances treat "restricted" as "all"
  */
 export function assertAgentAccess(
   agent: AgentForAccess,
@@ -39,7 +48,7 @@ export function assertAgentAccess(
   userRole: string,
   userGroupIds: string[] = [],
   agentGroupIds: string[] = [],
-  enterprise: boolean = true
+  licenseState: LicenseState = "paid"
 ): void {
   // Personal agents are private to their owner — this applies to everyone,
   // including admins. The admin fast-path must NOT bypass this check.
@@ -50,7 +59,7 @@ export function assertAgentAccess(
   if (userRole === "admin") return;
 
   // Shared agent — check visibility
-  const visibility = effectiveVisibility(agent.visibility, enterprise);
+  const visibility = effectiveVisibility(agent.visibility, licenseState);
   switch (visibility) {
     case "all":
       return;
@@ -114,10 +123,10 @@ export async function getAgentWithAccess(agentId: string, userId: string, userRo
     return NextResponse.json({ error: "Agent not found" }, { status: 404 });
   }
 
-  const enterprise = await isEnterprise();
-  const effVis = effectiveVisibility(agent.visibility, enterprise);
+  const licenseState = await getLicenseState();
+  const effVis = effectiveVisibility(agent.visibility, licenseState);
 
-  // Load group data only when needed (skip for admins, non-restricted, or non-enterprise)
+  // Load group data only when needed (skip for admins and non-restricted)
   const needsGroups = userRole !== "admin" && effVis === "restricted";
   const [userGroupIds, agentGroupIds] = await Promise.all([
     needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
@@ -125,7 +134,7 @@ export async function getAgentWithAccess(agentId: string, userId: string, userRo
   ]);
 
   try {
-    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, enterprise);
+    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
   } catch {
     return NextResponse.json({ error: "Forbidden" }, { status: 403 });
   }

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -48,6 +48,7 @@ export type AuditEventType =
   | "user.updated"
   | "user.deleted"
   | "config.changed"
+  | "config.gated_config_removed"
   | "group.created"
   | "group.updated"
   | "group.deleted"
@@ -275,7 +276,8 @@ export type AuditLogEntry =
         | `${AuditResource}.created`
         | "user.invited"
         | "user.invite_blocked"
-        | "config.changed";
+        | "config.changed"
+        | "config.gated_config_removed";
       detail: Record<string, unknown>;
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/conversion-links.ts
+++ b/packages/web/src/lib/conversion-links.ts
@@ -1,0 +1,45 @@
+/**
+ * Conversion link targets and UTM vocabulary from the pricing concept (§ 6).
+ *
+ * D-011 zero-telemetry: every link is passive and fully static. The UTM
+ * params identify the in-app SURFACE, never the instance or user. Adding a
+ * dynamic value here would violate the concept — don't.
+ */
+
+export const PRICING_URL = "https://heypinchy.com/pricing";
+export const PRICING_TRIAL_URL = "https://heypinchy.com/pricing#trial";
+/** Odoo resolves the trailing product id, so this survives the Pro-10 rename. */
+export const BUY_PRO_URL = "https://buy.heypinchy.com/shop/pinchy-pro-5";
+/** Odoo customer portal — renewal keys are delivered there and by email. */
+export const PORTAL_URL = "https://buy.heypinchy.com/my";
+export const SALES_MAILTO = "mailto:sales@heypinchy.com?subject=Pinchy%20seats%20quote%20request";
+export const CALENDLY_URL = "https://calendly.com/clemenshelm/pinchy-demo";
+
+/** In-app UTM mediums (§ 6 vocabulary — do not invent new values). */
+export type UtmMedium =
+  | "cliff-modal"
+  | "trial-banner"
+  | "expired-banner"
+  | "seat-limit-banner"
+  | "seat-limit-modal"
+  | "settings-license";
+
+/** In-app UTM campaigns (§ 6 vocabulary — feature cliffs and the one SKU). */
+export type UtmCampaign =
+  | "groups"
+  | "visibility"
+  | "analytics"
+  | "csv-export"
+  | "seat-limit"
+  | "pro-10";
+
+/**
+ * Append the static UTM triple to a target URL, keeping any #fragment
+ * after the query string (e.g. /pricing#trial).
+ */
+export function conversionLink(url: string, medium: UtmMedium, campaign: UtmCampaign): string {
+  const [base, fragment] = url.split("#");
+  const separator = base.includes("?") ? "&" : "?";
+  const utm = `utm_source=pinchy-app&utm_medium=${medium}&utm_campaign=${campaign}`;
+  return `${base}${separator}${utm}${fragment ? `#${fragment}` : ""}`;
+}

--- a/packages/web/src/lib/enterprise.ts
+++ b/packages/web/src/lib/enterprise.ts
@@ -1,17 +1,22 @@
 import { getSetting } from "@/lib/settings";
 import { validateLicense, type LicenseStatus } from "@/lib/license";
+import { deriveLicenseState, type LicenseState } from "@/lib/license-state";
 
 export type { LicenseStatus, LicenseType } from "@/lib/license";
+export type { LicenseState } from "@/lib/license-state";
 
 export interface LicenseInfo {
   enterprise: boolean;
+  state: LicenseState;
   type: string | null;
   org: string | null;
   expiresAt: string | null;
+  paidUntil: string | null;
   daysRemaining: number | null;
   managedByEnv: boolean;
   maxUsers: number;
   seatsUsed: number;
+  hasGatedConfig: boolean;
 }
 
 // Production public key (ES256 / P-256)
@@ -78,4 +83,15 @@ export function clearLicenseCache(): void {
 export async function isEnterprise(publicKeyPem: string = PRODUCTION_PUBLIC_KEY): Promise<boolean> {
   const status = await getLicenseStatus(publicKeyPem);
   return status.active;
+}
+
+/**
+ * The license state per pricing concept § 6, derived offline from the
+ * (cached) license status and the current clock.
+ */
+export async function getLicenseState(
+  publicKeyPem: string = PRODUCTION_PUBLIC_KEY
+): Promise<LicenseState> {
+  const status = await getLicenseStatus(publicKeyPem);
+  return deriveLicenseState(status, new Date());
 }

--- a/packages/web/src/lib/gated-config.ts
+++ b/packages/web/src/lib/gated-config.ts
@@ -2,6 +2,12 @@ import { count, and, eq, isNull } from "drizzle-orm";
 import { db } from "@/db";
 import { agents, groups } from "@/db/schema";
 
+const RESTRICTED_SHARED_AGENTS = and(
+  eq(agents.visibility, "restricted"),
+  eq(agents.isPersonal, false),
+  isNull(agents.deletedAt)
+);
+
 /**
  * Whether any license-gated configuration exists: groups, or shared agents
  * with restricted visibility. Used to decide if the "Remove all
@@ -10,16 +16,37 @@ import { agents, groups } from "@/db/schema";
 export async function hasGatedConfig(): Promise<boolean> {
   const [groupRows, restrictedAgentRows] = await Promise.all([
     db.select({ count: count() }).from(groups),
-    db
-      .select({ count: count() })
-      .from(agents)
-      .where(
-        and(
-          eq(agents.visibility, "restricted"),
-          eq(agents.isPersonal, false),
-          isNull(agents.deletedAt)
-        )
-      ),
+    db.select({ count: count() }).from(agents).where(RESTRICTED_SHARED_AGENTS),
   ]);
   return groupRows[0].count > 0 || restrictedAgentRows[0].count > 0;
+}
+
+export interface RemovedGatedConfig {
+  groups: Array<{ id: string; name: string }>;
+  agents: Array<{ id: string; name: string }>;
+}
+
+/**
+ * The "Remove all license-gated configuration" escape hatch (pricing concept
+ * § 5, carve-out 2): deletes all groups (memberships and agent links cascade)
+ * and resets restricted shared agents to be visible to all users — back to
+ * community semantics. Deliberately widens access, which is why it only runs
+ * as an explicit, audited admin action.
+ *
+ * Returns name snapshots for the audit entry — the rows are gone afterwards.
+ */
+export async function removeGatedConfig(): Promise<RemovedGatedConfig> {
+  const [allGroups, restrictedAgents] = await Promise.all([
+    db.select({ id: groups.id, name: groups.name }).from(groups),
+    db.select({ id: agents.id, name: agents.name }).from(agents).where(RESTRICTED_SHARED_AGENTS),
+  ]);
+
+  if (allGroups.length > 0) {
+    await db.delete(groups);
+  }
+  if (restrictedAgents.length > 0) {
+    await db.update(agents).set({ visibility: "all" }).where(RESTRICTED_SHARED_AGENTS);
+  }
+
+  return { groups: allGroups, agents: restrictedAgents };
 }

--- a/packages/web/src/lib/gated-config.ts
+++ b/packages/web/src/lib/gated-config.ts
@@ -1,0 +1,25 @@
+import { count, and, eq, isNull } from "drizzle-orm";
+import { db } from "@/db";
+import { agents, groups } from "@/db/schema";
+
+/**
+ * Whether any license-gated configuration exists: groups, or shared agents
+ * with restricted visibility. Used to decide if the "Remove all
+ * license-gated configuration" escape hatch (pricing concept § 5) applies.
+ */
+export async function hasGatedConfig(): Promise<boolean> {
+  const [groupRows, restrictedAgentRows] = await Promise.all([
+    db.select({ count: count() }).from(groups),
+    db
+      .select({ count: count() })
+      .from(agents)
+      .where(
+        and(
+          eq(agents.visibility, "restricted"),
+          eq(agents.isPersonal, false),
+          isNull(agents.deletedAt)
+        )
+      ),
+  ]);
+  return groupRows[0].count > 0 || restrictedAgentRows[0].count > 0;
+}

--- a/packages/web/src/lib/license-state.ts
+++ b/packages/web/src/lib/license-state.ts
@@ -1,0 +1,26 @@
+import type { LicenseStatus } from "@/lib/license";
+
+/**
+ * The four license states of the pricing concept (§ 6), with the expired
+ * branch split by key type so trial and paid expiry get their own copy.
+ * Derived purely offline from the JWT claims — no network, no telemetry.
+ */
+export type LicenseState = "community" | "trial" | "trial-expired" | "paid" | "grace" | "expired";
+
+export function deriveLicenseState(status: LicenseStatus, now: Date): LicenseState {
+  if (status.expired) {
+    return status.type === "trial" ? "trial-expired" : "expired";
+  }
+  if (!status.active) return "community";
+  if (status.type === "trial") return "trial";
+  if (status.paidUntilAt && now.getTime() > status.paidUntilAt.getTime()) return "grace";
+  return "paid";
+}
+
+/**
+ * States in which gated features are unlocked. Grace counts as active —
+ * the key is still valid (exp = paidUntil + grace, § 1).
+ */
+export function isLicenseActive(state: LicenseState): boolean {
+  return state === "paid" || state === "trial" || state === "grace";
+}

--- a/packages/web/src/lib/license.ts
+++ b/packages/web/src/lib/license.ts
@@ -4,16 +4,60 @@ export type LicenseType = "trial" | "paid";
 
 export interface LicenseStatus {
   active: boolean;
+  /**
+   * True when the token's signature is valid but its exp has passed.
+   * Lets the app tell "expired" apart from "community" (no key at all)
+   * while keeping the gates closed (`active` stays false).
+   */
+  expired?: boolean;
   type?: LicenseType;
   org?: string;
   features: string[];
   expiresAt?: Date;
+  /**
+   * End of the paid period (`paidUntil` claim, epoch seconds). For paid keys
+   * `exp = paidUntil + grace`; absent on keys issued before the claim existed.
+   */
+  paidUntilAt?: Date;
   daysRemaining?: number;
   ver: number;
   maxUsers: number;
 }
 
 const INACTIVE: LicenseStatus = { active: false, features: [], ver: 1, maxUsers: 0 };
+
+const ISSUER = "heypinchy.com";
+
+function readClaims(payload: jose.JWTPayload): Omit<LicenseStatus, "active" | "expired"> {
+  const features = (payload.features as string[]) ?? [];
+  const ver = typeof payload.ver === "number" ? payload.ver : 1;
+  const maxUsers = typeof payload.maxUsers === "number" ? payload.maxUsers : 0;
+
+  if (ver > 1) {
+    console.warn(
+      `License token has ver=${ver}, this app understands up to ver=1. Unknown fields ignored.`
+    );
+  }
+
+  const expiresAt = payload.exp ? new Date(payload.exp * 1000) : undefined;
+  const paidUntilAt =
+    typeof payload.paidUntil === "number" ? new Date(payload.paidUntil * 1000) : undefined;
+  const now = new Date();
+  const daysRemaining = expiresAt
+    ? Math.max(0, Math.floor((expiresAt.getTime() - now.getTime()) / 86400000))
+    : undefined;
+
+  return {
+    type: payload.type as LicenseType | undefined,
+    org: payload.sub,
+    features,
+    expiresAt,
+    paidUntilAt,
+    daysRemaining,
+    ver,
+    maxUsers,
+  };
+}
 
 /**
  * Validate a JWT license token against a public key.
@@ -25,38 +69,25 @@ export async function validateLicense(token: string, publicKeyPem: string): Prom
   try {
     const publicKey = await jose.importSPKI(publicKeyPem, "ES256");
     const { payload } = await jose.jwtVerify(token, publicKey, {
-      issuer: "heypinchy.com",
+      issuer: ISSUER,
     });
 
-    const features = (payload.features as string[]) ?? [];
-    if (!features.includes("enterprise")) return INACTIVE;
+    const claims = readClaims(payload);
+    if (!claims.features.includes("enterprise")) return INACTIVE;
 
-    const ver = typeof payload.ver === "number" ? payload.ver : 1;
-    const maxUsers = typeof payload.maxUsers === "number" ? payload.maxUsers : 0;
-
-    if (ver > 1) {
-      console.warn(
-        `License token has ver=${ver}, this app understands up to ver=1. Unknown fields ignored.`
-      );
+    return { active: true, ...claims };
+  } catch (err) {
+    // jose verifies the signature before validating claims, so a JWTExpired
+    // error proves the token is authentic — only exp has passed. Preserve the
+    // claims so the app can distinguish "expired" from "community", but
+    // re-check the claims jose may not have reached before throwing.
+    if (err instanceof jose.errors.JWTExpired) {
+      const payload = jose.decodeJwt(token);
+      if (payload.iss !== ISSUER) return INACTIVE;
+      const claims = readClaims(payload);
+      if (!claims.features.includes("enterprise")) return INACTIVE;
+      return { active: false, expired: true, ...claims };
     }
-
-    const expiresAt = payload.exp ? new Date(payload.exp * 1000) : undefined;
-    const now = new Date();
-    const daysRemaining = expiresAt
-      ? Math.max(0, Math.floor((expiresAt.getTime() - now.getTime()) / 86400000))
-      : undefined;
-
-    return {
-      active: true,
-      type: payload.type as LicenseType | undefined,
-      org: payload.sub,
-      features,
-      expiresAt,
-      daysRemaining,
-      ver,
-      maxUsers,
-    };
-  } catch {
     return INACTIVE;
   }
 }

--- a/packages/web/src/lib/seat-grace.ts
+++ b/packages/web/src/lib/seat-grace.ts
@@ -1,0 +1,32 @@
+/**
+ * Seat-limit grace semantics from the pricing concept (§ 5): soft cap with a
+ * 20% grace window so a new hire never waits on procurement. Invites keep
+ * working up to floor(1.2 * maxUsers) seats; beyond that, only the invite
+ * endpoint blocks — existing users are never deactivated or degraded.
+ *
+ * Pure function, shared by the API route and the client UI.
+ */
+
+export interface SeatPressure {
+  /** No seat cap at all (maxUsers 0 — community or uncapped key). */
+  unlimited: boolean;
+  /** More seats in use than licensed (inside or beyond the grace window). */
+  overCap: boolean;
+  /** Whether one more invite may be created. */
+  inviteAllowed: boolean;
+  /** floor(1.2 * maxUsers), or null when unlimited. */
+  graceCap: number | null;
+}
+
+export function evaluateSeatPressure(used: number, maxUsers: number): SeatPressure {
+  if (maxUsers <= 0) {
+    return { unlimited: true, overCap: false, inviteAllowed: true, graceCap: null };
+  }
+  const graceCap = Math.floor(maxUsers * 1.2);
+  return {
+    unlimited: false,
+    overCap: used > maxUsers,
+    inviteAllowed: used < graceCap,
+    graceCap,
+  };
+}

--- a/packages/web/src/lib/visible-agents.ts
+++ b/packages/web/src/lib/visible-agents.ts
@@ -1,13 +1,15 @@
 import { db } from "@/db";
 import { activeAgents } from "@/db/schema";
 import { getUserGroupIds, getAllAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
 import { effectiveVisibility } from "@/lib/agent-access";
 
 export async function getVisibleAgents(userId: string, userRole: string) {
   const isAdmin = userRole === "admin";
-  const enterprise = await isEnterprise();
-  const needsGroups = !isAdmin && enterprise;
+  const licenseState = await getLicenseState();
+  // Restricted visibility stays enforced after expiry (fail closed, § 5) —
+  // only community instances skip group resolution entirely.
+  const needsGroups = !isAdmin && licenseState !== "community";
 
   const [userGroupIds, allAgents, agentGroupMap] = await Promise.all([
     needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
@@ -27,7 +29,7 @@ export async function getVisibleAgents(userId: string, userRole: string) {
       visible.push(agent);
       continue;
     }
-    switch (effectiveVisibility(agent.visibility, enterprise)) {
+    switch (effectiveVisibility(agent.visibility, licenseState)) {
       case "all":
         visible.push(agent);
         break;

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -4,7 +4,7 @@ import { waitForAgentInRuntime } from "@/server/agent-readiness";
 import type { WebSocket } from "ws";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
-import { isEnterprise } from "@/lib/enterprise";
+import { getLicenseState } from "@/lib/enterprise";
 import { buildMemoryPromptBlock } from "@/lib/memory-prompt";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
@@ -119,8 +119,8 @@ export class ClientRouter {
       return;
     }
 
-    const enterprise = await isEnterprise();
-    const effVis = effectiveVisibility(agent.visibility, enterprise);
+    const licenseState = await getLicenseState();
+    const effVis = effectiveVisibility(agent.visibility, licenseState);
     const needsGroups = this.userRole !== "admin" && effVis === "restricted";
 
     const [userGroupIds, agentGroupIds] = await Promise.all([
@@ -129,7 +129,14 @@ export class ClientRouter {
     ]);
 
     try {
-      assertAgentAccess(agent, this.userId, this.userRole, userGroupIds, agentGroupIds, enterprise);
+      assertAgentAccess(
+        agent,
+        this.userId,
+        this.userRole,
+        userGroupIds,
+        agentGroupIds,
+        licenseState
+      );
     } catch {
       this.sendToClient(clientWs, { type: "error", message: "Access denied" });
       const auditEntry = {


### PR DESCRIPTION
Implements the in-app conversion surfaces of the approved pricing concept (Phase A, single SKU). Zero-telemetry by design (D-011): every CTA is a passive link with a static UTM triple — no requests, no events, no instance or user identifiers ever leave the instance.

## License states (offline, from the JWT)

- `validateLicense` now reads the additive `paidUntil` claim (tolerant — absent on current keys) and preserves the claims of **expired but signature-valid** tokens (`expired: true`). jose verifies the signature before claim validation, so catching `JWTExpired` + re-checking issuer/features is sound.
- New pure `deriveLicenseState`: `community` / `trial` / `trial-expired` / `paid` / `grace` / `expired`. Grace = between `paidUntil` and `exp` (key still valid).
- `/api/enterprise/status` exposes `state`, `paidUntil`, and `hasGatedConfig`.

## Conversion surfaces (§ 6 state table)

- **Banner** (admins only, dismissible per session, never red): trial countdown (amber from T-7) with Buy/Compare links, trial-expired → pricing, renewal reminder from `paidUntil − 14d`, grace and expired → customer portal. Community gets no permanent banner.
- **Cliff modal** at gated features (Groups, Agent Access Control, analytics cards): community → "Start free 30-day trial" (+ "See pricing"), trial-expired → "See pricing", expired → "Renew". Dismiss is a plain "Not now" — no guilt copy.
- **Non-admins** never see sales copy — only "This feature requires a Pro license. Ask your administrator."
- Existing CTAs (`enterprise-banner`, `enterprise-feature-card`, `settings-license`) retargeted from `/enterprise` to the § 6 targets. Product URL `buy.heypinchy.com/shop/pinchy-pro-5` verified against the live shop (Odoo resolves the trailing id, so it survives the Pro-10 rename).
- UTM vocabulary is type-enforced in `conversion-links.ts`: `utm_source=pinchy-app`, mediums `cliff-modal | trial-banner | expired-banner | settings-license`, campaigns `groups | visibility | analytics | pro-10`.

## Seat grace (§ 5)

- Soft cap: invites keep working up to `floor(1.2 × maxUsers)` (10 → 12). Previously the endpoint hard-blocked at 100%.
- 100–120%: factual notice in the invite flow + dismissible admin banner ("Grace seats keep a new hire never waits on procurement" framing), no red.
- Beyond 120%: structured 403 (`graceCap` included) and a quote dialog — `mailto:sales@heypinchy.com` with a static subject + Calendly as secondary. **No band products are linked** (Phase A has one SKU).
- Existing users are never deactivated or degraded; `user.invite_blocked` audit event extended with `graceCap`.

## Fail-closed expiry with carve-outs (§ 5) — behavior change

- `effectiveVisibility` no longer fails open: **an expired license keeps restrictions enforced** (UI, API, WebSocket router, agent list). The old code mapped `restricted → all` whenever no license was active.
- Exception: `community` instances (never licensed) keep the `restricted → all` mapping, because shared agents default to `visibility: "restricted"` in the DB without anyone having restricted them — strict enforcement would lock out every community instance.
- **Carve-out 1 — restriction-tightening always works without a license:** removing users from groups (`PUT …/members`, `PUT …/groups` allow removal-only updates; adding returns a structured 403) and deactivating users (pinned by a test). Group/member GETs are unlocked (admin-only) so the removal UI works.
- **Carve-out 2 — audited escape hatch:** `DELETE /api/enterprise/gated-config` (+ confirm dialog in Settings → License) deletes all groups and resets restricted agents to "all" — the explicit way back to community semantics. Audited as `config.gated_config_removed` with `{id, name}` snapshots (capped at 20 + counts).
- Telegram allow-stores were already fail-closed (no license check) — unchanged.

## Docs

`guides/enterprise-setup.mdx` updated in the same PR: 30-day trial via /pricing, seat grace semantics, fail-closed expiry with carve-outs and the escape hatch. URL unchanged.

## Out of scope (deliberate)

- Cliff-modal screenshot asset (marketing repo task).
- "Included in your trial" badges (gated UIs are fully unlocked during trial — no surface).
- Band preselect / seat-limit checkout links (Phase B — band products don't exist yet).
- `paidUntil` emission in the key-issuing Odoo plugin (§ 8 step 2a/b); the app reads it tolerantly once keys carry it.

## Verification

- 5825 unit tests green (net +~80 new tests, TDD throughout), `tsc` clean, ESLint 0 errors, `pnpm test:scripts` 94/94, docs build green, Next production build green, test-deletion guard: 33 changed test files, no net removal.

Note: § 6 of the concept and `content/utm-konvention.md` disagree on the in-app UTM values (`pinchy-app`/`cliff-modal` vs. `app`/`cliff`). This PR follows § 6 as instructed; the marketing-repo convention doc may want a follow-up alignment.