### PR TITLE
docs(glossary): batch 2 — 5 more definition pages (GEO data-void)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -170,11 +170,16 @@ export default defineConfig({
         {
           label: 'Glossary',
           items: [
+            { label: 'AI Agent Platform', slug: 'glossary/ai-agent-platform' },
+            { label: 'What Is OpenClaw?', slug: 'glossary/what-is-openclaw' },
             { label: 'AI Agent Governance', slug: 'glossary/ai-agent-governance' },
             { label: 'AI Agent Permissions', slug: 'glossary/ai-agent-permissions' },
             { label: 'RBAC for AI Agents', slug: 'glossary/rbac-for-ai-agents' },
             { label: 'AI Agent Audit Trail', slug: 'glossary/ai-agent-audit-trail' },
             { label: 'Self-Hosted AI Agents', slug: 'glossary/self-hosted-ai-agents' },
+            { label: 'Air-Gapped AI Agents', slug: 'glossary/air-gapped-ai-agents' },
+            { label: 'GDPR & AI Agents', slug: 'glossary/gdpr-ai-agents' },
+            { label: 'Local LLMs for Business', slug: 'glossary/local-llm-for-business' },
           ],
         },
         {

--- a/docs/src/content/docs/glossary/ai-agent-platform.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-platform.mdx
@@ -1,0 +1,71 @@
+---
+title: What is an AI agent platform?
+description: An AI agent platform is the layer that lets a team run, govern, and operate AI agents — not just a library to build one. It adds the user management, permissions, audit, and deployment that a framework or runtime leaves out.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is an AI agent platform?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "An AI agent platform is the operational layer that lets a team run and govern AI agents, rather than a library for building one. It provides multi-user access, per-agent permissions, an audit trail, a chat interface, and a deployment story. A framework or runtime gives you the engine; the platform is what makes that engine safe to put in front of a whole organization."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between an AI agent platform and a framework?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "A framework such as LangChain or CrewAI is a library: you write code to assemble an agent, and you are responsible for the UI, users, permissions, and deployment yourself. A platform ships those pieces — user management, access control, audit, and a way to run it in production — so a team can operate agents without building the surrounding infrastructure."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Do I need an AI agent platform or just a framework?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "For a single developer prototyping one agent, a framework or runtime is enough. For a team or company, the questions that decide it are: who is allowed to use which agent, what can each agent do, can you prove what happened, and how is it deployed and updated. When those questions matter, you need a platform, because that is exactly the layer a platform provides."
+            }
+          }
+        ]
+      }
+---
+
+An **AI agent platform** is the layer that lets a team run, govern, and operate AI agents — not just a library to build one. It adds the user management, permissions, audit, and deployment story that a framework or runtime leaves out.
+
+## Framework vs. runtime vs. platform
+
+These three terms are often used interchangeably, but they sit at different levels:
+
+|           | What it is                                | Examples                   | What you still build yourself      |
+| --------- | ----------------------------------------- | -------------------------- | ---------------------------------- |
+| Framework | A code library for assembling agents      | LangChain, CrewAI, AutoGen | UI, users, permissions, deployment |
+| Runtime   | An engine that runs an agent with tools   | OpenClaw                   | Governance, multi-user, audit      |
+| Platform  | The operational layer on top of a runtime | Pinchy                     | Mostly configuration, not code     |
+
+A framework gives you building blocks. A runtime gives you a working engine. A platform gives you the thing you can hand to a whole team.
+
+## What a platform provides
+
+- **Multi-user access** — invite a team, with roles, not a single local user.
+- **Per-agent permissions** — [allow-listed tools](/glossary/ai-agent-permissions/) so each agent can do only what it should.
+- **Audit trail** — a [verifiable record](/glossary/ai-agent-audit-trail/) of every agent action.
+- **A chat interface and channels** — somewhere for end users to actually reach the agents.
+- **Deployment** — a defined way to run, update, and host the whole stack.
+
+## In Pinchy
+
+Pinchy is an AI agent platform built on the [OpenClaw](/glossary/what-is-openclaw/) runtime. OpenClaw provides the engine — model, tools, sessions, channels. Pinchy adds the enterprise layer on top: multi-user accounts, [role-based access control](/glossary/rbac-for-ai-agents/), per-agent tool permissions, a signed audit trail, web and Telegram access, and a single Docker Compose deployment. See the [Pinchy website](https://heypinchy.com) and the [Installation Guide](/installation/).
+
+## Related terms
+
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)
+- [AI agent governance](/glossary/ai-agent-governance/)
+- [What is OpenClaw?](/glossary/what-is-openclaw/)

