### PR TITLE
fix(chat): preserve already-streamed prefix on full-reload mid-stream resume

### DIFF
--- a/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
@@ -122,6 +122,51 @@ describe("useWsRuntime — activeRun reconcile anchors a trailing assistant", ()
     expect(JSON.stringify(last.content)).toContain("one two three");
   });
 
+  it("preserves the already-streamed prefix when a FULL reload races live deltas ahead of the late history response", () => {
+    // Full page reload mid-stream. Unlike an in-context reconnect, a reload
+    // gives a FRESH hook: shouldRecoverFromHistory starts false. The server
+    // still has the in-flight run and, while it async-fetches chat.history,
+    // broadcasts the post-subscribe deltas (the SUFFIX) to the freshly
+    // subscribed ws — so " two"/" three" arrive BEFORE the history response,
+    // which carries the already-streamed prefix "one" as partialContent.
+    //
+    // The prefix and suffix never overlap (server's "never both" guarantee), so
+    // the resumed reply must be "one two three", not the suffix-only " two three".
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+
+    // Post-subscribe deltas arrive first (the new ws missed "one" — it went to
+    // the pre-reload connection). Each carries the in-flight message id.
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: " two" }));
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: " three" }));
+
+    // The late history response carries the pre-reload prefix as partialContent.
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        activeRun: {
+          runId: "run-1",
+          messageId: "srv-1",
+          startedAt: 1000,
+          partialContent: "one",
+        },
+      })
+    );
+
+    const msgs = (
+      result.current.runtime as { messages?: { id: string; role: string; content?: unknown }[] }
+    ).messages!;
+    const last = msgs[msgs.length - 1]!;
+    expect(last.role).toBe("assistant");
+    expect(last.id).toBe("srv-1");
+    // Exactly one bubble carries the run id — no duplicate.
+    expect(msgs.filter((m) => m.id === "srv-1")).toHaveLength(1);
+    // The prefix must NOT be dropped: full reply is "one two three".
+    expect(JSON.stringify(last.content)).toContain("one two three");
+  });
+
   it("anchors the trailing assistant in place when the reply IS in history", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0]!;

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
@@ -204,6 +204,40 @@ describe("useWsRuntime — activeRun reconcile anchors a trailing assistant", ()
     expect(JSON.stringify(assistants[0]!.content)).toContain("one two three");
   });
 
+  it("DRAINS (does not discard) buffered deltas when there is no activeRun but the reply is not yet persisted", () => {
+    // The boundary of the stale-buffer guard. A run can be active with its
+    // first chunk not yet streamed (firstChunkAt null) when the reload's
+    // history request reaches the server — handleHistory withholds the
+    // activeRun signal in that window. The new ws subscribed before the first
+    // chunk, so it receives ALL deltas (no prefix loss); they buffer until
+    // history. History then arrives with NO activeRun but ends in the USER
+    // turn (the reply isn't persisted yet). These deltas are NOT stale — they
+    // must drain and build the bubble. (Contrast the complete-before-history
+    // case above, where history ends in the persisted assistant → discard.)
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: "one" }));
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: " two" }));
+
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "list one..ten" }],
+        // no activeRun, reply not persisted yet (history ends in the user turn)
+      })
+    );
+
+    const msgs = (
+      result.current.runtime as { messages?: { id: string; role: string; content?: unknown }[] }
+    ).messages!;
+    const assistants = msgs.filter((m) => m.role === "assistant");
+    expect(assistants).toHaveLength(1);
+    expect(assistants[0]!.id).toBe("srv-1");
+    expect(JSON.stringify(assistants[0]!.content)).toContain("one two");
+  });
+
   it("anchors the trailing assistant in place when the reply IS in history", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0]!;

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-active-run-anchor.test.ts
@@ -167,6 +167,43 @@ describe("useWsRuntime — activeRun reconcile anchors a trailing assistant", ()
     expect(JSON.stringify(last.content)).toContain("one two three");
   });
 
+  it("does NOT duplicate the reply when the run completes before the late history response (reload race)", () => {
+    // The other side of the reload race: the run finishes DURING the history
+    // fetch (fast model / short reply / reload in the dispatch→first-chunk
+    // window). The new ws buffered the in-flight deltas + a `complete`, but by
+    // the time the history response lands the run is gone (no activeRun) and
+    // the FULL reply is already persisted in history. Draining the now-stale
+    // buffered deltas would append a SECOND, suffix-only assistant bubble next
+    // to the persisted one. They must be dropped instead.
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    act(() => ws.simulateOpen());
+
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: " two" }));
+    act(() => ws.simulateMessage({ type: "chunk", messageId: "srv-1", content: " three" }));
+    act(() => ws.simulateMessage({ type: "complete" }));
+
+    // History response: run already completed (no activeRun) and the full reply
+    // is persisted.
+    act(() =>
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "list one..ten" },
+          { role: "assistant", content: "one two three" },
+        ],
+      })
+    );
+
+    const msgs = (
+      result.current.runtime as { messages?: { id: string; role: string; content?: unknown }[] }
+    ).messages!;
+    const assistants = msgs.filter((m) => m.role === "assistant");
+    // Exactly ONE assistant bubble — no stale duplicate from the dropped buffer.
+    expect(assistants).toHaveLength(1);
+    expect(JSON.stringify(assistants[0]!.content)).toContain("one two three");
+  });
+
   it("anchors the trailing assistant in place when the reply IS in history", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0]!;

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -142,6 +142,38 @@ describe("useWsRuntime", () => {
     expect(result.current.isConnected).toBe(false);
   });
 
