### PR TITLE
ci(links): exclude star-history.com from lychee (403 blocks every PR)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1965,7 +1965,7 @@ jobs:
           # --accept treats transient server responses (rate-limit + 5xx, e.g.
           # GitHub returning a 504 during a brief outage) as OK so they don't
           # red-light unrelated PRs. Genuinely broken links (404/410) still fail.
-          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org'"
+          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org' --exclude 'star-history\\.com'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Why

The `Check links` (lychee) job fails on **every** PR that re-runs it:

```
### Errors in README.md
* [403] https://api.star-history.com/svg?repos=heypinchy/pinchy&type=Date | Rejected status code: 403 Forbidden
```

The README star-history chart badge (added in `6f32fe0b`, marketing overhaul) is a **dynamic external SVG badge** that returns **403 Forbidden** to lychee's bot user-agent. It's not a navigable link, and the lychee `--accept` range only covers 2xx/429/5xx. `main` is stale-green — its last link check predates the README change.

## Change

Add `star-history.com` to lychee's `--exclude` list, exactly like the other bot-blocking / rate-limiting external hosts already excluded (`linkedin.com`, `sonner.emilkowal.dev`, `squawkhq.com`, `contributor-covenant.org`). One-line CI-config change; no link coverage lost for navigable docs links.

Unblocks the `Check links` check on all open PRs (incl. #520, #509).