### PR TITLE
docs: fix audit-found truth + staleness issues across 12 pages

### DIFF
--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -5,7 +5,7 @@ description: How Pinchy wraps OpenClaw, the request flow, and the tech stack.
 
 ## Overview
 
-Pinchy is **not a fork** of OpenClaw. It's a governance layer on top of it. OpenClaw handles agent execution, tool use, and model communication. Pinchy adds authentication, provider management, agent permissions, cryptographic audit trails, and (soon) team management.
+Pinchy is **not a fork** of OpenClaw. It's a governance layer on top of it. OpenClaw handles agent execution, tool use, and model communication. Pinchy adds authentication, provider management, agent permissions, cryptographic audit trails, and team management.
 
 ```mermaid
 ---
@@ -158,7 +158,7 @@ When an agent has safe tools enabled, the `pinchy-files` plugin validates every 
 
 In addition to the allow-list, every agent has built-in PDF and image readers that are **scoped to its own [workspace](/concepts/workspaces/)** — they cannot reach files outside the workspace, regardless of permissions. Each workspace has two subdirectories: `uploads/` (files the user attached in chat) and `workbench/` (the agent's writable area for `pinchy_write` deliverables). Both are created eagerly on workspace spawn, so a fresh agent can save files immediately without needing a prior user upload.
 
-Smithers agents also use the `pinchy-context` plugin, which provides `save_user_context` and `save_org_context` tools. These tools call Pinchy's internal API (authenticated via a shared gateway token) to save context from the onboarding interview directly to the database and sync it to agent workspaces.
+Smithers agents also use the `pinchy-context` plugin, which provides `pinchy_save_user_context` and `pinchy_save_org_context` tools. These tools call Pinchy's internal API (authenticated via a shared gateway token) to save context from the onboarding interview directly to the database and sync it to agent workspaces.
 
 All agent-accessible files live under `/data/` in the container, mounted via Docker volumes. This means even if all software layers failed, the agent can only see files that were explicitly mounted.
 

--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -19,7 +19,7 @@ Pinchy logs event types across several categories:
 
 | Event Type        | Description                                                                                                       |
 | ----------------- | ----------------------------------------------------------------------------------------------------------------- |
-| `tool.<toolName>` | An agent executed a tool — event type is dynamic per tool (e.g. `tool.shell`, `tool.pinchy_read`, `tool.fs_read`) |
+| `tool.<toolName>` | An agent executed a tool — event type is dynamic per tool (e.g. `tool.pinchy_read`, `tool.odoo_read`, `tool.pinchy_web_search`) |
 | `tool.denied`     | An agent attempted to use a tool that was not in its allow-list                                                   |
 
 Each tool execution produces **one audit entry** — logged when the tool call completes (end phase only). The detail includes the tool name, parameters, and result. Start events are received but not persisted.
@@ -65,7 +65,7 @@ exports too.
 | `auth.login`                    | A user successfully logged in                                                                                                                                                                                                                                                                                                                                                           |
 | `auth.failed`                   | A login attempt failed (wrong password, unknown email)                                                                                                                                                                                                                                                                                                                                  |
 | `auth.logout`                   | A user logged out                                                                                                                                                                                                                                                                                                                                                                       |
-| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#csrf-gate).                                                                                                                              |
+| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#cross-site-request-forgery-csrf-protection).                                                                                                                              |
 | `auth.password_reset_completed` | A user finished a password-reset invite. On success, detail snapshots the target `{id, name}` and the invite id; all of that user's existing sessions are revoked in the same transaction. On failure (rare — e.g. DB error mid-flow), `outcome: failure` is written with the error message and the entire reset rolls back so the old password and the reset token both remain usable. |
 
 ### Agent management
@@ -282,7 +282,7 @@ Every export — regardless of format — contains:
 
 - **Timestamp** (UTC, ISO 8601)
 - **Actor** — name (snapshotted) and ID, plus type (user, agent, system)
-- **Event type** — what happened (`auth.login`, `agent.updated`, `tool.shell`, …)
+- **Event type** — what happened (`auth.login`, `agent.updated`, `tool.pinchy_read`, …)
 - **Resource** — name (snapshotted) and ID of the affected entity, where applicable
 - **Status** — `success` or `failure` (legacy entries before status tracking show empty)
 - **Error message** — for failed events
@@ -308,7 +308,7 @@ curl -b session_cookie "https://your-pinchy-instance/api/audit/export?from=2026-
 curl -b session_cookie "https://your-pinchy-instance/api/audit/export?format=pdf&from=2026-01-01&to=2026-02-01" -o audit-log.pdf
 
 # Filter to a specific agent's tool calls
-curl -b session_cookie "https://your-pinchy-instance/api/audit/export?resource=agent:abc123&eventType=tool.shell" -o smithers-shell-audit.csv
+curl -b session_cookie "https://your-pinchy-instance/api/audit/export?resource=agent:abc123&eventType=tool.pinchy_read" -o smithers-read-audit.csv
 ```
 
 The PDF report contains a header with generation timestamp, the active filters, and the total number of entries, followed by a paginated table of the entries themselves. Each page is footed with a page counter and a reminder that the underlying data is HMAC-SHA256 signed.

