### PR TITLE
docs(release): generalize deployment-override step in release skill

### DIFF
--- a/.claude/skills/cut-pinchy-release/SKILL.md
+++ b/.claude/skills/cut-pinchy-release/SKILL.md
@@ -57,7 +57,7 @@ Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** �
 
 1. **Watch the Release workflow.** `gh run watch "$(gh run list --workflow Release --limit 1 --json databaseId --jq '.[0].databaseId')"`. A failure means the release is **not installable** — do not announce until green. Recovery steps are in CONTRIBUTING.md § "If the release workflow fails".
 2. **Tags are immutable — never force-update a tag.** A broken release is fixed with a _patch release_, not a re-push.
-3. **Re-check the production-server overrides.** `demo.heypinchy.com` and `pinchy.heypinchy.com` both track released tags and each carry a `docker-compose.override.yml` holding workarounds for upstream bugs. After each release, check whether the override is still needed (the upstream fix may have shipped in this release) and remove it if not.
+3. **Re-check deployment overrides.** Any long-running deployment that pins a `docker-compose.override.yml` (to work around upstream bugs not yet fixed) should be reviewed after each release — the upstream fix may have shipped in this release, in which case drop the override.
 
 ## Red flags — STOP
 


### PR DESCRIPTION
## What

Generalizes the "After the release → re-check overrides" step in `.claude/skills/cut-pinchy-release/SKILL.md` so it no longer names production hostnames or describes their override mechanism.

**Before:**
> **Re-check the production-server overrides.** `demo.heypinchy.com` and `pinchy.heypinchy.com` both track released tags and each carry a `docker-compose.override.yml` holding workarounds for upstream bugs. …

**After:**
> **Re-check deployment overrides.** Any long-running deployment that pins a `docker-compose.override.yml` (to work around upstream bugs not yet fixed) should be reviewed after each release — the upstream fix may have shipped in this release, in which case drop the override.

## Why

The skill lives in a **public** AGPL repo. Committing project skills is the intended pattern, and the rest of this runbook only restates already-public `CONTRIBUTING.md` / workflow content. But this one step leaked detail that previously lived only in private operator notes: two production-ish hostnames plus the fact that they run `docker-compose.override.yml` workarounds for known upstream bugs.

That's low-severity (no credentials, no IPs, no PII) but gratuitous recon, and a poor fit for a security/governance product's public surface ("would a CISO sign off?"). The generalized wording keeps the actionable instruction intact; specific hosts/IPs stay in private operator notes.

No-op for the release procedure itself — documentation hygiene only.