### PR TITLE
fix(chat): stop tab-refocus tapClientLookup crash on shorter activeRun reconcile

### DIFF
--- a/packages/web/e2e/18-tab-refocus-shrink.spec.ts
+++ b/packages/web/e2e/18-tab-refocus-shrink.spec.ts
@@ -113,7 +113,14 @@ test.describe("tab refocus reconcile", () => {
                       partialContent: "",
                     },
                   };
-            setTimeout(() => this.onmessage?.({ data: JSON.stringify(payload) }), 0);
+            // Record DELIVERY (not just the request) so the test can poll for
+            // the recovery reconcile instead of sleeping a fixed interval.
+            const deliveredNo = globalState.historyRequests;
+            setTimeout(() => {
+              this.onmessage?.({ data: JSON.stringify(payload) });
+              (window as unknown as { __historyDelivered?: number }).__historyDelivered =
+                deliveredNo;
+            }, 0);
             return;
           }
         }
@@ -157,28 +164,39 @@ test.describe("tab refocus reconcile", () => {
     await expect(page.getByText("reply four")).toBeVisible();
 
     // Tab backgrounded, then refocused — drops the WS and re-requests history.
+    // The two visibility events are separate round-trips, so they serialize
+    // (suspend closes the WS before recover reconnects) without a fixed gap.
     await page.evaluate(() => {
       (window as unknown as { __setVisibility: (v: string) => void }).__setVisibility("hidden");
     });
-    await page.waitForTimeout(150);
     await page.evaluate(() => {
       (window as unknown as { __setVisibility: (v: string) => void }).__setVisibility("visible");
     });
 
-    // Give the recovery history + activeRun reconcile time to land (and crash,
-    // pre-fix). A short settle is enough — the reconcile is synchronous.
-    await page.waitForTimeout(1000);
+    // Wait for the recovery history (request #2 — the empty + activeRun frame)
+    // to be DELIVERED, rather than sleeping a fixed interval.
+    await expect
+      .poll(() =>
+        page.evaluate(
+          () => (window as unknown as { __historyDelivered?: number }).__historyDelivered ?? 0
+        )
+      )
+      .toBeGreaterThanOrEqual(2);
+    // The reconcile's setMessages → React commit (where the pre-fix crash throws)
+    // lands one task after delivery; a short, bounded settle covers that commit.
+    await page.waitForTimeout(200);
 
-    // The error boundary must NOT have replaced the chat view.
+    // The error boundary must NOT have replaced the chat view, and no
+    // tapClientLookup error may have been thrown.
     await expect(page.getByText("Something went wrong")).toHaveCount(0);
     expect(
       pageErrors.find((m) => m.includes("tapClientLookup") || m.includes("out of bounds")),
       `page threw: ${pageErrors.join(" | ")}`
     ).toBeUndefined();
 
-    // The locally-known conversation is preserved (not shrunk away), and the
-    // composer is still interactive — a crashed view would have neither.
-    await expect(assistantBubbles.count()).resolves.toBeGreaterThanOrEqual(4);
+    // The locally-known conversation is preserved (pre-fix the list shrinks away
+    // and a trailing-index child throws), and "reply four" is still visible.
+    await expect(assistantBubbles).toHaveCount(4);
     await expect(page.getByText("reply four")).toBeVisible();
   });
 });