--- a/docs/src/content/docs/glossary/air-gapped-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/air-gapped-ai-agents.mdx
@@ -1,0 +1,70 @@
+---
+title: What are air-gapped AI agents?
+description: Air-gapped AI agents run in an environment with no connection to the public internet — every part of the stack, including the language model, runs inside the isolated network so no prompt or document can ever leave.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What are air-gapped AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Air-gapped AI agents run inside a network that has no connection to the public internet. The agent runtime, the tools it uses, and the language model itself all run on local infrastructure, so no prompt, document, or output can leave the isolated environment. This is the strictest form of self-hosting and is used in defense, critical infrastructure, and highly regulated environments."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between air-gapped and self-hosted AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Self-hosted means you own and operate the infrastructure, but it may still reach the internet, for example to call a cloud model API. Air-gapped goes further: the network is physically or logically isolated from the public internet, so even cloud model APIs are off the table. Every air-gapped deployment is self-hosted, but not every self-hosted deployment is air-gapped."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can AI agents run without any internet connection?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes, if the language model runs locally and the platform has no mandatory phone-home. A local model runtime such as Ollama keeps inference inside the network, and a platform whose licensing is validated offline never needs to reach a license server. The trade-off is that model choice is limited to what you can run on local hardware."
+            }
+          }
+        ]
+      }
+---
+
+**Air-gapped AI agents** run in an environment with no connection to the public internet. The agent runtime, the tools it uses, and the language model itself all run inside the isolated network, so no prompt, document, or output can ever leave.
+
+This is the strictest form of [self-hosting](/glossary/self-hosted-ai-agents/), used in defense, critical infrastructure, finance, and any setting where "the data physically cannot leave" is a hard requirement.
+
+## Air-gapped vs. self-hosted
+
+The two terms are related but not the same:
+
+- **Self-hosted** is about ownership — you run the infrastructure, but it may still reach out to a cloud model API.
+- **Air-gapped** is about isolation — the network has no path to the public internet, so even cloud APIs are unavailable.
+
+Every air-gapped deployment is self-hosted; not every self-hosted deployment is air-gapped.
+
+## What an air-gapped deployment requires
+
+- A **local model runtime** so inference never leaves the network. Cloud model APIs cannot be used.
+- **No mandatory phone-home** anywhere in the stack — no telemetry, no license server, no update check that blocks startup.
+- **Offline installation** — images and dependencies brought in deliberately rather than pulled at runtime.
+
+The main trade-off is model choice: you are limited to what runs on your own hardware, rather than the frontier models behind cloud APIs.
+
+## In Pinchy
+
+Pinchy can run fully offline. Paired with [local models](/glossary/local-llm-for-business/) via **Ollama**, inference stays inside the network and no request ever reaches an external service. The license key is validated offline with no license server in the path, and the whole stack ships as a single Docker Compose deployment that can be installed without internet access. When isolation is not a requirement, the same instance can use cloud model APIs instead. See the [Installation Guide](/installation/) and [Set Up Local Ollama](/guides/ollama-setup/).
+
+## Related terms
+
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)
+- [Local LLMs for business](/glossary/local-llm-for-business/)
+- [GDPR-compliant AI agents](/glossary/gdpr-ai-agents/)

