### PR TITLE
docs(model-resolver): pin gemini tool-block rationale to family-level leak evidence

### DIFF
--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -12,8 +12,13 @@ const RULES: BlockRule[] = [
     forbiddenWhen: ["tools"],
     reason: "DeepSeek-R1 tool-calling unreliable without reasoning:false flag",
   },
-  // Remove once pinchy#344 / openclaw#72879 (thought_signature drop) and the
-  // silent-hang variant on the reasoning+vision+tools path are resolved upstream.
+  // Do NOT remove this rule when pinchy#344 / openclaw#72879 (thought_signature
+  // drop) are fixed upstream. The plain-text tool-call leak — "default_api"
+  // calls emitted as assistant text instead of structured tool_calls — is
+  // Gemini-family model behavior, reproduced even on Google's native API
+  // (livekit/agents#5662) and observed in production on 2026-06-11
+  // (ollama-cloud/gemini-3-flash-preview). Lifting this block requires a fresh
+  // multi-round tool probe against the live endpoint, not just closed issues.
   {
     modelPattern: /-preview\b/i,
     forbiddenWhen: ["tools"],

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -94,6 +94,11 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
+    // Capable vision/long-context model for chat-only agents, but it leaks
+    // tool calls as plain text ("default_api" signature) in agentic sessions —
+    // observed in production 2026-06-11. The resolver blocklist (-preview +
+    // tools) keeps it out of every tool slot; do not hand-pick it for agents
+    // that use tools.
     id: "gemini-3-flash-preview",
     contextWindow: 1048576,
     maxTokens: 65536,


### PR DESCRIPTION
## Why

On 2026-06-11 production (Piper, `ollama-cloud/gemini-3-flash-preview`) emitted a raw `default_api:odoo_write{...}` tool call as assistant text — the structured `tool_calls` block was never produced, so the action silently did not execute (no audit entry).

Research findings:
- The plain-text tool-call leak is **Gemini-family model behavior**, reproduced even on Google's native API (livekit/agents#5662, with OpenAI/Groq as negative controls) — independent of pinchy#344 / openclaw#72879.
- The existing `-preview` + tools blocklist rule already keeps the model out of every resolver slot, but its comment instructed removal once those two issues are resolved upstream. Following that guidance would re-expose the leak.

## What

Comment-only changes, no behavior:
- `blocklist.ts`: replace the removal guidance — lifting the block requires a fresh multi-round tool probe against the live endpoint, not just closed upstream issues.
- `ollama-cloud-models.ts`: document the leak on the catalog entry so the model isn't hand-picked for tool-using agents.

## Verification

- `blocklist.test.ts`, `ollama-cloud.test.ts`, `provider-models.test.ts`: 105/105 green (no behavior change to guard).
- ESLint clean on both files.