### PR TITLE
feat(odoo): add odoo_schedule_activity tool, fix broken mail.activity creation

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -161,6 +161,143 @@ const MODEL_FIELDS = {
       readonly: true,
     },
   },
+  // External-id registry. Backs xmlid → record-id resolution (e.g. the
+  // canonical "To-Do" activity type `mail.mail_activity_data_todo`).
+  "ir.model.data": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    module: { string: "Module", type: "char", required: true, readonly: false },
+    name: {
+      string: "External Identifier",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    model: { string: "Model", type: "char", required: true, readonly: false },
+    res_id: {
+      string: "Record ID",
+      type: "integer",
+      required: false,
+      readonly: false,
+    },
+  },
+  "res.users": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: { string: "Name", type: "char", required: true, readonly: false },
+    login: { string: "Login", type: "char", required: true, readonly: false },
+  },
+  "crm.lead": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: {
+      string: "Opportunity",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    type: {
+      string: "Type",
+      type: "selection",
+      required: false,
+      readonly: false,
+      selection: [
+        ["lead", "Lead"],
+        ["opportunity", "Opportunity"],
+      ],
+    },
+    user_id: {
+      string: "Salesperson",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.users",
+    },
+    partner_id: {
+      string: "Customer",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.partner",
+    },
+  },
+  "mail.activity.type": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: { string: "Name", type: "char", required: true, readonly: false },
+    category: {
+      string: "Action",
+      type: "selection",
+      required: false,
+      readonly: false,
+      selection: [
+        ["default", "None"],
+        ["upload_file", "Upload Document"],
+        ["phonecall", "Phonecall"],
+      ],
+    },
+  },
+  // Mirrors Odoo's real mail.activity field contract: `res_model_id` is the
+  // required FK to ir.model; `res_model` is a READONLY related char computed
+  // from it; `res_id` is a many2one_reference guarded by a SQL CHECK that it
+  // is non-null and non-zero. Writing `res_model` directly is a no-op — the
+  // exact trap that broke direct mail.activity creation (see create handler).
+  "mail.activity": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    res_model_id: {
+      string: "Document Model",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "ir.model",
+    },
+    res_model: {
+      string: "Related Document Model",
+      type: "char",
+      required: false,
+      readonly: true,
+    },
+    res_id: {
+      string: "Related Document ID",
+      type: "many2one_reference",
+      required: false,
+      readonly: false,
+    },
+    activity_type_id: {
+      string: "Activity Type",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "mail.activity.type",
+    },
+    summary: {
+      string: "Summary",
+      type: "char",
+      required: false,
+      readonly: false,
+    },
+    note: { string: "Note", type: "html", required: false, readonly: false },
+    date_deadline: {
+      string: "Due Date",
+      type: "date",
+      required: true,
+      readonly: false,
+    },
+    user_id: {
+      string: "Assigned to",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.users",
+    },
+    state: {
+      string: "State",
+      type: "selection",
+      required: false,
+      readonly: true,
+      selection: [
+        ["overdue", "Overdue"],
+        ["today", "Today"],
+        ["planned", "Planned"],
+      ],
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -287,7 +424,48 @@ function getDefaultRecords() {
       { id: 2, model: "res.partner", name: "Contact" },
       { id: 3, model: "product.product", name: "Product" },
       { id: 4, model: "res.country", name: "Country" },
+      { id: 5, model: "crm.lead", name: "Lead/Opportunity" },
+      { id: 6, model: "mail.activity", name: "Activity" },
+      { id: 7, model: "mail.activity.type", name: "Activity Type" },
+      { id: 8, model: "res.users", name: "User" },
     ],
+    "res.users": [
+      { id: 2, name: "Mitch Admin", login: "admin" },
+      { id: 7, name: "Sally Seller", login: "sally" },
+    ],
+    "crm.lead": [
+      {
+        id: 1,
+        name: "Big Fence Order — Müller GmbH",
+        type: "opportunity",
+        user_id: [7, "Sally Seller"],
+        partner_id: [1, "Müller GmbH"],
+      },
+      {
+        id: 2,
+        name: "Cold inbound — no owner yet",
+        type: "lead",
+        user_id: false,
+        partner_id: false,
+      },
+    ],
+    "mail.activity.type": [
+      { id: 1, name: "To-Do", category: "default" },
+      { id: 2, name: "Call", category: "phonecall" },
+    ],
+    // The canonical xmlid for the To-Do activity type, mirroring Odoo's
+    // `mail.mail_activity_data_todo`. Lets the plugin resolve the default
+    // activity type locale-independently via ir.model.data.
+    "ir.model.data": [
+      {
+        id: 1,
+        module: "mail",
+        name: "mail_activity_data_todo",
+        model: "mail.activity.type",
+        res_id: 1,
+      },
+    ],
+    "mail.activity": [],
   };
 }
 
