### PR TITLE
docs(glossary): AI agent concept hub (5 GEO definition pages)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -168,6 +168,16 @@ export default defineConfig({
           ],
         },
         {
+          label: 'Glossary',
+          items: [
+            { label: 'AI Agent Governance', slug: 'glossary/ai-agent-governance' },
+            { label: 'AI Agent Permissions', slug: 'glossary/ai-agent-permissions' },
+            { label: 'RBAC for AI Agents', slug: 'glossary/rbac-for-ai-agents' },
+            { label: 'AI Agent Audit Trail', slug: 'glossary/ai-agent-audit-trail' },
+            { label: 'Self-Hosted AI Agents', slug: 'glossary/self-hosted-ai-agents' },
+          ],
+        },
+        {
           label: 'Reference',
           items: [
             { label: 'API Reference', slug: 'reference/api' },

--- a/docs/src/content/docs/glossary/ai-agent-audit-trail.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-audit-trail.mdx
@@ -1,0 +1,79 @@
+---
+title: What is an AI agent audit trail?
+description: An AI agent audit trail is a tamper-evident record of every action an AI agent takes — which tool it called, when, on whose behalf, and with what outcome.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is an AI agent audit trail?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "An AI agent audit trail is a record of every action an AI agent takes: which tool it called, when, on whose behalf, with what inputs, and with what outcome. A strong audit trail is tamper-evident, meaning entries are cryptographically signed so after-the-fact edits can be detected. It answers the question a security or compliance reviewer always asks: who did what, and how would we prove it?"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why do AI agents need an audit trail?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Because an AI agent takes actions on behalf of people, often with access to real business systems. Without an audit trail you cannot attribute an action to a user, reconstruct an incident, or prove compliance. The audit trail turns 'the agent did something' into 'this user asked the agent to do this, at this time, and here is the signed record.'"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What makes an audit trail tamper-evident?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Each entry is signed with a cryptographic message authentication code (such as HMAC) computed over the entry's contents. If anyone edits a stored entry afterward, its signature no longer matches and verification fails. Exporting the entries with their signatures lets an independent party re-verify integrity."
+            }
+          }
+        ]
+      }
+---
+
+An **AI agent audit trail** is a record of every action an AI agent takes: which tool it called, when, on whose behalf, with what inputs, and with what outcome. A strong audit trail is _tamper-evident_, meaning entries are cryptographically signed so that after-the-fact edits can be detected.
+
+It answers the question a security or compliance reviewer always asks about automation: **who did what, and how would we prove it?**
+
+## Why AI agents need one
+
+An AI agent is different from a chatbot: it takes _actions_. It can write a record in your ERP, send an email, post to a channel, or read a document. The moment an agent acts on behalf of a person with access to real systems, three questions become unavoidable:
+
+- **Attribution.** Which user asked the agent to do this?
+- **Reconstruction.** What exactly happened, in what order, during an incident?
+- **Proof.** Can you demonstrate to an auditor that the record was not altered?
+
+Without an audit trail, "the agent did something" stays vague. With one, it becomes "this user asked this agent to take this action at this time, and here is the signed record."
+
+## What a good audit trail records
+
+| Field                  | Why it matters                                |
+| ---------------------- | --------------------------------------------- |
+| Actor (user and agent) | Attribution: who initiated, which agent acted |
+| Action / tool call     | What the agent actually did                   |
+| Timestamp              | Ordering and incident timelines               |
+| Inputs and outcome     | Reconstruction and dispute resolution         |
+| Signature              | Tamper-evidence                               |
+
+## What makes it tamper-evident
+
+Each entry is signed with a cryptographic message authentication code, such as **HMAC**, computed over the entry's contents. Edit a stored entry afterward and its signature no longer matches, so verification fails. Exporting the entries together with their signatures lets an independent party re-verify integrity without trusting the system that produced them.
+
+This is the difference between a log file (useful for debugging, editable by anyone with disk access) and an audit trail (evidence).
+
+## In Pinchy
+
+Pinchy records every agent action in an audit trail where each entry is individually HMAC-signed, and CSV exports include the signatures for independent verification. See [Audit Trail](/concepts/audit-trail/) for the full model.
+
+## Related terms
+
+- [AI agent permissions](/glossary/ai-agent-permissions/)
+- [RBAC for AI agents](/glossary/rbac-for-ai-agents/)
+- [AI agent governance](/glossary/ai-agent-governance/)