--- a/docs/src/content/docs/glossary/gdpr-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/gdpr-ai-agents.mdx
@@ -1,0 +1,77 @@
+---
+title: Are AI agents GDPR-compliant?
+description: GDPR compliance for AI agents is mainly a data-flow question — where prompts, documents, and outputs are processed, and who can access them. Self-hosting removes the cross-border transfer problem, but tooling alone does not make an organization compliant.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Are AI agents GDPR-compliant?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "AI agents are not compliant or non-compliant on their own. GDPR compliance depends on where prompts and documents are processed, who can access them, and whether you can demonstrate control. Cloud AI agents send data to a vendor, which raises processor and cross-border transfer obligations. Self-hosted AI agents keep the data inside your boundary, which removes the transfer problem, but the surrounding controls, contracts, and processes still have to be in place."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Can I use cloud AI agents like ChatGPT under GDPR?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "It is possible but adds obligations. You become a controller sending personal data to a processor, often outside the EU, which means data processing agreements, a transfer mechanism, and a lawful basis. For many regulated teams this is a non-starter, which is why they prefer self-hosted agents where prompts and documents never leave their infrastructure."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Does self-hosting make AI agents GDPR-compliant?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Self-hosting removes the largest single problem, namely sending personal data to an external service, and it gives you data residency and full audit visibility. But compliance is organizational, not just technical. You still need a lawful basis, data minimization, retention rules, access control, and the ability to honor data-subject requests. Self-hosting makes those achievable on your terms instead of a vendor's."
+            }
+          }
+        ]
+      }
+---
+
+GDPR compliance for AI agents is mainly a **data-flow question**: where prompts, documents, and outputs are processed, who can access them, and whether you can demonstrate that control. The agent itself is neither compliant nor non-compliant — the deployment is.
+
+## Why cloud AI agents are hard under GDPR
+
+When an AI agent runs in a vendor's cloud, every prompt and every document it reads is personal data leaving your environment. That makes you a controller handing data to a processor, frequently outside the EU. The obligations stack up quickly:
+
+- A data processing agreement with the vendor.
+- A valid mechanism for any transfer outside the EU.
+- A lawful basis for the processing, and a way to honor access and erasure requests.
+- Assurance the data is not used to train shared models.
+
+For regulated industries, "where does the prompt go?" often has a mandatory answer that a multi-tenant cloud cannot give.
+
+## What makes an AI agent deployment GDPR-friendly
+
+| Control              | Why it matters under GDPR                                  |
+| -------------------- | ---------------------------------------------------------- |
+| Data residency       | Personal data stays in a jurisdiction you control          |
+| Access control       | Only the right people and agents can reach the right data  |
+| Audit trail          | You can show who did what, when — accountability in Art. 5 |
+| Data minimization    | Agents see only the data scoped to their task              |
+| No external training | Prompts and documents are never sent to a shared model     |
+
+## Tooling is necessary, not sufficient
+
+No platform makes you compliant by installation. Compliance is organizational: a lawful basis, retention rules, a data-protection process, and the ability to answer data-subject requests. The right architecture makes all of that achievable on your terms instead of being constrained by a vendor's defaults.
+
+## In Pinchy
+
+Pinchy is self-hosted first, so prompts and documents stay inside your boundary — there is no vendor cloud in the path. [Role-based access control](/glossary/rbac-for-ai-agents/) scopes who can reach which agent, an [HMAC-signed audit trail](/glossary/ai-agent-audit-trail/) records every action for accountability, and the license key is validated offline so the instance never phones home. Pinchy does not carry a compliance certification, and it cannot replace your own data-protection process — it gives you the architecture to run agents without sending personal data to a third party. See [Self-hosting](https://heypinchy.com/self-hosted-ai-agents/) and [GDPR & AI agents](https://heypinchy.com/gdpr-ai-agents/) on the main site.
+
+## Related terms
+
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)
+- [AI agent governance](/glossary/ai-agent-governance/)
+- [AI agent audit trail](/glossary/ai-agent-audit-trail/)
+- [Air-gapped AI agents](/glossary/air-gapped-ai-agents/)

