### PR TITLE
docs: prettier-format two mdx files (unblocks format check on all PRs)

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -17,10 +17,10 @@ Pinchy logs event types across several categories:
 
 ### Tool execution
 
-| Event Type        | Description                                                                                                       |
-| ----------------- | ----------------------------------------------------------------------------------------------------------------- |
+| Event Type        | Description                                                                                                                     |
+| ----------------- | ------------------------------------------------------------------------------------------------------------------------------- |
 | `tool.<toolName>` | An agent executed a tool — event type is dynamic per tool (e.g. `tool.pinchy_read`, `tool.odoo_read`, `tool.pinchy_web_search`) |
-| `tool.denied`     | An agent attempted to use a tool that was not in its allow-list                                                   |
+| `tool.denied`     | An agent attempted to use a tool that was not in its allow-list                                                                 |
 
 Each tool execution produces **one audit entry** — logged when the tool call completes (end phase only). The detail includes the tool name, parameters, and result. Start events are received but not persisted.
 
@@ -65,7 +65,7 @@ exports too.
 | `auth.login`                    | A user successfully logged in                                                                                                                                                                                                                                                                                                                                                           |
 | `auth.failed`                   | A login attempt failed (wrong password, unknown email)                                                                                                                                                                                                                                                                                                                                  |
 | `auth.logout`                   | A user logged out                                                                                                                                                                                                                                                                                                                                                                       |
-| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#cross-site-request-forgery-csrf-protection).                                                                                                                              |
+| `auth.csrf_blocked`             | A state-changing request was rejected because its `Origin` / `Referer` headers didn't match the locked domain. Detail captures `method`, `pathname`, `origin`, `referer`, and `remoteAddress` — see [Hardening › CSRF gate](/guides/hardening/#cross-site-request-forgery-csrf-protection).                                                                                             |
 | `auth.password_reset_completed` | A user finished a password-reset invite. On success, detail snapshots the target `{id, name}` and the invite id; all of that user's existing sessions are revoked in the same transaction. On failure (rare — e.g. DB error mid-flow), `outcome: failure` is written with the error message and the entire reset rolls back so the old password and the reset token both remain usable. |
 
 ### Agent management

--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -1086,14 +1086,14 @@ Retrieve a paginated, filterable audit log. **Admin only.**
 
 **Query parameters:**
 
-| Parameter   | Type   | Default | Description                                             |
-| ----------- | ------ | ------- | ------------------------------------------------------- |
-| `page`      | number | 1       | Page number                                             |
-| `limit`     | number | 50      | Entries per page                                        |
+| Parameter   | Type   | Default | Description                                                   |
+| ----------- | ------ | ------- | ------------------------------------------------------------- |
+| `page`      | number | 1       | Page number                                                   |
+| `limit`     | number | 50      | Entries per page                                              |
 | `eventType` | string | —       | Filter by event type (e.g., `auth.login`, `tool.pinchy_read`) |
-| `actorId`   | string | —       | Filter by user ID                                       |
-| `from`      | string | —       | Start date (ISO 8601)                                   |
-| `to`        | string | —       | End date (ISO 8601)                                     |
+| `actorId`   | string | —       | Filter by user ID                                             |
+| `from`      | string | —       | Start date (ISO 8601)                                         |
+| `to`        | string | —       | End date (ISO 8601)                                           |
 
 **Response:**
 


### PR DESCRIPTION
## Why

The docs commit `8f089c78` ("docs: fix audit-found truth...") edited `concepts/audit-trail.mdx` and `reference/api.mdx` but left their markdown tables unformatted. The CI step **Format check (docs & workflows)** runs `prettier --check` (via `packages/web`'s prettier — `docs/` has no prettier of its own) over `docs/src/**/*.{mdx,md}`, so it now fails on **every open PR**.

`main` is **stale-green**: its last CI run was for the prior commit (51325a06), before `8f089c78` landed — so the breakage isn't visible on main's status but reproduces on any new run.

## Change

Pure `prettier --write` on the two affected files (markdown table column-width normalization). No content change.

Verified: `pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"` → "All matched files use Prettier code style!".

Unblocks PR #509 (refactor) and #520 (flaky usage-tracking fix), which both fail this pre-existing check; they just need a rebase once this lands.