### PR TITLE
feat(models): Ollama Cloud catalog update tooling + add glm-5.2, drop 5 removed

### DIFF
--- a/.claude/skills/update-ollama-cloud-models/SKILL.md
+++ b/.claude/skills/update-ollama-cloud-models/SKILL.md
@@ -1,0 +1,149 @@
+---
+name: update-ollama-cloud-models
+description: Use when a new Ollama Cloud model is announced or available (e.g. an ollama-cloud email about a new GLM/Qwen/DeepSeek/Kimi/MiniMax version), when preparing a Pinchy release, or when the curated Ollama Cloud model list may have drifted from ollama.com.
+---
+
+# Update the Ollama Cloud model list
+
+## Overview
+
+Pinchy curates the tool-capable Ollama Cloud models it surfaces in
+`packages/web/src/lib/ollama-cloud-models.ts`. This skill keeps that list
+fresh and correct when Ollama adds, removes, or resizes models.
+
+**Core principle: never trust the `ollama.com/library/<name>` capability tags.**
+They lie — `devstral-small-2` and `qwen3.5` advertise vision but hallucinate
+image contents; `gemini-3-flash-preview` advertises tools but leaks the call as
+plain text. Every `vision`/`reasoning` flag in the list is set from what the
+**live API actually does**, not from what a page claims. The whole file exists
+because the tags are unreliable. Setting a flag from a library page instead of a
+probe is the one mistake this skill is here to prevent.
+
+## When to use
+
+- An ollama-cloud email/announcement mentions a new model or version.
+- Preparing a Pinchy release (this is a pre-release checklist item — run it
+  even for tiny releases).
+- You suspect the catalog drifted (a model 404s, a tier pick feels stale).
+
+Do **not** add a model from its library page alone, ever. No key → no verified
+flags → no add (see "If you have no API key").
+
+## Prerequisite
+
+The probes hit the live API and need a key:
+
+```bash
+export OLLAMA_CLOUD_API_KEY=...   # an Ollama Pro/Max key
+```
+
+Without it every script below skips with exit 0 — useful in CI, useless for
+actually verifying. Ask the user for the key; do not guess flags to work around
+a missing key.
+
+## Source of truth and everything derived from it
+
+`ollama-cloud-models.ts` is the single source. When you change it, re-check
+these derived sites in the SAME change:
+
+| Site | What to check |
+|------|---------------|
+| `model-resolver/providers/ollama-cloud.ts` | Per-tier `general`/`coder`/`vision` picks. Does a new model deserve to lead a tier? Did a removed model leave a dangling pick? (The `OllamaCloudModelId` union makes a removed ID a `tsc` error here.) |
+| `model-resolver/families.ts` | Family prefix lists — add a prefix only for a genuinely new family. (Local-resolver prefixes; not coupled to the cloud catalog, so a removed cloud model does not force a change here.) |
+| `model-resolver/blocklist.ts` | If a model emits tools but leaks them as text (gemini-3 case), block it instead of dropping it, so it stays usable for chat-only agents. |
+| `openclaw-config/default-media-models.ts` → `OLLAMA_CLOUD_IMAGE_PREFERENCE` | The ordered best-vision image-fallback picks. Removing a model that appears here breaks the `ollama-cloud-image-preference-drift` test; re-point to another vision-verified model. Removing/demoting a vision model means dropping it here too. |
+| `__tests__/lib/ollama-cloud-models.test.ts` | Add a dated, empirical assertion pinning each non-obvious flag (see step 5). |
+
+## Procedure
+
+1. **Discover the delta.** `pnpm models:discover`.
+   - `REMOVED` = a curated model is gone upstream → drop it (step 6). The run
+     exits non-zero so this is never silent.
+   - `ADDED` = served models we don't carry. `/v1/models` has no capability
+     tags, so this includes chat-only models. Triage, don't bulk-add.
+
+2. **Narrow ADDED to tool-capable cloud candidates.** Cross-check each against
+   `ollama.com/library/<name>` and `ollama.com/search?c=tools&c=cloud`. The
+   search page is incomplete — trust the individual library page. A model with
+   no "tools" tag is not a candidate (every Pinchy agent uses tools).
+
+3. **Read each candidate's library page** for:
+   - **context window** → `contextWindow`. Ollama uses "NK" = N × 1024
+     (`160K` → 163840). For a "up to X / minimum Y" model, use the guaranteed
+     floor (e.g. minimax-m3 → 524288).
+   - whether it carries the **thinking** tag → provisional `reasoning`.
+   - whether it claims **Image** input → provisional `vision` (to be verified, not trusted).
+   - `maxTokens`: 8192 by default; use the higher value only for output-heavy
+     Gemini-Flash-class models.
+
+4. **Add a provisional entry** to `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS` (alphabetical
+   within its family block) with your provisional flags. Keep `cost` zero — Ollama
+   Cloud is subscription-billed, not per-token.
+
+5. **Verify empirically and set flags from the RESULT:**
+
+   ```bash
+   pnpm models:verify:tools --only=<id>     # round-1 tool_call + multi-turn follow-up
+   pnpm models:verify:vision --only=<id>    # only if you set vision:true
+   ```
+
+   - `models:verify:tools` probes **two rounds**: a structured tool_call, then a
+     follow-up after a tool result. Both must pass. This catches the gemma3 /
+     kimi-k2-thinking failure mode (clean single-turn call, then HTTP 500 once
+     the history carries a tool result) that single-turn probing misses.
+   - **A single passing run is a smoke test, not a reliability proof.** Some
+     models are intermittent — qwen3-next emits a clean call 3 of 4 rounds, and
+     gemma3 flip-flopped from multi-turn-500 (2026-06-12) to passing (2026-06-17).
+     For a **new** addition, run the probe several times before trusting it; the
+     existing catalog entries cite "4/4 rounds" for exactly this reason.
+   - Tools drift (empty content, or leaked-as-text) → the model is **not**
+     tool-capable. If it leaks but is otherwise good for chat, add it to the
+     blocklist rather than the catalog. If it just never calls, drop it.
+   - Vision: `OK (api accepts)` confirms `vision:true`. `DRIFT (flag=true but
+     API rejects)` → `vision:false`. **The script only catches outright
+     rejection** — a model that returns HTTP 200 but hallucinates the image
+     (qwen3.5) still needs the manual number+color check described in the test
+     file header. When unsure, set `vision:false` (conservative side).
+   - Record the verdict + date in a code comment, matching the existing entries.
+
+6. **Handle REMOVED.** Delete the stale entry, then fix any `tsc` error it
+   surfaces in `providers/ollama-cloud.ts` (re-point the tier).
+
+7. **Update the drift test.** Add an assertion in
+   `ollama-cloud-models.test.ts` for each non-obvious flag, with the empirical
+   evidence in the comment (this is the TDD record of what you verified).
+
+8. **Run the gates:**
+
+   ```bash
+   pnpm test:scripts
+   pnpm -C packages/web test src/__tests__/lib/ollama-cloud-models.test.ts
+   pnpm -C packages/web exec tsc --noEmit   # union catches stale IDs in resolvers
+   ```
+
+## If you have no API key
+
+Do steps 1–4 and 6 as far as the data goes (discovery, library-page context
+windows, removals), but **stop before setting `vision`/`reasoning` from
+guesses**. Leave the candidate out and hand the verification commands
+(`pnpm models:verify:tools/vision --only=<id>`) to whoever has the key. Shipping
+an unverified capability flag is exactly the CISO-unfriendly drift this skill
+prevents.
+
+## Common mistakes
+
+| Mistake | Fix |
+|---------|-----|
+| Set `vision:true` from the library page | Probe it. Pages lie. |
+| Treated `models:discover` ADDED as "add all" | ADDED includes chat-only models; triage against library tags. |
+| Forgot the tier picks / blocklist | A new leader or a leaky model needs `providers/ollama-cloud.ts` / `blocklist.ts` updated too. |
+| Dropped a leaky-but-good model entirely | Blocklist it instead — it stays usable for chat-only agents. |
+| Skipped the dated test assertion | The empirical record is the point; future-you will re-trust a page without it. |
+
+## Quick reference
+
+```bash
+pnpm models:discover                       # delta vs ollama.com/v1/models
+pnpm models:verify:tools  [--only=<id>]    # structured tool_calls check
+pnpm models:verify:vision [--only=<id>]    # live image-input check
+```

--- a/.claude/skills/update-ollama-cloud-models/SKILL.md
+++ b/.claude/skills/update-ollama-cloud-models/SKILL.md
@@ -109,15 +109,27 @@ these derived sites in the SAME change:
 6. **Handle REMOVED.** Delete the stale entry, then fix any `tsc` error it
    surfaces in `providers/ollama-cloud.ts` (re-point the tier).
 
