### PR TITLE
feat(usage): lossless per-turn token accounting from the trajectory (#483)

### DIFF
--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -48,19 +48,19 @@ Both filters apply to every card and tab on the page.
 
 ## Where the numbers come from
 
-Pinchy writes a usage record whenever an LLM call completes — both for chat turns (captured by a background poller that reads OpenClaw session snapshots) and for plugin-internal LLM calls (reported directly by the plugin). Each record carries the input/output tokens the provider reported, plus cache read and write tokens when the provider supports prompt caching.
+Pinchy writes a usage record whenever an LLM call completes. **Agent chat turns** are recorded individually and exactly — each turn's OpenClaw trajectory entry carries that turn's precise tokens, so Pinchy records one row per turn (deduplicated, so restarts and retries never double-count). **System usage** (scheduled tasks, channel bots) and **plugin-internal LLM calls** (e.g. a plugin transcoding a scanned PDF) are captured separately — the former sampled from OpenClaw's per-session counters, the latter reported directly by the plugin. Each record carries the input/output tokens the provider reported, plus cache read and write tokens when the provider supports prompt caching.
 
 Pinchy multiplies those by the per-million-token prices configured for the model and stores the result in USD with six decimals. Cache tokens use Anthropic-style pricing ratios: cache reads at 10% of the input price, cache writes at 125%.
 
 :::note[Tuning the poll interval]
-The chat-turn poller reads OpenClaw session snapshots every 60 seconds by default. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
+Chat turns are recorded the moment they complete, and a background sweep (every 60 seconds by default) backstops anything missed and records system-session usage. Set `PINCHY_USAGE_POLL_INTERVAL_MS` to override the sweep cadence (the value is in milliseconds, clamped to a 1000 ms floor so a misconfigured value can't hammer OpenClaw). Most deployments never need to set it.
 :::
 
 A few honest caveats:
 
 - **It's an estimate.** Provider invoices are the source of truth. Pinchy uses the prices baked into the OpenClaw model config, which can drift from a provider's current published rates.
 - **Cache pricing is approximate.** The 10%/125% ratios match Anthropic's published pricing. If your provider uses different cache pricing, the estimate will be off.
-- **Token counts are close, not exact.** Chat usage is captured by sampling OpenClaw's per-session counters, which are overwritten each turn — turns that complete between two polls can be missed on busy sessions. Exact per-turn accounting is tracked in [#483](https://github.com/heypinchy/pinchy/issues/483).
+- **Chat token counts are exact, per turn.** Each agent chat turn is recorded individually from its OpenClaw trajectory entry (the precise input/output/cache tokens that turn used), so nothing is dropped or double-counted even on busy sessions. System usage (scheduled tasks, channel bots) is still sampled from OpenClaw's per-session counters and can lag slightly.
 - **Local Ollama shows "—" for cost.** Local models record token counts but have no pricing config. The dashboard shows a dash instead of $0.00 to make this clear.
 - **Tool execution time isn't tracked here.** Only the LLM tokens count. The Audit Trail at `/audit` is where you go for tool-use details.
 

--- a/packages/web/drizzle/0039_faithful_tyger_tiger.sql
+++ b/packages/web/drizzle/0039_faithful_tyger_tiger.sql
@@ -1,0 +1,3 @@
+ALTER TABLE "usage_records" ADD COLUMN "run_id" text;--> statement-breakpoint
+ALTER TABLE "usage_records" ADD COLUMN "seq" integer;--> statement-breakpoint
+CREATE UNIQUE INDEX "uq_usage_session_run" ON "usage_records" USING btree ("session_key","run_id");

--- a/packages/web/drizzle/meta/0039_snapshot.json
+++ b/packages/web/drizzle/meta/0039_snapshot.json
@@ -1,0 +1,1825 @@
+{
+  "id": "8085d2df-aafd-440f-8beb-d46942515cbf",
+  "prevId": "ca8096b7-b22f-4b4f-8d12-65666a4287bf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -274,6 +274,13 @@
       "when": 1781252434491,
       "tag": "0038_drop_dead_capability_columns",
       "breakpoints": true
+    },
+    {
+      "idx": 39,
+      "version": "7",
+      "when": 1781544172048,
+      "tag": "0039_faithful_tyger_tiger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/e2e/integration/usage-tracking.spec.ts
+++ b/packages/web/e2e/integration/usage-tracking.spec.ts
@@ -1,36 +1,26 @@
 // packages/web/e2e/integration/usage-tracking.spec.ts
 //
 // Tier-2 usage tracking — the real fake-LLM → OpenClaw → Pinchy path
-// (issue #426, cases 1 & 2).
+// (issue #426 cases 1 & 2, reworked for #483 lossless per-turn accounting).
 //
-// This is the only layer that can honestly prove the poller delta path stays
-// in sync with OpenClaw's per-session token counters: `openclaw-node@0.11.0`
-// types `sessions.list()` as `Promise<Record<string, unknown>>`, so a faked
-// client in a unit test would only validate Pinchy's own assumption about the
-// wire format against itself. Here a real Docker OpenClaw consumes the fake
-// Ollama provider (which now reports a usage block) and the running Pinchy
-// poller turns its cumulative counters into `usage_records` rows, which we
-// assert against directly over the DB back-door.
+// This is the only layer that can honestly prove chat usage flows end-to-end:
+// a real Docker OpenClaw consumes the fake Ollama provider (which reports a
+// usage block per turn), writes a `model.completed` trajectory event with that
+// turn's EXACT tokens, and Pinchy's per-turn recorder (kicked by the chat
+// `done` path and backstopped by the poller) turns each turn into one exact
+// `usage_records` row — which we assert directly over the DB back-door.
+//
+// Unlike the old gauge-sampling version, this is DETERMINISTIC: the fake
+// reports a flat 42 input / 17 output per turn, recording is per-turn and
+// deduped by (sessionKey, runId), so N turns == N rows == exactly 42*N / 17*N.
+// No ratio-invariant hack, no 40s delta race (that was the gauge flake:
+// "usage delta predicate not met within 40000ms, 0 rows").
 //
 // Case 3 (the internal usage endpoint — pure Pinchy HTTP + DB, no OpenClaw
-// dependency) lives in src/__tests__/integration/usage-tracking.integration.test.ts
-// where it runs in the lighter `pnpm test:db` CI job.
-//
-// The poll interval is forced to 10s for this stack via
-// PINCHY_USAGE_POLL_INTERVAL_MS in docker-compose.integration.yml, so deltas
-// land within the test's 40s delta-wait window instead of after the 60s
-// production default. (It's kept at 10s rather than lower to minimise extra
-// sessions.list() load on the shared OpenClaw — see the compose comment.)
-//
-// Why a ratio invariant instead of exact token counts: the Smithers chat
-// session (`agent:<id>:direct:<adminUserId>`) is shared across the whole
-// integration run, so its counters already carry history from earlier specs,
-// and OpenClaw's exact accumulate-vs-replace semantics for cumulative counters
-// are an implementation detail. The fake reports a fixed 42:17 input:output
-// ratio (scaled per turn), so the robust, semantics-independent assertion is
-// that every recorded delta preserves that ratio and that multi-turn traffic
-// strictly grows the recorded total. That proves the declared provider usage
-// flows end-to-end into usage_records without depending on session freshness.
+// dependency) lives in src/__tests__/integration/usage-tracking.integration.test.ts;
+// the per-turn recorder + dedup unit/integration coverage lives in
+// src/__tests__/lib/usage-from-trajectory.test.ts and
+// src/__tests__/integration/usage-per-turn.integration.test.ts.
 import { test, expect } from "@playwright/test";
 import type { Page } from "@playwright/test";
 import {
@@ -42,29 +32,34 @@ import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 import { stackDbUrl } from "../shared/stack-db";
 
 const INTEGRATION_DB_URL = stackDbUrl(5435);
-const PROMPT = FAKE_OLLAMA_DEFAULT_PROMPT_TOKENS; // 42
-const COMPLETION = FAKE_OLLAMA_DEFAULT_COMPLETION_TOKENS; // 17
+const PROMPT = FAKE_OLLAMA_DEFAULT_PROMPT_TOKENS; // 42 input tokens / turn
+const COMPLETION = FAKE_OLLAMA_DEFAULT_COMPLETION_TOKENS; // 17 output tokens / turn
 
 interface ChatUsage {
   input: number;
   output: number;
+  cacheRead: number;
+  cacheWrite: number;
   rows: number;
 }
 
-// Sum the usage_records rows for this agent's browser-chat sessions
-// (sessionKey shape `agent:<id>:direct:<userId>`), excluding system/plugin
-// rows. Reads the integration DB directly via the host-mapped 5435 port.
+// Sum the per-turn usage_records rows for this agent's browser-chat sessions
+// (sessionKey shape `agent:<id>:direct:<userId>`, run_id NOT NULL), reading
+// the integration DB directly via the host-mapped 5435 port.
 async function chatUsageTotals(agentId: string): Promise<ChatUsage> {
   const postgres = (await import("postgres")).default;
   const sql = postgres(INTEGRATION_DB_URL);
   try {
-    const rows = await sql<{ input: number; output: number; rows: number }[]>`
-      SELECT COALESCE(SUM(input_tokens), 0)::int  AS input,
-             COALESCE(SUM(output_tokens), 0)::int AS output,
-             COUNT(*)::int                        AS rows
+    const rows = await sql<ChatUsage[]>`
+      SELECT COALESCE(SUM(input_tokens), 0)::int        AS input,
+             COALESCE(SUM(output_tokens), 0)::int       AS output,
+             COALESCE(SUM(cache_read_tokens), 0)::int   AS "cacheRead",
+             COALESCE(SUM(cache_write_tokens), 0)::int  AS "cacheWrite",
+             COUNT(*)::int                              AS rows
       FROM usage_records
       WHERE agent_id = ${agentId}
         AND session_key LIKE 'agent:%:direct:%'
+        AND run_id IS NOT NULL
     `;
     return rows[0];
   } finally {
@@ -79,33 +74,36 @@ async function sendChat(page: Page, text: string) {
   await input.press("Enter");
 }
 
-// Poll the chat-usage totals until `predicate(delta)` holds, where delta is
-// measured against `baseline`. Returns the satisfying delta.
-async function waitForUsageDelta(
+// Poll the chat-usage totals until at least `minNewRows` new rows (vs baseline)
+// have been recorded. Returns the delta. Deterministic — the chat `done`
+// trigger records near-instantly; the poller backstops within its interval.
+async function waitForNewTurns(
   agentId: string,
   baseline: ChatUsage,
-  predicate: (delta: { input: number; output: number; rows: number }) => boolean,
-  timeoutMs = 40000
-): Promise<{ input: number; output: number; rows: number }> {
+  minNewRows: number,
+  timeoutMs = 30000
+): Promise<ChatUsage> {
   const deadline = Date.now() + timeoutMs;
-  let delta = { input: 0, output: 0, rows: 0 };
+  let delta: ChatUsage = { input: 0, output: 0, cacheRead: 0, cacheWrite: 0, rows: 0 };
   while (Date.now() < deadline) {
     const now = await chatUsageTotals(agentId);
     delta = {
       input: now.input - baseline.input,
       output: now.output - baseline.output,
+      cacheRead: now.cacheRead - baseline.cacheRead,
+      cacheWrite: now.cacheWrite - baseline.cacheWrite,
       rows: now.rows - baseline.rows,
     };
-    if (predicate(delta)) return delta;
-    await new Promise((r) => setTimeout(r, 1000));
+    if (delta.rows >= minNewRows) return delta;
+    await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(
-    `usage delta predicate not met within ${timeoutMs}ms (last delta: ${JSON.stringify(delta)})`
+    `expected ≥${minNewRows} new usage rows within ${timeoutMs}ms (last delta: ${JSON.stringify(delta)})`
   );
 }
 
-test.describe("Usage tracking — chat → OpenClaw → poller → usage_records", () => {
-  test("a chat turn records token usage whose input:output ratio matches the provider", async ({
+test.describe("Usage tracking — chat → OpenClaw → per-turn recorder → usage_records", () => {
+  test("a chat turn records one usage row with the provider's EXACT per-turn tokens", async ({
     page,
   }) => {
     await login(page);
@@ -117,26 +115,22 @@ test.describe("Usage tracking — chat → OpenClaw → poller → usage_records
 
     await sendChat(page, "Hello, are you there?");
     // The Smithers session is shared across the integration run, so prior
-    // specs' identical replies are already rendered — match the newest one to
-    // avoid a strict-mode multiple-match.
+    // specs' identical replies are already rendered — match the newest one.
     await expect(page.getByText(FAKE_OLLAMA_RESPONSE).last()).toBeVisible({ timeout: 30000 });
 
-    // The poller (every 10s) records the delta from this turn. A turn always
-    // produces a strictly positive delta on both axes (the fake scales both
-    // counts by the turn's user-message count).
-    const delta = await waitForUsageDelta(agentId, before, (d) => d.input > 0 && d.output > 0);
+    const delta = await waitForNewTurns(agentId, before, 1);
 
-    // The recorded numbers came straight from the provider's usage block via
-    // OpenClaw's session counters: their input:output ratio must equal the
-    // fake's declared 42:17, regardless of how many turns the delta merged or
-    // whether OpenClaw accumulates or replaces its counters.
-    expect(delta.input * COMPLETION).toBe(delta.output * PROMPT);
-    // The delta is a whole number of turns' worth of the declared base.
-    expect(delta.input % PROMPT).toBe(0);
-    expect(delta.output % COMPLETION).toBe(0);
+    // Per-turn lossless accounting: every new row is exactly 42 in / 17 out, so
+    // the delta is an exact whole multiple — NOT a ratio invariant.
+    expect(delta.input).toBe(PROMPT * delta.rows);
+    expect(delta.output).toBe(COMPLETION * delta.rows);
+    // The fake provider doesn't cache, so cache classes are recorded as 0 (the
+    // columns are populated, not dropped — guards the #482 regression class).
+    expect(delta.cacheRead).toBe(0);
+    expect(delta.cacheWrite).toBe(0);
   });
 
-  test("multiple turns in the same session accumulate a growing recorded total", async ({
+  test("each additional turn adds exactly one more exact row (deduped, no double-count)", async ({
     page,
   }) => {
     await login(page);
@@ -146,26 +140,19 @@ test.describe("Usage tracking — chat → OpenClaw → poller → usage_records
 
     const before = await chatUsageTotals(agentId);
 
-    // Turn 1
     await sendChat(page, "First question.");
     await expect(page.getByText(FAKE_OLLAMA_RESPONSE).last()).toBeVisible({ timeout: 30000 });
-    const afterTurn1 = await waitForUsageDelta(agentId, before, (d) => d.input > 0 && d.output > 0);
+    const afterTurn1 = await waitForNewTurns(agentId, before, 1);
+    expect(afterTurn1.input).toBe(PROMPT * afterTurn1.rows);
 
-    // Turn 2 — same session, so OpenClaw's cumulative counter grows and the
-    // poller records a further delta. The total recorded for this session must
-    // strictly exceed the single-turn total, proving the multi-turn delta path
-    // captures additional turns without dropping or double-counting them.
     await sendChat(page, "Second question.");
-    const afterTurn2 = await waitForUsageDelta(
-      agentId,
-      before,
-      (d) => d.input > afterTurn1.input && d.output > afterTurn1.output,
-      40000
-    );
+    await expect(page.getByText(FAKE_OLLAMA_RESPONSE).last()).toBeVisible({ timeout: 30000 });
+    const afterTurn2 = await waitForNewTurns(agentId, before, afterTurn1.rows + 1);
 
-    expect(afterTurn2.input).toBeGreaterThan(afterTurn1.input);
-    expect(afterTurn2.output).toBeGreaterThan(afterTurn1.output);
-    // The cumulative delta still preserves the provider's declared ratio.
-    expect(afterTurn2.input * COMPLETION).toBe(afterTurn2.output * PROMPT);
+    // Strictly one (or more) additional rows; tokens stay an exact multiple —
+    // proving the second turn was captured without dropping or double-counting.
+    expect(afterTurn2.rows).toBeGreaterThan(afterTurn1.rows);
+    expect(afterTurn2.input).toBe(PROMPT * afterTurn2.rows);
+    expect(afterTurn2.output).toBe(COMPLETION * afterTurn2.rows);
   });
 });

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -36,20 +36,21 @@ const DEFAULT_COMPLETION_TOKENS = 17;
 // the declared 42:17 input:output ratio intact — which is the invariant the
 // spec checks. (Real output tokens don't grow with history; this is a
 // deliberate determinism concession in the fake, not a fidelity claim.)
-function getUsageTokens(userMessageCount = 1): {
+function getUsageTokens(_userMessageCount = 1): {
   promptTokens: number;
   completionTokens: number;
 } {
-  const turn = Math.max(1, userMessageCount);
+  // Flat per-turn usage (#483): with lossless per-turn accounting, each turn's
+  // trajectory `model.completed` carries that turn's exact tokens and lands as
+  // one usage_records row. The fake reports a constant 42:17 per turn (no
+  // userMessageCount scaling — that was a gauge-era concession to make a
+  // CUMULATIVE counter grow). The E2E asserts EXACT per-turn counts.
   const prompt = Number(process.env.FAKE_OLLAMA_PROMPT_TOKENS);
   const completion = Number(process.env.FAKE_OLLAMA_COMPLETION_TOKENS);
   const basePrompt = Number.isFinite(prompt) && prompt >= 0 ? prompt : DEFAULT_PROMPT_TOKENS;
   const baseCompletion =
     Number.isFinite(completion) && completion >= 0 ? completion : DEFAULT_COMPLETION_TOKENS;
-  return {
-    promptTokens: basePrompt * turn,
-    completionTokens: baseCompletion * turn,
-  };
+  return { promptTokens: basePrompt, completionTokens: baseCompletion };
 }
 
 function countUserMessages(messages: unknown[]): number {

--- a/packages/web/src/__tests__/e2e-shared/fake-ollama-usage.test.ts
+++ b/packages/web/src/__tests__/e2e-shared/fake-ollama-usage.test.ts
@@ -65,13 +65,15 @@ describe("fake-ollama usage block — OpenAI /v1/chat/completions (the path OC u
     });
   });
 
-  it("scales both token counts with the user-message count so multi-turn usage grows", async () => {
+  it("reports FLAT per-turn usage regardless of user-message count (#483)", async () => {
     process.env.FAKE_OLLAMA_PROMPT_TOKENS = "42";
     process.env.FAKE_OLLAMA_COMPLETION_TOKENS = "17";
 
-    // Two user messages (a second turn re-sending history) → both axes double,
-    // preserving the 42:17 ratio. The growth guarantees a positive poller
-    // delta even on a session that already carries history.
+    // A second turn re-sends history (multiple user messages), but with lossless
+    // per-turn accounting each turn's usage is recorded as its OWN exact row —
+    // there is no cumulative gauge to inflate. The fake therefore reports a flat
+    // 42:17 per turn, no userMessageCount scaling (a gauge-era concession the
+    // #483 rework removed). The E2E asserts exact per-turn counts.
     const raw = await postChat("/v1/chat/completions", {
       stream: true,
       messages: [
@@ -90,9 +92,9 @@ describe("fake-ollama usage block — OpenAI /v1/chat/completions (the path OC u
       .find((u) => u !== undefined);
 
     expect(usage).toEqual({
-      prompt_tokens: 84,
-      completion_tokens: 34,
-      total_tokens: 118,
+      prompt_tokens: 42,
+      completion_tokens: 17,
+      total_tokens: 59,
     });
   });
 

--- a/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
+++ b/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Tier-2 per-turn usage accounting (#483) against a REAL PostgreSQL.
+ *
+ * Proves the two things a faked DB cannot: (1) the unique index
+ * uq_usage_session_run(session_key, run_id) actually makes a repeated
+ * (sessionKey, runId) insert a no-op under real PG (gauge/internal rows keep
+ * run_id NULL, exempt via Postgres NULLS DISTINCT), so
+ * re-scans / restarts / the chat-`done` trigger never double-count; (2) a
+ * crafted trajectory replays into rows whose token sums equal the trajectory's
+ * model.completed usage EXACTLY (the #483 acceptance oracle).
+ */
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { usageRecords } from "@/db/schema";
+import {
+  insertPerTurnUsage,
+  recordSessionTurnsUsage,
+  type InsertableUsageRow,
+} from "@/lib/usage-per-turn";
+import { _resetPricingCacheForTest } from "@/lib/usage";
+
+const AGENT = "agent-pt-1";
+const USER = "user-pt-1";
+const SESSION_KEY = `agent:${AGENT}:direct:${USER}`.toLowerCase();
+const SESSION_ID = "sess-pt-1";
+
+function row(over: Partial<InsertableUsageRow>): InsertableUsageRow {
+  return {
+    userId: USER,
+    agentId: AGENT,
+    agentName: "Ada",
+    sessionKey: SESSION_KEY,
+    model: "anthropic/claude-sonnet-4-6",
+    inputTokens: 5,
+    outputTokens: 630,
+    cacheReadTokens: 100,
+    cacheWriteTokens: 50,
+    estimatedCostUsd: null,
+    runId: "run-1",
+    seq: 5,
+    ...over,
+  };
+}
+
+function modelCompleted(runId: string, seq: number, usage: Record<string, number>) {
+  return JSON.stringify({
+    type: "model.completed",
+    seq,
+    sessionId: SESSION_ID,
+    sessionKey: SESSION_KEY,
+    runId,
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-6",
+    data: { usage },
+  });
+}
+
+async function rowsForSession() {
+  return db.select().from(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+}
+
+describe("per-turn usage accounting (#483) — real Postgres", () => {
+  let stateDir: string;
+
+  beforeEach(async () => {
+    _resetPricingCacheForTest();
+    await db.delete(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+    stateDir = mkdtempSync(join(tmpdir(), "pinchy-pt-state-"));
+    vi.stubEnv("OPENCLAW_STATE_DIR", stateDir);
+  });
+
+  afterEach(async () => {
+    vi.unstubAllEnvs();
+    rmSync(stateDir, { recursive: true, force: true });
+    await db.delete(usageRecords).where(eq(usageRecords.sessionKey, SESSION_KEY));
+  });
+
+  it("insertPerTurnUsage dedups by (sessionKey, runId): re-inserting the same turn is a no-op", async () => {
+    expect(await insertPerTurnUsage([row({ runId: "r1" })])).toBe(1);
+    // Same (sessionKey, runId) again — different token values must NOT create a
+    // second row nor overwrite; the unique index swallows it.
+    expect(await insertPerTurnUsage([row({ runId: "r1", inputTokens: 999 })])).toBe(0);
+    expect(await insertPerTurnUsage([row({ runId: "r2" })])).toBe(1);
+
+    const rows = await rowsForSession();
+    expect(rows).toHaveLength(2);
+    expect(rows.find((r) => r.runId === "r1")?.inputTokens).toBe(5); // original, not 999
+  });
+
+  it("a batch with a duplicate runId among new ones inserts only the new turns", async () => {
+    await insertPerTurnUsage([row({ runId: "a" })]);
+    const inserted = await insertPerTurnUsage([
+      row({ runId: "a" }), // already present
+      row({ runId: "b" }),
+      row({ runId: "c" }),
+    ]);
+    expect(inserted).toBe(2);
+    expect((await rowsForSession()).map((r) => r.runId).sort()).toEqual(["a", "b", "c"]);
+  });
+
+  it("recordSessionTurnsUsage replays a trajectory into exact per-turn rows, idempotently", async () => {
+    // Write the OpenClaw session index + a 3-turn trajectory into the temp state dir.
+    const dir = join(stateDir, "agents", AGENT, "sessions");
+    mkdirSync(dir, { recursive: true });
+    writeFileSync(
+      join(dir, "sessions.json"),
+      JSON.stringify({ [SESSION_KEY]: { sessionId: SESSION_ID } })
+    );
+    writeFileSync(
+      join(dir, `${SESSION_ID}.trajectory.jsonl`),
+      [
+        JSON.stringify({ type: "session.started", seq: 1 }),
+        modelCompleted("run-a", 2, {
+          input: 5,
+          output: 100,
+          cacheRead: 1000,
+          cacheWrite: 200,
+          total: 1305,
+        }),
+        modelCompleted("run-b", 4, {
+          input: 7,
+          output: 200,
+          cacheRead: 2000,
+          cacheWrite: 0,
+          total: 2207,
+        }),
+        modelCompleted("run-c", 6, { input: 3, output: 50, total: 53 }), // no cache
+      ].join("\n")
+    );
+
+    // Fake OpenClaw client: pricing for the model so cost is also exercised.
+    const openclawClient = {
+      config: {
+        get: async () => ({
+          config: {
+            models: {
+              providers: {
+                anthropic: {
+                  models: [{ id: "anthropic/claude-sonnet-4-6", cost: { input: 3, output: 15 } }],
+                },
+              },
+            },
+          },
+        }),
+      },
+    } as never;
+
+    const inserted = await recordSessionTurnsUsage({
+      openclawClient,
+      agentId: AGENT,
+      userId: USER,
+      agentName: "Ada",
+      sessionKey: SESSION_KEY,
+    });
+    expect(inserted).toBe(3);
+
+    const rows = await rowsForSession();
+    expect(rows).toHaveLength(3);
+    // Exact per-turn token sums == the trajectory's model.completed sums.
+    const sum = (f: (r: (typeof rows)[number]) => number) => rows.reduce((a, r) => a + f(r), 0);
+    expect(sum((r) => r.inputTokens)).toBe(5 + 7 + 3);
+    expect(sum((r) => r.outputTokens)).toBe(100 + 200 + 50);
+    expect(sum((r) => r.cacheReadTokens)).toBe(1000 + 2000 + 0);
+    expect(sum((r) => r.cacheWriteTokens)).toBe(200 + 0 + 0);
+    // Cost is populated per turn (run-a: (5*3+100*15+1000*0.3+200*3.75)/1e6).
+    const runA = rows.find((r) => r.runId === "run-a")!;
+    expect(runA.estimatedCostUsd).toBe("0.002565");
+    expect(runA.seq).toBe(2);
+
+    // Idempotent: a second scan of the same trajectory records nothing new.
+    const again = await recordSessionTurnsUsage({
+      openclawClient,
+      agentId: AGENT,
+      userId: USER,
+      agentName: "Ada",
+      sessionKey: SESSION_KEY,
+    });
+    expect(again).toBe(0);
+    expect(await rowsForSession()).toHaveLength(3);
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-cost.test.ts
+++ b/packages/web/src/__tests__/lib/usage-cost.test.ts
@@ -1,0 +1,45 @@
+import { describe, it, expect } from "vitest";
+import { estimateTurnCostUsd } from "@/lib/usage-cost";
+
+describe("estimateTurnCostUsd", () => {
+  const pricing = { input: 3, output: 15 }; // $/M tokens (claude-sonnet-ish)
+
+  it("prices input + output", () => {
+    // (1_000_000*3 + 1_000_000*15) / 1e6 = 18
+    expect(
+      estimateTurnCostUsd(
+        {
+          inputTokens: 1_000_000,
+          outputTokens: 1_000_000,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        },
+        pricing
+      )
+    ).toBe("18.000000");
+  });
+
+  it("prices cache read at 0.1x and cache write at 1.25x the input price", () => {
+    // cacheRead: 1e6 * 0.3 = 0.3 ; cacheWrite: 1e6 * 3.75 = 3.75 → 4.05
+    expect(
+      estimateTurnCostUsd(
+        {
+          inputTokens: 0,
+          outputTokens: 0,
+          cacheReadTokens: 1_000_000,
+          cacheWriteTokens: 1_000_000,
+        },
+        pricing
+      )
+    ).toBe("4.050000");
+  });
+
+  it("returns 0 for an all-zero turn", () => {
+    expect(
+      estimateTurnCostUsd(
+        { inputTokens: 0, outputTokens: 0, cacheReadTokens: 0, cacheWriteTokens: 0 },
+        pricing
+      )
+    ).toBe("0.000000");
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
+++ b/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { extractPerTurnUsage } from "@/lib/usage-from-trajectory";
+
+// Shapes verified empirically against the live staging OpenClaw 2026.6.5
+// trajectory: each `model.completed` event carries the EXACT per-turn token
+// usage in `data.usage` — `{input, output, total}` for non-caching providers
+// (ollama-cloud) and `{input, output, cacheRead, cacheWrite, total}` for
+// caching providers (anthropic). Cache fields are absent (→ 0) when the
+// provider doesn't cache. One event = one turn, uniquely keyed by `runId`.
+function modelCompleted(over: Record<string, unknown> = {}): Record<string, unknown> {
+  return {
+    type: "model.completed",
+    seq: 5,
+    sessionId: "sess-1",
+    sessionKey: "agent:a1:direct:u1",
+    runId: "run-1",
+    provider: "anthropic",
+    modelId: "claude-sonnet-4-6",
+    data: { usage: { input: 5, output: 630, cacheRead: 32336, cacheWrite: 16956, total: 49927 } },
+    ...over,
+  };
+}
+
+describe("extractPerTurnUsage", () => {
+  it("extracts exact per-turn token classes from data.usage (anthropic, with cache)", () => {
+    expect(extractPerTurnUsage([modelCompleted()])).toEqual([
+      {
+        runId: "run-1",
+        seq: 5,
+        sessionId: "sess-1",
+        sessionKey: "agent:a1:direct:u1",
+        model: "anthropic/claude-sonnet-4-6",
+        inputTokens: 5,
+        outputTokens: 630,
+        cacheReadTokens: 32336,
+        cacheWriteTokens: 16956,
+      },
+    ]);
+  });
+
+  it("defaults cache classes to 0 for non-caching providers (ollama-cloud)", () => {
+    const [row] = extractPerTurnUsage([
+      modelCompleted({
+        seq: 7,
+        runId: "run-2",
+        provider: "ollama-cloud",
+        modelId: "deepseek-v4-flash",
+        data: { usage: { input: 86377, output: 508, total: 86885 } },
+      }),
+    ]);
+    expect(row).toMatchObject({
+      runId: "run-2",
+      model: "ollama-cloud/deepseek-v4-flash",
+      inputTokens: 86377,
+      outputTokens: 508,
+      cacheReadTokens: 0,
+      cacheWriteTokens: 0,
+    });
+  });
+
+  it("ignores non-model.completed events", () => {
+    const events = [
+      { type: "session.started", seq: 1 },
+      { type: "prompt.submitted", seq: 2 },
+      modelCompleted({ seq: 3, runId: "run-3" }),
+      { type: "session.ended", seq: 99 },
+    ];
+    expect(extractPerTurnUsage(events).map((r) => r.runId)).toEqual(["run-3"]);
+  });
+
+  it("skips a model.completed without a runId (cannot dedup it) or without usage", () => {
+    const events = [
+      modelCompleted({ runId: undefined }),
+      modelCompleted({ runId: "run-x", data: {} }),
+      modelCompleted({ runId: "run-ok" }),
+    ];
+    expect(extractPerTurnUsage(events).map((r) => r.runId)).toEqual(["run-ok"]);
+  });
+
+  it("captures subagent turns (their own runId) — they are real token spend", () => {
+    const sub = modelCompleted({
+      runId: "announce:v1:agent:a1:subagent:s1:r9",
+      provider: "ollama-cloud",
+      modelId: "deepseek-v4-flash",
+      data: { usage: { input: 100, output: 10, total: 110 } },
+    });
+    const rows = extractPerTurnUsage([modelCompleted({ runId: "run-main" }), sub]);
+    expect(rows.map((r) => r.runId)).toEqual(["run-main", "announce:v1:agent:a1:subagent:s1:r9"]);
+  });
+
+  it("returns [] for empty input", () => {
+    expect(extractPerTurnUsage([])).toEqual([]);
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -1,0 +1,82 @@
+import { describe, it, expect } from "vitest";
+import { buildUsageRows } from "@/lib/usage-per-turn";
+import type { PerTurnUsage } from "@/lib/usage-from-trajectory";
+
+const ctx = {
+  userId: "u1",
+  agentId: "a1",
+  agentName: "Ada",
+  sessionKey: "agent:a1:direct:u1",
+};
+
+function turn(over: Partial<PerTurnUsage> = {}): PerTurnUsage {
+  return {
+    runId: "run-1",
+    seq: 5,
+    sessionId: "sess-1",
+    sessionKey: "agent:a1:direct:u1",
+    model: "anthropic/claude-sonnet-4-6",
+    inputTokens: 5,
+    outputTokens: 630,
+    cacheReadTokens: 32336,
+    cacheWriteTokens: 16956,
+    ...over,
+  };
+}
+
+describe("buildUsageRows", () => {
+  it("maps a per-turn usage into an insertable row with attribution, runId/seq, and cost", () => {
+    const rows = buildUsageRows([turn()], ctx, () => ({ input: 3, output: 15 }));
+    expect(rows).toEqual([
+      {
+        userId: "u1",
+        agentId: "a1",
+        agentName: "Ada",
+        sessionKey: "agent:a1:direct:u1",
+        model: "anthropic/claude-sonnet-4-6",
+        inputTokens: 5,
+        outputTokens: 630,
+        cacheReadTokens: 32336,
+        cacheWriteTokens: 16956,
+        // (5*3 + 630*15 + 32336*0.3 + 16956*3.75) / 1e6
+        estimatedCostUsd: "0.082751",
+        runId: "run-1",
+        seq: 5,
+      },
+    ]);
+  });
+
+  it("prices each turn by its OWN model (a subagent turn can use a different model)", () => {
+    const rows = buildUsageRows(
+      [
+        turn({ runId: "main", model: "anthropic/claude-sonnet-4-6" }),
+        turn({
+          runId: "sub",
+          model: "ollama-cloud/deepseek-v4-flash",
+          inputTokens: 100,
+          outputTokens: 10,
+          cacheReadTokens: 0,
+          cacheWriteTokens: 0,
+        }),
+      ],
+      ctx,
+      (model) =>
+        model?.startsWith("anthropic/") ? { input: 3, output: 15 } : { input: 0, output: 0 }
+    );
+    expect(rows.map((r) => [r.runId, r.estimatedCostUsd])).toEqual([
+      ["main", "0.082751"],
+      ["sub", "0.000000"],
+    ]);
+  });
+
+  it("records null cost when no pricing is known (e.g. local model)", () => {
+    const rows = buildUsageRows([turn({ model: "ollama/llama" })], ctx, () => null);
+    expect(rows[0].estimatedCostUsd).toBeNull();
+    expect(rows[0].inputTokens).toBe(5);
+  });
+
+  it("uses the context sessionKey (normalized), not the raw event one", () => {
+    const rows = buildUsageRows([turn({ sessionKey: "AGENT:A1:DIRECT:U1" })], ctx, () => null);
+    expect(rows[0].sessionKey).toBe("agent:a1:direct:u1");
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -1,11 +1,17 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
 const mockRecordUsage = vi.fn();
+const mockRecordSessionTurns = vi.fn();
 const mockSelect = vi.fn();
 const mockFrom = vi.fn();
 
 vi.mock("@/lib/usage", () => ({
   recordUsage: (...args: unknown[]) => mockRecordUsage(...args),
+}));
+
+// #483: chat sessions are recorded per-turn from the trajectory, not the gauge.
+vi.mock("@/lib/usage-per-turn", () => ({
+  recordSessionTurnsUsage: (...args: unknown[]) => mockRecordSessionTurns(...args),
 }));
 
 const mockWhere = vi.fn();
@@ -135,15 +141,54 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).not.toHaveBeenCalled();
   });
 
-  it("maps OpenClaw's cacheRead/cacheWrite session fields into the snapshot", async () => {
-    // OpenClaw's session store (verified live on staging, OC 2026.5.28) names
-    // the cache counters `cacheRead` / `cacheWrite` — NOT `cacheReadTokens` /
-    // `cacheWriteTokens`. Reading the wrong names left every usage_record with
-    // cache=0 while Anthropic served ~97% of input from the prompt cache, so
-    // the dashboard showed "Input: 7" for a ~400k-token day.
+  it("routes chat sessions to the per-turn trajectory recorder, not the gauge (#483)", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50, model: "claude" },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith({
+      openclawClient: client,
+      agentId: "agent-1",
+      userId: "user-1",
+      agentName: "Smithers",
+      sessionKey: "agent:agent-1:direct:user-1",
+    });
+  });
+
+  it("scans every chat session regardless of the gauge token counts (dedup makes it safe)", async () => {
+    // A chat session whose gauge shows 0/0 still gets scanned — the just-
+    // completed turn lives in the trajectory even when the gauge was reset.
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 0, outputTokens: 0 },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+    expect(mockRecordUsage).not.toHaveBeenCalled();
+  });
+
+  it("system sessions use the gauge delta path, not the per-turn recorder", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50, model: "claude" },
+    ]);
+    await pollAllSessions(client);
+    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
+    expect(mockRecordUsage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        userId: "system",
+        agentId: "agent-1",
+        sessionKey: "agent:agent-1:cron:job-1",
+      })
+    );
+  });
+
+  it("maps OpenClaw's cacheRead/cacheWrite session fields into the gauge snapshot (system sessions)", async () => {
+    // The #482 cache-field-name fix: OpenClaw's session store names the
+    // counters `cacheRead`/`cacheWrite` (verified live, OC 2026.5.28), NOT the
+    // `*Tokens` spellings. Still applies to the gauge path (system sessions).
     const client = makeOpenClawClient([
       {
-        key: "agent:agent-1:direct:user-1",
+        key: "agent:agent-1:cron:job-1",
         inputTokens: 3,
         outputTokens: 80,
         cacheRead: 14404,
@@ -164,10 +209,10 @@ describe("pollAllSessions", () => {
     );
   });
 
-  it("still accepts the cacheReadTokens/cacheWriteTokens spelling as fallback", async () => {
+  it("still accepts the cacheReadTokens/cacheWriteTokens spelling as fallback (gauge)", async () => {
     const client = makeOpenClawClient([
       {
-        key: "agent:agent-1:direct:user-1",
+        key: "agent:agent-1:cron:job-1",
         inputTokens: 10,
         outputTokens: 5,
         cacheReadTokens: 111,
@@ -188,11 +233,11 @@ describe("pollAllSessions", () => {
     );
   });
 
-  it("does not skip a session whose only activity is cache traffic", async () => {
+  it("does not skip a system session whose only activity is cache traffic (gauge)", async () => {
     // Last-turn gauges can show input=0/output=0 while cache counters moved.
     const client = makeOpenClawClient([
       {
-        key: "agent:agent-1:direct:user-1",
+        key: "agent:agent-1:cron:job-1",
         inputTokens: 0,
         outputTokens: 0,
         cacheRead: 5000,
@@ -206,55 +251,25 @@ describe("pollAllSessions", () => {
     expect(mockRecordUsage).toHaveBeenCalledTimes(1);
   });
 
-  it("calls recordUsage for each session with tokens", async () => {
-    mockFrom._agentResult = [
-      { id: "agent-1", name: "Smithers" },
-      { id: "agent-2", name: "Burns" },
-    ];
+  it("records gauge usage for a system session with the forwarded snapshot", async () => {
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     const client = makeOpenClawClient([
-      {
-        key: "agent:agent-1:direct:user-1",
-        inputTokens: 100,
-        outputTokens: 50,
-        model: "claude",
-      },
-      {
-        key: "agent:agent-2:direct:user-2",
-        inputTokens: 200,
-        outputTokens: 80,
-        model: "claude",
-      },
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50, model: "claude" },
     ]);
 
     await pollAllSessions(client);
 
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
     // The poller MUST pass sessionSnapshot so recordUsage does not issue a
-    // second sessions.list() round-trip per session. Check the full shape
-    // including the forwarded snapshot fields.
+    // second sessions.list() round-trip per session.
     expect(mockRecordUsage).toHaveBeenCalledWith({
       openclawClient: client,
-      userId: "user-1",
+      userId: "system",
       agentId: "agent-1",
       agentName: "Smithers",
-      sessionKey: "agent:agent-1:direct:user-1",
+      sessionKey: "agent:agent-1:cron:job-1",
       sessionSnapshot: {
         inputTokens: 100,
         outputTokens: 50,
-        cacheReadTokens: undefined,
-        cacheWriteTokens: undefined,
-        model: "claude",
-      },
-    });
-    expect(mockRecordUsage).toHaveBeenCalledWith({
-      openclawClient: client,
-      userId: "user-2",
-      agentId: "agent-2",
-      agentName: "Burns",
-      sessionKey: "agent:agent-2:direct:user-2",
-      sessionSnapshot: {
-        inputTokens: 200,
-        outputTokens: 80,
         cacheReadTokens: undefined,
         cacheWriteTokens: undefined,
         model: "claude",
@@ -262,9 +277,9 @@ describe("pollAllSessions", () => {
     });
   });
 
-  it("skips sessions with zero tokens", async () => {
+  it("skips system sessions with zero tokens", async () => {
     const client = makeOpenClawClient([
-      { key: "agent:agent-1:direct:user-1", inputTokens: 0, outputTokens: 0 },
+      { key: "agent:agent-1:main", inputTokens: 0, outputTokens: 0 },
     ]);
     await pollAllSessions(client);
     expect(mockRecordUsage).not.toHaveBeenCalled();
@@ -276,6 +291,7 @@ describe("pollAllSessions", () => {
     ]);
     await pollAllSessions(client);
     expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
   });
 
   it("records system sessions with userId='system'", async () => {
@@ -292,13 +308,15 @@ describe("pollAllSessions", () => {
     );
   });
 
-  it("falls back to agentId when agent name is not in DB", async () => {
+  it("falls back to agentId when agent name is not in DB (path-agnostic)", async () => {
     mockFrom._agentResult = []; // empty agents table
     const client = makeOpenClawClient([
       { key: "agent:ghost-agent:direct:user-1", inputTokens: 100, outputTokens: 50 },
     ]);
     await pollAllSessions(client);
-    expect(mockRecordUsage).toHaveBeenCalledWith(
+    // Chat session → per-turn recorder; the agentName fallback is computed
+    // before the chat/system branch, so it applies on either path.
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith(
       expect.objectContaining({
         agentId: "ghost-agent",
         agentName: "ghost-agent",
@@ -333,7 +351,8 @@ describe("pollAllSessions", () => {
 
     await pollAllSessions(client);
 
-    expect(mockRecordUsage).toHaveBeenCalledWith(
+    // Chat session → per-turn recorder, which receives the resolved userId.
+    expect(mockRecordSessionTurns).toHaveBeenCalledWith(
       expect.objectContaining({
         // userId should be the original-case DB id, not the lowercase from the key
         userId: "zLGhGKUwYqZeQfA4IMwG2oIDSxoYJVqz",
@@ -358,16 +377,18 @@ describe("pollAllSessions", () => {
     );
   });
 
-  it("does not throw when a single recordUsage call rejects", async () => {
+  it("does not throw when a single gauge recordUsage call rejects", async () => {
     mockFrom._agentResult = [
       { id: "agent-1", name: "A1" },
       { id: "agent-2", name: "A2" },
     ];
     mockRecordUsage.mockRejectedValueOnce(new Error("db error")).mockResolvedValueOnce(undefined);
 
+    // System sessions use the gauge path; a rejecting recordUsage must not
+    // abort the whole poll.
     const client = makeOpenClawClient([
-      { key: "agent:agent-1:direct:u1", inputTokens: 10, outputTokens: 5 },
-      { key: "agent:agent-2:direct:u2", inputTokens: 20, outputTokens: 8 },
+      { key: "agent:agent-1:cron:j1", inputTokens: 10, outputTokens: 5 },
+      { key: "agent:agent-2:cron:j2", inputTokens: 20, outputTokens: 8 },
     ]);
 
     await expect(pollAllSessions(client)).resolves.toBeUndefined();
@@ -441,21 +462,21 @@ describe("startUsagePoller honors the configured interval", () => {
 
     // No poll before the (short) interval elapses.
     await vi.advanceTimersByTimeAsync(1_999);
-    expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
 
     // First tick at 2s, not 60s.
     await vi.advanceTimersByTimeAsync(1);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(2_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("startUsagePoller / stopUsagePoller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    mockRecordUsage.mockResolvedValue(undefined);
+    mockRecordSessionTurns.mockResolvedValue(undefined);
     mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     stopUsagePoller();
     vi.useFakeTimers();
@@ -491,7 +512,7 @@ describe("startUsagePoller / stopUsagePoller", () => {
     // Flush any microtasks — no poll should have fired yet
     await vi.advanceTimersByTimeAsync(0);
 
-    expect(mockRecordUsage).not.toHaveBeenCalled();
+    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
 
     stopUsagePoller();
   });
@@ -504,11 +525,11 @@ describe("startUsagePoller / stopUsagePoller", () => {
 
     // First interval tick at 60s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
 
     // Second interval tick at 120s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
   });
 
   it("stops polling on stopUsagePoller", async () => {
@@ -517,13 +538,13 @@ describe("startUsagePoller / stopUsagePoller", () => {
     ]);
     startUsagePoller(client);
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // first tick only
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1); // first tick only
 
     stopUsagePoller();
     expect(_isPollerRunning()).toBe(false);
 
     await vi.advanceTimersByTimeAsync(120_000);
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1); // no more calls after stop
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1); // no more calls after stop
   });
 
   it("is idempotent — multiple starts don't create duplicate intervals", async () => {
@@ -536,6 +557,6 @@ describe("startUsagePoller / stopUsagePoller", () => {
 
     await vi.advanceTimersByTimeAsync(60_000);
     // Three start calls but only one interval — one tick = 1
-    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
   });
 });

--- a/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
+++ b/packages/web/src/__tests__/lib/usage-polling-timing.test.ts
@@ -167,9 +167,9 @@ function makeClient(sessionRef: { current: MutableSession }) {
   } as unknown as Parameters<typeof pollAllSessions>[0];
 }
 
-const SESSION_KEY = "agent:agent-1:direct:user-1";
+const SESSION_KEY = "agent:agent-1:cron:job-1";
 const baseParams = {
-  userId: "user-1",
+  userId: "system",
   agentId: "agent-1",
   agentName: "Smithers",
   sessionKey: SESSION_KEY,

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -359,12 +359,24 @@ export const usageRecords = pgTable(
       precision: 10,
       scale: 6,
     }),
+    // Per-turn accounting (#483): the OpenClaw run id of the `model.completed`
+    // turn this row records, plus the trajectory `seq` watermark. Both nullable
+    // so the gauge poller (system sessions) and the /api/internal/usage/record
+    // sink (plugin vision tokens) keep inserting without a run id.
+    runId: text("run_id"),
+    seq: integer("seq"),
   },
   (table) => [
     index("idx_usage_timestamp").on(table.timestamp),
     index("idx_usage_user").on(table.userId),
     index("idx_usage_agent").on(table.agentId),
     index("idx_usage_session_key").on(table.sessionKey),
+    // Idempotent per-turn inserts: one row per (session, run). A plain unique
+    // index suffices — Postgres treats NULLs as distinct (default NULLS
+    // DISTINCT), so per-turn rows (run_id NOT NULL) dedup while the gauge poller
+    // and the /api/internal/usage/record sink (run_id NULL) insert freely.
+    // onConflictDoNothing(target [sessionKey, runId]) relies on this index.
+    uniqueIndex("uq_usage_session_run").on(table.sessionKey, table.runId),
   ]
 );
 

--- a/packages/web/src/lib/usage-cost.ts
+++ b/packages/web/src/lib/usage-cost.ts
@@ -1,0 +1,30 @@
+/**
+ * Pure USD cost estimate for a set of token classes — the single source of
+ * truth shared by the gauge poller (system sessions) and the per-turn recorder
+ * (#483 chat sessions). OpenClaw's model config carries only input/output
+ * prices, so cache classes use Anthropic-style ratios: a cache READ is 10% of
+ * the input price, a cache WRITE is 125%.
+ */
+export interface ModelPricing {
+  input: number;
+  output: number;
+}
+
+export interface TokenClasses {
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+export function estimateTurnCostUsd(tokens: TokenClasses, pricing: ModelPricing): string {
+  const cacheReadPrice = pricing.input * 0.1;
+  const cacheWritePrice = pricing.input * 1.25;
+  const cost =
+    (tokens.inputTokens * pricing.input +
+      tokens.outputTokens * pricing.output +
+      tokens.cacheReadTokens * cacheReadPrice +
+      tokens.cacheWriteTokens * cacheWritePrice) /
+    1_000_000;
+  return cost.toFixed(6);
+}

--- a/packages/web/src/lib/usage-from-trajectory.ts
+++ b/packages/web/src/lib/usage-from-trajectory.ts
@@ -1,0 +1,80 @@
+import type { JsonlEvent } from "@/lib/diagnostics/jsonl-parser";
+
+/**
+ * Exact per-turn token usage extracted from one OpenClaw `model.completed`
+ * trajectory event. This is the LOSSLESS replacement for the gauge-sampling
+ * usage poller (#483): OpenClaw overwrites its per-session counters every turn,
+ * so sampling them misses turns — but every completed turn writes a
+ * `model.completed` event whose `data.usage` carries that turn's exact token
+ * classes. One event = one turn, uniquely identified by `runId`.
+ *
+ * Shape verified against live OpenClaw 2026.6.5: `data.usage` is
+ * `{input, output, total}` for non-caching providers and
+ * `{input, output, cacheRead, cacheWrite, total}` for caching providers
+ * (anthropic) — cache fields are simply absent (→ 0) when the provider
+ * doesn't cache. Subagent turns carry their own `runId` and are real spend.
+ */
+export interface PerTurnUsage {
+  runId: string;
+  seq: number;
+  sessionId: string;
+  sessionKey: string;
+  /** Fully-qualified `<provider>/<modelId>`, or null if either is missing. */
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+}
+
+function asRecord(value: unknown): Record<string, unknown> | undefined {
+  return value && typeof value === "object" && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : undefined;
+}
+
+function asString(value: unknown): string | undefined {
+  return typeof value === "string" && value.length > 0 ? value : undefined;
+}
+
+function asTokenCount(value: unknown): number {
+  return typeof value === "number" && Number.isFinite(value) && value > 0 ? value : 0;
+}
+
+function qualifiedModel(provider: unknown, modelId: unknown): string | null {
+  const p = asString(provider);
+  const m = asString(modelId);
+  return p && m ? `${p}/${m}` : (m ?? null);
+}
+
+/**
+ * Map a session's trajectory events to one exact usage row per completed turn.
+ * Events without a `runId` (cannot be deduped) or without a `data.usage`
+ * object (not a real completion) are skipped.
+ */
+export function extractPerTurnUsage(events: JsonlEvent[]): PerTurnUsage[] {
+  const rows: PerTurnUsage[] = [];
+  for (const event of events) {
+    if (event.type !== "model.completed") continue;
+
+    const runId = asString(event.runId);
+    if (!runId) continue;
+
+    const data = asRecord(event.data);
+    const usage = asRecord(data?.usage);
+    if (!usage) continue;
+
+    rows.push({
+      runId,
+      seq: typeof event.seq === "number" ? event.seq : 0,
+      sessionId: asString(event.sessionId) ?? "",
+      sessionKey: asString(event.sessionKey) ?? "",
+      model: qualifiedModel(event.provider, event.modelId),
+      inputTokens: asTokenCount(usage.input),
+      outputTokens: asTokenCount(usage.output),
+      cacheReadTokens: asTokenCount(usage.cacheRead),
+      cacheWriteTokens: asTokenCount(usage.cacheWrite),
+    });
+  }
+  return rows;
+}

--- a/packages/web/src/lib/usage-per-turn.ts
+++ b/packages/web/src/lib/usage-per-turn.ts
@@ -1,0 +1,157 @@
+import { db } from "@/db";
+import { usageRecords } from "@/db/schema";
+import type { OpenClawClient } from "openclaw-node";
+import { parseJsonlLines } from "@/lib/diagnostics/jsonl-parser";
+import { resolveSessionId, readTrajectoryJsonl } from "@/lib/diagnostics/jsonl-reader";
+import { extractPerTurnUsage, type PerTurnUsage } from "@/lib/usage-from-trajectory";
+import { getModelPricing } from "@/lib/usage";
+import { estimateTurnCostUsd, type ModelPricing } from "@/lib/usage-cost";
+
+/**
+ * Lossless per-turn token accounting (#483). OpenClaw overwrites its
+ * per-session token counters every turn, so the gauge poller (which samples
+ * those counters on an interval) silently drops turns that complete between
+ * polls. Each completed turn instead writes a `model.completed` trajectory
+ * event carrying that turn's EXACT token classes; this recorder reads them and
+ * inserts one usage_records row per turn, deduped by (sessionKey, runId) at the
+ * DB layer so re-scans / restarts / the low-latency chat-`done` trigger are all
+ * idempotent. Chat sessions move to this path; the poller keeps system
+ * sessions (cron/channel/main), which have no per-user trajectory we scan.
+ */
+
+export interface InsertableUsageRow {
+  userId: string;
+  agentId: string;
+  agentName: string;
+  sessionKey: string;
+  model: string | null;
+  inputTokens: number;
+  outputTokens: number;
+  cacheReadTokens: number;
+  cacheWriteTokens: number;
+  estimatedCostUsd: string | null;
+  runId: string;
+  seq: number;
+}
+
+export interface UsageRowContext {
+  userId: string;
+  agentId: string;
+  agentName: string;
+  /** Normalized (lowercased) session key, authoritative for the DB row. */
+  sessionKey: string;
+}
+
+/**
+ * Map extracted per-turn usages to insertable rows. Pure: cost comes from the
+ * injected `priceFor` so each turn is priced by its OWN model (a subagent turn
+ * can run on a different model than the main turn).
+ */
+export function buildUsageRows(
+  turns: PerTurnUsage[],
+  ctx: UsageRowContext,
+  priceFor: (model: string | null) => ModelPricing | null
+): InsertableUsageRow[] {
+  const sessionKey = ctx.sessionKey.toLowerCase();
+  return turns.map((t) => {
+    const pricing = priceFor(t.model);
+    return {
+      userId: ctx.userId,
+      agentId: ctx.agentId,
+      agentName: ctx.agentName,
+      sessionKey,
+      model: t.model,
+      inputTokens: t.inputTokens,
+      outputTokens: t.outputTokens,
+      cacheReadTokens: t.cacheReadTokens,
+      cacheWriteTokens: t.cacheWriteTokens,
+      estimatedCostUsd: pricing
+        ? estimateTurnCostUsd(
+            {
+              inputTokens: t.inputTokens,
+              outputTokens: t.outputTokens,
+              cacheReadTokens: t.cacheReadTokens,
+              cacheWriteTokens: t.cacheWriteTokens,
+            },
+            pricing
+          )
+        : null,
+      runId: t.runId,
+      seq: t.seq,
+    };
+  });
+}
+
+/**
+ * Insert per-turn usage rows idempotently. The unique index
+ * uq_usage_session_run(session_key, run_id) makes a repeated (sessionKey,
+ * runId) a no-op (gauge/internal rows have run_id NULL and are exempt via
+ * Postgres NULLS DISTINCT), so concurrent/duplicate scans never double-count.
+ * Returns how many rows were newly inserted.
+ */
+export async function insertPerTurnUsage(rows: InsertableUsageRow[]): Promise<number> {
+  if (rows.length === 0) return 0;
+  const inserted = await db
+    .insert(usageRecords)
+    .values(rows)
+    .onConflictDoNothing({
+      target: [usageRecords.sessionKey, usageRecords.runId],
+    })
+    .returning({ id: usageRecords.id });
+  return inserted.length;
+}
+
+export interface RecordSessionTurnsParams {
+  openclawClient: OpenClawClient;
+  agentId: string;
+  userId: string;
+  agentName: string;
+  sessionKey: string;
+  /** Optional: skip the sessions-index lookup if the caller already has it. */
+  sessionId?: string;
+}
+
+/**
+ * Scan one chat session's trajectory and record any not-yet-recorded turns.
+ * Safe to call repeatedly (DB dedup) — from the interval poller and from the
+ * chat `done` path. Returns the number of newly recorded turns.
+ */
+export async function recordSessionTurnsUsage(params: RecordSessionTurnsParams): Promise<number> {
+  const { openclawClient, agentId, userId, agentName, sessionKey } = params;
+  try {
+    const sessionId = params.sessionId ?? (await resolveSessionId(agentId, sessionKey));
+    if (!sessionId) return 0;
+
+    const jsonl = await readTrajectoryJsonl(agentId, sessionId);
+    const turns = extractPerTurnUsage(parseJsonlLines(jsonl));
+    if (turns.length === 0) return 0;
+
+    const rows = buildUsageRows(turns, { userId, agentId, agentName, sessionKey }, () => null);
+    // Price per distinct model (cached in getModelPricing); attach cost.
+    const priced = await Promise.all(
+      rows.map(async (row) => {
+        if (!row.model) return row;
+        const pricing = await getModelPricing(openclawClient, row.model);
+        if (!pricing) return row;
+        return {
+          ...row,
+          estimatedCostUsd: estimateTurnCostUsd(
+            {
+              inputTokens: row.inputTokens,
+              outputTokens: row.outputTokens,
+              cacheReadTokens: row.cacheReadTokens,
+              cacheWriteTokens: row.cacheWriteTokens,
+            },
+            pricing
+          ),
+        };
+      })
+    );
+    return await insertPerTurnUsage(priced);
+  } catch (error) {
+    // Trajectory missing / unreadable / DB hiccup — never throw into the
+    // poller or chat path. The next scan retries; dedup keeps it safe.
+    console.error("[usage-per-turn] Failed to record session turns:", error);
+    return 0;
+  }
+}

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -1,6 +1,7 @@
 import type { OpenClawClient } from "openclaw-node";
 import { isNull } from "drizzle-orm";
 import { recordUsage } from "@/lib/usage";
+import { recordSessionTurnsUsage } from "@/lib/usage-per-turn";
 import { db } from "@/db";
 import { agents, users } from "@/db/schema";
 
@@ -106,6 +107,31 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
     const userIdMap = new Map(allUsers.map((u) => [u.id.toLowerCase(), u.id]));
 
     for (const session of sessions) {
+      const parsed = parseSessionKey(session.key);
+      if (!parsed) continue;
+
+      const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
+
+      if (parsed.type === "chat") {
+        // Lossless per-turn accounting (#483): chat usage is recorded from the
+        // trajectory's exact per-turn `model.completed` events, NOT the gauge
+        // counters (which OpenClaw overwrites each turn, so sampling drops
+        // turns). This poll is a backstop scan; the chat `done` path scans with
+        // lower latency. DB dedup by (sessionKey, runId) makes re-scans no-ops,
+        // so we scan every chat session regardless of the gauge token counts.
+        const userId = userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId;
+        await recordSessionTurnsUsage({
+          openclawClient,
+          agentId: parsed.agentId,
+          userId,
+          agentName,
+          sessionKey: session.key,
+        });
+        continue;
+      }
+
+      // System sessions (main/cron/hook/channel) have no per-user trajectory we
+      // scan, so they stay on the gauge delta path.
       const cacheReadTokens = session.cacheRead ?? session.cacheReadTokens;
       const cacheWriteTokens = session.cacheWrite ?? session.cacheWriteTokens;
       const hasTokens =
@@ -115,18 +141,9 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
         (cacheWriteTokens ?? 0) > 0;
       if (!hasTokens) continue;
 
-      const parsed = parseSessionKey(session.key);
-      if (!parsed) continue;
-
-      const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
-      const userId =
-        parsed.type === "chat"
-          ? (userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId)
-          : parsed.userId; // "system" stays as-is
-
       await recordUsage({
         openclawClient,
-        userId,
+        userId: parsed.userId, // "system"
         agentId: parsed.agentId,
         agentName,
         sessionKey: session.key,

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -1,4 +1,5 @@
 import { db } from "@/db";
+import { estimateTurnCostUsd } from "@/lib/usage-cost";
 import { usageRecords } from "@/db/schema";
 import { eq, sum } from "drizzle-orm";
 import type { OpenClawClient } from "openclaw-node";
@@ -79,7 +80,7 @@ export function _resetUsageWatermarksForTest(): void {
   sessionWatermarks.clear();
 }
 
-async function getModelPricing(
+export async function getModelPricing(
   openclawClient: OpenClawClient,
   modelId: string
 ): Promise<{ input: number; output: number } | null> {
@@ -221,16 +222,15 @@ async function recordUsageImpl(params: RecordUsageParams, normalizedKey: string)
       if (model) {
         const pricing = await getModelPricing(openclawClient, model);
         if (pricing) {
-          // Cache pricing defaults: Anthropic-style ratios (OpenClaw config lacks cache-specific pricing)
-          const cacheReadPrice = pricing.input * 0.1;
-          const cacheWritePrice = pricing.input * 1.25;
-          const cost =
-            (deltaInput * pricing.input +
-              deltaOutput * pricing.output +
-              deltaCacheRead * cacheReadPrice +
-              deltaCacheWrite * cacheWritePrice) /
-            1_000_000;
-          estimatedCostUsd = cost.toFixed(6);
+          estimatedCostUsd = estimateTurnCostUsd(
+            {
+              inputTokens: deltaInput,
+              outputTokens: deltaOutput,
+              cacheReadTokens: deltaCacheRead,
+              cacheWriteTokens: deltaCacheWrite,
+            },
+            pricing
+          );
         }
       }
     } catch (costError) {

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -9,6 +9,7 @@ import { buildMemoryPromptBlock } from "@/lib/memory-prompt";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { ActiveRuns } from "@/server/active-runs";
+import { recordSessionTurnsUsage } from "@/lib/usage-per-turn";
 import {
   shouldEmitModelUnavailableAudit,
   shouldEmitSilentStreamAudit,
@@ -1021,6 +1022,18 @@ export class ClientRouter {
           if (activeRunRegistered) {
             this.activeRuns.updateMessageId(sessionKey, messageId);
           }
+          // #483: low-latency per-turn usage. The just-completed turn is now in
+          // OpenClaw history; scan this session's trajectory and record its
+          // exact tokens NOW rather than waiting up to a poll interval. Fire-
+          // and-forget — recordSessionTurnsUsage never throws, and DB dedup by
+          // (sessionKey, runId) makes this and the poll backstop idempotent.
+          void recordSessionTurnsUsage({
+            openclawClient: this.openclawClient,
+            agentId: agent.id,
+            userId: this.userId,
+            agentName: agent.name,
+            sessionKey,
+          });
         }
       }
 


### PR DESCRIPTION
Closes #483. Replaces gauge-sampling usage tracking with exact per-turn accounting — and kills the flaky `usage-tracking.spec.ts` (the "usage delta predicate not met within 40000ms, 0 rows" race) at its root.

## Problem
OpenClaw overwrites its per-session token counters every turn. The poller **samples** them on an interval, so turns that complete between polls are silently dropped (the "Input: 7 for a ~400k-token day" class). Watermark deltas on a last-turn gauge are noise.

## Mechanism (verified against live OpenClaw 2026.6.5, not assumed)
Every completed turn writes a `model.completed` trajectory event whose `data.usage` carries that turn's **exact** token classes — `{input, output, total}` for non-caching providers, `{input, output, cacheRead, cacheWrite, total}` for caching ones (read directly; cache → 0 when absent). One event = one turn, uniquely keyed by `runId` (subagent turns included).

- **`usage-from-trajectory.ts`** — pure extractor (model.completed → per-turn rows).
- **`usage-cost.ts`** — the cache-aware cost formula, now shared by the gauge and per-turn paths.
- **`usage-per-turn.ts`** — the recorder: reads a session's trajectory, prices each turn by its **own** model (subagents differ), inserts one row per turn with `onConflictDoNothing(sessionKey, runId)`.
- **migration 0039** — `run_id` + `seq` columns + a unique index on `(session_key, run_id)`. A *plain* index suffices: Postgres `NULLS DISTINCT` lets the gauge poller and the internal usage sink keep inserting with `run_id NULL` while per-turn rows dedup. Idempotent across re-scans, restarts, and both triggers.
- **Two idempotent triggers** — the chat `done` path records a turn the instant it completes (low latency); the poller backstops every chat session each tick.
- **Poller now records only system sessions** (main/cron/hook/channel) via the gauge — they have no per-user trajectory we scan; chat is lossless.

## Why trajectory, not the openclaw-node stream-hook (the issue's first-ranked option)
The pinned `ChatChunk` carries no usage and openclaw-node discards the gateway `lifecycle.end` payload — option 1 needs a speculative upstream change. The trajectory `model.completed` is the **exact same source** #483's acceptance measures against, so the implementation and the test oracle can't drift.

## Tests (TDD)
- Units: extractor, cost, `buildUsageRows`.
- Integration (real Postgres): dedup is a real no-op under PG; a replayed trajectory yields rows whose token sums equal the trajectory's `model.completed` sums **exactly** (the #483 acceptance oracle); idempotent re-scan.
- Poller units adapted to the chat→per-turn / system→gauge split (net +3 cases, no deletions).
- E2E rewritten from the 40s ratio-invariant race to **deterministic exact per-turn** assertions; fake-ollama now reports a flat 42/17 per turn (the `userMessageCount` scaling was a gauge-era concession).
- Docs: chat token counts are now exact per turn.

**Local gates green:** web unit **5938**, `test:db` **115**, typecheck, docs build, lint (0 errors). The E2E's first real run is CI — the Playwright+Docker stack isn't runnable locally.