--- a/docs/src/content/docs/glossary/ai-agent-governance.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-governance.mdx
@@ -1,0 +1,72 @@
+---
+title: What is AI agent governance?
+description: AI agent governance is the set of controls that make AI agents safe to run in an organization — identity, permissions, approval, and a tamper-evident audit trail, enforced in code rather than by prompt.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is AI agent governance?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "AI agent governance is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, human approval for sensitive actions, and a tamper-evident audit trail. The defining property is that these controls are enforced in code, outside the model, rather than relying on the agent's prompt to behave."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why is AI agent governance becoming important now?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Because agents have moved from answering questions to taking actions in real systems. The moment an agent can write to an ERP, send email, or act on behalf of multiple users, an organization needs to control who can use which agent, what each agent may do, and how to prove what happened. That is governance."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What are the core components of AI agent governance?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Five components: identity (each user is a real account, not a shared login), role-based access control (who may use which agent), per-agent tool permissions on an allow-list (what each agent may do), human approval for sensitive or irreversible actions, and a tamper-evident audit trail (proof of what happened). Each is enforced in code, not requested in a prompt."
+            }
+          }
+        ]
+      }
+---
+
+**AI agent governance** is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, human approval for sensitive actions, and a tamper-evident audit trail.
+
+The defining property is that these controls are **enforced in code, outside the model**, not left to the agent's prompt to behave.
+
+## Why it matters now
+
+Agents have moved from answering questions to taking actions in real systems. A chatbot that drafts text needs little governance. An agent that can write to your ERP, send email, or act for multiple people needs all of it. The shift from _answer_ to _act_ is exactly the point where governance stops being optional.
+
+## The five components
+
+1. **Identity.** Each person is a real account, not a shared login or token. Without identity, nothing below can attribute or restrict by user.
+2. **[Role-based access control](/glossary/rbac-for-ai-agents/).** Who may use which agent.
+3. **[Tool permissions](/glossary/ai-agent-permissions/).** What each agent may do, on an allow-list: nothing until explicitly granted.
+4. **Human approval.** For sensitive or irreversible actions, the agent drafts and a human confirms before it acts.
+5. **[Tamper-evident audit trail](/glossary/ai-agent-audit-trail/).** Proof of who did what, signed so it cannot be quietly altered.
+
+Miss any one and the others leak. Perfect permissions with shared logins lose attribution. A perfect audit trail of an agent that can do anything is just a detailed record of an incident.
+
+## Enforced in code, not in a prompt
+
+A prompt is a request. Prompt injection and model drift mean an agent can be talked or nudged out of its instructions. Governance controls sit outside the model: if a user lacks the role, they cannot reach the agent; if a tool is not granted, the agent cannot call it; if an action is sensitive, it waits for approval. The model operates _within_ the boundary, never defines it.
+
+## In Pinchy
+
+Pinchy is built as a governance layer: identity and roles, [groups](/concepts/groups/) for agent access, allow-list [tool permissions](/concepts/agent-permissions/) per agent, and an HMAC-signed [audit trail](/concepts/audit-trail/), all self-hosted so the data never leaves your boundary.
+
+## Related terms
+
+- [RBAC for AI agents](/glossary/rbac-for-ai-agents/)
+- [AI agent permissions](/glossary/ai-agent-permissions/)
+- [AI agent audit trail](/glossary/ai-agent-audit-trail/)
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)

