### PR TITLE
fix(deps): bump hono >=4.12.25 and docs astro >=6.3.3 (3 OSV advisories)

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -10,7 +10,7 @@
   "dependencies": {
     "@astrojs/starlight": "^0.38.3",
     "@pasqal-io/starlight-client-mermaid": "^0.1.0",
-    "astro": "^6.3.1",
+    "astro": "^6.3.3",
     "astro-loader-github-releases": "^3.0.0",
     "mermaid": "^11.15.0"
   },

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -26,16 +26,16 @@ importers:
     dependencies:
       '@astrojs/starlight':
         specifier: ^0.38.3
-        version: 0.38.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
+        version: 0.38.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
       '@pasqal-io/starlight-client-mermaid':
         specifier: ^0.1.0
-        version: 0.1.0(@astrojs/markdown-remark@7.1.1)(@astrojs/starlight@0.38.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)))
+        version: 0.1.0(@astrojs/markdown-remark@7.2.0)(@astrojs/starlight@0.38.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)))
       astro:
-        specifier: ^6.3.1
-        version: 6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
+        specifier: ^6.3.3
+        version: 6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
       astro-loader-github-releases:
         specifier: ^3.0.0
-        version: 3.0.0(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
+        version: 3.0.0(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
       mermaid:
         specifier: ^11.15.0
         version: 11.15.0
@@ -48,17 +48,17 @@ packages:
   '@astrojs/compiler@4.0.0':
     resolution: {integrity: sha512-eouss7G8ygdZqHuke033VMcVw5HTZUu+PXd/h06DGDUg/jt5btPYPqh66ENWw/mU78rBrf/oeC4oqoBwMtDMNA==}
 
+  '@astrojs/internal-helpers@0.10.0':
+    resolution: {integrity: sha512-Ry2R3VPeIN4uPCSA4xQc+e+vsJXkalKpEbDc07hV+a/o5Bs2N/s/uDcPJH/05L19DKh9tAy7e6JM3YZ6Cxfezw==}
+
   '@astrojs/internal-helpers@0.8.0':
     resolution: {integrity: sha512-J56GrhEiV+4dmrGLPNOl2pZjpHXAndWVyiVDYGDuw6MWKpBSEMLdFxHzeM/6sqaknw9M+HFfHZAcvi3OfT3D/w==}
-
-  '@astrojs/internal-helpers@0.9.0':
-    resolution: {integrity: sha512-GdYkzR26re8izmyYlBqf4z2s7zNngmWLFuxw0UKiPNqHraZGS6GKWIwSHgS22RDlu2ePFJ8bzmpBcUszut/SDg==}
 
   '@astrojs/markdown-remark@7.1.0':
     resolution: {integrity: sha512-P+HnCsu2js3BoTc8kFmu+E9gOcFeMdPris75g+Zl4sY8+bBRbSQV6xzcBDbZ27eE7yBGEGQoqjpChx+KJYIPYQ==}
 
-  '@astrojs/markdown-remark@7.1.1':
-    resolution: {integrity: sha512-C6e9BnLGlbdv6bV8MYGeHpHxsUHrCrB4OuRLqi5LI7oiBVcBcqfUN06zpwFQdHgV48QCCrMmLpyqBr7VqC+swA==}
+  '@astrojs/markdown-remark@7.2.0':
+    resolution: {integrity: sha512-+YxmVQu1Bd+MFfSzjq1rOJvD9+nIOJzz5YIIhdIH01RrxRkKbyKoEgyIqP3yv51MhzMDgd79QaPv+kCVPT8vHw==}
 
   '@astrojs/mdx@5.0.3':
     resolution: {integrity: sha512-zv/OlM5sZZvyjHqJjR3FjJvoCgbxdqj3t4jO/gSEUNcck3BjdtMgNQw8UgPfAGe4yySdG4vjZ3OC5wUxhu7ckg==}
@@ -68,6 +68,10 @@ packages:
 
   '@astrojs/prism@4.0.1':
     resolution: {integrity: sha512-nksZQVjlferuWzhPsBpQ1JE5XuKAf1id1/9Hj4a9KG4+ofrlzxUUwX4YGQF/SuDiuiGKEnzopGOt38F3AnVWsQ==}
+    engines: {node: '>=22.12.0'}
+
+  '@astrojs/prism@4.0.2':
+    resolution: {integrity: sha512-KTivpmnz6lDsC6o9H4+DNm2SrE/GHzw8cNAvEJwAvUT+eoaEnn/4NtbDNfRRaxaJHdp15gf+tfHAWiXR4wB3BA==}
     engines: {node: '>=22.12.0'}
 
   '@astrojs/sitemap@3.7.2':
@@ -996,8 +1000,8 @@ packages:
     peerDependencies:
       astro: '>=4.14.0 <7.0.0'
 
-  astro@6.3.1:
-    resolution: {integrity: sha512-atz6dmkE3Gu24bDgb7g2RE/BYnKqPYIHd6hTUM1UXvu/i7qNZOKLAqEHvgYpv9PQVcgWsXpk4/OOXZ0E/FzvSQ==}
+  astro@6.4.7:
+    resolution: {integrity: sha512-5vsXx0H52u23Jpshs9tM81D03Tb3Oh2Vt2Zo0bpqjXN+njkAWjFyGjTfmWJLAcrCQd9Q+iWB1eqfhR1sZJEaUA==}
     engines: {node: '>=22.12.0', npm: '>=9.6.5', pnpm: '>=7.1.0'}
     hasBin: true
 
@@ -2428,11 +2432,18 @@ snapshots:
 
   '@astrojs/compiler@4.0.0': {}
 
-  '@astrojs/internal-helpers@0.8.0':
+  '@astrojs/internal-helpers@0.10.0':
     dependencies:
+      '@types/hast': 3.0.4
+      '@types/mdast': 4.0.4
+      js-yaml: 4.2.0
       picomatch: 4.0.4
+      retext-smartypants: 6.2.0
+      shiki: 4.0.2
+      smol-toml: 1.6.1
+      unified: 11.0.5
 
-  '@astrojs/internal-helpers@0.9.0':
+  '@astrojs/internal-helpers@0.8.0':
     dependencies:
       picomatch: 4.0.4
 
@@ -2462,14 +2473,13 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/markdown-remark@7.1.1':
+  '@astrojs/markdown-remark@7.2.0':
     dependencies:
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/prism': 4.0.1
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/prism': 4.0.2
       github-slugger: 2.0.0
       hast-util-from-html: 2.0.3
       hast-util-to-text: 4.0.2
-      js-yaml: 4.2.0
       mdast-util-definitions: 6.0.0
       rehype-raw: 7.0.0
       rehype-stringify: 10.0.1
@@ -2477,9 +2487,6 @@ snapshots:
       remark-parse: 11.0.0
       remark-rehype: 11.1.2
       remark-smartypants: 3.0.2
-      retext-smartypants: 6.2.0
-      shiki: 4.0.2
-      smol-toml: 1.6.1
       unified: 11.0.5
       unist-util-remove-position: 5.0.0
       unist-util-visit: 5.1.0
@@ -2488,12 +2495,12 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@astrojs/mdx@5.0.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))':
+  '@astrojs/mdx@5.0.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
       '@mdx-js/mdx': 3.1.1
       acorn: 8.16.0