--- a/docs/src/content/docs/glossary/ai-agent-governance.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-governance.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is AI agent governance?
-description: AI agent governance is the set of controls that make AI agents safe to run in an organization — identity, permissions, approval, and a tamper-evident audit trail, enforced in code rather than by prompt.
+description: AI agent governance is the set of controls that make AI agents safe to run in an organization — identity, permissions, and a tamper-evident audit trail, enforced in code rather than by prompt.
 head:
   - tag: script
     attrs:
@@ -15,7 +15,7 @@ head:
             "name": "What is AI agent governance?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "AI agent governance is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, human approval for sensitive actions, and a tamper-evident audit trail. The defining property is that these controls are enforced in code, outside the model, rather than relying on the agent's prompt to behave."
+              "text": "AI agent governance is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, and a tamper-evident audit trail. The defining property is that these controls are enforced in code, outside the model, rather than relying on the agent's prompt to behave."
             }
           },
           {
@@ -31,14 +31,14 @@ head:
             "name": "What are the core components of AI agent governance?",
             "acceptedAnswer": {
               "@type": "Answer",
-              "text": "Five components: identity (each user is a real account, not a shared login), role-based access control (who may use which agent), per-agent tool permissions on an allow-list (what each agent may do), human approval for sensitive or irreversible actions, and a tamper-evident audit trail (proof of what happened). Each is enforced in code, not requested in a prompt."
+              "text": "Four components: identity (each user is a real account, not a shared login), role-based access control (who may use which agent), per-agent tool permissions on an allow-list (what each agent may do), and a tamper-evident audit trail (proof of what happened). Each is enforced in code, not requested in a prompt."
             }
           }
         ]
       }
 ---
 
-**AI agent governance** is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, human approval for sensitive actions, and a tamper-evident audit trail.
+**AI agent governance** is the set of controls that make AI agents safe to run in an organization: per-user identity, role-based access to agents, per-agent tool permissions, and a tamper-evident audit trail.
 
 The defining property is that these controls are **enforced in code, outside the model**, not left to the agent's prompt to behave.
 
@@ -46,19 +46,18 @@ The defining property is that these controls are **enforced in code, outside the
 
 Agents have moved from answering questions to taking actions in real systems. A chatbot that drafts text needs little governance. An agent that can write to your ERP, send email, or act for multiple people needs all of it. The shift from _answer_ to _act_ is exactly the point where governance stops being optional.
 