@@ -485,7 +663,10 @@ function handleJsonRpc(body) {
     // object/execute_kw
     if (service === "object" && svcMethod === "execute_kw") {
       if (authMode === "fail") {
-        return { __jsonrpc_error: true, message: "access denied: invalid credentials" };
+        return {
+          __jsonrpc_error: true,
+          message: "access denied: invalid credentials",
+        };
       }
       const args = params.args || [];
       // args: [db, uid, apiKey, model, method, positionalArgs, kwArgs]
@@ -591,7 +772,36 @@ function handleJsonRpc(body) {
 
       // create
       if (objMethod === "create") {
-        const values = positionalArgs[0] || {};
+        const values = { ...(positionalArgs[0] || {}) };
+
+        // mail.activity enforces Odoo's real contract:
+        //  - `res_model` is a READONLY related field of `res_model_id`; any
+        //    incoming value is dropped (writing it is a no-op in Odoo).
+        //  - the SQL CHECK `res_id IS NOT NULL AND res_id != 0` rejects an
+        //    activity that is not linked to a concrete record. Without a
+        //    `res_model_id` the related `res_model` stays empty and the
+        //    many2one_reference `res_id` never persists — which is exactly
+        //    how a create that only passes `res_model` + `res_id` fails.
+        if (model === "mail.activity") {
+          delete values.res_model;
+          if (!values.res_model_id || !values.res_id) {
+            return {
+              __jsonrpc_error: true,
+              message:
+                "Activities have to be linked to records with a not null res_id.",
+            };
+          }
+          // Compute the readonly related `res_model` from res_model_id so
+          // reads surface it the way Odoo does.
+          const irModelId = Array.isArray(values.res_model_id)
+            ? values.res_model_id[0]
+            : values.res_model_id;
+          const modelRec = (store["ir.model"] || []).find(
+            (r) => r.id === irModelId,
+          );
+          if (modelRec) values.res_model = modelRec.model;
+        }
+
         const newId = nextIds[model] || 1;
         nextIds[model] = newId + 1;
         const newRecord = { id: newId, ...values };

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -844,6 +844,16 @@ function handleJsonRpc(body) {
         return true;
       }
 
+      // mail.activity.action_feedback — mark an activity done. In real Odoo
+      // this posts a completion message to the chatter and then unlinks the
+      // activity; we model the unlink (the visible end state) and ignore the
+      // optional `feedback` kwarg.
+      if (objMethod === "action_feedback") {
+        const ids = positionalArgs[0] || [];
+        store[model] = store[model].filter((r) => !ids.includes(r.id));
+        return true;
+      }
+
       return false;
     }
   }

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -469,23 +469,27 @@ function getDefaultRecords() {
   };
 }
 
-// In-memory data store
-let store = getDefaultRecords();
-let nextIds = {}; // per-model auto-increment counters
+// In-memory data store. `store` and `nextIds` are keyed by the model name,
+// which arrives from the (test-only) JSON-RPC request. They are Maps — not
+// plain objects — so a request-supplied model name is never used as an object
+// property key, structurally eliminating the remote-property-injection /
+// prototype-pollution sink that a `store[model] = …` write would otherwise be.
+let store = new Map(Object.entries(getDefaultRecords()));
+let nextIds = new Map(); // per-model auto-increment counters
 let accessRights = {}; // { "sale.order": { read: true, create: false, ... } }
 
 function resetNextIds() {
-  nextIds = {};
-  for (const [model, records] of Object.entries(store)) {
+  nextIds = new Map();
+  for (const [model, records] of store) {
     const maxId = records.reduce((m, r) => Math.max(m, r.id || 0), 0);
-    nextIds[model] = maxId + 1;
+    nextIds.set(model, maxId + 1);
   }
 }
 
 function ensureModel(model) {
-  if (!store[model]) {
-    store[model] = [];
-    nextIds[model] = 1;
+  if (!store.has(model)) {
+    store.set(model, []);
+    nextIds.set(model, 1);
   }
 }
 
@@ -676,7 +680,7 @@ function handleJsonRpc(body) {
       const kwArgs = args[6] || {};
 
       ensureModel(model);
-      const allRecords = store[model];
+      const allRecords = store.get(model);
 
       // search_read
       if (objMethod === "search_read") {
@@ -796,16 +800,16 @@ function handleJsonRpc(body) {
           const irModelId = Array.isArray(values.res_model_id)
             ? values.res_model_id[0]
             : values.res_model_id;
-          const modelRec = (store["ir.model"] || []).find(
+          const modelRec = (store.get("ir.model") || []).find(
             (r) => r.id === irModelId,
           );
           if (modelRec) values.res_model = modelRec.model;
         }
 
-        const newId = nextIds[model] || 1;
-        nextIds[model] = newId + 1;
+        const newId = nextIds.get(model) || 1;
+        nextIds.set(model, newId + 1);
         const newRecord = { id: newId, ...values };
-        store[model].push(newRecord);
+        store.get(model).push(newRecord);
         return newId;
       }
 
@@ -813,7 +817,7 @@ function handleJsonRpc(body) {
       if (objMethod === "write") {
         const ids = positionalArgs[0] || [];
         const values = positionalArgs[1] || {};
-        for (const record of store[model]) {
+        for (const record of store.get(model)) {
           if (ids.includes(record.id)) {
             Object.assign(record, values);
           }
@@ -840,7 +844,10 @@ function handleJsonRpc(body) {
       // unlink
       if (objMethod === "unlink") {
         const ids = positionalArgs[0] || [];
-        store[model] = store[model].filter((r) => !ids.includes(r.id));
+        store.set(
+          model,
+          store.get(model).filter((r) => !ids.includes(r.id)),
+        );
         return true;
       }
 
@@ -850,7 +857,10 @@ function handleJsonRpc(body) {
       // optional `feedback` kwarg.
       if (objMethod === "action_feedback") {
         const ids = positionalArgs[0] || [];
-        store[model] = store[model].filter((r) => !ids.includes(r.id));
+        store.set(
+          model,
+          store.get(model).filter((r) => !ids.includes(r.id)),
+        );
         return true;
       }
 
@@ -953,7 +963,7 @@ const controlServer = http.createServer(async (req, res) => {
 
   // Reset to defaults
   if (req.method === "POST" && path === "/control/reset") {
-    store = getDefaultRecords();
+    store = new Map(Object.entries(getDefaultRecords()));
     resetNextIds();
     accessRights = {};
     authMode = "ok";
@@ -978,15 +988,18 @@ const controlServer = http.createServer(async (req, res) => {
     for (const record of body.records) {
       if (record.id) {
         // Remove existing record with same id
-        store[body.model] = store[body.model].filter((r) => r.id !== record.id);
-        store[body.model].push(record);
-        if (record.id >= (nextIds[body.model] || 1)) {
-          nextIds[body.model] = record.id + 1;
+        store.set(
+          body.model,
+          store.get(body.model).filter((r) => r.id !== record.id),
+        );
+        store.get(body.model).push(record);
+        if (record.id >= (nextIds.get(body.model) || 1)) {
+          nextIds.set(body.model, record.id + 1);
         }
       } else {
-        const newId = nextIds[body.model] || 1;
-        nextIds[body.model] = newId + 1;
-        store[body.model].push({ id: newId, ...record });
+        const newId = nextIds.get(body.model) || 1;
+        nextIds.set(body.model, newId + 1);
+        store.get(body.model).push({ id: newId, ...record });
       }
     }
     sendJson(res, 200, {
@@ -1004,7 +1017,7 @@ const controlServer = http.createServer(async (req, res) => {
       sendJson(res, 400, { error: "Need ?model= parameter" });
       return;
     }
-    sendJson(res, 200, store[model] || []);
+    sendJson(res, 200, store.get(model) || []);
     return;
   }
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -152,7 +152,7 @@ Pinchy uses an **allow-list** model for agent permissions: agents have **no tool
 Tools are organized into two categories:
 
 - **Safe tools** — workspace and approved-directory read access (`pinchy_ls`, `pinchy_read`), plus opt-in web search/fetch (`pinchy_web_search`, `pinchy_web_fetch`). All paths are validated against the agent's allow-list at runtime.
-- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_schedule_activity`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
+- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_schedule_activity`, `odoo_complete_activity`, `odoo_reschedule_activity`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
 
 When an agent has safe tools enabled, the `pinchy-files` plugin validates every file access request against the agent's allowed directories, with symlink resolution to prevent escapes.
 

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -152,7 +152,7 @@ Pinchy uses an **allow-list** model for agent permissions: agents have **no tool
 Tools are organized into two categories:
 
 - **Safe tools** — workspace and approved-directory read access (`pinchy_ls`, `pinchy_read`), plus opt-in web search/fetch (`pinchy_web_search`, `pinchy_web_fetch`). All paths are validated against the agent's allow-list at runtime.
-- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
+- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_schedule_activity`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
 
 When an agent has safe tools enabled, the `pinchy-files` plugin validates every file access request against the agent's allowed directories, with symlink resolution to prevent escapes.
 

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -98,20 +98,22 @@ This conversion runs automatically whenever the OpenClaw config is regenerated �
 
 When you connect Odoo and grant an agent access to it, Pinchy automatically enables the appropriate tools based on the access level you choose. You don't need to enable these tools manually — they're managed through the Permissions tab.
 
-| Tool                  | Tool ID                  | What it does                                                                                      | Access level required |
-| --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------- | --------------------- |
-| **List models**       | `odoo_list_models`       | List all available Odoo models on the connection                                                  | Read-only             |
-| **Describe model**    | `odoo_describe_model`    | Discover fields and types for a specific model                                                    | Read-only             |
-| **Read data**         | `odoo_read`              | Query records with filters and field selection                                                    | Read-only             |
-| **Count records**     | `odoo_count`             | Count matching records without transferring data                                                  | Read-only             |
-| **Aggregate data**    | `odoo_aggregate`         | Server-side sums, averages, and grouping                                                          | Read-only             |
-| **Create records**    | `odoo_create`            | Create new records                                                                                | Read & Write          |
-| **Schedule activity** | `odoo_schedule_activity` | Schedule a follow-up activity (planned to-do) on a record so it surfaces in Odoo's activity views | Read & Write          |
-| **Update records**    | `odoo_write`             | Modify existing records                                                                           | Read & Write          |
-| **Attach file**       | `odoo_attach_file`       | Attach an uploaded file to an existing record as `ir.attachment`                                  | Read & Write          |
-| **Delete records**    | `odoo_delete`            | Delete records                                                                                    | Full                  |
+| Tool                    | Tool ID                    | What it does                                                                                      | Access level required |
+| ----------------------- | -------------------------- | ------------------------------------------------------------------------------------------------- | --------------------- |
+| **List models**         | `odoo_list_models`         | List all available Odoo models on the connection                                                  | Read-only             |
+| **Describe model**      | `odoo_describe_model`      | Discover fields and types for a specific model                                                    | Read-only             |
+| **Read data**           | `odoo_read`                | Query records with filters and field selection                                                    | Read-only             |
+| **Count records**       | `odoo_count`               | Count matching records without transferring data                                                  | Read-only             |
+| **Aggregate data**      | `odoo_aggregate`           | Server-side sums, averages, and grouping                                                          | Read-only             |
+| **Create records**      | `odoo_create`              | Create new records                                                                                | Read & Write          |
+| **Schedule activity**   | `odoo_schedule_activity`   | Schedule a follow-up activity (planned to-do) on a record so it surfaces in Odoo's activity views | Read & Write          |
+| **Complete activity**   | `odoo_complete_activity`   | Mark a scheduled activity as done — posts a completion note and clears it from the to-do list     | Read & Write          |
+| **Reschedule activity** | `odoo_reschedule_activity` | Change a scheduled activity's due date and/or assignee without closing it                         | Read & Write          |
+| **Update records**      | `odoo_write`               | Modify existing records                                                                           | Read & Write          |
+| **Attach file**         | `odoo_attach_file`         | Attach an uploaded file to an existing record as `ir.attachment`                                  | Read & Write          |
+| **Delete records**      | `odoo_delete`              | Delete records                                                                                    | Full                  |
 
-For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, schedule-activity, write, and attach-file. "Full" adds delete.
+For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, the three activity tools (schedule / complete / reschedule), write, and attach-file. "Full" adds delete.
 
 :::note[Cross-company write protection]
 For multi-company Odoo databases, the `pinchy-odoo` plugin refuses to write a record whose embedded `_pinchy_ref` company tag disagrees with the company implied by the relation chain (top-level field only). This prevents a class of silent cross-company mistakes — for example, applying a Company A fiscal position to a partner that lives under Company B. See [Connect Odoo → Multi-company databases](/guides/connect-odoo/#multi-company-databases) for the full story.

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -98,19 +98,20 @@ This conversion runs automatically whenever the OpenClaw config is regenerated �
 
 When you connect Odoo and grant an agent access to it, Pinchy automatically enables the appropriate tools based on the access level you choose. You don't need to enable these tools manually — they're managed through the Permissions tab.
 
-| Tool               | Tool ID               | What it does                                                     | Access level required |
-| ------------------ | --------------------- | ---------------------------------------------------------------- | --------------------- |
-| **List models**    | `odoo_list_models`    | List all available Odoo models on the connection                 | Read-only             |
-| **Describe model** | `odoo_describe_model` | Discover fields and types for a specific model                   | Read-only             |
-| **Read data**      | `odoo_read`           | Query records with filters and field selection                   | Read-only             |
-| **Count records**  | `odoo_count`          | Count matching records without transferring data                 | Read-only             |
-| **Aggregate data** | `odoo_aggregate`      | Server-side sums, averages, and grouping                         | Read-only             |
-| **Create records** | `odoo_create`         | Create new records                                               | Read & Write          |
-| **Update records** | `odoo_write`          | Modify existing records                                          | Read & Write          |
-| **Attach file**    | `odoo_attach_file`    | Attach an uploaded file to an existing record as `ir.attachment` | Read & Write          |
-| **Delete records** | `odoo_delete`         | Delete records                                                   | Full                  |
+| Tool                  | Tool ID                  | What it does                                                                                      | Access level required |
+| --------------------- | ------------------------ | ------------------------------------------------------------------------------------------------- | --------------------- |
+| **List models**       | `odoo_list_models`       | List all available Odoo models on the connection                                                  | Read-only             |
+| **Describe model**    | `odoo_describe_model`    | Discover fields and types for a specific model                                                    | Read-only             |
+| **Read data**         | `odoo_read`              | Query records with filters and field selection                                                    | Read-only             |
+| **Count records**     | `odoo_count`             | Count matching records without transferring data                                                  | Read-only             |
+| **Aggregate data**    | `odoo_aggregate`         | Server-side sums, averages, and grouping                                                          | Read-only             |
+| **Create records**    | `odoo_create`            | Create new records                                                                                | Read & Write          |
+| **Schedule activity** | `odoo_schedule_activity` | Schedule a follow-up activity (planned to-do) on a record so it surfaces in Odoo's activity views | Read & Write          |
+| **Update records**    | `odoo_write`             | Modify existing records                                                                           | Read & Write          |
+| **Attach file**       | `odoo_attach_file`       | Attach an uploaded file to an existing record as `ir.attachment`                                  | Read & Write          |
+| **Delete records**    | `odoo_delete`            | Delete records                                                                                    | Full                  |
 
-For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, write, and attach-file. "Full" adds delete.
+For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, schedule-activity, write, and attach-file. "Full" adds delete.
 
 :::note[Cross-company write protection]
 For multi-company Odoo databases, the `pinchy-odoo` plugin refuses to write a record whose embedded `_pinchy_ref` company tag disagrees with the company implied by the relation chain (top-level field only). This prevents a class of silent cross-company mistakes — for example, applying a Company A fiscal position to a partner that lives under Company B. See [Connect Odoo → Multi-company databases](/guides/connect-odoo/#multi-company-databases) for the full story.

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -17,10 +17,10 @@ Pinchy logs event types across several categories:
 
 ### Tool execution
 
-| Event Type        | Description                                                                                                       |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Event Type        | Description                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `tool.<toolName>` | An agent executed a tool — event type is dynamic per tool (e.g. `tool.pinchy_read`, `tool.odoo_read`, `tool.pinchy_web_search`) |
-| `tool.denied`     | An agent attempted to use a tool that was not in its allow-list                                                   |
+| `tool.denied`     | An agent attempted to use a tool that was not in its allow-list                                                                 |
 
 Each tool execution produces **one audit entry** — logged when the tool call completes (end phase only). The detail includes the tool name, parameters, and result. Start events are received but not persisted.
 
@@ -65,7 +65,7 @@ exports too.
 | `auth.login`                    | A user successfully logged in                                                                                                                                                                                                                                                                                                                                                           |
 | `auth.failed`                   | A login attempt failed (wrong password, unknown email)                                                                                                                                                                                                                                                                                                                                  |
 | `auth.logout`                   | A user logged out                                                                                                                                                                                                                                                                                                                                                                       |
-| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#cross-site-request-forgery-csrf-protection).                                                                                                                              |
+| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#cross-site-request-forgery-csrf-protection).                                                                                             |
 | `auth.password_reset_completed` | A user finished a password-reset invite. On success, detail snapshots the target `{id, name}` and the invite id; all of that user's existing sessions are revoked in the same transaction. On failure (rare — e.g. DB error mid-flow), `outcome: failure` is written with the error message and the entire reset rolls back so the old password and the reset token both remain usable. |
 
 ### Agent management

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1086,14 +1086,14 @@ Retrieve a paginated, filterable audit log. **Admin only.**
 
 **Query parameters:**
 
-| Parameter   | Type   | Default | Description                                             |
-| ----------- | ------ | ------- | ------------------------------------------------------- |
-| `page`      | number | 1       | Page number                                             |
-| `limit`     | number | 50      | Entries per page                                        |
+| Parameter   | Type   | Default | Description                                                   |
+| ----------- | ------ | ------- | ------------------------------------------------------------- |
+| `page`      | number | 1       | Page number                                                   |
+| `limit`     | number | 50      | Entries per page                                              |
 | `eventType` | string | —       | Filter by event type (e.g., `auth.login`, `tool.pinchy_read`) |
-| `actorId`   | string | —       | Filter by user ID                                       |
-| `from`      | string | —       | Start date (ISO 8601)                                   |
-| `to`        | string | —       | End date (ISO 8601)                                     |
+| `actorId`   | string | —       | Filter by user ID                                             |
+| `from`      | string | —       | Start date (ISO 8601)                                         |
+| `to`        | string | —       | End date (ISO 8601)                                           |
 
 **Response:**
 

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -20,6 +20,7 @@ import { createRequire } from "module";
 import { createServer, type Server } from "http";
 import { AddressInfo } from "net";
 import plugin from "../index";
+import { encodeRef } from "../integration-ref";
 
 const require = createRequire(import.meta.url);
 
@@ -327,5 +328,140 @@ describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () =
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("404");
+  });
+});
+
+describe("pinchy-odoo mail.activity scheduling against real mock-odoo", () => {
+  const activityAgentId = "agent-activity";
+  const activityConnectionId = "conn-activity";
+  const activityConfig = {
+    connectionId: activityConnectionId,
+    permissions: {
+      "crm.lead": ["read", "create", "write"],
+      "mail.activity": ["read", "create", "write"],
+    },
+    modelNames: { "crm.lead": "Lead/Opportunity", "mail.activity": "Activity" },
+  };
+
+  beforeAll(async () => {
+    // Reset the store (its defaults now seed crm.lead / mail.activity /
+    // ir.model.data) and point this connection at the in-process mock-odoo.
+    await fetch(`http://127.0.0.1:${mockOdoo.controlPort}/control/reset`, {
+      method: "POST",
+    });
+    credentialsByConnectionId.set(activityConnectionId, {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  function leadRef(id: number, label: string): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: activityConnectionId,
+      model: "crm.lead",
+      id,
+      label,
+    });
+  }
+
+  async function activities(): Promise<Array<Record<string, unknown>>> {
+    return (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=mail.activity`,
+    ).then((r) => r.json())) as Array<Record<string, unknown>>;
+  }
+
+  it("GUARD: the mock enforces Odoo's res_id CHECK — an activity with no model link is rejected", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const tool = findTool(tools, "odoo_create", activityAgentId);
+    const result = await tool.execute("c-orphan", {
+      model: "mail.activity",
+      values: { res_id: 1, summary: "orphan", date_deadline: "2026-06-30" },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("not null res_id");
+  });
+
+  it("odoo_schedule_activity resolves res_model_id from the target ref and links the activity to the right record", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", activityAgentId);
+    const result = await tool.execute("c-schedule", {
+      target: leadRef(1, "Big Fence Order — Müller GmbH"),
+      summary: "Call the customer about the quote",
+      dueDate: "2026-06-30",
+    });
+    expect(result.isError).toBeFalsy();
+
+    const created = (await activities()).find(
+      (a) => a.summary === "Call the customer about the quote",
+    );
+    expect(created).toBeTruthy();
+    // res_model_id resolved to the ir.model id for crm.lead (seed id 5)
+    expect(created!.res_model_id).toBe(5);
+    expect(created!.res_model).toBe("crm.lead");
+    expect(created!.res_id).toBe(1);
+    // default To-Do activity type resolved via ir.model.data (seed id 1)
+    expect(created!.activity_type_id).toBe(1);
+    // assignee defaults to the lead's salesperson (seed user 7)
+    expect(created!.user_id).toBe(7);
+    expect(created!.date_deadline).toBe("2026-06-30");
+  });
+
+  it("odoo_schedule_activity accepts an explicit assignee by exact name", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", activityAgentId);
+    const result = await tool.execute("c-assignee", {
+      target: leadRef(1, "Big Fence Order"),
+      summary: "Send revised proposal",
+      dueDate: "2026-07-01",
+      assignee: "Mitch Admin",
+    });
+    expect(result.isError).toBeFalsy();
+
+    const created = (await activities()).find(
+      (a) => a.summary === "Send revised proposal",
+    );
+    expect(created!.user_id).toBe(2);
+  });
+
+  it("odoo_schedule_activity links a lead with no salesperson without forcing a user", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", activityAgentId);
+    const result = await tool.execute("c-noowner", {
+      target: leadRef(2, "Cold inbound — no owner yet"),
+      summary: "Qualify this lead",
+      dueDate: "2026-07-02",
+    });
+    expect(result.isError).toBeFalsy();
+
+    const created = (await activities()).find(
+      (a) => a.summary === "Qualify this lead",
+    );
+    expect(created!.res_id).toBe(2);
+    expect(created!.user_id).toBeUndefined();
+  });
+
+  it("SAFETY-NET: odoo_create on mail.activity with a res_model string (legacy agent path) is translated to res_model_id", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const tool = findTool(tools, "odoo_create", activityAgentId);
+    const result = await tool.execute("c-legacy", {
+      model: "mail.activity",
+      values: {
+        res_model: "crm.lead",
+        res_id: 1,
+        summary: "Legacy path follow-up",
+        date_deadline: "2026-07-03",
+      },
+    });
+    expect(result.isError).toBeFalsy();
+
+    const created = (await activities()).find(
+      (a) => a.summary === "Legacy path follow-up",
+    );
+    expect(created!.res_model_id).toBe(5);
+    expect(created!.res_model).toBe("crm.lead");
+    expect(created!.res_id).toBe(1);
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -464,4 +464,64 @@ describe("pinchy-odoo mail.activity scheduling against real mock-odoo", () => {
     expect(created!.res_model).toBe("crm.lead");
     expect(created!.res_id).toBe(1);
   });
+
+  it("odoo_complete_activity marks a scheduled activity done (removes it)", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const schedule = findTool(tools, "odoo_schedule_activity", activityAgentId);
+    const complete = findTool(tools, "odoo_complete_activity", activityAgentId);
+
+    const scheduled = await schedule.execute("c-sched-complete", {
+      target: leadRef(1, "Big Fence Order"),
+      summary: "Activity to complete",
+      dueDate: "2026-07-10",
+    });
+    const { _pinchy_ref } = JSON.parse(scheduled.content[0].text) as {
+      _pinchy_ref: string;
+    };
+    expect(
+      (await activities()).some((a) => a.summary === "Activity to complete"),
+    ).toBe(true);
+
+    const result = await complete.execute("c-complete", {
+      target: _pinchy_ref,
+      feedback: "Spoke to the customer, quote accepted",
+    });
+    expect(result.isError).toBeFalsy();
+
+    // action_feedback marks done → the activity is gone from the open list.
+    expect(
+      (await activities()).some((a) => a.summary === "Activity to complete"),
+    ).toBe(false);
+  });
+
+  it("odoo_reschedule_activity updates the deadline and reassigns the activity", async () => {
+    const tools = createApi({ [activityAgentId]: activityConfig });
+    const schedule = findTool(tools, "odoo_schedule_activity", activityAgentId);
+    const reschedule = findTool(
+      tools,
+      "odoo_reschedule_activity",
+      activityAgentId,
+    );
+
+    const scheduled = await schedule.execute("c-sched-resched", {
+      target: leadRef(1, "Big Fence Order"),
+      summary: "Activity to reschedule",
+      dueDate: "2026-07-11",
+    });
+    const { id, _pinchy_ref } = JSON.parse(scheduled.content[0].text) as {
+      id: number;
+      _pinchy_ref: string;
+    };
+
+    const result = await reschedule.execute("c-resched", {
+      target: _pinchy_ref,
+      dueDate: "2026-08-01",
+      assignee: "Mitch Admin",
+    });
+    expect(result.isError).toBeFalsy();
+
+    const updated = (await activities()).find((a) => a.id === id);
+    expect(updated!.date_deadline).toBe("2026-08-01");
+    expect(updated!.user_id).toBe(2);
+  });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -10,6 +10,7 @@ const mockCreate = vi.fn();
 const mockWrite = vi.fn();
 const mockUnlink = vi.fn();
 const mockFields = vi.fn();
+const mockCallMethod = vi.fn();
 
 vi.mock("odoo-node", () => {
   const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {
@@ -20,6 +21,7 @@ vi.mock("odoo-node", () => {
     this.write = mockWrite;
     this.unlink = mockUnlink;
     this.fields = mockFields;
+    this.callMethod = mockCallMethod;
   });
   return { OdooClient: MockOdooClient };
 });
@@ -905,9 +907,9 @@ describe("odoo_list_models", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 11 tools (including the deprecated odoo_schema alias)", () => {
+  it("registers all 13 tools (including the deprecated odoo_schema alias)", () => {
     const tools = createApi({ [agentId]: agentConfig });
-    expect(tools).toHaveLength(11);
+    expect(tools).toHaveLength(13);
     const names = tools.map((t) => t.name);
     expect(names).toContain("odoo_list_models");
     expect(names).toContain("odoo_describe_model");
@@ -917,6 +919,8 @@ describe("tool registration", () => {
     expect(names).toContain("odoo_aggregate");
     expect(names).toContain("odoo_create");
     expect(names).toContain("odoo_schedule_activity");
+    expect(names).toContain("odoo_complete_activity");
+    expect(names).toContain("odoo_reschedule_activity");
     expect(names).toContain("odoo_write");
     expect(names).toContain("odoo_delete");
     expect(names).toContain("odoo_attach_file");
@@ -3680,5 +3684,173 @@ describe("odoo_schedule_activity", () => {
       "does not belong to this Odoo connection",
     );
     expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo_complete_activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const cfg = {
+    connectionId: "conn-test-1",
+    permissions: { "mail.activity": ["read", "create", "write"] },
+  };
+  const activityRef = (connectionId = "conn-test-1"): string =>
+    encodeRef({
+      integrationType: "odoo",
+      connectionId,
+      model: "mail.activity",
+      id: 5,
+      label: "Call about the quote",
+    });
+
+  it("is registered as a tool", () => {
+    const tools = createApi({ [agentId]: cfg });
+    expect(tools.map((t) => t.name)).toContain("odoo_complete_activity");
+  });
+
+  it("calls action_feedback on the activity with the feedback note", async () => {
+    mockCallMethod.mockResolvedValue(true);
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_complete_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: activityRef(),
+      feedback: "Spoke to the customer",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCallMethod).toHaveBeenCalledWith(
+      "mail.activity",
+      "action_feedback",
+      [[5]],
+      { feedback: "Spoke to the customer" },
+    );
+  });
+
+  it("omits the feedback kwarg when none is given", async () => {
+    mockCallMethod.mockResolvedValue(true);
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_complete_activity", agentId)!;
+    await tool.execute("c", { target: activityRef() });
+    expect(mockCallMethod).toHaveBeenCalledWith(
+      "mail.activity",
+      "action_feedback",
+      [[5]],
+      {},
+    );
+  });
+
+  it("requires write on mail.activity", async () => {
+    const tools = createApi({
+      [agentId]: {
+        connectionId: "conn-test-1",
+        permissions: { "mail.activity": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_complete_activity", agentId)!;
+    const result = await tool.execute("c", { target: activityRef() });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("rejects a target that is not a mail.activity record", async () => {
+    const leadRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "crm.lead",
+      id: 1,
+      label: "x",
+    });
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_complete_activity", agentId)!;
+    const result = await tool.execute("c", { target: leadRef });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/mail\.activity/);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo_reschedule_activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const cfg = {
+    connectionId: "conn-test-1",
+    permissions: { "mail.activity": ["read", "create", "write"] },
+  };
+  const activityRef = (): string =>
+    encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "mail.activity",
+      id: 5,
+      label: "Call about the quote",
+    });
+
+  it("is registered as a tool", () => {
+    const tools = createApi({ [agentId]: cfg });
+    expect(tools.map((t) => t.name)).toContain("odoo_reschedule_activity");
+  });
+
+  it("writes the new deadline and resolves the new assignee", async () => {
+    mockSearchRead.mockImplementation(async (model: string) =>
+      model === "res.users"
+        ? { records: [{ id: 2 }], total: 1, limit: 2, offset: 0 }
+        : { records: [], total: 0, limit: 0, offset: 0 },
+    );
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_reschedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: activityRef(),
+      dueDate: "2026-08-01",
+      assignee: "Mitch Admin",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("mail.activity", [5], {
+      date_deadline: "2026-08-01",
+      user_id: 2,
+    });
+  });
+
+  it("writes only the deadline when no assignee is given", async () => {
+    mockWrite.mockResolvedValue(true);
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_reschedule_activity", agentId)!;
+    await tool.execute("c", { target: activityRef(), dueDate: "2026-08-01" });
+    expect(mockWrite).toHaveBeenCalledWith("mail.activity", [5], {
+      date_deadline: "2026-08-01",
+    });
+  });
+
+  it("errors when neither dueDate nor assignee is provided", async () => {
+    const tools = createApi({ [agentId]: cfg });
+    const tool = findTool(tools, "odoo_reschedule_activity", agentId)!;
+    const result = await tool.execute("c", { target: activityRef() });
+    expect(result.isError).toBe(true);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("requires write on mail.activity", async () => {
+    const tools = createApi({
+      [agentId]: {
+        connectionId: "conn-test-1",
+        permissions: { "mail.activity": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_reschedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: activityRef(),
+      dueDate: "2026-08-01",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockWrite).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -905,9 +905,9 @@ describe("odoo_list_models", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 10 tools (including the deprecated odoo_schema alias)", () => {
+  it("registers all 11 tools (including the deprecated odoo_schema alias)", () => {
     const tools = createApi({ [agentId]: agentConfig });
-    expect(tools).toHaveLength(10);
+    expect(tools).toHaveLength(11);
     const names = tools.map((t) => t.name);
     expect(names).toContain("odoo_list_models");
     expect(names).toContain("odoo_describe_model");
@@ -916,6 +916,7 @@ describe("tool registration", () => {
     expect(names).toContain("odoo_count");
     expect(names).toContain("odoo_aggregate");
     expect(names).toContain("odoo_create");
+    expect(names).toContain("odoo_schedule_activity");
     expect(names).toContain("odoo_write");
     expect(names).toContain("odoo_delete");
     expect(names).toContain("odoo_attach_file");
@@ -2184,7 +2185,9 @@ describe("client caching (#209 layer 2: credentials fetched lazily, cached)", ()
       json: async () => ({ type: "odoo", credentials: testCredentials }),
     } as unknown as Response);
 
-    mockSearchRead.mockRejectedValueOnce(new Error("HTTP 503 Service Unavailable"));
+    mockSearchRead.mockRejectedValueOnce(
+      new Error("HTTP 503 Service Unavailable"),
+    );
 
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId)!;
@@ -3535,5 +3538,147 @@ describe("cross-company write guard", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/cross-company/i);
     expect(mockWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo_schedule_activity", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const activityConfig = {
+    connectionId: "conn-test-1",
+    permissions: {
+      "crm.lead": ["read", "create", "write"],
+      "mail.activity": ["read", "create", "write"],
+    },
+  };
+
+  function leadRef(connectionId = "conn-test-1"): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId,
+      model: "crm.lead",
+      id: 1,
+      label: "Big Fence Order",
+    });
+  }
+
+  it("is registered as a tool", () => {
+    const tools = createApi({ [agentId]: activityConfig });
+    expect(tools.map((t) => t.name)).toContain("odoo_schedule_activity");
+  });
+
+  it("builds the mail.activity payload with resolved res_model_id, default To-Do type, and the lead's salesperson", async () => {
+    mockSearchRead.mockImplementation(async (model: string) => {
+      if (model === "ir.model")
+        return { records: [{ id: 5 }], total: 1, limit: 1, offset: 0 };
+      if (model === "ir.model.data")
+        return {
+          records: [{ id: 1, res_id: 9 }],
+          total: 1,
+          limit: 1,
+          offset: 0,
+        };
+      if (model === "crm.lead")
+        return {
+          records: [{ id: 1, user_id: [7, "Sally Seller"] }],
+          total: 1,
+          limit: 1,
+          offset: 0,
+        };
+      return { records: [], total: 0, limit: 0, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(42);
+
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: leadRef(),
+      summary: "Call about the quote",
+      dueDate: "2026-06-30",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("mail.activity", {
+      res_model_id: 5,
+      res_id: 1,
+      date_deadline: "2026-06-30",
+      summary: "Call about the quote",
+      activity_type_id: 9,
+      user_id: 7,
+    });
+    const data = JSON.parse(result.content[0].text);
+    expect(data.id).toBe(42);
+    expect(data._pinchy_ref).toMatch(/^pinchy_ref:v1:/);
+  });
+
+  it("falls back to Odoo's default activity type when the To-Do xmlid is absent", async () => {
+    mockSearchRead.mockImplementation(async (model: string) => {
+      if (model === "ir.model")
+        return { records: [{ id: 5 }], total: 1, limit: 1, offset: 0 };
+      // ir.model.data lookup finds nothing → no activity_type_id forced
+      return { records: [], total: 0, limit: 0, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(1);
+
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+    await tool.execute("c", {
+      target: leadRef(),
+      summary: "Follow up",
+      dueDate: "2026-06-30",
+    });
+
+    const [, values] = mockCreate.mock.calls[0];
+    expect(values).not.toHaveProperty("activity_type_id");
+    expect(values).not.toHaveProperty("user_id");
+  });
+
+  it("denies the call when the agent lacks create on mail.activity", async () => {
+    const tools = createApi({
+      [agentId]: {
+        connectionId: "conn-test-1",
+        permissions: { "crm.lead": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: leadRef(),
+      summary: "x",
+      dueDate: "2026-06-30",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a malformed dueDate before touching Odoo", async () => {
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: leadRef(),
+      summary: "x",
+      dueDate: "next friday",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("YYYY-MM-DD");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a target ref from a different connection", async () => {
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+    const result = await tool.execute("c", {
+      target: leadRef("conn-OTHER"),
+      summary: "x",
+      dueDate: "2026-06-30",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "does not belong to this Odoo connection",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -910,6 +910,180 @@ async function normalizeMany2OneValues(
   return normalized;
 }
 
+// The canonical Odoo external id for the built-in "To-Do" activity type.
+// Resolving the type through ir.model.data keeps the default locale-
+// independent — `mail.activity.type.name` is translated ("To-Do" vs
+// "Zu erledigen"), the xmlid is not.
+const TODO_ACTIVITY_XMLID = { module: "mail", name: "mail_activity_data_todo" };
+
+/**
+ * Resolve the ir.model database id for a technical model name
+ * (e.g. "crm.lead" → 5). `mail.activity` links to its document through the
+ * required `res_model_id` FK to ir.model — NOT the readonly related
+ * `res_model` char. Writing `res_model` is silently dropped by Odoo, which
+ * leaves the activity's `res_id` reference dangling and trips the
+ * `res_id IS NOT NULL AND res_id != 0` SQL CHECK. ir.model is world-readable
+ * for internal users, so this lookup needs no extra model grant.
+ */
+async function resolveIrModelId(
+  client: OdooClient,
+  technicalModel: string,
+): Promise<number> {
+  const result = await client.searchRead(
+    "ir.model",
+    [["model", "=", technicalModel]],
+    { fields: ["id"], limit: 1 },
+  );
+  const record = getSearchReadRecords(result)[0];
+  const id = record ? recordId(record) : null;
+  if (id === null) {
+    throw new Error(
+      `Could not resolve the Odoo model "${technicalModel}" — no ir.model row found.`,
+    );
+  }
+  return id;
+}
+
+/**
+ * Resolve the default "To-Do" activity type id via its xmlid. Returns null
+ * (rather than throwing) when ir.model.data is unreadable or the xmlid is
+ * absent, so the caller can fall back to Odoo's own default activity type.
+ */
+async function resolveDefaultActivityTypeId(
+  client: OdooClient,
+): Promise<number | null> {
+  try {
+    const result = await client.searchRead(
+      "ir.model.data",
+      [
+        ["module", "=", TODO_ACTIVITY_XMLID.module],
+        ["name", "=", TODO_ACTIVITY_XMLID.name],
+      ],
+      { fields: ["res_id"], limit: 1 },
+    );
+    const record = getSearchReadRecords(result)[0];
+    return record && typeof record.res_id === "number" ? record.res_id : null;
+  } catch {
+    return null;
+  }
+}
+
+/** Resolve an activity type id from its exact (untranslated) name. */
+async function resolveActivityTypeByName(
+  client: OdooClient,
+  name: string,
+): Promise<number> {
+  const result = await client.searchRead(
+    "mail.activity.type",
+    [["name", "=", name]],
+    { fields: ["id"], limit: 1 },
+  );
+  const record = getSearchReadRecords(result)[0];
+  const id = record ? recordId(record) : null;
+  if (id === null) {
+    throw new Error(
+      `Could not resolve activity type "${name}". Use an exact activity type name (e.g. "To-Do", "Call", "Email").`,
+    );
+  }
+  return id;
+}
+
+/**
+ * Resolve an `assignee` to a res.users id. Accepts an opaque res.users ref
+ * (`pinchy_ref:…`) or an exact user name. Throws a clear error on an
+ * ambiguous name or a ref that does not point at res.users.
+ */
+async function resolveAssigneeUserId(
+  client: OdooClient,
+  connectionId: string,
+  assignee: string,
+): Promise<number> {
+  if (assignee.startsWith("pinchy_ref:")) {
+    const ref = decodeRef(assignee);
+    if (
+      ref.integrationType !== "odoo" ||
+      ref.connectionId !== connectionId ||
+      ref.model !== "res.users"
+    ) {
+      throw new Error("`assignee` ref must point to a res.users record.");
+    }
+    return ref.id;
+  }
+  const result = await client.searchRead(
+    "res.users",
+    [["name", "=", assignee]],
+    {
+      fields: ["id"],
+      limit: 2,
+    },
+  );
+  const ids = uniqueIds(getSearchReadRecords(result));
+  if (ids.length === 1) return ids[0];
+  if (ids.length === 0) {
+    throw new Error(
+      `Could not resolve assignee "${assignee}" — no matching user.`,
+    );
+  }
+  throw new Error(
+    `Could not resolve assignee "${assignee}" — multiple users match; pass an opaque res.users ref instead.`,
+  );
+}
+
+/**
+ * Best-effort lookup of a target record's salesperson (`user_id`) so a
+ * scheduled activity lands in the right person's "My Activities" list.
+ * Returns null when the model has no `user_id` field or none is set —
+ * Odoo then assigns the activity to its creator.
+ */
+async function resolveTargetSalespersonId(
+  client: OdooClient,
+  targetModel: string,
+  targetId: number,
+): Promise<number | null> {
+  try {
+    const result = await client.searchRead(
+      targetModel,
+      [["id", "=", targetId]],
+      { fields: ["user_id"], limit: 1 },
+    );
+    const record = getSearchReadRecords(result)[0];
+    const userId = record?.user_id;
+    return Array.isArray(userId) && typeof userId[0] === "number"
+      ? userId[0]
+      : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Legacy-path safety net for direct `mail.activity` creation. Agent
+ * instructions written before `odoo_schedule_activity` existed tell the model
+ * to write `res_model` (a string) — but `res_model` is a readonly related
+ * field of the required `res_model_id` FK, so Odoo drops the write and the
+ * create fails the `res_id` CHECK. When we see that shape, resolve
+ * `res_model_id` from the technical name and drop the inert `res_model`.
+ * Production agents carry a frozen AGENTS.md, so this keeps them working
+ * without a manual re-align. Runs AFTER many2one normalization, so the
+ * injected integer id reaches Odoo verbatim (the "raw numeric IDs" guard
+ * only inspects agent-supplied values, never this resolved one).
+ */
+async function ensureActivityResModelId(
+  client: OdooClient,
+  model: string,
+  values: Record<string, unknown>,
+): Promise<Record<string, unknown>> {
+  if (model !== "mail.activity") return values;
+  if (values.res_model_id != null) return values;
+  if (typeof values.res_model !== "string" || values.res_model.length === 0) {
+    return values;
+  }
+  const irModelId = await resolveIrModelId(client, values.res_model);
+  const next: Record<string, unknown> = { ...values, res_model_id: irModelId };
+  delete next.res_model;
+  return next;
+}
+
 /**
  * Pull a human-readable company name out of a raw Odoo `company_id` value.
  * Odoo returns m2o values as `[id, "display_name"]` tuples (before we wrap
@@ -1182,8 +1356,14 @@ const plugin = {
         try {
           return await fn(fresh);
         } catch (retryErr) {
-          const retryMsg = retryErr instanceof Error ? retryErr.message : String(retryErr);
-          await reportAuthFailure(apiBaseUrl, config.connectionId, gatewayToken, retryMsg);
+          const retryMsg =
+            retryErr instanceof Error ? retryErr.message : String(retryErr);
+          await reportAuthFailure(
+            apiBaseUrl,
+            config.connectionId,
+            gatewayToken,
+            retryMsg,
+          );
           throw retryErr;
         }
       }
@@ -1686,6 +1866,11 @@ const plugin = {
                       model,
                       cleaned,
                     );
+                    values = await ensureActivityResModelId(
+                      client,
+                      model,
+                      values,
+                    );
                   } else {
                     values = params.values as Record<string, unknown>;
                   }
@@ -1731,6 +1916,191 @@ const plugin = {
         };
       },
       { name: "odoo_create" },
+    );
+
+    // 5b. odoo_schedule_activity
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_schedule_activity",
+          label: "Odoo Schedule Activity",
+          description:
+            'Schedule a follow-up activity (a planned to-do with a due date) on an existing Odoo record such as a CRM lead, so it surfaces in Odoo\'s activity views and shows the team which record needs attention. Pass the `_pinchy_ref` of the target record (from odoo_read or odoo_create), a short `summary`, and a `dueDate` (YYYY-MM-DD). Optionally set `note`, an `assignee` (exact user name or an opaque res.users ref; defaults to the record\'s salesperson), and an `activityType` (exact name such as "Call"; defaults to "To-Do"). This is the correct way to create activities — do NOT create `mail.activity` records directly with odoo_create.',
+          parameters: {
+            type: "object",
+            properties: {
+              target: {
+                type: "string",
+                description:
+                  'Opaque `_pinchy_ref` of the record to attach the activity to (from odoo_read or odoo_create). Do NOT pass raw numeric IDs or "model,id" strings.',
+              },
+              summary: {
+                type: "string",
+                description:
+                  'Short title of the follow-up, e.g. "Call about the quote".',
+              },
+              dueDate: {
+                type: "string",
+                description: "Deadline in YYYY-MM-DD format.",
+              },
+              note: {
+                type: "string",
+                description:
+                  "Optional longer description / context for the activity.",
+              },
+              assignee: {
+                type: "string",
+                description:
+                  "Optional. Exact user name or an opaque res.users ref. Defaults to the target record's salesperson, or the API user if none is set.",
+              },
+              activityType: {
+                type: "string",
+                description:
+                  'Optional exact activity type name (e.g. "To-Do", "Call", "Email"). Defaults to "To-Do".',
+              },
+            },
+            required: ["target", "summary", "dueDate"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const target = params.target;
+              if (typeof target !== "string" || target.length === 0) {
+                return errorResult(
+                  new Error(
+                    "`target` is required: pass the _pinchy_ref of the record to attach the activity to.",
+                  ),
+                );
+              }
+              const summary = params.summary;
+              if (typeof summary !== "string" || summary.trim().length === 0) {
+                return errorResult(new Error("`summary` is required."));
+              }
+              const dueDate = params.dueDate;
+              if (
+                typeof dueDate !== "string" ||
+                !/^\d{4}-\d{2}-\d{2}$/.test(dueDate)
+              ) {
+                return errorResult(
+                  new Error("`dueDate` is required in YYYY-MM-DD format."),
+                );
+              }
+
+              const decoded = decodeRef(target);
+              if (
+                decoded.integrationType !== "odoo" ||
+                decoded.connectionId !== config.connectionId
+              ) {
+                return errorResult(
+                  new Error(
+                    "`target` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              const targetModel = decoded.model;
+              const targetId = decoded.id;
+
+              if (
+                !checkPermission(config.permissions, "mail.activity", "create")
+              ) {
+                return permissionDenied("create", "mail.activity");
+              }
+              if (!checkPermission(config.permissions, targetModel, "read")) {
+                return permissionDenied("read", targetModel);
+              }
+
+              const id = await withAuthRetry(
+                agentId,
+                config,
+                async (client) => {
+                  const resModelId = await resolveIrModelId(
+                    client,
+                    targetModel,
+                  );
+
+                  const activityTypeRequested =
+                    typeof params.activityType === "string"
+                      ? params.activityType.trim()
+                      : "";
+                  const activityTypeId =
+                    activityTypeRequested.length > 0
+                      ? await resolveActivityTypeByName(
+                          client,
+                          activityTypeRequested,
+                        )
+                      : await resolveDefaultActivityTypeId(client);
+
+                  const assigneeRequested =
+                    typeof params.assignee === "string"
+                      ? params.assignee.trim()
+                      : "";
+                  const userId =
+                    assigneeRequested.length > 0
+                      ? await resolveAssigneeUserId(
+                          client,
+                          config.connectionId,
+                          assigneeRequested,
+                        )
+                      : await resolveTargetSalespersonId(
+                          client,
+                          targetModel,
+                          targetId,
+                        );
+
+                  const values: Record<string, unknown> = {
+                    res_model_id: resModelId,
+                    res_id: targetId,
+                    date_deadline: dueDate,
+                    summary: summary.trim(),
+                  };
+                  if (
+                    typeof params.note === "string" &&
+                    params.note.length > 0
+                  ) {
+                    values.note = params.note;
+                  }
+                  if (activityTypeId != null) {
+                    values.activity_type_id = activityTypeId;
+                  }
+                  if (userId != null) {
+                    values.user_id = userId;
+                  }
+
+                  return client.create("mail.activity", values);
+                },
+              );
+
+              const ref = encodeRef({
+                integrationType: "odoo",
+                connectionId: config.connectionId,
+                model: "mail.activity",
+                id: id as number,
+                label: summary.trim(),
+              });
+
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ id, _pinchy_ref: ref }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, {
+                operation: "create",
+                model: "mail.activity",
+              });
+            }
+          },
+        };
+      },
+      { name: "odoo_schedule_activity" },
     );
 
     // 6. odoo_write
@@ -1783,6 +2153,11 @@ const plugin = {
                       config.connectionId,
                       model,
                       cleaned,
+                    );
+                    values = await ensureActivityResModelId(
+                      client,
+                      model,
+                      values,
                     );
                   } else {
                     values = params.values as Record<string, unknown>;

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2103,6 +2103,234 @@ const plugin = {
       { name: "odoo_schedule_activity" },
     );
 
+    // 5c. odoo_complete_activity
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_complete_activity",
+          label: "Odoo Complete Activity",
+          description:
+            "Mark a scheduled activity as done — posts a completion note to the record's chatter and clears the activity from the to-do list so it no longer shows as pending or overdue. Pass the activity's `_pinchy_ref` (from `odoo_read` on `mail.activity`, or the response of `odoo_schedule_activity`) and an optional `feedback` note. Use this to close out follow-ups you have handled.",
+          parameters: {
+            type: "object",
+            properties: {
+              target: {
+                type: "string",
+                description:
+                  "Opaque `_pinchy_ref` of the mail.activity to complete (from `odoo_read` on `mail.activity` or the response of `odoo_schedule_activity`).",
+              },
+              feedback: {
+                type: "string",
+                description:
+                  'Optional note recorded in the completion message, e.g. "Called, customer confirmed".',
+              },
+            },
+            required: ["target"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const target = params.target;
+              if (typeof target !== "string" || target.length === 0) {
+                return errorResult(
+                  new Error(
+                    "`target` is required: pass the _pinchy_ref of the activity to complete.",
+                  ),
+                );
+              }
+              const decoded = decodeRef(target);
+              if (
+                decoded.integrationType !== "odoo" ||
+                decoded.connectionId !== config.connectionId
+              ) {
+                return errorResult(
+                  new Error(
+                    "`target` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              if (decoded.model !== "mail.activity") {
+                return errorResult(
+                  new Error(
+                    "`target` must be a mail.activity ref — read the activity with `odoo_read` on `mail.activity` first.",
+                  ),
+                );
+              }
+              if (
+                !checkPermission(config.permissions, "mail.activity", "write")
+              ) {
+                return permissionDenied("write", "mail.activity");
+              }
+
+              const kwargs: Record<string, unknown> = {};
+              if (
+                typeof params.feedback === "string" &&
+                params.feedback.trim().length > 0
+              ) {
+                kwargs.feedback = params.feedback.trim();
+              }
+
+              await withAuthRetry(agentId, config, (client) =>
+                client.callMethod(
+                  "mail.activity",
+                  "action_feedback",
+                  [[decoded.id]],
+                  kwargs,
+                ),
+              );
+
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ completed: true, id: decoded.id }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, {
+                operation: "write",
+                model: "mail.activity",
+              });
+            }
+          },
+        };
+      },
+      { name: "odoo_complete_activity" },
+    );
+
+    // 5d. odoo_reschedule_activity
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_reschedule_activity",
+          label: "Odoo Reschedule Activity",
+          description:
+            "Change a scheduled activity's due date and/or assignee without closing it. Pass the activity's `_pinchy_ref` and at least one of `dueDate` (YYYY-MM-DD) or `assignee` (exact user name or an opaque res.users ref). Use this to push a follow-up to a new date or hand it to someone else.",
+          parameters: {
+            type: "object",
+            properties: {
+              target: {
+                type: "string",
+                description:
+                  "Opaque `_pinchy_ref` of the mail.activity to reschedule (from `odoo_read` on `mail.activity`).",
+              },
+              dueDate: {
+                type: "string",
+                description: "New deadline in YYYY-MM-DD format.",
+              },
+              assignee: {
+                type: "string",
+                description:
+                  "New assignee: exact user name or an opaque res.users ref.",
+              },
+            },
+            required: ["target"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const target = params.target;
+              if (typeof target !== "string" || target.length === 0) {
+                return errorResult(
+                  new Error(
+                    "`target` is required: pass the _pinchy_ref of the activity to reschedule.",
+                  ),
+                );
+              }
+              const dueDateRaw =
+                typeof params.dueDate === "string" ? params.dueDate.trim() : "";
+              const assigneeRaw =
+                typeof params.assignee === "string"
+                  ? params.assignee.trim()
+                  : "";
+              if (dueDateRaw.length === 0 && assigneeRaw.length === 0) {
+                return errorResult(
+                  new Error(
+                    "Provide at least one of `dueDate` (YYYY-MM-DD) or `assignee` to reschedule.",
+                  ),
+                );
+              }
+              if (
+                dueDateRaw.length > 0 &&
+                !/^\d{4}-\d{2}-\d{2}$/.test(dueDateRaw)
+              ) {
+                return errorResult(
+                  new Error("`dueDate` must be in YYYY-MM-DD format."),
+                );
+              }
+
+              const decoded = decodeRef(target);
+              if (
+                decoded.integrationType !== "odoo" ||
+                decoded.connectionId !== config.connectionId
+              ) {
+                return errorResult(
+                  new Error(
+                    "`target` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              if (decoded.model !== "mail.activity") {
+                return errorResult(
+                  new Error(
+                    "`target` must be a mail.activity ref — read the activity with `odoo_read` on `mail.activity` first.",
+                  ),
+                );
+              }
+              if (
+                !checkPermission(config.permissions, "mail.activity", "write")
+              ) {
+                return permissionDenied("write", "mail.activity");
+              }
+
+              const success = await withAuthRetry(
+                agentId,
+                config,
+                async (client) => {
+                  const values: Record<string, unknown> = {};
+                  if (dueDateRaw.length > 0) values.date_deadline = dueDateRaw;
+                  if (assigneeRaw.length > 0) {
+                    values.user_id = await resolveAssigneeUserId(
+                      client,
+                      config.connectionId,
+                      assigneeRaw,
+                    );
+                  }
+                  return client.write("mail.activity", [decoded.id], values);
+                },
+              );
+
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ success, id: decoded.id }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, {
+                operation: "write",
+                model: "mail.activity",
+              });
+            }
+          },
+        };
+      },
+      { name: "odoo_reschedule_activity" },
+    );
+
     // 6. odoo_write
     api.registerTool(
       (ctx: PluginToolContext) => {

--- a/packages/plugins/pinchy-odoo/openclaw.plugin.json
+++ b/packages/plugins/pinchy-odoo/openclaw.plugin.json
@@ -12,6 +12,8 @@
       "odoo_aggregate",
       "odoo_create",
       "odoo_schedule_activity",
+      "odoo_complete_activity",
+      "odoo_reschedule_activity",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file"

--- a/packages/plugins/pinchy-odoo/openclaw.plugin.json
+++ b/packages/plugins/pinchy-odoo/openclaw.plugin.json
@@ -11,6 +11,7 @@
       "odoo_count",
       "odoo_aggregate",
       "odoo_create",
+      "odoo_schedule_activity",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file"

--- a/packages/plugins/pinchy-odoo/package.json
+++ b/packages/plugins/pinchy-odoo/package.json
@@ -8,7 +8,7 @@
     "test:watch": "vitest"
   },
   "dependencies": {
-    "odoo-node": "^0.2.0"
+    "odoo-node": "^0.3.0"
   },
   "devDependencies": {
     "typescript": "^6.0.3",

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -53,7 +53,7 @@
     "mammoth": "^1.12.0",
     "next": "16.2.6",
     "next-themes": "^0.4.6",
-    "odoo-node": "0.2.0",
+    "odoo-node": "0.3.0",
     "openclaw-node": "0.12.1",
     "pdfkit": "^0.18.0",
     "postgres": "^3.4.9",

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -37,12 +37,14 @@ describe("TOOL_REGISTRY", () => {
 
   it("contains powerful tools", () => {
     const powerful = TOOL_REGISTRY.filter((t) => t.category === "powerful");
-    expect(powerful.length).toBe(10);
+    expect(powerful.length).toBe(12);
     expect(powerful.map((t) => t.id)).toEqual([
       "pinchy_web_search",
       "pinchy_web_fetch",
       "odoo_create",
       "odoo_schedule_activity",
+      "odoo_complete_activity",
+      "odoo_reschedule_activity",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file",
@@ -161,8 +163,8 @@ describe("computeDeniedGroups", () => {
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));
-    // 10 active tools + 1 deprecated alias (odoo_schema) = 11.
-    expect(odooTools.length).toBe(11);
+    // 12 active tools + 1 deprecated alias (odoo_schema) = 13.
+    expect(odooTools.length).toBe(13);
     for (const tool of odooTools) {
       expect(tool.integration).toBe("odoo");
     }
@@ -224,7 +226,7 @@ describe("Odoo access level helpers", () => {
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('read-write') returns 9 tools", () => {
+  it("getOdooToolsForAccessLevel('read-write') returns 11 tools", () => {
     const tools = getOdooToolsForAccessLevel("read-write");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -234,12 +236,14 @@ describe("Odoo access level helpers", () => {
       "odoo_aggregate",
       "odoo_create",
       "odoo_schedule_activity",
+      "odoo_complete_activity",
+      "odoo_reschedule_activity",
       "odoo_write",
       "odoo_attach_file",
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('full') returns all 10 tools", () => {
+  it("getOdooToolsForAccessLevel('full') returns all 12 tools", () => {
     const tools = getOdooToolsForAccessLevel("full");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -249,6 +253,8 @@ describe("Odoo access level helpers", () => {
       "odoo_aggregate",
       "odoo_create",
       "odoo_schedule_activity",
+      "odoo_complete_activity",
+      "odoo_reschedule_activity",
       "odoo_write",
       "odoo_attach_file",
       "odoo_delete",
@@ -260,9 +266,9 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_list_models", "odoo_describe_model"]);
   });
 
-  it("getOdooTools() returns exactly 11 tools (10 active + 1 deprecated alias)", () => {
+  it("getOdooTools() returns exactly 13 tools (12 active + 1 deprecated alias)", () => {
     const tools = getOdooTools();
-    expect(tools).toHaveLength(11);
+    expect(tools).toHaveLength(13);
     expect(tools.every((t) => t.integration === "odoo")).toBe(true);
   });
 

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -37,11 +37,12 @@ describe("TOOL_REGISTRY", () => {
 
   it("contains powerful tools", () => {
     const powerful = TOOL_REGISTRY.filter((t) => t.category === "powerful");
-    expect(powerful.length).toBe(9);
+    expect(powerful.length).toBe(10);
     expect(powerful.map((t) => t.id)).toEqual([
       "pinchy_web_search",
       "pinchy_web_fetch",
       "odoo_create",
+      "odoo_schedule_activity",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file",
@@ -160,8 +161,8 @@ describe("computeDeniedGroups", () => {
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));
-    // 9 active tools + 1 deprecated alias (odoo_schema) = 10.
-    expect(odooTools.length).toBe(10);
+    // 10 active tools + 1 deprecated alias (odoo_schema) = 11.
+    expect(odooTools.length).toBe(11);
     for (const tool of odooTools) {
       expect(tool.integration).toBe("odoo");
     }
@@ -223,7 +224,7 @@ describe("Odoo access level helpers", () => {
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('read-write') returns 8 tools", () => {
+  it("getOdooToolsForAccessLevel('read-write') returns 9 tools", () => {
     const tools = getOdooToolsForAccessLevel("read-write");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -232,12 +233,13 @@ describe("Odoo access level helpers", () => {
       "odoo_count",
       "odoo_aggregate",
       "odoo_create",
+      "odoo_schedule_activity",
       "odoo_write",
       "odoo_attach_file",
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('full') returns all 9 tools", () => {
+  it("getOdooToolsForAccessLevel('full') returns all 10 tools", () => {
     const tools = getOdooToolsForAccessLevel("full");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -246,6 +248,7 @@ describe("Odoo access level helpers", () => {
       "odoo_count",
       "odoo_aggregate",
       "odoo_create",
+      "odoo_schedule_activity",
       "odoo_write",
       "odoo_attach_file",
       "odoo_delete",
@@ -257,9 +260,9 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_list_models", "odoo_describe_model"]);
   });
 
-  it("getOdooTools() returns exactly 10 tools (9 active + 1 deprecated alias)", () => {
+  it("getOdooTools() returns exactly 11 tools (10 active + 1 deprecated alias)", () => {
     const tools = getOdooTools();
-    expect(tools).toHaveLength(10);
+    expect(tools).toHaveLength(11);
     expect(tools.every((t) => t.integration === "odoo")).toBe(true);
   });
 
@@ -276,6 +279,41 @@ describe("Odoo access level helpers", () => {
   });
 
   it("detectOdooAccessLevel correctly identifies read-write preset", () => {
+    expect(
+      detectOdooAccessLevel([
+        "odoo_list_models",
+        "odoo_describe_model",
+        "odoo_read",
+        "odoo_count",
+        "odoo_aggregate",
+        "odoo_create",
+        "odoo_write",
+        "odoo_attach_file",
+      ])
+    ).toBe("read-write");
+  });
+
+  it("detectOdooAccessLevel keeps a read-write agent classified after odoo_schedule_activity is added", () => {
+    // New agents created from the updated preset carry odoo_schedule_activity;
+    // it is additive and must still read as "read-write", not "custom".
+    expect(
+      detectOdooAccessLevel([
+        "odoo_list_models",
+        "odoo_describe_model",
+        "odoo_read",
+        "odoo_count",
+        "odoo_aggregate",
+        "odoo_create",
+        "odoo_schedule_activity",
+        "odoo_write",
+        "odoo_attach_file",
+      ])
+    ).toBe("read-write");
+  });
+
+  it("detectOdooAccessLevel keeps a pre-existing read-write agent (without odoo_schedule_activity) classified", () => {
+    // Production agents predate the tool and never received it. Their absence
+    // of odoo_schedule_activity must NOT flip them to "custom".
     expect(
       detectOdooAccessLevel([
         "odoo_list_models",

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -459,8 +459,13 @@ Use \`odoo_aggregate\` on \`crm.lead\` with \`filters: [["type", "=", "opportuni
 ### Overdue follow-ups
 Use \`odoo_read\` on \`mail.activity\` with \`filters: [["state", "=", "overdue"]]\`.
 
-### Schedule a follow-up on a lead
-Read the lead with \`odoo_read\` to get its \`_pinchy_ref\`, then call \`odoo_schedule_activity\` with that \`target\`, a \`summary\` (e.g. "Call about the quote"), and a \`dueDate\` (\`YYYY-MM-DD\`). It defaults to a "To-Do" assigned to the lead's salesperson. This is how you record that a lead needs attention — do not write \`mail.activity\` directly.
+### Manage follow-ups on a lead
+This is the loop that keeps the pipeline honest — schedule, close, or push follow-ups so the team always sees which lead needs attention.
+- **Schedule**: read the lead with \`odoo_read\` to get its \`_pinchy_ref\`, then \`odoo_schedule_activity\` with that \`target\`, a \`summary\` (e.g. "Call about the quote"), and a \`dueDate\` (\`YYYY-MM-DD\`). Defaults to a "To-Do" assigned to the lead's salesperson.
+- **Complete**: once handled, \`odoo_read\` the activity on \`mail.activity\` to get its \`_pinchy_ref\`, then \`odoo_complete_activity\` with that \`target\` and an optional \`feedback\` note — this marks it done and clears it from the to-do list.
+- **Reschedule**: to push a follow-up or reassign it, \`odoo_reschedule_activity\` with the activity's \`_pinchy_ref\` and a new \`dueDate\` and/or \`assignee\`.
+
+Never write \`mail.activity\` directly with \`odoo_create\`/\`odoo_write\` — use these three tools.
 
 ### Win rate per salesperson
 Use \`odoo_aggregate\` on \`crm.lead\` with \`groupby: ["user_id"]\` and count won vs total.

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -148,7 +148,7 @@ You run the operational stock floor — recording goods receipts, confirming pic
 - **product.product** — Products (read-only). Key fields: \`name\`, \`default_code\` (SKU), \`barcode\`, \`tracking\` ("none", "lot", "serial")
 - **product.category** — Categories (read-only). Key fields: \`name\`, \`complete_name\`
 - **res.partner** — Partners on pickings (read-only). Key fields: \`name\`, \`is_company\`, \`supplier_rank\`, \`customer_rank\`
-- **mail.activity** — Follow-ups on stock issues. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`
+- **mail.activity** — Follow-ups on stock issues. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 
 **Important**: Always call \`odoo_describe_model\` first. Field names trip people up here (e.g. \`product_uom_qty\` not \`quantity\`).
 
@@ -438,7 +438,7 @@ You manage the sales pipeline — tracking leads, following up on opportunities,
 - **account.fiscal.position** — Tax regimes (e.g. "EU B2B reverse-charge", "Export non-EU"). Key fields: \`name\`, \`auto_apply\`, \`country_id\`, \`vat_required\`. Set this on \`res.partner.property_account_position_id\` so subsequent quotes auto-apply the right taxes.
 - **account.move** — Invoices and journal entries. **Read-only** for this agent. Key fields: \`name\`, \`partner_id\`, \`move_type\` ("out_invoice"=customer invoice, "out_refund"=credit note), \`state\` ("draft", "posted", "cancel"), \`payment_state\` ("paid", "not_paid", "partial", "in_payment"), \`amount_total\`, \`invoice_date\`, \`invoice_date_due\`. Use this to answer "is this invoice paid?" — never to draft or post invoices.
 - **mail.message** — Messages. Key fields: \`res_id\`, \`model\`, \`body\`, \`date\`, \`author_id\`
-- **mail.activity** — Activities. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`, \`state\` ("overdue", "today", "planned")
+- **mail.activity** — The "needs attention" signal on a lead or order. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add a follow-up, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
@@ -458,6 +458,9 @@ Use \`odoo_aggregate\` on \`crm.lead\` with \`filters: [["type", "=", "opportuni
 
 ### Overdue follow-ups
 Use \`odoo_read\` on \`mail.activity\` with \`filters: [["state", "=", "overdue"]]\`.
+
+### Schedule a follow-up on a lead
+Read the lead with \`odoo_read\` to get its \`_pinchy_ref\`, then call \`odoo_schedule_activity\` with that \`target\`, a \`summary\` (e.g. "Call about the quote"), and a \`dueDate\` (\`YYYY-MM-DD\`). It defaults to a "To-Do" assigned to the lead's salesperson. This is how you record that a lead needs attention — do not write \`mail.activity\` directly.
 
 ### Win rate per salesperson
 Use \`odoo_aggregate\` on \`crm.lead\` with \`groupby: ["user_id"]\` and count won vs total.
@@ -699,7 +702,7 @@ You handle the operational side of HR — recording leave, logging attendance, a
 - **hr.leave.allocation** — Leave allocations / quotas (read-only). Key fields: \`employee_id\`, \`holiday_status_id\`, \`number_of_days\`
 - **hr.attendance** — Attendance records. Key fields: \`employee_id\`, \`check_in\`, \`check_out\`, \`worked_hours\`
 - **hr.contract** — Contracts (read-only). Key fields: \`employee_id\`, \`date_start\`, \`date_end\`, \`wage\`, \`state\`
-- **mail.activity** — HR follow-ups. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`
+- **mail.activity** — HR follow-ups. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 - **mail.message** — Notes on records. Key fields: \`res_id\`, \`model\`, \`body\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
@@ -719,7 +722,7 @@ Before any \`odoo_create\` or \`odoo_write\` on HR data, present the change as a
 - Don't leak one employee's data when answering a question about another.
 
 ### 3. Out of scope: contracts, payroll, hires, terminations
-These are HR-admin territory and you do not have write access to them. If the user asks you to change a wage, end-date a contract, create a new employee, or terminate someone, respond with: "That's out of scope for me — please loop in HR admin." Then offer to draft a \`mail.activity\` reminder for the HR admin.
+These are HR-admin territory and you do not have write access to them. If the user asks you to change a wage, end-date a contract, create a new employee, or terminate someone, respond with: "That's out of scope for me — please loop in HR admin." Then offer to schedule a follow-up for the HR admin with \`odoo_schedule_activity\`.
 
 ### 4. Read \`hr.contract\` only for context, never share details
 You can read \`hr.contract\` to know an employee's working time (for attendance correctness) or contract end-date (for allocation sanity). You may not share wage, terms, or contract content with anyone.
@@ -844,7 +847,7 @@ You plan and run projects — creating tasks, assigning them, tracking progress,
 - **project.task.type** — Kanban stages. Key fields: \`name\`, \`sequence\`, \`fold\` (true = closed stage), \`project_ids\`
 - **account.analytic.line** — Timesheet entries. Key fields: \`employee_id\`, \`task_id\`, \`project_id\`, \`date\`, \`unit_amount\` (hours), \`name\` (description)
 - **hr.employee** — Employees (read-only, for assignee lookups). Key fields: \`name\`, \`user_id\`, \`department_id\`
-- **mail.activity** — Follow-up activities. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`
+- **mail.activity** — Follow-up activities. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 - **mail.message** — Comments/notes on records. Key fields: \`res_id\`, \`model\`, \`body\`, \`author_id\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
@@ -1000,7 +1003,7 @@ You run the shop floor side of manufacturing — creating manufacturing orders f
 - **stock.move.line** — Detailed component picks and finished good registrations. Key fields: \`product_id\`, \`quantity\`, \`lot_id\`, \`move_id\`
 - **stock.quant** — Component on-hand (read-only). Key fields: \`product_id\`, \`location_id\`, \`quantity\`, \`available_quantity\`
 - **product.product** — Products (read-only). Key fields: \`name\`, \`default_code\`, \`barcode\`, \`tracking\`
-- **mail.activity** — Follow-ups on production issues. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`
+- **mail.activity** — Follow-ups on production issues. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 
 **Important**: Always call \`odoo_describe_model\` first — MRP field names are notoriously product-version-specific.
 
@@ -1021,7 +1024,7 @@ Before \`odoo_write\` on \`state\` to transition the MO to \`done\`, always pres
 ### 2. BOMs are read-only — flag mismatches, do not edit
 If a delivered component differs from the BOM (substitute, version change, shortage), do NOT modify the \`mrp.bom\`. Instead:
 - Flag the discrepancy back to the user
-- Offer to create a \`mail.activity\` for the engineering / R&D owner of the BOM
+- Offer to schedule a follow-up activity (\`odoo_schedule_activity\`) for the engineering / R&D owner of the BOM
 - If the user wants to consume a substitute anyway, edit the relevant \`stock.move\` line on this single MO — never the underlying BOM.
 
 ### 3. qty_producing must match the user's count
@@ -1054,7 +1057,7 @@ If a component is short (\`stock.quant.available_quantity\` < BOM-required), sur
 
 ### Report scrap during production
 1. Verify the user's intent and product/qty.
-2. Use the scrap-creation flow (verify the exact model + method via \`odoo_describe_model\` — typically \`stock.scrap\` if available; if not granted in this template, hand off via \`mail.activity\`).
+2. Use the scrap-creation flow (verify the exact model + method via \`odoo_describe_model\` — typically \`stock.scrap\` if available; if not granted in this template, hand off via \`odoo_schedule_activity\`).
 
 ${ODOO_OUTPUT_FORMATTING}
 
@@ -1100,7 +1103,7 @@ You manage the recruitment pipeline — tracking open positions, moving candidat
 - **hr.applicant** — Candidate records. Key fields: \`name\`, \`partner_name\` (candidate name), \`email_from\`, \`phone\`, \`job_id\`, \`stage_id\`, \`kanban_state\` ("normal", "done", "blocked"), \`user_id\` (recruiter), \`date_open\`, \`date_closed\`, \`priority\` ("0"=normal, "1"=good, "2"=excellent, "3"=barbaric)
 - **hr.recruitment.stage** — Pipeline stages. Key fields: \`name\`, \`sequence\`, \`fold\`
 - **hr.recruitment.source** — Sourcing channels. Key fields: \`name\`
-- **mail.activity** — Activities (interviews, follow-ups). Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`
+- **mail.activity** — Activities (interviews, follow-ups). Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 - **mail.message** — Notes and communication. Key fields: \`res_id\`, \`model\`, \`body\`, \`date\`
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying.
@@ -1389,7 +1392,7 @@ You review and approve operational requests across HR, finance, and purchasing �
 - **approval.category** — Approval categories (read-only, when available). Key fields: \`name\`, \`approval_minimum\`, \`approval_type\`
 - **hr.employee** — For requester context (read-only). Key fields: \`name\`, \`department_id\`, \`parent_id\` (manager)
 - **res.partner** — For supplier / vendor context on POs (read-only). Key fields: \`name\`, \`vat\`, \`supplier_rank\`
-- **mail.activity** — Escalation handoffs. Key fields: \`res_id\`, \`res_model\`, \`activity_type_id\`, \`summary\`, \`date_deadline\`, \`user_id\`
+- **mail.activity** — Escalation handoffs. Read with \`odoo_read\` (filter \`state\`: "overdue", "today", "planned"). To add one, use \`odoo_schedule_activity\` with the record's \`_pinchy_ref\` — never \`odoo_create\` on \`mail.activity\` directly.
 - **mail.message** — Notes / approval rationale on records. Key fields: \`res_id\`, \`model\`, \`body\`
 
 **Important**: Always call \`odoo_describe_model\` first. Approval state machines vary across Odoo versions and modules (e.g. \`approval_state\` vs. \`state\`, single vs. two-step validation).
@@ -1417,7 +1420,7 @@ For every record you touch, you follow this exact ritual. No shortcuts.
 Apply the user's policies to the record:
 - Within authority and within policy → present to user with "approve" recommendation.
 - Within authority but outside policy → present with "refuse" recommendation + concise reason.
-- Above authority → "escalate" — do NOT approve, even if policy would allow it. Draft a \`mail.activity\` for the approver above.
+- Above authority → "escalate" — do NOT approve, even if policy would allow it. Schedule a follow-up activity (\`odoo_schedule_activity\`) for the approver above.
 
 ### 3. Confirm with the user
 Show the user: requester, amount/dates, category, policy decision, recommended action. Wait for an unambiguous yes.

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -93,6 +93,14 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     integration: "odoo",
   },
   {
+    id: "odoo_schedule_activity",
+    label: "Odoo: Schedule activity",
+    description:
+      "Schedule a follow-up activity (planned to-do) on an Odoo record so it surfaces in activity views",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
     id: "odoo_write",
     label: "Odoo: Update records",
     description: "Modify existing records in Odoo",
@@ -231,8 +239,20 @@ const ODOO_READ_TOOLS = [
   "odoo_count",
   "odoo_aggregate",
 ] as const;
-const ODOO_WRITE_TOOLS = ["odoo_create", "odoo_write", "odoo_attach_file"] as const;
+const ODOO_WRITE_TOOLS = [
+  "odoo_create",
+  "odoo_schedule_activity",
+  "odoo_write",
+  "odoo_attach_file",
+] as const;
 const ODOO_DELETE_TOOLS = ["odoo_delete"] as const;
+
+// Additive Odoo tools introduced after the read-write/full presets shipped.
+// Existing agents predate them, so their presence or absence must NOT flip
+// preset detection to "custom" (mirrors the deprecated-alias handling in
+// `detectOdooAccessLevel`). New agents get them via the preset; old agents
+// stay classified by their base read/write/delete tools until re-aligned.
+const ODOO_ADDITIVE_TOOLS = new Set<string>(["odoo_schedule_activity"]);
 
 /** Returns all Odoo tool definitions from the registry. */
 export function getOdooTools(): ToolDefinition[] {
@@ -268,7 +288,10 @@ export function detectOdooAccessLevel(allowedToolIds: string[]): OdooAccessLevel
   const deprecatedIds = new Set(
     TOOL_REGISTRY.filter((t) => t.deprecated && t.integration === "odoo").map((t) => t.id)
   );
-  const odooIds = allowedToolIds.filter((id) => id.startsWith("odoo_") && !deprecatedIds.has(id));
+  // Ignore both deprecated aliases and additive post-preset tools so neither
+  // flips an otherwise-matching agent to "custom".
+  const ignored = (id: string) => deprecatedIds.has(id) || ODOO_ADDITIVE_TOOLS.has(id);
+  const odooIds = allowedToolIds.filter((id) => id.startsWith("odoo_") && !ignored(id));
   const odooSet = new Set(odooIds);
 
   const presets: [OdooAccessLevel, readonly string[]][] = [
@@ -277,7 +300,8 @@ export function detectOdooAccessLevel(allowedToolIds: string[]): OdooAccessLevel
     ["read-only", getOdooToolsForAccessLevel("read-only")],
   ];
 
-  for (const [level, tools] of presets) {
+  for (const [level, presetTools] of presets) {
+    const tools = presetTools.filter((t) => !ignored(t));
     if (odooSet.size === tools.length && tools.every((t) => odooSet.has(t))) {
       return level;
     }

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -101,6 +101,21 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     integration: "odoo",
   },
   {
+    id: "odoo_complete_activity",
+    label: "Odoo: Complete activity",
+    description:
+      "Mark a scheduled activity as done (posts a completion note and clears it from the to-do list)",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
+    id: "odoo_reschedule_activity",
+    label: "Odoo: Reschedule activity",
+    description: "Change a scheduled activity's due date and/or assignee without closing it",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
     id: "odoo_write",
     label: "Odoo: Update records",
     description: "Modify existing records in Odoo",
@@ -242,6 +257,8 @@ const ODOO_READ_TOOLS = [
 const ODOO_WRITE_TOOLS = [
   "odoo_create",
   "odoo_schedule_activity",
+  "odoo_complete_activity",
+  "odoo_reschedule_activity",
   "odoo_write",
   "odoo_attach_file",
 ] as const;
@@ -252,7 +269,11 @@ const ODOO_DELETE_TOOLS = ["odoo_delete"] as const;
 // preset detection to "custom" (mirrors the deprecated-alias handling in
 // `detectOdooAccessLevel`). New agents get them via the preset; old agents
 // stay classified by their base read/write/delete tools until re-aligned.
-const ODOO_ADDITIVE_TOOLS = new Set<string>(["odoo_schedule_activity"]);
+const ODOO_ADDITIVE_TOOLS = new Set<string>([
+  "odoo_schedule_activity",
+  "odoo_complete_activity",
+  "odoo_reschedule_activity",
+]);
 
 /** Returns all Odoo tool definitions from the registry. */
 export function getOdooTools(): ToolDefinition[] {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -133,8 +133,8 @@ importers:
   packages/plugins/pinchy-odoo:
     dependencies:
       odoo-node:
-        specifier: ^0.2.0
-        version: 0.2.0
+        specifier: ^0.3.0
+        version: 0.3.0
     devDependencies:
       typescript:
         specifier: ^6.0.3
@@ -237,8 +237,8 @@ importers:
         specifier: ^0.4.6
         version: 0.4.6(react-dom@19.2.6(react@19.2.6))(react@19.2.6)
       odoo-node:
-        specifier: 0.2.0
-        version: 0.2.0
+        specifier: 0.3.0
+        version: 0.3.0
       openclaw-node:
         specifier: 0.12.1
         version: 0.12.1
@@ -5288,8 +5288,8 @@ packages:
   obug@2.1.1:
     resolution: {integrity: sha512-uTqF9MuPraAQ+IsnPf366RG4cP9RtUi7MLO1N3KEc+wb0a6yKpeL0lmk2IB1jY5KHPAlTc6T/JRdC/YqxHNwkQ==}
 
-  odoo-node@0.2.0:
-    resolution: {integrity: sha512-ov7PNKyyR3YUqU0nrubjA+CuRO5ehzKMky3+WCtGanRxqMQAUOODFX/4kY+UTE1ygJlY+sF+IhZwc1Uf5Suu3w==}
+  odoo-node@0.3.0:
+    resolution: {integrity: sha512-Mos5zrln/P9Rqq+phKoCeGWBBpfUo3WMd67k0q+89e3yz0QQUaG4OkoJkU0hmAy1yE8PrPHNT3QE5iIkKwRqqA==}
     engines: {node: '>=20.0.0'}
 
   on-finished@2.4.1:
@@ -11913,7 +11913,7 @@ snapshots:
 
   obug@2.1.1: {}
 
-  odoo-node@0.2.0: {}
+  odoo-node@0.3.0: {}
 
   on-finished@2.4.1:
     dependencies:


### PR DESCRIPTION
## Problem

Production CRM agents (e.g. **Piper**) could not record follow-up activities on leads/opportunities — the very mechanism that tells the team *which lead needs attention*. The agent reported:

> Activities have to be linked to records with a not null res_id — even though res_id is set.

It then fell back to dumping next-steps into lead **descriptions**, which never surface in Odoo's activity views.

## Root cause (verified against Odoo 18 source)

The Odoo templates told agents to write `mail.activity` with `res_id` + `res_model`. But:

- `res_model` is a **readonly related** field of the required `res_model_id` FK (`related='res_model_id.model'`). Odoo silently drops the write.
- Without `res_model_id`, the `res_id` `Many2oneReference` never persists, and the create fails the SQL CHECK `res_id IS NOT NULL AND res_id != 0`.
- The plugin's many2one guard made `res_model_id` practically unsettable: raw numeric ids are rejected, and an `ir.model` *name* lookup misses because `ir.model.name` is the label ("Lead/Opportunity"), not the technical model (`crm.lead`).
- No tool exposed the idiomatic path.

So the agent wasn't hallucinating — it hit a real, reproducible defect.

## Fix

- **New `odoo_schedule_activity` tool** (governed + audited): takes a record's `_pinchy_ref`, `summary`, `dueDate` (+ optional `note` / `assignee` / `activityType`). Resolves `res_model_id` via `ir.model`, resolves the default **To-Do** type locale-independently via the `mail.mail_activity_data_todo` xmlid (`ir.model.data`), defaults the assignee to the target record's **salesperson**, and creates the activity correctly. Permission-gated on `create:mail.activity` + `read` on the target model.
- **Safety net** in `odoo_create`/`odoo_write`: when a legacy agent writes `mail.activity` with a `res_model` string, translate it to `res_model_id`. Production agents carry a frozen `AGENTS.md`, so this keeps them working with **no manual re-align**.
- **Preset wiring**: added to the read-write/full tool presets; detection treats it as *additive* so existing read-write agents are **not** reclassified as "custom".
- **Templates + docs**: all 7 Odoo templates that grant `mail.activity` create now point at the tool (the misleading `res_model` framing is gone); permission table + architecture docs updated.

## Why a raw create, not `activity_schedule()`?

`activity_schedule()` forces `automated=True` (system activities) and would need an `odoo-node` release. A clean raw create with a resolved `res_model_id` reproduces the manual *"Schedule Activity"* behaviour (`automated=False`), stays pure CRUD, and needs no third-party release.

## Tests

The `odoo-mock` was extended to model the real `mail.activity` contract (incl. the `res_id` CHECK constraint), `ir.model.data`, `mail.activity.type`, `crm.lead`, `res.users`. Integration tests prove **both** the failure mode and the fix end-to-end over real JSON-RPC; unit tests cover payload shape, permission gating, dueDate validation, and cross-connection ref rejection. Drift- and per-plugin coverage-guards updated/satisfied.

## Follow-up (intentionally out of scope)

Marking activities **done** still needs a method-call capability — a separate feature, not bundled here.

Local gates green: full web unit suite (5952), plugin suite, `test:db` (115), `tsc`, `eslint`, `prettier`, `next build`.