### PR TITLE
fix(e2e): deterministic fake-ollama usage on every completion path (flaky usage-tracking)

### DIFF
--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -204,6 +204,7 @@ function streamTextResponse(res: http.ServerResponse, text: string, userMessageC
 }
 
 async function streamTextResponseSlow(res: http.ServerResponse, text: string) {
+  const { promptTokens, completionTokens } = getUsageTokens();
   res.writeHead(200, {
     "Content-Type": "application/x-ndjson",
     "Cache-Control": "no-cache",
@@ -233,7 +234,12 @@ async function streamTextResponseSlow(res: http.ServerResponse, text: string) {
         created_at: new Date().toISOString(),
         message: { role: "assistant", content: index === 0 ? word : " " + word },
         done: isLast,
-        ...(isLast && { done_reason: "stop", total_duration: 1000000 }),
+        ...(isLast && {
+          done_reason: "stop",
+          total_duration: 1000000,
+          prompt_eval_count: promptTokens,
+          eval_count: completionTokens,
+        }),
       };
       res.write(JSON.stringify(chunk) + "\n");
       if (!isLast) {
@@ -427,6 +433,8 @@ async function streamOpenAiTextSlow(res: http.ServerResponse, text: string) {
       }
     }
     sseWrite(res, chatCompletionChunk({ finishReason: "stop" }));
+    // Usage on the slow path too — same no-usage flake class as tool calls.
+    sseWrite(res, usageChunk());
     sseDone(res);
   } catch {
     // Client disconnected mid-stream — normal in mid-stream disconnect tests.
@@ -441,6 +449,10 @@ function streamOpenAiToolCalls(
   sseHeaders(res);
   sseWrite(res, chatCompletionChunk({ toolCalls: [{ name: toolName, arguments: args }] }));
   sseWrite(res, chatCompletionChunk({ finishReason: "tool_calls" }));
+  // Emit usage even on tool-call turns. Without it OpenClaw self-estimates the
+  // real prompt size (~18k) and writes that into the trajectory, contaminating
+  // the per-turn usage_records rows and flaking usage-tracking.spec.ts.
+  sseWrite(res, usageChunk());
   sseDone(res);
 }
 
@@ -503,6 +515,7 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
     const activeTrigger = TOOL_TRIGGERS.find(({ trigger }) => lastContent.includes(trigger));
 
     if (activeTrigger && !hasToolResult) {
+      const { promptTokens, completionTokens } = getUsageTokens(countUserMessages(messages));
       writeNdjson(res, [
         {
           model: MODEL_NAME,
@@ -522,6 +535,9 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
           done: true,
           done_reason: "stop",
           total_duration: 1000000,
+          // Usage even on tool-call turns — see streamOpenAiToolCalls for why.
+          prompt_eval_count: promptTokens,
+          eval_count: completionTokens,
         },
       ]);
       return;

--- a/packages/web/src/__tests__/e2e-shared/fake-ollama-usage.test.ts
+++ b/packages/web/src/__tests__/e2e-shared/fake-ollama-usage.test.ts
@@ -10,7 +10,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import * as http from "http";
 import type { AddressInfo } from "net";
-import { handleRequest } from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+import {
+  handleRequest,
+  FAKE_OLLAMA_FILES_LS_TOOL_TRIGGER,
+  FAKE_OLLAMA_SLOW_STREAM_TRIGGER,
+} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
 
 let server: http.Server;
 let baseUrl: string;
@@ -37,6 +41,16 @@ async function postChat(path: string, body: unknown): Promise<string> {
     body: JSON.stringify(body),
   });
   return res.text();
+}
+
+/** Pull the usage object out of whichever OpenAI SSE chunk carries it. */
+function sseUsage(raw: string): Record<string, number> | undefined {
+  return raw
+    .split("\n\n")
+    .map((line) => line.replace(/^data: /, "").trim())
+    .filter((p) => p && p !== "[DONE]")
+    .map((p) => (JSON.parse(p) as { usage?: Record<string, number> }).usage)
+    .find((u) => u !== undefined);
 }
 
 describe("fake-ollama usage block — OpenAI /v1/chat/completions (the path OC uses)", () => {
@@ -104,18 +118,43 @@ describe("fake-ollama usage block — OpenAI /v1/chat/completions (the path OC u
       messages: [{ role: "user", content: "hello" }],
     });
 
-    const usage = raw
-      .split("\n\n")
-      .map((line) => line.replace(/^data: /, "").trim())
-      .filter((p) => p && p !== "[DONE]")
-      .map((p) => JSON.parse(p) as { usage?: Record<string, number> })
-      .map((c) => c.usage)
-      .find((u) => u !== undefined);
+    const usage = sseUsage(raw);
 
     expect(usage).toBeDefined();
     expect(usage!.prompt_tokens).toBeGreaterThan(0);
     expect(usage!.completion_tokens).toBeGreaterThan(0);
     expect(usage!.total_tokens).toBe(usage!.prompt_tokens + usage!.completion_tokens);
+  });
+
+  // Tool-call and slow-stream turns must ALSO report usage. When they don't,
+  // OpenClaw self-estimates the real prompt size (~18k for the Smithers
+  // bootstrap) into the trajectory, which the per-turn recorder stores as a
+  // ~18k usage_records row — the source of the usage-tracking.spec.ts flake
+  // (one row != 42 in). Pin every completion shape to the configured usage.
+  it("emits the usage block on tool-call turns", async () => {
+    process.env.FAKE_OLLAMA_PROMPT_TOKENS = "42";
+    process.env.FAKE_OLLAMA_COMPLETION_TOKENS = "17";
+
+    const raw = await postChat("/v1/chat/completions", {
+      stream: true,
+      messages: [{ role: "user", content: FAKE_OLLAMA_FILES_LS_TOOL_TRIGGER }],
+    });
+
+    // Sanity: this really is a tool-call response, not a plain text reply.
+    expect(raw).toContain("tool_calls");
+    expect(sseUsage(raw)).toEqual({ prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 });
+  });
+
+  it("emits the usage block on slow-stream turns", { timeout: 20000 }, async () => {
+    process.env.FAKE_OLLAMA_PROMPT_TOKENS = "42";
+    process.env.FAKE_OLLAMA_COMPLETION_TOKENS = "17";
+
+    const raw = await postChat("/v1/chat/completions", {
+      stream: true,
+      messages: [{ role: "user", content: FAKE_OLLAMA_SLOW_STREAM_TRIGGER }],
+    });
+
+    expect(sseUsage(raw)).toEqual({ prompt_tokens: 42, completion_tokens: 17, total_tokens: 59 });
   });
 });
 
