### PR TITLE
feat(odoo): governed record-action method tools (confirm / validate / approve …)

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -477,6 +477,9 @@ function getDefaultRecords() {
 let store = new Map(Object.entries(getDefaultRecords()));
 let nextIds = new Map(); // per-model auto-increment counters
 let accessRights = {}; // { "sale.order": { read: true, create: false, ... } }
+// Override results for generic record-action method calls, keyed by
+// "<model>.<method>" — used to simulate Odoo returning a wizard action.
+let methodResponses = {};
 
 function resetNextIds() {
   nextIds = new Map();
@@ -864,6 +867,20 @@ function handleJsonRpc(body) {
         return true;
       }
 
+      // Generic record-action methods (action_*, button_*, and a few approval
+      // methods). In real Odoo these return `true` when they finish cleanly,
+      // or an `ir.actions.act_window` dict when a wizard (backorder, etc.) is
+      // needed. Default to `true`; a test can override the result per
+      // (model, method) via POST /control/method-response to simulate a wizard.
+      if (
+        /^(action_|button_)/.test(objMethod) ||
+        objMethod === "approve_expense_sheets" ||
+        objMethod === "refuse_sheet"
+      ) {
+        const key = `${model}.${objMethod}`;
+        return key in methodResponses ? methodResponses[key] : true;
+      }
+
       return false;
     }
   }