--- a/docs/src/content/docs/glossary/ai-agent-permissions.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-permissions.mdx
@@ -1,0 +1,75 @@
+---
+title: What are AI agent permissions?
+description: AI agent permissions define exactly which tools an agent may use and which data it may reach — ideally as an allow-list, where an agent can do nothing until each capability is explicitly granted.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What are AI agent permissions?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "AI agent permissions define which tools an AI agent may use and which data it may reach. The safest model is an allow-list: a new agent can do nothing until an administrator explicitly grants each capability, tool by tool. This is the opposite of giving an agent broad access and hoping its prompt keeps it in bounds."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between an allow-list and a deny-list for AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "An allow-list starts with nothing permitted and adds capabilities explicitly, so anything not granted is forbidden by default. A deny-list starts with everything permitted and removes specific capabilities, so anything you forget to block stays allowed. For AI agents, allow-lists are safer because the failure mode of forgetting is 'the agent cannot do it' rather than 'the agent can do it.'"
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why are prompt instructions not enough to control an AI agent?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A prompt is a request, not a boundary. A model can be talked out of its instructions through prompt injection or simply ignore them. Real permissions are enforced in code, outside the model: if a tool is not granted, the agent cannot call it, no matter what the prompt or the user says."
+            }
+          }
+        ]
+      }
+---
+
+**AI agent permissions** define which tools an AI agent may use and which data it may reach. The safest model is an **allow-list**: a new agent can do nothing until an administrator explicitly grants each capability, tool by tool.
+
+This is the opposite of the common default, where an agent gets broad access and a prompt is supposed to keep it in bounds.
+
+## Allow-list vs. deny-list
+
+The distinction decides what happens when you forget something.
+
+- **Allow-list.** Start with nothing permitted; add capabilities explicitly. Anything not granted is forbidden by default. Forgetting means "the agent cannot do it."
+- **Deny-list.** Start with everything permitted; remove specific capabilities. Anything you forget to block stays allowed. Forgetting means "the agent can do it."
+
+For agents that touch real systems, the allow-list failure mode is the safe one.
+
+## Why prompts are not permissions
+
+A prompt is a request, not a boundary. Two ways it fails as a control:
+
+1. **Prompt injection.** A malicious document or message can talk the model out of its instructions.
+2. **Drift.** A model can simply not follow an instruction reliably.
+
+Real permissions live in code, outside the model. If a tool is not granted, the agent cannot call it, regardless of what the prompt or the user says. The model decides _whether_ to use a granted tool; it can never reach an ungranted one.
+
+## Granularity that matters
+
+Good permission systems are specific. "Can use Odoo" is coarse. "Can read sales orders but not write them, for this agent, for these users" is the kind of boundary a business actually needs. The finer the grant, the smaller the blast radius if an agent misbehaves.
+
+## In Pinchy
+
+In Pinchy a new agent starts with zero tools. Admins enable each tool explicitly, per agent. Combined with [roles and groups](/glossary/rbac-for-ai-agents/), this controls both what an agent can do and who can ask it to. See [Agent Permissions](/concepts/agent-permissions/).
+
+## Related terms
+
+- [RBAC for AI agents](/glossary/rbac-for-ai-agents/)
+- [AI agent audit trail](/glossary/ai-agent-audit-trail/)
+- [AI agent governance](/glossary/ai-agent-governance/)

--- a/docs/src/content/docs/glossary/rbac-for-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/rbac-for-ai-agents.mdx
@@ -1,0 +1,76 @@
+---
+title: What is RBAC for AI agents?
+description: RBAC for AI agents is role-based access control applied to an agent platform — it governs which people may use which agents, separately from which tools each agent may use.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is RBAC for AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "RBAC (role-based access control) for AI agents governs which people may use which agents, based on their role. It is distinct from per-agent tool permissions: RBAC controls who can talk to an agent, while tool permissions control what that agent may do. A finance agent might be usable only by the finance group, while separately being allowed only to read accounting data."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "How is RBAC different from agent tool permissions?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "They answer two different questions. RBAC answers 'who may use this agent' by mapping users and groups to roles. Tool permissions answer 'what may this agent do' by allow-listing the tools the agent can call. A complete governance model needs both: identity on one axis, capability on the other."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Why does a single shared login break governance for AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "If everyone shares one login or token, the system cannot tell who is calling. There is no per-user access control and no attribution in the audit trail. RBAC requires that each person has their own identity, so access and accountability can both be tied to a real user."
+            }
+          }
+        ]
+      }
+---
+
+**RBAC for AI agents** is role-based access control applied to an agent platform. It governs which people may use which agents, based on their role. It is distinct from the agent's _tool_ permissions: RBAC controls **who can talk to an agent**, while [tool permissions](/glossary/ai-agent-permissions/) control **what that agent may do**.
+
+## Two axes, not one
+
+A complete governance model needs both:
+
+- **Identity axis (RBAC).** Map users and groups to roles. The finance group can use the finance agent; the support group cannot even see it.
+- **Capability axis (tool permissions).** Allow-list the tools each agent may call. The finance agent may read accounting data but not write it.
+
+Confusing the two is a common mistake. Letting the right people use an agent that can do too much is just as dangerous as locking down an agent that the wrong people can reach.
+
+## Why shared logins break it
+
+If everyone shares one login or one gateway token, the system cannot tell who is calling. That breaks RBAC at the root:
+
+- No per-user access control: access is all-or-nothing.
+- No attribution: the [audit trail](/glossary/ai-agent-audit-trail/) cannot name a user.
+
+RBAC requires that each person has their own identity, so both access and accountability tie back to a real user.
+
+## Basic vs. granular RBAC
+
+- **Basic RBAC** distinguishes a small set of roles, such as admin and member, plus groups for visibility.
+- **Granular RBAC** adds custom roles, per-resource permissions (who may view the audit log, who may manage providers), and enterprise identity via SSO/SAML.
+
+Most teams start with basic RBAC and grow into granular as the deployment matures.
+
+## In Pinchy
+
+Pinchy provides admin and member roles, plus [groups](/concepts/groups/) that scope which users can see and use which agents, separately from each agent's tool allow-list. Granular RBAC (custom roles, SSO/SAML) is on the roadmap.
+
+## Related terms
+
+- [AI agent permissions](/glossary/ai-agent-permissions/)
+- [AI agent governance](/glossary/ai-agent-governance/)
+- [AI agent audit trail](/glossary/ai-agent-audit-trail/)