-      astro: 6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
+      astro: 6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
       es-module-lexer: 2.0.0
       estree-util-visit: 2.0.0
       hast-util-to-html: 9.0.5
@@ -2511,23 +2518,27 @@ snapshots:
     dependencies:
       prismjs: 1.30.0
 
+  '@astrojs/prism@4.0.2':
+    dependencies:
+      prismjs: 1.30.0
+
   '@astrojs/sitemap@3.7.2':
     dependencies:
       sitemap: 9.0.1
       stream-replace-string: 2.0.0
       zod: 4.3.6
 
-  '@astrojs/starlight@0.38.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))':
+  '@astrojs/starlight@0.38.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))':
     dependencies:
       '@astrojs/markdown-remark': 7.1.0
-      '@astrojs/mdx': 5.0.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
+      '@astrojs/mdx': 5.0.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
       '@astrojs/sitemap': 3.7.2
       '@pagefind/default-ui': 1.4.0
       '@types/hast': 3.0.4
       '@types/js-yaml': 4.0.9
       '@types/mdast': 4.0.4
-      astro: 6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
-      astro-expressive-code: 0.41.6(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
+      astro: 6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
+      astro-expressive-code: 0.41.6(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
       bcp-47: 2.1.0
       hast-util-from-html: 2.0.3
       hast-util-select: 6.0.4
@@ -3015,10 +3026,10 @@ snapshots:
   '@pagefind/windows-x64@1.4.0':
     optional: true
 
-  '@pasqal-io/starlight-client-mermaid@0.1.0(@astrojs/markdown-remark@7.1.1)(@astrojs/starlight@0.38.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)))':
+  '@pasqal-io/starlight-client-mermaid@0.1.0(@astrojs/markdown-remark@7.2.0)(@astrojs/starlight@0.38.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)))':
     dependencies:
-      '@astrojs/markdown-remark': 7.1.1
-      '@astrojs/starlight': 0.38.3(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
+      '@astrojs/markdown-remark': 7.2.0
+      '@astrojs/starlight': 0.38.3(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1))
       mermaid: 11.15.0
       unist-util-visit: 5.1.0
 
@@ -3368,21 +3379,21 @@ snapshots:
 
   astring@1.9.0: {}
 
-  astro-expressive-code@0.41.6(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)):
+  astro-expressive-code@0.41.6(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)):
     dependencies:
-      astro: 6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
+      astro: 6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
       rehype-expressive-code: 0.41.6
 
-  astro-loader-github-releases@3.0.0(astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)):
+  astro-loader-github-releases@3.0.0(astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)):
     dependencies:
-      astro: 6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
+      astro: 6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1)
       octokit: 5.0.5
 
-  astro@6.3.1(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1):
+  astro@6.4.7(@types/node@24.12.2)(lightningcss@1.32.0)(rollup@4.60.1):
     dependencies:
       '@astrojs/compiler': 4.0.0
-      '@astrojs/internal-helpers': 0.9.0
-      '@astrojs/markdown-remark': 7.1.1
+      '@astrojs/internal-helpers': 0.10.0
+      '@astrojs/markdown-remark': 7.2.0
       '@astrojs/telemetry': 3.3.2
       '@capsizecss/unpack': 4.0.0
       '@clack/prompts': 1.2.0
@@ -4818,7 +4829,7 @@ snapshots:
     dependencies:
       destr: 2.0.5
       node-fetch-native: 1.6.7
-      ufo: 1.6.3
+      ufo: 1.6.4
 
   ohash@2.0.11: {}
 

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
       "brace-expansion@<1.1.13": "^1.1.13",
       "brace-expansion@>=5.0.0 <5.0.6": ">=5.0.6",
       "flatted@<3.4.2": "^3.4.2",
-      "hono@>=4.0.0 <4.12.21": ">=4.12.21",
+      "hono@>=4.0.0 <4.12.25": ">=4.12.25",
       "typescript-eslint@>=8.0.0 <8.58.2": ">=8.58.2",
       "@typescript-eslint/parser@>=8.0.0 <8.58.2": ">=8.58.2",
       "@typescript-eslint/eslint-plugin@>=8.0.0 <8.58.2": ">=8.58.2",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,7 +17,7 @@ overrides:
   brace-expansion@<1.1.13: ^1.1.13
   brace-expansion@>=5.0.0 <5.0.6: '>=5.0.6'
   flatted@<3.4.2: ^3.4.2
-  hono@>=4.0.0 <4.12.21: '>=4.12.21'
+  hono@>=4.0.0 <4.12.25: '>=4.12.25'
   typescript-eslint@>=8.0.0 <8.58.2: '>=8.58.2'
   '@typescript-eslint/parser@>=8.0.0 <8.58.2': '>=8.58.2'
   '@typescript-eslint/eslint-plugin@>=8.0.0 <8.58.2': '>=8.58.2'
@@ -1111,7 +1111,7 @@ packages:
     resolution: {integrity: sha512-GwtvgtXxnWsucXvbQXkRgqksiH2Qed37H9xHZocE5sA3N8O8O8/8FA3uclQXxXVzc9XBZuEOMK7+r02FmSpHtw==}
     engines: {node: '>=18.14.1'}
     peerDependencies:
-      hono: '>=4.12.21'
+      hono: '>=4.12.25'
 
   '@hookform/resolvers@5.4.0':
     resolution: {integrity: sha512-EIsqr/t/qbinPIhGjMdtvutIN1Kk4uwbROE9/UQ93CAVGR7GkA7Y92+fX80OzXi/OB67jVFYwKGO1WzkxmkFZw==}
@@ -4398,8 +4398,8 @@ packages:
     resolution: {integrity: sha512-Xwwo44whKBVCYoliBQwaPvtd/2tYFkRQtXDWj1nackaV2JPXx3L0+Jvd8/qCJ2p+ML0/XVkJ2q+Mr+UVdpJK5w==}
     engines: {node: '>=12.0.0'}
 