@@ -961,11 +978,26 @@ const controlServer = http.createServer(async (req, res) => {
     return;
   }
 
+  // Configure a record-action method to return a wizard action (instead of
+  // the default `true`), to exercise the Variant A handoff path.
+  // Body: { model, method, response }
+  if (req.method === "POST" && path === "/control/method-response") {
+    const body = await readBody(req);
+    if (!body || !body.model || !body.method) {
+      sendJson(res, 400, { error: "Need { model, method, response }" });
+      return;
+    }
+    methodResponses[`${body.model}.${body.method}`] = body.response;
+    sendJson(res, 200, { status: "configured" });
+    return;
+  }
+
   // Reset to defaults
   if (req.method === "POST" && path === "/control/reset") {
     store = new Map(Object.entries(getDefaultRecords()));
     resetNextIds();
     accessRights = {};
+    methodResponses = {};
     authMode = "ok";
     authConfig = {
       db: "testdb",

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -152,7 +152,7 @@ Pinchy uses an **allow-list** model for agent permissions: agents have **no tool
 Tools are organized into two categories:
 
 - **Safe tools** — workspace and approved-directory read access (`pinchy_ls`, `pinchy_read`), plus opt-in web search/fetch (`pinchy_web_search`, `pinchy_web_fetch`). All paths are validated against the agent's allow-list at runtime.
-- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_schedule_activity`, `odoo_complete_activity`, `odoo_reschedule_activity`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
+- **Powerful tools** — actions that change state outside the conversation: `pinchy_write` for workspace writes, and the Odoo / email write tools (`odoo_create`, `odoo_schedule_activity`, `odoo_complete_activity`, `odoo_reschedule_activity`, `odoo_confirm_order`, `odoo_apply_inventory`, `odoo_validate_picking`, `odoo_mark_mo_done`, `odoo_set_approval`, `odoo_write`, `odoo_attach_file`, `odoo_delete`, `email_draft`, `email_send`). Pinchy does not expose a shell-execution tool or an unrestricted "read any file" tool; OpenClaw's native filesystem and shell groups are explicitly denied at config-generation time.
 
 When an agent has safe tools enabled, the `pinchy-files` plugin validates every file access request against the agent's allowed directories, with symlink resolution to prevent escapes.
 

--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -98,22 +98,27 @@ This conversion runs automatically whenever the OpenClaw config is regenerated �
 
 When you connect Odoo and grant an agent access to it, Pinchy automatically enables the appropriate tools based on the access level you choose. You don't need to enable these tools manually — they're managed through the Permissions tab.
 
-| Tool                    | Tool ID                    | What it does                                                                                      | Access level required |
-| ----------------------- | -------------------------- | ------------------------------------------------------------------------------------------------- | --------------------- |
-| **List models**         | `odoo_list_models`         | List all available Odoo models on the connection                                                  | Read-only             |
-| **Describe model**      | `odoo_describe_model`      | Discover fields and types for a specific model                                                    | Read-only             |
-| **Read data**           | `odoo_read`                | Query records with filters and field selection                                                    | Read-only             |
-| **Count records**       | `odoo_count`               | Count matching records without transferring data                                                  | Read-only             |
-| **Aggregate data**      | `odoo_aggregate`           | Server-side sums, averages, and grouping                                                          | Read-only             |
-| **Create records**      | `odoo_create`              | Create new records                                                                                | Read & Write          |
-| **Schedule activity**   | `odoo_schedule_activity`   | Schedule a follow-up activity (planned to-do) on a record so it surfaces in Odoo's activity views | Read & Write          |
-| **Complete activity**   | `odoo_complete_activity`   | Mark a scheduled activity as done — posts a completion note and clears it from the to-do list     | Read & Write          |
-| **Reschedule activity** | `odoo_reschedule_activity` | Change a scheduled activity's due date and/or assignee without closing it                         | Read & Write          |
-| **Update records**      | `odoo_write`               | Modify existing records                                                                           | Read & Write          |
-| **Attach file**         | `odoo_attach_file`         | Attach an uploaded file to an existing record as `ir.attachment`                                  | Read & Write          |
-| **Delete records**      | `odoo_delete`              | Delete records                                                                                    | Full                  |
+| Tool                      | Tool ID                    | What it does                                                                                                   | Access level required |
+| ------------------------- | -------------------------- | -------------------------------------------------------------------------------------------------------------- | --------------------- |
+| **List models**           | `odoo_list_models`         | List all available Odoo models on the connection                                                               | Read-only             |
+| **Describe model**        | `odoo_describe_model`      | Discover fields and types for a specific model                                                                 | Read-only             |
+| **Read data**             | `odoo_read`                | Query records with filters and field selection                                                                 | Read-only             |
+| **Count records**         | `odoo_count`               | Count matching records without transferring data                                                               | Read-only             |
+| **Aggregate data**        | `odoo_aggregate`           | Server-side sums, averages, and grouping                                                                       | Read-only             |
+| **Create records**        | `odoo_create`              | Create new records                                                                                             | Read & Write          |
+| **Schedule activity**     | `odoo_schedule_activity`   | Schedule a follow-up activity (planned to-do) on a record so it surfaces in Odoo's activity views              | Read & Write          |
+| **Complete activity**     | `odoo_complete_activity`   | Mark a scheduled activity as done — posts a completion note and clears it from the to-do list                  | Read & Write          |
+| **Reschedule activity**   | `odoo_reschedule_activity` | Change a scheduled activity's due date and/or assignee without closing it                                      | Read & Write          |
+| **Confirm sale order**    | `odoo_confirm_order`       | Confirm a quotation (Odoo's `action_confirm` — creates deliveries/procurement; not a raw state write)          | Read & Write          |
+| **Apply inventory count** | `odoo_apply_inventory`     | Post a counted inventory adjustment on a `stock.quant` (`action_apply_inventory`)                              | Read & Write          |
+| **Validate picking**      | `odoo_validate_picking`    | Validate a stock transfer (`button_validate`); hands off if Odoo needs a backorder decision                    | Read & Write          |
+| **Mark MO done**          | `odoo_mark_mo_done`        | Mark a manufacturing order done (`button_mark_done`); hands off if Odoo needs a backorder/consumption decision | Read & Write          |
+| **Set approval decision** | `odoo_set_approval`        | Approve/refuse an expense report, purchase order, leave request, or approval request via its blessed method    | Read & Write          |
+| **Update records**        | `odoo_write`               | Modify existing records                                                                                        | Read & Write          |
+| **Attach file**           | `odoo_attach_file`         | Attach an uploaded file to an existing record as `ir.attachment`                                               | Read & Write          |
+| **Delete records**        | `odoo_delete`              | Delete records                                                                                                 | Full                  |
 
-For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, the three activity tools (schedule / complete / reschedule), write, and attach-file. "Full" adds delete.
+For example, setting an agent to "Read-only" enables the five read-shaped tools. "Read & Write" adds create, the three activity tools (schedule / complete / reschedule), the governed action tools (confirm order, apply inventory, validate picking, mark MO done, set approval), write, and attach-file. "Full" adds delete.
 
 :::note[Cross-company write protection]
 For multi-company Odoo databases, the `pinchy-odoo` plugin refuses to write a record whose embedded `_pinchy_ref` company tag disagrees with the company implied by the relation chain (top-level field only). This prevents a class of silent cross-company mistakes — for example, applying a Company A fiscal position to a partner that lives under Company B. See [Connect Odoo → Multi-company databases](/guides/connect-odoo/#multi-company-databases) for the full story.

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -525,3 +525,88 @@ describe("pinchy-odoo mail.activity scheduling against real mock-odoo", () => {
     expect(updated!.user_id).toBe(2);
   });
 });
+
+describe("pinchy-odoo record-action tools against real mock-odoo", () => {
+  const actionAgentId = "agent-actions";
+  const actionConnectionId = "conn-actions";
+  const actionConfig = {
+    connectionId: actionConnectionId,
+    permissions: {
+      "sale.order": ["read", "write"],
+      "stock.picking": ["read", "write"],
+      "hr.expense.sheet": ["read", "write"],
+    },
+  };
+
+  beforeAll(async () => {
+    await fetch(`http://127.0.0.1:${mockOdoo.controlPort}/control/reset`, {
+      method: "POST",
+    });
+    credentialsByConnectionId.set(actionConnectionId, {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  function ref(model: string, id: number): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: actionConnectionId,
+      model,
+      id,
+      label: model,
+    });
+  }
+
+  it("odoo_confirm_order calls action_confirm and reports completed", async () => {
+    const tools = createApi({ [actionAgentId]: actionConfig });
+    const tool = findTool(tools, "odoo_confirm_order", actionAgentId);
+    const result = await tool.execute("c-confirm", {
+      target: ref("sale.order", 1),
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0].text).completed).toBe(true);
+  });
+
+  it("odoo_validate_picking hands off (Variant A) when Odoo returns a backorder wizard", async () => {
+    await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/method-response`,
+      {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({
+          model: "stock.picking",
+          method: "button_validate",
+          response: {
+            type: "ir.actions.act_window",
+            res_model: "stock.backorder.confirmation",
+          },
+        }),
+      },
+    );
+    const tools = createApi({ [actionAgentId]: actionConfig });
+    const tool = findTool(tools, "odoo_validate_picking", actionAgentId);
+    const result = await tool.execute("c-validate", {
+      target: ref("stock.picking", 5),
+    });
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    expect(data.completed).toBe(false);
+    expect(data.needsHuman).toBe(true);
+    expect(data.pendingStep).toBe("stock.backorder.confirmation");
+  });
+
+  it("odoo_set_approval refuses an expense sheet end-to-end", async () => {
+    const tools = createApi({ [actionAgentId]: actionConfig });
+    const tool = findTool(tools, "odoo_set_approval", actionAgentId);
+    const result = await tool.execute("c-refuse", {
+      target: ref("hr.expense.sheet", 9),
+      decision: "refuse",
+      reason: "Over budget",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(JSON.parse(result.content[0].text).completed).toBe(true);
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -907,9 +907,9 @@ describe("odoo_list_models", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 13 tools (including the deprecated odoo_schema alias)", () => {
+  it("registers all 18 tools (including the deprecated odoo_schema alias)", () => {
     const tools = createApi({ [agentId]: agentConfig });
-    expect(tools).toHaveLength(13);
+    expect(tools).toHaveLength(18);
     const names = tools.map((t) => t.name);
     expect(names).toContain("odoo_list_models");
     expect(names).toContain("odoo_describe_model");
@@ -921,6 +921,11 @@ describe("tool registration", () => {
     expect(names).toContain("odoo_schedule_activity");
     expect(names).toContain("odoo_complete_activity");
     expect(names).toContain("odoo_reschedule_activity");
+    expect(names).toContain("odoo_confirm_order");
+    expect(names).toContain("odoo_apply_inventory");
+    expect(names).toContain("odoo_validate_picking");
+    expect(names).toContain("odoo_mark_mo_done");
+    expect(names).toContain("odoo_set_approval");
     expect(names).toContain("odoo_write");
     expect(names).toContain("odoo_delete");
     expect(names).toContain("odoo_attach_file");
@@ -3852,5 +3857,234 @@ describe("odoo_reschedule_activity", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("Permission denied");
     expect(mockWrite).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo record-action tools (confirm / apply / validate / mark-done)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const RECORD_ACTIONS = [
+    {
+      tool: "odoo_confirm_order",
+      model: "sale.order",
+      method: "action_confirm",
+    },
+    {
+      tool: "odoo_apply_inventory",
+      model: "stock.quant",
+      method: "action_apply_inventory",
+    },
+    {
+      tool: "odoo_validate_picking",
+      model: "stock.picking",
+      method: "button_validate",
+    },
+    {
+      tool: "odoo_mark_mo_done",
+      model: "mrp.production",
+      method: "button_mark_done",
+    },
+  ] as const;
+
+  function ref(model: string): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model,
+      id: 7,
+      label: "x",
+    });
+  }
+
+  for (const { tool, model, method } of RECORD_ACTIONS) {
+    describe(tool, () => {
+      const cfg = {
+        connectionId: "conn-test-1",
+        permissions: { [model]: ["read", "write"] },
+      };
+
+      it("is registered", () => {
+        expect(createApi({ [agentId]: cfg }).map((t) => t.name)).toContain(
+          tool,
+        );
+      });
+
+      it(`calls ${method} and reports completed`, async () => {
+        mockCallMethod.mockResolvedValue(true);
+        const t = findTool(createApi({ [agentId]: cfg }), tool, agentId)!;
+        const result = await t.execute("c", { target: ref(model) });
+        expect(result.isError).toBeFalsy();
+        expect(mockCallMethod).toHaveBeenCalledWith(model, method, [[7]], {});
+        expect(JSON.parse(result.content[0].text).completed).toBe(true);
+      });
+
+      it("hands off (does not claim success) on a wizard action", async () => {
+        mockCallMethod.mockResolvedValue({
+          type: "ir.actions.act_window",
+          res_model: "stock.backorder.confirmation",
+        });
+        const t = findTool(createApi({ [agentId]: cfg }), tool, agentId)!;
+        const result = await t.execute("c", { target: ref(model) });
+        expect(result.isError).toBeFalsy();
+        const data = JSON.parse(result.content[0].text);
+        expect(data.completed).toBe(false);
+        expect(data.needsHuman).toBe(true);
+        expect(data.pendingStep).toBe("stock.backorder.confirmation");
+      });
+
+      it("requires write permission", async () => {
+        const t = findTool(
+          createApi({
+            [agentId]: {
+              connectionId: "conn-test-1",
+              permissions: { [model]: ["read"] },
+            },
+          }),
+          tool,
+          agentId,
+        )!;
+        const result = await t.execute("c", { target: ref(model) });
+        expect(result.isError).toBe(true);
+        expect(result.content[0].text).toContain("Permission denied");
+        expect(mockCallMethod).not.toHaveBeenCalled();
+      });
+
+      it("rejects a ref for the wrong model", async () => {
+        const t = findTool(createApi({ [agentId]: cfg }), tool, agentId)!;
+        const result = await t.execute("c", { target: ref("res.partner") });
+        expect(result.isError).toBe(true);
+        expect(mockCallMethod).not.toHaveBeenCalled();
+      });
+    });
+  }
+});
+
+describe("odoo_set_approval", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  function ref(model: string): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model,
+      id: 3,
+      label: "x",
+    });
+  }
+
+  it("approves a purchase order via button_confirm", async () => {
+    mockCallMethod.mockResolvedValue(true);
+    const t = findTool(
+      createApi({
+        [agentId]: {
+          connectionId: "conn-test-1",
+          permissions: { "purchase.order": ["read", "write"] },
+        },
+      }),
+      "odoo_set_approval",
+      agentId,
+    )!;
+    const result = await t.execute("c", {
+      target: ref("purchase.order"),
+      decision: "approve",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCallMethod).toHaveBeenCalledWith(
+      "purchase.order",
+      "button_confirm",
+      [[3]],
+      {},
+    );
+  });
+
+  it("refuses an expense sheet via refuse_sheet with the reason as a positional arg", async () => {
+    mockCallMethod.mockResolvedValue(true);
+    const t = findTool(
+      createApi({
+        [agentId]: {
+          connectionId: "conn-test-1",
+          permissions: { "hr.expense.sheet": ["read", "write"] },
+        },
+      }),
+      "odoo_set_approval",
+      agentId,
+    )!;
+    const result = await t.execute("c", {
+      target: ref("hr.expense.sheet"),
+      decision: "refuse",
+      reason: "Over budget",
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCallMethod).toHaveBeenCalledWith(
+      "hr.expense.sheet",
+      "refuse_sheet",
+      [[3], "Over budget"],
+      {},
+    );
+  });
+
+  it("rejects an unsupported model", async () => {
+    const t = findTool(
+      createApi({
+        [agentId]: {
+          connectionId: "conn-test-1",
+          permissions: { "sale.order": ["read", "write"] },
+        },
+      }),
+      "odoo_set_approval",
+      agentId,
+    )!;
+    const result = await t.execute("c", {
+      target: ref("sale.order"),
+      decision: "approve",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/not an approvable model/);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("rejects an invalid decision", async () => {
+    const t = findTool(
+      createApi({
+        [agentId]: {
+          connectionId: "conn-test-1",
+          permissions: { "purchase.order": ["read", "write"] },
+        },
+      }),
+      "odoo_set_approval",
+      agentId,
+    )!;
+    const result = await t.execute("c", {
+      target: ref("purchase.order"),
+      decision: "maybe",
+    });
+    expect(result.isError).toBe(true);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("requires write permission on the target model", async () => {
+    const t = findTool(
+      createApi({
+        [agentId]: {
+          connectionId: "conn-test-1",
+          permissions: { "purchase.order": ["read"] },
+        },
+      }),
+      "odoo_set_approval",
+      agentId,
+    )!;
+    const result = await t.execute("c", {
+      target: ref("purchase.order"),
+      decision: "approve",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCallMethod).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1085,6 +1085,48 @@ async function ensureActivityResModelId(
 }
 
 /**
+ * Variant A wizard handling for record-action tools. Odoo button/action
+ * methods (e.g. `stock.picking.button_validate`, `mrp.production.button_mark_done`)
+ * return `True` when they finish cleanly, but return an `ir.actions.act_window`
+ * dict when Odoo needs a human decision first — a backorder, an
+ * immediate-transfer confirmation, a consumption warning. We never claim the
+ * operation succeeded in that case; we surface the pending wizard's model so
+ * the caller can tell the user to finish it in Odoo. Returns the wizard's
+ * `res_model` (or a generic label) when the result is such an action, else null.
+ */
+export function describePendingWizard(result: unknown): string | null {
+  if (!isRecord(result)) return null;
+  const type = result.type;
+  if (typeof type === "string" && type.startsWith("ir.actions")) {
+    return typeof result.res_model === "string" && result.res_model.length > 0
+      ? result.res_model
+      : "a follow-up confirmation step";
+  }
+  return null;
+}
+
+/**
+ * Allow-list of approval-style state transitions reachable through
+ * `odoo_set_approval`. Each model maps a decision to the exact Odoo method.
+ * This IS the governance surface — only these blessed (model, method) pairs are
+ * callable, never an arbitrary method. `reasonPositional` methods take the
+ * refusal reason as the first method argument after the recordset ids.
+ */
+export const APPROVAL_ROUTES: Record<
+  string,
+  { approve: string; refuse: string; reasonPositional?: boolean }
+> = {
+  "hr.expense.sheet": {
+    approve: "approve_expense_sheets",
+    refuse: "refuse_sheet",
+    reasonPositional: true,
+  },
+  "purchase.order": { approve: "button_confirm", refuse: "button_cancel" },
+  "hr.leave": { approve: "action_approve", refuse: "action_refuse" },
+  "approval.request": { approve: "action_approve", refuse: "action_refuse" },
+};
+
+/**
  * Pull a human-readable company name out of a raw Odoo `company_id` value.
  * Odoo returns m2o values as `[id, "display_name"]` tuples (before we wrap
  * them) or `false` for single-company tenants. Returns `null` for any other
@@ -2329,6 +2371,287 @@ const plugin = {
         };
       },
       { name: "odoo_reschedule_activity" },
+    );
+
+    // 5e–5h. Governed record-action tools. Each invokes one allow-listed Odoo
+    // button/action method via callMethod. Variant A: if Odoo returns a wizard
+    // action instead of completing, we report a handoff rather than faking
+    // success.
+    function recordActionFactory(spec: {
+      name: string;
+      label: string;
+      description: string;
+      model: string;
+      method: string;
+    }) {
+      return (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: spec.name,
+          label: spec.label,
+          description: spec.description,
+          parameters: {
+            type: "object",
+            properties: {
+              target: {
+                type: "string",
+                description: `Opaque \`_pinchy_ref\` of the ${spec.model} record (from odoo_read or odoo_create).`,
+              },
+            },
+            required: ["target"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const target = params.target;
+              if (typeof target !== "string" || target.length === 0) {
+                return errorResult(
+                  new Error(
+                    `\`target\` is required: pass the _pinchy_ref of the ${spec.model} record.`,
+                  ),
+                );
+              }
+              const decoded = decodeRef(target);
+              if (
+                decoded.integrationType !== "odoo" ||
+                decoded.connectionId !== config.connectionId
+              ) {
+                return errorResult(
+                  new Error(
+                    "`target` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              if (decoded.model !== spec.model) {
+                return errorResult(
+                  new Error(`\`target\` must be a ${spec.model} ref.`),
+                );
+              }
+              if (!checkPermission(config.permissions, spec.model, "write")) {
+                return permissionDenied("write", spec.model);
+              }
+
+              const result = await withAuthRetry(agentId, config, (client) =>
+                client.callMethod(spec.model, spec.method, [[decoded.id]], {}),
+              );
+
+              const pending = describePendingWizard(result);
+              if (pending) {
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        completed: false,
+                        needsHuman: true,
+                        pendingStep: pending,
+                        message: `Odoo could not finish this automatically — it needs a human decision in the "${pending}" step (e.g. a backorder, immediate-transfer, or consumption confirmation). Ask the user to complete it in Odoo.`,
+                      }),
+                    },
+                  ],
+                };
+              }
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({ completed: true, id: decoded.id }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, {
+                operation: "write",
+                model: spec.model,
+              });
+            }
+          },
+        };
+      };
+    }
+
+    api.registerTool(
+      recordActionFactory({
+        name: "odoo_confirm_order",
+        label: "Odoo Confirm Sale Order",
+        description:
+          "Confirm a draft/sent quotation into a sales order via Odoo's `action_confirm` — the only correct way to confirm an order (it creates the deliveries and procurement). Do NOT confirm by writing `state` directly; that skips those side effects. Pass the sale.order `_pinchy_ref`.",
+        model: "sale.order",
+        method: "action_confirm",
+      }),
+      { name: "odoo_confirm_order" },
+    );
+
+    api.registerTool(
+      recordActionFactory({
+        name: "odoo_apply_inventory",
+        label: "Odoo Apply Inventory Count",
+        description:
+          "Apply a counted inventory adjustment on a `stock.quant` (Odoo's `action_apply_inventory`) — run this AFTER writing `inventory_quantity` on the quant, to post the adjustment into real stock. Pass the stock.quant `_pinchy_ref`.",
+        model: "stock.quant",
+        method: "action_apply_inventory",
+      }),
+      { name: "odoo_apply_inventory" },
+    );
+
+    api.registerTool(
+      recordActionFactory({
+        name: "odoo_validate_picking",
+        label: "Odoo Validate Picking",
+        description:
+          "Validate a stock transfer / picking (Odoo's `button_validate`) to post the physical move. If Odoo needs a backorder or immediate-transfer decision it will NOT auto-complete — the tool reports that so a human can finish it. Pass the stock.picking `_pinchy_ref`. Always confirm the per-line quantities with the user first.",
+        model: "stock.picking",
+        method: "button_validate",
+      }),
+      { name: "odoo_validate_picking" },
+    );
+
+    api.registerTool(
+      recordActionFactory({
+        name: "odoo_mark_mo_done",
+        label: "Odoo Mark Manufacturing Order Done",
+        description:
+          "Mark a manufacturing order done (Odoo's `button_mark_done`) to record consumption and finished goods. If Odoo needs a backorder / consumption decision it will NOT auto-complete — the tool reports that for a human to finish. Pass the mrp.production `_pinchy_ref`. Confirm quantities with the user first.",
+        model: "mrp.production",
+        method: "button_mark_done",
+      }),
+      { name: "odoo_mark_mo_done" },
+    );
+
+    // 5i. odoo_set_approval (parameterized over an allow-list of approval models)
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_set_approval",
+          label: "Odoo Set Approval Decision",
+          description:
+            'Approve or refuse an approval-style record (expense report, purchase order, leave request, or generic approval) via its blessed Odoo method — never by writing `state` directly. Pass the record\'s `_pinchy_ref`, a `decision` ("approve" or "refuse"), and an optional `reason` (recorded on refusal where supported, e.g. expense reports). Supported models: hr.expense.sheet, purchase.order, hr.leave, approval.request.',
+          parameters: {
+            type: "object",
+            properties: {
+              target: {
+                type: "string",
+                description:
+                  "Opaque `_pinchy_ref` of the record to approve or refuse.",
+              },
+              decision: {
+                type: "string",
+                enum: ["approve", "refuse"],
+                description: '"approve" or "refuse".',
+              },
+              reason: {
+                type: "string",
+                description:
+                  "Optional reason, recorded on refusal where the model supports it (e.g. expense reports).",
+              },
+            },
+            required: ["target", "decision"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const target = params.target;
+              if (typeof target !== "string" || target.length === 0) {
+                return errorResult(
+                  new Error(
+                    "`target` is required: pass the _pinchy_ref of the record.",
+                  ),
+                );
+              }
+              const decision: "approve" | "refuse" | null =
+                params.decision === "approve"
+                  ? "approve"
+                  : params.decision === "refuse"
+                    ? "refuse"
+                    : null;
+              if (!decision) {
+                return errorResult(
+                  new Error('`decision` must be "approve" or "refuse".'),
+                );
+              }
+              const decoded = decodeRef(target);
+              if (
+                decoded.integrationType !== "odoo" ||
+                decoded.connectionId !== config.connectionId
+              ) {
+                return errorResult(
+                  new Error(
+                    "`target` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              const route = APPROVAL_ROUTES[decoded.model];
+              if (!route) {
+                return errorResult(
+                  new Error(
+                    `${decoded.model} is not an approvable model. Supported: ${Object.keys(
+                      APPROVAL_ROUTES,
+                    ).join(", ")}.`,
+                  ),
+                );
+              }
+              if (
+                !checkPermission(config.permissions, decoded.model, "write")
+              ) {
+                return permissionDenied("write", decoded.model);
+              }
+
+              const method = route[decision];
+              const reason =
+                typeof params.reason === "string" ? params.reason.trim() : "";
+              const args: unknown[] =
+                decision === "refuse" && route.reasonPositional
+                  ? [[decoded.id], reason || "Refused"]
+                  : [[decoded.id]];
+
+              const result = await withAuthRetry(agentId, config, (client) =>
+                client.callMethod(decoded.model, method, args, {}),
+              );
+
+              const pending = describePendingWizard(result);
+              if (pending) {
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        completed: false,
+                        needsHuman: true,
+                        pendingStep: pending,
+                        message: `Odoo opened a follow-up step ("${pending}") that needs a human decision — ask the user to complete it in Odoo.`,
+                      }),
+                    },
+                  ],
+                };
+              }
+              return {
+                content: [
+                  {
+                    type: "text",
+                    text: JSON.stringify({
+                      completed: true,
+                      id: decoded.id,
+                      decision,
+                    }),
+                  },
+                ],
+              };
+            } catch (error) {
+              return errorResult(error, { operation: "write" });
+            }
+          },
+        };
+      },
+      { name: "odoo_set_approval" },
     );
 
     // 6. odoo_write