-## The five components
+## The four components
 
 1. **Identity.** Each person is a real account, not a shared login or token. Without identity, nothing below can attribute or restrict by user.
 2. **[Role-based access control](/glossary/rbac-for-ai-agents/).** Who may use which agent.
 3. **[Tool permissions](/glossary/ai-agent-permissions/).** What each agent may do, on an allow-list: nothing until explicitly granted.
-4. **Human approval.** For sensitive or irreversible actions, the agent drafts and a human confirms before it acts.
-5. **[Tamper-evident audit trail](/glossary/ai-agent-audit-trail/).** Proof of who did what, signed so it cannot be quietly altered.
+4. **[Tamper-evident audit trail](/glossary/ai-agent-audit-trail/).** Proof of who did what, signed so it cannot be quietly altered.
 
 Miss any one and the others leak. Perfect permissions with shared logins lose attribution. A perfect audit trail of an agent that can do anything is just a detailed record of an incident.
 
 ## Enforced in code, not in a prompt
 
-A prompt is a request. Prompt injection and model drift mean an agent can be talked or nudged out of its instructions. Governance controls sit outside the model: if a user lacks the role, they cannot reach the agent; if a tool is not granted, the agent cannot call it; if an action is sensitive, it waits for approval. The model operates _within_ the boundary, never defines it.
+A prompt is a request. Prompt injection and model drift mean an agent can be talked or nudged out of its instructions. Governance controls sit outside the model: if a user lacks the role, they cannot reach the agent; if a tool is not granted, the agent cannot call it; every action is recorded in a tamper-evident audit trail. The model operates _within_ the boundary, never defines it.
 
 ## In Pinchy
 

--- a/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
+++ b/docs/src/content/docs/guides/create-knowledge-base-agent.mdx
@@ -27,7 +27,7 @@ Choose **Knowledge Base** from the template options. This template pre-configure
 
 Give your agent a descriptive name, for example "HR Policy Assistant" or "Engineering Docs". You can also add an optional tagline like "Answers questions about company HR policies". Then click **Create**.
 
-The agent is created with an auto-generated avatar and you are taken to its chat page. The Knowledge Base template pre-fills operating instructions (AGENTS.md) with document-answering guidelines. The agent has safe file tools enabled by default, but it does not yet know which directories to access. You need to configure that in the Permissions tab.
+The agent is created with an auto-generated avatar and you are taken to its chat page. The Knowledge Base template pre-fills operating instructions (AGENTS.md) with document-answering guidelines. The agent can already list and read files — that capability is built in, not a toggle — but it does not yet know which directories to access. You scope that in the Permissions tab with the **Allowed Directories** picker.
 
 ## 5. Configure directory access
 
@@ -35,7 +35,7 @@ Open the agent's settings by clicking the gear icon, then select the **Permissio
 
 ![Permissions tab with safe tools and directory picker](/screenshots/agent-settings-permissions.png)
 
-Under **Safe Tools**, you will see that "List approved directories" and "Read approved files" are already enabled (because the Knowledge Base template includes them). Below the safe tools checkboxes, the **Allowed Directories** picker shows all directories found under `/data/`.
+Under **Knowledge Base**, the **Allowed Directories** picker shows all directories found under `/data/`. Listing and reading files is built into the agent, so there are no separate file-tool toggles to enable — you only choose which directories the agent may reach.
 
 Select the directories that contain the documents this agent should be able to read. For example, if you mounted your HR policies at `/data/hr-policies` and your engineering handbook at `/data/engineering`, select one or both.
 

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -204,7 +204,7 @@ Never commit `.env` files or secrets to version control. The `.gitignore` in the
 
 Pinchy's Docker Compose setup uses an internal network. PostgreSQL and OpenClaw are not exposed to the host network.
 
-### Localhost binding (default since v0.4.3)
+### Localhost binding (default)
 
 Pinchy's default port binding is `127.0.0.1:7777`, which means it only accepts connections from localhost. A reverse proxy (Caddy, nginx) running on the same host forwards traffic from ports 80/443 to Pinchy on 7777.
 

