### PR TITLE
fix(telegram-mock): keep update_id monotonic across /control/reset

### DIFF
--- a/config/telegram-mock/__tests__/reset-offset.test.mjs
+++ b/config/telegram-mock/__tests__/reset-offset.test.mjs
@@ -1,0 +1,68 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { createRequire } from "node:module";
+
+// server.js is CommonJS and exports a testable core. Importing it does NOT
+// boot the HTTPS/control servers (guarded by `require.main === module`), so
+// no ports are bound — this runs hermetically under `node --test`.
+const require = createRequire(import.meta.url);
+const { resetState, injectMessage, handleGetUpdates } = require("../server.js");
+
+const TOKEN = "123456:ABC-test-token-for-e2e";
+const CHAT_ID = "999888777";
+
+function inject(text) {
+  return injectMessage({
+    token: TOKEN,
+    chatId: CHAT_ID,
+    text,
+    userId: CHAT_ID,
+    username: "e2e_tester",
+    firstName: "E2E",
+    lastName: "Tester",
+  });
+}
+
+// Regression guard for the Telegram E2E flakiness: every spec's beforeAll calls
+// /control/reset. OpenClaw's already-running long-poll keeps its acknowledged
+// getUpdates offset across that reset and never re-calls getMe. If reset rewound
+// update_id to a low value, the next injected message would carry an id BELOW
+// that stale offset, handleGetUpdates would filter it out, and the bot would
+// never reply (waitForBotResponse times out at 150s). update_id must stay
+// monotonic across resets so a stale poller still receives fresh messages.
+test("update_id stays monotonic across reset so a stale poller offset still receives new messages", async () => {
+  resetState();
+
+  // Simulate prior traffic; OpenClaw would now poll with offset = last + 1.
+  inject("first");
+  inject("second");
+  const lastBeforeReset = inject("third");
+  const stalePollerOffset = lastBeforeReset + 1;
+
+  // A test's beforeAll wipes per-test state mid-stack.
+  resetState();
+
+  // The next inbound message after the reset.
+  const idAfterReset = inject("after reset");
+
+  assert.ok(
+    idAfterReset >= stalePollerOffset,
+    `update_id must not rewind across reset: got ${idAfterReset}, ` +
+      `stale poller offset is ${stalePollerOffset}`
+  );
+
+  // Behavioural check against the real symptom: a poller holding the stale
+  // offset must still be handed the freshly injected update. timeout:"0" keeps
+  // the buggy (empty) path from blocking on the 30s long-poll.
+  const res = await handleGetUpdates(TOKEN, {
+    offset: String(stalePollerOffset),
+    timeout: "0",
+  });
+  const deliveredIds = (res.result || []).map((u) => u.update_id);
+
+  assert.ok(
+    deliveredIds.includes(idAfterReset),
+    `stale poller (offset ${stalePollerOffset}) should receive update ` +
+      `${idAfterReset}, got ${JSON.stringify(deliveredIds)}`
+  );
+});

--- a/config/telegram-mock/server.js
+++ b/config/telegram-mock/server.js
@@ -55,6 +55,30 @@ const pollingTokens = new Set();
 const conflict409Tokens = new Set();
 let conflict409All = false;
 