-  hono@4.12.23:
-    resolution: {integrity: sha512-eIaZ9qDgu7XV0pxOCrg7/WhnQ6Ivm22UcxhXx/A3dcbqbbYgBEkc6e/J/s7j2tS96zoB0S9VBdLwQNCWwUo4LA==}
+  hono@4.12.25:
+    resolution: {integrity: sha512-2NFaIyNVgJmBs/ecmtGzlmluTFs5cHEWGTdu0t1HBwYzoGXOL5nUQBRMXsXWla5i4KkG//QMzVP88m1+I3fdAQ==}
     engines: {node: '>=16.9.0'}
 
   hosted-git-info@10.1.1:
@@ -7567,9 +7567,9 @@ snapshots:
     transitivePeerDependencies:
       - supports-color
 
-  '@hono/node-server@1.19.14(hono@4.12.23)':
+  '@hono/node-server@1.19.14(hono@4.12.25)':
     dependencies:
-      hono: 4.12.23
+      hono: 4.12.25
 
   '@hookform/resolvers@5.4.0(react-hook-form@7.76.1(react@19.2.6))':
     dependencies:
@@ -7746,7 +7746,7 @@ snapshots:
 
   '@modelcontextprotocol/sdk@1.29.0(zod@4.4.3)':
     dependencies:
-      '@hono/node-server': 1.19.14(hono@4.12.23)
+      '@hono/node-server': 1.19.14(hono@4.12.25)
       ajv: 8.20.0
       ajv-formats: 3.0.1(ajv@8.20.0)
       content-type: 1.0.5
@@ -7756,7 +7756,7 @@ snapshots:
       eventsource-parser: 3.0.8
       express: 5.2.1
       express-rate-limit: 8.5.0(express@5.2.1)
-      hono: 4.12.23
+      hono: 4.12.25
       jose: 6.2.3
       json-schema-typed: 8.0.2
       pkce-challenge: 5.0.1
@@ -10864,7 +10864,7 @@ snapshots:
 
   highlight.js@11.11.1: {}
 
-  hono@4.12.23: {}
+  hono@4.12.25: {}
 
   hosted-git-info@10.1.1:
     dependencies:


### PR DESCRIPTION
## What

Three OSV advisories went live **2026-06-16** and are failing the `Security audit / osv-scan` CI job on every open PR (and would fail `main` on its next run). They are **not** caused by any code change — the lockfiles were unchanged; the advisory DB updated. Fixed per the established playbook (cf. #505): a separate, focused dependency-bump PR off `main` via `pnpm.overrides` / direct dep bump.

| Advisory | Package | Was | Now | CVSS |
|---|---|---|---|---|
| `GHSA-j6c9-x7qj-28xf` | hono | 4.12.23 | **4.12.25** | 5.3 |
| `GHSA-wwfh-h76j-fc44` | hono | 4.12.23 | **4.12.25** | 5.9 |
| `GHSA-8hv8-536x-4wqp` | astro (docs) | 6.3.1 | **6.4.7** | 7.1 (High) |

## Changes

- **Root `package.json`**: bumped the existing hono override floor `hono@>=4.0.0 <4.12.21` → `hono@>=4.0.0 <4.12.25` (resolves transitive hono to **4.12.25**). hono is a transitive devDep (via openclaw → `@hono/node-server`); not in the production image.
- **`docs/package.json`**: bumped the direct `astro` dependency `^6.3.1` → `^6.3.3` (resolves to **6.4.7**, ≥ the fixed 6.3.3). `docs/` is a standalone project with its own lockfile.
- Refreshed both lockfiles via `pnpm install`.

## Verification

- `osv-scanner v2.3.5` (same as CI) over both lockfiles with `osv-scanner.toml`: **No issues found**, exit 0.
- `docs` build: **exit 0**, 56 pages built — no regression from the astro 6.3→6.4 minor bump.
- Existing `osv-scanner.toml` ignore filters left untouched (`GHSA-v2v4-37r5-5v8g` and the openclaw test-only transitive entries).
- Scope: only the 4 expected files changed; root lockfile diff is hono-only, docs lockfile diff is confined to the astro ecosystem.

Closes the stale-red osv-scan across open PRs once merged to `main` (then rebase #509).