### PR TITLE
docs(connect-odoo): App-Store-Modul Pinchy Connector erwähnen

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -5,6 +5,10 @@ description: Connect your Odoo ERP instance to Pinchy and give agents access to 
 
 This guide walks you through connecting your Odoo instance to Pinchy so your agents can query sales orders, contacts, inventory, and other business data — without giving them direct database access.
 
+:::tip[Install from the Odoo App Store]
+Prefer to set this up from inside Odoo? The free **[Pinchy Connector](https://apps.odoo.com/apps/modules/19.0/pinchy_connector)** module (Odoo 17, 18 and 19) adds a Pinchy section to your Odoo settings: it stores your Pinchy URL, tests the connection, and walks you through creating the API key described below. It's optional — the steps in this guide work with or without it.
+:::
+
 ## Prerequisites
 
 - Pinchy is running (see [Quick Start](/getting-started/))


### PR DESCRIPTION
Tipp-Callout am Anfang des Connect-Odoo-Guides, der auf das freie App-Store-Modul **Pinchy Connector** (Odoo 17/18/19) verweist — es automatisiert URL- + API-Key-Setup aus Odoo heraus.

**Warum:** Schließt den Kreis Doku ↔ Store. Die Store-Seite des Moduls verlinkt bereits auf diesen Guide; mit diesem Callout verweist der Guide zurück — beides verstärkt sich gegenseitig als Citation-Quelle (GEO). Als optional gekennzeichnet, damit der bestehende manuelle Pfad gleichwertig bleibt.

Docs-Build grün (45 Seiten), Callout im dist-Output verifiziert.