+// Clear all per-test state. Mirrors POST /control/reset so the route and the
+// unit test share one definition.
+//
+// IMPORTANT: `updateIdCounter` is deliberately NOT reset here. Real Telegram
+// hands out `update_id` as a globally monotonic counter that never restarts,
+// and an already-running getUpdates long-poll keeps its acknowledged offset
+// across our resets (it does not re-call getMe). If we rewound the counter to
+// a low value, freshly injected updates would carry an `update_id` below that
+// stale offset and `handleGetUpdates` would silently filter them out — the bot
+// would never see the message. Keeping the counter monotonic guarantees every
+// post-reset update still exceeds any offset OpenClaw could be holding.
+function resetState() {
+  botResponses.length = 0;
+  pendingUpdates.clear();
+  bots.clear();
+  pollingTokens.clear();
+  conflict409Tokens.clear();
+  conflict409All = false;
+  // message_id may safely reset, unlike update_id: nothing filters on it
+  // (botResponses is cleared and read back by timestamp), whereas a stale
+  // long-poll offset filters incoming updates against update_id.
+  messageIdCounter = 1000;
+}
+
 // ── Anthropic API mock (for model prewarm) ─────────────────────────────
 
 function handleAnthropicRequest(url, body) {
@@ -95,6 +119,45 @@ function notifyUpdateListeners(token) {
   const listeners = updateListeners.get(token) || [];
   updateListeners.set(token, []);
   for (const cb of listeners) cb();
+}
+
+// Simulate a user sending a message to the bot: build a Telegram update,
+// queue it for the token's long-poll, and wake any waiting getUpdates. Shared
+// by POST /control/sendMessage and the unit test. Returns the new update_id.
+function injectMessage({ token, chatId, text, userId, username, firstName, lastName }) {
+  const updateId = ++updateIdCounter;
+  const update = {
+    update_id: updateId,
+    message: {
+      message_id: ++messageIdCounter,
+      from: {
+        id: parseInt(userId || chatId),
+        is_bot: false,
+        first_name: firstName || "TestUser",
+        last_name: lastName || "",
+        username: username || "testuser",
+      },
+      chat: {
+        id: parseInt(chatId),
+        type: "private",
+        first_name: firstName || "TestUser",
+        last_name: lastName || "",
+        username: username || "testuser",
+      },
+      date: Math.floor(Date.now() / 1000),
+      text,
+    },
+  };
+
+  if (!pendingUpdates.has(token)) {
+    pendingUpdates.set(token, []);
+  }
+  pendingUpdates.get(token).push(update);
+
+  // Notify any long-polling getUpdates requests
+  notifyUpdateListeners(token);
+
+  return updateId;
 }
 
 // getUpdates is async (long-poll) — handled separately
@@ -280,51 +343,24 @@ function startControlServer() {
 
       // POST /control/sendMessage — simulate user sending a message to bot
       if (req.method === "POST" && url.pathname === "/control/sendMessage") {
-        const { token, chatId, text, userId, username, firstName, lastName } =
-          JSON.parse(body);
+        const opts = JSON.parse(body);
 
-        if (!token || !chatId || !text) {
+        if (!opts.token || !opts.chatId || !opts.text) {
           res.writeHead(400);
           res.end(JSON.stringify({ error: "token, chatId, and text required" }));
           return;
         }
 
-        const updateId = ++updateIdCounter;
-        const update = {
-          update_id: updateId,
-          message: {
-            message_id: ++messageIdCounter,
-            from: {
-              id: parseInt(userId || chatId),
-              is_bot: false,
-              first_name: firstName || "TestUser",
-              last_name: lastName || "",
-              username: username || "testuser",
-            },
-            chat: {
-              id: parseInt(chatId),
-              type: "private",
-              first_name: firstName || "TestUser",
-              last_name: lastName || "",
-              username: username || "testuser",
-            },
-            date: Math.floor(Date.now() / 1000),
-            text,
-          },
-        };
-
-        if (!pendingUpdates.has(token)) {
-          pendingUpdates.set(token, []);
-        }
-        pendingUpdates.get(token).push(update);
-
-        // Notify any long-polling getUpdates requests
-        notifyUpdateListeners(token);
+        const updateId = injectMessage(opts);
 
         res.writeHead(200);
         res.end(JSON.stringify({ ok: true, updateId }));
+        // Strip CR/LF from the user-provided values before logging (CodeQL
+        // js/log-injection — it only recognises an explicit newline replace).
+        const safeChatId = String(opts.chatId).replace(/[\r\n]/g, "");
+        const safeText = String(opts.text).replace(/[\r\n]/g, "");
         console.log(
-          `[telegram-mock] Injected message from user ${chatId}: "${text}"`
+          `[telegram-mock] Injected message from user ${safeChatId}: "${safeText}"`
         );
         return;
       }
@@ -349,14 +385,7 @@ function startControlServer() {
 
       // POST /control/reset — clear all state
       if (req.method === "POST" && url.pathname === "/control/reset") {
-        botResponses.length = 0;
-        pendingUpdates.clear();
-        bots.clear();
-        pollingTokens.clear();
-        conflict409Tokens.clear();
-        conflict409All = false;
-        messageIdCounter = 1000;
-        updateIdCounter = 100;
+        resetState();
         res.writeHead(200);
         res.end(JSON.stringify({ ok: true }));
         console.log("[telegram-mock] State reset");
@@ -446,7 +475,14 @@ async function main() {
   console.log("[telegram-mock] Ready");
 }
 
-main().catch((err) => {
-  console.error("[telegram-mock] Fatal:", err);
-  process.exit(1);
-});
+// Only boot the servers when run directly (node server.js / Docker CMD).
+// When required from a unit test we just want the pure handlers below, with
+// no ports bound (443 is privileged and unavailable outside the container).
+if (require.main === module) {
+  main().catch((err) => {
+    console.error("[telegram-mock] Fatal:", err);
+    process.exit(1);
+  });
+}
+
+module.exports = { resetState, injectMessage, handleGetUpdates };

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter @pinchy/web dev",
     "build": "pnpm --filter @pinchy/web build",
     "test": "pnpm --filter @pinchy/web test",
-    "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs",
+    "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs",
     "release": "node scripts/release.mjs",
     "docs:paths": "node scripts/generate-docs-paths.mjs",
     "models:discover": "node scripts/discover-ollama-cloud-models.mjs",


### PR DESCRIPTION
## What

`config/telegram-mock/server.js` no longer rewinds `updateIdCounter` on `/control/reset`. The counter now stays monotonic across resets, matching real Telegram (which never restarts `update_id`).

Supporting changes:
- Extract `resetState()` and `injectMessage()` so the `/control/*` routes and a new unit test share one definition (behaviour-preserving).
- Guard `main()` with `require.main === module` so the mock core can be `require()`d without binding privileged port 443.
- New hermetic regression test `config/telegram-mock/__tests__/reset-offset.test.mjs` (node:test), wired into `pnpm test:scripts` (runs in CI).

## Why

The Telegram E2E suite shared a flaky failure mode — most visibly `telegram-flow`'s **"unlinked user receives pairing response"**: after a `beforeAll` reset, the bot never replied and `waitForBotResponse` timed out at 150s.

**Root cause (confirmed in code):** `/control/reset` set `updateIdCounter = 100`, but OpenClaw's already-running `getUpdates` long-poll keeps its acknowledged offset across the reset and does **not** re-call `getMe`. `handleGetUpdates` filters `update_id >= offset`, so freshly injected updates carried a *low* `update_id` below the stale offset and were silently dropped — inbound messages never reached OpenClaw, so no reply.

On a pristine CI stack the mock counter (~100) and OpenClaw's offset (0) happen to align, so it passes. The desync emerges once resets accumulate — local re-runs, or multiple specs each calling `resetMockTelegram()` in `beforeAll`.

Real Telegram hands out `update_id` as a globally monotonic counter that never restarts, so the reset rewinding it was the actual protocol violation. Fixing at the source means every post-reset update exceeds any offset OpenClaw could be holding. `bots:0` after a reset is a correlated symptom (getMe not re-called), not the delivery cause — `handleGetUpdates` does not check `bots`.

## Verification

- Regression test verified **red before the fix** (`got 101, stale poller offset is 104`) and **green after** — it exercises the same `resetState()`/`injectMessage()`/`handleGetUpdates()` the HTTP routes call.
- `pnpm test:scripts`: 95/95 green, new test included.
- No assertions weakened, no skips added.
- No spec asserts a concrete `update_id` value (grep-checked), so the monotonic counter is safe for the rest of the suite.

## Reviewer notes

- The repository-described E2E repro (`pnpm -C packages/web test:e2e:telegram` twice against the same stack) was **not** run locally: the Telegram test stack publishes host ports 7777 and 5434, which were held by another active worktree's dev stack — bringing it up would have collided with that parallel session. CI's `telegram-e2e` job runs exactly this suite on the PR and is the integration gate.
- The report that motivated this work referenced a `sendTelegramAndAwaitReply` helper / `chats.spec.ts` "re-send-until-reply" mitigation; those live on a different feature branch, not here, and would only mask the symptom. This PR fixes the mock at the source instead.