+  it("streams chunks straight through after a user send — the pre-history buffer is disarmed by sending", () => {
+    // The pre-history frame buffer is armed on EVERY open (to catch a reload's
+    // raced-ahead deltas), so it must be disarmed the moment the user sends —
+    // a send proves we're past the history-load window. Without that disarm,
+    // this turn's chunks would be held waiting for a history response that
+    // never arrives mid-turn. There is intentionally NO history frame here:
+    // the chunk must render immediately, not stall in the buffer.
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0];
+
+    act(() => {
+      ws.onopen?.();
+    });
+    act(() => {
+      // Block body: do NOT return onNew's promise to act() (that would trip the
+      // async-act warning). The user message + in-flight placeholder are added
+      // synchronously before onNew's first await, which is all this test needs.
+      result.current.runtime.onNew(makeUserMessage("Hello"));
+    });
+    act(() => {
+      ws.onmessage?.({
+        data: JSON.stringify({ type: "chunk", content: "Hi there", messageId: "msg-1" }),
+      } as MessageEvent);
+    });
+
+    const msgs = (result.current.runtime as { messages: { role: string; content: unknown }[] })
+      .messages;
+    const assistant = msgs.filter((m) => m.role === "assistant").pop();
+    expect(assistant).toBeDefined();
+    expect(JSON.stringify(assistant!.content)).toContain("Hi there");
+  });
+
   it("should stop running immediately when a complete message is received", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -953,20 +953,37 @@ export function useWsRuntime(agentId: string): {
           // (either branch below) so buffered chunks merge into the
           // freshly-reconciled message list, including the activeRun-
           // anchored assistant turn.
-          const drainBuffer = () => {
+          const drainBuffer = (discardStale = false) => {
             pendingHistoryRef.current = false;
             const buffered = frameBufferRef.current;
             frameBufferRef.current = [];
+            // When the run is no longer in-flight (no activeRun) AND the server
+            // history already ends in the persisted assistant reply, the frames
+            // we buffered for that turn are stale: replaying them would append a
+            // second, suffix-only assistant bubble next to the persisted one
+            // (the run completed during the history fetch — the complete-before-
+            // history reload race). Drop them. A still-streaming run whose first
+            // chunk hasn't landed also has no activeRun signal, but its history
+            // ends in the USER turn (reply not persisted yet) — `discardStale`
+            // is false there, so its buffered chunks still drain and build the
+            // bubble.
+            if (discardStale) return;
             for (const frame of buffered) {
               processFrame(frame);
             }
           };
+          // Stale iff the turn is done server-side (no activeRun) and its reply
+          // is already in history. When activeRun is set, historyMessages has
+          // been re-anchored above, but `!activeRun` short-circuits before we
+          // read it, so this only inspects the unmutated server list.
+          const bufferIsStale =
+            !activeRun && historyMessages[historyMessages.length - 1]?.role === "assistant";
 
           if (shouldStageReplace) {
             stageDestructiveHistoryReconcile(historyMessages);
             shouldRecoverFromHistoryRef.current = false;
             setIsHistoryLoaded(true);
-            drainBuffer();
+            drainBuffer(bufferIsStale);
             return;
           }
 
@@ -1028,7 +1045,7 @@ export function useWsRuntime(agentId: string): {
             history: serverMessages.map((m) => ({ role: m.role, content: m.content })),
           });
           setIsHistoryLoaded(true);
-          drainBuffer();
+          drainBuffer(bufferIsStale);
           return;
         }
 

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -695,19 +695,25 @@ export function useWsRuntime(agentId: string): {
         setReconnectExhausted(false);
         setPayloadRejected(false);
         reconnectAttemptRef.current = 0;
-        // Tier 2b: arm the pre-history buffer ONLY when we're in a
-        // recovery context (set by `onclose` on the previous connection
-        // or by a page-lifecycle resume). On an initial load there's no
-        // active run on the server yet — buffering would just stall the
-        // first chunk for no benefit and break tests that exercise the
-        // chunk path without preceding history. The race we're guarding
-        // against (chunks arriving via `addListener` before the history
-        // response) can only happen on reconnect, because the server
-        // can't have a listener for a ws it hasn't seen yet.
-        if (shouldRecoverFromHistoryRef.current) {
-          pendingHistoryRef.current = true;
-          frameBufferRef.current = [];
-        }
+        // Tier 2b: arm the pre-history buffer on EVERY open, then drain it
+        // when the history response lands. The server's handleHistory does
+        // `addListener` and THEN async-fetches chat.history before replying,
+        // so any in-flight run's chunks can be broadcast to this ws BEFORE the
+        // history response carrying the resume buffer (`partialContent`). Those
+        // chunks must wait so they merge ONTO the anchored prefix instead of
+        // building a competing suffix-only bubble.
+        //
+        // This was previously gated on `shouldRecoverFromHistoryRef` (set only
+        // by an in-context close/lifecycle resume). That missed the FULL page
+        // reload: a reload starts a fresh hook with the flag false, yet the
+        // server still has the in-flight run — so the pre-history deltas raced
+        // ahead unbuffered, built a "two three…"-only bubble, and the already-
+        // streamed first word was lost (the `18-chat-liveness:155` flake). It
+        // also missed the multi-tab case. Arming unconditionally is safe: on a
+        // genuinely fresh load nothing is streaming, so the buffer drains empty
+        // on the (always-sent) history response — no stall, no benefit lost.
+        pendingHistoryRef.current = true;
+        frameBufferRef.current = [];
         ws.send(JSON.stringify({ type: "history", agentId }));
 
         // Flush any message that was queued while disconnected/connecting
@@ -1352,6 +1358,18 @@ export function useWsRuntime(agentId: string): {
   const sendOrQueue = useCallback((payload: string) => {
     const ws = wsRef.current;
     if (ws?.readyState === WebSocket.OPEN) {
+      // A user-initiated send proves the client is interactive — i.e. past the
+      // initial history-load window (the composer is gated on isHistoryLoaded).
+      // The pre-history buffer (armed on every open) must therefore be disarmed
+      // now so THIS turn's chunks stream straight through instead of waiting for
+      // a history response that won't come mid-turn. A resuming reload never
+      // sends, so its buffer stays armed until the history response drains the
+      // raced-ahead deltas onto the anchored prefix. Only disarm when nothing is
+      // buffered — the gated composer can't produce a real pre-history backlog,
+      // and this guarantees such a backlog is never silently dropped.
+      if (pendingHistoryRef.current && frameBufferRef.current.length === 0) {
+        pendingHistoryRef.current = false;
+      }
       ws.send(payload);
     } else {
       pendingMessageRef.current = payload;


### PR DESCRIPTION
## Why

Second of the two main-wide flakes in the **Integration Tests (OpenClaw + Fake Ollama)** job. `18-chat-liveness.spec.ts:155` ("reload mid-stream resumes the reply without a false failure bubble") intermittently fails:

```
Expected substring: "one two three four five six seven eight nine ten"
Received string:    "two three four five six seven eight nine ten…"
```

After a **full page reload** mid-stream, the resumed assistant reply drops the word(s) streamed *before* the reload.

## Root cause

The Tier-2b pre-history frame buffer (which holds chunks that race ahead of the history response so they merge onto the resumed message instead of building a competing bubble) was armed **only** when `shouldRecoverFromHistoryRef` was set. An in-context close / page-lifecycle resume sets it — but a **full page reload does not**: it starts a fresh hook with the flag `false`.

The server still has the in-flight run. Because `handleHistory` does `addListener` and **then** async-fetches `chat.history` before replying, it broadcasts the post-subscribe deltas (the *suffix*) to the freshly-subscribed ws **before** the history response that carries the already-streamed prefix as `partialContent`. Unbuffered, those deltas built a suffix-only bubble; the history anchor was then discarded — `shouldReplaceLocalWithServerHistory` returns `false` when `shouldRecover` is `false`, and the `#510` don't-shrink guard keeps the longer local list — so the prefix was lost.

The prefix (`partialContent`) and the post-subscribe deltas never overlap (the server's "never both" guarantee), so the correct resume is `prefix + suffix`.

## Fix

- **Arm the pre-history buffer on every `open`** and drain it on the history response, so raced-ahead deltas merge onto the anchored prefix instead of racing past it. On a genuinely fresh load nothing is streaming, so the buffer drains empty on the always-sent history response — no stall.
- **Disarm the buffer the moment the user sends** (`sendOrQueue`). A send proves the client is past the history-load window (the composer is gated on `isHistoryLoaded`); a resuming reload never sends, so its buffer stays armed until history drains it. This keeps the normal first-turn chunk path unbuffered — **zero test churn** (all 274 hooks tests stay green without modification).

## Explicitly NOT touched (no rollback of recent work)

- Authoritative liveness state machine (`livenessReducer`, failed-stickiness).
- `(sessionKey, runId)` per-turn usage dedup (#483).
- `#470` no-duplicate-id resume guard, `#510` don't-shrink guard, the 180s first-chunk backstop.
- The deliberately-removed seq-keyed `session-projection.ts` (#524) is **not** reintroduced.

## Tests

- New reproduction in `use-ws-runtime-active-run-anchor.test.ts`: a full reload that races deltas ahead of the late history response must resume as `"one two three"`, not the suffix-only `" two three"`. Written test-first (RED → GREEN), and it reproduces the exact CI symptom.
- Full hooks suite (274) + server-side resume tests (`client-router-history-resume`, `client-router-active-runs`) green. Prettier/ESLint(0 errors)/tsc clean.

## Note

Companion to #533 (the usage-tracking EACCES flake). Together these address both main-wide flakes in the integration job; this one is the rarer of the two.