--- a/docs/src/content/docs/glossary/self-hosted-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/self-hosted-ai-agents.mdx
@@ -1,0 +1,73 @@
+---
+title: What are self-hosted AI agents?
+description: Self-hosted AI agents run on infrastructure you control instead of a vendor's cloud — your data, your models, and the agent runtime all stay inside your own boundary.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What are self-hosted AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Self-hosted AI agents run on infrastructure you control, such as your own servers or private cloud, instead of a vendor's multi-tenant cloud. The data, the agent runtime, and optionally the language model all stay inside your boundary. This matters most for regulated industries and any organization that cannot send prompts and documents to an external service."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between self-hosted and cloud AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Cloud AI agents are operated by a vendor on shared infrastructure: easiest to start, but your prompts and data leave your environment. Self-hosted AI agents run on your own infrastructure: more setup, but data residency, network isolation, and the option to run fully offline with local models are under your control."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can self-hosted AI agents run fully offline?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, if paired with a local model. Running a self-hosted agent platform with a local model runtime such as Ollama means no request ever leaves the network, which is what air-gapped and high-compliance environments require. Cloud model APIs can still be used when offline operation is not a requirement."
+            }
+          }
+        ]
+      }
+---
+
+**Self-hosted AI agents** run on infrastructure you control, such as your own servers or private cloud, instead of a vendor's multi-tenant cloud. The data, the agent runtime, and optionally the language model all stay inside your boundary.
+
+This matters most for regulated industries, and for any organization that cannot send its prompts and documents to an external service.
+
+## Self-hosted vs. cloud
+
+|                            | Cloud AI agents                      | Self-hosted AI agents       |
+| -------------------------- | ------------------------------------ | --------------------------- |
+| Operated by                | The vendor, on shared infrastructure | You, on your infrastructure |
+| Where data goes            | To the vendor's servers              | Stays in your boundary      |
+| Time to first run          | Lowest                               | Higher (you deploy it)      |
+| Data residency / isolation | Vendor-controlled                    | You control it              |
+| Offline / air-gapped       | Not possible                         | Possible with local models  |
+
+Cloud is the easiest way to start. Self-hosting is what you choose when "where does the data go?" has a mandatory answer.
+
+## The data-residency argument
+
+For teams under GDPR, sector regulation, or the EU Cloud Act, sending prompts and documents to a US-operated cloud is often a non-starter. Self-hosting removes the question entirely: the data never leaves. That is an architecture decision, not a settings toggle, which is why it has to be designed in from the start rather than bolted on.
+
+## Running fully offline
+
+Paired with a local model runtime such as **Ollama**, a self-hosted agent platform can run with no external network calls at all, which is what air-gapped and high-compliance environments require. When offline operation is not a requirement, the same platform can use cloud model APIs.
+
+## In Pinchy
+
+Pinchy is self-hosted first: a single Docker Compose stack, pre-built images, and support for local models via Ollama for fully offline operation. The license key is validated offline, so the instance never phones home. See [Self-hosting](/self-hosted-ai-agents/) on the main site and the [Installation Guide](/installation/).
+
+## Related terms
+
+- [AI agent governance](/glossary/ai-agent-governance/)
+- [AI agent permissions](/glossary/ai-agent-permissions/)
+- [AI agent audit trail](/glossary/ai-agent-audit-trail/)


### PR DESCRIPTION
First batch of an evergreen **glossary/concept hub** in the docs. These target the thin, young 'data void' terms that (a) map exactly to Pinchy's differentiation and (b) are the GEO probing queries, where a first-mover with a clean definition gets cited before the big players arrive.

Pages (each definition-first, with FAQPage JSON-LD, a concrete example, internal cross-links):
- `/glossary/ai-agent-governance`
- `/glossary/ai-agent-permissions`
- `/glossary/rbac-for-ai-agents`
- `/glossary/ai-agent-audit-trail`
- `/glossary/self-hosted-ai-agents`

Why this format: the opening sentence of each page is a standalone definition (what LLMs extract as a citable snippet), modeled on Cloudflare Learning Center / PostHog concept guides. PostHog's evidence: concept content tripled their organic traffic in a year without selling anything.

**Truth discipline:** the definitions are general-concept (low Pinchy-specific-claim risk); Pinchy mentions are kept accurate and modest, each linking to the existing concept docs. Body prose em-dash-free. New 'Glossary' sidebar group. Build green (50 pages).

This is batch 1 of ~8–15 planned (autonomous-marketing-backlog #2). Next candidates: 'what is prompt injection', 'air-gapped AI', 'AI agent vs chatbot', 'human-in-the-loop AI'.