-7. **Update the drift test.** Add an assertion in
-   `ollama-cloud-models.test.ts` for each non-obvious flag, with the empirical
-   evidence in the comment (this is the TDD record of what you verified).
+7. **Update the drift tests.** The catalog is snapshotted in several tests —
+   adding/removing a model drifts ALL of them, not just the first one:
+   - `__tests__/lib/ollama-cloud-models.test.ts` — add a dated, empirical
+     assertion for each non-obvious flag (the TDD record of what you verified).
+   - `__tests__/lib/provider-models.test.ts` — model-ID lists + a hardcoded
+     count (`toHaveLength`).
+   - `__tests__/lib/openclaw-config.test.ts` — the written-config list, the
+     per-model `contextWindow`, and the `reasoning`/`input` lists.
+   - `__tests__/lib/model-vision.integration.test.ts` — `isModelVisionCapable`
+     assertions (DB-backed; only `pnpm test:db` runs it, not `pnpm test`).
+   - `__tests__/lib/ollama-cloud-image-preference-drift.test.ts` — guards the
+     image-preference list.
 
-8. **Run the gates:**
+8. **Run the gates** — the FULL suites, not just the one drift test. A removed
+   model drifts unit AND DB-backed snapshots; `pnpm test` alone misses the
+   `*.integration.test.ts` ones (that gap cost a red CI run once):
 
    ```bash
    pnpm test:scripts
-   pnpm -C packages/web test src/__tests__/lib/ollama-cloud-models.test.ts
+   pnpm -C packages/web test          # full unit suite — all the snapshot tests
+   pnpm -C packages/web test:db       # DB-backed: model-vision.integration etc.
    pnpm -C packages/web exec tsc --noEmit   # union catches stale IDs in resolvers
    ```
 

--- a/package.json
+++ b/package.json
@@ -10,6 +10,9 @@
     "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs",
     "release": "node scripts/release.mjs",
     "docs:paths": "node scripts/generate-docs-paths.mjs",
+    "models:discover": "node scripts/discover-ollama-cloud-models.mjs",
+    "models:verify:vision": "node scripts/verify-ollama-cloud-vision.mjs",
+    "models:verify:tools": "node scripts/verify-ollama-cloud-tools.mjs",
     "prepare": "husky"
   },
   "keywords": [],

--- a/packages/web/src/__tests__/lib/model-vision.integration.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.integration.test.ts
@@ -70,9 +70,12 @@ describe("Ollama cloud vision models (from DB seed)", () => {
     expect(isModelVisionCapable("ollama-cloud/ministral-3:14b")).toBe(true);
   });
 
