### PR TITLE
fix(models): gate the tools-blocklist in the agent model picker and write path

### DIFF
--- a/packages/web/src/__tests__/components/agent-settings-general.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-general.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, within } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentSettingsGeneral } from "@/components/agent-settings-general";
@@ -263,6 +263,64 @@ describe("AgentSettingsGeneral", () => {
       const sonnetOption = options.find((o) => o.textContent?.includes("Claude Sonnet 4"));
       expect(sonnetOption).toBeDefined();
       expect(sonnetOption).not.toHaveAttribute("aria-disabled", "true");
+    });
+  });
+
+  describe("tools-blocklist guard", () => {
+    const providersWithBlocked = [
+      {
+        id: "ollama-cloud",
+        name: "Ollama Cloud",
+        models: [
+          { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini-3-flash-preview" },
+          { id: "ollama-cloud/qwen3-vl:235b", name: "qwen3-vl" },
+        ],
+      },
+    ];
+
+    it("warns when the agent's current model is blocklisted for tool use", () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/gemini-3-flash-preview" }}
+          providers={providersWithBlocked}
+          onChange={vi.fn()}
+        />
+      );
+
+      // Scope to the alert: the block reason also appears in the disabled
+      // picker option, so assert it specifically inside the warning banner.
+      const alert = screen.getByRole("alert");
+      expect(within(alert).getByText(/unreliable for tool use/i)).toBeInTheDocument();
+      expect(within(alert).getByText(/Preview models/i)).toBeInTheDocument();
+    });
+
+    it("shows no warning when the current model is reliable", () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/qwen3-vl:235b" }}
+          providers={providersWithBlocked}
+          onChange={vi.fn()}
+        />
+      );
+
+      expect(screen.queryByText(/unreliable for tool use/i)).not.toBeInTheDocument();
+    });
+
+    it("disables a blocklisted model in the dropdown so it cannot be picked", async () => {
+      render(
+        <AgentSettingsGeneral
+          agent={{ ...defaultAgent, model: "ollama-cloud/qwen3-vl:235b" }}
+          providers={providersWithBlocked}
+          onChange={vi.fn()}
+        />
+      );
+
+      await userEvent.click(screen.getByRole("combobox"));
+
+      const options = screen.getAllByRole("option");
+      const blockedOption = options.find((o) => o.textContent?.includes("gemini-3-flash-preview"));
+      expect(blockedOption).toBeDefined();
+      expect(blockedOption).toHaveAttribute("aria-disabled", "true");
     });
   });
 

--- a/packages/web/src/__tests__/lib/agent-model-validation.test.ts
+++ b/packages/web/src/__tests__/lib/agent-model-validation.test.ts
@@ -1,0 +1,71 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockFetchProviderModels = vi.fn();
+vi.mock("@/lib/provider-models", () => ({
+  fetchProviderModels: () => mockFetchProviderModels(),
+}));
+
+import { validateAgentModel } from "@/lib/agent-model-validation";
+
+const OLLAMA_CLOUD = (
+  models: Array<{ id: string; name: string; compatible?: boolean; incompatibleReason?: string }>
+) => [{ id: "ollama-cloud", name: "Ollama Cloud", models }];
+
+describe("validateAgentModel — tools blocklist", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("rejects switching to a tools-blocklisted model even when the provider reports it compatible", async () => {
+    // The provider says compatible:true (key configured, supports agents) — but
+    // gemini-3-flash-preview is unreliable for the tool loop every Pinchy agent
+    // drives. The write path must reject it, not just the picker.
+    mockFetchProviderModels.mockResolvedValue(
+      OLLAMA_CLOUD([
+        {
+          id: "ollama-cloud/gemini-3-flash-preview",
+          name: "gemini-3-flash-preview",
+          compatible: true,
+        },
+        { id: "ollama-cloud/qwen3-vl:235b", name: "qwen3-vl", compatible: true },
+      ])
+    );
+
+    const err = await validateAgentModel("ollama-cloud/gemini-3-flash-preview");
+    expect(err).toBeTruthy();
+    expect(err).toContain("Preview models");
+  });
+
+  it("rejects a deepseek-r1 model with its specific reason", async () => {
+    mockFetchProviderModels.mockResolvedValue(
+      OLLAMA_CLOUD([{ id: "ollama-cloud/deepseek-r1:32b", name: "deepseek-r1", compatible: true }])
+    );
+    expect(await validateAgentModel("ollama-cloud/deepseek-r1:32b")).toContain("DeepSeek-R1");
+  });
+
+  it("allows a reliable vision+tools model", async () => {
+    mockFetchProviderModels.mockResolvedValue(
+      OLLAMA_CLOUD([{ id: "ollama-cloud/qwen3-vl:235b", name: "qwen3-vl", compatible: true }])
+    );
+    expect(await validateAgentModel("ollama-cloud/qwen3-vl:235b")).toBeNull();
+  });
+
+  it("still surfaces the provider's own incompatibility reason (unchanged behavior)", async () => {
+    mockFetchProviderModels.mockResolvedValue(
+      OLLAMA_CLOUD([
+        {
+          id: "ollama-cloud/some-model",
+          name: "some-model",
+          compatible: false,
+          incompatibleReason: "Provider not configured",
+        },
+      ])
+    );
+    expect(await validateAgentModel("ollama-cloud/some-model")).toBe("Provider not configured");
+  });
+
+  it("still reports an unavailable model whose provider is not configured", async () => {
+    mockFetchProviderModels.mockResolvedValue(OLLAMA_CLOUD([]));
+    expect(await validateAgentModel("ollama-cloud/whatever")).toContain("not available");
+  });
+});

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -13,10 +13,13 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
+import { AlertTriangle } from "lucide-react";
+import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { DeleteAgentDialog } from "@/components/delete-agent-dialog";
 import { ModelPicker } from "@/components/model-picker";
 import { useModelCapabilities } from "@/hooks/use-model-capabilities";
 import { attachCapabilities } from "@/lib/model-capabilities/attach-capabilities";