--- a/packages/web/e2e/18-tab-refocus-shrink.spec.ts
+++ b/packages/web/e2e/18-tab-refocus-shrink.spec.ts
@@ -1,0 +1,184 @@
+// packages/web/e2e/18-tab-refocus-shrink.spec.ts
+//
+// Real-browser regression guard for the intermittent tab-refocus crash (#510)
+// `tapClientLookup: Index N out of bounds (length: N)` ("Something went wrong").
+//
+// This crash survived BOTH earlier fixes (v0.5.7 in-flight anchor, v0.5.8 own
+// in-flight placeholder). Root cause: assistant-ui renders
+// `thread.messages.length` message components keyed by INDEX, each reading
+// `aui.thread().message({ index }).getState()`. If `messages.length` SHRINKS
+// while <ThreadPrimitive.Messages> is mounted, a trailing-index child re-renders
+// (via its own store subscription) before React unmounts it and reads
+// `tapClientLookup.get({ index })` out of bounds — throwing into the chat error
+// boundary. jsdom renders synchronously and can't show this race; only a real
+// browser can (this spec is authoritative; the proximate invariant is also
+// pinned by use-ws-runtime-refocus-shrink.test.tsx).
+//
+// Trigger: a tab refocus reconnects and re-requests history. Mid-run the server
+// can return a history SHORTER than the rich local list together with an
+// `activeRun` signal (the in-flight reply isn't persisted yet, or OpenClaw
+// history is transiently empty during a restart — see client-router.ts
+// handleHistory, the `{ messages: [], sessionKnown: true, activeRun }` branch).
+// The destructive-reconcile unmount gate (isReconcilingMessages) is skipped when
+// an activeRun is present, so pre-fix the shorter list is applied synchronously
+// and the message list shrinks while mounted → crash.
+//
+// The WebSocket is fully mocked client-side so the exact server frame sequence
+// is deterministic (same technique as 04-chat-reconnect.spec.ts).
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig } from "./helpers";
+
+const HISTORY_MESSAGES = [
+  { role: "user", content: "refocus turn one" },
+  { role: "assistant", content: "reply one" },
+  { role: "user", content: "refocus turn two" },
+  { role: "assistant", content: "reply two" },
+  { role: "user", content: "refocus turn three" },
+  { role: "assistant", content: "reply three" },
+  { role: "user", content: "refocus turn four" },
+  { role: "assistant", content: "reply four" },
+];
+
+test.describe("tab refocus reconcile", () => {
+  test("refocus with a shorter history + activeRun must not crash the chat view", async ({
+    page,
+    request,
+  }) => {
+    const setupResponse = await request.post("/api/setup", {
+      data: { name: "Test Admin", email: "admin@test.local", password: "test-password-123" },
+    });
+    expect([201, 403]).toContain(setupResponse.status());
+
+    await seedProviderConfig();
+
+    await page.addInitScript((historyMessages) => {
+      type ClientMessage = { type?: string };
+      const globalState = { historyRequests: 0 };
+      const RealWebSocket = window.WebSocket;
+
+      // Let the test drive the page-visibility lifecycle deterministically.
+      let visibility = "visible";
+      Object.defineProperty(document, "visibilityState", {
+        configurable: true,
+        get: () => visibility,
+      });
+      (window as unknown as { __setVisibility: (v: string) => void }).__setVisibility = (v) => {
+        visibility = v;
+        document.dispatchEvent(new Event("visibilitychange"));
+      };
+
+      class MockWebSocket {
+        static CONNECTING = 0;
+        static OPEN = 1;
+        static CLOSING = 2;
+        static CLOSED = 3;
+        CONNECTING = 0;
+        OPEN = 1;
+        CLOSING = 2;
+        CLOSED = 3;
+        onopen: (() => void) | null = null;
+        onmessage: ((event: { data: string }) => void) | null = null;
+        onclose: (() => void) | null = null;
+        onerror: (() => void) | null = null;
+        readyState = 1;
+        binaryType = "blob";
+        constructor(url: string) {
+          if (url.includes("/_next/")) {
+            return new RealWebSocket(url) as unknown as MockWebSocket;
+          }
+          queueMicrotask(() => this.onopen?.());
+        }
+        addEventListener() {}
+        removeEventListener() {}
+        send(raw: string) {
+          const message = JSON.parse(raw) as ClientMessage;
+          if (message.type === "history") {
+            globalState.historyRequests += 1;
+            const payload =
+              globalState.historyRequests === 1
+                ? // Initial load: a rich, multi-message conversation. This mounts
+                  // one assistant-ui message component per message (keyed by index).
+                  { type: "history", messages: historyMessages }
+                : // Recovery after refocus: OpenClaw history is transiently empty
+                  // but the run is still active — the exact frame that shrinks the
+                  // list under the activeRun path.
+                  {
+                    type: "history",
+                    messages: [],
+                    sessionKnown: true,
+                    activeRun: {
+                      runId: "run-refocus",
+                      messageId: "srv-refocus",
+                      startedAt: 1000,
+                      partialContent: "",
+                    },
+                  };
+            setTimeout(() => this.onmessage?.({ data: JSON.stringify(payload) }), 0);
+            return;
+          }
+        }
+        close() {
+          this.readyState = 3;
+          this.onclose?.();
+        }
+      }
+
+      Object.defineProperty(window, "WebSocket", {
+        configurable: true,
+        writable: true,
+        value: MockWebSocket,
+      });
+    }, HISTORY_MESSAGES);
+
+    // Surface any uncaught page error in the test output for diagnosis.
+    const pageErrors: string[] = [];
+    page.on("pageerror", (err) => pageErrors.push(err.message));
+
+    // Sign in via the auth API rather than the login form. The form's onSubmit
+    // races React hydration on a cold server's first compile (the click beats
+    // the handler, the browser does a native GET submit, and the page is
+    // stranded on /login?email=…&password=…) — pure test-infra flake unrelated
+    // to this regression. The API path is deterministic; page.request shares the
+    // page's cookie jar (same technique as the switchUser helper), so the
+    // session applies to the subsequent navigation.
+    const signIn = await page.request.post("/api/auth/sign-in/email", {
+      data: { email: "admin@test.local", password: "test-password-123" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(signIn.ok()).toBeTruthy();
+    const agents = (await (await page.request.get("/api/agents")).json()) as { id: string }[];
+    expect(agents.length).toBeGreaterThan(0);
+    await page.goto(`/chat/${agents[0]!.id}`);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+
+    // The full conversation is rendered: 4 assistant bubbles + 4 user bubbles.
+    const assistantBubbles = page.locator('[data-role="assistant"]');
+    await expect(assistantBubbles).toHaveCount(4, { timeout: 15000 });
+    await expect(page.getByText("reply four")).toBeVisible();
+
+    // Tab backgrounded, then refocused — drops the WS and re-requests history.
+    await page.evaluate(() => {
+      (window as unknown as { __setVisibility: (v: string) => void }).__setVisibility("hidden");
+    });
+    await page.waitForTimeout(150);
+    await page.evaluate(() => {
+      (window as unknown as { __setVisibility: (v: string) => void }).__setVisibility("visible");
+    });
+
+    // Give the recovery history + activeRun reconcile time to land (and crash,
+    // pre-fix). A short settle is enough — the reconcile is synchronous.
+    await page.waitForTimeout(1000);
+
+    // The error boundary must NOT have replaced the chat view.
+    await expect(page.getByText("Something went wrong")).toHaveCount(0);
+    expect(
+      pageErrors.find((m) => m.includes("tapClientLookup") || m.includes("out of bounds")),
+      `page threw: ${pageErrors.join(" | ")}`
+    ).toBeUndefined();
+
+    // The locally-known conversation is preserved (not shrunk away), and the
+    // composer is still interactive — a crashed view would have neither.
+    await expect(assistantBubbles.count()).resolves.toBeGreaterThanOrEqual(4);
+    await expect(page.getByText("reply four")).toBeVisible();
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
@@ -1,0 +1,209 @@
+/**
+ * Regression guard for the tab-refocus tapClientLookup crash (#510) that survived
+ * BOTH prior fixes (v0.5.7 anchor, v0.5.8 in-flight placeholder).
+ *
+ * Root cause: assistant-ui renders `thread.messages.length` message components,
+ * KEYED BY INDEX, and each child reads `aui.thread().message({ index }).getState()`
+ * — i.e. `tapClientLookup.get({ index })`, which throws
+ * `tapClientLookup: Index N out of bounds (length: N)` when its index is >= the
+ * current resource-list length. So ANY reduction of `messages.length` while
+ * <ThreadPrimitive.Messages> is mounted can crash: a trailing-index child
+ * re-renders (via its own store subscription) before the parent drops it.
+ *
+ * The destructive history reconcile is supposed to run behind the
+ * `isReconcilingMessages` unmount gate (stageDestructiveHistoryReconcile). But
+ * that staging is SKIPPED whenever an `activeRun` signal is present
+ * (`!activeRun` in the `shouldStageReplace` predicate). On a tab refocus mid-run
+ * the server can legitimately return a history SHORTER than the rich local list
+ * (the in-flight reply isn't persisted yet, or OpenClaw history is transiently
+ * empty during a restart — see client-router.ts handleHistory, the
+ * `messages: [], sessionKnown: true, activeRun` branch). With activeRun present
+ * the staged path is bypassed, so the shorter history is applied SYNCHRONOUSLY
+ * and `messages.length` shrinks while the thread is mounted → tapClientLookup.
+ *
+ * jsdom renders synchronously and so does NOT reproduce the concurrent-mode
+ * tapClientLookup throw itself (the real-browser e2e is authoritative for that —
+ * see use-ws-runtime-resume-crash.test.tsx). These tests pin the proximate,
+ * deterministic invariant instead: a refocus/recovery reconcile must NEVER
+ * reduce the rendered message count outside the unmount gate.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: vi.fn() }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+vi.mock("@assistant-ui/react", () => ({
+  useExternalStoreRuntime: (config: unknown) => config,
+  SimpleImageAttachmentAdapter: class {
+    accept = "image/*";
+  },
+  SimpleTextAttachmentAdapter: class {
+    accept = "text/plain";
+  },
+  CompositeAttachmentAdapter: class {
+    accept = "";
+    constructor() {}
+  },
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+  simulateClose(code = 1006) {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent("close", { code }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+type Converted = { id: string; role: string };
+function messagesOf(runtime: unknown): Converted[] {
+  return ((runtime as { messages?: Converted[] }).messages ?? []) as Converted[];
+}
+function sendText(result: { current: { runtime: unknown } }, text: string) {
+  (
+    result.current.runtime as {
+      onNew: (m: { content: { type: string; text: string }[]; parentId: string }) => void;
+    }
+  ).onNew({ content: [{ type: "text", text }], parentId: "root" });
+}
+
+describe("useWsRuntime — tab-refocus reconcile must not shrink the message list", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("empty recovery history + activeRun must not drop the in-flight conversation (crash precondition)", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    // Established conversation, then a new turn that is mid-stream.
+    act(() =>
+      ws1.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "a" },
+          { role: "assistant", content: "A" },
+        ],
+      })
+    );
+    act(() => sendText(result, "question")); // appends user + in-flight placeholder
+    act(() => ws1.simulateMessage({ type: "chunk", messageId: "srv-1", content: "answer so far" })); // placeholder adopts srv-1
+
+    const before = messagesOf(result.current.runtime).length;
+    expect(before).toBe(4);
+    expect(result.current.isRunning).toBe(true);
+
+    // Tab backgrounded → ws drops → reconnect → recovery history request.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+
+    // OpenClaw history is transiently empty during the run (restart race); the
+    // server still signals the in-flight run. client-router.ts emits exactly
+    // this frame: { messages: [], sessionKnown: true, activeRun }.
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [],
+        sessionKnown: true,
+        activeRun: {
+          runId: "run-1",
+          messageId: "srv-1",
+          startedAt: 1000,
+          partialContent: "answer so far",
+        },
+      })
+    );
+
+    const after = messagesOf(result.current.runtime).length;
+    // The refocus must NOT reduce the rendered count: a shorter list applied
+    // while the thread is mounted (isReconcilingMessages stays false here) is the
+    // tapClientLookup crash precondition. Current code shrinks 4 → 1.
+    expect(result.current.isReconcilingMessages).toBe(false);
+    expect(after).toBeGreaterThanOrEqual(before);
+    expect(result.current.isRunning).toBe(true);
+  });
+
+  it("shorter (non-empty) recovery history + activeRun must not drop locally-known turns", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    act(() =>
+      ws1.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "a" },
+          { role: "assistant", content: "A" },
+        ],
+      })
+    );
+    act(() => sendText(result, "question"));
+    act(() => ws1.simulateMessage({ type: "chunk", messageId: "srv-1", content: "answer so far" }));
+
+    const before = messagesOf(result.current.runtime).length;
+    expect(before).toBe(4);
+
+    // Refocus: server history lags behind local — the latest turn (user
+    // "question" + its in-flight reply) is not persisted yet, so history only
+    // carries the older turn, while activeRun points at the live message.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "a" },
+          { role: "assistant", content: "A" },
+        ],
+        activeRun: {
+          runId: "run-1",
+          messageId: "srv-1",
+          startedAt: 1000,
+          partialContent: "answer so far",
+        },
+      })
+    );
+
+    const after = messagesOf(result.current.runtime).length;
+    expect(after).toBeGreaterThanOrEqual(before);
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
@@ -26,6 +26,11 @@
  * see use-ws-runtime-resume-crash.test.tsx). These tests pin the proximate,
  * deterministic invariant instead: a refocus/recovery reconcile must NEVER
  * reduce the rendered message count outside the unmount gate.
+ *
+ * These tests drive that recovery reconcile via a WS close+reconnect, which hits
+ * the IDENTICAL history-reconcile path as a real tab refocus (visibilitychange →
+ * suspend → recover → history). The literal visibilitychange round-trip is
+ * exercised by the real-browser e2e (18-tab-refocus-shrink.spec.ts).
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
@@ -152,7 +157,7 @@ describe("useWsRuntime — tab-refocus reconcile must not shrink the message lis
     const after = messagesOf(result.current.runtime).length;
     // The refocus must NOT reduce the rendered count: a shorter list applied
     // while the thread is mounted (isReconcilingMessages stays false here) is the
-    // tapClientLookup crash precondition. Current code shrinks 4 → 1.
+    // tapClientLookup crash precondition. Without the fix the list shrinks 4 → 1.
     expect(result.current.isReconcilingMessages).toBe(false);
     expect(after).toBeGreaterThanOrEqual(before);
     expect(result.current.isRunning).toBe(true);

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -1071,7 +1071,33 @@ export function useWsRuntime(agentId: string): {
             if (
               shouldReplaceLocalWithServerHistory(prev, historyMessages, shouldRecoverFromHistory)
             ) {
-              return capMessages(historyMessages);
+              const next = capMessages(historyMessages);
+              // Never let this synchronous (un-gated) replace SHRINK the rendered
+              // list. assistant-ui renders `thread.messages.length` message
+              // components keyed by INDEX; if the array gets shorter while
+              // <ThreadPrimitive.Messages> is mounted, a trailing-index child
+              // re-renders (via its own store subscription) before React drops it
+              // and reads `tapClientLookup.get({ index })` out of bounds — the
+              // intermittent "Index N out of bounds (length: N)" tab-refocus
+              // crash (#510) that survived the placeholder (#470) and anchor fixes.
+              //
+              // Genuine shrinks are supposed to go through
+              // stageDestructiveHistoryReconcile (the isReconcilingMessages
+              // unmount gate), but that staging is SKIPPED whenever an `activeRun`
+              // is in play — and a mid-run refocus can legitimately hand us a
+              // server history SHORTER than the rich local list (the in-flight
+              // reply isn't persisted yet, or OpenClaw history is transiently
+              // empty during a restart — see client-router.ts handleHistory's
+              // `messages: [], sessionKnown: true, activeRun` branch). In every
+              // such case the local list is the more-complete view, so keep it:
+              // isRunning was already preserved by the activeRun block above and
+              // future chunks still merge into the trailing assistant by id. This
+              // also guards the concurrent-render case where `prev` is longer than
+              // the messagesRef snapshot the staging decision used.
+              if (next.length < prev.length) {
+                return prev;
+              }
+              return next;
             }
             return prev;
           });


### PR DESCRIPTION
Closes #510

## Problem

Intermittently, switching back to the Pinchy tab replaces the chat with the error boundary:

> **Something went wrong** — `tapClientLookup: Index 31 out of bounds (length: 31)`

Still reproduces on **v0.5.8** despite the v0.5.7 in-flight **anchor** and v0.5.8 own-**placeholder** (#470) fixes — they only covered the optimistic-injection and `!activeRun` shrink paths.

## Root cause

assistant-ui renders `thread.messages.length` message components **keyed by index**, each reading `tapClientLookup.get({ index })`. **Any shrink of the list while `<ThreadPrimitive.Messages>` is mounted can crash:** a trailing-index child re-renders (via its own store subscription) before React unmounts it and reads out of bounds. Notification order is non-deterministic → intermittent.

Destructive (shrinking) reconciles are meant to run behind the `isReconcilingMessages` **unmount gate** (`stageDestructiveHistoryReconcile`), but that staging is **skipped whenever an `activeRun` signal is present** (`!activeRun` in `shouldStageReplace`). On a mid-run tab refocus the server can return a history **shorter than the rich local list** together with `activeRun` (the in-flight reply isn't persisted yet, or OpenClaw history is transiently empty during a restart — `client-router.ts` `handleHistory`'s `{ messages: [], sessionKnown: true, activeRun }` branch). With `activeRun` the staged path is bypassed, so the shorter list is applied **synchronously** and `messages.length` shrinks while mounted → crash.

## Fix

Enforce the missing invariant at the single un-gated choke point: the synchronous reconcile `setMessages` must **never reduce** the rendered count. When the server history is shorter, keep the richer local list (`isRunning` is already preserved and future chunks still merge by id). Genuine shrinks keep going through the unmount gate. Also covers the concurrent-render case where React's `prev` is longer than the `messagesRef` snapshot the staging decision used.

## Testing

- **`use-ws-runtime-refocus-shrink.test.tsx`** (hook invariant): a refocus/recovery reconcile with `activeRun` must not reduce the rendered count outside the unmount gate. Red → green (list no longer shrinks 4 → 1 / 4 → 2).
- **`e2e/18-tab-refocus-shrink.spec.ts`** (real-browser, authoritative): mocks the WS client-side, renders an 8-message conversation, fires `visibilitychange`, answers recovery `history` with `{ messages: [], sessionKnown: true, activeRun }`. Without the fix the page throws into the error boundary with the exact production string (`tapClientLookup: Index N out of bounds (length: N)`); with the fix it stays intact. Uses an API login so it's robust against the cold-start hydration race.
- Full unit suite green (0 failures); ESLint + Prettier clean.

jsdom renders synchronously and can't reproduce the concurrent-mode `tapClientLookup` throw itself, so the hook test pins the proximate invariant and the e2e is authoritative for the crash.