--- a/packages/plugins/pinchy-odoo/openclaw.plugin.json
+++ b/packages/plugins/pinchy-odoo/openclaw.plugin.json
@@ -14,6 +14,11 @@
       "odoo_schedule_activity",
       "odoo_complete_activity",
       "odoo_reschedule_activity",
+      "odoo_confirm_order",
+      "odoo_apply_inventory",
+      "odoo_validate_picking",
+      "odoo_mark_mo_done",
+      "odoo_set_approval",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file"

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -37,7 +37,7 @@ describe("TOOL_REGISTRY", () => {
 
   it("contains powerful tools", () => {
     const powerful = TOOL_REGISTRY.filter((t) => t.category === "powerful");
-    expect(powerful.length).toBe(12);
+    expect(powerful.length).toBe(17);
     expect(powerful.map((t) => t.id)).toEqual([
       "pinchy_web_search",
       "pinchy_web_fetch",
@@ -45,6 +45,11 @@ describe("TOOL_REGISTRY", () => {
       "odoo_schedule_activity",
       "odoo_complete_activity",
       "odoo_reschedule_activity",
+      "odoo_confirm_order",
+      "odoo_apply_inventory",
+      "odoo_validate_picking",
+      "odoo_mark_mo_done",
+      "odoo_set_approval",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file",
@@ -163,8 +168,8 @@ describe("computeDeniedGroups", () => {
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));
-    // 12 active tools + 1 deprecated alias (odoo_schema) = 13.
-    expect(odooTools.length).toBe(13);
+    // 17 active tools + 1 deprecated alias (odoo_schema) = 18.
+    expect(odooTools.length).toBe(18);
     for (const tool of odooTools) {
       expect(tool.integration).toBe("odoo");
     }
@@ -226,7 +231,7 @@ describe("Odoo access level helpers", () => {
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('read-write') returns 11 tools", () => {
+  it("getOdooToolsForAccessLevel('read-write') returns 16 tools", () => {
     const tools = getOdooToolsForAccessLevel("read-write");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -238,12 +243,17 @@ describe("Odoo access level helpers", () => {
       "odoo_schedule_activity",
       "odoo_complete_activity",
       "odoo_reschedule_activity",
+      "odoo_confirm_order",
+      "odoo_apply_inventory",
+      "odoo_validate_picking",
+      "odoo_mark_mo_done",
+      "odoo_set_approval",
       "odoo_write",
       "odoo_attach_file",
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('full') returns all 12 tools", () => {
+  it("getOdooToolsForAccessLevel('full') returns all 17 tools", () => {
     const tools = getOdooToolsForAccessLevel("full");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -255,6 +265,11 @@ describe("Odoo access level helpers", () => {
       "odoo_schedule_activity",
       "odoo_complete_activity",
       "odoo_reschedule_activity",
+      "odoo_confirm_order",
+      "odoo_apply_inventory",
+      "odoo_validate_picking",
+      "odoo_mark_mo_done",
+      "odoo_set_approval",
       "odoo_write",
       "odoo_attach_file",
       "odoo_delete",
@@ -266,9 +281,9 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_list_models", "odoo_describe_model"]);
   });
 
-  it("getOdooTools() returns exactly 13 tools (12 active + 1 deprecated alias)", () => {
+  it("getOdooTools() returns exactly 18 tools (17 active + 1 deprecated alias)", () => {
     const tools = getOdooTools();
-    expect(tools).toHaveLength(13);
+    expect(tools).toHaveLength(18);
     expect(tools.every((t) => t.integration === "odoo")).toBe(true);
   });
 

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -159,13 +159,13 @@ ${ODOO_QUERY_INSTRUCTIONS}
 Stock data is physical. A wrong validate or wrong adjustment shows up in the warehouse the next morning.
 
 ### 1. Validate is irreversible — always confirm first
-Calling \`odoo_write\` with \`state="done"\` on a \`stock.picking\` consumes the planned moves, decrements source stock, increments destination stock, and triggers downstream automation (invoicing, MRP, accounting). Before validating, show the user the lines (product, qty, source → destination) and ask "Validate?". Only on yes do you proceed.
+Validate a transfer with \`odoo_validate_picking\` (the picking's \`_pinchy_ref\`) — that runs Odoo's \`button_validate\`, which consumes the planned moves, decrements source stock, increments destination stock, and triggers downstream automation (invoicing, MRP, accounting). Writing \`state\` by hand does **not** process the transfer. Before validating, show the user the lines (product, qty, source → destination) and ask "Validate?". Only on yes do you proceed. If Odoo needs a backorder or immediate-transfer decision the tool reports that instead of completing — relay it to the user rather than retrying.
 
 ### 2. Don't create pickings without an origin
 When you receive a delivery from a supplier, the picking should normally already exist (linked to a PO via \`origin\`). If you cannot find one, stop and ask the user — creating a free-standing \`stock.picking\` bypasses purchasing and accounting linkages.
 
 ### 3. Quants are managed by moves, not by hand
-\`stock.quant\` cannot be created freely; quants exist because moves landed them. To correct an on-hand quantity, use the inventory adjustment flow: \`odoo_write\` on \`stock.quant\` to set \`inventory_quantity\`, then trigger the apply step. Always confirm the delta with the user before applying.
+\`stock.quant\` cannot be created freely; quants exist because moves landed them. To correct an on-hand quantity, use the inventory adjustment flow: \`odoo_write\` on \`stock.quant\` to set \`inventory_quantity\`, then \`odoo_apply_inventory\` on the quant to post it. Always confirm the delta with the user before applying.
 
 ### 4. Duplicate-check before creating a transfer
 \`odoo_read\` on \`stock.picking\` filtered by \`partner_id\`, \`scheduled_date\`, \`picking_type_id\` before creating a new one. Duplicate transfers double-count goods on the floor.
@@ -183,7 +183,7 @@ If only some lines on a picking are ready, leave the picking open. Only validate
 2. If multiple match, ask the user which PO.
 3. For each line on the delivery note, find the matching \`stock.move.line\` (by product) and \`odoo_write\` the actually-received \`quantity\`. If quantities differ from the planned, flag it.
 4. Summarise lines + quantities to the user and ask: "Validate this receipt?"
-5. On confirmation, validate the picking.
+5. On confirmation, validate the picking with \`odoo_validate_picking\`.
 
 ### Internal transfer between locations
 1. \`odoo_read\` on \`stock.location\` to get source + destination IDs.
@@ -193,7 +193,7 @@ If only some lines on a picking are ready, leave the picking open. Only validate
 ### Inventory adjustment after a count
 1. \`odoo_read\` on \`stock.quant\` with \`filters: [["location_id", "=", LOCATION_ID], ["product_id", "in", PRODUCT_IDS]]\` to fetch current on-hand.
 2. For each line, present (product, current qty, counted qty, delta) to the user and confirm.
-3. \`odoo_write\` on each \`stock.quant\` to set \`inventory_quantity\` to the counted value. Trigger the apply step (verify the exact method via \`odoo_describe_model\` if unsure).
+3. \`odoo_write\` on each \`stock.quant\` to set \`inventory_quantity\` to the counted value, then \`odoo_apply_inventory\` on each quant to post the adjustment.
 
 ${ODOO_OUTPUT_FORMATTING}
 
@@ -447,7 +447,7 @@ You manage the sales pipeline — tracking leads, following up on opportunities,
 - **Create** leads, contacts, sales orders + lines, messages, and activities
 - **Update** lead stages, contact info (including the customer's fiscal position), order details, quotation lines, and activity status
 - **Never** draft, post, or amend invoices (\`account.move\`) — that's the Bookkeeper agent's job
-- You may **confirm** a sale order (\`state\` → "sale"), but never trigger the downstream "Create Invoice" action (Odoo method \`_create_invoices\`). If a customer needs an invoice, hand off to the Bookkeeper agent
+- You may **confirm** a sale order with \`odoo_confirm_order\` (the order's \`_pinchy_ref\`) — this runs Odoo's \`action_confirm\`, which creates the deliveries and procurement. Do **not** "confirm" by writing \`state\` directly; that skips those side effects and leaves a broken order. Never trigger the downstream "Create Invoice" action (Odoo method \`_create_invoices\`); if a customer needs an invoice, hand off to the Bookkeeper agent
 
 ${ODOO_QUERY_INSTRUCTIONS}
 
@@ -1058,11 +1058,11 @@ If a component is short (\`stock.quant.available_quantity\` < BOM-required), sur
 2. If \`qty_producing\` differs from \`product_qty\`, ask the user about backorder/scrap.
 3. For lot/serial products, ensure \`stock.move.line.lot_id\` is set on the finished-good move.
 4. Summarise the consumption + finished good to the user.
-5. On confirmation, call the appropriate done method (verify via \`odoo_describe_model\`).
+5. On confirmation, \`odoo_mark_mo_done\` with the MO's \`_pinchy_ref\` (runs Odoo's \`button_mark_done\`). If Odoo needs a backorder/consumption decision the tool reports that instead of completing — relay it to the user rather than retrying.
 
 ### Report scrap during production
 1. Verify the user's intent and product/qty.
-2. Use the scrap-creation flow (verify the exact model + method via \`odoo_describe_model\` — typically \`stock.scrap\` if available; if not granted in this template, hand off via \`odoo_schedule_activity\`).
+2. Finalizing scrap is **not** an agent tool (it needs Odoo's scrap-validation step). Summarise the scrap (product, qty, reason) for the user and hand off — schedule a follow-up for the warehouse/quality owner with \`odoo_schedule_activity\`.
 
 ${ODOO_OUTPUT_FORMATTING}
 
@@ -1430,11 +1430,8 @@ Apply the user's policies to the record:
 ### 3. Confirm with the user
 Show the user: requester, amount/dates, category, policy decision, recommended action. Wait for an unambiguous yes.
 
-### 4. Write the state transition + log a rationale
-- For \`hr.expense.sheet\`: \`odoo_write\` to set \`state="approve"\` (approve) or call the refuse method (verify via \`odoo_describe_model\`).
-- For \`hr.leave\`: \`odoo_write\` to set \`state="validate"\` (approve) or \`"refuse"\`.
-- For \`purchase.order\`: \`odoo_write\` to set \`state="purchase"\` (confirm), or call \`button_cancel\` (verify via \`odoo_describe_model\`).
-- For \`approval.request\`: set \`request_status="approved"\` or \`"refused"\`.
+### 4. Record the decision + log a rationale
+Use \`odoo_set_approval\` with the record's \`_pinchy_ref\` and \`decision: "approve"\` or \`"refuse"\` (add a \`reason\` on refusal where supported, e.g. expense reports). It calls the correct Odoo method per model — \`hr.expense.sheet\`, \`hr.leave\`, \`purchase.order\`, \`approval.request\` — instead of a raw \`state\` write, so the proper downstream side effects fire. If Odoo opens a follow-up step, the tool reports it for you to hand off rather than faking success.
 
 Always pair the state change with a \`mail.message\` recording the rationale ("Approved per <policy reference>" or "Refused: missing receipt, see expense policy §4"). Approvals without rationale create audit headaches downstream.
 

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -116,6 +116,45 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     integration: "odoo",
   },
   {
+    id: "odoo_confirm_order",
+    label: "Odoo: Confirm sale order",
+    description:
+      "Confirm a quotation into a sales order (action_confirm — creates deliveries/procurement)",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
+    id: "odoo_apply_inventory",
+    label: "Odoo: Apply inventory count",
+    description: "Post a counted inventory adjustment on a stock.quant (action_apply_inventory)",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
+    id: "odoo_validate_picking",
+    label: "Odoo: Validate picking",
+    description:
+      "Validate a stock transfer (button_validate); reports a handoff if Odoo needs a backorder decision",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
+    id: "odoo_mark_mo_done",
+    label: "Odoo: Mark MO done",
+    description:
+      "Mark a manufacturing order done (button_mark_done); reports a handoff if Odoo needs a backorder/consumption decision",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
+    id: "odoo_set_approval",
+    label: "Odoo: Set approval decision",
+    description:
+      "Approve or refuse an expense report, purchase order, leave request, or approval request via its blessed method",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
     id: "odoo_write",
     label: "Odoo: Update records",
     description: "Modify existing records in Odoo",
@@ -259,6 +298,11 @@ const ODOO_WRITE_TOOLS = [
   "odoo_schedule_activity",
   "odoo_complete_activity",
   "odoo_reschedule_activity",
+  "odoo_confirm_order",
+  "odoo_apply_inventory",
+  "odoo_validate_picking",
+  "odoo_mark_mo_done",
+  "odoo_set_approval",
   "odoo_write",
   "odoo_attach_file",
 ] as const;
@@ -273,6 +317,11 @@ const ODOO_ADDITIVE_TOOLS = new Set<string>([
   "odoo_schedule_activity",
   "odoo_complete_activity",
   "odoo_reschedule_activity",
+  "odoo_confirm_order",
+  "odoo_apply_inventory",
+  "odoo_validate_picking",
+  "odoo_mark_mo_done",
+  "odoo_set_approval",
 ]);
 
 /** Returns all Odoo tool definitions from the registry. */


### PR DESCRIPTION
Part 2 of the Odoo template audit follow-up (part 1 = #523). **Stacks on #523** — it contains #523's commit too; once #523 merges I'll rebase so only this commit remains.

## The problem (same class as the mail.activity bug)

Several operator templates told the agent to "call a method" that **no tool exposed** — confirm a sale order, apply an inventory count, validate a picking, mark an MO done, approve/refuse a request. The agent could only fail, hallucinate, or fake it. Worse, some templates told it to fake these by **writing `state` directly** (`state="sale"`, `state="done"`, `state="approve"`), which skips Odoo's `action_confirm` / `button_validate` / approval side effects and leaves **broken records** (no deliveries, no stock moves). The audit (#523 description) flagged this; this PR fixes it now that `odoo-node` has `callMethod`.

## Five named, governed, audited tools — never a generic `execute_kw`

| Tool | Method | Gate |
|---|---|---|
| `odoo_confirm_order` | `sale.order.action_confirm` | `write:sale.order` |
| `odoo_apply_inventory` | `stock.quant.action_apply_inventory` | `write:stock.quant` |
| `odoo_validate_picking` | `stock.picking.button_validate` | `write:stock.picking` |
| `odoo_mark_mo_done` | `mrp.production.button_mark_done` | `write:mrp.production` |
| `odoo_set_approval` | expense / PO / leave / approval, decision-routed | `write:<model>` |

`odoo_set_approval`'s model→method allow-list **is** the governance surface — only blessed `(model, method)` pairs are callable.

## Variant A: never fake success on a wizard

`button_validate` / `button_mark_done` (and others) return an `ir.actions.act_window` dict when Odoo needs a human decision (backorder, immediate-transfer, consumption). The tools detect that and report a **handoff** (`completed: false, needsHuman: true, pendingStep: <wizard model>`) instead of claiming the operation finished. This is the safe, CISO-appropriate default for physical stock / manufacturing moves.

## Also

- Rewrote the five operator-template workflows (CRM confirm, warehouse apply/validate, production MO-done, approval) to use the tools and stop the dangerous `state`-write "confirmations". Scrap (no tool) is now an honest hand-off.
- `odoo-node` `callMethod` (0.3.0, already shipped) is the only primitive; governance stays in the plugin's narrow tools.
- Mock gains a generic action-method handler + `/control/method-response` override to exercise the Variant A handoff path.

## Tests

Unit (mocked) + integration (real mock, **including the Variant A handoff**) for all five tools; tool-registry counts, the manifest drift guard, and #523's template tool-ref guard updated. Full web unit suite green (6036), plugin suite (259), `tsc`, `eslint`, `prettier`, `next build`. (Local `test:db` hit a Postgres-auth env issue unrelated to this change — no DB/integration-test files touched; CI runs it against its own DB.)