+import { getAgentModelBlockReason, markToolBlockedModels } from "@/lib/model-resolver/blocklist";
 
 import { AGENT_NAME_MAX_LENGTH } from "@/lib/agent-constants";
 
@@ -68,10 +71,21 @@ export function AgentSettingsGeneral({
   // capability flags) with the capability map so the picker can render each
   // model's capability icons. Undefined while the map loads → icon-free, no crash.
   const { data: capabilities } = useModelCapabilities();
+  // Attach capability icons, then disable models the tools-blocklist flags as
+  // unreliable for the function-calling loop every agent runs (e.g.
+  // gemini-3-flash-preview). This stops the gap that let an agent be pointed at
+  // a tool-broken model and silently fail at runtime.
   const providersWithCapabilities = useMemo(
-    () => attachCapabilities(providers, capabilities),
+    () => markToolBlockedModels(attachCapabilities(providers, capabilities)),
     [providers, capabilities]
   );
+
+  // Non-destructive surfacing of an EXISTING bad assignment: an agent created
+  // before the blocklist (or via a path that skipped it) keeps its model until
+  // an admin changes it. We don't rewrite it — we warn, and the picker above
+  // guides them to a working model. Driven by the live form value so the warning
+  // clears the moment they pick a reliable model.
+  const currentModelBlockReason = values.model ? getAgentModelBlockReason(values.model) : null;
 
   useEffect(() => {
     onChange(
@@ -137,6 +151,16 @@ export function AgentSettingsGeneral({
                     deprecatedModelId={agent.model}
                   />
                 </FormControl>
+                {currentModelBlockReason && (
+                  <Alert variant="destructive" className="mt-2">
+                    <AlertTriangle className="size-4" />
+                    <AlertTitle>This model is unreliable for tool use</AlertTitle>
+                    <AlertDescription>
+                      {currentModelBlockReason} Pick a recommended model above to keep this agent
+                      working.
+                    </AlertDescription>
+                  </Alert>
+                )}
                 <FormMessage />
               </FormItem>
             )}

--- a/packages/web/src/lib/agent-model-validation.ts
+++ b/packages/web/src/lib/agent-model-validation.ts
@@ -1,4 +1,5 @@
 import { fetchProviderModels } from "@/lib/provider-models";
+import { getAgentModelBlockReason } from "@/lib/model-resolver/blocklist";
 
 /**
  * Validates that a qualified model id (`provider/model`) can actually serve
@@ -20,6 +21,14 @@ export async function validateAgentModel(model: string): Promise<string | null> 
     if (match.compatible === false) {
       return match.incompatibleReason ?? `Model ${model} is not compatible with agents`;
     }
+    // The provider reporting `compatible` only means "key configured + supports
+    // agents" — it does NOT mean the model is reliable for tool-calling. Reject
+    // models the tools-blocklist flags (e.g. `gemini-3-flash-preview`, whose
+    // multi-turn tool calls Gemini rejects over the ollama-cloud path). The
+    // route only calls this when the model actually changes, so an agent already
+    // on a blocked model can still save other fields — this gates new picks only.
+    const blockReason = getAgentModelBlockReason(model);
+    if (blockReason) return blockReason;
     return null;
   }
   return `Model ${model} is not available — its provider is not configured`;

--- a/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from "vitest";
-import { getForbiddenCapabilitySets, isBlocked } from "../blocklist";
+import {
+  getBlockReason,
+  getForbiddenCapabilitySets,
+  isBlocked,
+  markToolBlockedModels,
+} from "../blocklist";
 
 describe("isBlocked", () => {
   it("blocks deepseek-r1 when tools capability is required", () => {
@@ -35,6 +40,89 @@ describe("isBlocked", () => {
   it("does not block stable gemini models", () => {
     expect(isBlocked("gemini-2.5-pro", ["tools"])).toBe(false);
     expect(isBlocked("gemini-2.5-flash-lite", ["tools"])).toBe(false);
+  });
+});
+
+describe("getBlockReason", () => {
+  it("returns the rule reason when a model is blocked for the required capabilities", () => {
+    const reason = getBlockReason("gemini-3-flash-preview", ["tools"]);
+    expect(reason).toBeTruthy();
+    expect(reason).toContain("Preview models");
+  });
+
+  it("returns the deepseek-specific reason for deepseek-r1 + tools", () => {
+    expect(getBlockReason("deepseek-r1:32b", ["tools"])).toContain("DeepSeek-R1");
+  });
+
+  it("returns null when the model is not blocked for the given capabilities", () => {
+    expect(getBlockReason("gemini-3-flash-preview", ["vision"])).toBeNull();
+    expect(getBlockReason("qwen3-vl:235b", ["tools"])).toBeNull();
+  });
+
+  it("agrees with isBlocked: non-null reason iff blocked", () => {
+    for (const [model, caps] of [
+      ["gemini-3-flash-preview", ["tools"]],
+      ["deepseek-r1:32b", ["tools"]],
+      ["qwen3-vl:235b", ["tools"]],
+      ["gemini-3-flash-preview", []],
+    ] as const) {
+      expect(getBlockReason(model, [...caps]) !== null).toBe(isBlocked(model, [...caps]));
+    }
+  });
+});
+
+describe("markToolBlockedModels", () => {
+  it("marks a tools-blocklisted model incompatible with the block reason, leaving others untouched", () => {
+    const out = markToolBlockedModels([
+      {
+        id: "ollama-cloud",
+        models: [
+          { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini", compatible: true },
+          { id: "ollama-cloud/qwen3-vl:235b", name: "qwen", compatible: true },
+        ],
+      },
+    ]);
+    expect(out[0].models[0].compatible).toBe(false);
+    expect(out[0].models[0].incompatibleReason).toContain("Preview models");
+    expect(out[0].models[1].compatible).toBe(true);
+    expect(out[0].models[1].incompatibleReason).toBeUndefined();
+  });
+
+  it("preserves an existing provider incompatibility reason rather than overwriting it", () => {
+    const out = markToolBlockedModels([
+      {
+        id: "p",
+        models: [
+          {
+            id: "x/some-model",
+            name: "x",
+            compatible: false,
+            incompatibleReason: "Provider not configured",
+          },
+        ],
+      },
+    ]);
+    expect(out[0].models[0].incompatibleReason).toBe("Provider not configured");
+  });
+
+  it("leaves reliable models untouched", () => {
+    const out = markToolBlockedModels([
+      {
+        id: "anthropic",
+        models: [{ id: "anthropic/claude-opus-4-8", name: "c", compatible: true }],
+      },
+    ]);
+    expect(out[0].models[0].compatible).toBe(true);
+    expect(out[0].models[0].incompatibleReason).toBeUndefined();
+  });
+
+  it("does not mutate the input", () => {
+    const input = [
+      { id: "p", models: [{ id: "x/gemini-3-flash-preview", name: "g", compatible: true }] },
+    ];
+    markToolBlockedModels(input);
+    expect(input[0].models[0].compatible).toBe(true);
+    expect(input[0].models[0]).not.toHaveProperty("incompatibleReason");
   });
 });
 

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -28,11 +28,26 @@ const RULES: BlockRule[] = [
 ];
 
 export function isBlocked(modelId: string, requiredCapabilities: ModelCapability[]): boolean {
-  return RULES.some(
-    (rule) =>
-      rule.modelPattern.test(modelId) &&
-      rule.forbiddenWhen.some((c) => requiredCapabilities.includes(c))
+  return getBlockReason(modelId, requiredCapabilities) !== null;
+}
+
+/**
+ * Returns the human-readable reason a model is blocked for the given required
+ * capabilities, or null when it is not blocked. Same matching as `isBlocked`,
+ * but surfaces the rule's `reason` so callers (model picker, agent-model write
+ * validation, settings warning) can tell the user WHY a model is unsuitable
+ * instead of silently failing at runtime — the gap that left agents stuck on
+ * tool-broken models like `gemini-3-flash-preview`.
+ */
+export function getBlockReason(
+  modelId: string,
+  requiredCapabilities: ModelCapability[]
+): string | null {
+  const rule = RULES.find(
+    (r) =>
+      r.modelPattern.test(modelId) && r.forbiddenWhen.some((c) => requiredCapabilities.includes(c))
   );
+  return rule?.reason ?? null;
 }
 
 /**
@@ -43,4 +58,42 @@ export function isBlocked(modelId: string, requiredCapabilities: ModelCapability
  */
 export function getForbiddenCapabilitySets(): ReadonlyArray<readonly ModelCapability[]> {
   return RULES.map((r) => r.forbiddenWhen);
+}
+
+// Every Pinchy agent drives a function-calling loop, so its chat model always
+// needs to be tool-reliable (see agent-model-validation.ts for the same
+// rationale). Kept here so the picker transform and predicate share one source.
+const AGENT_MODEL_REQUIRED_CAPABILITIES: ModelCapability[] = ["tools"];
+
+/**
+ * Returns a copy of a model-picker provider list with every model the
+ * tools-blocklist flags marked `compatible: false` plus the rule's reason, so
+ * the picker disables it with an explanation — the same treatment configured
+ * providers already give models without an API key. Models that are already
+ * incompatible keep their existing reason; reliable models pass through
+ * untouched. Pure and non-mutating.
+ */
+export function markToolBlockedModels<
+  M extends { id: string; compatible?: boolean; incompatibleReason?: string },
+  P extends { models: M[] },
+>(providers: P[]): P[] {
+  return providers.map((provider) => ({
+    ...provider,
+    models: provider.models.map((model) => {
+      if (model.compatible === false) return model;
+      const blockReason = getBlockReason(model.id, AGENT_MODEL_REQUIRED_CAPABILITIES);
+      if (!blockReason) return model;
+      return { ...model, compatible: false, incompatibleReason: blockReason };
+    }),
+  }));
+}
+
+/** True when the given agent chat model is flagged unreliable for tool use. */
+export function isAgentModelToolBlocked(modelId: string): boolean {
+  return isBlocked(modelId, AGENT_MODEL_REQUIRED_CAPABILITIES);
+}
+
+/** The reason an agent chat model is tool-blocked, or null. For settings warnings. */
+export function getAgentModelBlockReason(modelId: string): string | null {
+  return getBlockReason(modelId, AGENT_MODEL_REQUIRED_CAPABILITIES);
 }


### PR DESCRIPTION
## Problem

An agent could be assigned a model Pinchy's own blocklist (`model-resolver/blocklist.ts`) flags as unreliable for tool use — e.g. `gemini-3-flash-preview`, whose multi-turn tool calls Gemini rejects over the ollama-cloud path with `400 "missing thought_signature"` — and then fail silently at runtime. On Telegram the user just sees OpenClaw's generic "Something went wrong…".

The blocklist was only consulted by the resolver's auto-picks. It did **not** cover:

- the agent-settings **model picker** (an admin could manually select a blocked model),
- the **write-path validation**, or
- **existing agents** assigned a model before the block existed.

A 2026-06-15 production audit found 4 agents on blocked models (Penny — since switched to `minimax-m3` —, Smithers, Ledger, Piper).

## Fix (non-destructive — no migration)

Shared helpers in `blocklist.ts` (`getBlockReason`, `markToolBlockedModels`, `getAgentModelBlockReason`) now gate three surfaces:

1. **Server write-path** — `validateAgentModel` rejects a *change to* a blocked model. The route only validates when the model actually changes, so an agent already on a blocked model can still save other fields — existing data is never rewritten.
2. **Picker** — the agent-settings `ModelPicker` disables blocked models with the block reason (reuses the existing `compatible:false` rendering; no picker-component change).
3. **Warning banner** — a non-destructive alert when the agent's *current* model is blocked, guiding the admin to a working model. Clears the moment a reliable model is selected.

Every Pinchy agent drives a function-calling loop (built-in pdf/image/memory + allow-listed tools), so agent chat models always require `["tools"]`.

## Tests

- `getBlockReason` + `markToolBlockedModels` unit tests (pure, in `blocklist.test.ts`).
- `validateAgentModel` rejects blocked models; keeps existing behavior for provider-incompatible and unavailable models.
- Component tests: the warning banner renders for a blocked current model, hides for a reliable one, and the picker disables a blocked option.

## Follow-ups (out of scope)

- `recovery-panel.tsx` reuses the same picker but isn't wired to the disable transform; the server guard backstops it. Optional consistency change.
- Smithers / Ledger / Piper are still on blocked models — now self-service via the warning banner in their settings.
