### PR TITLE
fix(attachments): read PDFs via pinchy_read, not OpenClaw's broken built-in pdf tool

### DIFF
--- a/packages/web/e2e/integration/upload-and-send.spec.ts
+++ b/packages/web/e2e/integration/upload-and-send.spec.ts
@@ -9,7 +9,11 @@
 import { test, expect } from "@playwright/test";
 import path from "path";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
-import { FAKE_OLLAMA_RESPONSE } from "../shared/fake-ollama/fake-ollama-server";
+import {
+  FAKE_OLLAMA_RESPONSE,
+  FAKE_OLLAMA_PDF_ATTACHMENT_READ_TOOL_TRIGGER,
+} from "../shared/fake-ollama/fake-ollama-server";
+import { pollAuditForTool } from "../shared/dispatch-probe";
 
 test.describe("upload and send — happy path", () => {
   test("PDF upload chip reaches ready state and message embed uses uploads URL with zero 404s", async ({
@@ -93,5 +97,46 @@ test.describe("upload and send — happy path", () => {
 
     // ── 10. Assert zero 404s from uploads fetches ─────────────────────────────
     expect(failedUploadFetches).toHaveLength(0);
+  });
+
+  // The tool-EXECUTING coverage that was missing and let the v0.5.8 PDF bug
+  // ship: an uploaded PDF must be analyzed via `pinchy_read` (pinchy-files' own
+  // PDF subsystem), NOT OpenClaw's built-in `pdf` tool — which resolves its
+  // model only against the per-agent catalog and fails "Unknown model" for the
+  // common (built-in-provider) case. This drives the read end-to-end against
+  // real OpenClaw + pinchy-files and asserts the pinchy_read dispatch lands.
+  test("uploaded PDF is analyzed via pinchy_read (not OpenClaw's built-in pdf tool)", async ({
+    page,
+  }) => {
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+    await page.goto(`/chat/${agentId}`);
+    await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10000 });
+    await waitForOpenClawConnected(page);
+
+    const input = page.getByLabel("Message input");
+    await expect(input).toBeVisible({ timeout: 10000 });
+
+    const fixturesDir = path.join(__dirname, "../fixtures");
+    const [fileChooser] = await Promise.all([
+      page.waitForEvent("filechooser"),
+      page.locator(".aui-composer-add-attachment").click(),
+    ]);
+    await fileChooser.setFiles(path.join(fixturesDir, "test.pdf"));
+
+    const readyChip = page
+      .locator(".text-green-600")
+      .locator("xpath=ancestor::*[@class and contains(@class,'rounded-lg')]")
+      .first();
+    await expect(readyChip).toBeVisible({ timeout: 20000 });
+
+    await input.fill(`${FAKE_OLLAMA_PDF_ATTACHMENT_READ_TOOL_TRIGGER}: summarize the attached PDF`);
+    await page.keyboard.press("Enter");
+
+    // The decisive assertion: a tool.pinchy_read audit for this agent — proving
+    // the uploaded PDF was read via pinchy_read on the real stack. With the old
+    // routing the agent was told to use the `pdf` tool, which fails to resolve.
+    const found = await pollAuditForTool(page, { toolName: "pinchy_read", agentId });
+    expect(found).toBe(true);
   });
 });

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -86,6 +86,11 @@ const WORKSPACE_READ_TRIGGER = "E2E_WORKSPACE_READ_TOOL";
 const WORKSPACE_READ_RESPONSE = "File read: coverage probe complete.";
 const WORKSPACE_WRITE_TRIGGER = "E2E_WORKSPACE_WRITE_TOOL";
 const WORKSPACE_WRITE_RESPONSE = "File written: coverage probe complete.";
+// An uploaded PDF must be analyzed via pinchy_read (pinchy-files' own PDF
+// subsystem), NOT OpenClaw's built-in `pdf` tool — which fails "Unknown model"
+// because it resolves only against the per-agent catalog (v0.5.8 finding).
+const PDF_ATTACHMENT_READ_TRIGGER = "E2E_PDF_ATTACHMENT_READ_TOOL";
+const PDF_ATTACHMENT_READ_RESPONSE = "PDF read: coverage probe complete.";
 
 interface TriggerConfig {
   trigger: string;
@@ -164,6 +169,12 @@ const TOOL_TRIGGERS: TriggerConfig[] = [
     response: WORKSPACE_WRITE_RESPONSE,
     toolName: "pinchy_write",
     arguments: { path: "uploads/result.csv", content: "id,value\n1,E2E probe\n" },
+  },
+  {
+    trigger: PDF_ATTACHMENT_READ_TRIGGER,
+    response: PDF_ATTACHMENT_READ_RESPONSE,
+    toolName: "pinchy_read",
+    arguments: { path: "uploads/test.pdf" },
   },
 ];
 
@@ -623,6 +634,8 @@ export const FAKE_OLLAMA_WORKSPACE_READ_TOOL_TRIGGER = WORKSPACE_READ_TRIGGER;
 export const FAKE_OLLAMA_WORKSPACE_READ_TOOL_RESPONSE = WORKSPACE_READ_RESPONSE;
 export const FAKE_OLLAMA_WORKSPACE_WRITE_TOOL_TRIGGER = WORKSPACE_WRITE_TRIGGER;
 export const FAKE_OLLAMA_WORKSPACE_WRITE_TOOL_RESPONSE = WORKSPACE_WRITE_RESPONSE;
+export const FAKE_OLLAMA_PDF_ATTACHMENT_READ_TOOL_TRIGGER = PDF_ATTACHMENT_READ_TRIGGER;
+export const FAKE_OLLAMA_PDF_ATTACHMENT_READ_TOOL_RESPONSE = PDF_ATTACHMENT_READ_RESPONSE;
 
 let server: http.Server | null = null;
 

--- a/packages/web/src/__tests__/server/attachment-pipeline.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline.test.ts
@@ -37,6 +37,29 @@ describe("buildAttachmentBlock", () => {
     expect(block).toContain("application/pdf");
   });
 
+  it("routes PDFs to `pinchy_read`, not OpenClaw's built-in `pdf` tool", async () => {
+    // The OpenClaw built-in `pdf` tool resolves its model only against the
+    // per-agent models.json catalog (which never contains built-in providers
+    // like anthropic/openai), so it fails "Unknown model" for the common case.
+    // pinchy-files' own pinchy_read has a full, tested PDF subsystem
+    // (pdf-extract for text, pdf-vision for scans) that resolves credentials
+    // via the runtime modelAuth API — it works on every provider/model. PDFs
+    // must be analyzed with pinchy_read.
+    const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
+    const block = buildAttachmentBlock([
+      {
+        relativePath: "uploads/statement.pdf",
+        absolutePath: "/root/.openclaw/workspaces/test/uploads/statement.pdf",
+        mimeType: "application/pdf",
+        sizeBytes: 120_000,
+        contentHash: "b".repeat(64),
+        reused: false,
+      },
+    ]);
+    expect(block).toContain("analyze with `pinchy_read`");
+    expect(block).not.toContain("analyze with `pdf`");
+  });
+
   it("returns empty string when no uploads", async () => {
     const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
     expect(buildAttachmentBlock([])).toBe("");

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -1220,7 +1220,7 @@ describe("ClientRouter", () => {
           content:
             "Was steht in dieser Datei?\n\n<pinchy:attachments>\n" +
             "The user attached these files (already saved into your workspace). Read each file with the listed built-in tool, using the exact absolute path:\n" +
-            "- `/root/.openclaw/workspaces/agent-1/uploads/invoice.pdf` (application/pdf, 240 KB) — analyze with `pdf`\n" +
+            "- `/root/.openclaw/workspaces/agent-1/uploads/invoice.pdf` (application/pdf, 240 KB) — analyze with `pinchy_read`\n" +
             "\nIf you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.\n" +
             "</pinchy:attachments>",
           timestamp: 1708460000000,
@@ -1258,7 +1258,7 @@ describe("ClientRouter", () => {
           content:
             "<pinchy:attachments>\n" +
             "The user attached these files (already saved into your workspace). Read each file with the listed built-in tool, using the exact absolute path:\n" +
-            "- `/root/.openclaw/workspaces/agent-1/uploads/silent-pdf.pdf` (application/pdf, 100 KB) — analyze with `pdf`\n" +
+            "- `/root/.openclaw/workspaces/agent-1/uploads/silent-pdf.pdf` (application/pdf, 100 KB) — analyze with `pinchy_read`\n" +
             "\nIf you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.\n" +
             "</pinchy:attachments>",
           timestamp: 1708460000000,

--- a/packages/web/src/lib/attachment-capability.ts
+++ b/packages/web/src/lib/attachment-capability.ts
@@ -4,10 +4,10 @@
  *
  * Only images require a capability (vision): they are base64-encoded and
  * shipped as direct model input. PDFs deliberately return null — they are
- * placed in the agent workspace and analyzed via OpenClaw's built-in `pdf`
- * tool, whose model Pinchy resolves itself (`resolveDefaultPdfModel()`),
- * independent of the agent's chat model. Text formats are workspace files
- * read via `pinchy_read`.
+ * placed in the agent workspace and read via pinchy-files' own `pinchy_read`,
+ * whose PDF subsystem (pdf-extract for the text layer, pdf-vision for scanned
+ * pages) needs no capability of the agent's chat model. Text formats are also
+ * workspace files read via `pinchy_read`.
  */
 export function requiredCapabilityForFile(mimeType: string): "vision" | null {
   if (mimeType.startsWith("image/")) return "vision";

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -264,7 +264,15 @@ export async function materializeAttachments(
  * updated in the same change.
  */
 function toolNameForMime(mimeType: string): string {
-  if (mimeType === "application/pdf") return "`pdf`";
+  // PDFs are read via pinchy-files' own `pinchy_read`, which has a full,
+  // tested PDF subsystem (pdf-extract for the text layer; pdf-vision for
+  // scanned pages) and resolves credentials through the runtime modelAuth
+  // API. We deliberately do NOT use OpenClaw's built-in `pdf` tool: it
+  // resolves its model only against the per-agent models.json catalog, which
+  // never contains the built-in providers (anthropic/openai/google) a typical
+  // pdfModel points at — so it fails "Unknown model" for the common case
+  // (v0.5.8 staging finding; OpenClaw upstream issue filed separately).
+  if (mimeType === "application/pdf") return "`pinchy_read`";
   if (mimeType.startsWith("image/")) return "`image`";
   // Text formats (CSV, Markdown, JSON, YAML, plain text) are workspace files
   // read via the pinchy_read plugin tool rather than an OpenClaw built-in.


### PR DESCRIPTION
## Symptom (v0.5.8 staging)
Attaching a PDF made the agent fail 17× with `Unknown model: …` on OpenClaw's built-in `pdf` tool, emit a misleading "pdfModel unavailable" apology, and only recover by falling back to the `read` tool. (The recovered analysis was *correct*, not hallucinated — verified against the source PDF — but the UX was broken and burned tokens.)

## Root cause (verified, not OpenClaw-version-specific)
The `pdf` tool resolves its model **only** against the per-agent `models.json` catalog, which never contains the built-in providers (anthropic/openai/google) a typical `pdfModel` points at — and unlike the chat path it has **no fallback** to `cfg.models.providers`. I confirmed the writer (`ensureOpenClawModelsJson`), reader (`discoverModels`), and resolver are **byte-identical between OpenClaw 2026.5.28 and 2026.6.5** — so **pinning OpenClaw does not fix it** (an early candidate plan, ruled out before wasting a handoff). It's an upstream resolver gap; OC issue filed separately.

## Fix
The robust reader already lives in our own plugin: **`pinchy_read` (pinchy-files) has a full, tested PDF subsystem** — `pdf-extract` (text layer), `pdf-vision` (scanned pages) — and resolves credentials via the runtime `modelAuth` API, so it works on **every provider/model/OpenClaw version**, needs no agent-model capability for text PDFs, and avoids a second model call. One line in `attachment-pipeline.ts` routed PDFs to the broken built-in `pdf` tool; now they route to `pinchy_read`. a82911a7's capability-gate removal stays correct.

## Why not the alternatives
- **Pin OpenClaw** → proven no-op (identical machinery).
- **Force pdfModel to ollama-cloud** → leaves built-in-only stacks (the common enterprise config) with no PDF support.
- **Inject built-ins into the per-agent catalog** → Pinchy doesn't own that file; fighting the framework, brittle across OC upgrades.

## Tests
- `attachment-pipeline`: a PDF now instructs `pinchy_read`, never `` `pdf` `` (red→green on the routing).
- **New E2E** (`upload-and-send`): an uploaded PDF drives a `tool.pinchy_read` dispatch on the **real** OpenClaw + pinchy-files stack — the tool-executing coverage whose absence let this ship (built-in OC tools escape the plugin-dispatch coverage guard). fake-ollama gains a PDF-attachment trigger.
- pinchy-files' own `pdf-extract`/`pdf-format`/`pdf-render`/`pdf-vision` suites (20) already prove `pinchy_read` reads real text/table/scanned PDFs.
- Full web unit suite: **5905 passed**; typecheck + drift/coverage guards clean.

**Note:** the new E2E was authored against proven patterns (mirrors `workspace-fs` pinchy_read dispatch + the existing PDF upload flow) but its **first real run is CI** — I can't run the Playwright+Docker stack locally. The unit + pinchy-files coverage is locally verified.

## Follow-ups (separate, not blocking)
- OpenClaw upstream issue: `pdf`/`image` tool resolver needs the same `cfg.models.providers` fallback the chat resolver has.
- Minor Pinchy bug found en route: `resolveDefaultPdfModel` cache-miss on live date-suffixed Anthropic models (catalog-vs-live drift) — now lower-impact since attachments no longer depend on the OC pdf tool.