--- a/docs/src/content/docs/glossary/local-llm-for-business.mdx
+++ b/docs/src/content/docs/glossary/local-llm-for-business.mdx
@@ -1,0 +1,66 @@
+---
+title: Can you run local LLMs for business?
+description: Running a local LLM means the model itself runs on your own hardware — no prompt or response ever goes to a model vendor's API. For businesses that means data control, predictable cost, and offline operation, traded against hardware and raw model capability.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "Can you run local LLMs for business?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. A local LLM runs on your own hardware through a runtime such as Ollama, so no prompt or response goes to a model vendor's API. Businesses run local models for data control, predictable cost, and offline operation. The trade-offs are the hardware you need and that the most capable frontier models are still cloud-only."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Are local LLMs as good as cloud models?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "For many business tasks, yes — modern open-weight models handle summarization, extraction, drafting, and tool use well. For the hardest reasoning and the longest context, the frontier cloud models are still ahead. A practical approach is to use local models where data sensitivity or cost matters most, and cloud models where you need maximum capability."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Which local model runtime works with AI agents?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Ollama is the most common local model runtime and works well behind a self-hosted agent platform. The agent platform points at the local runtime instead of a cloud API, so inference stays on your hardware. A good platform is model-agnostic, letting you mix local and cloud models per agent."
+            }
+          }
+        ]
+      }
+---
+
+Running a **local LLM** means the model itself runs on your own hardware — no prompt or response ever goes to a model vendor's API. For a business, that turns the language model from an external dependency into part of your own infrastructure.
+
+## Why businesses run local models
+
+- **Data never leaves** — prompts and documents stay on your hardware, which is the foundation of [air-gapped](/glossary/air-gapped-ai-agents/) and high-compliance deployments.
+- **Predictable cost** — you pay for hardware once instead of per token, which matters at high volume.
+- **No vendor lock-in** — open-weight models can be swapped, pinned, and run for as long as you need them.
+- **Offline operation** — agents keep working with no internet connection at all.
+
+## The trade-offs
+
+Local models are not free of cost — they shift it. You need capable hardware (a GPU for anything beyond small models), and you take on the operations of running and updating the runtime. The most capable frontier models are still cloud-only, so for the hardest reasoning tasks a cloud API may still win. The pragmatic answer is rarely "all local" or "all cloud" but a mix.
+
+## How local models fit an agent platform
+
+A **model-agnostic** [agent platform](/glossary/ai-agent-platform/) points at a local runtime instead of a cloud API, so inference stays on your hardware. The strongest setups let you choose the model per agent: a local model for the agent that reads sensitive documents, a frontier cloud model for the agent that does open-ended research.
+
+## In Pinchy
+
+Pinchy supports local models through **Ollama** alongside the cloud providers (OpenAI, Anthropic, Google), and the model is configurable per agent. Point an agent at a local model and its data never leaves the network; point another at a cloud API when you need maximum capability. See [Set Up Local Ollama](/guides/ollama-setup/) and [Manage LLM Providers](/guides/llm-providers/).
+
+## Related terms
+
+- [Air-gapped AI agents](/glossary/air-gapped-ai-agents/)
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)
+- [What is an AI agent platform?](/glossary/ai-agent-platform/)

--- a/docs/src/content/docs/glossary/self-hosted-ai-agents.mdx
+++ b/docs/src/content/docs/glossary/self-hosted-ai-agents.mdx
@@ -64,7 +64,7 @@ Paired with a local model runtime such as **Ollama**, a self-hosted agent platfo
 
 ## In Pinchy
 