-  it("returns true for both qwen3-vl variants", () => {
-    expect(isModelVisionCapable("ollama-cloud/qwen3-vl:235b")).toBe(true);
-    expect(isModelVisionCapable("ollama-cloud/qwen3-vl:235b-instruct")).toBe(true);
+  it("returns true for kimi-k2.6", () => {
+    // Replaces the old qwen3-vl:235b(-instruct) block — Ollama dropped both
+    // from the cloud catalog (2026-06-17). kimi-k2.5 / minimax-m3 /
+    // mistral-large-3 already have their own dedicated cases above; kimi-k2.6
+    // was the one vision model still lacking one.
+    expect(isModelVisionCapable("ollama-cloud/kimi-k2.6")).toBe(true);
   });
 
   it("returns true for gemma4:31b", () => {

--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -73,17 +73,27 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     expect(m!.contextWindow).toBe(262144);
   });
 
-  it("includes kimi-k2:1t as tool-capable, non-reasoning, text-only", () => {
-    // Library tags: "tools cloud" (no thinking tag — the thinking variant is
-    // the separate kimi-k2-thinking, which stays out, see below), input
-    // text-only, 256K context. Tools confirmed empirically 2026-06-12:
-    // structured tool_calls in 4/4 single-turn rounds plus a clean multi-turn
-    // follow-up call after a tool result.
-    const m = byId("kimi-k2:1t");
+  it("includes glm-5.2 with reasoning, text-only, 976K context", () => {
+    // Added 2026-06-17 (Ollama announced GLM-5.2). Library tags
+    // "tools thinking cloud", Text-only input, 976K context. Verified against
+    // the live API: a structured tool_call in round 1 plus a clean multi-turn
+    // follow-up (HTTP 200 with a coherent answer after a tool result), and
+    // HTTP 400 "this model does not support image input" on image payloads —
+    // text-only, like the rest of the GLM line.
+    const m = byId("glm-5.2");
     expect(m).toBeDefined();
-    expect(m!.reasoning).toBe(false);
+    expect(m!.reasoning).toBe(true);
     expect(m!.vision).toBe(false);
-    expect(m!.contextWindow).toBe(262144);
+    expect(m!.contextWindow).toBe(999424);
+    expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("glm-5.2")).toBe(false);
+  });
+
+  it("dropped kimi-k2:1t — Ollama removed it from the cloud catalog (2026-06-17)", () => {
+    // Verified tool-capable on 2026-06-12 (4/4 single-turn + a clean multi-turn
+    // follow-up), but the 2026-06-17 `models:discover` sweep found it gone from
+    // /v1/models. Leaving a model the live API no longer serves would resurface
+    // the llama3.3:70b -> HTTP 404 class of bug, so it was dropped.
+    expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain("kimi-k2:1t");
   });
 
   it("keeps cogito-2.1:671b out — leaks raw tool-call template text", () => {
@@ -113,6 +123,14 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     // across two independent runs, the same multi-turn failure mode that got
     // kimi-k2-thinking removed in #305. Every Pinchy agent runs multi-turn
     // tool loops, so all three stay out despite the library page's vision tag.
+    //
+    // Re-probed 2026-06-17 (during the GLM-5.2 sweep): all three now passed a
+    // single multi-turn round (round-2 HTTP 200 with a coherent answer). That
+    // flip-flop is exactly the intermittency that disqualified qwen3-next — one
+    // clean run does not certify reliability — and gemma3 is an older sibling
+    // of gemma4:31b, which we already carry with verified vision. Vision could
+    // not be re-confirmed (the image endpoint was returning blanket 5xx that
+    // day). They stay out until a deliberate multi-run + vision re-evaluation.
     for (const id of ["gemma3:4b", "gemma3:12b", "gemma3:27b"]) {
       expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain(id);
     }

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1826,16 +1826,14 @@ describe("regenerateOpenClawConfig", () => {
         "devstral-small-2:24b",
         "gemini-3-flash-preview",
         "gemma4:31b",
-        "glm-4.6",
         "glm-4.7",
         "glm-5",
         "glm-5.1",
+        "glm-5.2",
         "gpt-oss:120b",
         "gpt-oss:20b",
         "kimi-k2.5",
         "kimi-k2.6",
-        "kimi-k2:1t",
-        "minimax-m2",
         "minimax-m2.1",
         "minimax-m2.5",
         "minimax-m2.7",
@@ -1849,8 +1847,6 @@ describe("regenerateOpenClawConfig", () => {
         "nemotron-3-ultra",
         "qwen3-coder-next",
         "qwen3-coder:480b",
-        "qwen3-vl:235b",
-        "qwen3-vl:235b-instruct",
         "qwen3.5:397b",
         "rnj-1:8b",
       ].sort()
@@ -1885,14 +1881,14 @@ describe("regenerateOpenClawConfig", () => {
     // 160K
     expect(ctx["deepseek-v3.1:671b"]).toBe(163840);
     expect(ctx["deepseek-v3.2"]).toBe(163840);
-    // 198K (GLM family, minimax-m2.5)
-    expect(ctx["glm-4.6"]).toBe(202752);
+    // 198K (GLM 4.x/5.x family, minimax-m2.5)
     expect(ctx["glm-4.7"]).toBe(202752);
     expect(ctx["glm-5"]).toBe(202752);
     expect(ctx["glm-5.1"]).toBe(202752);
     expect(ctx["minimax-m2.5"]).toBe(202752);
+    // 976K (GLM-5.2 — "NK" = N×1024 → 999424)
+    expect(ctx["glm-5.2"]).toBe(999424);
     // 200K (other minimax variants)
-    expect(ctx["minimax-m2"]).toBe(204800);
     expect(ctx["minimax-m2.1"]).toBe(204800);
     expect(ctx["minimax-m2.7"]).toBe(204800);
     // 256K — the most common class
@@ -1900,7 +1896,6 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["gemma4:31b"]).toBe(262144);
     expect(ctx["kimi-k2.5"]).toBe(262144);
     expect(ctx["kimi-k2.6"]).toBe(262144);
-    expect(ctx["kimi-k2:1t"]).toBe(262144);
     expect(ctx["ministral-3:3b"]).toBe(262144);
     expect(ctx["ministral-3:8b"]).toBe(262144);
     expect(ctx["ministral-3:14b"]).toBe(262144);
@@ -1909,8 +1904,6 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["nemotron-3-ultra"]).toBe(262144);
     expect(ctx["qwen3-coder-next"]).toBe(262144);
     expect(ctx["qwen3-coder:480b"]).toBe(262144);
-    expect(ctx["qwen3-vl:235b"]).toBe(262144);
-    expect(ctx["qwen3-vl:235b-instruct"]).toBe(262144);
     expect(ctx["qwen3.5:397b"]).toBe(262144);
     // 384K
     expect(ctx["devstral-small-2:24b"]).toBe(393216);
@@ -1961,8 +1954,6 @@ describe("regenerateOpenClawConfig", () => {
       "ministral-3:8b",
       "ministral-3:14b",
       "mistral-large-3:675b",
-      "qwen3-vl:235b",
-      "qwen3-vl:235b-instruct",
     ];
     for (const id of visionModels) {
       expect(byId[id].input).toEqual(["text", "image"]);
@@ -1980,7 +1971,9 @@ describe("regenerateOpenClawConfig", () => {
     // 2026-06 additions: both are text-only lines (no image input tag, and
     // vision is never assumed without an empirical probe).
     expect(byId["nemotron-3-ultra"].input).toEqual(["text"]);
-    expect(byId["kimi-k2:1t"].input).toEqual(["text"]);
+    // glm-5.2: library lists Text-only; live API returns HTTP 400 "does not
+    // support image input" (2026-06-17). Text-only like the rest of the GLM line.
+    expect(byId["glm-5.2"].input).toEqual(["text"]);
 
     // Reasoning-capable cloud models per ollama.com/search?c=thinking&c=cloud
     const reasoningModels = [
@@ -1990,23 +1983,20 @@ describe("regenerateOpenClawConfig", () => {
       "deepseek-v4-pro",
       "gemini-3-flash-preview",
       "gemma4:31b",
-      "glm-4.6",
       "glm-4.7",
       "glm-5",
       "glm-5.1",
+      "glm-5.2",
       "gpt-oss:20b",
       "gpt-oss:120b",
       "kimi-k2.5",
       "kimi-k2.6",
-      "minimax-m2",
       "minimax-m2.5",
       "minimax-m2.7",
       "minimax-m3",
       "nemotron-3-nano:30b",
       "nemotron-3-super",
       "nemotron-3-ultra",
-      "qwen3-vl:235b",
-      "qwen3-vl:235b-instruct",
       "qwen3.5:397b",
     ];
     for (const id of reasoningModels) {
@@ -2014,13 +2004,10 @@ describe("regenerateOpenClawConfig", () => {
     }
     // Non-reasoning — qwen3-coder-next explicitly "Non-thinking mode only",
     // ministral-3 / mistral-large-3 / devstral-* and rnj-1 not tagged,
-    // minimax-m2.1 absent from Ollama's thinking tag list, kimi-k2:1t is the
-    // non-thinking kimi-k2 line (the thinking variant is the separate — and
-    // broken — kimi-k2-thinking).
+    // minimax-m2.1 absent from Ollama's thinking tag list.
     const nonReasoningModels = [
       "devstral-2:123b",
       "devstral-small-2:24b",
-      "kimi-k2:1t",
       "minimax-m2.1",
       "ministral-3:3b",
       "ministral-3:8b",
@@ -6889,7 +6876,8 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     // and kimi-k2.5/k2.6 accept image input but occasionally misread digits,
     // and qwen3.5:397b only claims vision (it hallucinates image contents and
     // is flagged text-only). The image-default picker explicitly prefers the
-    // "canonical vision line" — qwen3-vl > gemini-3-flash > gemma4 — over
+    // best empirically vision-verified models — gemini-3-flash > minimax-m3 >
+    // gemma4 (qwen3-vl led this list until Ollama dropped it upstream) — over
     // those weaker models.
     mockedGetSetting.mockImplementation(async (key: string) =>
       key === "ollama_cloud_api_key" ? "test-key" : null
@@ -6897,7 +6885,7 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     await regenerateOpenClawConfig();
 
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
-    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/qwen3-vl:235b-instruct");
+    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/gemini-3-flash-preview");
   });
 
   it("native vision providers (anthropic, google) beat ollama-cloud for imageModel", async () => {

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -286,18 +286,16 @@ describe("fetchProviderModels", () => {
             { id: "devstral-small-2:24b" },
             { id: "gemini-3-flash-preview" },
             { id: "gemma4:31b" },
-            { id: "glm-4.6" },
             { id: "glm-4.7" },
             { id: "glm-5" },
             { id: "glm-5.1" },
+            { id: "glm-5.2" },
             { id: "gpt-oss:20b" },
             { id: "gpt-oss:120b" },
             // kimi-k2-thinking: still returned by Ollama API but removed from Pinchy allowlist (#305)
             { id: "kimi-k2-thinking" },
             { id: "kimi-k2.5" },
             { id: "kimi-k2.6" },
-            { id: "kimi-k2:1t" },
-            { id: "minimax-m2" },
             { id: "minimax-m2.1" },
             { id: "minimax-m2.5" },
             { id: "minimax-m2.7" },
@@ -312,8 +310,6 @@ describe("fetchProviderModels", () => {
             { id: "qwen3-coder-next" },
             { id: "qwen3-coder:480b" },
             { id: "qwen3-next:80b" },
-            { id: "qwen3-vl:235b" },
-            { id: "qwen3-vl:235b-instruct" },
             { id: "qwen3.5:397b" },
             { id: "rnj-1:8b" },
             // Tool-broken on the live chat/completions endpoint — must be filtered out
@@ -343,16 +339,14 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/devstral-small-2:24b",
         "ollama-cloud/gemini-3-flash-preview",
         "ollama-cloud/gemma4:31b",
-        "ollama-cloud/glm-4.6",
         "ollama-cloud/glm-4.7",
         "ollama-cloud/glm-5",
         "ollama-cloud/glm-5.1",
+        "ollama-cloud/glm-5.2",
         "ollama-cloud/gpt-oss:20b",
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
-        "ollama-cloud/kimi-k2:1t",
-        "ollama-cloud/minimax-m2",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
@@ -366,8 +360,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/nemotron-3-ultra",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
-        "ollama-cloud/qwen3-vl:235b",
-        "ollama-cloud/qwen3-vl:235b-instruct",
         "ollama-cloud/qwen3.5:397b",
         "ollama-cloud/rnj-1:8b",
       ])
@@ -380,7 +372,7 @@ describe("fetchProviderModels", () => {
     expect(ids).not.toContain("ollama-cloud/qwen3-next:80b");
     // minimax-m3 was added to the allowlist (vision + tools confirmed live).
     expect(ids).toContain("ollama-cloud/minimax-m3");
-    expect(ids).toHaveLength(35);
+    expect(ids).toHaveLength(31);
 
     // Tool-broken models are filtered out (probed 2026-06-12: gemma3:4b leaks
     // pseudo tool calls as text, gemma3:12b serves HTTP 500, gemma3:27b
@@ -429,7 +421,7 @@ describe("fetchProviderModels", () => {
     const ids = ollama!.models.map((m) => m.id);
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
-    expect(ids).toHaveLength(35);
+    expect(ids).toHaveLength(31);
     expect(ids).toEqual(
       expect.arrayContaining([
         "ollama-cloud/deepseek-v3.1:671b",
@@ -440,16 +432,14 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/devstral-small-2:24b",
         "ollama-cloud/gemini-3-flash-preview",
         "ollama-cloud/gemma4:31b",
-        "ollama-cloud/glm-4.6",
         "ollama-cloud/glm-4.7",
         "ollama-cloud/glm-5",
         "ollama-cloud/glm-5.1",
+        "ollama-cloud/glm-5.2",
         "ollama-cloud/gpt-oss:20b",
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
-        "ollama-cloud/kimi-k2:1t",
-        "ollama-cloud/minimax-m2",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
@@ -463,8 +453,6 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/nemotron-3-ultra",
         "ollama-cloud/qwen3-coder-next",
         "ollama-cloud/qwen3-coder:480b",
-        "ollama-cloud/qwen3-vl:235b",
-        "ollama-cloud/qwen3-vl:235b-instruct",
         "ollama-cloud/qwen3.5:397b",
         "ollama-cloud/rnj-1:8b",
       ])

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -30,7 +30,11 @@ const BY_TIER_FAMILY: Record<
   balanced: {
     general: "ollama-cloud/glm-4.7",
     coder: "ollama-cloud/qwen3-coder:480b",
-    vision: "ollama-cloud/qwen3-vl:235b",
+    // qwen3-vl:235b(-instruct) was the pick but Ollama dropped both from the
+    // cloud catalog (2026-06-17 discovery sweep). gemma4:31b is the balanced
+    // vision replacement: vision+reasoning+tools, 262K context, already
+    // empirically verified in ollama-cloud-models.ts.
+    vision: "ollama-cloud/gemma4:31b",
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -113,13 +113,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: true,
   },
   {
-    id: "glm-4.6",
-    contextWindow: 202752,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
-  },
-  {
     id: "glm-4.7",
     contextWindow: 202752,
     maxTokens: 8192,
@@ -136,6 +129,19 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
   {
     id: "glm-5.1",
     contextWindow: 202752,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
+    // GLM-5.2, verified against the live API on 2026-06-17: structured
+    // tool_call in round 1 plus a clean multi-turn follow-up (HTTP 200 with a
+    // coherent answer after a tool result), and the /v1/chat/completions
+    // endpoint returns HTTP 400 "this model does not support image input" —
+    // text-only, like the rest of the GLM line. Library page: 976K context
+    // ("NK" = N×1024 → 999424), tags "tools thinking cloud", Text-only input.
+    id: "glm-5.2",
+    contextWindow: 999424,
     maxTokens: 8192,
     reasoning: true,
     vision: false,
@@ -167,28 +173,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     maxTokens: 8192,
     reasoning: true,
     vision: true,
-  },
-  {
-    // Non-thinking kimi-k2 line (the thinking variant, kimi-k2-thinking, is
-    // NOT in this catalog: removed in #305 for HTTP 500s, and a 2026-06-11
-    // re-probe showed every request now fails HTTP 400 "prompt too long" even
-    // for ~1k-token prompts — its serving-side context accounting is broken).
-    // kimi-k2:1t itself probed clean against the live API on 2026-06-12:
-    // structured tool_calls in 4/4 single-turn rounds plus a clean multi-turn
-    // follow-up. Text-only input; library page: 256K context, "tools" tag
-    // without "thinking".
-    id: "kimi-k2:1t",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: false,
-    vision: false,
-  },
-  {
-    id: "minimax-m2",
-    contextWindow: 204800,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: false,
   },
   {
     id: "minimax-m2.1",
@@ -290,20 +274,6 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     maxTokens: 8192,
     reasoning: false,
     vision: false,
-  },
-  {
-    id: "qwen3-vl:235b",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: true,
-  },
-  {
-    id: "qwen3-vl:235b-instruct",
-    contextWindow: 262144,
-    maxTokens: 8192,
-    reasoning: true,
-    vision: true,
   },
   {
     // The ollama.com/library/qwen3.5 page lists image input, but the live

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -81,8 +81,10 @@ export async function resolveDefaultPdfModel(): Promise<string | null> {
  * image input but occasionally misread digits, and `qwen3.5:397b` only
  * claims vision — it hallucinates image contents and is now flagged
  * vision:false (see ollama-cloud-models.ts). We pin the choice to the
- * canonical vision line (`qwen3-vl` > `gemini-3-flash-preview` > `gemma4`)
- * via the typed `OLLAMA_CLOUD_IMAGE_PREFERENCE` list. The TypeScript
+ * best empirically vision-verified models (`gemini-3-flash-preview` >
+ * `minimax-m3` > `gemma4:31b`; qwen3-vl led this list until Ollama dropped it
+ * from the cloud catalog) via the typed `OLLAMA_CLOUD_IMAGE_PREFERENCE` list.
+ * The TypeScript
  * constraint on that list (must be `OllamaCloudModelId`) means an unknown
  * ID fails to compile, so a runtime fallback to
  * `getDefaultModel("ollama-cloud")` would only fire if every preference
@@ -107,9 +109,14 @@ const IMAGE_MODEL_PREFERENCE: readonly ProviderName[] = [
 // silently de-syncing (e.g. if a future catalog update demotes one of
 // these models the way #416 demoted devstral).
 export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
-  "qwen3-vl:235b-instruct",
-  "qwen3-vl:235b",
+  // qwen3-vl:235b(-instruct) led this list but Ollama dropped both from the
+  // cloud catalog (2026-06-17 discovery sweep). The remaining picks are all
+  // empirically vision-verified: gemini-3-flash-preview (1M context; blocked
+  // only for *tool* slots, fine for pure image description) and minimax-m3
+  // (reads numbers + circle colors correctly across distinct images) lead,
+  // with gemma4:31b behind them.
   "gemini-3-flash-preview",
+  "minimax-m3",
   "gemma4:31b",
 ];
 

--- a/scripts/discover-ollama-cloud-models.mjs
+++ b/scripts/discover-ollama-cloud-models.mjs
@@ -1,0 +1,116 @@
+#!/usr/bin/env node
+// Discover drift between the live Ollama Cloud catalog and Pinchy's curated list.
+//
+// Fetches https://ollama.com/v1/models and compares the served model IDs
+// against TOOL_CAPABLE_OLLAMA_CLOUD_MODELS in
+// packages/web/src/lib/ollama-cloud-models.ts:
+//
+//   REMOVED  - a model we curate is no longer served -> stale entry to drop
+//              (the llama3.3:70b -> HTTP 404 class of bug). Exits 1 so this is
+//              never silent.
+//   ADDED    - a served model we don't carry -> candidate. /v1/models has no
+//              capability tags, so this list includes chat-only models too;
+//              triage each against ollama.com/library/<name> + the tool/vision
+//              probes before adding. Informational (does not fail the run).
+//
+// Why this exists: we otherwise only learn about new models when Ollama emails
+// us, and they don't announce every one. This turns "they mentioned GLM-5.2"
+// into "here is the full delta."
+//
+// Usage:
+//   OLLAMA_CLOUD_API_KEY=... node scripts/discover-ollama-cloud-models.mjs
+//
+// Skips with exit 0 if OLLAMA_CLOUD_API_KEY is unset (so CI can run it
+// conditionally). Exits 1 on a removed model or an unusable API response.
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import { parseOllamaCloudModels } from "./lib/ollama-cloud-source.mjs";
+import { diffModels } from "./lib/ollama-cloud-discovery.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODELS_TS = resolve(
+  __dirname,
+  "../packages/web/src/lib/ollama-cloud-models.ts",
+);
+
+async function fetchLiveModelIds(apiKey) {
+  const res = await fetch("https://ollama.com/v1/models", {
+    headers: { Authorization: `Bearer ${apiKey}` },
+  });
+  if (!res.ok) {
+    throw new Error(
+      `GET /v1/models returned HTTP ${res.status}: ${(await res.text()).slice(0, 200)}`,
+    );
+  }
+  const json = await res.json();
+  const data = Array.isArray(json?.data) ? json.data : [];
+  return data.map((m) => m?.id).filter((id) => typeof id === "string");
+}
+
+async function main() {
+  const apiKey = process.env.OLLAMA_CLOUD_API_KEY;
+  if (!apiKey) {
+    process.stdout.write(
+      "OLLAMA_CLOUD_API_KEY is unset — skipping discover-ollama-cloud-models (exit 0).\n",
+    );
+    process.exit(0);
+  }
+
+  const liveIds = await fetchLiveModelIds(apiKey);
+  if (liveIds.length === 0) {
+    process.stderr.write(
+      "GET /v1/models returned no model IDs — refusing to report the whole catalog as removed.\n",
+    );
+    process.exit(1);
+  }
+
+  const curated = parseOllamaCloudModels(readFileSync(MODELS_TS, "utf8"));
+  const curatedIds = curated.map((m) => m.id);
+  const { added, removed, present } = diffModels(liveIds, curatedIds);
+
+  // If nothing we curate still appears live, the comparison is almost certainly
+  // broken (API shape changed, or IDs now carry a suffix) — not a real mass
+  // removal. Bail loudly instead of "discovering" an empty catalog.
+  if (present.length === 0 && curatedIds.length > 0) {
+    process.stderr.write(
+      `None of our ${curatedIds.length} curated models appear in the ${liveIds.length} live IDs. ` +
+        "The /v1/models response shape or ID format likely changed — inspect it before trusting this diff.\n",
+    );
+    process.exit(1);
+  }
+
+  process.stdout.write(
+    `Live cloud models: ${liveIds.length} | curated: ${curatedIds.length} | still present: ${present.length}\n\n`,
+  );
+
+  if (removed.length > 0) {
+    process.stdout.write(
+      `REMOVED — ${removed.length} curated model(s) no longer served (drop from ollama-cloud-models.ts):\n`,
+    );
+    for (const id of removed) process.stdout.write(`  - ${id}\n`);
+    process.stdout.write("\n");
+  }
+
+  process.stdout.write(
+    `ADDED — ${added.length} served model(s) not in our catalog (candidates; /v1/models has no\n` +
+      "capability tags, so triage each against ollama.com/library/<name> + the vision/tool probes):\n",
+  );
+  for (const id of added) process.stdout.write(`  + ${id}\n`);
+  process.stdout.write("\n");
+
+  if (removed.length > 0) {
+    process.stderr.write(
+      `${removed.length} curated model(s) vanished from the live catalog — action required.\n`,
+    );
+    process.exit(1);
+  }
+  process.stdout.write("No curated model has been removed upstream.\n");
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/scripts/lib/ollama-cloud-discovery.mjs
+++ b/scripts/lib/ollama-cloud-discovery.mjs
@@ -1,0 +1,26 @@
+// Pure set-diff logic for Ollama Cloud model discovery.
+//
+// `discover-ollama-cloud-models.mjs` fetches the live cloud catalog from
+// https://ollama.com/v1/models and compares it against the IDs Pinchy curates
+// in ollama-cloud-models.ts. This module is the comparison, kept pure so it is
+// testable without the network.
+
+/**
+ * @param {string[]} liveIds   - model IDs currently served by ollama.com
+ * @param {string[]} curatedIds - model IDs in Pinchy's curated catalog
+ * @returns {{ added: string[], removed: string[], present: string[] }}
+ *   added   - live but not curated -> candidates a human/agent must triage
+ *             (may be chat-only or not tool-capable; never auto-added)
+ *   removed - curated but no longer live -> stale entries to drop
+ *   present - curated and still live
+ */
+export function diffModels(liveIds, curatedIds) {
+  const live = new Set(liveIds);
+  const curated = new Set(curatedIds);
+
+  const added = [...live].filter((id) => !curated.has(id)).sort();
+  const removed = [...curated].filter((id) => !live.has(id)).sort();
+  const present = [...curated].filter((id) => live.has(id)).sort();
+
+  return { added, removed, present };
+}

--- a/scripts/lib/ollama-cloud-discovery.test.mjs
+++ b/scripts/lib/ollama-cloud-discovery.test.mjs
@@ -1,0 +1,37 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import { diffModels } from "./ollama-cloud-discovery.mjs";
+
+test("reports added (live-only), removed (curated-only), and present", () => {
+  const diff = diffModels(
+    ["a", "b", "c"], // live on ollama.com
+    ["b", "c", "d"], // curated in our catalog
+  );
+  assert.deepEqual(diff.added, ["a"]);
+  assert.deepEqual(diff.removed, ["d"]);
+  assert.deepEqual(diff.present, ["b", "c"]);
+});
+
+test("output is sorted and de-duplicated", () => {
+  const diff = diffModels(["b", "a", "a", "z"], ["b", "b", "m"]);
+  assert.deepEqual(diff.added, ["a", "z"]);
+  assert.deepEqual(diff.removed, ["m"]);
+  assert.deepEqual(diff.present, ["b"]);
+});
+
+test("an empty live list marks every curated model as removed (caller must guard)", () => {
+  // The wrapper must refuse to act on an empty/failed API response so it never
+  // 'discovers' that the whole catalog vanished. The pure diff still reports it.
+  const diff = diffModels([], ["a", "b"]);
+  assert.deepEqual(diff.removed, ["a", "b"]);
+  assert.deepEqual(diff.added, []);
+  assert.deepEqual(diff.present, []);
+});
+
+test("identical lists produce no churn", () => {
+  const diff = diffModels(["a", "b"], ["a", "b"]);
+  assert.deepEqual(diff.added, []);
+  assert.deepEqual(diff.removed, []);
+  assert.deepEqual(diff.present, ["a", "b"]);
+});

--- a/scripts/lib/ollama-cloud-source.mjs
+++ b/scripts/lib/ollama-cloud-source.mjs
@@ -1,0 +1,79 @@
+// Shared parser for Pinchy's curated Ollama Cloud catalog
+// (packages/web/src/lib/ollama-cloud-models.ts).
+//
+// The discovery, vision-verification, and tool-verification scripts all need
+// the same thing: the list of model IDs (and their capability flags) as they
+// appear in the source file, without pulling in TypeScript tooling. This
+// module is that one parser, covered by ollama-cloud-source.test.mjs so the
+// three scripts can trust it instead of each re-implementing a regex.
+
+// Tight allowlist for model IDs as they appear in the curated source file.
+// Ollama Cloud IDs use lowercase letters, digits, and the punctuation set
+// `[.:_-]` (e.g. `qwen3-vl:235b-instruct`, `gpt-oss:120b`, `deepseek-v3.1:671b`).
+// Validating against this pattern at parse time gives any outbound HTTP
+// request built from these IDs a guaranteed-safe shape and stops anything
+// pathological from flowing from the file into a network sink. CodeQL
+// recognises this as a sanitizer for the "file data -> outbound request"
+// finding; the verify scripts re-assert it at the sink for good measure.
+export const MODEL_ID_PATTERN = /^[a-z0-9][a-z0-9.:_-]*$/;
+
+// Per-field extractors use fixed literal regexes (never `new RegExp(...)`):
+// a dynamically built RegExp trips CodeQL's js/incomplete-sanitization even
+// on harmless literal input, which has cost real CI rounds here before.
+function firstNumber(chunk, regex) {
+  const m = chunk.match(regex);
+  return m ? Number(m[1]) : null;
+}
+
+function firstBoolean(chunk, regex) {
+  const m = chunk.match(regex);
+  return m ? m[1] === "true" : null;
+}
+
+/**
+ * Parse the `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS` entries out of the source text.
+ *
+ * @param {string} source - contents of ollama-cloud-models.ts
+ * @returns {Array<{id: string, contextWindow: number|null, maxTokens: number|null, reasoning: boolean|null, vision: boolean|null}>}
+ */
+export function parseOllamaCloudModels(source) {
+  // Strip comments first so prose like `id: "foo"` or `vision: true` written
+  // inside a comment can never be parsed as a real field. Each replace uses a
+  // non-backtracking pattern (no nested quantifiers) — no ReDoS risk.
+  const stripped = source
+    .replace(/\/\/[^\n]*/g, "")
+    .replace(/\/\*[\s\S]*?\*\//g, "");
+
+  const idMatches = [...stripped.matchAll(/id:\s*"([^"]+)"/g)];
+  if (idMatches.length === 0) {
+    throw new Error(
+      "parseOllamaCloudModels: no model entries parsed from source",
+    );
+  }
+
+  const models = [];
+  for (let i = 0; i < idMatches.length; i++) {
+    const id = idMatches[i][1];
+    if (!MODEL_ID_PATTERN.test(id)) {
+      throw new Error(
+        `parseOllamaCloudModels: parsed model ID "${id}" does not match the safe ID allowlist (${MODEL_ID_PATTERN}). ` +
+          "Refusing to use it — fix the source file or widen the pattern deliberately.",
+      );
+    }
+    // Scope the remaining fields to this entry: from this `id:` up to the next
+    // `id:` (or end of file). Order-independent within the entry.
+    const start = idMatches[i].index;
+    const end =
+      i + 1 < idMatches.length ? idMatches[i + 1].index : stripped.length;
+    const chunk = stripped.slice(start, end);
+
+    models.push({
+      id,
+      contextWindow: firstNumber(chunk, /contextWindow:\s*(\d+)/),
+      maxTokens: firstNumber(chunk, /maxTokens:\s*(\d+)/),
+      reasoning: firstBoolean(chunk, /reasoning:\s*(true|false)/),
+      vision: firstBoolean(chunk, /vision:\s*(true|false)/),
+    });
+  }
+  return models;
+}

--- a/scripts/lib/ollama-cloud-source.test.mjs
+++ b/scripts/lib/ollama-cloud-source.test.mjs
@@ -1,0 +1,99 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseOllamaCloudModels,
+  MODEL_ID_PATTERN,
+} from "./ollama-cloud-source.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const REAL_SOURCE = resolve(
+  __dirname,
+  "../../packages/web/src/lib/ollama-cloud-models.ts",
+);
+
+const FIXTURE = `
+export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
+  {
+    // a stray comment containing id: "fake-from-comment" that must be ignored
+    id: "glm-5.2",
+    contextWindow: 202752,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
+    /* block comment with vision: true buried inside it */
+    id: "qwen3-vl:235b-instruct",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: true,
+  },
+] as const satisfies readonly OllamaCloudModel[];
+`;
+
+test("parses every field for each entry", () => {
+  const models = parseOllamaCloudModels(FIXTURE);
+  assert.equal(models.length, 2);
+  assert.deepEqual(models[0], {
+    id: "glm-5.2",
+    contextWindow: 202752,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  });
+  assert.deepEqual(models[1], {
+    id: "qwen3-vl:235b-instruct",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: true,
+  });
+});
+
+test("ignores id- and flag-looking text inside comments", () => {
+  const models = parseOllamaCloudModels(FIXTURE);
+  assert.ok(!models.some((m) => m.id === "fake-from-comment"));
+  // The block comment's `vision: true` must not flip the real flag.
+  assert.equal(models[0].vision, false);
+});
+
+test("throws on a model id that fails the safe allowlist", () => {
+  const bad = `TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
+    { id: "EVIL ID; rm -rf", contextWindow: 1, maxTokens: 1, reasoning: false, vision: false },
+  ]`;
+  assert.throws(() => parseOllamaCloudModels(bad), /allowlist/i);
+});
+
+test("throws when no entries are found", () => {
+  assert.throws(
+    () => parseOllamaCloudModels("const unrelated = 1;"),
+    /no model entries/i,
+  );
+});
+
+test("MODEL_ID_PATTERN accepts real ollama ids and rejects unsafe ones", () => {
+  assert.ok(MODEL_ID_PATTERN.test("qwen3-vl:235b-instruct"));
+  assert.ok(MODEL_ID_PATTERN.test("deepseek-v3.1:671b"));
+  assert.ok(MODEL_ID_PATTERN.test("gpt-oss:120b"));
+  assert.ok(!MODEL_ID_PATTERN.test("Evil Id"));
+  assert.ok(!MODEL_ID_PATTERN.test("ollama-cloud/glm-4.7")); // no slashes — prefix is added elsewhere
+});
+
+test("parses the real curated source and finds a known model with correct fields", () => {
+  const models = parseOllamaCloudModels(readFileSync(REAL_SOURCE, "utf8"));
+  const glm = models.find((m) => m.id === "glm-4.7");
+  assert.ok(glm, "glm-4.7 should be present in the real catalog");
+  assert.equal(glm.contextWindow, 202752);
+  assert.equal(glm.reasoning, true);
+  assert.equal(glm.vision, false);
+  // Catch a parser that silently matches only the first entry.
+  assert.ok(
+    models.length >= 25,
+    `expected the full catalog, parsed ${models.length}`,
+  );
+});

--- a/scripts/lib/ollama-cloud-tool-probe.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.mjs
@@ -1,0 +1,135 @@
+// Pure helpers for the Ollama Cloud tool-calling probe.
+//
+// `verify-ollama-cloud-tools.mjs` POSTs a small function-tool request to
+// https://ollama.com/v1/chat/completions for each curated model and checks the
+// reply. Every model in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS is, by definition,
+// expected to emit a *structured* tool_call — a model that silently skips the
+// call (qwen3-next's empty-content failure) or leaks the call as plain text
+// (gemini-3-flash-preview's `default_api` signature) must not be surfaced as
+// tool-capable, because every Pinchy agent relies on tools (files/context/docs).
+//
+// These two functions are the request shape and the response classifier, kept
+// pure so the network wrapper stays thin and this logic is unit-tested.
+
+// Signatures of a tool call that a model rendered into plain text instead of
+// returning a structured `tool_calls` array. `get_weather` is the probe's own
+// tool name (see buildToolProbeRequest).
+const LEAK_PATTERNS = [
+  /default_api[.\s]/i, // gemini-3-flash-preview's leak signature
+  /<\/?tool_call>/i, // <tool_call>…</tool_call> blobs
+  /<\/?tools>/i, // <tools>…</tools> blobs
+  /\bget_weather\s*\(/, // a parenthesised call written as prose
+  /\bfunctions?\.\w+/i, // functions.get_weather style
+];
+
+/**
+ * Build the probe request body for a model id.
+ * @param {string} id
+ */
+export function buildToolProbeRequest(id) {
+  return {
+    model: id,
+    max_tokens: 128,
+    tool_choice: "auto",
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "get_weather",
+          description: "Get the current weather for a city.",
+          parameters: {
+            type: "object",
+            properties: {
+              city: { type: "string", description: "City name, e.g. Paris" },
+            },
+            required: ["city"],
+          },
+        },
+      },
+    ],
+    messages: [
+      {
+        role: "user",
+        content:
+          "What's the current weather in Paris? Use the get_weather tool to find out.",
+      },
+    ],
+  };
+}
+
+/**
+ * True for HTTP statuses that are infra noise (rate limit / server overload),
+ * not a capability verdict. The verify wrapper retries these and, if they
+ * persist, reports the model as INCONCLUSIVE rather than drift — a 503
+ * "temporarily overloaded" must never be mistaken for "this model lost its
+ * tools, remove it." 400/404 (capability error / model gone) are definitive.
+ * @param {number} status
+ */
+export function isTransientStatus(status) {
+  return (
+    status === 429 ||
+    status === 500 ||
+    status === 502 ||
+    status === 503 ||
+    status === 504
+  );
+}
+
+/**
+ * Build the multi-turn follow-up: replay the model's tool_call, then hand it a
+ * tool result. A genuinely tool-capable model answers (HTTP 200); gemma3 and
+ * kimi-k2-thinking return HTTP 500 once the history carries a tool result,
+ * which is the failure mode this round exists to catch.
+ * @param {string} id
+ * @param {{content?: string, tool_calls: Array<{id: string}>}} assistantMessage - the round-1 message
+ */
+export function buildToolFollowupRequest(id, assistantMessage) {
+  const firstCall = assistantMessage.tool_calls[0];
+  return {
+    model: id,
+    max_tokens: 64,
+    messages: [
+      {
+        role: "user",
+        content:
+          "What's the current weather in Paris? Use the get_weather tool to find out.",
+      },
+      {
+        role: "assistant",
+        content: assistantMessage.content ?? "",
+        tool_calls: assistantMessage.tool_calls,
+      },
+      {
+        role: "tool",
+        tool_call_id: firstCall.id,
+        content: "It is 22°C and sunny in Paris.",
+      },
+    ],
+  };
+}
+
+/**
+ * Classify a parsed /v1/chat/completions response.
+ * @param {any} parsed - the JSON-parsed response body
+ * @returns {{ supportsTools: boolean, leakedAsText: boolean, detail: string }}
+ */
+export function classifyToolResponse(parsed) {
+  const message = parsed?.choices?.[0]?.message ?? {};
+  const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+  const content = typeof message.content === "string" ? message.content : "";
+
+  const supportsTools = toolCalls.length > 0;
+  const leakedAsText =
+    !supportsTools && LEAK_PATTERNS.some((re) => re.test(content));
+
+  let detail;
+  if (supportsTools) {
+    detail = `emitted ${toolCalls.length} structured tool_call(s)`;
+  } else if (leakedAsText) {
+    detail = "leaked a tool call as plain text (no structured tool_calls)";
+  } else {
+    detail = "no tool_calls and no leak — model did not call the tool";
+  }
+
+  return { supportsTools, leakedAsText, detail };
+}

--- a/scripts/lib/ollama-cloud-tool-probe.test.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.test.mjs
@@ -1,0 +1,126 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  buildToolProbeRequest,
+  buildToolFollowupRequest,
+  classifyToolResponse,
+  isTransientStatus,
+} from "./ollama-cloud-tool-probe.mjs";
+
+test("isTransientStatus flags retriable infra errors, not capability verdicts", () => {
+  // 429/5xx are infra noise → retry, never report as "model lost tools".
+  for (const s of [429, 500, 502, 503, 504]) {
+    assert.equal(isTransientStatus(s), true, `${s} should be transient`);
+  }
+  // 200 = success, 400 = capability error, 404 = model gone — all definitive.
+  for (const s of [200, 400, 404]) {
+    assert.equal(isTransientStatus(s), false, `${s} should be definitive`);
+  }
+});
+
+test("buildToolProbeRequest offers one function tool and a prompt that needs it", () => {
+  const body = buildToolProbeRequest("glm-5.2");
+  assert.equal(body.model, "glm-5.2");
+  assert.ok(Array.isArray(body.tools) && body.tools.length === 1);
+  assert.equal(body.tools[0].type, "function");
+  assert.equal(body.tools[0].function.name, "get_weather");
+  // A real user turn that should provoke the call.
+  assert.equal(body.messages.at(-1).role, "user");
+  assert.match(body.messages.at(-1).content, /weather/i);
+  // Bounded so the probe is cheap.
+  assert.ok(body.max_tokens > 0 && body.max_tokens <= 256);
+});
+
+test("buildToolFollowupRequest echoes the tool_call and feeds back a tool result", () => {
+  // The multi-turn round is what catches gemma3 / kimi-k2-thinking: those emit
+  // a clean single-turn tool_call but HTTP 500 once the history carries a tool
+  // result. The follow-up must replay the assistant tool_call and answer it.
+  const assistantMessage = {
+    content: "",
+    tool_calls: [
+      {
+        id: "call_abc123",
+        type: "function",
+        function: { name: "get_weather", arguments: '{"city":"Paris"}' },
+      },
+    ],
+  };
+  const body = buildToolFollowupRequest("glm-5.2", assistantMessage);
+  assert.equal(body.model, "glm-5.2");
+  assert.equal(body.messages.length, 3);
+  assert.equal(body.messages[0].role, "user");
+  assert.equal(body.messages[1].role, "assistant");
+  assert.deepEqual(body.messages[1].tool_calls, assistantMessage.tool_calls);
+  assert.equal(body.messages[2].role, "tool");
+  assert.equal(body.messages[2].tool_call_id, "call_abc123");
+  assert.match(body.messages[2].content, /\S/); // non-empty tool result
+});
+
+test("a structured tool_calls response counts as tool-capable", () => {
+  const result = classifyToolResponse({
+    choices: [
+      {
+        message: {
+          content: "",
+          tool_calls: [
+            {
+              type: "function",
+              function: {
+                name: "get_weather",
+                arguments: '{"city":"Paris"}',
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  assert.equal(result.supportsTools, true);
+  assert.equal(result.leakedAsText, false);
+});
+
+test("empty content with no tool_calls is NOT tool-capable (qwen3-next failure mode)", () => {
+  const result = classifyToolResponse({
+    choices: [{ message: { content: "", tool_calls: [] } }],
+  });
+  assert.equal(result.supportsTools, false);
+  assert.equal(result.leakedAsText, false);
+});
+
+test("a tool call leaked as plain text is flagged, not counted as capable (gemini-3 default_api)", () => {
+  const result = classifyToolResponse({
+    choices: [
+      {
+        message: {
+          content:
+            "I'll check that for you.\ndefault_api.get_weather(city='Paris')",
+        },
+      },
+    ],
+  });
+  assert.equal(result.supportsTools, false);
+  assert.equal(result.leakedAsText, true);
+});
+
+test("an XML-style <tool_call> blob in content is also a leak", () => {
+  const result = classifyToolResponse({
+    choices: [
+      {
+        message: {
+          content: '<tool_call>{"name": "get_weather"}</tool_call>',
+        },
+      },
+    ],
+  });
+  assert.equal(result.supportsTools, false);
+  assert.equal(result.leakedAsText, true);
+});
+
+test("a plain prose answer with no call and no leak is just not tool-capable here", () => {
+  const result = classifyToolResponse({
+    choices: [{ message: { content: "It is sunny in Paris today." } }],
+  });
+  assert.equal(result.supportsTools, false);
+  assert.equal(result.leakedAsText, false);
+});

--- a/scripts/verify-ollama-cloud-tools.mjs
+++ b/scripts/verify-ollama-cloud-tools.mjs
@@ -1,0 +1,240 @@
+#!/usr/bin/env node
+// Verify Pinchy's curated Ollama Cloud models still emit structured tool calls.
+//
+// Every model in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS is, by its name, expected to
+// be tool-capable. For each one this script POSTs a function-tool probe to
+// https://ollama.com/v1/chat/completions across TWO rounds: round 1 must carry
+// a structured `tool_calls` array, and a round-2 follow-up (the same history
+// plus a tool result) must return HTTP 200. A model is reported as drift if it
+// returns empty content (qwen3-next's failure mode), leaks the call as plain
+// text (gemini-3-flash-preview's `default_api` signature), or HTTP 500s on the
+// follow-up once the history carries a tool result (gemma3 / kimi-k2-thinking).
+// Every Pinchy agent runs multi-turn tool loops, so a model that fails any of
+// these must not be surfaced as tool-capable.
+//
+// NOTE: a single passing run is a smoke test, not a reliability proof — some
+// models are intermittent (qwen3-next 3/4, gemma3 flip-flopped between days).
+// Run the probe several times before trusting a NEW addition.
+//
+// This is the tool-calling sibling of verify-ollama-cloud-vision.mjs. The
+// request shape and response classifier live in
+// scripts/lib/ollama-cloud-tool-probe.mjs and are unit-tested; this wrapper is
+// the thin network layer.
+//
+// Usage:
+//   OLLAMA_CLOUD_API_KEY=... node scripts/verify-ollama-cloud-tools.mjs
+//   OLLAMA_CLOUD_API_KEY=... node scripts/verify-ollama-cloud-tools.mjs --only=glm-5.2
+//
+// Exits 0 on full agreement, 1 on any drift. Skips with exit 0 if
+// OLLAMA_CLOUD_API_KEY is unset (so CI can run it conditionally).
+
+import { readFileSync } from "node:fs";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+import {
+  parseOllamaCloudModels,
+  MODEL_ID_PATTERN,
+} from "./lib/ollama-cloud-source.mjs";
+import {
+  buildToolProbeRequest,
+  buildToolFollowupRequest,
+  classifyToolResponse,
+  isTransientStatus,
+} from "./lib/ollama-cloud-tool-probe.mjs";
+
+const sleep = (ms) => new Promise((r) => setTimeout(r, ms));
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const MODELS_TS = resolve(
+  __dirname,
+  "../packages/web/src/lib/ollama-cloud-models.ts",
+);
+
+function parseArgs(argv) {
+  const args = { only: null };
+  for (const a of argv) {
+    if (a.startsWith("--only=")) args.only = a.slice("--only=".length);
+  }
+  return args;
+}
+
+async function postChat(body, apiKey, attempts = 5) {
+  let last;
+  for (let i = 0; i < attempts; i++) {
+    const res = await fetch("https://ollama.com/v1/chat/completions", {
+      method: "POST",
+      headers: {
+        "Content-Type": "application/json",
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify(body),
+    });
+    const text = await res.text();
+    let parsed = null;
+    try {
+      parsed = JSON.parse(text);
+    } catch {
+      parsed = null;
+    }
+    last = { status: res.status, body: text, parsed };
+    // Retry only infra noise (overload/5xx). 200 and capability errors are final.
+    if (!isTransientStatus(res.status)) return last;
+    await sleep(3000 + i * 2000);
+  }
+  return last; // exhausted retries — still transient
+}
+
+// Probe a model across two rounds. A model is only OK if it emits a structured
+// tool_call AND survives the multi-turn follow-up (HTTP 200 once the history
+// carries a tool result). Single-turn alone is a false-positive trap: gemma3
+// emits a clean single-turn call but HTTP 500s on the follow-up, which is why
+// gemma3 stays out of the catalog (see ollama-cloud-models.test.ts).
+async function probeModel(id, apiKey) {
+  // Re-assert the safe-ID allowlist right at the network sink. The shared
+  // parser already validates, but co-locating the barrier with the fetch keeps
+  // the file-data -> outbound-request dataflow provably sanitized for CodeQL.
+  if (!MODEL_ID_PATTERN.test(id)) {
+    throw new Error(
+      `verify-ollama-cloud-tools: refusing to send unsafe model id "${id}" to the API.`,
+    );
+  }
+
+  const r1 = await postChat(buildToolProbeRequest(id), apiKey);
+  if (r1.status !== 200 || !r1.parsed) {
+    // Overload that outlived the retries isn't a capability verdict.
+    const stage = isTransientStatus(r1.status) ? "inconclusive" : "round1-http";
+    return { stage, status: r1.status, body: r1.body };
+  }
+  const verdict = classifyToolResponse(r1.parsed);
+  if (!verdict.supportsTools) {
+    return { stage: "round1-verdict", verdict, body: r1.body };
+  }
+
+  const assistantMessage = r1.parsed.choices[0].message;
+  const r2 = await postChat(
+    buildToolFollowupRequest(id, assistantMessage),
+    apiKey,
+  );
+  if (r2.status !== 200) {
+    const stage = isTransientStatus(r2.status) ? "inconclusive" : "round2-fail";
+    return { stage, status: r2.status, r2status: r2.status, body: r2.body };
+  }
+  return { stage: "ok", detail: verdict.detail };
+}
+
+async function main() {
+  const apiKey = process.env.OLLAMA_CLOUD_API_KEY;
+  if (!apiKey) {
+    process.stdout.write(
+      "OLLAMA_CLOUD_API_KEY is unset — skipping verify-ollama-cloud-tools (exit 0).\n",
+    );
+    process.exit(0);
+  }
+
+  const args = parseArgs(process.argv.slice(2));
+  const all = parseOllamaCloudModels(readFileSync(MODELS_TS, "utf8"));
+  const targets = args.only ? all.filter((m) => m.id === args.only) : all;
+  if (targets.length === 0) {
+    process.stderr.write(`No models matched --only=${args.only}\n`);
+    process.exit(1);
+  }
+
+  const drift = [];
+  const inconclusive = [];
+  for (const model of targets) {
+    process.stdout.write(`testing ${model.id}… `);
+    let result;
+    try {
+      result = await probeModel(model.id, apiKey);
+    } catch (err) {
+      process.stdout.write(`NETWORK ERROR: ${err.message}\n`);
+      drift.push({
+        id: model.id,
+        actual: "network-error",
+        detail: err.message,
+      });
+      continue;
+    }
+
+    if (result.stage === "ok") {
+      process.stdout.write(`OK (${result.detail} + clean multi-turn)\n`);
+      continue;
+    }
+
+    if (result.stage === "inconclusive") {
+      // Overload outlived the retries — NOT a verdict. Never report "remove".
+      process.stdout.write(
+        `SKIP (infra: HTTP ${result.status}, retry later)\n`,
+      );
+      inconclusive.push({ id: model.id, status: result.status });
+      continue;
+    }
+
+    if (result.stage === "round1-http") {
+      process.stdout.write(`DRIFT (round 1 HTTP ${result.status})\n`);
+      drift.push({
+        id: model.id,
+        stage: result.stage,
+        status: result.status,
+        bodySnippet: result.body.slice(0, 200),
+      });
+      continue;
+    }
+
+    if (result.stage === "round1-verdict") {
+      process.stdout.write(
+        `DRIFT (${result.verdict.leakedAsText ? "leaked as text" : "no tool call"})\n`,
+      );
+      drift.push({
+        id: model.id,
+        stage: result.stage,
+        leakedAsText: result.verdict.leakedAsText,
+        detail: result.verdict.detail,
+        bodySnippet: result.body.slice(0, 200),
+      });
+      continue;
+    }
+
+    // round2-fail: clean single-turn call but the follow-up broke — the gemma3
+    // multi-turn failure mode. Every Pinchy agent runs multi-turn tool loops.
+    process.stdout.write(`DRIFT (multi-turn HTTP ${result.r2status})\n`);
+    drift.push({
+      id: model.id,
+      stage: result.stage,
+      r2status: result.r2status,
+      bodySnippet: result.body.slice(0, 200),
+    });
+  }
+
+  if (inconclusive.length > 0) {
+    // Surfaced loudly so an overloaded run is never silently read as "all pass".
+    process.stderr.write(
+      `\nINCONCLUSIVE — ${inconclusive.length} model(s) only returned infra errors (overload) ` +
+        `after retries; re-run later: ${inconclusive.map((m) => m.id).join(", ")}\n`,
+    );
+  }
+
+  if (drift.length > 0) {
+    process.stderr.write("\n=== DRIFT REPORT ===\n");
+    process.stderr.write(JSON.stringify(drift, null, 2) + "\n");
+    process.stderr.write(
+      `\n${drift.length} model(s) no longer emit clean tool calls. ` +
+        "Remove them from packages/web/src/lib/ollama-cloud-models.ts.\n",
+    );
+    process.exit(1);
+  }
+
+  const verified = targets.length - inconclusive.length;
+  process.stdout.write(
+    `\n${verified}/${targets.length} model(s) verified tool-capable` +
+      (inconclusive.length > 0
+        ? ` (${inconclusive.length} inconclusive — see above).\n`
+        : ".\n"),
+  );
+}
+
+main().catch((err) => {
+  process.stderr.write(`fatal: ${err.stack || err.message}\n`);
+  process.exit(1);
+});

--- a/scripts/verify-ollama-cloud-vision.mjs
+++ b/scripts/verify-ollama-cloud-vision.mjs
@@ -24,6 +24,11 @@ import { readFileSync } from "node:fs";
 import { dirname, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
+import {
+  parseOllamaCloudModels,
+  MODEL_ID_PATTERN,
+} from "./lib/ollama-cloud-source.mjs";
+
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const MODELS_TS = resolve(
   __dirname,
@@ -52,53 +57,15 @@ function parseArgs(argv) {
   return args;
 }
 
-// Tight allowlist for model IDs as they appear in the curated source file.
-// Ollama Cloud IDs use lowercase letters, digits, and the punctuation set
-// `[.:_-]` (e.g. `qwen3-vl:235b-instruct`, `gpt-oss:120b`, `deepseek-v3.1:671b`).
-// Validating against this pattern at parse time gives the outbound HTTP
-// request a guaranteed-safe shape and prevents anything pathological from
-// flowing from the file into the network sink. CodeQL recognises this as
-// a sanitizer for the "file data → outbound request" finding.
-const MODEL_ID_PATTERN = /^[a-z0-9][a-z0-9.:_-]*$/;
-
-function extractModelEntries(source) {
-  // Parse the `id` / `vision` pairs inside TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.
-  // Strategy: strip line and block comments first (each with a simple
-  // non-backtracking regex — no nested quantifiers, no ReDoS risk), then
-  // run a flat match-pair regex over the cleaned source. The previous
-  // single-regex approach used an alternation-with-quantifier inside the
-  // object body that could backtrack catastrophically on adversarial input.
-  // A proper TS parser is overkill for a one-shot script; this two-pass
-  // approach is both faster and easier to reason about.
-  const stripped = source
-    // Line comments: `//…\n`. `[^\n]*` cannot backtrack across newlines.
-    .replace(/\/\/[^\n]*/g, "")
-    // Block comments: `/*…*/`. Lazy `[\s\S]*?` paired with a single
-    // terminator means no alternation-induced backtracking.
-    .replace(/\/\*[\s\S]*?\*\//g, "");
-
-  const entries = [];
-  const pairRegex = /id:\s*"([^"]+)"\s*,[\s\S]*?vision:\s*(true|false)/g;
-  let match;
-  while ((match = pairRegex.exec(stripped)) !== null) {
-    const id = match[1];
-    if (!MODEL_ID_PATTERN.test(id)) {
-      throw new Error(
-        `verify-ollama-cloud-vision: parsed model ID "${id}" does not match the safe ID allowlist (${MODEL_ID_PATTERN}). ` +
-          `Refusing to send this to the Ollama Cloud API — fix the source file or widen the pattern deliberately.`,
-      );
-    }
-    entries.push({ id, vision: match[2] === "true" });
-  }
-  if (entries.length === 0) {
+async function testModel(id, apiKey) {
+  // Re-assert the safe-ID allowlist right at the network sink. The shared
+  // parser already validates, but co-locating the barrier with the fetch keeps
+  // the file-data -> outbound-request dataflow provably sanitized for CodeQL.
+  if (!MODEL_ID_PATTERN.test(id)) {
     throw new Error(
-      "verify-ollama-cloud-vision: no model entries parsed from ollama-cloud-models.ts",
+      `verify-ollama-cloud-vision: refusing to send unsafe model id "${id}" to the API.`,
     );
   }
-  return entries;
-}
-
-async function testModel(id, apiKey) {
   const body = {
     model: id,
     max_tokens: 16,
@@ -142,7 +109,7 @@ async function main() {
 
   const args = parseArgs(process.argv.slice(2));
   const source = readFileSync(MODELS_TS, "utf8");
-  const all = extractModelEntries(source);
+  const all = parseOllamaCloudModels(source);
   const targets = args.only ? all.filter((m) => m.id === args.only) : all;
   if (targets.length === 0) {
     process.stderr.write(`No models matched --only=${args.only}\n`);


### PR DESCRIPTION
## Why

Ollama announced GLM-5.2, and "probably other models/versions" too. Updating the curated Ollama Cloud catalog by hand is error-prone — the whole `ollama-cloud-models.ts` file exists because ollama.com's capability tags lie (devstral/qwen3.5 claim vision but hallucinate; gemini-3 claims tools but leaks them as text). This PR makes the update a **repeatable, empirically-verified procedure**, then runs it.

## What

### Tooling (commit 1)
- **`pnpm models:discover`** — diffs `ollama.com/v1/models` against the curated catalog. Fails on a curated model that vanished upstream (the `llama3.3:70b → HTTP 404` class of bug), lists uncurated candidates to triage.
- **`pnpm models:verify:tools`** — two-round probe (structured `tool_call` **+ multi-turn follow-up**). The follow-up catches the gemma3/kimi-k2-thinking *HTTP-500-after-tool-result* failure mode a single-turn probe misses. Retries transient overload and reports **INCONCLUSIVE** rather than a false "remove this model".
- **`pnpm models:verify:vision`** — existing script, refactored onto a shared, unit-tested parser.
- **`.claude/skills/update-ollama-cloud-models`** — the procedure as a runbook skill (subagent-tested).
- **CONTRIBUTING.md** — run it every release (upstream changes the catalog independent of our code).

Pure logic (parser, diff, probe classification, multi-turn follow-up, transient-status) is covered by `node:test` suites under `scripts/lib` (`pnpm test:scripts`).

### Catalog refresh (commit 2) — dogfooded
First `models:discover` run surfaced a full delta, not just GLM-5.2:
- **Add `glm-5.2`** — verified live 2026-06-17: structured `tool_call` + clean multi-turn follow-up, HTTP 400 "does not support image input" (text-only), 976K context, reasoning.
- **Drop 5** no longer served by Ollama (confirmed stable across two discovery runs): `glm-4.6`, `kimi-k2:1t`, `minimax-m2`, `qwen3-vl:235b`, `qwen3-vl:235b-instruct`.
- **Re-point derived sites** the removed `qwen3-vl` models fed: `balanced.vision` tier pick → `gemma4:31b`; `OLLAMA_CLOUD_IMAGE_PREFERENCE` → `gemini-3-flash-preview > minimax-m3 > gemma4:31b`. Drift-snapshot tests updated.

`gemma3:*` and `kimi-k2.7-code` deliberately **stayed out**: older sibling of `gemma4` / no official tools tag / intermittent multi-turn, and vision was unverifiable (endpoint-wide 5xx that day). No unverified capability flag ships.

## Verification
- Full web unit suite: **6051 pass, 0 fail**
- `pnpm test:scripts`: 112 pass (18 new ollama lib tests) · `tsc`: clean · prettier: clean
- `pnpm models:verify:tools --only=glm-5.2` against the live API: **OK (tool_call + clean multi-turn)**

Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com)'s self-hosted, governed agent platform.