--- a/docs/src/content/docs/guides/image-attachments.mdx
+++ b/docs/src/content/docs/guides/image-attachments.mdx
@@ -62,8 +62,8 @@ The `models` table is seeded automatically at boot from Pinchy's built-in model 
 
 Whether the agent can actually see an image depends on the underlying LLM. As of today:
 
-- **OpenAI** GPT-4o and newer — full vision support
-- **Anthropic** Claude 3.5 Sonnet and newer — full vision support
+- **OpenAI** GPT-5.x — full vision support
+- **Anthropic** Claude 4.x (Opus/Sonnet/Haiku) — full vision support
 - **Google** Gemini Pro/Flash — full vision support
 - **Local Ollama** — only models marked as vision-capable (e.g. `llama3.2-vision`, `gemma3`)
 

--- a/docs/src/content/docs/guides/llm-providers.mdx
+++ b/docs/src/content/docs/guides/llm-providers.mdx
@@ -14,7 +14,7 @@ For the very first provider during the setup wizard, see [Installation](/install
 | Provider           | Auth    | What you get                                                                 |
 | ------------------ | ------- | ---------------------------------------------------------------------------- |
 | **Anthropic**      | API key | Claude family — strongest tool calling and reasoning                         |
-| **OpenAI**         | API key | GPT-4o family, o-series reasoning models                                     |
+| **OpenAI**         | API key | GPT-5 family, o-series reasoning models                                      |
 | **Google**         | API key | Gemini family — long context, fast and cheap                                 |
 | **Ollama Cloud**   | API key | Hosted open-source models (Kimi, Qwen, Mistral, Gemini Flash) via ollama.com |
 | **Ollama (Local)** | URL     | Fully air-gapped local inference — see [Ollama setup](/guides/ollama-setup/) |

--- a/docs/src/content/docs/guides/mount-data-directories.mdx
+++ b/docs/src/content/docs/guides/mount-data-directories.mdx
@@ -98,4 +98,4 @@ Knowledge Base agents can read text files, Markdown, **Word documents** (`.docx`
 
 Directories mounted under `/data/` are **admin-curated and read-only for agents** — they hold your organization's reference documents and are not writable by agents under any configuration.
 
-This is intentional: it keeps your authoritative documents separate from anything an agent might generate or derive. An agent that has the **Write files** permission saves results to its own `uploads/` workspace, not to `/data/`. See [Agent Permissions](/concepts/agent-permissions/) for details on the workspace write capability.
+This is intentional: it keeps your authoritative documents separate from anything an agent might generate or derive. An agent that has the **Write files** permission saves results to its own `workbench/` workspace, not to `/data/`. (The legacy `uploads/` directory stays writable for backward compatibility, but new agents should write to `workbench/`.) See [Agent Permissions](/concepts/agent-permissions/) for details on the workspace write capability.

--- a/docs/src/content/docs/guides/ollama-setup.mdx
+++ b/docs/src/content/docs/guides/ollama-setup.mdx
@@ -23,10 +23,12 @@ This is the setup for teams that need full air-gap compliance or simply want to 
 ## Connect Ollama to Pinchy
 
 <Steps>
-  1. Go to **Settings → LLM Provider** 2. Click **Ollama (Local)** 3. Enter the
-  URL where Ollama is running (see [deployment options](#deployment-options)
-  below) 4. Click **Save** — Pinchy validates the connection and discovers your
-  models
+
+1.  Go to **Settings → LLM Provider**
+2.  Click **Ollama (Local)**
+3.  Enter the URL where Ollama is running (see [deployment options](#deployment-options) below)
+4.  Click **Save** — Pinchy validates the connection and discovers your models
+
 </Steps>
 
 That's it. Your agents now use your local Ollama models.
@@ -269,7 +271,7 @@ agents) with cloud providers (interactive agents).
 
 **Agents reply with "Blocked hostname or private/internal/special-use IP address"**
 
-- OpenClaw 2026.5.x ships an SSRF guard that blocks outbound HTTP to private-network destinations by default. Pinchy %%PINCHY_VERSION%% works around this by setting `request.allowPrivateNetwork: true` only on the `ollama-local` provider in the generated `openclaw.json`, so calls to local Ollama go through but the guard stays active for every other provider.
+- OpenClaw 2026.6.x ships an SSRF guard that blocks outbound HTTP to private-network destinations by default. Pinchy %%PINCHY_VERSION%% works around this by setting `request.allowPrivateNetwork: true` only on the `ollama-local` provider in the generated `openclaw.json`, so calls to local Ollama go through but the guard stays active for every other provider.
 - If you see this error after upgrading, regenerate the config — restart Pinchy or change any provider setting in **Settings → Providers** and save, which triggers a fresh write. Verify the resulting `openclaw.json` has `request.allowPrivateNetwork: true` under your `ollama-local` provider entry.
 
 **No models appear after connecting**

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -74,7 +74,7 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
 
    ```bash
    curl -s http://localhost:7777/api/version
-   # {"pinchyVersion":"0.5.7","openclawVersion":"2026.5.28","build":"<git sha>","nodeEnv":"production"}
+   # {"pinchyVersion":"0.5.8","openclawVersion":"2026.6.5","build":"<git sha>","nodeEnv":"production"}
    ```
 
    Then open Pinchy in your browser at the URL you normally use (e.g. `https://your-domain.example`) and check the logs for any warnings:

--- a/docs/src/content/docs/guides/vps-deployment.mdx
+++ b/docs/src/content/docs/guides/vps-deployment.mdx
@@ -89,9 +89,9 @@ All three start together via Docker Compose. Only the `pinchy` container publish
    | `BETTER_AUTH_SECRET` | Signs user sessions                                  |
    | `ENCRYPTION_KEY`     | Encrypts LLM provider API keys at rest (AES-256-GCM) |
 
-   If you don't set them, Pinchy auto-generates `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY` and persists them as files in a Docker volume (`pinchy-secrets`). This works fine for normal operation — **but** if that volume is ever deleted (e.g. during a server migration or an accidental `docker compose down -v`), the generated secrets are lost and encrypted data becomes unreadable. `DB_PASSWORD` defaults to a weak development value.
+   If you don't set them, Pinchy auto-manages all three on first boot: it generates `BETTER_AUTH_SECRET` and `ENCRYPTION_KEY`, and the entrypoint also generates a strong `DB_PASSWORD` (rewriting `DATABASE_URL` to match). All three are persisted as files in a Docker volume (`pinchy-secrets`). This works fine for normal operation — **but** if that volume is ever deleted (e.g. during a server migration or an accidental `docker compose down -v`), the generated secrets are lost and encrypted data becomes unreadable.
 
-   For production, pin all three explicitly:
+   You only need to set these manually if you want to pin your own values. For production, you may prefer to pin all three explicitly so they live in your `.env` (and your backups) rather than only in the volume:
 
    ```bash
    nano /opt/pinchy/.env

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -930,7 +930,7 @@ Get the current enterprise license status and seat usage. Any authenticated user
 | `seatsUsed`     | number         | Number of seats currently in use: active users + valid pending invitations                                     |
 | `maxUsers`      | number         | Maximum seats allowed by the license. `0` means unlimited.                                                     |
 
-**Seat cap behaviour:** when `seatsUsed >= maxUsers` and `maxUsers > 0`, the **Invite User** button is disabled and the API rejects new invitations with `403`. Existing users are never affected. See [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement) for the full explanation.
+**Seat cap behaviour:** the seat cap is a **soft cap with a 20% grace window**. When `maxUsers > 0`, invites keep working up to `floor(1.2 * maxUsers)` seats (for example 12 on a 10-seat license); in the 100–120% grace band admins see a notice but invites still succeed and nothing is blocked. Only when `seatsUsed >= floor(1.2 * maxUsers)` is the **Invite User** button disabled and the API rejects new invitations with `403` (the response includes `graceCap`). Existing users are never affected. See [Enterprise Setup — Seat cap enforcement](/guides/enterprise-setup/#seat-cap-enforcement) for the full explanation.
 
 **Errors:**
 
@@ -1090,7 +1090,7 @@ Retrieve a paginated, filterable audit log. **Admin only.**
 | ----------- | ------ | ------- | ------------------------------------------------------- |
 | `page`      | number | 1       | Page number                                             |
 | `limit`     | number | 50      | Entries per page                                        |
-| `eventType` | string | —       | Filter by event type (e.g., `auth.login`, `tool.shell`) |
+| `eventType` | string | —       | Filter by event type (e.g., `auth.login`, `tool.pinchy_read`) |
 | `actorId`   | string | —       | Filter by user ID                                       |
 | `from`      | string | —       | Start date (ISO 8601)                                   |
 | `to`        | string | —       | End date (ISO 8601)                                     |
@@ -1186,7 +1186,8 @@ List the distinct event types present in the current audit log. Useful for popul
     "file.upload.staged",
     "file.upload.attached",
     "file.upload.expired",
-    "tool.shell",
+    "tool.pinchy_read",
+    "tool.odoo_read",
     "tool.denied"
   ]
 }


### PR DESCRIPTION
## What

Applies the **truth + staleness fixes** from a docs-wide audit (multi-agent workflow; every truth finding adversarially re-verified against the codebase). 12 pages, build passes.

## Truth (code-verified)

- **`reference/api.mdx` (HIGH):** seat cap was documented as a hard cap at `maxUsers`, but it is a **soft cap with a 20% grace window** — invites work up to `floor(1.2 * maxUsers)`, and the `403` fires only at the grace cap. Verified against `seat-grace.ts` + the invite route.
- **`glossary/ai-agent-governance.mdx`:** removed the **"code-enforced human approval gate"** claim everywhere (lede, frontmatter description, 2 FAQPage JSON-LD answers, the components list `five → four`, the "enforced in code" section). Pinchy ships no platform approval gate; approval is a prompt convention in agent templates, not an in-code governance control.
- **`reference/api.mdx` + `concepts/audit-trail.mdx`:** fictional `tool.shell` / `tool.fs_read` audit examples → real tool event types (`tool.pinchy_read`, `tool.odoo_read`, …).
- **`architecture.mdx`:** tool names corrected to the prefixed `pinchy_save_user_context` / `pinchy_save_org_context`.

## Staleness

- `architecture`: "team management" ships now (dropped "(soon)").
- `create-knowledge-base-agent`: file read/list is implicit, not a toggleable "safe tool"; only Allowed Directories is configured.
- `vps-deployment`: `DB_PASSWORD` is auto-managed on boot (`resolve-db-password.mjs`), like the other secrets.
- `ollama-setup`: `<Steps>` block now renders as discrete steps; SSRF-guard version phrasing updated.
- `image-attachments` + `llm-providers`: model names → current catalog (GPT-5.x, Claude 4.x).
- `mount-data-directories`: `workbench/` is the primary write area now (`uploads/` = back-compat).
- `upgrading`: evergreen verify example → v0.5.8 / OpenClaw 2026.6.5.
- `hardening`: dropped unverifiable "since v0.4.3" provenance.
- `concepts/audit-trail`: fixed broken `#csrf-gate` anchor.

## Notes

- Screenshot references left untouched — they are generated by CI (`screenshots.yml`) into `docs/public/screenshots/` at deploy, so the in-repo "missing asset" findings are false positives.
- The 69 GEO findings from the same audit are a separate follow-up pass.