@@ -138,6 +177,35 @@ describe("fake-ollama usage block — Ollama-native /api/chat", () => {
       .find((c) => c.done === true);
 
     expect(finalChunk).toBeDefined();
+    expect(finalChunk!.prompt_eval_count).toBe(100);
+    expect(finalChunk!.eval_count).toBe(25);
+  });
+
+  it("reports prompt_eval_count / eval_count on tool-call turns too", async () => {
+    process.env.FAKE_OLLAMA_PROMPT_TOKENS = "100";
+    process.env.FAKE_OLLAMA_COMPLETION_TOKENS = "25";
+
+    const raw = await postChat("/api/chat", {
+      stream: true,
+      messages: [{ role: "user", content: FAKE_OLLAMA_FILES_LS_TOOL_TRIGGER }],
+    });
+
+    const finalChunk = raw
+      .split("\n")
+      .filter((l) => l.trim())
+      .map(
+        (l) =>
+          JSON.parse(l) as {
+            done?: boolean;
+            prompt_eval_count?: number;
+            eval_count?: number;
+            message?: { tool_calls?: unknown };
+          }
+      )
+      .find((c) => c.done === true);
+
+    expect(finalChunk).toBeDefined();
+    expect(finalChunk!.message?.tool_calls, "should be a tool-call response").toBeDefined();
     expect(finalChunk!.prompt_eval_count).toBe(100);
     expect(finalChunk!.eval_count).toBe(25);
   });


### PR DESCRIPTION
## Problem

`usage-tracking.spec.ts:106` ("a chat turn records one usage row with the provider's EXACT per-turn tokens") is **flaky**. On PR #509 CI run 27631565765 it failed with `delta.input = 18173` instead of the expected `42 × rows`, then **passed on a diagnostic rerun of the same commit** — nondeterministic, not a code regression.

## Root cause

The fake-ollama server attaches its fixed `42/17` usage block only on **plain text** replies. Two response shapes emitted **no usage**:

- tool-call turns — `streamOpenAiToolCalls` (SSE) and the `/api/chat` tool branch (NDJSON)
- slow-stream turns — `streamOpenAiTextSlow` (SSE) and `streamTextResponseSlow` (NDJSON)

When OpenClaw receives a completion **without** provider usage, it self-estimates the input tokens from the real prompt (~18k for the Smithers bootstrap) and writes that into the trajectory `model.completed.data.usage`. Pinchy's per-turn recorder (`usage-from-trajectory.ts`) stores it as a `usage_records` row with `inputTokens ≈ 18k`.

The integration suite runs many tool-dispatch probes and slow-stream specs against the **shared** Smithers direct session before `usage-tracking.spec.ts`. Because recording is poller-backed, one of those ~18k rows can land inside this test's `before → waitForNewTurns` delta window. Then `delta.input = 42 (this turn) + ~18131 (leaked turn) = 18173`, and `delta.rows = 2`, so `42 × 2 = 84 ≠ 18173`. The exact-multiple invariant only holds if **every** recorded row is 42.

## Fix

Emit the deterministic usage block on **every** completion-producing path of the fake server (tool-call + slow-stream, both OpenAI-compatible and Ollama-native). Now every turn OpenClaw records carries the configured `42/17`, so the per-turn assertion holds regardless of turn shape or recording timing.

No assertion loosening, no timeout bumps, no reliance on reruns — per the project flaky-test policy.

## Tests

Extends the existing `e2e-shared/fake-ollama-usage.test.ts` (which previously only covered plain-text turns) to pin the usage contract on tool-call and slow-stream turns for both APIs — failing before the fix, passing after.

- Full unit suite green locally (5936 passed); `tsc` clean; lint clean.
- The integration guard (`usage-tracking.spec.ts`) is exercised by the `Integration Tests (OpenClaw + Fake Ollama)` CI job.

Surfaced during refactoring PR #509 (unrelated — that PR only decomposes `openclaw-config/build.ts` and extracts a client-router helper; emitted config is byte-identical).