### PR TITLE
fix(usage): retry transient EACCES when reading OpenClaw session files

### DIFF
--- a/packages/web/src/__tests__/lib/diagnostics/jsonl-reader-eacces-retry.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/jsonl-reader-eacces-retry.test.ts
@@ -1,0 +1,86 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// OpenClaw (root) rewrites `sessions.json` / `*.trajectory.jsonl` as mode 0600
+// on every session update; start-openclaw.sh's chmod loop reopens them to
+// 0644/0755 within ~50ms, but Pinchy (uid 999) can read in that window and hit
+// a TRANSIENT EACCES. The per-turn usage recorder reads these files on the
+// low-latency chat-`done` path and the poller backstop — if a transient EACCES
+// silently aborts the read, the turn's usage is dropped until a later poll,
+// which under-records usage in production and (in CI) leaks a prior turn's row
+// into a later test's usage-tracking measurement window.
+//
+// We can't reproduce a privileged chmod race against real files in a unit test,
+// so we mock `readFile` to drive the transient-EACCES sequence deterministically
+// and assert the retry contract (mirrors the established #314 retry pattern in
+// openclaw-config/write.ts: a bounded budget that covers two chmod-loop ticks).
+const { readFileMock } = vi.hoisted(() => ({ readFileMock: vi.fn() }));
+vi.mock("node:fs/promises", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("node:fs/promises")>();
+  return { ...actual, default: { ...actual, readFile: readFileMock }, readFile: readFileMock };
+});
+
+import {
+  resolveSessionId,
+  readTrajectoryJsonl,
+  TrajectoryFileNotFoundError,
+} from "@/lib/diagnostics/jsonl-reader";
+
+function errno(code: string): NodeJS.ErrnoException {
+  const err = new Error(`${code}: simulated`) as NodeJS.ErrnoException;
+  err.code = code;
+  return err;
+}
+
+const AGENT = "agt_retry";
+const KEY = "agent:agt_retry:direct:user1";
+const SESSION = "ses_111";
+
+beforeEach(() => {
+  readFileMock.mockReset();
+});
+
+describe("jsonl-reader EACCES resilience (sessions-file chmod race)", () => {
+  it("resolveSessionId retries a transient EACCES and resolves once the file is readable", async () => {
+    readFileMock
+      .mockRejectedValueOnce(errno("EACCES"))
+      .mockRejectedValueOnce(errno("EACCES"))
+      .mockResolvedValueOnce(JSON.stringify({ [KEY]: { sessionId: SESSION } }));
+
+    await expect(resolveSessionId(AGENT, KEY)).resolves.toBe(SESSION);
+    expect(readFileMock).toHaveBeenCalledTimes(3);
+  });
+
+  it("resolveSessionId propagates a persistent EACCES after exhausting the bounded budget", async () => {
+    readFileMock.mockRejectedValue(errno("EACCES"));
+
+    await expect(resolveSessionId(AGENT, KEY)).rejects.toThrow(/EACCES/);
+    // Retried (more than one attempt) but bounded — never an unbounded spin.
+    expect(readFileMock.mock.calls.length).toBeGreaterThan(1);
+    expect(readFileMock.mock.calls.length).toBeLessThanOrEqual(8);
+  });
+
+  it("resolveSessionId does NOT retry ENOENT — a genuinely missing index returns null on the first miss", async () => {
+    readFileMock.mockRejectedValueOnce(errno("ENOENT"));
+
+    await expect(resolveSessionId(AGENT, KEY)).resolves.toBeNull();
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("readTrajectoryJsonl retries a transient EACCES and resolves once the file is readable", async () => {
+    readFileMock
+      .mockRejectedValueOnce(errno("EACCES"))
+      .mockResolvedValueOnce('{"type":"model.completed"}\n');
+
+    await expect(readTrajectoryJsonl(AGENT, SESSION)).resolves.toBe('{"type":"model.completed"}\n');
+    expect(readFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("readTrajectoryJsonl does NOT retry ENOENT — a genuinely missing trajectory throws the typed error on the first miss", async () => {
+    readFileMock.mockRejectedValueOnce(errno("ENOENT"));
+
+    await expect(readTrajectoryJsonl(AGENT, SESSION)).rejects.toBeInstanceOf(
+      TrajectoryFileNotFoundError
+    );
+    expect(readFileMock).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/lib/diagnostics/jsonl-reader.ts
+++ b/packages/web/src/lib/diagnostics/jsonl-reader.ts
@@ -11,6 +11,39 @@ import { join } from "node:path";
 
 const DEFAULT_STATE_DIR = "/openclaw-config";
 
+// OpenClaw (root) rewrites `sessions.json` / `*.trajectory.jsonl` as mode 0600
+// on every session update; start-openclaw.sh's chmod loop reopens them to
+// 0644/0755 within ~50ms, but Pinchy (uid 999) can read in that window and hit
+// a TRANSIENT EACCES. Letting that abort the read silently drops the turn's
+// per-turn usage (the chat-`done` recorder and the poller both read these
+// files): in production the turn is under-counted until a later poll happens to
+// land outside a 0600 window; in CI the delayed row leaks into a later
+// usage-tracking spec's before→after measurement window and flakes the
+// exact-token assertion. A transient EACCES therefore means "retry after a
+// chmod-loop tick", NOT "give up".
+//
+// ENOENT is deliberately NOT retried — it's the legitimate "no session /
+// trajectory recorded yet" case the callers translate to null /
+// TrajectoryFileNotFoundError and the usage poller backstops on its next pass.
+//
+// Bounded budget mirrors openclaw-config/write.ts's #314 retry: 5 × 100ms
+// covers two chmod-loop ticks worst case. Async sleep (not the sync busy-wait
+// used there) because these readers are already async and run off-request.
+const EACCES_RETRY_ATTEMPTS = 5;
+const EACCES_RETRY_DELAY_MS = 100;
+
+async function readFileResilient(path: string): Promise<string> {
+  for (let attempt = 0; ; attempt++) {
+    try {
+      return await readFile(path, "utf8");
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException).code;
+      if (code !== "EACCES" || attempt >= EACCES_RETRY_ATTEMPTS - 1) throw err;
+      await new Promise((resolve) => setTimeout(resolve, EACCES_RETRY_DELAY_MS));
+    }
+  }
+}
+
 function getStateDir(): string {
   return process.env.OPENCLAW_STATE_DIR ?? DEFAULT_STATE_DIR;
 }
@@ -65,7 +98,7 @@ export async function resolveSessionId(
   const path = join(sessionsDir(agentId), "sessions.json");
   let raw: string;
   try {
-    raw = await readFile(path, "utf8");
+    raw = await readFileResilient(path);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") return null;
     throw err;
@@ -105,7 +138,7 @@ export async function readTrajectoryJsonl(agentId: string, sessionId: string): P
   assertSafeSegment(sessionId, "sessionId");
   const path = join(sessionsDir(agentId), `${sessionId}.trajectory.jsonl`);
   try {
-    return await readFile(path, "utf8");
+    return await readFileResilient(path);
   } catch (err) {
     if ((err as NodeJS.ErrnoException).code === "ENOENT") {
       throw new TrajectoryFileNotFoundError(path);


### PR DESCRIPTION
## Why

The **Integration Tests (OpenClaw + Fake Ollama)** job is intermittently red on `main`. Pulling the real CI logs across four failed runs showed the recurring main-wide failure is `usage-tracking.spec.ts:106` — `expect(delta.input).toBe(42 * delta.rows)` failing with `delta.input` = 84 (post-`0fc858ee`) or 18128 (pre-`0fc858ee`), passing on re-run.

Root cause is a real **production data-integrity race**, not just a test issue:

- Per-turn usage recording (`recordSessionTurnsUsage`, the chat-`done` trigger + the poller backstop) reads `sessions.json` and `*.trajectory.jsonl` from the shared `openclaw-config` volume.
- OpenClaw (root) rewrites those files as mode `0600` on every session update. `start-openclaw.sh`'s ~50ms chmod loop reopens them to `0644/0755`, but Pinchy (uid 999, in prod and in CI) can read in that window and hit a **transient `EACCES`**.
- `resolveSessionId` / `readTrajectoryJsonl` only handled `ENOENT`, so a transient `EACCES` aborted the read and the turn's usage was **silently dropped** until a later poll.
  - In production: usage is under-counted on the permission race.
  - In CI: the delayed row lands in a *later* `usage-tracking` spec's `before→after` window instead of its own baseline — contaminating the exact-token assertion (e.g. a preceding `pinchy_read` tool turn's row showing up as `delta.input=84`).

## What

Add a bounded `EACCES` retry to both readers in `jsonl-reader.ts`, mirroring the established `#314` retry pattern in `openclaw-config/write.ts` (`5 × 100ms` covers two chmod-loop ticks), async since these readers are already async:

- Transient `EACCES` → retry after a chmod-loop tick.
- `ENOENT` → unchanged ("no session/trajectory yet", poller backstops).
- Persistent `EACCES` → still propagates (logged) so a real permission problem isn't masked.

Recording becomes prompt, so in the serial integration suite each turn's row lands in its own measurement window rather than a later spec's.

## Explicitly NOT touched (no rollback of recent work)

- `#483` per-turn accounting + `(sessionKey, runId)` dedup — unchanged.
- `0fc858ee` fake-ollama deterministic-usage paths — unchanged.
- Authoritative liveness state machine, removed orphan/watchdog timers, the deliberately-dropped seq-keyed `session-projection.ts` — untouched.
- The `start-openclaw.sh` chmod loop (incl. its ctime-churn guard) — untouched; this is a reader-only change.

## Tests

- New `jsonl-reader-eacces-retry.test.ts`: transient `EACCES` retried and resolves; persistent `EACCES` propagates within a bounded budget; `ENOENT` not retried (returns null / throws `TrajectoryFileNotFoundError` on first miss). Written test-first (RED → GREEN).
- Existing `jsonl-reader.test.ts` and the usage unit suites (`usage-per-turn`, `usage-poller`, `usage-from-trajectory`) still green.

## Note

This fixes the dominant, main-wide usage-tracking flake. A separate flake in `18-chat-liveness.spec.ts:155` (mid-stream reload dropping the first streamed word) is a distinct resume-path root cause and will be addressed in its own focused PR.