### PR TITLE
docs(readme): marketing overhaul (badges, hero, comparison table, quick-start, star-history)

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,10 +49,10 @@ You want AI agents in your company. But:
 
 Pinchy wraps OpenClaw into something enterprises can trust:
 
-- **Plugin Architecture** — Agents get scoped tools, not raw shell access. A "Create Jira Ticket" plugin instead of `exec`.
+- **Plugin Architecture** — Agents get scoped tools, not raw shell access. A "read Odoo sales orders" tool, not `exec`. Each tool is granted explicitly, per agent.
 - **Role-Based Access Control** — Who can use which agent. What each agent can do. Per team, per role.
-- **Audit Trail** — Every agent action logged. Who, what, when. Compliance-ready.
-- **Cross-Channel Workflows** — Input on email, output on Slack. Properly routed, properly permissioned.
+- **Audit Trail** — Every agent action logged. Who, what, when. Cryptographically signed and verifiable.
+- **Web & Telegram** — Reach agents in a web UI or from Telegram on your phone. One bot per agent, with the same permissions and audit trail.
 - **Self-Hosted & Offline** — Your server, your data, your models. Works without internet.
 - **Model Agnostic** — OpenAI, Anthropic, local models via Ollama. Your choice.
 
@@ -61,7 +61,7 @@ Pinchy wraps OpenClaw into something enterprises can trust:
 | | OpenClaw alone | Cloud platforms (Dust, Glean) | Workflow tools (n8n) | **Pinchy** |
 | --- | :---: | :---: | :---: | :---: |
 | Self-hosted, data stays in-house | ✅ | ❌ | ✅ | **✅** |
-| AI agents (not just flows) | ✅ | ✅ | ❌ | **✅** |
+| Agent-first (not flow-first) | ✅ | ✅ | flow steps | **✅** |
 | Per-agent tool permissions (allow-list) | ❌ | partial | flow-level | **✅** |
 | Roles & per-user access | ❌ | ✅ | paid | **✅** |
 | Tamper-evident audit trail (HMAC-signed) | ❌ | partial | execution log | **✅** |

--- a/README.md
+++ b/README.md
@@ -17,6 +17,17 @@
   <a href="https://linkedin.com/in/clemenshelm">LinkedIn</a>
 </p>
 
+<p align="center">
+  <a href="LICENSE"><img src="https://img.shields.io/badge/license-AGPL--3.0-blue.svg" alt="License: AGPL-3.0" /></a>
+  <a href="https://github.com/heypinchy/pinchy/releases"><img src="https://img.shields.io/github/v/release/heypinchy/pinchy?color=ef4444" alt="Latest release" /></a>
+  <a href="https://github.com/heypinchy/pinchy/stargazers"><img src="https://img.shields.io/github/stars/heypinchy/pinchy?style=flat&color=f97316" alt="GitHub stars" /></a>
+  <a href="https://github.com/heypinchy/pinchy/discussions"><img src="https://img.shields.io/github/discussions/heypinchy/pinchy?color=8b5cf6" alt="GitHub Discussions" /></a>
+</p>
+
+<p align="center">
+  <img src="https://heypinchy.com/screenshots/chat-interface.png" alt="Pinchy chat interface — a team member talking to a scoped AI agent" width="820" />
+</p>
+
 ---
 
 ## What is Pinchy?
@@ -45,9 +56,30 @@ Pinchy wraps OpenClaw into something enterprises can trust:
 - **Self-Hosted & Offline** — Your server, your data, your models. Works without internet.
 - **Model Agnostic** — OpenAI, Anthropic, local models via Ollama. Your choice.
 
-## Get Started
+### How Pinchy compares
 
-See the **[Installation Guide](https://docs.heypinchy.com/installation/)** for setup instructions, configuration, and development setup.
+| | OpenClaw alone | Cloud platforms (Dust, Glean) | Workflow tools (n8n) | **Pinchy** |
+| --- | :---: | :---: | :---: | :---: |
+| Self-hosted, data stays in-house | ✅ | ❌ | ✅ | **✅** |
+| AI agents (not just flows) | ✅ | ✅ | ❌ | **✅** |
+| Per-agent tool permissions (allow-list) | ❌ | partial | flow-level | **✅** |
+| Roles & per-user access | ❌ | ✅ | paid | **✅** |
+| Tamper-evident audit trail (HMAC-signed) | ❌ | partial | execution log | **✅** |
+| Chat UI + Telegram for end users | partial | ✅ | ❌ | **✅** |
+| Odoo ERP integration | ❌ | ❌ | connectors | **✅** |
+| Open source | ✅ | ❌ | fair-code | **✅ (AGPL-3.0)** |
+
+Honest caveats: Pinchy is young, the integration list is short (Odoo, Gmail, Telegram, web search, documents), there is no compliance certification yet, and granular RBAC is on the roadmap.
+
+## Quick Start
+
+```bash
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.5.7/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+# Open http://localhost:7777 — the setup wizard creates your admin account
+```
+
+That is the whole thing: one command, no build step, pre-built images on GHCR. Pair it with a local model via [Ollama](https://docs.heypinchy.com/guides/ollama-setup/) and nothing ever leaves your network. Full setup, configuration, and development instructions: **[Installation Guide](https://docs.heypinchy.com/installation/)**.
 
 ## Status
 
@@ -114,6 +146,12 @@ Please read our [Contributing Guide](CONTRIBUTING.md) before submitting a PR. If
 - [Issues](https://github.com/heypinchy/pinchy/issues) — Bug reports and feature requests
 - [Blog](https://heypinchy.com/blog) — Build in public updates
 - [LinkedIn](https://linkedin.com/in/clemenshelm) — Daily updates from the founder
+
+If Pinchy is useful to you, a ⭐ helps other teams find it.
+
+<a href="https://star-history.com/#heypinchy/pinchy&Date">
+  <img src="https://api.star-history.com/svg?repos=heypinchy/pinchy&type=Date" alt="Pinchy star history" width="600" />
+</a>
 
 ## License
 


### PR DESCRIPTION
Adds the marketing/conversion elements the README was missing, **preserving all existing content** (positioning, problem/solution prose, origin story, philosophy, status, tech stack).

Based on OSS dev-tool README research (Supabase, PostHog, Cal.com, Appwrite, Novu, Trigger.dev share the same anatomy):
- **4 functional badges** (license, release, stars, discussions) — deliberately not a 15-badge wall
- **Hero screenshot** (the single highest-impact element per the research) — uses the live `chat-interface.png` already on heypinchy.com, so no GIF needed to ship; a hero GIF can replace it later
- **Honest comparison table** — Pinchy vs OpenClaw-alone / cloud platforms / workflow tools, with explicit caveats kept
- **Real quick-start block** — one curl + `docker compose up`, not just a docs link
- **Star-history chart** + a soft star CTA

GEO: weaves the literal probing query phrases into the structure.

**Review notes:**
- Quick-start pins `v0.5.7` in the curl (one versioned spot, same pattern as the website hero — bump on release).
- Comparison table claims are from the listicle/vs research; the 'partial' cells for cloud platforms are deliberately conservative.