### PR TITLE
ci: add workflow_dispatch trigger to the CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,6 +19,11 @@ on:
       - "PERSONALITY.md"
       - "sample-data/**"
       - "screenshots/**"
+  # Manual trigger: lets a maintainer re-run the full CI (incl. osv-scan) on a
+  # ref on demand. Needed because docs-only / *.md changes are paths-ignored
+  # above, so a docs-lockfile security bump (osv-scan reads docs/pnpm-lock.yaml)
+  # cannot otherwise produce a fresh green run on main to clear a stale red one.
+  workflow_dispatch:
 
 # Cancel in-progress runs on the same PR/branch when a new commit is pushed.
 # For main, never cancel — release/post-merge runs must always complete.


### PR DESCRIPTION
## Why

CI is `paths-ignore`d for `docs/**` and `**/*.md`. That's correct for most docs edits — but `osv-scan` (in the CI workflow) reads `docs/pnpm-lock.yaml`, so a **docs-only security bump** produces *no* CI run, and there was no `workflow_dispatch` to trigger one manually.

Concretely: the dompurify osv fix (#506) landed on `main` as a docs-only change, so it triggered no CI. `main`'s "latest CI run" stayed the earlier **red** osv-scan run, which blocks the release script's green-CI gate (`gh run list --branch main --workflow CI --limit 1` must be `success`) even though the vulnerability is already fixed.

## What

Adds `workflow_dispatch:` to the CI workflow's `on:` triggers. A maintainer can now re-run the full CI (including osv-scan) on any ref on demand. Merging this PR also touches a non-`paths-ignore`d file, so it produces the fresh green run on `main` that clears the stale dompurify red ahead of the v0.5.8 cut.

No job logic changes — trigger only.

## Test plan

- This PR's own CI run is the validation (full suite + osv-scan green on the dompurify-fixed lockfile).