-Pinchy is self-hosted first: a single Docker Compose stack, pre-built images, and support for local models via Ollama for fully offline operation. The license key is validated offline, so the instance never phones home. See [Self-hosting](/self-hosted-ai-agents/) on the main site and the [Installation Guide](/installation/).
+Pinchy is self-hosted first: a single Docker Compose stack, pre-built images, and support for local models via Ollama for fully offline operation. The license key is validated offline, so the instance never phones home. See [Self-hosting](https://heypinchy.com/self-hosted-ai-agents/) on the main site and the [Installation Guide](/installation/).
 
 ## Related terms
 

--- a/docs/src/content/docs/glossary/what-is-openclaw.mdx
+++ b/docs/src/content/docs/glossary/what-is-openclaw.mdx
@@ -1,0 +1,75 @@
+---
+title: What is OpenClaw?
+description: OpenClaw is an open-source AI agent runtime — the engine that connects a language model to tools, memory, and channels so an agent can actually do things. Pinchy builds the enterprise layer on top of it.
+head:
+  - tag: script
+    attrs:
+      type: application/ld+json
+    content: |
+      {
+        "@context": "https://schema.org",
+        "@type": "FAQPage",
+        "mainEntity": [
+          {
+            "@type": "Question",
+            "name": "What is OpenClaw?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "OpenClaw is an open-source AI agent runtime: the engine that connects a language model to tools, memory, sessions, and channels so an agent can take actions rather than only chat. It is extensible through plugins and runs locally, which makes it popular with individual power users who want a capable, self-hosted agent."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "Is OpenClaw free and open source?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "Yes. OpenClaw is open-source software you can run on your own infrastructure. That is one reason it is a strong foundation for a self-hosted, offline-capable agent stack, with no dependency on a vendor cloud for the runtime itself."
+            }
+          },
+          {
+            "@type": "Question",
+            "name": "What is the difference between OpenClaw and Pinchy?",
+            "acceptedAnswer": {
+              "@type": "Answer",
+              "text": "OpenClaw is the agent runtime, excellent for an individual power user. It does not, on its own, provide user management, role-based access control, or an audit trail, which teams and companies need. Pinchy is an enterprise platform built on top of OpenClaw that adds exactly those governance and multi-user features while keeping the deployment self-hosted and offline-capable."
+            }
+          }
+        ]
+      }
+---
+
+**OpenClaw** is an open-source AI agent runtime — the engine that connects a language model to tools, memory, sessions, and channels so an agent can actually _do_ things, not just chat. It is the foundation that [Pinchy](https://heypinchy.com) builds on.
+
+## What OpenClaw does
+
+A language model on its own only produces text. A runtime turns it into an agent by wiring in:
+
+- **Tools** the model can call to take real actions.
+- **Memory and sessions** so a conversation has continuity.
+- **Channels** so the agent can be reached where people already are.
+- **A plugin system** so new capabilities can be added without forking the core.
+
+OpenClaw is extensible and local-first, which makes it a favorite for individual power users who want a capable, self-hosted agent under their own control.
+
+## What OpenClaw does not provide on its own
+
+OpenClaw is built around the single powerful operator. For a team or company, critical pieces are missing:
+
+- No user management or per-user accounts.
+- No role-based access control over who can use which agent.
+- No audit trail of who did what, when.
+- No governance layer for permissions across many agents and people.
+
+These are not flaws in the runtime — they are simply a different layer, the enterprise layer.
+
+## How Pinchy relates to OpenClaw
+
+Pinchy is an [AI agent platform](/glossary/ai-agent-platform/) built on top of OpenClaw. OpenClaw stays the runtime; Pinchy wraps it with multi-user accounts, [role-based access control](/glossary/rbac-for-ai-agents/), [per-agent permissions](/glossary/ai-agent-permissions/), a [signed audit trail](/glossary/ai-agent-audit-trail/), and a single self-hosted deployment. You get OpenClaw's runtime power with the governance a team needs around it.
+
+Learn more at the [OpenClaw project](https://github.com/openclaw/openclaw) and the [OpenClaw documentation](https://docs.openclaw.ai).
+
+## Related terms
+
+- [What is an AI agent platform?](/glossary/ai-agent-platform/)
+- [Self-hosted AI agents](/glossary/self-hosted-ai-agents/)
+- [AI agent governance](/glossary/ai-agent-governance/)


### PR DESCRIPTION
## What

Extends the glossary/concept hub started in #499 with **five more definition pages**, each with FAQPage JSON-LD schema and internal cross-links. This is the GEO data-void play: definition pages that LLMs and search engines can cite, mapped to Pinchy's real strengths.

| Page | Angle |
|---|---|
| `ai-agent-platform` | platform vs framework vs runtime — captures category searchers |
| `what-is-openclaw` | the runtime Pinchy builds on; honest OpenClaw↔Pinchy relationship |
| `gdpr-ai-agents` | data-flow framing; **no compliance overclaim** (explicit caveat) |
| `air-gapped-ai-agents` | network isolation vs self-hosting |
| `local-llm-for-business` | Ollama + per-agent model choice |

## Truth discipline

Every product claim was verified against the codebase (providers OpenAI/Anthropic/Google/Ollama, per-agent model config, offline license validation, web+Telegram channels, HMAC audit trail). The GDPR page deliberately avoids any "Pinchy makes you compliant" claim and states there is no compliation certification — compliance is organizational.

## Also

- Fixes a broken main-site link in the batch-1 `self-hosted-ai-agents` page: a root-relative `/self-hosted-ai-agents/` 404s on the docs subdomain; now an absolute `https://heypinchy.com/...` URL.
- All 5 new main-site/docs links verified to resolve (footer + sidebar).

## Verification

`pnpm build` passes (55 pages, all 5 new pages emit FAQPage schema, no broken-link warnings). The two remaining build warnings (`caddyfile` highlight in `hardening.mdx`, generic chunk-size) are pre-existing and unrelated.