### PR TITLE
feat(chats): per-agent Chats overview + per-task sessions (fixes cross-channel /new history loss)

### DIFF
--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -221,9 +221,16 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
       username: TG_USERNAME,
       firstName: "ChatsE2E",
     });
-    const codeMatch = pairResp.match(/Pairing code:\s*(\S+)/i);
+    // OpenClaw sends the pairing code wrapped in HTML under parse_mode=HTML
+    // ("Pairing code:\n\n<pre><code>CODE\n</code></pre>"). Skip leading
+    // whitespace, HTML tags, and Markdown backtick fences, then capture only the
+    // alphanumeric code. Capturing a restricted charset (no `<`) instead of
+    // stripping the tags with a `.replace` afterwards avoids CodeQL's
+    // incomplete-multi-character-sanitization finding while still ignoring the
+    // wrapping markup, and stays correct if OpenClaw switches to a code fence.
+    const codeMatch = pairResp.match(/Pairing code:(?:\s|<[^>]+>|`)*([A-Za-z0-9][A-Za-z0-9_-]*)/i);
     expect(codeMatch, `expected a pairing code, got: ${pairResp.slice(0, 200)}`).toBeTruthy();
-    const code = codeMatch![1].replace(/<[^>]+>/g, "").trim();
+    const code = codeMatch![1].trim();
 
     const linkRes = await linkTelegram(code);
     expect(linkRes.status).toBe(200);

--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -184,9 +184,12 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
     const aChatIds = aChats.map((c) => c.chatId);
     expect(aChatIds).toContain(chatIdA);
     expect(aChatIds).not.toContain(chatIdB);
-    // Every chat A sees is a web chat owned by A (no foreign principals leaked).
-    for (const c of aChats) {
-      expect(c.origin === "web" || c.origin === "telegram").toBe(true);
+    // No foreign web chat leaks into A's list: every web chat A sees is A's own
+    // (chatIdA, or the legacy null chat) — never user B's chatIdB. A bare
+    // `origin === "web" || "telegram"` check would be a tautology on the union
+    // type; this asserts the real per-row boundary.
+    for (const c of aChats.filter((x) => x.origin === "web")) {
+      expect(c.chatId === chatIdA || c.chatId === null).toBe(true);
     }
 
     // And the reverse: user B sees their own chat, never user A's.
@@ -301,22 +304,20 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
       "web chat must survive a Telegram /new — the per-task model keeps them separate"
     ).toContain(chatIdA);
 
-    // 2. Its history STILL loads (the web session was not reset/archived). We
-    //    re-send into the SAME web session and confirm the turn round-trips —
-    //    a wiped session would have surfaced as a fresh, separate key. The web
-    //    chat being present in (1) with the same chatId already proves the
-    //    session key survived; this is the stronger liveness check.
-    await sendWebChatMessage({
-      cookie: adminCookie,
-      agentId,
-      chatId: chatIdA,
-      text: "Still here after the Telegram reset?",
-    });
-    const stillThere = await getChatsAs(adminCookie, agentId);
-    const webChat = stillThere.find((c) => c.chatId === chatIdA);
-    expect(webChat, "web chat session is still reachable after Telegram /new").toBeTruthy();
-    expect(webChat!.origin).toBe("web");
-    expect(webChat!.writable).toBe(true);
+    // 2. The web SESSION itself is untouched — same OpenClaw sessionId before
+    //    and after the reset. A session reset rotates the sessionId and archives
+    //    the old transcript, so an unchanged id is positive proof the history was
+    //    not wiped. This is strictly stronger than re-sending a message (which
+    //    would re-materialize a wiped session and pass even on a regression).
+    const beforeSessionId = beforeWeb.find((c) => c.chatId === chatIdA)!.sessionId;
+    const afterChat = afterWeb.find((c) => c.chatId === chatIdA);
+    expect(afterChat, "web chat session is still reachable after Telegram /new").toBeTruthy();
+    expect(
+      afterChat!.sessionId,
+      "the web session must NOT be reset/rotated by a Telegram /new — same id = history intact"
+    ).toBe(beforeSessionId);
+    expect(afterChat!.origin).toBe("web");
+    expect(afterChat!.writable).toBe(true);
   });
 
   test("Telegram read-only view: transcript renders, no composer, Continue-on-Telegram present", async ({

--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -1,0 +1,368 @@
+/**
+ * Chats E2E (#508) — the critical integration verification for the per-task
+ * session model: cross-user isolation, the un-unification "footgun" fix, and
+ * the read-only Telegram mirror.
+ *
+ * Runs against the same protocol-real Telegram mock stack as the rest of this
+ * suite (per the project's "E2E with mocks for external deps" convention):
+ *   docker compose -f docker-compose.yml -f docker-compose.e2e.yml \
+ *                  -f docker-compose.test.yml up --build -d
+ *   pnpm -C packages/web test:e2e:telegram
+ *
+ * What makes this protocol-real rather than a re-mock of OpenClaw:
+ *   - Web chats are created by sending over the genuine Pinchy chat WebSocket
+ *     (`/api/ws`), so the server's ClientRouter computes the real per-user
+ *     session key and OpenClaw materializes a real `sessions.list` entry.
+ *   - The Telegram conversation is created by injecting an inbound message
+ *     through the Telegram mock's `/control/sendMessage`, exactly as a real
+ *     Telegram peer would, and the bot's reply round-trips through OpenClaw.
+ *   - The `/new` reset is delivered the same way — as the literal `/new` text a
+ *     Telegram client sends — so OpenClaw's own slash-command handling resets
+ *     ONLY the Telegram session.
+ *
+ * The three assertions read back through the actual #508 surfaces:
+ * `GET /api/agents/<id>/chats`, `GET /api/agents/<id>/telegram-chat`, the
+ * `/chat/<id>/telegram` view, and the ChatSwitcher.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  login,
+  loginAs,
+  getAgentId,
+  makeAgentShared,
+  setAgentPersonalOwnedByAdmin,
+  connectBot,
+  linkTelegram,
+  unlinkTelegram,
+  sendTelegramMessage,
+  sendTelegramAndAwaitReply,
+  waitForBotResponse,
+  waitForPinchy,
+  waitForMockTelegram,
+  waitForOpenClawConnected,
+  waitForTelegramPolling,
+  seedSetup,
+  getAdminEmail,
+  createMemberUser,
+  sendWebChatMessage,
+  getChatsAs,
+  getTelegramChatAs,
+  type ChatListItem,
+} from "./helpers";
+import { waitForOpenClawStable, waitForAgentDispatchable } from "../shared/dispatch-probe";
+
+// We reuse the seeded Smithers agent (already in OpenClaw's runtime, so chat-
+// dispatchable) and flip it to SHARED so the member user B can access it too.
+// Creating a fresh agent would need a full config regen, which EACCES-fails on
+// the production E2E image once OpenClaw has written a root-owned session dir
+// (see makeAgentShared's rationale). Smithers is shared by telegram-flow's bot
+// token; we use the SAME token so running this suite first doesn't rotate it.
+const BOT_TOKEN = "123456:ABC-test-token-for-e2e";
+const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
+
+// A distinct Telegram peer for the Chats suite so it never collides with the
+// peer telegram-flow.spec.ts links/unlinks (they run in the same stack).
+const TG_PEER_ID = "555444333";
+const TG_USERNAME = "chats_e2e_peer";
+
+const MEMBER_PASSWORD = "test-password-123";
+
+/**
+ * Poll a user's chats list until `predicate` is satisfied (or timeout). The web
+ * session can take a beat to surface in OpenClaw's `sessions.list`, so we poll
+ * rather than assert once.
+ */
+async function waitForChats(
+  cookie: string,
+  agentId: string,
+  predicate: (chats: ChatListItem[]) => boolean,
+  { timeout = 30000 }: { timeout?: number } = {}
+): Promise<ChatListItem[]> {
+  const start = Date.now();
+  let last: ChatListItem[] = [];
+  while (Date.now() - start < timeout) {
+    last = await getChatsAs(cookie, agentId);
+    if (predicate(last)) return last;
+    await new Promise((r) => setTimeout(r, 1500));
+  }
+  return last;
+}
+
+test.describe.serial("Chats — per-task session model (#508)", () => {
+  let agentId: string;
+  let adminCookie: string;
+  let userB: { id: string; email: string; password: string };
+  let userBCookie: string;
+
+  // Distinct chatIds (nanoid-shaped: lowercase alnum + dash, ≤64) so each user's
+  // web chat is its own OpenClaw session, never the legacy default key.
+  const chatIdA = "chatse2e-user-a-web";
+  const chatIdB = "chatse2e-user-b-web";
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(300000); // services can be slow in CI
+    await waitForPinchy();
+    await waitForMockTelegram();
+    await seedSetup();
+    // Deliberately NOT calling resetMockTelegram() here. Reset zeroes the mock's
+    // update_id counter, but OpenClaw's already-running long-poll keeps its
+    // higher getUpdates offset — so freshly injected updates (now numbered below
+    // that offset) are filtered out and never delivered to the bot. On a fresh
+    // CI stack the offset and counter start aligned so it's harmless there, but
+    // resetting mid-life silently breaks Telegram delivery. We scope reads by a
+    // distinct peer id + `since` timestamps instead, so stale state can't leak in.
+    await waitForOpenClawConnected(120000);
+
+    // Admin (user A) — reuse the suite's seeded admin.
+    await login();
+    adminCookie = await loginAs(getAdminEmail(), "test-password-123");
+
+    // User B — a second, independent member user. Smithers is personal to the
+    // admin by default; we flip it to shared below so B can access it too.
+    userB = await createMemberUser("chats-b@test.local", MEMBER_PASSWORD);
+    userBCookie = await loginAs(userB.email, MEMBER_PASSWORD);
+    expect(userBCookie).toBeTruthy();
+
+    // Reuse the already-dispatchable Smithers agent.
+    agentId = await getAgentId();
+    expect(agentId).toBeTruthy();
+
+    // Ensure Smithers is PERSONAL before connecting the bot. A prior run may have
+    // left it shared (makeAgentShared persists), and the channel route's main-bot
+    // guard rejects connecting a NON-personal agent when no main bot exists yet —
+    // Smithers IS the main bot. Self-heal so the suite is re-runnable.
+    await setAgentPersonalOwnedByAdmin(agentId);
+
+    // Connect the bot (same token telegram-flow uses on Smithers) and wait for
+    // polling so the Telegram-side tests can round-trip. Idempotent re-connect.
+    await connectBot(agentId, BOT_TOKEN);
+    await waitForTelegramPolling();
+
+    // Now flip Smithers to SHARED so the member user B can access it too (takes
+    // effect immediately — Pinchy reads is_personal/visibility per request, no
+    // regen needed). The Telegram channel config (token already written) is
+    // unaffected by the is_personal flip.
+    await makeAgentShared(agentId);
+
+    // connectBot pushes a config.apply that briefly tears the OpenClaw bridge
+    // down and triggers openclaw-node's reconnect backoff. Sending a web chat
+    // during that window fails with "Not connected to OpenClaw Gateway" (the
+    // cold-start churn the rest of this suite absorbs with generous waits). Gate
+    // on a contiguous connected+settled window, then confirm the agent is in
+    // OpenClaw's runtime, before any test dispatches a chat.
+    await waitForOpenClawStable(() => fetch(`${PINCHY_URL}/api/health/openclaw`), {
+      stableForMs: 10_000,
+      deadlineMs: 180_000,
+    });
+    await waitForAgentDispatchable(
+      (id) => fetch(`${PINCHY_URL}/api/health/openclaw?agentId=${id}`),
+      agentId,
+      { deadlineMs: 90_000 }
+    );
+  });
+
+  test("cross-user isolation: each user sees ONLY their own web chats", async () => {
+    // Each user creates a distinct web chat WITH content via the real chat WS.
+    await sendWebChatMessage({
+      cookie: adminCookie,
+      agentId,
+      chatId: chatIdA,
+      text: "User A's private web chat content",
+    });
+    await sendWebChatMessage({
+      cookie: userBCookie,
+      agentId,
+      chatId: chatIdB,
+      text: "User B's private web chat content",
+    });
+
+    // User A must see their own chat and must NEVER see user B's.
+    const aChats = await waitForChats(adminCookie, agentId, (c) =>
+      c.some((x) => x.chatId === chatIdA)
+    );
+    const aChatIds = aChats.map((c) => c.chatId);
+    expect(aChatIds).toContain(chatIdA);
+    expect(aChatIds).not.toContain(chatIdB);
+    // Every chat A sees is a web chat owned by A (no foreign principals leaked).
+    for (const c of aChats) {
+      expect(c.origin === "web" || c.origin === "telegram").toBe(true);
+    }
+
+    // And the reverse: user B sees their own chat, never user A's.
+    const bChats = await waitForChats(userBCookie, agentId, (c) =>
+      c.some((x) => x.chatId === chatIdB)
+    );
+    const bChatIds = bChats.map((c) => c.chatId);
+    expect(bChatIds).toContain(chatIdB);
+    expect(bChatIds).not.toContain(chatIdA);
+  });
+
+  test("footgun-fixed: Telegram /new resets ONLY Telegram, web chat survives", async ({}, testInfo) => {
+    // Telegram round-trips after a channel restart can be slow (polling churn +
+    // pairing re-send loop), so give this test a generous budget — above the
+    // config default — the same way the suite's beforeAll hooks do.
+    testInfo.setTimeout(300000);
+
+    // Precondition: user A still has the web chat from the previous test.
+    const beforeWeb = await getChatsAs(adminCookie, agentId);
+    expect(beforeWeb.map((c) => c.chatId)).toContain(chatIdA);
+
+    // Link user A's Telegram peer via the pairing flow, then have a real
+    // Telegram conversation so a SECOND, separate OpenClaw session exists.
+    // Connecting the bot in beforeAll restarts OpenClaw's Telegram channel; a
+    // message injected during that window can be skipped by the post-restart
+    // getUpdates offset, so we re-send until the pairing reply lands.
+    const pairResp = await sendTelegramAndAwaitReply({
+      token: BOT_TOKEN,
+      chatId: TG_PEER_ID,
+      text: "Pair me please",
+      userId: TG_PEER_ID,
+      username: TG_USERNAME,
+      firstName: "ChatsE2E",
+    });
+    const codeMatch = pairResp.match(/Pairing code:\s*(\S+)/i);
+    expect(codeMatch, `expected a pairing code, got: ${pairResp.slice(0, 200)}`).toBeTruthy();
+    const code = codeMatch![1].replace(/<[^>]+>/g, "").trim();
+
+    const linkRes = await linkTelegram(code);
+    expect(linkRes.status).toBe(200);
+
+    // Brief wait for OpenClaw to pick up the link, then a real linked-user turn
+    // through the genuine Telegram channel. The assistant reply fails to stream
+    // (the E2E mock Anthropic isn't a faithful streaming endpoint — same reason
+    // the suite's @llm tests are CI-skipped), but OpenClaw still APPENDS this
+    // user message into the Telegram-keyed session, which is all we need: a
+    // separate, populated session distinct from the web chat.
+    await new Promise((r) => setTimeout(r, 2000));
+    await sendTelegramMessage({
+      token: BOT_TOKEN,
+      chatId: TG_PEER_ID,
+      text: "Hello over Telegram — remember this",
+      userId: TG_PEER_ID,
+      username: TG_USERNAME,
+      firstName: "ChatsE2E",
+    });
+
+    // The Telegram conversation now surfaces in user A's chats AND has content.
+    // We poll the read-only transcript API (server-derived from user A's own
+    // linked peer) until the user message lands, rather than waiting on a bot
+    // reply the mock can't produce.
+    const withTelegram = await waitForChats(adminCookie, agentId, (c) =>
+      c.some((x) => x.origin === "telegram")
+    );
+    expect(
+      withTelegram.some((c) => c.origin === "telegram"),
+      "Telegram chat should surface in the user's chats list"
+    ).toBe(true);
+    let tgBefore = await getTelegramChatAs(adminCookie, agentId);
+    for (let i = 0; i < 20 && (tgBefore.status !== 200 || tgBefore.messages.length === 0); i++) {
+      await new Promise((r) => setTimeout(r, 1500));
+      tgBefore = await getTelegramChatAs(adminCookie, agentId);
+    }
+    expect(tgBefore.status).toBe(200);
+    expect(
+      tgBefore.messages.length,
+      "the Telegram session should carry the user's message"
+    ).toBeGreaterThan(0);
+
+    // ── THE REGRESSION: deliver a literal `/new` from the Telegram peer. ──
+    // OpenClaw handles the slash command itself and resets the session keyed to
+    // the Telegram peer. With the #508 un-unification (no session.identityLinks),
+    // that reset MUST NOT touch user A's separate web session.
+    const resetBefore = new Date().toISOString();
+    await sendTelegramMessage({
+      token: BOT_TOKEN,
+      chatId: TG_PEER_ID,
+      text: "/new",
+      userId: TG_PEER_ID,
+      username: TG_USERNAME,
+      firstName: "ChatsE2E",
+    });
+    // Slash commands are handled by OpenClaw natively; it acks (or replies).
+    // We don't assert on the ack text — just give the reset time to apply.
+    await waitForBotResponse(TG_PEER_ID, { timeout: 60000, since: resetBefore }).catch(() => {
+      // Some OpenClaw versions ack /new silently; absence of a reply is fine.
+    });
+    await new Promise((r) => setTimeout(r, 3000));
+
+    // ── ASSERT THE FOOTGUN IS GONE ──
+    // 1. User A's web chat is STILL listed.
+    const afterWeb = await getChatsAs(adminCookie, agentId);
+    expect(
+      afterWeb.map((c) => c.chatId),
+      "web chat must survive a Telegram /new — the per-task model keeps them separate"
+    ).toContain(chatIdA);
+
+    // 2. Its history STILL loads (the web session was not reset/archived). We
+    //    re-send into the SAME web session and confirm the turn round-trips —
+    //    a wiped session would have surfaced as a fresh, separate key. The web
+    //    chat being present in (1) with the same chatId already proves the
+    //    session key survived; this is the stronger liveness check.
+    await sendWebChatMessage({
+      cookie: adminCookie,
+      agentId,
+      chatId: chatIdA,
+      text: "Still here after the Telegram reset?",
+    });
+    const stillThere = await getChatsAs(adminCookie, agentId);
+    const webChat = stillThere.find((c) => c.chatId === chatIdA);
+    expect(webChat, "web chat session is still reachable after Telegram /new").toBeTruthy();
+    expect(webChat!.origin).toBe("web");
+    expect(webChat!.writable).toBe(true);
+  });
+
+  test("Telegram read-only view: transcript renders, no composer, Continue-on-Telegram present", async ({
+    page,
+    context,
+  }) => {
+    // Authenticate the browser as user A by injecting the session cookie. The
+    // `url` form lets Playwright derive domain/path/secure from the baseURL so
+    // we don't hardcode (and risk mismatching) the cookie attributes.
+    const eq = adminCookie.indexOf("=");
+    await context.addCookies([
+      {
+        name: adminCookie.slice(0, eq),
+        value: adminCookie.slice(eq + 1),
+        url: "http://localhost:7777",
+        httpOnly: true,
+        sameSite: "Lax",
+      },
+    ]);
+
+    await page.goto(`/chat/${agentId}/telegram`);
+
+    // Header + Telegram channel indicator render.
+    await expect(page.getByTestId("telegram-chat-header")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId("telegram-channel-indicator")).toBeVisible();
+
+    // The transcript renders with at least one message (seeded above). The peer
+    // was linked + chatted in the previous test; the read-only mirror reads the
+    // server-derived session for user A's own peer.
+    await expect(page.getByTestId("telegram-transcript")).toBeVisible({ timeout: 30000 });
+    await expect(page.getByTestId("telegram-message-0")).toBeVisible();
+
+    // NO composer: the read-only view renders no message input. assistant-ui's
+    // composer textarea (present on the live chat) must be absent here.
+    await expect(page.locator("textarea")).toHaveCount(0);
+    await expect(page.getByRole("textbox")).toHaveCount(0);
+
+    // The "Continue on Telegram" affordance is present (the bot username was
+    // persisted on connectBot, so the deep link resolves).
+    const continueLink = page.getByRole("link", { name: /Continue on Telegram/i });
+    await expect(continueLink).toBeVisible();
+    await expect(continueLink).toHaveAttribute("href", /t\.me\//);
+
+    // The read-only banner makes the nature explicit.
+    await expect(page.getByText(/This conversation happens on Telegram/i)).toBeVisible();
+  });
+
+  test.afterAll(async () => {
+    // Leave the suite's shared state clean for any later spec (e.g.
+    // telegram-flow, which expects Smithers to be the PERSONAL main bot):
+    // unlink this user's peer and restore Smithers to personal. Best-effort —
+    // a failure here must not fail the suite.
+    await unlinkTelegram().catch(() => {});
+    if (agentId) await setAgentPersonalOwnedByAdmin(agentId).catch(() => {});
+  });
+});

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -8,6 +8,7 @@
  */
 
 import { execSync } from "child_process";
+import { WebSocket } from "ws";
 import { stackDbUrl } from "../shared/stack-db";
 
 const PINCHY_URL = process.env.PINCHY_URL || "http://localhost:7777";
@@ -192,6 +193,52 @@ export async function waitForBotResponse(
   }
 
   throw new Error(`No bot response for chatId ${chatId} within ${timeout}ms`);
+}
+
+/**
+ * Send an inbound Telegram message and wait for the bot's reply, RE-SENDING the
+ * message if no reply lands within `perAttemptMs`. Connecting a bot triggers an
+ * OpenClaw channel restart (SIGUSR1); a message injected into the mock during
+ * that restart window can be skipped by the post-restart `getUpdates` offset and
+ * silently lost — there is no reply and nothing retries it. Re-injecting the
+ * message (fresh update_id) once polling has resumed gets it delivered. This is
+ * the documented Telegram-restart polling churn the whole suite contends with;
+ * re-sending an idempotent inbound is safe (the bot just answers the latest).
+ */
+export async function sendTelegramAndAwaitReply(
+  opts: {
+    token: string;
+    chatId: string;
+    text: string;
+    userId?: string;
+    username?: string;
+    firstName?: string;
+    lastName?: string;
+  },
+  waitOpts: { totalTimeout?: number; perAttemptMs?: number } = {}
+): Promise<string> {
+  const { totalTimeout = 180000, perAttemptMs = 45000 } = waitOpts;
+  const start = Date.now();
+  let lastErr: unknown;
+  while (Date.now() - start < totalTimeout) {
+    const since = new Date(Date.now() - 500).toISOString();
+    await sendTelegramMessage(opts);
+    try {
+      return await waitForBotResponse(opts.chatId, {
+        timeout: Math.min(perAttemptMs, totalTimeout - (Date.now() - start)),
+        since,
+      });
+    } catch (err) {
+      lastErr = err;
+      // No reply this attempt — loop re-sends (new update_id) after the bot's
+      // polling has had time to resume post-restart.
+    }
+  }
+  throw new Error(
+    `sendTelegramAndAwaitReply: no reply for chatId ${opts.chatId} within ${totalTimeout}ms (${
+      lastErr instanceof Error ? lastErr.message : String(lastErr)
+    })`
+  );
 }
 
 export async function resetMockTelegram(): Promise<void> {
@@ -437,4 +484,334 @@ export async function waitForBotPolling(token: string, timeout = 120000): Promis
     await new Promise((r) => setTimeout(r, 500));
   }
   throw new Error(`Bot ${token.slice(0, 6)}... did not start polling within ${timeout}ms`);
+}
+
+// ── Multi-user helpers (Chats E2E #508) ─────────────────────────────────
+//
+// The Chats feature's authorization boundary is "one user can only ever see
+// their OWN chats with an agent". Verifying that needs at least two real,
+// independently-authenticated users hitting the same shared agent — so these
+// helpers create a second member user and drive the per-user-cookie API and
+// the per-user web-chat WebSocket. They live here so the Telegram E2E suite
+// (which already owns the seedSetup/login plumbing) can exercise them without
+// a parallel auth harness.
+
+export interface SeededUser {
+  id: string;
+  email: string;
+  password: string;
+  /** The auth session cookie (`name=value`), set by `loginAs`. */
+  cookie: string;
+}
+
+/**
+ * Create a non-admin (`member`) user directly in the DB with a Better Auth-
+ * compatible scrypt password hash, exactly as `lib/reset-admin.ts` does: a
+ * `user` row plus a `credential` `account` row. Direct insertion (rather than
+ * the public `/sign-up` endpoint) keeps the helper independent of whether open
+ * registration is enabled and of the sign-up rate limiter.
+ */
+export async function createMemberUser(
+  email: string,
+  password = "test-password-123"
+): Promise<{ id: string; email: string; password: string }> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const { hashPassword } = await import("better-auth/crypto");
+  const sql = postgres(dbUrl);
+  try {
+    const existing = await sql<{ id: string }[]>`SELECT id FROM "user" WHERE email = ${email}`;
+    if (existing.length > 0) {
+      return { id: existing[0].id, email, password };
+    }
+    const id = crypto.randomUUID();
+    const hashed = await hashPassword(password);
+    await sql`
+      INSERT INTO "user" (id, name, email, email_verified, role)
+      VALUES (${id}, ${"Member " + email}, ${email}, true, 'member')
+    `;
+    await sql`
+      INSERT INTO account (id, user_id, account_id, provider_id, password)
+      VALUES (${crypto.randomUUID()}, ${id}, ${id}, 'credential', ${hashed})
+    `;
+    return { id, email, password };
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Make an existing agent SHARED and "all"-visibility directly in the DB, so a
+ * second member user can access it. Pinchy's access check (`getAgentWithAccess`
+ * / `assertAgentAccess`) reads `is_personal` + `visibility` from the agent row
+ * on every request, so this takes effect immediately with NO OpenClaw config
+ * regenerate — which is exactly why we use it instead of creating a new agent.
+ *
+ * Why not create a fresh agent: the only way to get an agent into OpenClaw's
+ * `agents.list` (so it's chat-dispatchable) is a full `regenerateOpenClawConfig`
+ * (a targeted channel write from connectBot does NOT). But on the production
+ * E2E image (uid 999), once OpenClaw has written an agent's session dir as root,
+ * a full regen EACCES-fails on `agents/<id>/agent` (writeAgentAuthProfiles
+ * mkdir). Reusing the already-dispatchable seeded agent sidesteps that entirely.
+ */
+export async function makeAgentShared(agentId: string): Promise<void> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+  try {
+    await sql`
+      UPDATE agents
+      SET is_personal = false, visibility = 'all', owner_id = NULL
+      WHERE id = ${agentId}
+    `;
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Restore an agent to PERSONAL, owned by the first admin. Counterpart to
+ * `makeAgentShared`: the Telegram channel route's main-bot guard rejects
+ * connecting a bot to a NON-personal agent when no main bot exists yet, and the
+ * seeded Smithers agent IS the main bot. Since `makeAgentShared` persists, a
+ * prior run can leave Smithers shared — call this FIRST so connectBot succeeds,
+ * then flip to shared again. Returns the admin id used as owner.
+ */
+export async function setAgentPersonalOwnedByAdmin(agentId: string): Promise<string> {
+  const dbUrl = process.env.DATABASE_URL || stackDbUrl(5434);
+  const { default: postgres } = await import("postgres");
+  const sql = postgres(dbUrl);
+  try {
+    const admins = await sql<{ id: string }[]>`SELECT id FROM "user" WHERE role = 'admin' LIMIT 1`;
+    const adminId = admins[0]?.id;
+    await sql`
+      UPDATE agents
+      SET is_personal = true, visibility = 'restricted', owner_id = ${adminId ?? null}
+      WHERE id = ${agentId}
+    `;
+    return adminId ?? "";
+  } finally {
+    await sql.end();
+  }
+}
+
+/**
+ * Sign in as a specific user and return the session cookie. Unlike `login()`,
+ * this does NOT mutate the module-global cookie used by `pinchyGet/Post/Delete`
+ * — callers pass the returned cookie to the `*As` helpers so two users can be
+ * driven side by side in one test.
+ */
+export async function loginAs(email: string, password = "test-password-123"): Promise<string> {
+  const res = await fetch(`${PINCHY_URL}/api/auth/sign-in/email`, {
+    method: "POST",
+    headers: { "Content-Type": "application/json", Origin: PINCHY_URL },
+    body: JSON.stringify({ email, password }),
+    redirect: "manual",
+  });
+  const setCookie = res.headers.get("set-cookie");
+  const cookie = setCookie ? setCookie.split(";")[0] : null;
+  if (!cookie) {
+    throw new Error(`loginAs(${email}) failed: ${res.status} ${await res.text()}`);
+  }
+  return cookie;
+}
+
+function authHeadersFor(cookie: string): Record<string, string> {
+  return { "Content-Type": "application/json", Origin: PINCHY_URL, Cookie: cookie };
+}
+
+export async function pinchyGetAs(cookie: string, path: string): Promise<Response> {
+  return fetch(`${PINCHY_URL}${path}`, { headers: authHeadersFor(cookie) });
+}
+
+export async function pinchyPostAs(cookie: string, path: string, body: unknown): Promise<Response> {
+  return fetch(`${PINCHY_URL}${path}`, {
+    method: "POST",
+    headers: authHeadersFor(cookie),
+    body: JSON.stringify(body),
+  });
+}
+
+export async function pinchyDeleteAs(cookie: string, path: string): Promise<Response> {
+  return fetch(`${PINCHY_URL}${path}`, { method: "DELETE", headers: authHeadersFor(cookie) });
+}
+
+export interface ChatListItem {
+  chatId: string | null;
+  sessionId: string;
+  origin: "web" | "telegram";
+  writable: boolean;
+  title: string | null;
+  lastInteractionAt: number;
+}
+
+/** GET /api/agents/<agentId>/chats as a specific user (their own chats only). */
+export async function getChatsAs(cookie: string, agentId: string): Promise<ChatListItem[]> {
+  const res = await pinchyGetAs(cookie, `/api/agents/${agentId}/chats`);
+  if (!res.ok) {
+    throw new Error(`getChatsAs failed: ${res.status} ${await res.text()}`);
+  }
+  const data = (await res.json()) as { chats?: ChatListItem[] };
+  return data.chats ?? [];
+}
+
+export interface TelegramTranscriptMessage {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: number;
+}
+
+/** GET /api/agents/<agentId>/telegram-chat as a specific user. */
+export async function getTelegramChatAs(
+  cookie: string,
+  agentId: string
+): Promise<{ status: number; messages: TelegramTranscriptMessage[]; botDeepLink: string | null }> {
+  const res = await pinchyGetAs(cookie, `/api/agents/${agentId}/telegram-chat`);
+  if (!res.ok) {
+    return { status: res.status, messages: [], botDeepLink: null };
+  }
+  const data = (await res.json()) as {
+    messages?: TelegramTranscriptMessage[];
+    botDeepLink?: string | null;
+  };
+  return {
+    status: res.status,
+    messages: data.messages ?? [],
+    botDeepLink: data.botDeepLink ?? null,
+  };
+}
+
+/**
+ * Send ONE web-chat message over the real Pinchy chat WebSocket (`/api/ws`),
+ * authenticated with the given user's session cookie, and wait until OpenClaw
+ * has MATERIALIZED the session for it. This is the genuine web path: the
+ * server's `ClientRouter` computes the per-(user, agent[, chatId]) session key
+ * and dispatches to OpenClaw, which appends the user message into a real
+ * session keyed `agent:<id>:direct:<userId>[:<chatId>]` — the same session the
+ * Chats list later reads back through `sessions.list`.
+ *
+ * Why we resolve on session creation rather than a completed assistant turn:
+ * the E2E stack's mock Anthropic is NOT a faithful streaming endpoint, so the
+ * agent turn fails late with `incomplete_result` — but OpenClaw has already
+ * persisted the user message into the session by then (verified: the chat shows
+ * up in `sessions.list` despite the turn error). For the Chats feature we only
+ * need the session to exist; the turn's content is irrelevant. This is also why
+ * the suite's `@llm` tests, which DO assert on reply content, are CI-skipped.
+ *
+ * No browser / assistant-ui involved on purpose: the previous chat-UI E2E was
+ * dropped for model-prewarm + render flakes (see agent-create-no-restart.spec.ts).
+ *
+ * Discriminating a real dispatch failure from a tolerable turn failure: the
+ * server sends `thinking` the moment it ACCEPTS + dispatches the message (after
+ * which the user turn is persisted). So `thinking`-then-anything ⇒ the session
+ * exists ⇒ resolve. An error WITHOUT a preceding `thinking` means dispatch
+ * itself failed (e.g. "Not connected to OpenClaw Gateway" during reconnect
+ * churn) ⇒ no session ⇒ retry once.
+ */
+export async function sendWebChatMessage(opts: {
+  cookie: string;
+  agentId: string;
+  text: string;
+  chatId?: string;
+  timeout?: number;
+}): Promise<void> {
+  const { cookie, agentId, text, chatId, timeout = 60000 } = opts;
+  const wsUrl = `${PINCHY_URL.replace(/^http/, "ws")}/api/ws?agentId=${agentId}`;
+
+  // Resolves `true` when the session was materialized (turn dispatched), `false`
+  // when dispatch failed before reaching OpenClaw (caller retries). Rejects only
+  // on a definitive protocol rejection that a retry can't fix.
+  const attempt = (): Promise<boolean> =>
+    new Promise<boolean>((resolve, reject) => {
+      const ws = new WebSocket(wsUrl, { headers: { Cookie: cookie, Origin: PINCHY_URL } });
+      const timer = setTimeout(() => {
+        ws.close();
+        // No frame at all within the window — treat as a dispatch miss so the
+        // caller retries rather than hard-failing on a slow reconnect.
+        resolve(false);
+      }, timeout);
+
+      let dispatched = false; // saw `thinking` ⇒ user turn persisted
+      let graceTimer: ReturnType<typeof setTimeout> | null = null;
+
+      const settle = (ok: boolean) => {
+        if (graceTimer) clearTimeout(graceTimer);
+        clearTimeout(timer);
+        ws.close();
+        resolve(ok);
+      };
+
+      ws.on("open", () => {
+        ws.send(
+          JSON.stringify({ type: "message", agentId, content: text, ...(chatId ? { chatId } : {}) })
+        );
+      });
+
+      ws.on("message", (raw) => {
+        let msg: { type?: string; message?: string; code?: string };
+        try {
+          msg = JSON.parse(raw.toString());
+        } catch {
+          return;
+        }
+        // A completed turn (mock can sometimes echo) is unambiguous success.
+        if (msg.type === "complete" || msg.type === "done") {
+          settle(true);
+          return;
+        }
+        // `thinking` ⇒ accepted + dispatched ⇒ the user turn is now in the
+        // session. Give OpenClaw a brief grace window to finish persisting,
+        // then resolve as created regardless of how the assistant turn ends.
+        if (msg.type === "thinking") {
+          dispatched = true;
+          if (!graceTimer) graceTimer = setTimeout(() => settle(true), 3000);
+          return;
+        }
+        if (msg.type === "text" || msg.type === "chunk") {
+          settle(true);
+          return;
+        }
+        if (msg.type === "error") {
+          const code = `${msg.code ?? ""} ${msg.message ?? ""}`;
+          // Definitive protocol rejections can never succeed on retry — fail fast.
+          if (/INVALID_CHAT_ID|PROTOCOL_OUTDATED|Access denied|Agent not found/i.test(code)) {
+            clearTimeout(timer);
+            if (graceTimer) clearTimeout(graceTimer);
+            ws.close();
+            reject(new Error(`web chat rejected: ${code.trim() || "unknown"}`));
+            return;
+          }
+          // An error AFTER `thinking` is a turn failure (e.g. the mock's
+          // non-streaming reply → `incomplete_result`); the session already
+          // exists, so this counts as created. An error BEFORE `thinking` is a
+          // dispatch miss (reconnect churn) ⇒ retry.
+          settle(dispatched);
+        }
+      });
+
+      ws.on("error", () => {
+        clearTimeout(timer);
+        if (graceTimer) clearTimeout(graceTimer);
+        // Socket-level failure before/around dispatch ⇒ let the caller retry.
+        resolve(false);
+      });
+    });
+
+  let created = await attempt();
+  if (!created) {
+    // Cold-start / reconnect churn (a config.apply from connectBot drops the
+    // openclaw-node bridge). Retry once after a short backoff — the exact
+    // transient the rest of the Telegram suite absorbs with generous waits.
+    await new Promise((r) => setTimeout(r, 5000));
+    created = await attempt();
+  }
+  if (!created) {
+    throw new Error(
+      "sendWebChatMessage: OpenClaw never accepted the message (no `thinking` frame after retry)"
+    );
+  }
+
+  // Settle: OpenClaw persists the user turn into the session JSONL just after
+  // dispatch; a small wait avoids reading `sessions.list` before it lands.
+  await new Promise((r) => setTimeout(r, 1500));
 }

--- a/packages/web/src/__tests__/api/agent-chats-list.test.ts
+++ b/packages/web/src/__tests__/api/agent-chats-list.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+const mockList = vi.fn();
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ sessions: { list: mockList } }),
+}));
+
+// `db.select().from().where()` returns the linked channel rows for THIS user.
+const mockWhere = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: (...args: unknown[]) => mockWhere(...args),
+      }),
+    }),
+  },
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/agents/agent-1/chats", {
+    method: "GET",
+  });
+}
+
+const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+/**
+ * A mixed `sessions.list` payload spanning every classification branch, so a
+ * single assertion proves both the cross-user AND cross-agent authorization
+ * boundary. The authed user is `user-1`; their linked Telegram peer is
+ * `tg-peer-111` (OpenClaw principals are a single key segment — no colons).
+ * The classifier lowercases the principal, so the link set is compared
+ * lowercased.
+ */
+function mixedSessions() {
+  return {
+    sessions: [
+      // authed user's web chat WITH a chatId (newer)
+      {
+        key: "agent:agent-1:direct:user-1:chat-abc",
+        sessionId: "s-web-new",
+        label: "Quarterly report",
+        lastInteractionAt: 5000,
+      },
+      // authed user's LEGACY web chat (no chatId, older)
+      {
+        key: "agent:agent-1:direct:user-1",
+        sessionId: "s-web-legacy",
+        lastInteractionAt: 1000,
+      },
+      // authed user's linked Telegram peer (read-only, middle recency)
+      {
+        key: "agent:agent-1:direct:tg-peer-111",
+        sessionId: "s-telegram",
+        label: "Telegram chat",
+        lastInteractionAt: 3000,
+      },
+      // ANOTHER user's web chat — must be excluded (cross-user isolation)
+      {
+        key: "agent:agent-1:direct:user-2:chat-zzz",
+        sessionId: "s-other-user",
+        lastInteractionAt: 9000,
+      },
+      // an UNLINKED Telegram peer — must be excluded
+      {
+        key: "agent:agent-1:direct:tg-peer-999",
+        sessionId: "s-unlinked-peer",
+        lastInteractionAt: 9000,
+      },
+      // a cron key — must be excluded
+      {
+        key: "agent:agent-1:cron:nightly",
+        sessionId: "s-cron",
+        lastInteractionAt: 9000,
+      },
+      // a subagent key — must be excluded
+      {
+        key: "agent:agent-1:subagent:helper",
+        sessionId: "s-subagent",
+        lastInteractionAt: 9000,
+      },
+      // the authed user's chat under a DIFFERENT agent — must be excluded
+      // (cross-agent isolation)
+      {
+        key: "agent:agent-2:direct:user-1:chat-other",
+        sessionId: "s-other-agent",
+        lastInteractionAt: 9000,
+      },
+    ],
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("GET /api/agents/[agentId]/chats", () => {
+  let GET: typeof import("@/app/api/agents/[agentId]/chats/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-1", email: "user@test.com", role: "member" },
+    });
+    mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
+    // This user has one linked Telegram peer.
+    mockWhere.mockResolvedValue([
+      { channel: "telegram", userId: "user-1", channelUserId: "tg-peer-111" },
+    ]);
+    mockList.mockResolvedValue(mixedSessions());
+
+    const mod = await import("@/app/api/agents/[agentId]/chats/route");
+    GET = mod.GET;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(401);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("propagates the access decision from getAgentWithAccess (403/404)", async () => {
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(403);
+    expect(mockList).not.toHaveBeenCalled();
+  });
+
+  it("enforces cross-user AND cross-agent isolation: returns only the user's own chats for this agent", async () => {
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    const sessionIds = body.chats.map((c: { sessionId: string }) => c.sessionId);
+
+    // ONLY the authed user's chats for agent-1.
+    expect(sessionIds).toEqual(expect.arrayContaining(["s-web-new", "s-web-legacy", "s-telegram"]));
+    expect(sessionIds).toHaveLength(3);
+
+    // Cross-user: another user's chat is excluded.
+    expect(sessionIds).not.toContain("s-other-user");
+    // Cross-agent: the user's own chat under agent-2 is excluded.
+    expect(sessionIds).not.toContain("s-other-agent");
+    // Other exclusions: unlinked peer, cron, subagent.
+    expect(sessionIds).not.toContain("s-unlinked-peer");
+    expect(sessionIds).not.toContain("s-cron");
+    expect(sessionIds).not.toContain("s-subagent");
+  });
+
+  it("sorts chats by lastInteractionAt descending", async () => {
+    const res = await GET(makeRequest(), ctx as never);
+    const body = await res.json();
+    const ids = body.chats.map((c: { sessionId: string }) => c.sessionId);
+    // 5000 (web-new) > 3000 (telegram) > 1000 (web-legacy)
+    expect(ids).toEqual(["s-web-new", "s-telegram", "s-web-legacy"]);
+  });
+
+  it("marks Telegram chats read-only and web chats writable, carrying the title", async () => {
+    const res = await GET(makeRequest(), ctx as never);
+    const body = await res.json();
+    const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+
+    const telegram = byId.get("s-telegram") as { writable: boolean; title: string | null };
+    expect(telegram.writable).toBe(false);
+    expect(telegram.title).toBe("Telegram chat");
+
+    const web = byId.get("s-web-new") as { writable: boolean; title: string | null };
+    expect(web.writable).toBe(true);
+    expect(web.title).toBe("Quarterly report");
+
+    // Legacy web chat has no label → title is null.
+    const legacy = byId.get("s-web-legacy") as { title: string | null };
+    expect(legacy.title).toBeNull();
+  });
+
+  it("returns 502 when OpenClaw sessions.list fails", async () => {
+    mockList.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(502);
+  });
+});

--- a/packages/web/src/__tests__/api/agent-chats-list.test.ts
+++ b/packages/web/src/__tests__/api/agent-chats-list.test.ts
@@ -18,8 +18,9 @@ vi.mock("@/lib/agent-access", () => ({
 }));
 
 const mockList = vi.fn();
+const mockHistory = vi.fn();
 vi.mock("@/server/openclaw-client", () => ({
-  getOpenClawClient: () => ({ sessions: { list: mockList } }),
+  getOpenClawClient: () => ({ sessions: { list: mockList, history: mockHistory } }),
 }));
 
 // `db.select().from().where()` returns the linked channel rows for THIS user.
@@ -117,6 +118,10 @@ describe("GET /api/agents/[agentId]/chats", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    // Fresh module per test so the route's process-local title cache (keyed by
+    // sessionId, 60s TTL) doesn't leak a derived title from one test into the
+    // next (several tests reuse the s-web-legacy sessionId).
+    vi.resetModules();
     mockGetSession.mockResolvedValue({
       user: { id: "user-1", email: "user@test.com", role: "member" },
     });
@@ -126,6 +131,9 @@ describe("GET /api/agents/[agentId]/chats", () => {
       { channel: "telegram", userId: "user-1", channelUserId: "tg-peer-111" },
     ]);
     mockList.mockResolvedValue(mixedSessions());
+    // Default: no transcript, so labelless chats stay title-null unless a test
+    // opts a session into a first-user-message history below.
+    mockHistory.mockResolvedValue({ messages: [] });
 
     const mod = await import("@/app/api/agents/[agentId]/chats/route");
     GET = mod.GET;
@@ -197,5 +205,100 @@ describe("GET /api/agents/[agentId]/chats", () => {
     mockList.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(502);
+  });
+
+  // ── Fix 2: derive list titles from the first user message ────────────────
+
+  describe("title derivation from the first user message", () => {
+    /**
+     * Route `mockHistory` per session KEY. Web chats are keyed
+     * `agent:agent-1:direct:user-1[:<chatId>]`. Anything not mapped returns an
+     * empty transcript.
+     */
+    function historyByKey(entries: Record<string, { role: string; content: unknown }[]>) {
+      const map = new Map(Object.entries(entries));
+      mockHistory.mockImplementation(async (key: string) => ({ messages: map.get(key) ?? [] }));
+    }
+
+    it("derives a labelless web chat's title from its first user message", async () => {
+      // s-web-legacy is the labelless web chat keyed at `…:direct:user-1`.
+      historyByKey({
+        "agent:agent-1:direct:user-1": [
+          { role: "assistant", content: "Hi, how can I help?" },
+          { role: "user", content: "What were our Q3 sales numbers?" },
+          { role: "assistant", content: "Let me check." },
+        ],
+      });
+
+      const res = await GET(makeRequest(), ctx as never);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+
+      const legacy = byId.get("s-web-legacy") as { title: string | null };
+      expect(legacy.title).toBe("What were our Q3 sales numbers?");
+    });
+
+    it("truncates a long first user message to ~60 chars", async () => {
+      const long =
+        "Please summarize the entire quarterly earnings report including every regional breakdown and footnote";
+      historyByKey({ "agent:agent-1:direct:user-1": [{ role: "user", content: long }] });
+
+      const res = await GET(makeRequest(), ctx as never);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+      const legacy = byId.get("s-web-legacy") as { title: string | null };
+
+      expect(legacy.title).not.toBeNull();
+      expect(legacy.title!.length).toBeLessThanOrEqual(61); // 60 + an ellipsis char
+      expect(legacy.title!).toMatch(/^Please summarize the entire quarterly earnings/);
+      expect(legacy.title!.endsWith("…")).toBe(true);
+    });
+
+    it("keeps the saved label and does NOT read history when a label exists", async () => {
+      // s-web-new HAS a label ("Quarterly report"); its history must not be read.
+      const res = await GET(makeRequest(), ctx as never);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+
+      const web = byId.get("s-web-new") as { title: string | null };
+      expect(web.title).toBe("Quarterly report");
+
+      // The labelled chat's session key was never passed to sessions.history.
+      const fetchedKeys = mockHistory.mock.calls.map((c) => c[0]);
+      expect(fetchedKeys).not.toContain("agent:agent-1:direct:user-1:chat-abc");
+    });
+
+    it("leaves title null for a labelless chat with no user message", async () => {
+      // Default mockHistory returns empty messages → no first user message.
+      const res = await GET(makeRequest(), ctx as never);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+
+      const legacy = byId.get("s-web-legacy") as { title: string | null };
+      expect(legacy.title).toBeNull();
+    });
+
+    it("does NOT read history for Telegram chats — their title stays the label", async () => {
+      const res = await GET(makeRequest(), ctx as never);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+
+      const telegram = byId.get("s-telegram") as { title: string | null };
+      expect(telegram.title).toBe("Telegram chat");
+
+      // The Telegram peer's session key was never passed to sessions.history.
+      const fetchedKeys = mockHistory.mock.calls.map((c) => c[0]);
+      expect(fetchedKeys).not.toContain("agent:agent-1:direct:tg-peer-111");
+    });
+
+    it("still returns chats when history reads fail (title falls back to null)", async () => {
+      mockHistory.mockRejectedValue(new Error("history unavailable"));
+      const res = await GET(makeRequest(), ctx as never);
+      expect(res.status).toBe(200);
+      const body = await res.json();
+      const byId = new Map(body.chats.map((c: { sessionId: string }) => [c.sessionId, c]));
+      const legacy = byId.get("s-web-legacy") as { title: string | null };
+      expect(legacy.title).toBeNull();
+    });
   });
 });

--- a/packages/web/src/__tests__/api/agent-session-compact.test.ts
+++ b/packages/web/src/__tests__/api/agent-session-compact.test.ts
@@ -85,6 +85,35 @@ describe("POST /api/agents/[agentId]/sessions/compact", () => {
     expect(mockCompact).toHaveBeenCalledWith("agent:agent-1:direct:user-1", { maxLines: 200 });
   });
 
+  it("compacts the per-CHAT session when a chatId is provided (#508)", async () => {
+    // On /chat/<agentId>/<chatId> the header action must target THAT chat's
+    // session, not the default one — the session key gets the chatId segment.
+    const res = await POST(makeRequest({ chatId: "chat-abc" }), ctx as never);
+    expect(res.status).toBe(200);
+    expect(mockCompact).toHaveBeenCalledTimes(1);
+    expect(mockCompact.mock.calls[0][0]).toBe("agent:agent-1:direct:user-1:chat-abc");
+  });
+
+  it("rejects an invalid chatId (400, no OC call)", async () => {
+    // A malformed chatId must never route a compaction into the wrong/default
+    // conversation — reject at the body-validation edge, like the WS boundary.
+    const res = await POST(makeRequest({ chatId: "bad:id" }), ctx as never);
+    expect(res.status).toBe(400);
+    expect(mockCompact).not.toHaveBeenCalled();
+  });
+
+  it("throttles per session key — compacting a different chat is NOT blocked", async () => {
+    const a = await POST(makeRequest({ chatId: "chat-a" }), ctx as never);
+    expect(a.status).toBe(200);
+    // A different chat is a different session key, so its first compaction
+    // must go through rather than hitting the previous chat's throttle window.
+    const b = await POST(makeRequest({ chatId: "chat-b" }), ctx as never);
+    expect(b.status).toBe(200);
+    expect(mockCompact).toHaveBeenCalledTimes(2);
+    expect(mockCompact.mock.calls[0][0]).toBe("agent:agent-1:direct:user-1:chat-a");
+    expect(mockCompact.mock.calls[1][0]).toBe("agent:agent-1:direct:user-1:chat-b");
+  });
+
   it("returns 400 on an invalid body (maxLines not a positive int)", async () => {
     const res = await POST(makeRequest({ maxLines: -5 }), ctx as never);
     expect(res.status).toBe(400);

--- a/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
@@ -1,0 +1,173 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest, NextResponse } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: () => mockGetSession(),
+}));
+
+const mockGetAgentWithAccess = vi.fn();
+vi.mock("@/lib/agent-access", () => ({
+  getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
+}));
+
+const mockHistory = vi.fn();
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ sessions: { history: mockHistory } }),
+}));
+
+// `db.select().from().where()` returns the linked channel rows for THIS user.
+const mockWhere = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: (...args: unknown[]) => mockWhere(...args),
+      }),
+    }),
+  },
+}));
+
+// `getSetting("telegram_bot_username:<agentId>")` resolves the bot username.
+const mockGetSetting = vi.fn();
+vi.mock("@/lib/settings", () => ({
+  getSetting: (...args: unknown[]) => mockGetSetting(...args),
+}));
+
+// ── Helpers ──────────────────────────────────────────────────────────────
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/agents/agent-1/telegram-chat", {
+    method: "GET",
+  });
+}
+
+const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
+
+/**
+ * A realistic OpenClaw `sessions.history` payload mixing the shapes the live
+ * web chat already normalizes: a user turn with OpenClaw's `[timestamp]`
+ * prefix, an assistant turn wrapped in `<final>` tags, and tool/system noise
+ * that must be dropped.
+ */
+function transcriptPayload() {
+  return {
+    messages: [
+      { role: "user", content: "[2026-06-16T10:00:00Z] Hello from Telegram", timestamp: 1000 },
+      {
+        role: "assistant",
+        content: [{ type: "text", text: "<final>Hi there!</final>" }],
+        timestamp: 2000,
+      },
+      // tool/system noise the read-only view drops, exactly like the live chat
+      { role: "tool", content: "tool result blob", timestamp: 1500 },
+      { role: "system", content: "system prompt", timestamp: 500 },
+    ],
+  };
+}
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("GET /api/agents/[agentId]/telegram-chat", () => {
+  let GET: typeof import("@/app/api/agents/[agentId]/telegram-chat/route").GET;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockGetSession.mockResolvedValue({
+      user: { id: "user-1", email: "user@test.com", role: "member" },
+    });
+    mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
+    // This user has one linked Telegram peer (note mixed case to prove lowercasing).
+    mockWhere.mockResolvedValue([
+      { channel: "telegram", userId: "user-1", channelUserId: "TG-Peer-111" },
+    ]);
+    mockHistory.mockResolvedValue(transcriptPayload());
+    mockGetSetting.mockResolvedValue("smithers_bot");
+
+    const mod = await import("@/app/api/agents/[agentId]/telegram-chat/route");
+    GET = mod.GET;
+  });
+
+  it("returns 401 when unauthenticated", async () => {
+    mockGetSession.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(401);
+    expect(mockHistory).not.toHaveBeenCalled();
+  });
+
+  it("propagates the access decision from getAgentWithAccess (403/404)", async () => {
+    mockGetAgentWithAccess.mockResolvedValueOnce(
+      NextResponse.json({ error: "Forbidden" }, { status: 403 })
+    );
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(403);
+    expect(mockHistory).not.toHaveBeenCalled();
+  });
+
+  it("resolves the session key from the authed user's link and returns mapped messages", async () => {
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+
+    // Session key is server-derived: agent:<agentId>:direct:<lowercased peerId>.
+    expect(mockHistory).toHaveBeenCalledWith("agent:agent-1:direct:tg-peer-111", expect.anything());
+
+    const body = await res.json();
+    expect(body.messages).toEqual([
+      { role: "user", text: "Hello from Telegram", timestamp: 1000 },
+      { role: "assistant", text: "Hi there!", timestamp: 2000 },
+    ]);
+  });
+
+  it("returns 404 when the authed user has no linked Telegram conversation", async () => {
+    mockWhere.mockResolvedValueOnce([]);
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(404);
+    const body = await res.json();
+    expect(body.error).toBe("No linked Telegram conversation");
+    // Never hit OpenClaw without a resolved peer.
+    expect(mockHistory).not.toHaveBeenCalled();
+  });
+
+  it("derives the peer from the AUTHED user only — a second user gets THEIR peer, never the first user's", async () => {
+    // A different authed user with their OWN, different link.
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: "user-2", email: "other@test.com", role: "member" },
+    });
+    mockWhere.mockResolvedValueOnce([
+      { channel: "telegram", userId: "user-2", channelUserId: "tg-peer-222" },
+    ]);
+
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+
+    // The session key uses user-2's peer (222), NOT user-1's peer (111).
+    expect(mockHistory).toHaveBeenCalledWith("agent:agent-1:direct:tg-peer-222", expect.anything());
+    const calledKey = mockHistory.mock.calls[0][0] as string;
+    expect(calledKey).not.toContain("tg-peer-111");
+  });
+
+  it("returns 502 when OpenClaw sessions.history fails", async () => {
+    mockHistory.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(502);
+  });
+
+  it("returns a botDeepLink when the bot username resolves", async () => {
+    const res = await GET(makeRequest(), ctx as never);
+    const body = await res.json();
+    expect(body.botDeepLink).toBe("https://t.me/smithers_bot");
+  });
+
+  it("returns botDeepLink null when no bot username is configured", async () => {
+    mockGetSetting.mockResolvedValueOnce(null);
+    const res = await GET(makeRequest(), ctx as never);
+    const body = await res.json();
+    expect(body.botDeepLink).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -201,6 +201,72 @@ describe("POST /api/internal/audit/tool-use", () => {
     });
   });
 
+  // Chats feature (#508): once session keys gain a chatId segment
+  // (agent:<agentId>:direct:<userId>:<chatId>), user attribution must capture
+  // ONLY the userId segment. A greedy parser would mis-attribute the audit row
+  // to the bogus actor "<userId>:<chatId>".
+  describe("user attribution with chatId session keys (#508)", () => {
+    it("extracts only the userId from a legacy 4-segment direct session key", async () => {
+      const res = await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "browser",
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:direct:user-1",
+          result: { ok: true },
+        })
+      );
+
+      expect(res.status).toBe(200);
+      expect(appendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: "user",
+          actorId: "user-1",
+        })
+      );
+    });
+
+    it("extracts only the userId from a 5-segment direct session key with a chatId", async () => {
+      const res = await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "browser",
+          agentId: "agent-1",
+          sessionKey: "agent:agent-1:direct:user-1:chat-abc",
+          result: { ok: true },
+        })
+      );
+
+      expect(res.status).toBe(200);
+      // NOT "user-1:chat-abc" — the chatId must not bleed into the actor id.
+      expect(appendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: "user",
+          actorId: "user-1",
+        })
+      );
+    });
+
+    it("falls back to agent actor for non-direct session keys", async () => {
+      const res = await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "pinchy_read",
+          sessionKey: "agent:agent-9:main",
+          result: "ok",
+        })
+      );
+
+      expect(res.status).toBe(200);
+      expect(appendAuditLog).toHaveBeenCalledWith(
+        expect.objectContaining({
+          actorType: "agent",
+          actorId: "agent-9",
+        })
+      );
+    });
+  });
+
   it("derives outcome='success' and error=null when payload has no error", async () => {
     await POST(
       makeRequest({

--- a/packages/web/src/__tests__/api/settings-telegram.test.ts
+++ b/packages/web/src/__tests__/api/settings-telegram.test.ts
@@ -16,10 +16,11 @@ vi.mock("@/lib/telegram-pairing", () => ({
   resolvePairingCode: (...args: unknown[]) => mockResolvePairingCode(...args),
 }));
 
-const mockUpdateIdentityLinks = vi.fn();
-vi.mock("@/lib/openclaw-config", () => ({
-  updateIdentityLinks: (...args: unknown[]) => mockUpdateIdentityLinks(...args),
-}));
+// #508: the route no longer writes session.identityLinks (per-task session
+// model — each Telegram peer keeps its own per-peer OpenClaw session). It no
+// longer imports anything from @/lib/openclaw-config, so there is nothing to
+// mock here; the assertions below verify channel_links + allow-store remain
+// the only effects of link/unlink.
 
 const mockRecalculateTelegramAllowStores = vi.fn().mockResolvedValue(undefined);
 const mockRemovePairingRequest = vi.fn();
@@ -124,7 +125,6 @@ describe("POST /api/settings/telegram", () => {
       }),
     });
     mockResolvePairingCode.mockReturnValue({ found: true, telegramUserId: "8734062810" });
-    mockUpdateIdentityLinks.mockReturnValue(undefined);
   });
 
   it("returns 401 when unauthenticated", async () => {
@@ -155,8 +155,8 @@ describe("POST /api/settings/telegram", () => {
     // Per-account allow-from stores recalculated (permission-aware)
     expect(mockRecalculateTelegramAllowStores).toHaveBeenCalled();
 
-    // identityLinks updated (targeted write, no full config regeneration)
-    expect(mockUpdateIdentityLinks).toHaveBeenCalled();
+    // #508: no session.identityLinks write — channel_links + the allow-store
+    // recalc are the only effects of linking under the per-task session model.
   });
 
   it("returns 400 when pairing code is invalid", async () => {
@@ -214,7 +214,7 @@ describe("DELETE /api/settings/telegram", () => {
     // Per-account allow-from stores recalculated (removes unlinked user)
     expect(mockRecalculateTelegramAllowStores).toHaveBeenCalled();
 
-    // identityLinks updated (targeted write, no full config regeneration)
-    expect(mockUpdateIdentityLinks).toHaveBeenCalled();
+    // #508: no session.identityLinks write on unlink either — the allow-store
+    // recalc (driven by channel_links) is the sole config-side effect.
   });
 });

--- a/packages/web/src/__tests__/app/chat-chatid-page.test.tsx
+++ b/packages/web/src/__tests__/app/chat-chatid-page.test.tsx
@@ -1,0 +1,156 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+
+// Mirrors chat-page.test.tsx but targets the [chatId] dynamic segment (#508):
+// the page must apply the SAME agent DB load + assertAgentAccess auth gate as
+// the base chat/[agentId]/page.tsx, and additionally thread the chatId param
+// down to <Chat chatId={...} />.
+
+const mockNotFound = vi.fn(() => {
+  throw new Error("NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+}));
+
+const dbSelectMock = {
+  where: vi.fn(),
+  from: vi.fn(),
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: (...args: unknown[]) => dbSelectMock.from(...args),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  activeAgents: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+}));
+
+vi.mock("@/lib/require-auth", () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/agent-access")>();
+  return {
+    ...actual,
+    assertAgentAccess: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
+}));
+
+vi.mock("@/lib/avatar", () => ({
+  getAgentAvatarSvg: vi.fn(
+    (agent: { avatarSeed: string | null; name: string }) =>
+      `data:image/svg+xml;utf8,mock-${agent.avatarSeed ?? agent.name}`
+  ),
+}));
+
+let capturedChatProps: Record<string, unknown> = {};
+
+vi.mock("@/components/chat", () => ({
+  Chat: (props: Record<string, unknown>) => {
+    capturedChatProps = props;
+    return (
+      <div data-testid="mock-chat">
+        {props.agentName as string} ({props.agentId as string}/{props.chatId as string})
+      </div>
+    );
+  },
+}));
+
+import { requireAuth } from "@/lib/require-auth";
+import { assertAgentAccess } from "@/lib/agent-access";
+import ChatChatIdPage from "@/app/(app)/chat/[agentId]/[chatId]/page";
+import { render, screen } from "@testing-library/react";
+
+const mockRequireAuth = requireAuth as ReturnType<typeof vi.fn>;
+const mockAssertAgentAccess = assertAgentAccess as ReturnType<typeof vi.fn>;
+
+describe("ChatPage [chatId] segment (#508)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedChatProps = {};
+    dbSelectMock.from.mockReturnValue({ where: dbSelectMock.where });
+  });
+
+  it("passes the chatId param through to Chat", async () => {
+    const sharedAgent = {
+      id: "agent-2",
+      name: "Shared Agent",
+      ownerId: null,
+      isPersonal: false,
+    };
+
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([sharedAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {});
+
+    const result = await ChatChatIdPage({
+      params: Promise.resolve({ agentId: "agent-2", chatId: "chat-x" }),
+    });
+    render(result);
+
+    expect(screen.getByTestId("mock-chat")).toBeInTheDocument();
+    expect(capturedChatProps.agentId).toBe("agent-2");
+    expect(capturedChatProps.chatId).toBe("chat-x");
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("enforces the same auth gate as the base chat page (notFound on access denial)", async () => {
+    const personalAgent = {
+      id: "agent-1",
+      name: "Personal Agent",
+      ownerId: "owner-user",
+      isPersonal: true,
+    };
+
+    mockRequireAuth.mockResolvedValue({ user: { id: "other-user", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([personalAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {
+      throw new Error("Access denied");
+    });
+
+    await expect(
+      ChatChatIdPage({ params: Promise.resolve({ agentId: "agent-1", chatId: "chat-x" }) })
+    ).rejects.toThrow("NOT_FOUND");
+
+    expect(mockAssertAgentAccess).toHaveBeenCalledWith(
+      personalAgent,
+      "other-user",
+      "member",
+      [],
+      [],
+      "paid"
+    );
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it("calls notFound when the agent does not exist", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([]);
+
+    await expect(
+      ChatChatIdPage({ params: Promise.resolve({ agentId: "missing", chatId: "chat-x" }) })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/app/chat-telegram-page.test.tsx
+++ b/packages/web/src/__tests__/app/chat-telegram-page.test.tsx
@@ -1,0 +1,161 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+
+// Mirrors chat-chatid-page.test.tsx but targets the static `telegram` segment
+// (#508): the page must apply the SAME agent DB load + assertAgentAccess auth
+// gate as the base chat/[agentId]/page.tsx, and render the read-only
+// <TelegramChatView> with the agent props instead of <Chat>.
+
+const mockNotFound = vi.fn(() => {
+  throw new Error("NOT_FOUND");
+});
+
+vi.mock("next/navigation", () => ({
+  notFound: () => mockNotFound(),
+}));
+
+const dbSelectMock = {
+  where: vi.fn(),
+  from: vi.fn(),
+};
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: (...args: unknown[]) => dbSelectMock.from(...args),
+    }),
+  },
+}));
+
+vi.mock("@/db/schema", () => ({
+  activeAgents: { id: "id" },
+}));
+
+vi.mock("drizzle-orm", () => ({
+  eq: vi.fn((col, val) => ({ col, val })),
+}));
+
+vi.mock("@/lib/require-auth", () => ({
+  requireAuth: vi.fn(),
+}));
+
+vi.mock("@/lib/agent-access", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/agent-access")>();
+  return {
+    ...actual,
+    assertAgentAccess: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
+}));
+
+vi.mock("@/lib/avatar", () => ({
+  getAgentAvatarSvg: vi.fn(
+    (agent: { avatarSeed: string | null; name: string }) =>
+      `data:image/svg+xml;utf8,mock-${agent.avatarSeed ?? agent.name}`
+  ),
+}));
+
+let capturedViewProps: Record<string, unknown> = {};
+
+vi.mock("@/components/telegram-chat-view", () => ({
+  TelegramChatView: (props: Record<string, unknown>) => {
+    capturedViewProps = props;
+    return (
+      <div data-testid="mock-telegram-view">
+        {props.agentName as string} ({props.agentId as string})
+      </div>
+    );
+  },
+}));
+
+import { requireAuth } from "@/lib/require-auth";
+import { assertAgentAccess } from "@/lib/agent-access";
+import TelegramChatPage from "@/app/(app)/chat/[agentId]/telegram/page";
+import { render, screen } from "@testing-library/react";
+
+const mockRequireAuth = requireAuth as ReturnType<typeof vi.fn>;
+const mockAssertAgentAccess = assertAgentAccess as ReturnType<typeof vi.fn>;
+
+describe("ChatPage telegram segment (#508)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    capturedViewProps = {};
+    dbSelectMock.from.mockReturnValue({ where: dbSelectMock.where });
+  });
+
+  it("renders the read-only TelegramChatView with the agent props", async () => {
+    const personalAgent = {
+      id: "agent-1",
+      name: "Smithers",
+      ownerId: "user-1",
+      isPersonal: true,
+      avatarSeed: "seed-x",
+    };
+
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([personalAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {});
+
+    const result = await TelegramChatPage({
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+    render(result);
+
+    expect(screen.getByTestId("mock-telegram-view")).toBeInTheDocument();
+    expect(capturedViewProps.agentId).toBe("agent-1");
+    expect(capturedViewProps.agentName).toBe("Smithers");
+    expect(capturedViewProps.isPersonal).toBe(true);
+    expect(capturedViewProps.avatarUrl).toBe("data:image/svg+xml;utf8,mock-seed-x");
+    // Owner viewing their own personal agent can edit.
+    expect(capturedViewProps.canEdit).toBe(true);
+    expect(mockNotFound).not.toHaveBeenCalled();
+  });
+
+  it("enforces the same auth gate as the base chat page (notFound on access denial)", async () => {
+    const personalAgent = {
+      id: "agent-1",
+      name: "Personal Agent",
+      ownerId: "owner-user",
+      isPersonal: true,
+    };
+
+    mockRequireAuth.mockResolvedValue({ user: { id: "other-user", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([personalAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {
+      throw new Error("Access denied");
+    });
+
+    await expect(
+      TelegramChatPage({ params: Promise.resolve({ agentId: "agent-1" }) })
+    ).rejects.toThrow("NOT_FOUND");
+
+    expect(mockAssertAgentAccess).toHaveBeenCalledWith(
+      personalAgent,
+      "other-user",
+      "member",
+      [],
+      [],
+      "paid"
+    );
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+
+  it("calls notFound when the agent does not exist", async () => {
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([]);
+
+    await expect(
+      TelegramChatPage({ params: Promise.resolve({ agentId: "missing" }) })
+    ).rejects.toThrow("NOT_FOUND");
+    expect(mockNotFound).toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-mounts.test.tsx
@@ -18,8 +18,8 @@ vi.mock("next/navigation", () => ({
 const useWsRuntimeSpy = vi.fn();
 
 vi.mock("@/hooks/use-ws-runtime", () => ({
-  useWsRuntime: (agentId: string) => {
-    useWsRuntimeSpy(agentId);
+  useWsRuntime: (agentId: string, chatId?: string) => {
+    useWsRuntimeSpy(agentId, chatId);
     return {
       runtime: { __id: `rt-${agentId}` } as never,
       isRunning: mockIsRunning,
@@ -39,6 +39,7 @@ vi.mock("@/hooks/use-ws-runtime", () => ({
 
 function seedBundle(agentId: string, publish: (b: any) => void) {
   publish({
+    agentId,
     runtime: { __id: `seed-${agentId}` } as never,
     isRunning: false,
     isConnected: false,
@@ -82,8 +83,47 @@ describe("ChatSessionMounts", () => {
       </ChatSessionProvider>
     );
 
-    expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-A");
-    expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-B");
+    // chatId is undefined for legacy (no-chatId) sessions (#508).
+    expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-A", undefined);
+    expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-B", undefined);
+  });
+
+  it("passes the chatId to useWsRuntime for a chat-scoped session (#508)", () => {
+    function Visitor() {
+      const session = useChatSession("agent-A", "chat-x");
+      if (!session.bundle) {
+        session.publish({
+          agentId: "agent-A",
+          chatId: "chat-x",
+          runtime: { __id: "seed-agent-A:chat-x" } as never,
+          isRunning: false,
+          isConnected: false,
+          isHistoryLoaded: false,
+          isReconcilingMessages: false,
+          hasInitialContent: false,
+          isOpenClawConnected: false,
+          isDelayed: false,
+          reconnectExhausted: false,
+          payloadRejected: false,
+          isOrphaned: false,
+          onRetryContinue: vi.fn(),
+          onRetryResend: vi.fn(),
+          lastError: null,
+        } as any);
+      }
+      return null;
+    }
+
+    useWsRuntimeSpy.mockClear();
+
+    render(
+      <ChatSessionProvider>
+        <Visitor />
+        <ChatSessionMounts />
+      </ChatSessionProvider>
+    );
+
+    expect(useWsRuntimeSpy).toHaveBeenCalledWith("agent-A", "chat-x");
   });
 
   it("keeps a mount alive when an unrelated child remounts", () => {

--- a/packages/web/src/__tests__/components/chat-session-provider.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-provider.test.tsx
@@ -5,6 +5,7 @@ import {
   MAX_LIVE_BUNDLES,
   useChatSession,
   useVisitedAgentIds,
+  useVisitedSessions,
   type RuntimeBundle,
 } from "@/components/chat-session-provider";
 
@@ -14,6 +15,7 @@ const wrapper = ({ children }: { children: React.ReactNode }) => (
 
 function fakeBundle(overrides: Partial<RuntimeBundle> = {}): RuntimeBundle {
   return {
+    agentId: "fake-agent",
     runtime: { __id: "fake-runtime" } as never,
     isRunning: false,
     isConnected: true,
@@ -115,6 +117,67 @@ describe("ChatSessionProvider", () => {
 
     act(() => result.current.remove());
     expect(result.current.bundle).toBeUndefined();
+  });
+
+  describe("chatId session keying (#508)", () => {
+    it("isolates bundles for the same agent across different chatIds", () => {
+      const { result } = renderHook(
+        () => ({
+          legacy: useChatSession("agent-A"),
+          chatX: useChatSession("agent-A", "chat-x"),
+          chatY: useChatSession("agent-A", "chat-y"),
+        }),
+        { wrapper }
+      );
+
+      act(() => result.current.chatX.publish(fakeBundle({ agentId: "agent-A", isRunning: true })));
+
+      // Only the chat-x bundle exists; the legacy and chat-y keys stay empty.
+      expect(result.current.chatX.bundle?.isRunning).toBe(true);
+      expect(result.current.legacy.bundle).toBeUndefined();
+      expect(result.current.chatY.bundle).toBeUndefined();
+    });
+
+    it("keeps the legacy (no-chatId) bundle independent from a chat-scoped one", () => {
+      const { result } = renderHook(
+        () => ({
+          legacy: useChatSession("agent-A"),
+          chatX: useChatSession("agent-A", "chat-x"),
+        }),
+        { wrapper }
+      );
+
+      act(() =>
+        result.current.legacy.publish(fakeBundle({ agentId: "agent-A", hasInitialContent: true }))
+      );
+
+      expect(result.current.legacy.bundle?.hasInitialContent).toBe(true);
+      expect(result.current.chatX.bundle).toBeUndefined();
+    });
+
+    it("useVisitedSessions reports agentId + chatId for each live session", () => {
+      const { result } = renderHook(
+        () => ({
+          sessions: useVisitedSessions(),
+          publishLegacy: useChatSession("agent-A").publish,
+          publishChat: useChatSession("agent-A", "chat-x").publish,
+        }),
+        { wrapper }
+      );
+
+      expect(result.current.sessions).toEqual([]);
+
+      act(() => result.current.publishLegacy(fakeBundle({ agentId: "agent-A" })));
+      act(() => result.current.publishChat(fakeBundle({ agentId: "agent-A", chatId: "chat-x" })));
+
+      const byKey = Object.fromEntries(result.current.sessions.map((s) => [s.key, s]));
+      expect(byKey["agent-A"]).toEqual({ key: "agent-A", agentId: "agent-A", chatId: undefined });
+      expect(byKey["agent-A:chat-x"]).toEqual({
+        key: "agent-A:chat-x",
+        agentId: "agent-A",
+        chatId: "chat-x",
+      });
+    });
   });
 
   describe("LRU eviction (MAX_LIVE_BUNDLES cap)", () => {

--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -104,6 +104,16 @@ describe("Chat", () => {
     expect(screen.getByTestId("thread")).toBeInTheDocument();
   });
 
+  it("passes the chatId through to useChatSession (#508)", () => {
+    render(<Chat agentId="agent-1" agentName="Smithers" chatId="chat-x" />);
+    expect(mockUseChatSession).toHaveBeenCalledWith("agent-1", "chat-x");
+  });
+
+  it("calls useChatSession without a chatId for the legacy/default chat", () => {
+    render(<Chat agentId="agent-1" agentName="Smithers" />);
+    expect(mockUseChatSession).toHaveBeenCalledWith("agent-1", undefined);
+  });
+
   describe("status indicator colors and labels", () => {
     function getDotColor(label: string | RegExp): string {
       // The accessible label sits on the wrapping <button> (focusable, larger

--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -65,6 +65,18 @@ vi.mock("next/link", () => ({
   ),
 }));
 
+// The desktop header now renders <ChatSwitcher>, which uses the app router and
+// fetches the chat list. Stub both so Chat renders in isolation (with no other
+// chats, the switcher falls back to the agent name in its trigger).
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn().mockResolvedValue({ chats: [] }) };
+});
+
 const DEFAULT_BUNDLE = {
   runtime: {} as any,
   isConnected: true,

--- a/packages/web/src/__tests__/components/mobile-chat-header.test.tsx
+++ b/packages/web/src/__tests__/components/mobile-chat-header.test.tsx
@@ -1,7 +1,18 @@
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { MobileChatHeader } from "@/components/mobile-chat-header";
+
+// The header now renders <ChatSwitcher>, which uses the app router and fetches
+// the chat list. Stub both so the header renders in isolation.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push: vi.fn() }),
+}));
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn().mockResolvedValue({ chats: [] }) };
+});
 
 describe("MobileChatHeader", () => {
   const defaultProps = {

--- a/packages/web/src/__tests__/components/session-actions-menu.test.tsx
+++ b/packages/web/src/__tests__/components/session-actions-menu.test.tsx
@@ -50,6 +50,30 @@ describe("SessionActionsMenu", () => {
     expect(toast.error).not.toHaveBeenCalled();
   });
 
+  it("includes chatId in the request body when on a per-chat URL (#508)", async () => {
+    const user = userEvent.setup();
+    fetchSpy.mockResolvedValue(jsonResponse({ ok: true }));
+
+    render(<SessionActionsMenu agentId="agent-1" chatId="chat-abc" />);
+    await openMenuAndCompact(user);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(opts.body as string)).toEqual({ chatId: "chat-abc" });
+  });
+
+  it("omits chatId from the body for the default chat", async () => {
+    const user = userEvent.setup();
+    fetchSpy.mockResolvedValue(jsonResponse({ ok: true }));
+
+    render(<SessionActionsMenu agentId="agent-1" />);
+    await openMenuAndCompact(user);
+
+    await waitFor(() => expect(fetchSpy).toHaveBeenCalled());
+    const [, opts] = fetchSpy.mock.calls[0] as [string, RequestInit];
+    expect(JSON.parse(opts.body as string)).toEqual({});
+  });
+
   it("surfaces the server error message via toast.error on failure", async () => {
     const user = userEvent.setup();
     fetchSpy.mockResolvedValue(

--- a/packages/web/src/__tests__/components/sidebar-running-indicator.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar-running-indicator.test.tsx
@@ -9,6 +9,7 @@ import { AgentSidebarIndicator } from "@/components/agent-sidebar-indicator";
 
 function makeBundle(overrides: Partial<RuntimeBundle> = {}): RuntimeBundle {
   return {
+    agentId: "agent-A",
     runtime: {} as never,
     isRunning: false,
     isConnected: true,

--- a/packages/web/src/__tests__/hooks/use-draft-id.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-draft-id.test.tsx
@@ -22,4 +22,28 @@ describe("useDraftId", () => {
     const { result: b } = renderHook(() => useDraftId("agent-2"));
     expect(a.current).not.toBe(b.current);
   });
+
+  it("uses distinct IDs for different chatIds of the same agent (#508)", () => {
+    // Two chats of one agent must not share a draft id, or a file staged while
+    // composing in chat A would surface as a pending attachment in chat B.
+    const { result: a } = renderHook(() => useDraftId("agent-1", "chat-a"));
+    const { result: b } = renderHook(() => useDraftId("agent-1", "chat-b"));
+    expect(a.current).not.toBe(b.current);
+  });
+
+  it("scopes the storage key by chatId; the default chat stays backward-compatible", () => {
+    const { result: def } = renderHook(() => useDraftId("agent-1"));
+    expect(localStorage.getItem("pinchy:composer:agent-1:draftId")).toBe(def.current);
+
+    const { result: chat } = renderHook(() => useDraftId("agent-1", "chat-a"));
+    expect(localStorage.getItem("pinchy:composer:agent-1:chat-a:draftId")).toBe(chat.current);
+    expect(chat.current).not.toBe(def.current);
+  });
+
+  it("returns the same ID on re-mount for the same (agent, chat)", () => {
+    const { result: first } = renderHook(() => useDraftId("agent-1", "chat-a"));
+    const firstId = first.current;
+    const { result: second } = renderHook(() => useDraftId("agent-1", "chat-a"));
+    expect(second.current).toBe(firstId);
+  });
 });

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -828,6 +828,82 @@ describe("useWsRuntime", () => {
     expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "history", agentId: "agent-1" }));
   });
 
+  // #508 — the chats feature threads an optional chatId from the URL all the
+  // way to the WS frames. When present it selects a distinct OpenClaw session
+  // within the (user, agent) pair; when absent the legacy per-user key is used.
+  // The server (client-router) already accepts message.chatId on both the send
+  // and history paths, so these tests pin the CLIENT half of that contract.
+  describe("chatId threading (#508)", () => {
+    it("includes chatId on the initial history frame when provided", () => {
+      renderHook(() => useWsRuntime("agent-1", "chat-abc"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      const historyFrame = JSON.parse(ws.send.mock.calls[0][0]);
+      expect(historyFrame.type).toBe("history");
+      expect(historyFrame.agentId).toBe("agent-1");
+      expect(historyFrame.chatId).toBe("chat-abc");
+    });
+
+    it("omits chatId on the history frame when not provided (legacy)", () => {
+      renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+
+      const historyFrame = JSON.parse(ws.send.mock.calls[0][0]);
+      expect(historyFrame.type).toBe("history");
+      expect(historyFrame.agentId).toBe("agent-1");
+      expect("chatId" in historyFrame).toBe(false);
+    });
+
+    it("includes chatId on the message send frame when provided", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1", "chat-abc"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      // calls[0] is the history request, calls[1] is the user message
+      const sentMessage = JSON.parse(ws.send.mock.calls[1][0]);
+      expect(sentMessage.type).toBe("message");
+      expect(sentMessage.content).toBe("Hello");
+      expect(sentMessage.agentId).toBe("agent-1");
+      expect(sentMessage.chatId).toBe("chat-abc");
+    });
+
+    it("omits chatId on the message send frame when not provided (legacy)", () => {
+      const { result } = renderHook(() => useWsRuntime("agent-1"));
+      const ws = wsInstances[0];
+
+      act(() => {
+        ws.onopen?.();
+      });
+      act(() => {
+        result.current.runtime.onNew({
+          content: [{ type: "text", text: "Hello" }],
+          parentId: "root",
+        });
+      });
+
+      const sentMessage = JSON.parse(ws.send.mock.calls[1][0]);
+      expect(sentMessage.type).toBe("message");
+      expect("chatId" in sentMessage).toBe(false);
+    });
+  });
+
   it("should populate messages from history response", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];

--- a/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
+++ b/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
@@ -178,4 +178,69 @@ describe("classifyUserSessions", () => {
     expect(result.some((c) => c.sessionId === "cron")).toBe(false);
     expect(result.some((c) => c.sessionId === "unlinked")).toBe(false);
   });
+
+  it("returns [] for an empty userId even with empty-principal keys (no fail-open leak)", () => {
+    // An empty userId must never become a matchable principal. Keys whose
+    // principal segment is empty (`agent:a:direct:` → parts[3]==="", or
+    // `agent::direct:`) must NOT be attributed to the empty user.
+    const sessions: RawSession[] = [
+      { key: "agent:a:direct:", sessionId: "x", lastInteractionAt: 1 },
+      { key: "agent::direct:", sessionId: "y", lastInteractionAt: 2 },
+    ];
+
+    const result = classifyUserSessions(sessions, "", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a key with an empty/trailing-colon principal for a normal userId (fail closed)", () => {
+    // A trailing-colon key produces an empty principal segment, which is never
+    // a valid identity. It must be excluded regardless of the requesting user.
+    const sessions: RawSession[] = [
+      { key: "agent:a:direct:", sessionId: "empty-principal", lastInteractionAt: 1 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("skips malformed entries without throwing and returns only the valid web chat (no DoS)", () => {
+    // OpenClaw's `sessions.list` is untyped wire output. A null/number/missing
+    // `key` or a null array element must be skipped, not throw and nuke the
+    // whole list. The cast mirrors the real untyped input crossing the boundary.
+    const sessions = [
+      { key: null, sessionId: "bad-null-key", lastInteractionAt: 1 },
+      { key: 12345, sessionId: "bad-number-key", lastInteractionAt: 2 },
+      { sessionId: "bad-missing-key", lastInteractionAt: 3 },
+      null,
+      { key: webKey("u-1", "chat-ok"), sessionId: "good-web", lastInteractionAt: 99 },
+    ] as unknown as RawSession[];
+
+    let result: ReturnType<typeof classifyUserSessions> | undefined;
+    expect(() => {
+      result = classifyUserSessions(sessions, "u-1", new Set());
+    }).not.toThrow();
+
+    expect(result).toEqual([
+      {
+        sessionId: "good-web",
+        key: webKey("u-1", "chat-ok"),
+        origin: "web",
+        writable: true,
+        chatId: "chat-ok",
+        lastInteractionAt: 99,
+      },
+    ]);
+  });
+
+  it("requires exact-equality principal matching, never a prefix/substring (userId 'u' vs principal 'u2')", () => {
+    const sessions: RawSession[] = [
+      { key: webKey("u2"), sessionId: "prefix-collision", lastInteractionAt: 1 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u", new Set());
+
+    expect(result).toEqual([]);
+  });
 });

--- a/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
+++ b/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
@@ -31,6 +31,29 @@ describe("classifyUserSessions", () => {
     ]);
   });
 
+  it("matches a linked Telegram peer case-insensitively (normalizes the set itself)", () => {
+    // Hardening: OpenClaw stores the principal lowercased, and callers are
+    // expected to lowercase the peer set — but the classifier no longer relies
+    // on that. Even an un-lowercased peer id must still match, so a future
+    // caller that forgets can't silently drop a user's Telegram chat.
+    const sessions: RawSession[] = [
+      { key: webKey("tg-peer-99"), sessionId: "ses_tg", lastInteractionAt: 2000 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set(["TG-Peer-99"]));
+
+    expect(result).toEqual([
+      {
+        sessionId: "ses_tg",
+        key: webKey("tg-peer-99"),
+        origin: "telegram",
+        writable: false,
+        chatId: null,
+        lastInteractionAt: 2000,
+      },
+    ]);
+  });
+
   it("includes the user's legacy web chat (no chatId) with chatId null", () => {
     const sessions: RawSession[] = [{ key: webKey("u-1"), sessionId: "ses_2", updatedAt: 500 }];
 

--- a/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
+++ b/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
@@ -1,0 +1,181 @@
+import { describe, it, expect } from "vitest";
+import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+
+const AGENT = "agt_1";
+
+function webKey(userId: string, ...extra: string[]): string {
+  return [`agent`, AGENT, `direct`, userId, ...extra].join(":");
+}
+
+describe("classifyUserSessions", () => {
+  it("includes the user's web chat with a chatId", () => {
+    const sessions: RawSession[] = [
+      {
+        key: webKey("u-1", "chat-abc"),
+        sessionId: "ses_1",
+        lastInteractionAt: 1000,
+      },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([
+      {
+        sessionId: "ses_1",
+        key: webKey("u-1", "chat-abc"),
+        origin: "web",
+        writable: true,
+        chatId: "chat-abc",
+        lastInteractionAt: 1000,
+      },
+    ]);
+  });
+
+  it("includes the user's legacy web chat (no chatId) with chatId null", () => {
+    const sessions: RawSession[] = [{ key: webKey("u-1"), sessionId: "ses_2", updatedAt: 500 }];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([
+      {
+        sessionId: "ses_2",
+        key: webKey("u-1"),
+        origin: "web",
+        writable: true,
+        chatId: null,
+        lastInteractionAt: 500,
+      },
+    ]);
+  });
+
+  it("matches a mixed-case userId against the lowercased key segment", () => {
+    const sessions: RawSession[] = [
+      { key: webKey("u-mixed"), sessionId: "ses_3", lastInteractionAt: 7 },
+    ];
+
+    const result = classifyUserSessions(sessions, "U-Mixed", new Set());
+
+    expect(result).toHaveLength(1);
+    expect(result[0].sessionId).toBe("ses_3");
+    expect(result[0].origin).toBe("web");
+    expect(result[0].writable).toBe(true);
+  });
+
+  it("includes a linked Telegram peer chat as read-only", () => {
+    const sessions: RawSession[] = [
+      { key: webKey("tg-peer-9"), sessionId: "ses_4", lastInteractionAt: 42 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set(["tg-peer-9"]));
+
+    expect(result).toEqual([
+      {
+        sessionId: "ses_4",
+        key: webKey("tg-peer-9"),
+        origin: "telegram",
+        writable: false,
+        chatId: null,
+        lastInteractionAt: 42,
+      },
+    ]);
+  });
+
+  it("excludes another user's direct key", () => {
+    const sessions: RawSession[] = [
+      { key: webKey("other-user"), sessionId: "ses_5", lastInteractionAt: 1 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a Telegram peer that is not in the linked set", () => {
+    const sessions: RawSession[] = [
+      { key: webKey("tg-peer-unlinked"), sessionId: "ses_6", lastInteractionAt: 1 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set(["tg-peer-linked"]));
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a :cron: key", () => {
+    const sessions: RawSession[] = [
+      {
+        key: `agent:${AGENT}:cron:u-1`,
+        sessionId: "ses_7",
+        lastInteractionAt: 1,
+      },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a :subagent: key", () => {
+    const sessions: RawSession[] = [
+      {
+        key: `agent:${AGENT}:subagent:u-1`,
+        sessionId: "ses_8",
+        lastInteractionAt: 1,
+      },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes an agent:<id>:main key", () => {
+    const sessions: RawSession[] = [
+      { key: `agent:${AGENT}:main`, sessionId: "ses_9", lastInteractionAt: 1 },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes a malformed direct key with extra segments (fail closed)", () => {
+    const sessions: RawSession[] = [
+      {
+        key: "agent:a:direct:u:c1:c2",
+        sessionId: "ses_10",
+        lastInteractionAt: 1,
+      },
+    ];
+
+    const result = classifyUserSessions(sessions, "u", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("security roll-up: returns ONLY user A's entries from a mixed list", () => {
+    const sessions: RawSession[] = [
+      // user A — web, with chatId
+      { key: webKey("user-a", "chat-1"), sessionId: "a-web", lastInteractionAt: 10 },
+      // user A — linked Telegram peer
+      { key: webKey("tg-a"), sessionId: "a-tg", lastInteractionAt: 11 },
+      // user B — web (must be excluded)
+      { key: webKey("user-b", "chat-2"), sessionId: "b-web", lastInteractionAt: 12 },
+      // user B — Telegram peer not linked to A (must be excluded)
+      { key: webKey("tg-b"), sessionId: "b-tg", lastInteractionAt: 13 },
+      // cron (must be excluded)
+      { key: `agent:${AGENT}:cron:user-a`, sessionId: "cron", lastInteractionAt: 14 },
+      // unlinked peer (must be excluded)
+      { key: webKey("tg-unknown"), sessionId: "unlinked", lastInteractionAt: 15 },
+    ];
+
+    const result = classifyUserSessions(sessions, "User-A", new Set(["tg-a"]));
+
+    const ids = result.map((c) => c.sessionId).sort();
+    expect(ids).toEqual(["a-tg", "a-web"]);
+    // Defense-in-depth: no other user's or system session leaked through.
+    expect(result.some((c) => c.sessionId === "b-web")).toBe(false);
+    expect(result.some((c) => c.sessionId === "b-tg")).toBe(false);
+    expect(result.some((c) => c.sessionId === "cron")).toBe(false);
+    expect(result.some((c) => c.sessionId === "unlinked")).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -4897,7 +4897,7 @@ describe("restart-state integration", () => {
     const { restartState } = await import("@/server/restart-state");
     mockedReadFileSync.mockReturnValue(JSON.stringify({ gateway: { mode: "local", bind: "lan" } }));
 
-    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null);
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
 
     expect(mockedWriteFileSync).toHaveBeenCalled();
     expect(restartState.notifyRestart).toHaveBeenCalledOnce();
@@ -4910,14 +4910,14 @@ describe("restart-state integration", () => {
 
     // First write produces canonical content
     mockedReadFileSync.mockReturnValue(JSON.stringify({ gateway: { mode: "local", bind: "lan" } }));
-    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null);
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
     const firstWrite = mockedWriteFileSync.mock.calls[0][1] as string;
 
     vi.clearAllMocks();
     // Second call with identical resulting content — dedup should kick in
     mockedReadFileSync.mockReturnValue(firstWrite);
 
-    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null);
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
 
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
     expect(restartState.notifyRestart).not.toHaveBeenCalled();
@@ -5186,6 +5186,99 @@ describe("restart-state integration", () => {
     // dmScope and the daily-reset override are still Pinchy-owned and stay.
     expect(config.session.dmScope).toBe("per-peer");
     expect(config.session.reset).toEqual({ mode: "idle", idleMinutes: 525600 });
+    // Per-user peer binding still routes the linked user's DMs to their agent.
+    expect(config.bindings).toEqual(
+      expect.arrayContaining([
+        {
+          agentId: "agent-1",
+          match: {
+            channel: "telegram",
+            accountId: "agent-1",
+            peer: { kind: "dm", id: "999888" },
+          },
+        },
+      ])
+    );
+  });
+
+  it("PURGES a stale session.identityLinks already on disk on regenerate (#508 upgrade path)", async () => {
+    // THE UPGRADE SCENARIO. The cold-start test above only proves we no longer
+    // EMIT identityLinks from scratch. But prod/demo installs that ran a
+    // pre-per-task version already have `session.identityLinks` baked into
+    // openclaw.json (it was written for every linked Telegram user). Commit
+    // 2517a0fb stopped writing it but does NOT remove a pre-existing one:
+    // regenerate spreads the on-disk `session` block, so a stale identityLinks
+    // rides along forever → OpenClaw keeps unifying Telegram with the web
+    // session → the #508 footgun stays UNFIXED on exactly the deployments that
+    // have it. The fix must actively PURGE the key, not just stop writing it.
+    //
+    // We purge ONLY identityLinks — any other foreign session key OpenClaw may
+    // have stamped is preserved (same denylist philosophy as the channels
+    // block above).
+    const existingConfig = {
+      gateway: { mode: "local", bind: "lan", auth: { token: "secret" } },
+      session: {
+        // Stale Pinchy-written unification link from before the per-task model.
+        identityLinks: { "user-1": ["telegram:999"] },
+        // Pinchy-owned reset override that must survive.
+        reset: { mode: "idle", idleMinutes: 525600 },
+        // A foreign OC-enriched session key that must NOT be purged.
+        ocEnrichedSessionField: "keep-me",
+      },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
+
+    let callCount = 0;
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          // agents table — personal agent so a per-user peer binding is made.
+          return Object.assign(
+            Promise.resolve([
+              {
+                id: "agent-1",
+                name: "Smithers",
+                model: "m",
+                allowedTools: [],
+                isPersonal: true,
+                ownerId: "user-1",
+              },
+            ]),
+            { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
+          );
+        }
+        if (callCount === 4) {
+          // channel_links table — a linked Telegram user exists.
+          return Object.assign(
+            Promise.resolve([{ userId: "user-1", channel: "telegram", channelUserId: "999888" }]),
+            { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
+          );
+        }
+        return Object.assign(Promise.resolve([]), {
+          innerJoin: mockInnerJoin([]),
+          where: vi.fn().mockResolvedValue([]),
+        });
+      }),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "token";
+      if (key === "telegram_bot_username:agent-1") return "bot";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    // The stale identityLinks must be GONE — this is the upgrade fix.
+    expect(config.session.identityLinks).toBeUndefined();
+    // Everything else stays: dmScope, the reset override, AND the foreign key.
+    expect(config.session.dmScope).toBe("per-peer");
+    expect(config.session.reset).toEqual({ mode: "idle", idleMinutes: 525600 });
+    expect(config.session.ocEnrichedSessionField).toBe("keep-me");
     // Per-user peer binding still routes the linked user's DMs to their agent.
     expect(config.bindings).toEqual(
       expect.arrayContaining([
@@ -6411,7 +6504,7 @@ describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support Se
       })
     );
 
-    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null);
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
 
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
@@ -6432,11 +6525,42 @@ describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support Se
       })
     );
 
-    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null);
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
 
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
     expect(config.channels.telegram.enabled).toBe(true);
+  });
+
+  it("updateTelegramChannelConfig PURGES a stale session.identityLinks on the targeted write path (#508 upgrade path)", () => {
+    // The targeted write (bot connect/disconnect, no full regenerate) spreads
+    // the on-disk `session` block independently of build.ts. On a prod/demo
+    // install that already has a stale `session.identityLinks` baked in from a
+    // pre-per-task version, a bot connect/disconnect would otherwise preserve
+    // it forever → OpenClaw keeps unifying Telegram with the web session. The
+    // targeted writer must ALSO purge it unconditionally. Only identityLinks
+    // is purged; other session fields are preserved.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan" },
+        session: {
+          identityLinks: { "user-1": ["telegram:999"] },
+          reset: { mode: "idle", idleMinutes: 525600 },
+          ocEnrichedSessionField: "keep-me",
+        },
+      })
+    );
+
+    updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    // Stale identityLinks gone.
+    expect(config.session.identityLinks).toBeUndefined();
+    // dmScope set, other session fields preserved.
+    expect(config.session.dmScope).toBe("per-peer");
+    expect(config.session.reset).toEqual({ mode: "idle", idleMinutes: 525600 });
+    expect(config.session.ocEnrichedSessionField).toBe("keep-me");
   });
 
   it("updateTelegramChannelConfig throws if existing config is unreadable (avoids clobber from EACCES, #314)", () => {
@@ -6458,9 +6582,9 @@ describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support Se
       throw err;
     });
 
-    expect(() =>
-      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" }, null)
-    ).toThrow(/EACCES|gateway\.mode/);
+    expect(() => updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" })).toThrow(
+      /EACCES|gateway\.mode/
+    );
     expect(mockedWriteFileSync).not.toHaveBeenCalled();
     warnSpy.mockRestore();
   });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -130,7 +130,6 @@ vi.mock("@/server/openclaw-client", () => ({
 import { writeFileSync, readFileSync, existsSync, mkdirSync } from "fs";
 import {
   regenerateOpenClawConfig,
-  updateIdentityLinks,
   sanitizeOpenClawConfig,
   seedRestartClassOverridesIfMissing,
   seedGatewayTokenIfMissing,
@@ -5122,15 +5121,36 @@ describe("restart-state integration", () => {
     expect(config.bindings).toBeUndefined();
   });
 
-  it("should include identityLinks from channel_links table", async () => {
+  it("should NOT emit session.identityLinks even when channel_links exist (#508 per-task sessions)", async () => {
+    // #508: We moved to a PER-TASK session model — web and Telegram are now
+    // SEPARATE OpenClaw sessions. Emitting `session.identityLinks` made
+    // OpenClaw fold a linked Telegram peer's DMs into the SAME session as the
+    // user's web chat (`agent:<id>:direct:<userId>`), which is what let a
+    // Telegram `/new` wipe the web history and prevented Telegram from showing
+    // as its own chat. Removing the identityLinks emission gives each Telegram
+    // peer its own per-peer session (`agent:<id>:direct:<peerId>`), surfaced as
+    // a read-only "Telegram" chat by the Chats list (attributed via
+    // channel_links). This is a DELIBERATE behaviour change: the unification
+    // was the bug. `dmScope: "per-peer"`, the reset override, and the per-user
+    // peer bindings (which route DMs to the right personal agent) must stay.
     let callCount = 0;
     mockedDb.select.mockReturnValue({
       from: vi.fn().mockImplementation(() => {
         callCount++;
         if (callCount === 1) {
-          // First call: agents table
+          // First call: agents table — personal agent so a per-user peer
+          // binding is generated for the linked user.
           return Object.assign(
-            Promise.resolve([{ id: "agent-1", name: "Smithers", model: "m", allowedTools: [] }]),
+            Promise.resolve([
+              {
+                id: "agent-1",
+                name: "Smithers",
+                model: "m",
+                allowedTools: [],
+                isPersonal: true,
+                ownerId: "user-1",
+              },
+            ]),
             { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
           );
         }
@@ -5161,9 +5181,24 @@ describe("restart-state integration", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written);
 
-    expect(config.session.identityLinks).toEqual({
-      "user-1": ["telegram:999888"],
-    });
+    // identityLinks must NOT be emitted (#508).
+    expect(config.session.identityLinks).toBeUndefined();
+    // dmScope and the daily-reset override are still Pinchy-owned and stay.
+    expect(config.session.dmScope).toBe("per-peer");
+    expect(config.session.reset).toEqual({ mode: "idle", idleMinutes: 525600 });
+    // Per-user peer binding still routes the linked user's DMs to their agent.
+    expect(config.bindings).toEqual(
+      expect.arrayContaining([
+        {
+          agentId: "agent-1",
+          match: {
+            channel: "telegram",
+            accountId: "agent-1",
+            peer: { kind: "dm", id: "999888" },
+          },
+        },
+      ])
+    );
   });
 
   it("preserves all non-Pinchy-owned fields from existingTelegram on regenerate", async () => {
@@ -6317,112 +6352,13 @@ describe("secrets provider config block", () => {
   });
 });
 
-describe("updateIdentityLinks", () => {
-  beforeEach(() => {
-    vi.clearAllMocks();
-    mockedExistsSync.mockReturnValue(true);
-  });
-
-  it("should only update session.identityLinks without touching other fields", async () => {
-    const existingConfig = {
-      gateway: { mode: "local", bind: "lan", auth: { token: "secret" } },
-      env: { ANTHROPIC_API_KEY: "sk-ant-key" },
-      agents: {
-        defaults: { model: { primary: "anthropic/claude" }, heartbeat: { intervalMs: 1800000 } },
-        list: [{ id: "agent-1", name: "Smithers" }],
-      },
-      channels: { telegram: { enabled: true, botToken: "123:abc", dmPolicy: "pairing" } },
-      plugins: { allow: ["telegram", "pinchy-audit"], entries: {} },
-      meta: { version: "1.0" },
-    };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
-
-    const { updateIdentityLinks } = await import("@/lib/openclaw-config");
-    await updateIdentityLinks({ "user-1": ["telegram:8754697762"] });
-
-    expect(mockedWriteFileSync).toHaveBeenCalledOnce();
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
-
-    // identityLinks updated
-    expect(written.session.identityLinks).toEqual({ "user-1": ["telegram:8754697762"] });
-
-    // Everything else preserved exactly
-    expect(written.agents.defaults.heartbeat).toEqual({ intervalMs: 1800000 });
-    expect(written.agents.defaults.model).toEqual({ primary: "anthropic/claude" });
-    expect(written.agents.list).toEqual([{ id: "agent-1", name: "Smithers" }]);
-    expect(written.env.ANTHROPIC_API_KEY).toBe("sk-ant-key");
-    expect(written.plugins.allow).toEqual(["telegram", "pinchy-audit"]);
-    expect(written.meta.version).toBe("1.0");
-    expect(written.channels.telegram.botToken).toBe("123:abc");
-  });
-
-  it("should remove identityLinks when called with empty object", async () => {
-    const existingConfig = {
-      gateway: { mode: "local" },
-      session: { dmScope: "per-peer", identityLinks: { "user-1": ["telegram:123"] } },
-    };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
-
-    const { updateIdentityLinks } = await import("@/lib/openclaw-config");
-    await updateIdentityLinks({});
-
-    const written = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
-    expect(written.session.identityLinks).toEqual({});
-    expect(written.session.dmScope).toBe("per-peer");
-    expect(written.gateway.mode).toBe("local");
-  });
-
-  it("should skip write when identityLinks unchanged", async () => {
-    const existingConfig = {
-      gateway: { mode: "local" },
-      session: { identityLinks: { "user-1": ["telegram:123"] } },
-    };
-    // readFileSync is called twice: once by readExistingConfig, once by the skip-if-unchanged check.
-    // Both must return the same content that would be produced by JSON.stringify(updated, null, 2)
-    // followed by trimEnd() + "\n" — see openclaw-config.ts for the format-match rationale.
-    const serialized = JSON.stringify(existingConfig, null, 2).trimEnd() + "\n";
-    mockedReadFileSync.mockReturnValue(serialized);
-
-    const { updateIdentityLinks } = await import("@/lib/openclaw-config");
-    updateIdentityLinks({ "user-1": ["telegram:123"] });
-
-    expect(mockedWriteFileSync).not.toHaveBeenCalled();
-  });
-
-  it("regression: throws if existing config is unreadable (avoids clobber from EACCES, #314)", async () => {
-    // This reproduces the production-image telegram-e2e cascade: while
-    // OpenClaw is mid-SIGUSR1-restart, openclaw.json is briefly root:0600.
-    //
-    // Two layers of defence:
-    //   1. `readExistingConfig` propagates persistent EACCES rather than
-    //      returning {} (#314 — returning {} let `regenerateOpenClawConfig`
-    //      emit a thin payload that triggered the inotify cascade).
-    //   2. `updateIdentityLinks` independently guards on missing gateway.mode
-    //      so non-EACCES paths (ENOENT, parse error) also can't clobber the
-    //      gateway block.
-    //
-    // Under EACCES the throw now comes from layer 1; either error message is
-    // acceptable as long as no file write happens.
-    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
-    mockedExistsSync.mockReturnValue(true);
-    mockedReadFileSync.mockImplementation(() => {
-      const err = new Error("EACCES: permission denied") as Error & { code: string };
-      err.code = "EACCES";
-      throw err;
-    });
-
-    const { updateIdentityLinks } = await import("@/lib/openclaw-config");
-
-    // Throwing (rather than silently returning) lets the API route surface
-    // the failure as a 5xx so the user can retry, instead of dropping the
-    // identity-link update on the floor.
-    expect(() => updateIdentityLinks({ "user-1": ["telegram:123"] })).toThrow(
-      /EACCES|gateway\.mode/
-    );
-    expect(mockedWriteFileSync).not.toHaveBeenCalled();
-    warnSpy.mockRestore();
-  });
-});
+// NOTE (#508): the `describe("updateIdentityLinks", ...)` block was removed
+// here together with the `updateIdentityLinks` helper it covered. We moved to
+// a per-task session model and stopped emitting `session.identityLinks`, so
+// the targeted-write helper has no remaining caller. The EACCES clobber-guard
+// it exercised is still covered for the surviving targeted writers by the
+// `updateTelegramChannelConfig` EACCES test below. Deletion authorized via the
+// `Allow-test-deletion: #508` commit trailer.
 
 describe("telegram botToken plain string (OpenClaw 2026.4.26 does not support SecretRef in channel configs)", () => {
   beforeEach(() => {

--- a/packages/web/src/__tests__/lib/schemas/sessions.test.ts
+++ b/packages/web/src/__tests__/lib/schemas/sessions.test.ts
@@ -1,0 +1,37 @@
+import { describe, it, expect } from "vitest";
+import { chatIdSchema } from "@/lib/schemas/sessions";
+
+describe("sessions schemas", () => {
+  it("chatIdSchema accepts a nanoid-style id", () => {
+    expect(chatIdSchema.parse("v1k2n3p4")).toBe("v1k2n3p4");
+  });
+
+  it("chatIdSchema rejects a colon", () => {
+    expect(() => chatIdSchema.parse(":")).toThrow();
+  });
+
+  it("chatIdSchema rejects a slash", () => {
+    expect(() => chatIdSchema.parse("a/b")).toThrow();
+  });
+
+  it("chatIdSchema rejects an empty string", () => {
+    expect(() => chatIdSchema.parse("")).toThrow();
+  });
+
+  it("chatIdSchema rejects an id longer than 64 characters", () => {
+    expect(() => chatIdSchema.parse("a".repeat(65))).toThrow();
+  });
+
+  it("chatIdSchema accepts an id of exactly 64 characters", () => {
+    const id = "a".repeat(64);
+    expect(chatIdSchema.parse(id)).toBe(id);
+  });
+
+  it("chatIdSchema rejects uppercase letters", () => {
+    expect(() => chatIdSchema.parse("ABC")).toThrow();
+  });
+
+  it("chatIdSchema rejects spaces", () => {
+    expect(() => chatIdSchema.parse("a b")).toThrow();
+  });
+});

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -95,11 +95,16 @@ describe("parseSessionKey", () => {
     });
   });
 
-  it("preserves userId with colons (e.g. OpenClaw lowercased UUIDs)", () => {
-    const result = parseSessionKey("agent:a1:direct:user-123:extra");
+  // Chats feature (#508): direct session keys gained a trailing chatId segment
+  // (agent:<agentId>:direct:<userId>:<chatId>). The userId segment never
+  // contains a colon, so it must be captured WITHOUT swallowing the chatId —
+  // otherwise usage is attributed to the bogus user id "<userId>:<chatId>"
+  // which never matches the users table.
+  it("extracts only the userId from a 5-segment chat session key with a chatId", () => {
+    const result = parseSessionKey("agent:a1:direct:user-123:chat-abc");
     expect(result).toEqual({
       agentId: "a1",
-      userId: "user-123:extra",
+      userId: "user-123",
       type: "chat",
     });
   });

--- a/packages/web/src/__tests__/lib/usage-source.test.ts
+++ b/packages/web/src/__tests__/lib/usage-source.test.ts
@@ -10,6 +10,13 @@ describe("classifyUsageSource", () => {
     expect(classifyUsageSource("agent:abc123:direct:user-with-dashes-42")).toBe("chat");
   });
 
+  it("classifies 5-segment chat sessions with a chatId as 'chat' (#508)", () => {
+    // The chats feature appends a chatId segment:
+    // agent:<agentId>:direct:<userId>:<chatId>. The prefix match must keep
+    // bucketing these as chat usage rather than falling through to system.
+    expect(classifyUsageSource("agent:smithers:direct:user-1:chat-abc")).toBe("chat");
+  });
+
   it("classifies plugin sessions as 'plugin'", () => {
     expect(classifyUsageSource("plugin:pinchy-files")).toBe("plugin");
   });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -220,6 +220,32 @@ describe("ClientRouter", () => {
     mockAgentsList.mockResolvedValue({ defaultId: "agent-1", agents: [{ id: "agent-1" }] });
   });
 
+  describe("computeSessionKey", () => {
+    // computeSessionKey is private; reach it via a typed cast seam, mirroring
+    // the `as unknown as` casts used elsewhere in this file. The userId
+    // segment must always come from the server-side `this.userId`, never from
+    // client input.
+    type SessionKeyAccess = { computeSessionKey(agentId: string, chatId?: string): string };
+
+    it("returns the bare per-user key when no chatId is given", () => {
+      const key = (router as unknown as SessionKeyAccess).computeSessionKey("agent-1");
+      expect(key).toBe("agent:agent-1:direct:user-1");
+    });
+
+    it("appends the chatId segment when a chatId is given", () => {
+      const key = (router as unknown as SessionKeyAccess).computeSessionKey("agent-1", "v1k2n3p4");
+      expect(key).toBe("agent:agent-1:direct:user-1:v1k2n3p4");
+    });
+
+    it("keeps the userId segment from this.userId regardless of chatId", () => {
+      const access = router as unknown as SessionKeyAccess;
+      expect(access.computeSessionKey("agent-1", "chat-a")).toBe(
+        "agent:agent-1:direct:user-1:chat-a"
+      );
+      expect(access.computeSessionKey("agent-2")).toBe("agent:agent-2:direct:user-1");
+    });
+  });
+
   it("should return error when agent not found", async () => {
     const clientWs = createMockClientWs();
     mockFindFirst.mockResolvedValue(null);

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -363,6 +363,122 @@ describe("ClientRouter", () => {
     ]);
   });
 
+  describe("chatId session-key threading (#508)", () => {
+    it("dispatches to the chatId-scoped session key when a valid chatId is sent", async () => {
+      // Seed the chatId-scoped key into the cache so the first-time-greeting
+      // prompt isn't appended — this test isolates the session-key value.
+      sessionCache.refresh([{ key: "agent:agent-1:direct:user-1:v1k2n3p4" }]);
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi Smithers",
+        agentId: "agent-1",
+        chatId: "v1k2n3p4",
+      });
+
+      expect(mockChat).toHaveBeenCalledWith("Hi Smithers", {
+        agentId: "agent-1",
+        sessionKey: "agent:agent-1:direct:user-1:v1k2n3p4",
+      });
+    });
+
+    it("falls back to the legacy per-user key when no chatId is sent", async () => {
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Hi Smithers",
+        agentId: "agent-1",
+      });
+
+      expect(mockChat).toHaveBeenCalledWith("Hi Smithers", {
+        agentId: "agent-1",
+        sessionKey: "agent:agent-1:direct:user-1",
+      });
+    });
+
+    it("rejects an invalid chatId with INVALID_CHAT_ID and does not dispatch", async () => {
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      const clientWs = createMockClientWs();
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi Smithers",
+        agentId: "agent-1",
+        chatId: "bad/id",
+      });
+
+      // No dispatch to OpenClaw — a malformed chatId must not leak the message
+      // into the wrong (or default) conversation.
+      expect(mockChat).not.toHaveBeenCalled();
+
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m) => m.type === "error" && m.code === "INVALID_CHAT_ID")).toBe(true);
+    });
+
+    it("rejects a colon-bearing chatId with INVALID_CHAT_ID and does not dispatch", async () => {
+      async function* fakeStream() {
+        yield { type: "text" as const, text: "Hello!" };
+        yield { type: "done" as const, text: "" };
+      }
+      mockChat.mockReturnValue(fakeStream());
+
+      const clientWs = createMockClientWs();
+      await router.handleMessage(clientWs as any, {
+        type: "message",
+        content: "Hi Smithers",
+        agentId: "agent-1",
+        chatId: "a:b",
+      });
+
+      expect(mockChat).not.toHaveBeenCalled();
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m) => m.type === "error" && m.code === "INVALID_CHAT_ID")).toBe(true);
+    });
+
+    it("loads history for the chatId-scoped session key when a valid chatId is sent", async () => {
+      const clientWs = createMockClientWs();
+      mockSessionsHistory.mockResolvedValue({
+        messages: [{ role: "user", content: "Hello", timestamp: 1708460000000 }],
+      });
+
+      await router.handleMessage(clientWs as any, {
+        type: "history",
+        agentId: "agent-1",
+        chatId: "v1k2n3p4",
+      });
+
+      expect(mockSessionsHistory).toHaveBeenCalledWith("agent:agent-1:direct:user-1:v1k2n3p4");
+    });
+
+    it("rejects an invalid chatId on the history path with INVALID_CHAT_ID and does not load history", async () => {
+      const clientWs = createMockClientWs();
+
+      await router.handleMessage(clientWs as any, {
+        type: "history",
+        agentId: "agent-1",
+        chatId: "bad/id",
+      });
+
+      expect(mockSessionsHistory).not.toHaveBeenCalled();
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages.some((m) => m.type === "error" && m.code === "INVALID_CHAT_ID")).toBe(true);
+    });
+  });
+
   it("should send streamed chunks to browser client", async () => {
     const clientWs = createMockClientWs();
     async function* fakeStream() {

--- a/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
@@ -1,0 +1,79 @@
+import type { Metadata } from "next";
+import { db } from "@/db";
+import { activeAgents } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { notFound } from "next/navigation";
+import { Chat } from "@/components/chat";
+import { requireAuth } from "@/lib/require-auth";
+import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
+import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
+import { getLicenseState } from "@/lib/enterprise";
+import { getAgentAvatarSvg } from "@/lib/avatar";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ agentId: string; chatId: string }>;
+}): Promise<Metadata> {
+  const { agentId } = await params;
+  const agent = await db
+    .select({ name: activeAgents.name })
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+
+  return { title: agent?.name ?? "Chat" };
+}
+
+export default async function ChatPage({
+  params,
+}: {
+  params: Promise<{ agentId: string; chatId: string }>;
+}) {
+  const { agentId, chatId } = await params;
+  const session = await requireAuth();
+  const userId = session.user.id!;
+  const userRole = session.user.role;
+
+  const agent = await db
+    .select()
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+
+  if (!agent) notFound();
+
+  const licenseState = await getLicenseState();
+  const effVis = effectiveVisibility(agent.visibility, licenseState);
+  const needsGroups = userRole !== "admin" && effVis === "restricted";
+
+  const [userGroupIds, agentGroupIds] = await Promise.all([
+    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
+    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
+  ]);
+
+  try {
+    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
+  } catch {
+    notFound();
+  }
+
+  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
+  const isAdmin = userRole === "admin";
+  const canEdit = isAdmin || (agent.isPersonal && agent.ownerId === userId);
+
+  return (
+    <Chat
+      // Keying on (agentId, chatId) (#508) remounts <Chat> on a chat switch so
+      // the runtime reconnects to the new session with no stale-message bleed.
+      key={`${agent.id}:${chatId}`}
+      agentId={agent.id}
+      chatId={chatId}
+      agentName={agent.name}
+      isPersonal={agent.isPersonal}
+      avatarUrl={avatarUrl}
+      canEdit={canEdit}
+      isAdmin={isAdmin}
+    />
+  );
+}

--- a/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/[chatId]/page.tsx
@@ -73,7 +73,6 @@ export default async function ChatPage({
       isPersonal={agent.isPersonal}
       avatarUrl={avatarUrl}
       canEdit={canEdit}
-      isAdmin={isAdmin}
     />
   );
 }

--- a/packages/web/src/app/(app)/chat/[agentId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/page.tsx
@@ -66,7 +66,6 @@ export default async function ChatPage({ params }: { params: Promise<{ agentId: 
       isPersonal={agent.isPersonal}
       avatarUrl={avatarUrl}
       canEdit={canEdit}
-      isAdmin={isAdmin}
     />
   );
 }

--- a/packages/web/src/app/(app)/chat/[agentId]/telegram/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/telegram/page.tsx
@@ -1,0 +1,82 @@
+import type { Metadata } from "next";
+import { db } from "@/db";
+import { activeAgents } from "@/db/schema";
+import { eq } from "drizzle-orm";
+import { notFound } from "next/navigation";
+import { TelegramChatView } from "@/components/telegram-chat-view";
+import { requireAuth } from "@/lib/require-auth";
+import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
+import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
+import { getLicenseState } from "@/lib/enterprise";
+import { getAgentAvatarSvg } from "@/lib/avatar";
+
+export async function generateMetadata({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}): Promise<Metadata> {
+  const { agentId } = await params;
+  const agent = await db
+    .select({ name: activeAgents.name })
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+
+  return { title: agent ? `${agent.name} on Telegram` : "Telegram chat" };
+}
+
+/**
+ * Read-only mirror of the user's Telegram conversation with an agent (#508).
+ *
+ * The static `telegram` segment wins over the dynamic `[chatId]` segment in
+ * Next.js routing (same as `settings`), so `/chat/<id>/<chatId>` is unaffected.
+ * Auth gating mirrors the base `chat/[agentId]/page.tsx`.
+ */
+export default async function TelegramChatPage({
+  params,
+}: {
+  params: Promise<{ agentId: string }>;
+}) {
+  const { agentId } = await params;
+  const session = await requireAuth();
+  const userId = session.user.id!;
+  const userRole = session.user.role;
+
+  const agent = await db
+    .select()
+    .from(activeAgents)
+    .where(eq(activeAgents.id, agentId))
+    .then((rows) => rows[0]);
+
+  if (!agent) notFound();
+
+  const licenseState = await getLicenseState();
+  const effVis = effectiveVisibility(agent.visibility, licenseState);
+  const needsGroups = userRole !== "admin" && effVis === "restricted";
+
+  const [userGroupIds, agentGroupIds] = await Promise.all([
+    needsGroups ? getUserGroupIds(userId) : Promise.resolve([]),
+    needsGroups ? getAgentGroupIds(agentId) : Promise.resolve([]),
+  ]);
+
+  try {
+    assertAgentAccess(agent, userId, userRole, userGroupIds, agentGroupIds, licenseState);
+  } catch {
+    notFound();
+  }
+
+  const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
+  const isAdmin = userRole === "admin";
+  const canEdit = isAdmin || (agent.isPersonal && agent.ownerId === userId);
+
+  return (
+    <TelegramChatView
+      key={agent.id}
+      agentId={agent.id}
+      agentName={agent.name}
+      avatarUrl={avatarUrl}
+      isPersonal={agent.isPersonal}
+      canEdit={canEdit}
+    />
+  );
+}

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -101,11 +101,7 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ age
   // fields like agents.defaults to avoid hot-reloads that break polling).
   // updateTelegramChannelConfig() also notifies restart-state on actual write so
   // /api/health/openclaw reflects the pending OC restart.
-  updateTelegramChannelConfig(
-    agentId,
-    { botToken },
-    null // Don't touch identityLinks — preserved from existing config
-  );
+  updateTelegramChannelConfig(agentId, { botToken });
 
   // Populate allow-from store with all linked users who have permission to this agent
   await recalculateTelegramAllowStores();
@@ -160,7 +156,7 @@ export async function DELETE(req: Request, { params }: { params: Promise<{ agent
   clearAllowStoreForAccount(agentId);
   // Remove this account from config (other accounts preserved).
   // updateTelegramChannelConfig() notifies restart-state on actual write.
-  updateTelegramChannelConfig(agentId, null, null);
+  updateTelegramChannelConfig(agentId, null);
 
   await appendAuditLog({
     actorType: "user",

--- a/packages/web/src/app/api/agents/[agentId]/chats/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/chats/route.ts
@@ -1,0 +1,63 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { withAuth } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
+import { getOpenClawClient } from "@/server/openclaw-client";
+import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import { db } from "@/db";
+import { channelLinks } from "@/db/schema";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
+
+/**
+ * List the requesting user's own chats with this agent. Read-only overview for
+ * the Chats UI — the authorization boundary lives in `classifyUserSessions`,
+ * which fails closed on anything it can't positively attribute to this user.
+ */
+// audit-exempt: read-only chats list — no state change.
+export const GET = withAuth<RouteContext>(async (_request, { params }, session) => {
+  const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+
+  const userId = session.user.id!;
+
+  // Telegram peers linked to THIS user, lowercased — the classifier compares
+  // verbatim against OpenClaw's lowercased principal segment, so a peer id that
+  // isn't lowercased here would silently never match.
+  const links = await db
+    .select()
+    .from(channelLinks)
+    .where(and(eq(channelLinks.channel, "telegram"), eq(channelLinks.userId, userId)));
+  const linkedTelegramPeerIds = new Set(links.map((l) => l.channelUserId.toLowerCase()));
+
+  // `sessions.list` is untyped wire output: `{ sessions?: RawSession[] }`.
+  let raw: { sessions?: RawSession[] } | undefined;
+  try {
+    raw = (await getOpenClawClient().sessions.list({})) as { sessions?: RawSession[] } | undefined;
+  } catch {
+    // OpenClaw unreachable / mid-reconnect. 502 (not 500) so the client can
+    // surface a retryable "couldn't load chats" toast rather than a hard error.
+    return NextResponse.json({ error: "Failed to load chats" }, { status: 502 });
+  }
+  const sessionsArr = Array.isArray(raw?.sessions) ? raw.sessions : [];
+
+  // Scope to THIS agent before classifying — the classifier checks identity and
+  // key shape but not the agentId, so cross-agent isolation is enforced here.
+  // Keys are `agent:<agentId>:direct:<principal>[:<chatId>]`.
+  const scoped = sessionsArr.filter(
+    (s) => typeof s?.key === "string" && s.key.split(":")[1] === agentId
+  );
+
+  const classified = classifyUserSessions(scoped, userId, linkedTelegramPeerIds);
+
+  // Carry the human-readable title (the session label, if any) and sort by
+  // recency so the most recent conversation surfaces first.
+  const labelByKey = new Map(scoped.map((s) => [s.key, s.label ?? null]));
+  const chats = classified
+    .map((c) => ({ ...c, title: labelByKey.get(c.key) ?? null }))
+    .sort((a, b) => b.lastInteractionAt - a.lastInteractionAt);
+
+  return NextResponse.json({ chats });
+});

--- a/packages/web/src/app/api/agents/[agentId]/chats/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/chats/route.ts
@@ -4,6 +4,7 @@ import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import type { ChatListItem } from "@/lib/schemas/sessions";
 import { db } from "@/db";
 import { channelLinks } from "@/db/schema";
 
@@ -53,10 +54,19 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
   const classified = classifyUserSessions(scoped, userId, linkedTelegramPeerIds);
 
   // Carry the human-readable title (the session label, if any) and sort by
-  // recency so the most recent conversation surfaces first.
+  // recency so the most recent conversation surfaces first. The internal
+  // session `key` stays server-side — the client only needs the fields in
+  // `ChatListItem`.
   const labelByKey = new Map(scoped.map((s) => [s.key, s.label ?? null]));
-  const chats = classified
-    .map((c) => ({ ...c, title: labelByKey.get(c.key) ?? null }))
+  const chats: ChatListItem[] = classified
+    .map((c) => ({
+      chatId: c.chatId,
+      sessionId: c.sessionId,
+      origin: c.origin,
+      writable: c.writable,
+      title: labelByKey.get(c.key) ?? null,
+      lastInteractionAt: c.lastInteractionAt,
+    }))
     .sort((a, b) => b.lastInteractionAt - a.lastInteractionAt);
 
   return NextResponse.json({ chats });

--- a/packages/web/src/app/api/agents/[agentId]/chats/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/chats/route.ts
@@ -4,11 +4,53 @@ import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import { firstUserMessageTitle } from "@/lib/chats/first-user-message-title";
+import type { RawHistoryMessage } from "@/lib/chats/telegram-transcript";
 import type { ChatListItem } from "@/lib/schemas/sessions";
 import { db } from "@/db";
 import { channelLinks } from "@/db/schema";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
+
+// How many trailing history entries to read when deriving a title — we only
+// need the FIRST user message, but OpenClaw returns the newest entries, so we
+// pull a small window that reliably contains the opening turn of short chats.
+const TITLE_HISTORY_LIMIT = 30;
+
+/**
+ * Short-lived, process-local cache of derived titles, keyed by sessionId. The
+ * dropdown re-fetches on every open, and a chat's first user message never
+ * changes, so a brief TTL spares us re-reading the same transcripts on rapid
+ * re-opens. Best-effort: it's fine for entries to be evicted or for the process
+ * to restart cold.
+ */
+const TITLE_CACHE_TTL_MS = 60_000;
+const titleCache = new Map<string, { title: string | null; at: number }>();
+
+/**
+ * Derive a labelless web chat's title from its first user message, with a brief
+ * cache. Returns `null` (the date-fallback signal) when the chat has no usable
+ * user message or its history can't be read — a title is a convenience, never a
+ * reason to fail the whole list.
+ */
+async function deriveWebChatTitle(sessionKey: string, sessionId: string): Promise<string | null> {
+  const cached = titleCache.get(sessionId);
+  if (cached && Date.now() - cached.at < TITLE_CACHE_TTL_MS) return cached.title;
+
+  let title: string | null = null;
+  try {
+    const raw = (await getOpenClawClient().sessions.history(sessionKey, {
+      limit: TITLE_HISTORY_LIMIT,
+    })) as { messages?: RawHistoryMessage[] } | undefined;
+    title = firstUserMessageTitle(raw?.messages ?? []);
+  } catch {
+    // History unreachable — fall back to the date-stamped label client-side.
+    title = null;
+  }
+
+  titleCache.set(sessionId, { title, at: Date.now() });
+  return title;
+}
 
 /**
  * List the requesting user's own chats with this agent. Read-only overview for
@@ -53,21 +95,34 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
 
   const classified = classifyUserSessions(scoped, userId, linkedTelegramPeerIds);
 
-  // Carry the human-readable title (the session label, if any) and sort by
-  // recency so the most recent conversation surfaces first. The internal
-  // session `key` stays server-side — the client only needs the fields in
-  // `ChatListItem`.
+  // Carry the human-readable title and sort by recency so the most recent
+  // conversation surfaces first. The internal session `key` stays server-side —
+  // the client only needs the fields in `ChatListItem`.
+  //
+  // Title precedence: the saved session label wins; otherwise, for the user's
+  // OWN web chats, derive it from the first user message. Telegram chats keep
+  // their label/null (their transcript has a dedicated endpoint), and labelled
+  // chats never trigger a history read.
   const labelByKey = new Map(scoped.map((s) => [s.key, s.label ?? null]));
-  const chats: ChatListItem[] = classified
-    .map((c) => ({
-      chatId: c.chatId,
-      sessionId: c.sessionId,
-      origin: c.origin,
-      writable: c.writable,
-      title: labelByKey.get(c.key) ?? null,
-      lastInteractionAt: c.lastInteractionAt,
-    }))
-    .sort((a, b) => b.lastInteractionAt - a.lastInteractionAt);
+  const chats: ChatListItem[] = (
+    await Promise.all(
+      classified.map(async (c) => {
+        const label = labelByKey.get(c.key) ?? null;
+        let title = label;
+        if (!title && c.origin === "web") {
+          title = await deriveWebChatTitle(c.key, c.sessionId);
+        }
+        return {
+          chatId: c.chatId,
+          sessionId: c.sessionId,
+          origin: c.origin,
+          writable: c.writable,
+          title,
+          lastInteractionAt: c.lastInteractionAt,
+        };
+      })
+    )
+  ).sort((a, b) => b.lastInteractionAt - a.lastInteractionAt);
 
   return NextResponse.json({ chats });
 });

--- a/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/sessions/compact/route.ts
@@ -31,10 +31,14 @@ export const POST = withAuth<RouteContext>(async (request, { params }, session) 
   const parsed = await parseRequestBody(compactSessionSchema, request);
   if ("error" in parsed) return parsed.error;
 
-  // Per-user session scoping, identical to ClientRouter.computeSessionKey:
-  // agent:<agentId>:direct:<userId>. OpenClaw validates that the agentId in the
-  // key matches the agentId argument — see MEMORY.md "OpenClaw Sessions API".
-  const sessionKey = `agent:${agentId}:direct:${session.user.id!}`;
+  // Per-user, per-chat session scoping, identical to
+  // ClientRouter.computeSessionKey: agent:<agentId>:direct:<userId>[:<chatId>].
+  // The optional chatId (#508) targets the chat the user is actually looking at
+  // on /chat/<agentId>/<chatId>; omitting it compacts the default per-user
+  // session. OpenClaw validates that the agentId in the key matches the agentId
+  // argument — see MEMORY.md "OpenClaw Sessions API".
+  const base = `agent:${agentId}:direct:${session.user.id!}`;
+  const sessionKey = parsed.data.chatId ? `${base}:${parsed.data.chatId}` : base;
 
   // Throttle repeated compactions of the same session. The UI debounces via a
   // disabled button; this guards direct API spamming from fanning out

--- a/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
@@ -1,0 +1,74 @@
+import { NextResponse } from "next/server";
+import { and, eq } from "drizzle-orm";
+import { withAuth } from "@/lib/api-auth";
+import { getAgentWithAccess } from "@/lib/agent-access";
+import { getOpenClawClient } from "@/server/openclaw-client";
+import { getSetting } from "@/lib/settings";
+import { db } from "@/db";
+import { channelLinks } from "@/db/schema";
+import { mapTelegramTranscript, type RawHistoryMessage } from "@/lib/chats/telegram-transcript";
+
+type RouteContext = { params: Promise<{ agentId: string }> };
+
+// How many trailing history entries to fetch for the read-only mirror. Matches
+// a reasonable chat backlog without pulling an unbounded transcript.
+const HISTORY_LIMIT = 200;
+
+/**
+ * Read-only mirror of the requesting user's linked Telegram conversation with
+ * this agent (#508). Pinchy mirrors Telegram into the web UI read-only — there
+ * is no posting from here — so this only fetches and projects the transcript.
+ *
+ * The Telegram peer is SERVER-DERIVED from the authed user's `channel_links`
+ * row; the client never supplies it. That is the authorization boundary: a
+ * user can only ever read the session keyed to their own linked peer, so one
+ * user's transcript can never leak to another.
+ */
+// audit-exempt: read-only telegram transcript mirror — no state change.
+export const GET = withAuth<RouteContext>(async (_request, { params }, session) => {
+  const { agentId } = await params;
+
+  const agentOrError = await getAgentWithAccess(agentId, session.user.id!, session.user.role);
+  if (agentOrError instanceof NextResponse) return agentOrError;
+
+  const userId = session.user.id!;
+
+  // The authed user's Telegram peer. One Telegram link per user, so the first
+  // (and only) row is the peer. Lowercased to match OpenClaw's stored principal
+  // segment — the classifier's contract (see classify-sessions.ts).
+  const links = await db
+    .select()
+    .from(channelLinks)
+    .where(and(eq(channelLinks.channel, "telegram"), eq(channelLinks.userId, userId)));
+
+  const peerId = links[0]?.channelUserId?.toLowerCase();
+  if (!peerId) {
+    return NextResponse.json({ error: "No linked Telegram conversation" }, { status: 404 });
+  }
+
+  // Per-task session model: the Telegram conversation is a SEPARATE OpenClaw
+  // session from the web chat, keyed by the user's Telegram peer id.
+  const sessionKey = `agent:${agentId}:direct:${peerId}`;
+
+  let raw: { messages?: RawHistoryMessage[] } | undefined;
+  try {
+    raw = (await getOpenClawClient().sessions.history(sessionKey, { limit: HISTORY_LIMIT })) as
+      | { messages?: RawHistoryMessage[] }
+      | undefined;
+  } catch {
+    // OpenClaw unreachable / mid-reconnect. 502 (not 500) so the client can
+    // surface a retryable "couldn't load conversation" toast.
+    return NextResponse.json({ error: "Failed to load Telegram conversation" }, { status: 502 });
+  }
+
+  const messages = mapTelegramTranscript(raw?.messages ?? []);
+
+  // "Continue on Telegram" deep link. The bot username is persisted per agent
+  // as `telegram_bot_username:<agentId>` when an admin connects the bot (see
+  // the agent telegram channel route). Null when this agent has no bot
+  // configured — the UI falls back gracefully.
+  const botUsername = await getSetting(`telegram_bot_username:${agentId}`);
+  const botDeepLink = botUsername ? `https://t.me/${botUsername}` : null;
+
+  return NextResponse.json({ messages, botDeepLink });
+});

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -47,7 +47,11 @@ function extractAgentIdFromSessionKey(sessionKey: string | undefined): string | 
 
 function extractUserIdFromSessionKey(sessionKey: string | undefined): string | undefined {
   if (!sessionKey) return undefined;
-  return /^agent:[^:]+:direct:(.+)$/.exec(sessionKey)?.[1];
+  // Capture only the userId segment. Direct session keys gained a trailing
+  // chatId segment with the chats feature (agent:<agentId>:direct:<userId>:<chatId>);
+  // a greedy `(.+)$` would swallow `<userId>:<chatId>` and mis-attribute the
+  // audit row. The userId itself never contains a colon.
+  return /^agent:[^:]+:direct:([^:]+)/.exec(sessionKey)?.[1];
 }
 
 // Trim and reject blank strings; turns "" or "   " into undefined so optional

--- a/packages/web/src/app/api/settings/telegram/all/route.ts
+++ b/packages/web/src/app/api/settings/telegram/all/route.ts
@@ -33,7 +33,7 @@ export async function DELETE() {
   // is auto-deduped when there's nothing to remove, avoiding a 30 s overlay for
   // a no-op.
   clearAllAllowStores();
-  updateTelegramChannelConfig(null, null, null);
+  updateTelegramChannelConfig(null, null);
 
   await appendAuditLog({
     actorType: "user",

--- a/packages/web/src/app/api/settings/telegram/route.ts
+++ b/packages/web/src/app/api/settings/telegram/route.ts
@@ -3,7 +3,6 @@ import { NextResponse } from "next/server";
 import { z } from "zod";
 import { withAuth } from "@/lib/api-auth";
 import { resolvePairingCode } from "@/lib/telegram-pairing";
-import { updateIdentityLinks } from "@/lib/openclaw-config";
 import { recalculateTelegramAllowStores, removePairingRequest } from "@/lib/telegram-allow-store";
 import { db } from "@/db";
 import { channelLinks } from "@/db/schema";
@@ -11,24 +10,6 @@ import { eq, and } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
 
 const linkTelegramSchema = z.object({ code: z.string().min(1) });
-
-/**
- * Build identityLinks map from all telegram channel links in DB.
- * Format: { userId: ["telegram:channelUserId"] }
- */
-async function buildIdentityLinks(): Promise<Record<string, string[]>> {
-  const links = await db.select().from(channelLinks);
-  const identityLinks: Record<string, string[]> = {};
-  for (const link of links) {
-    const identity = `${link.channel}:${link.channelUserId}`;
-    if (!identityLinks[link.userId]) {
-      identityLinks[link.userId] = [identity];
-    } else {
-      identityLinks[link.userId].push(identity);
-    }
-  }
-  return identityLinks;
-}
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const link = await db.query.channelLinks.findFirst({
@@ -79,9 +60,11 @@ export const POST = withAuth(async (req, _ctx, session) => {
   // Recalculate per-account allow-from stores (permission-aware)
   await recalculateTelegramAllowStores();
 
-  // Update only identityLinks in config (targeted write — no agents.defaults diff,
-  // no hot-reload, no Telegram polling disruption)
-  updateIdentityLinks(await buildIdentityLinks());
+  // #508: per-task session model. We no longer write session.identityLinks —
+  // each Telegram peer keeps its own per-peer OpenClaw session rather than
+  // being folded into the user's web chat session. Pinchy's own authorization
+  // (Chats list, Telegram allow-listing) reads channel_links directly, so the
+  // link is fully effective without any identityLinks emission.
 
   return NextResponse.json({ linked: true, telegramUserId });
 });
@@ -104,8 +87,9 @@ export const DELETE = withAuth(async (_req, _ctx, session) => {
   // Recalculate per-account allow-from stores (removes unlinked user)
   await recalculateTelegramAllowStores();
 
-  // Update identityLinks (targeted write — removes this user's mapping)
-  updateIdentityLinks(await buildIdentityLinks());
+  // #508: per-task session model — no session.identityLinks to update. The
+  // per-account allow-from recalculation above (driven by channel_links) is
+  // the sole config-side effect of unlinking.
 
   return NextResponse.json({ linked: false });
 });

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -21,9 +21,24 @@ import { apiGet } from "@/lib/api-client";
 
 // Render the dropdown content inline so we can assert items without Radix's
 // portal + pointer-capture mechanics (same approach template-selector.test.tsx
-// uses for tooltips).
+// uses for tooltips). We also expose a hidden "open-dropdown" button that fires
+// `onOpenChange(true)` so tests can simulate opening the menu (the component
+// re-fetches its chat list on open).
 vi.mock("@/components/ui/dropdown-menu", () => ({
-  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenu: ({
+    children,
+    onOpenChange,
+  }: {
+    children: React.ReactNode;
+    onOpenChange?: (open: boolean) => void;
+  }) => (
+    <div>
+      <button type="button" data-testid="open-dropdown" onClick={() => onOpenChange?.(true)}>
+        open
+      </button>
+      {children}
+    </div>
+  ),
   DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
     <div>{children}</div>
   ),
@@ -247,19 +262,33 @@ describe("ChatSwitcher", () => {
     await waitFor(() => expect(screen.queryByText(/Loading/i)).toBeNull());
   });
 
-  it("shows an empty state when there are no other chats", async () => {
+  it("shows an empty state when there are no chats", async () => {
     mockChats([]);
-    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+    // The empty state is only reachable on the read-only Telegram view: the web
+    // view always synthesizes the current chat optimistically (see Fix 1), so a
+    // web list is never truly empty. On the Telegram view there's no web chat to
+    // synthesize, so an empty server list stays empty.
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" activeTelegram />);
 
     expect(await screen.findByText(/No other chats yet/i)).toBeInTheDocument();
   });
 
   it("degrades to an empty list when the fetch fails", async () => {
     (apiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+    // On the Telegram view nothing is synthesized, so a failed fetch settles to
+    // the empty state — proving the failure path doesn't crash the header.
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" activeTelegram />);
+
+    expect(await screen.findByText(/No other chats yet/i)).toBeInTheDocument();
+  });
+
+  it("on the web view, a failed fetch still shows the current chat optimistically (no crash)", async () => {
+    (apiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
     render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
 
-    // No crash; resolves to the empty state once the failed fetch settles.
-    expect(await screen.findByText(/No other chats yet/i)).toBeInTheDocument();
+    // The default web chat is always visible even when the list fails to load.
+    const menu = await screen.findByRole("menu");
+    expect(optimisticRow(menu)).not.toBeNull();
   });
 
   it("renders the current chat's title in the trigger", async () => {
@@ -268,5 +297,104 @@ describe("ChatSwitcher", () => {
 
     // The trigger reflects the active chat's title once loaded.
     expect(await screen.findByRole("button", { name: /Quarterly report/i })).toBeInTheDocument();
+  });
+
+  // --- Fix 1: current/new chat is always visible (optimistic + refetch) -----
+
+  // The permanent "New chat" ACTION item (the one with the Plus icon that starts
+  // a fresh chat) also reads "New chat", so we can't disambiguate the synthetic
+  // current-chat ROW by text alone. A chat ROW renders its title inside a
+  // `truncate` span (the action item's label is a bare text node) — that's the
+  // stable structural discriminator. Returns the synthetic row, or null when no
+  // optimistic row was synthesized.
+  function optimisticRow(menu: HTMLElement): HTMLElement | null {
+    return (
+      within(menu)
+        .getAllByText("New chat")
+        .filter((el) => el.classList.contains("truncate"))
+        .map((el) => el.closest("[role='menuitem']") as HTMLElement | null)
+        .find((row): row is HTMLElement => row != null) ?? null
+    );
+  }
+
+  it("optimistically shows a brand-new chat (not in the server list) as the active 'New chat'", async () => {
+    // The server list does NOT contain the current chatId — a brand-new chat
+    // that has not produced an OpenClaw session yet.
+    mockChats([webChat, telegramChat, legacyChat]);
+    render(<ChatSwitcher agentId="agent-1" chatId="brand-new-chat" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+
+    // A synthetic "New chat" row appears, marked active.
+    const newChatRow = optimisticRow(menu)!;
+    expect(newChatRow).not.toBeNull();
+    expect(within(newChatRow).getByLabelText("Current chat")).toBeInTheDocument();
+
+    // The persistent header trigger keeps the agent name for an untitled
+    // optimistic chat (not a generic "New chat") — the dropdown row carries the
+    // "New chat" label, the header stays the agent identity.
+    expect(screen.getByRole("button", { name: /Smithers/i })).toBeInTheDocument();
+
+    // It sorts to the top (newest), ahead of the server chats — it's the first
+    // chat row (a menuitem whose title sits in a `truncate` span) below the
+    // "New chat" action item + separator.
+    const rows = within(menu).getAllByRole("menuitem");
+    const firstChatRow = rows.find((r) => r.querySelector(".truncate") != null)!;
+    expect(firstChatRow.textContent).toContain("New chat");
+  });
+
+  it("optimistically shows the default web chat (chatId null) as 'New chat' when the server list lacks it", async () => {
+    // Server list has only a telegram chat — no web chat at all. The default
+    // web chat (chatId null) must still surface optimistically and active.
+    mockChats([telegramChat]);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+    const newChatRow = optimisticRow(menu)!;
+    expect(newChatRow).not.toBeNull();
+    expect(within(newChatRow).getByLabelText("Current chat")).toBeInTheDocument();
+  });
+
+  it("does NOT synthesize a duplicate when the current chat IS in the server list", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+
+    // The current chat (chat-abc) is the server's "Quarterly report" entry — it
+    // is shown as-is, with no extra synthetic "New chat" row.
+    expect(optimisticRow(menu)).toBeNull();
+    const activeRow = within(menu).getByText("Quarterly report").closest("[role='menuitem']")!;
+    expect(within(activeRow as HTMLElement).getByLabelText("Current chat")).toBeInTheDocument();
+  });
+
+  it("does NOT synthesize a web 'New chat' when on the read-only Telegram view", async () => {
+    // On the Telegram view chatId is null but activeTelegram is set — the active
+    // chat is the telegram row, so we must not invent a web "New chat".
+    mockChats([telegramChat]);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" activeTelegram />);
+
+    const menu = await screen.findByRole("menu");
+    expect(optimisticRow(menu)).toBeNull();
+  });
+
+  it("re-fetches the chat list every time the dropdown opens", async () => {
+    const user = userEvent.setup();
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    // Initial mount fetch.
+    await screen.findByRole("menu");
+    expect(apiGet).toHaveBeenCalledTimes(1);
+
+    // Opening the dropdown triggers a fresh fetch so a just-created session
+    // (e.g. from a message sent moments ago) shows up.
+    await user.click(screen.getByTestId("open-dropdown"));
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(2));
+    expect(apiGet).toHaveBeenLastCalledWith("/api/agents/agent-1/chats");
+
+    // Re-opening fetches again.
+    await user.click(screen.getByTestId("open-dropdown"));
+    await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(3));
   });
 });

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -1,0 +1,238 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { ChatSwitcher } from "@/components/chat-switcher";
+import { chatIdSchema } from "@/lib/schemas/sessions";
+import type { ChatListItem } from "@/lib/schemas/sessions";
+
+// --- mocks ----------------------------------------------------------------
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn() };
+});
+import { apiGet } from "@/lib/api-client";
+
+// Render the dropdown content inline so we can assert items without Radix's
+// portal + pointer-capture mechanics (same approach template-selector.test.tsx
+// uses for tooltips).
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" role="menuitem" disabled={disabled} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// --- fixtures -------------------------------------------------------------
+
+const webChat: ChatListItem = {
+  chatId: "chat-abc",
+  sessionId: "s-web-new",
+  origin: "web",
+  writable: true,
+  title: "Quarterly report",
+  lastInteractionAt: 5_000,
+};
+
+const legacyChat: ChatListItem = {
+  chatId: null,
+  sessionId: "s-web-legacy",
+  origin: "web",
+  writable: true,
+  title: null, // forces the date fallback title
+  lastInteractionAt: 1_000,
+};
+
+const telegramChat: ChatListItem = {
+  chatId: null,
+  sessionId: "s-telegram",
+  origin: "telegram",
+  writable: false,
+  title: "Telegram chat",
+  lastInteractionAt: 3_000,
+};
+
+const allChats: ChatListItem[] = [webChat, telegramChat, legacyChat];
+
+function mockChats(chats: ChatListItem[]) {
+  (apiGet as ReturnType<typeof vi.fn>).mockResolvedValue({ chats });
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+// --- tests ----------------------------------------------------------------
+
+describe("ChatSwitcher", () => {
+  it("fetches and renders chats with titles, falling back to a localized date for null titles", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    expect(apiGet).toHaveBeenCalledWith("/api/agents/agent-1/chats");
+
+    const menu = await screen.findByRole("menu");
+    expect(within(menu).getByText("Quarterly report")).toBeInTheDocument();
+    expect(within(menu).getByText("Telegram chat")).toBeInTheDocument();
+
+    // legacyChat has a null title → fallback "Chat from <localized date>".
+    const fallback = new Date(legacyChat.lastInteractionAt).toLocaleDateString();
+    expect(within(menu).getByText(`Chat from ${fallback}`)).toBeInTheDocument();
+  });
+
+  it("shows the Telegram badge and a read-only marker only on the Telegram chat", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+
+    // Exactly one Telegram badge and one read-only marker.
+    expect(within(menu).getByText("Telegram")).toBeInTheDocument();
+    const readOnlyMarkers = within(menu).getAllByLabelText("Read-only");
+    expect(readOnlyMarkers).toHaveLength(1);
+
+    // The read-only marker belongs to the Telegram row, not a web row.
+    const telegramRow = within(menu).getByText("Telegram chat").closest("[role='menuitem']")!;
+    expect(within(telegramRow as HTMLElement).getByLabelText("Read-only")).toBeInTheDocument();
+
+    const webRow = within(menu).getByText("Quarterly report").closest("[role='menuitem']")!;
+    expect(within(webRow as HTMLElement).queryByLabelText("Read-only")).toBeNull();
+    expect(within(webRow as HTMLElement).queryByText("Telegram")).toBeNull();
+  });
+
+  it("marks the active chat (matching the chatId prop) with an active indicator", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+
+    const activeRow = within(menu).getByText("Quarterly report").closest("[role='menuitem']")!;
+    expect(within(activeRow as HTMLElement).getByLabelText("Current chat")).toBeInTheDocument();
+
+    // A different web chat is not marked active.
+    const telegramRow = within(menu).getByText("Telegram chat").closest("[role='menuitem']")!;
+    expect(within(telegramRow as HTMLElement).queryByLabelText("Current chat")).toBeNull();
+  });
+
+  it("treats the default chat (chatId null) as active when chatId prop is null", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+
+    // The legacy/default web chat (chatId null) is the active one now.
+    const fallback = new Date(legacyChat.lastInteractionAt).toLocaleDateString();
+    const defaultRow = within(menu)
+      .getByText(`Chat from ${fallback}`)
+      .closest("[role='menuitem']")!;
+    expect(within(defaultRow as HTMLElement).getByLabelText("Current chat")).toBeInTheDocument();
+
+    // The Telegram chat also has chatId null but is a different origin/session,
+    // so it must NOT be treated as the active default chat.
+    const telegramRow = within(menu).getByText("Telegram chat").closest("[role='menuitem']")!;
+    expect(within(telegramRow as HTMLElement).queryByLabelText("Current chat")).toBeNull();
+  });
+
+  it("starting a new chat pushes /chat/<agentId>/<schema-valid chatId>", async () => {
+    const user = userEvent.setup();
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    await screen.findByRole("menu");
+    await user.click(screen.getByRole("menuitem", { name: /New chat/i }));
+
+    expect(push).toHaveBeenCalledTimes(1);
+    const pushed = push.mock.calls[0][0] as string;
+    const prefix = "/chat/agent-1/";
+    expect(pushed.startsWith(prefix)).toBe(true);
+
+    const newId = pushed.slice(prefix.length);
+    expect(chatIdSchema.safeParse(newId).success).toBe(true);
+  });
+
+  it("selecting a web chat pushes /chat/<agentId>/<chatId>", async () => {
+    const user = userEvent.setup();
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+    await user.click(within(menu).getByText("Quarterly report"));
+
+    expect(push).toHaveBeenCalledWith("/chat/agent-1/chat-abc");
+  });
+
+  it("selecting the default chat (chatId null) pushes /chat/<agentId>", async () => {
+    const user = userEvent.setup();
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+    const fallback = new Date(legacyChat.lastInteractionAt).toLocaleDateString();
+    await user.click(within(menu).getByText(`Chat from ${fallback}`));
+
+    expect(push).toHaveBeenCalledWith("/chat/agent-1");
+  });
+
+  it("shows a loading state while fetching", async () => {
+    let resolve!: (value: { chats: ChatListItem[] }) => void;
+    (apiGet as ReturnType<typeof vi.fn>).mockReturnValue(
+      new Promise((r) => {
+        resolve = r;
+      })
+    );
+
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    expect(screen.getByText(/Loading/i)).toBeInTheDocument();
+
+    resolve({ chats: allChats });
+    await waitFor(() => expect(screen.queryByText(/Loading/i)).toBeNull());
+  });
+
+  it("shows an empty state when there are no other chats", async () => {
+    mockChats([]);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    expect(await screen.findByText(/No other chats yet/i)).toBeInTheDocument();
+  });
+
+  it("degrades to an empty list when the fetch fails", async () => {
+    (apiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("network"));
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" />);
+
+    // No crash; resolves to the empty state once the failed fetch settles.
+    expect(await screen.findByText(/No other chats yet/i)).toBeInTheDocument();
+  });
+
+  it("renders the current chat's title in the trigger", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    // The trigger reflects the active chat's title once loaded.
+    expect(await screen.findByRole("button", { name: /Quarterly report/i })).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -378,6 +378,20 @@ describe("ChatSwitcher", () => {
     expect(optimisticRow(menu)).toBeNull();
   });
 
+  it("shows 'Not saved yet' on the synthetic new-chat row, never a far-future time", async () => {
+    // The optimistic row carries a MAX_SAFE_INTEGER sentinel timestamp so it
+    // sorts to the top; it must NOT render as a relative time ("in 292 million
+    // years"). A brand-new chat has no real interaction time yet.
+    mockChats([webChat, telegramChat, legacyChat]);
+    render(<ChatSwitcher agentId="agent-1" chatId="brand-new-chat" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+    const newChatRow = optimisticRow(menu)!;
+    expect(newChatRow).not.toBeNull();
+    expect(within(newChatRow).getByText(/Not saved yet/i)).toBeInTheDocument();
+    expect(within(newChatRow).queryByText(/year/i)).toBeNull();
+  });
+
   it("re-fetches the chat list every time the dropdown opens", async () => {
     const user = userEvent.setup();
     mockChats(allChats);

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -197,6 +197,40 @@ describe("ChatSwitcher", () => {
     expect(push).toHaveBeenCalledWith("/chat/agent-1");
   });
 
+  it("selecting a Telegram chat pushes /chat/<agentId>/telegram (the read-only mirror)", async () => {
+    const user = userEvent.setup();
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+    const menu = await screen.findByRole("menu");
+    await user.click(within(menu).getByText("Telegram chat"));
+
+    // Telegram chats have a null chatId but must NOT collide with the default
+    // web chat — they navigate to the dedicated read-only Telegram view.
+    expect(push).toHaveBeenCalledWith("/chat/agent-1/telegram");
+  });
+
+  it("marks the Telegram chat active and labels the trigger 'Telegram' when activeTelegram is set", async () => {
+    mockChats(allChats);
+    render(<ChatSwitcher agentId="agent-1" chatId={null} agentName="Smithers" activeTelegram />);
+
+    const menu = await screen.findByRole("menu");
+
+    // On the Telegram view, the Telegram row carries the active indicator...
+    const telegramRow = within(menu).getByText("Telegram chat").closest("[role='menuitem']")!;
+    expect(within(telegramRow as HTMLElement).getByLabelText("Current chat")).toBeInTheDocument();
+
+    // ...and the default web chat is NOT treated as active even though chatId is null.
+    const fallback = new Date(legacyChat.lastInteractionAt).toLocaleDateString();
+    const defaultRow = within(menu)
+      .getByText(`Chat from ${fallback}`)
+      .closest("[role='menuitem']")!;
+    expect(within(defaultRow as HTMLElement).queryByLabelText("Current chat")).toBeNull();
+
+    // The trigger reflects the Telegram channel.
+    expect(screen.getByRole("button", { name: /Telegram/i })).toBeInTheDocument();
+  });
+
   it("shows a loading state while fetching", async () => {
     let resolve!: (value: { chats: ChatListItem[] }) => void;
     (apiGet as ReturnType<typeof vi.fn>).mockReturnValue(

--- a/packages/web/src/components/__tests__/telegram-chat-view.test.tsx
+++ b/packages/web/src/components/__tests__/telegram-chat-view.test.tsx
@@ -129,6 +129,9 @@ describe("TelegramChatView", () => {
     // unmistakable, distinct from the chat-switcher trigger.
     const indicator = within(header).getByTestId("telegram-channel-indicator");
     expect(indicator).toHaveTextContent("Telegram");
+    // It carries a distinct accessible name so a screen reader doesn't hear a
+    // bare "Telegram" twice (the chat-switcher trigger is also named "Telegram").
+    expect(indicator).toHaveAccessibleName(/telegram channel/i);
   });
 
   it("reflects the agent's visibility in the header (Private vs Shared)", async () => {

--- a/packages/web/src/components/__tests__/telegram-chat-view.test.tsx
+++ b/packages/web/src/components/__tests__/telegram-chat-view.test.tsx
@@ -1,0 +1,232 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, waitFor, within } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { TelegramChatView } from "@/components/telegram-chat-view";
+import { ApiError } from "@/lib/api-client";
+import type { TelegramTranscriptMessage } from "@/lib/schemas/sessions";
+
+// --- mocks ----------------------------------------------------------------
+//
+// Mirrors chat-switcher.test.tsx: stub next/navigation and apiGet, and flatten
+// the Radix dropdown so the embedded <ChatSwitcher> renders without portal /
+// pointer-capture mechanics.
+
+const push = vi.fn();
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push }),
+}));
+
+vi.mock("@/lib/api-client", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-client")>();
+  return { ...actual, apiGet: vi.fn() };
+});
+import { apiGet } from "@/lib/api-client";
+
+vi.mock("@/components/ui/dropdown-menu", () => ({
+  DropdownMenu: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuTrigger: ({ children }: { children: React.ReactNode; asChild?: boolean }) => (
+    <div>{children}</div>
+  ),
+  DropdownMenuContent: ({ children }: { children: React.ReactNode }) => (
+    <div role="menu">{children}</div>
+  ),
+  DropdownMenuItem: ({
+    children,
+    onSelect,
+    disabled,
+  }: {
+    children: React.ReactNode;
+    onSelect?: () => void;
+    disabled?: boolean;
+  }) => (
+    <button type="button" role="menuitem" disabled={disabled} onClick={() => onSelect?.()}>
+      {children}
+    </button>
+  ),
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuLabel: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+}));
+
+// --- fixtures -------------------------------------------------------------
+
+const messages: TelegramTranscriptMessage[] = [
+  { role: "user", text: "Hello from Telegram", timestamp: 1_000 },
+  { role: "assistant", text: "Hi! I'm Smithers, replying on Telegram.", timestamp: 2_000 },
+  { role: "user", text: "Great, thanks", timestamp: 3_000 },
+];
+
+const BOT_DEEP_LINK = "https://t.me/my_pinchy_bot";
+
+function mockTranscript(botDeepLink: string | null) {
+  (apiGet as ReturnType<typeof vi.fn>).mockResolvedValue({ messages, botDeepLink });
+}
+
+function renderView(overrides: Partial<React.ComponentProps<typeof TelegramChatView>> = {}) {
+  return render(
+    <TelegramChatView
+      agentId="agent-1"
+      agentName="Smithers"
+      avatarUrl="data:image/svg+xml;utf8,mock"
+      isPersonal={false}
+      canEdit={false}
+      {...overrides}
+    />
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  // ChatSwitcher (embedded in the header) fetches its chat list separately.
+  // Default it to an empty list; per-test mocks for the transcript override
+  // the first call.
+  (apiGet as ReturnType<typeof vi.fn>).mockResolvedValue({ chats: [] });
+});
+
+// --- tests ----------------------------------------------------------------
+
+describe("TelegramChatView", () => {
+  it("fetches the transcript from the telegram-chat endpoint on mount", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView();
+
+    await waitFor(() => expect(apiGet).toHaveBeenCalledWith("/api/agents/agent-1/telegram-chat"));
+  });
+
+  it("renders the messages read-only as role-styled bubbles, in order", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView();
+
+    expect(await screen.findByText("Hello from Telegram")).toBeInTheDocument();
+    expect(screen.getByText("Hi! I'm Smithers, replying on Telegram.")).toBeInTheDocument();
+    expect(screen.getByText("Great, thanks")).toBeInTheDocument();
+
+    // The transcript renders in the order the API returned them.
+    const transcript = screen.getByTestId("telegram-transcript");
+    const bubbleTexts = within(transcript)
+      .getAllByTestId(/^telegram-message-/)
+      .map((el) => el.textContent);
+    const firstUser = bubbleTexts.findIndex((t) => t?.includes("Hello from Telegram"));
+    const assistant = bubbleTexts.findIndex((t) => t?.includes("replying on Telegram"));
+    const secondUser = bubbleTexts.findIndex((t) => t?.includes("Great, thanks"));
+    expect(firstUser).toBeLessThan(assistant);
+    expect(assistant).toBeLessThan(secondUser);
+
+    // Role is encoded so user and assistant bubbles are visually distinct.
+    const userBubble = within(transcript).getByText("Hello from Telegram").closest("[data-role]")!;
+    const assistantBubble = within(transcript)
+      .getByText("Hi! I'm Smithers, replying on Telegram.")
+      .closest("[data-role]")!;
+    expect(userBubble.getAttribute("data-role")).toBe("user");
+    expect(assistantBubble.getAttribute("data-role")).toBe("assistant");
+  });
+
+  it("shows a clear Telegram channel indicator in the header", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView();
+
+    const header = await screen.findByTestId("telegram-chat-header");
+    // A dedicated channel-indicator badge surfaces "Telegram" so the channel is
+    // unmistakable, distinct from the chat-switcher trigger.
+    const indicator = within(header).getByTestId("telegram-channel-indicator");
+    expect(indicator).toHaveTextContent("Telegram");
+  });
+
+  it("reflects the agent's visibility in the header (Private vs Shared)", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView({ isPersonal: true });
+    let header = await screen.findByTestId("telegram-chat-header");
+    expect(within(header).getByText("Private")).toBeInTheDocument();
+
+    renderView({ isPersonal: false });
+    header = (await screen.findAllByTestId("telegram-chat-header"))[1];
+    expect(within(header).getByText("Shared")).toBeInTheDocument();
+  });
+
+  it("shows a Settings link only when the user can edit the agent", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    const { unmount } = renderView({ canEdit: true });
+    const editable = await screen.findByTestId("telegram-chat-header");
+    expect(within(editable).getByRole("link", { name: /settings/i })).toHaveAttribute(
+      "href",
+      "/chat/agent-1/settings"
+    );
+
+    unmount();
+    renderView({ canEdit: false });
+    const readOnly = await screen.findByTestId("telegram-chat-header");
+    expect(within(readOnly).queryByRole("link", { name: /settings/i })).toBeNull();
+  });
+
+  it("renders NO composer / message input (read-only)", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView();
+
+    await screen.findByText("Hello from Telegram");
+
+    // No textbox, no textarea — the conversation can't be typed into here.
+    expect(screen.queryByRole("textbox")).toBeNull();
+    expect(document.querySelector("textarea")).toBeNull();
+    expect(document.querySelector("input[type='text']")).toBeNull();
+  });
+
+  it("shows a 'Continue on Telegram' link to the bot deep link when present", async () => {
+    mockTranscript(BOT_DEEP_LINK);
+    renderView();
+
+    const link = await screen.findByRole("link", { name: /continue on telegram/i });
+    expect(link).toHaveAttribute("href", BOT_DEEP_LINK);
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("rel", expect.stringContaining("noopener"));
+
+    // The read-only banner explains where the conversation actually happens.
+    expect(screen.getByText(/this conversation happens on telegram/i)).toBeInTheDocument();
+  });
+
+  it("omits the 'Continue on Telegram' link gracefully when the deep link is null", async () => {
+    mockTranscript(null);
+    renderView();
+
+    // Banner text still renders so the read-only nature is explained.
+    expect(await screen.findByText(/this conversation happens on telegram/i)).toBeInTheDocument();
+    // ...but there is no actionable link without a deep link.
+    expect(screen.queryByRole("link", { name: /continue on telegram/i })).toBeNull();
+  });
+
+  it("shows a loading state while the transcript is fetching", async () => {
+    let resolve!: (value: {
+      messages: TelegramTranscriptMessage[];
+      botDeepLink: string | null;
+    }) => void;
+    (apiGet as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url.endsWith("/telegram-chat")) {
+        return new Promise((r) => {
+          resolve = r;
+        });
+      }
+      return Promise.resolve({ chats: [] });
+    });
+
+    renderView();
+
+    // Scope to the transcript body so we assert the transcript's own loading
+    // state, not the embedded chat-switcher's separate "Loading your chats…".
+    const body = screen.getByTestId("telegram-chat-body");
+    expect(within(body).getByText(/loading/i)).toBeInTheDocument();
+
+    resolve({ messages, botDeepLink: BOT_DEEP_LINK });
+    await waitFor(() => expect(within(body).queryByText(/loading/i)).toBeNull());
+  });
+
+  it("shows an empty state when no Telegram conversation is linked (404)", async () => {
+    (apiGet as ReturnType<typeof vi.fn>).mockImplementation((url: string) => {
+      if (url.endsWith("/telegram-chat")) {
+        return Promise.reject(new ApiError(404, "No linked Telegram conversation"));
+      }
+      return Promise.resolve({ chats: [] });
+    });
+
+    renderView();
+
+    expect(await screen.findByText(/no telegram conversation linked/i)).toBeInTheDocument();
+  });
+});

--- a/packages/web/src/components/chat-session-mounts.tsx
+++ b/packages/web/src/components/chat-session-mounts.tsx
@@ -3,22 +3,29 @@
 import { useContext, useEffect, useRef } from "react";
 import { usePathname } from "next/navigation";
 import { useWsRuntime } from "@/hooks/use-ws-runtime";
-import { useVisitedAgentIds, ChatSessionStoreContext } from "@/components/chat-session-provider";
+import {
+  useVisitedSessions,
+  chatSessionKey,
+  ChatSessionStoreContext,
+} from "@/components/chat-session-provider";
 import { apiPost } from "@/lib/api-client";
 
 export function ChatSessionMounts() {
-  const visitedAgentIds = useVisitedAgentIds();
+  const visitedSessions = useVisitedSessions();
   return (
     <>
-      {visitedAgentIds.map((agentId) => (
-        <ChatSessionInstance key={agentId} agentId={agentId} />
+      {visitedSessions.map(({ key, agentId, chatId }) => (
+        // `key` is the composite (agentId, chatId) store key (#508). Switching
+        // chats yields a new key → React remounts the instance → useWsRuntime
+        // reconnects to the new session, so no stale messages bleed across.
+        <ChatSessionInstance key={key} agentId={agentId} chatId={chatId} />
       ))}
     </>
   );
 }
 
-function ChatSessionInstance({ agentId }: { agentId: string }) {
-  const bundle = useWsRuntime(agentId);
+function ChatSessionInstance({ agentId, chatId }: { agentId: string; chatId?: string }) {
+  const bundle = useWsRuntime(agentId, chatId);
 
   // Access the store directly (not via useStore) so we can call publish
   // without subscribing to the bundle in the store. Subscribing to our own
@@ -52,7 +59,7 @@ function ChatSessionInstance({ agentId }: { agentId: string }) {
       turnStartedAt.current = null;
     }
     previousIsRunning.current = bundle.isRunning;
-  }, [bundle.isRunning, isOnThisChat, agentId]);
+  }, [bundle.isRunning, isOnThisChat, agentId, chatId]);
 
   // Capture the bundle callbacks in the effect closure. In production,
   // useWsRuntime memoizes them with useCallback so they are stable across
@@ -75,7 +82,9 @@ function ChatSessionInstance({ agentId }: { agentId: string }) {
     const lastError = bundle.reconnectExhausted
       ? "Connection lost. Reload the page to resume."
       : null;
-    store.getState().publish(agentId, {
+    store.getState().publish(chatSessionKey(agentId, chatId), {
+      agentId,
+      chatId,
       runtime: bundle.runtime,
       isRunning: bundle.isRunning,
       isConnected: bundle.isConnected,
@@ -97,6 +106,7 @@ function ChatSessionInstance({ agentId }: { agentId: string }) {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [
     agentId,
+    chatId,
     store,
     bundle.runtime,
     bundle.isRunning,

--- a/packages/web/src/components/chat-session-provider.tsx
+++ b/packages/web/src/components/chat-session-provider.tsx
@@ -5,7 +5,24 @@ import { create, type StoreApi, useStore } from "zustand";
 import type { AssistantRuntime } from "@assistant-ui/react";
 import type { PendingUpload } from "@/hooks/use-ws-runtime";
 
+/**
+ * Store key for a live chat runtime. Identifies one OpenClaw session within a
+ * (user, agent) pair. When `chatId` is omitted the key is the bare `agentId` —
+ * byte-identical to the pre-#508 key — so the legacy/default chat keeps its
+ * existing entry, LRU ordering, and sidebar lookup unchanged.
+ */
+export function chatSessionKey(agentId: string, chatId?: string): string {
+  return chatId ? `${agentId}:${chatId}` : agentId;
+}
+
 export interface RuntimeBundle {
+  /**
+   * The agent + optional chat this bundle belongs to (#508). Carried on the
+   * bundle so ChatSessionMounts can pass them straight to useWsRuntime without
+   * having to parse them back out of the composite store key.
+   */
+  agentId: string;
+  chatId?: string;
   runtime: AssistantRuntime;
   isRunning: boolean;
   isConnected: boolean;
@@ -30,8 +47,8 @@ interface ChatSessionStoreState {
 }
 
 interface ChatSessionStoreActions {
-  publish: (agentId: string, bundle: RuntimeBundle) => void;
-  remove: (agentId: string) => void;
+  publish: (key: string, bundle: RuntimeBundle) => void;
+  remove: (key: string) => void;
 }
 
 type Store = StoreApi<ChatSessionStoreState & ChatSessionStoreActions>;
@@ -55,17 +72,17 @@ export const ChatSessionStoreContext = createContext<Store | null>(null);
 function createChatSessionStore(): Store {
   return create<ChatSessionStoreState & ChatSessionStoreActions>()((set) => ({
     bundles: {},
-    publish: (agentId, bundle) =>
+    publish: (key, bundle) =>
       set((s) => {
-        // Rebuild the bundles object so re-publishing an existing agent
+        // Rebuild the bundles object so re-publishing an existing session
         // moves it to the most-recently-used (insertion-order last)
         // position. JS objects preserve string-key insertion order, so
         // the first key after this rebuild is the LRU candidate.
         const next: Record<string, RuntimeBundle | undefined> = {};
         for (const [k, v] of Object.entries(s.bundles)) {
-          if (k !== agentId && v !== undefined) next[k] = v;
+          if (k !== key && v !== undefined) next[k] = v;
         }
-        next[agentId] = bundle;
+        next[key] = bundle;
         // Enforce the cap. Worst case: overshoot by exactly one (the new
         // entry that just pushed us over). Drop the oldest until we fit.
         const keys = Object.keys(next);
@@ -74,10 +91,10 @@ function createChatSessionStore(): Store {
         }
         return { bundles: next };
       }),
-    remove: (agentId) =>
+    remove: (key) =>
       set((s) => {
         const next = { ...s.bundles };
-        delete next[agentId];
+        delete next[key];
         return { bundles: next };
       }),
   }));
@@ -97,19 +114,20 @@ function useStoreOrThrow(): Store {
   return store;
 }
 
-export function useChatSession(agentId: string) {
+export function useChatSession(agentId: string, chatId?: string) {
   const store = useStoreOrThrow();
-  const bundle = useStore(store, (s) => s.bundles[agentId]);
+  const key = chatSessionKey(agentId, chatId);
+  const bundle = useStore(store, (s) => s.bundles[key]);
   const publish = useStore(store, (s) => s.publish);
   const remove = useStore(store, (s) => s.remove);
 
   return useMemo(
     () => ({
       bundle,
-      publish: (b: RuntimeBundle) => publish(agentId, b),
-      remove: () => remove(agentId),
+      publish: (b: RuntimeBundle) => publish(key, b),
+      remove: () => remove(key),
     }),
-    [bundle, publish, remove, agentId]
+    [bundle, publish, remove, key]
   );
 }
 
@@ -125,4 +143,31 @@ export function useVisitedAgentIds(): string[] {
       .join("\0")
   );
   return useMemo(() => (keysStr ? keysStr.split("\0") : []), [keysStr]);
+}
+
+/**
+ * Live chat sessions to mount, one per (agentId, chatId) pair (#508). Derived
+ * from the bundles' own `agentId`/`chatId` fields rather than by parsing the
+ * composite store key, so it stays correct regardless of the key format.
+ */
+export function useVisitedSessions(): Array<{ key: string; agentId: string; chatId?: string }> {
+  const store = useStoreOrThrow();
+  // Serialize to a stable JSON string so the snapshot is referentially stable
+  // between renders when the set of visited sessions hasn't changed.
+  const serialized = useStore(store, (s) =>
+    JSON.stringify(
+      Object.entries(s.bundles)
+        .filter(([, v]) => v !== undefined)
+        .map(([k, v]) => [k, v!.agentId, v!.chatId ?? null] as const)
+        .sort((a, b) => (a[0] < b[0] ? -1 : a[0] > b[0] ? 1 : 0))
+    )
+  );
+  return useMemo(() => {
+    const triples = JSON.parse(serialized) as Array<[string, string, string | null]>;
+    return triples.map(([key, agentId, chatId]) => ({
+      key,
+      agentId,
+      chatId: chatId ?? undefined,
+    }));
+  }, [serialized]);
 }

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -258,7 +258,9 @@ export function ChatSwitcher({
                     )}
                   </span>
                   <span className="text-muted-foreground text-xs">
-                    {relativeTime(item.lastInteractionAt)}
+                    {item.sessionId === SYNTHETIC_CURRENT_SESSION_ID
+                      ? "Not saved yet"
+                      : relativeTime(item.lastInteractionAt)}
                   </span>
                 </span>
               </DropdownMenuItem>

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useEffect, useState } from "react";
+import { useCallback, useEffect, useMemo, useState } from "react";
 import { useRouter } from "next/navigation";
 import { Check, ChevronDown, Lock, Plus } from "lucide-react";
 import {
@@ -50,6 +50,44 @@ function chatTitle(item: ChatListItem): string {
   return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
 }
 
+/** sessionId we tag the optimistic current-chat row with (it has no real OpenClaw session yet). */
+const SYNTHETIC_CURRENT_SESSION_ID = "__optimistic-current__";
+
+/**
+ * Ensure the chat the URL currently points at is ALWAYS in the list, even
+ * before its first message creates an OpenClaw session (standard ChatGPT/Claude
+ * behaviour). If the server list already contains the current web chat we use
+ * that entry as-is; otherwise we prepend a synthetic "New chat" row so the user
+ * always sees where they are. Telegram is never synthesized — its sessions are
+ * created in Telegram, not here.
+ */
+function withOptimisticCurrentChat(
+  chats: ChatListItem[],
+  chatId: string | null,
+  activeTelegram: boolean
+): ChatListItem[] {
+  // On the Telegram view the active chat is a real telegram session, so there
+  // is no web chat to synthesize.
+  if (activeTelegram) return chats;
+
+  const alreadyListed = chats.some((c) => c.origin === "web" && c.chatId === chatId);
+  if (alreadyListed) return chats;
+
+  const synthetic: ChatListItem = {
+    chatId,
+    sessionId: SYNTHETIC_CURRENT_SESSION_ID,
+    origin: "web",
+    writable: true,
+    title: "New chat",
+    // A stable "always newest" sentinel (not Date.now(), which is impure in
+    // render) so the brand-new chat sorts to the top of the recency-ordered
+    // list. The dropdown shows relative-time per row but the current chat is
+    // expected at the top regardless.
+    lastInteractionAt: Number.MAX_SAFE_INTEGER,
+  };
+  return [synthetic, ...chats];
+}
+
 /**
  * Short, human relative-time hint ("2h ago", "just now"). Best-effort and
  * locale-aware; we never block the list on it.
@@ -96,11 +134,11 @@ export function ChatSwitcher({
   const [chats, setChats] = useState<ChatListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
 
-  // Fetch the chat list once per (agent) mount. `isLoading` starts true via
-  // useState, so we don't re-set it here — that keeps the effect free of a
-  // synchronous setState (react-hooks/set-state-in-effect). A failed fetch
-  // degrades quietly to the empty state rather than blocking the header.
-  useEffect(() => {
+  // Re-fetch the chat list on each load. Returns a cleanup-aware fetch so both
+  // the mount effect and the open handler can ignore a settled result after the
+  // component unmounts. A failed fetch degrades quietly to the empty state
+  // rather than blocking the header.
+  const loadChats = useCallback(() => {
     let cancelled = false;
     apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
       .then((res) => {
@@ -117,14 +155,42 @@ export function ChatSwitcher({
     };
   }, [agentId]);
 
-  const current = chats.find((c) => isActive(c, chatId, activeTelegram));
-  // On the Telegram view the active row may not have loaded yet, so fall back
-  // to a literal "Telegram" label there rather than the agent name.
-  const triggerLabel = current
-    ? chatTitle(current)
-    : activeTelegram
-      ? "Telegram"
-      : (agentName ?? "Chat");
+  // Fetch once on mount so the trigger label reflects the active chat's title
+  // without the user having to open the dropdown. `isLoading` starts true via
+  // useState so we don't re-set it here (keeps the effect free of a synchronous
+  // setState — react-hooks/set-state-in-effect).
+  useEffect(() => loadChats(), [loadChats]);
+
+  // Re-fetch every time the dropdown opens so sessions created since mount (e.g.
+  // by a message just sent in the active chat) appear. The result is discarded
+  // on close, so there's nothing to clean up here.
+  const handleOpenChange = useCallback(
+    (next: boolean) => {
+      if (next) loadChats();
+    },
+    [loadChats]
+  );
+
+  // Always include the current chat — optimistically as "New chat" when it has
+  // no OpenClaw session yet — sorted to the top.
+  const displayChats = useMemo(
+    () => withOptimisticCurrentChat(chats, chatId, activeTelegram),
+    [chats, chatId, activeTelegram]
+  );
+
+  const current = displayChats.find((c) => isActive(c, chatId, activeTelegram));
+  // The header trigger shows the active chat's title — but for the OPTIMISTIC
+  // current row (a brand-new/default chat with no real session yet) we keep the
+  // agent name in the persistent header rather than a generic "New chat"; the
+  // dropdown still lists that row as "New chat". On the Telegram view the active
+  // row may not have loaded yet, so fall back to a literal "Telegram" label.
+  const currentIsOptimistic = current?.sessionId === SYNTHETIC_CURRENT_SESSION_ID;
+  const triggerLabel =
+    current && !currentIsOptimistic
+      ? chatTitle(current)
+      : activeTelegram
+        ? "Telegram"
+        : (agentName ?? "Chat");
 
   function startNewChat() {
     router.push(`/chat/${agentId}/${generateChatId()}`);
@@ -141,7 +207,7 @@ export function ChatSwitcher({
   }
 
   return (
-    <DropdownMenu>
+    <DropdownMenu onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
         <Button variant="ghost" className="h-auto min-w-0 gap-1.5 px-2 py-1">
           <span className="truncate font-bold">{triggerLabel}</span>
@@ -158,12 +224,12 @@ export function ChatSwitcher({
           <DropdownMenuLabel className="text-muted-foreground font-normal">
             Loading your chats…
           </DropdownMenuLabel>
-        ) : chats.length === 0 ? (
+        ) : displayChats.length === 0 ? (
           <DropdownMenuLabel className="text-muted-foreground font-normal">
             No other chats yet
           </DropdownMenuLabel>
         ) : (
-          chats.map((item) => {
+          displayChats.map((item) => {
             const active = isActive(item, chatId, activeTelegram);
             return (
               <DropdownMenuItem

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -1,0 +1,179 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import { useRouter } from "next/navigation";
+import { Check, ChevronDown, Lock, Plus } from "lucide-react";
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import { Button } from "@/components/ui/button";
+import { Badge } from "@/components/ui/badge";
+import { apiGet } from "@/lib/api-client";
+import type { ChatListItem } from "@/lib/schemas/sessions";
+import { generateChatId } from "@/lib/chats/generate-chat-id";
+
+interface ChatSwitcherProps {
+  agentId: string;
+  /** The active chat from the URL, or null for the default/legacy chat. */
+  chatId: string | null;
+  agentName: string;
+}
+
+/**
+ * Whether `item` is the chat the URL currently points at. The active URL always
+ * refers to a WEB chat (`/chat/<agentId>` → default, `/chat/<agentId>/<id>` →
+ * specific), so Telegram chats are never active — even the default Telegram
+ * chat carries `chatId: null` and would otherwise collide with the default web
+ * chat.
+ */
+function isActive(item: ChatListItem, chatId: string | null): boolean {
+  return item.origin === "web" && item.chatId === chatId;
+}
+
+/** Title to show for a chat — the saved label, or a date-stamped fallback. */
+function chatTitle(item: ChatListItem): string {
+  if (item.title && item.title.trim().length > 0) return item.title;
+  return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
+}
+
+/**
+ * Short, human relative-time hint ("2h ago", "just now"). Best-effort and
+ * locale-aware; we never block the list on it.
+ */
+function relativeTime(ms: number, now: number = Date.now()): string {
+  const diffSeconds = Math.round((ms - now) / 1000);
+  const rtf = new Intl.RelativeTimeFormat(undefined, { numeric: "auto" });
+  const divisions: Array<{ amount: number; unit: Intl.RelativeTimeFormatUnit }> = [
+    { amount: 60, unit: "second" },
+    { amount: 60, unit: "minute" },
+    { amount: 24, unit: "hour" },
+    { amount: 7, unit: "day" },
+    { amount: 4.34524, unit: "week" },
+    { amount: 12, unit: "month" },
+    { amount: Number.POSITIVE_INFINITY, unit: "year" },
+  ];
+  let value = diffSeconds;
+  for (const division of divisions) {
+    if (Math.abs(value) < division.amount) {
+      return rtf.format(Math.round(value), division.unit);
+    }
+    value /= division.amount;
+  }
+  return rtf.format(Math.round(value), "year");
+}
+
+/**
+ * Header dropdown that lists the user's chats with an agent (#508) and lets
+ * them start a new one. Chats are fetched lazily on first open. Telegram chats
+ * surface read-only — they're shown so the user can read them here, but the
+ * conversation itself lives in Telegram.
+ *
+ * A fetch failure degrades quietly to an empty list (with a retry on the next
+ * open) rather than blocking the header — switching chats is a convenience, not
+ * a critical path.
+ */
+export function ChatSwitcher({ agentId, chatId, agentName }: ChatSwitcherProps) {
+  const router = useRouter();
+  const [chats, setChats] = useState<ChatListItem[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // Fetch the chat list once per (agent) mount. `isLoading` starts true via
+  // useState, so we don't re-set it here — that keeps the effect free of a
+  // synchronous setState (react-hooks/set-state-in-effect). A failed fetch
+  // degrades quietly to the empty state rather than blocking the header.
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
+      .then((res) => {
+        if (!cancelled) setChats(res.chats ?? []);
+      })
+      .catch(() => {
+        if (!cancelled) setChats([]);
+      })
+      .finally(() => {
+        if (!cancelled) setIsLoading(false);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  const current = chats.find((c) => isActive(c, chatId));
+  const triggerLabel = current ? chatTitle(current) : (agentName ?? "Chat");
+
+  function startNewChat() {
+    router.push(`/chat/${agentId}/${generateChatId()}`);
+  }
+
+  function openChat(item: ChatListItem) {
+    router.push(item.chatId ? `/chat/${agentId}/${item.chatId}` : `/chat/${agentId}`);
+  }
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild>
+        <Button variant="ghost" className="h-auto min-w-0 gap-1.5 px-2 py-1">
+          <span className="truncate font-bold">{triggerLabel}</span>
+          <ChevronDown className="size-4 shrink-0 opacity-70" />
+        </Button>
+      </DropdownMenuTrigger>
+      <DropdownMenuContent align="start" className="w-72">
+        <DropdownMenuItem onSelect={startNewChat}>
+          <Plus className="size-4" />
+          New chat
+        </DropdownMenuItem>
+        <DropdownMenuSeparator />
+        {isLoading ? (
+          <DropdownMenuLabel className="text-muted-foreground font-normal">
+            Loading your chats…
+          </DropdownMenuLabel>
+        ) : chats.length === 0 ? (
+          <DropdownMenuLabel className="text-muted-foreground font-normal">
+            No other chats yet
+          </DropdownMenuLabel>
+        ) : (
+          chats.map((item) => {
+            const active = isActive(item, chatId);
+            return (
+              <DropdownMenuItem
+                key={item.sessionId}
+                onSelect={() => openChat(item)}
+                className="flex items-start gap-2"
+              >
+                {active ? (
+                  <Check className="size-4 shrink-0" aria-label="Current chat" />
+                ) : (
+                  <span className="size-4 shrink-0" />
+                )}
+                <span className="flex min-w-0 flex-1 flex-col">
+                  <span className="flex items-center gap-1.5">
+                    <span className="truncate">{chatTitle(item)}</span>
+                    {item.origin === "telegram" && (
+                      <Badge variant="secondary" className="text-xs font-normal">
+                        Telegram
+                      </Badge>
+                    )}
+                    {!item.writable && (
+                      <Lock
+                        className="text-muted-foreground size-3 shrink-0"
+                        aria-label="Read-only"
+                      />
+                    )}
+                  </span>
+                  <span className="text-muted-foreground text-xs">
+                    {relativeTime(item.lastInteractionAt)}
+                  </span>
+                </span>
+              </DropdownMenuItem>
+            );
+          })
+        )}
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -209,8 +209,8 @@ export function ChatSwitcher({
   return (
     <DropdownMenu onOpenChange={handleOpenChange}>
       <DropdownMenuTrigger asChild>
-        <Button variant="ghost" className="h-auto min-w-0 gap-1.5 px-2 py-1">
-          <span className="truncate font-bold">{triggerLabel}</span>
+        <Button variant="ghost" className="h-auto min-w-0 shrink gap-1.5 px-2 py-1">
+          <span className="min-w-0 truncate font-bold">{triggerLabel}</span>
           <ChevronDown className="size-4 shrink-0 opacity-70" />
         </Button>
       </DropdownMenuTrigger>

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -22,17 +22,26 @@ interface ChatSwitcherProps {
   /** The active chat from the URL, or null for the default/legacy chat. */
   chatId: string | null;
   agentName: string;
+  /**
+   * True when the switcher is rendered on the read-only Telegram view
+   * (`/chat/<agentId>/telegram`). The Telegram view has no `chatId` of its own,
+   * so the URL-derived `isActive` (web-only) can't recognize it — this flag
+   * tells the switcher to mark the Telegram row active instead.
+   */
+  activeTelegram?: boolean;
 }
 
 /**
- * Whether `item` is the chat the URL currently points at. The active URL always
- * refers to a WEB chat (`/chat/<agentId>` → default, `/chat/<agentId>/<id>` →
- * specific), so Telegram chats are never active — even the default Telegram
- * chat carries `chatId: null` and would otherwise collide with the default web
- * chat.
+ * Whether `item` is the chat the URL currently points at.
+ *
+ * Web chats match by `chatId` (`/chat/<agentId>` → default, `/chat/<agentId>/<id>`
+ * → specific). Telegram chats live at the dedicated `/chat/<agentId>/telegram`
+ * view and carry `chatId: null`, so they'd otherwise collide with the default
+ * web chat — they are only active when `activeTelegram` is set.
  */
-function isActive(item: ChatListItem, chatId: string | null): boolean {
-  return item.origin === "web" && item.chatId === chatId;
+function isActive(item: ChatListItem, chatId: string | null, activeTelegram: boolean): boolean {
+  if (item.origin === "telegram") return activeTelegram;
+  return item.chatId === chatId && !activeTelegram;
 }
 
 /** Title to show for a chat — the saved label, or a date-stamped fallback. */
@@ -77,7 +86,12 @@ function relativeTime(ms: number, now: number = Date.now()): string {
  * open) rather than blocking the header — switching chats is a convenience, not
  * a critical path.
  */
-export function ChatSwitcher({ agentId, chatId, agentName }: ChatSwitcherProps) {
+export function ChatSwitcher({
+  agentId,
+  chatId,
+  agentName,
+  activeTelegram = false,
+}: ChatSwitcherProps) {
   const router = useRouter();
   const [chats, setChats] = useState<ChatListItem[]>([]);
   const [isLoading, setIsLoading] = useState(true);
@@ -103,14 +117,26 @@ export function ChatSwitcher({ agentId, chatId, agentName }: ChatSwitcherProps) 
     };
   }, [agentId]);
 
-  const current = chats.find((c) => isActive(c, chatId));
-  const triggerLabel = current ? chatTitle(current) : (agentName ?? "Chat");
+  const current = chats.find((c) => isActive(c, chatId, activeTelegram));
+  // On the Telegram view the active row may not have loaded yet, so fall back
+  // to a literal "Telegram" label there rather than the agent name.
+  const triggerLabel = current
+    ? chatTitle(current)
+    : activeTelegram
+      ? "Telegram"
+      : (agentName ?? "Chat");
 
   function startNewChat() {
     router.push(`/chat/${agentId}/${generateChatId()}`);
   }
 
   function openChat(item: ChatListItem) {
+    // Telegram chats open the dedicated read-only mirror; web chats open their
+    // own session (or the default chat when chatId is null).
+    if (item.origin === "telegram") {
+      router.push(`/chat/${agentId}/telegram`);
+      return;
+    }
     router.push(item.chatId ? `/chat/${agentId}/${item.chatId}` : `/chat/${agentId}`);
   }
 
@@ -138,7 +164,7 @@ export function ChatSwitcher({ agentId, chatId, agentName }: ChatSwitcherProps) 
           </DropdownMenuLabel>
         ) : (
           chats.map((item) => {
-            const active = isActive(item, chatId);
+            const active = isActive(item, chatId, activeTelegram);
             return (
               <DropdownMenuItem
                 key={item.sessionId}

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -237,13 +237,13 @@ export function Chat({
                                   canEdit={canEdit}
                                 />
                                 <header className="hidden md:flex p-4 border-b items-center justify-between shrink-0">
-                                  <div className="flex items-center gap-2 animate-in fade-in duration-300">
+                                  <div className="flex items-center gap-2 min-w-0 flex-1 animate-in fade-in duration-300">
                                     {displayAvatar && (
                                       // eslint-disable-next-line @next/next/no-img-element
                                       <img
                                         src={displayAvatar}
                                         alt=""
-                                        className="size-7 rounded-full"
+                                        className="size-7 rounded-full shrink-0"
                                       />
                                     )}
                                     <ChatSwitcher
@@ -254,7 +254,10 @@ export function Chat({
                                     <TooltipProvider>
                                       <Tooltip>
                                         <TooltipTrigger asChild>
-                                          <Badge variant="outline" className="text-xs font-normal">
+                                          <Badge
+                                            variant="outline"
+                                            className="text-xs font-normal shrink-0"
+                                          >
                                             {displayIsPersonal ? "Private" : "Shared"}
                                           </Badge>
                                         </TooltipTrigger>
@@ -266,7 +269,7 @@ export function Chat({
                                       </Tooltip>
                                     </TooltipProvider>
                                   </div>
-                                  <div className="flex items-center gap-3">
+                                  <div className="flex items-center gap-3 shrink-0">
                                     {hasInitialContent && <SessionActionsMenu agentId={agentId} />}
                                     {canEdit && (
                                       <Link

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -48,6 +48,12 @@ function getStatusIndicator(status: ChatStatus): { colorClass: string; label: st
 
 export const AgentAvatarContext = createContext<string | null>(null);
 export const AgentIdContext = createContext<string | null>(null);
+/**
+ * The current chat's id (#508), or null for the default/legacy chat. Provided
+ * alongside AgentIdContext so descendants can build chat-scoped URLs and
+ * API calls without re-deriving it from the route.
+ */
+export const ChatIdContext = createContext<string | null>(null);
 export const AgentNameContext = createContext<string | null>(null);
 export const AgentModelContext = createContext<string | null>(null);
 export const RetryResendContext = createContext<(messageId: string) => void>(() => {});
@@ -110,6 +116,8 @@ const PLACEHOLDER_RUNTIME = {} as AssistantRuntime;
 interface ChatProps {
   agentId: string;
   agentName: string;
+  /** Optional per-chat id (#508). Omitted → the default/legacy chat. */
+  chatId?: string;
   configuring?: boolean;
   isPersonal?: boolean;
   avatarUrl?: string;
@@ -120,6 +128,7 @@ interface ChatProps {
 export function Chat({
   agentId,
   agentName,
+  chatId,
   configuring = false,
   isPersonal = false,
   avatarUrl,
@@ -134,13 +143,15 @@ export function Chat({
     : avatarUrl;
   const displayIsPersonal = liveAgent?.isPersonal ?? isPersonal;
 
-  const { bundle: chatBundle, publish } = useChatSession(agentId);
+  const { bundle: chatBundle, publish } = useChatSession(agentId, chatId);
 
-  // Register this agent with the provider on first mount so
+  // Register this (agent, chat) with the provider on first mount so
   // ChatSessionMounts spins up a hidden runtime instance.
   useEffect(() => {
     if (!chatBundle) {
       publish({
+        agentId,
+        chatId,
         runtime: PLACEHOLDER_RUNTIME,
         isRunning: false,
         isConnected: false,
@@ -160,7 +171,7 @@ export function Chat({
         retryPendingUpload: () => {},
       });
     }
-  }, [chatBundle, publish]);
+  }, [chatBundle, publish, agentId, chatId]);
 
   // Hooks must be called unconditionally (Rules of Hooks), so we destructure
   // bundle fields with defaults and call useChatStatus on every render —
@@ -204,101 +215,103 @@ export function Chat({
 
   return (
     <AgentIdContext.Provider value={agentId}>
-      <AgentNameContext.Provider value={displayName}>
-        <AgentModelContext.Provider value={liveAgent?.model ?? null}>
-          <AssistantRuntimeProvider runtime={runtime}>
-            <ChatStatusContext.Provider value={chatStatus}>
-              <RetryContinueContext.Provider value={onRetryContinue}>
-                <RetryResendContext.Provider value={onRetryResend}>
-                  <PendingUploadsContext.Provider value={pendingUploads}>
-                    <AddPendingUploadContext.Provider value={addPendingUpload}>
-                      <RemovePendingUploadContext.Provider value={removePendingUpload}>
-                        <RetryPendingUploadContext.Provider value={retryPendingUpload}>
-                          <AgentAvatarContext.Provider value={displayAvatar ?? null}>
-                            <div className="flex flex-col h-full min-h-0">
-                              <MobileChatHeader
-                                agentId={agentId}
-                                agentName={displayName}
-                                avatarUrl={displayAvatar}
-                                canEdit={canEdit}
-                              />
-                              <header className="hidden md:flex p-4 border-b items-center justify-between shrink-0">
-                                <div className="flex items-center gap-2 animate-in fade-in duration-300">
-                                  {displayAvatar && (
-                                    // eslint-disable-next-line @next/next/no-img-element
-                                    <img
-                                      src={displayAvatar}
-                                      alt=""
-                                      className="size-7 rounded-full"
-                                    />
-                                  )}
-                                  <h1 className="font-bold">{displayName}</h1>
-                                  <TooltipProvider>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <Badge variant="outline" className="text-xs font-normal">
-                                          {displayIsPersonal ? "Private" : "Shared"}
-                                        </Badge>
-                                      </TooltipTrigger>
-                                      <TooltipContent>
-                                        {displayIsPersonal
-                                          ? "Your conversations are private and not shared with anyone."
-                                          : "Your conversations help build team knowledge that's available to all team members."}
-                                      </TooltipContent>
-                                    </Tooltip>
-                                  </TooltipProvider>
+      <ChatIdContext.Provider value={chatId ?? null}>
+        <AgentNameContext.Provider value={displayName}>
+          <AgentModelContext.Provider value={liveAgent?.model ?? null}>
+            <AssistantRuntimeProvider runtime={runtime}>
+              <ChatStatusContext.Provider value={chatStatus}>
+                <RetryContinueContext.Provider value={onRetryContinue}>
+                  <RetryResendContext.Provider value={onRetryResend}>
+                    <PendingUploadsContext.Provider value={pendingUploads}>
+                      <AddPendingUploadContext.Provider value={addPendingUpload}>
+                        <RemovePendingUploadContext.Provider value={removePendingUpload}>
+                          <RetryPendingUploadContext.Provider value={retryPendingUpload}>
+                            <AgentAvatarContext.Provider value={displayAvatar ?? null}>
+                              <div className="flex flex-col h-full min-h-0">
+                                <MobileChatHeader
+                                  agentId={agentId}
+                                  agentName={displayName}
+                                  avatarUrl={displayAvatar}
+                                  canEdit={canEdit}
+                                />
+                                <header className="hidden md:flex p-4 border-b items-center justify-between shrink-0">
+                                  <div className="flex items-center gap-2 animate-in fade-in duration-300">
+                                    {displayAvatar && (
+                                      // eslint-disable-next-line @next/next/no-img-element
+                                      <img
+                                        src={displayAvatar}
+                                        alt=""
+                                        className="size-7 rounded-full"
+                                      />
+                                    )}
+                                    <h1 className="font-bold">{displayName}</h1>
+                                    <TooltipProvider>
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <Badge variant="outline" className="text-xs font-normal">
+                                            {displayIsPersonal ? "Private" : "Shared"}
+                                          </Badge>
+                                        </TooltipTrigger>
+                                        <TooltipContent>
+                                          {displayIsPersonal
+                                            ? "Your conversations are private and not shared with anyone."
+                                            : "Your conversations help build team knowledge that's available to all team members."}
+                                        </TooltipContent>
+                                      </Tooltip>
+                                    </TooltipProvider>
+                                  </div>
+                                  <div className="flex items-center gap-3">
+                                    {hasInitialContent && <SessionActionsMenu agentId={agentId} />}
+                                    {canEdit && (
+                                      <Link
+                                        href={`/chat/${agentId}/settings`}
+                                        aria-label="Settings"
+                                        className="text-muted-foreground hover:text-foreground transition-colors"
+                                      >
+                                        <Settings className="size-5" />
+                                      </Link>
+                                    )}
+                                    <TooltipProvider delayDuration={200}>
+                                      <Tooltip>
+                                        <TooltipTrigger asChild>
+                                          <button
+                                            type="button"
+                                            aria-label={indicator.label}
+                                            className="cursor-default p-1.5 -m-1.5 inline-flex items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
+                                          >
+                                            <span
+                                              className={`size-2 rounded-full shrink-0 ${indicator.colorClass}`}
+                                            />
+                                          </button>
+                                        </TooltipTrigger>
+                                        <TooltipContent>{indicator.label}</TooltipContent>
+                                      </Tooltip>
+                                    </TooltipProvider>
+                                  </div>
+                                </header>
+                                <div className="flex-1 min-h-0 animate-in fade-in duration-300">
+                                  <Thread isReconcilingMessages={isReconcilingMessages} />
                                 </div>
-                                <div className="flex items-center gap-3">
-                                  {hasInitialContent && <SessionActionsMenu agentId={agentId} />}
-                                  {canEdit && (
-                                    <Link
-                                      href={`/chat/${agentId}/settings`}
-                                      aria-label="Settings"
-                                      className="text-muted-foreground hover:text-foreground transition-colors"
-                                    >
-                                      <Settings className="size-5" />
-                                    </Link>
-                                  )}
-                                  <TooltipProvider delayDuration={200}>
-                                    <Tooltip>
-                                      <TooltipTrigger asChild>
-                                        <button
-                                          type="button"
-                                          aria-label={indicator.label}
-                                          className="cursor-default p-1.5 -m-1.5 inline-flex items-center justify-center rounded-full focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring"
-                                        >
-                                          <span
-                                            className={`size-2 rounded-full shrink-0 ${indicator.colorClass}`}
-                                          />
-                                        </button>
-                                      </TooltipTrigger>
-                                      <TooltipContent>{indicator.label}</TooltipContent>
-                                    </Tooltip>
-                                  </TooltipProvider>
-                                </div>
-                              </header>
-                              <div className="flex-1 min-h-0 animate-in fade-in duration-300">
-                                <Thread isReconcilingMessages={isReconcilingMessages} />
+                                {!displayIsPersonal && (
+                                  <p className="text-xs text-muted-foreground px-3 py-1">
+                                    Files uploaded here are visible to anyone with access to this
+                                    agent.
+                                  </p>
+                                )}
+                                <ChatStatusBanner status={chatStatus} isDelayed={isDelayed} />
                               </div>
-                              {!displayIsPersonal && (
-                                <p className="text-xs text-muted-foreground px-3 py-1">
-                                  Files uploaded here are visible to anyone with access to this
-                                  agent.
-                                </p>
-                              )}
-                              <ChatStatusBanner status={chatStatus} isDelayed={isDelayed} />
-                            </div>
-                          </AgentAvatarContext.Provider>
-                        </RetryPendingUploadContext.Provider>
-                      </RemovePendingUploadContext.Provider>
-                    </AddPendingUploadContext.Provider>
-                  </PendingUploadsContext.Provider>
-                </RetryResendContext.Provider>
-              </RetryContinueContext.Provider>
-            </ChatStatusContext.Provider>
-          </AssistantRuntimeProvider>
-        </AgentModelContext.Provider>
-      </AgentNameContext.Provider>
+                            </AgentAvatarContext.Provider>
+                          </RetryPendingUploadContext.Provider>
+                        </RemovePendingUploadContext.Provider>
+                      </AddPendingUploadContext.Provider>
+                    </PendingUploadsContext.Provider>
+                  </RetryResendContext.Provider>
+                </RetryContinueContext.Provider>
+              </ChatStatusContext.Provider>
+            </AssistantRuntimeProvider>
+          </AgentModelContext.Provider>
+        </AgentNameContext.Provider>
+      </ChatIdContext.Provider>
     </AgentIdContext.Provider>
   );
 }

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -123,7 +123,6 @@ interface ChatProps {
   isPersonal?: boolean;
   avatarUrl?: string;
   canEdit?: boolean;
-  isAdmin?: boolean;
 }
 
 export function Chat({
@@ -134,7 +133,6 @@ export function Chat({
   isPersonal = false,
   avatarUrl,
   canEdit = false,
-  isAdmin = false,
 }: ChatProps) {
   const { getAgent } = useAgentsContext();
   const liveAgent = getAgent(agentId);
@@ -270,7 +268,9 @@ export function Chat({
                                     </TooltipProvider>
                                   </div>
                                   <div className="flex items-center gap-3 shrink-0">
-                                    {hasInitialContent && <SessionActionsMenu agentId={agentId} />}
+                                    {hasInitialContent && (
+                                      <SessionActionsMenu agentId={agentId} chatId={chatId} />
+                                    )}
                                     {canEdit && (
                                       <Link
                                         href={`/chat/${agentId}/settings`}

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -12,6 +12,7 @@ import Link from "next/link";
 import { Settings } from "lucide-react";
 import { MobileChatHeader } from "@/components/mobile-chat-header";
 import { SessionActionsMenu } from "@/components/session-actions-menu";
+import { ChatSwitcher } from "@/components/chat-switcher";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type ChatStatus, useChatStatus } from "@/hooks/use-chat-status";
@@ -231,6 +232,7 @@ export function Chat({
                                 <MobileChatHeader
                                   agentId={agentId}
                                   agentName={displayName}
+                                  chatId={chatId ?? null}
                                   avatarUrl={displayAvatar}
                                   canEdit={canEdit}
                                 />
@@ -244,7 +246,11 @@ export function Chat({
                                         className="size-7 rounded-full"
                                       />
                                     )}
-                                    <h1 className="font-bold">{displayName}</h1>
+                                    <ChatSwitcher
+                                      agentId={agentId}
+                                      chatId={chatId ?? null}
+                                      agentName={displayName}
+                                    />
                                     <TooltipProvider>
                                       <Tooltip>
                                         <TooltipTrigger asChild>

--- a/packages/web/src/components/mobile-chat-header.tsx
+++ b/packages/web/src/components/mobile-chat-header.tsx
@@ -1,9 +1,12 @@
 import Link from "next/link";
 import { ArrowLeft, Settings } from "lucide-react";
+import { ChatSwitcher } from "@/components/chat-switcher";
 
 interface MobileChatHeaderProps {
   agentId: string;
   agentName: string;
+  /** Active chat from the URL, or null for the default/legacy chat (#508). */
+  chatId?: string | null;
   avatarUrl?: string;
   canEdit?: boolean;
 }
@@ -11,6 +14,7 @@ interface MobileChatHeaderProps {
 export function MobileChatHeader({
   agentId,
   agentName,
+  chatId = null,
   avatarUrl,
   canEdit = false,
 }: MobileChatHeaderProps) {
@@ -25,7 +29,7 @@ export function MobileChatHeader({
           // eslint-disable-next-line @next/next/no-img-element
           <img src={avatarUrl} alt={agentName} className="size-6 rounded-full shrink-0" />
         )}
-        <span className="font-bold truncate">{agentName}</span>
+        <ChatSwitcher agentId={agentId} chatId={chatId} agentName={agentName} />
       </div>
 
       {canEdit ? (

--- a/packages/web/src/components/session-actions-menu.tsx
+++ b/packages/web/src/components/session-actions-menu.tsx
@@ -21,15 +21,25 @@ import type { CompactSessionRequest } from "@/lib/schemas/sessions";
  * deliberately do NOT reload history, so the user's visible messages don't
  * vanish from under them.
  */
-export function SessionActionsMenu({ agentId }: { agentId: string }) {
+export function SessionActionsMenu({
+  agentId,
+  chatId,
+}: {
+  agentId: string;
+  /** Per-chat id (#508). Omitted → the default/legacy chat. Scopes the
+   * compaction to the chat the user is actually viewing. */
+  chatId?: string;
+}) {
   const [isCompacting, setIsCompacting] = useState(false);
 
   async function handleCompact() {
     setIsCompacting(true);
     try {
+      // `chatId: undefined` is dropped by JSON.stringify, so the default chat
+      // sends `{}` and a per-chat URL sends `{ chatId }`.
       await apiPost<{ ok: boolean }, CompactSessionRequest>(
         `/api/agents/${agentId}/sessions/compact`,
-        {}
+        { chatId }
       );
       toast.success("Conversation compacted. It takes effect on your next message.");
     } catch (e) {

--- a/packages/web/src/components/telegram-chat-view.tsx
+++ b/packages/web/src/components/telegram-chat-view.tsx
@@ -129,6 +129,12 @@ export function TelegramChatView({
           </Badge>
           <Badge
             data-testid="telegram-channel-indicator"
+            // role=img + aria-label gives this indicator a single, distinct
+            // accessible name ("Telegram channel") so a screen reader doesn't
+            // announce a bare "Telegram" twice — the chat-switcher trigger is
+            // also named "Telegram" on this view.
+            role="img"
+            aria-label="Telegram channel"
             variant="secondary"
             className="gap-1 text-xs font-normal"
           >
@@ -174,7 +180,15 @@ export function TelegramChatView({
               </p>
             ) : (
               state.data.messages.map((message, index) => (
-                <TranscriptMessage key={index} message={message} index={index} />
+                // The transcript is fetched once and never reordered or
+                // paginated, so a position-derived key is stable; the
+                // timestamp/role prefix makes it descriptive and keeps it unique
+                // even if two turns ever share a position after a future change.
+                <TranscriptMessage
+                  key={`${message.timestamp}-${message.role}-${index}`}
+                  message={message}
+                  index={index}
+                />
               ))
             )}
           </div>

--- a/packages/web/src/components/telegram-chat-view.tsx
+++ b/packages/web/src/components/telegram-chat-view.tsx
@@ -1,0 +1,204 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { ExternalLink, Send, Settings } from "lucide-react";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { ChatSwitcher } from "@/components/chat-switcher";
+import { apiGet, ApiError } from "@/lib/api-client";
+import type { TelegramTranscriptMessage } from "@/lib/schemas/sessions";
+
+interface TelegramChatViewProps {
+  agentId: string;
+  agentName: string;
+  avatarUrl?: string;
+  isPersonal?: boolean;
+  canEdit?: boolean;
+}
+
+interface TelegramChatResponse {
+  messages: TelegramTranscriptMessage[];
+  botDeepLink: string | null;
+}
+
+type LoadState =
+  | { kind: "loading" }
+  | { kind: "empty" } // no linked Telegram conversation (404)
+  | { kind: "error" }
+  | { kind: "ready"; data: TelegramChatResponse };
+
+/** Best-effort local time stamp; empty when OpenClaw omitted the timestamp. */
+function formatTimestamp(ms: number): string {
+  if (!ms) return "";
+  return new Date(ms).toLocaleString(undefined, {
+    dateStyle: "medium",
+    timeStyle: "short",
+  });
+}
+
+/**
+ * One read-only transcript bubble. Mirrors the live chat's bubble styling
+ * (`thread.tsx`): user turns sit right-aligned in a muted pill, assistant
+ * turns read as left-aligned prose. `data-role` keeps the role assertable in
+ * tests and available for styling.
+ */
+function TranscriptMessage({
+  message,
+  index,
+}: {
+  message: TelegramTranscriptMessage;
+  index: number;
+}) {
+  const isUser = message.role === "user";
+  const timestamp = formatTimestamp(message.timestamp);
+  return (
+    <div
+      data-testid={`telegram-message-${index}`}
+      data-role={message.role}
+      className={`mx-auto flex w-full max-w-2xl flex-col px-2 py-3 ${
+        isUser ? "items-end" : "items-start"
+      }`}
+    >
+      {isUser ? (
+        <div className="wrap-break-word rounded-2xl bg-muted px-4 py-2.5 text-foreground whitespace-pre-wrap">
+          {message.text}
+        </div>
+      ) : (
+        <div className="wrap-break-word px-2 text-foreground leading-relaxed whitespace-pre-wrap">
+          {message.text}
+        </div>
+      )}
+      {timestamp && <span className="text-muted-foreground mt-1 px-2 text-xs">{timestamp}</span>}
+    </div>
+  );
+}
+
+/**
+ * Read-only mirror of the user's Telegram conversation with an agent (#508).
+ *
+ * The conversation itself lives in Telegram — this view fetches a static
+ * transcript on mount and renders it without a composer. A banner where the
+ * composer would normally be makes the read-only nature obvious and offers a
+ * "Continue on Telegram" deep link back to the bot.
+ */
+export function TelegramChatView({
+  agentId,
+  agentName,
+  avatarUrl,
+  isPersonal = false,
+  canEdit = false,
+}: TelegramChatViewProps) {
+  const [state, setState] = useState<LoadState>({ kind: "loading" });
+
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<TelegramChatResponse>(`/api/agents/${agentId}/telegram-chat`)
+      .then((data) => {
+        if (!cancelled) setState({ kind: "ready", data });
+      })
+      .catch((err: unknown) => {
+        if (cancelled) return;
+        // A 404 means the user has no linked Telegram conversation — that's an
+        // empty state, not a failure.
+        if (err instanceof ApiError && err.status === 404) {
+          setState({ kind: "empty" });
+        } else {
+          setState({ kind: "error" });
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId]);
+
+  return (
+    <div className="flex flex-col h-full min-h-0">
+      <header
+        data-testid="telegram-chat-header"
+        className="flex p-4 border-b items-center justify-between shrink-0"
+      >
+        <div className="flex items-center gap-2 min-w-0">
+          {avatarUrl && (
+            // eslint-disable-next-line @next/next/no-img-element
+            <img src={avatarUrl} alt="" className="size-7 rounded-full shrink-0" />
+          )}
+          <ChatSwitcher agentId={agentId} chatId={null} agentName={agentName} activeTelegram />
+          <Badge variant="outline" className="text-xs font-normal">
+            {isPersonal ? "Private" : "Shared"}
+          </Badge>
+          <Badge
+            data-testid="telegram-channel-indicator"
+            variant="secondary"
+            className="gap-1 text-xs font-normal"
+          >
+            <Send className="size-3" aria-hidden="true" />
+            Telegram
+          </Badge>
+        </div>
+        {canEdit && (
+          <Link
+            href={`/chat/${agentId}/settings`}
+            aria-label="Settings"
+            className="text-muted-foreground hover:text-foreground transition-colors"
+          >
+            <Settings className="size-5" />
+          </Link>
+        )}
+      </header>
+
+      <div data-testid="telegram-chat-body" className="flex-1 min-h-0 overflow-y-auto">
+        {state.kind === "loading" && (
+          <p className="text-muted-foreground p-6 text-center text-sm">
+            Loading your Telegram conversation…
+          </p>
+        )}
+
+        {state.kind === "empty" && (
+          <p className="text-muted-foreground p-6 text-center text-sm">
+            No Telegram conversation linked yet.
+          </p>
+        )}
+
+        {state.kind === "error" && (
+          <p className="text-destructive p-6 text-center text-sm">
+            We couldn&apos;t load your Telegram conversation. Please try again.
+          </p>
+        )}
+
+        {state.kind === "ready" && (
+          <div data-testid="telegram-transcript" className="py-4">
+            {state.data.messages.length === 0 ? (
+              <p className="text-muted-foreground p-6 text-center text-sm">
+                This Telegram conversation is empty so far.
+              </p>
+            ) : (
+              state.data.messages.map((message, index) => (
+                <TranscriptMessage key={index} message={message} index={index} />
+              ))
+            )}
+          </div>
+        )}
+      </div>
+
+      {/* The composer's spot — a banner instead, since this view is read-only. */}
+      {state.kind === "ready" && (
+        <div className="border-t bg-muted/30 px-4 py-3 shrink-0">
+          <div className="mx-auto flex max-w-2xl flex-col items-center gap-2 text-center sm:flex-row sm:justify-between sm:text-left">
+            <p className="text-muted-foreground text-sm">
+              This conversation happens on Telegram. You&apos;re reading it here.
+            </p>
+            {state.data.botDeepLink && (
+              <Button asChild size="sm" className="shrink-0">
+                <a href={state.data.botDeepLink} target="_blank" rel="noopener noreferrer">
+                  Continue on Telegram
+                  <ExternalLink className="size-4" aria-hidden="true" />
+                </a>
+              </Button>
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/packages/web/src/hooks/use-draft-id.ts
+++ b/packages/web/src/hooks/use-draft-id.ts
@@ -3,19 +3,29 @@
 import { useState } from "react";
 
 /**
- * Returns a stable draft ID scoped to the given agent.
+ * Returns a stable draft ID scoped to the given agent and chat (#508).
  *
  * The ID is generated once on first mount and persisted in localStorage so it
  * survives page reloads of the same composer. It is used as the `x-pinchy-draft-id`
- * header when POSTing to `/api/agents/<id>/uploads`.
+ * header when POSTing to `/api/agents/<id>/uploads`, which stages uploads
+ * server-side per draft id — so the id MUST be per-chat, otherwise a file
+ * staged while composing in one chat would surface as a pending attachment in
+ * a sibling chat of the same agent.
  *
- * IMPORTANT: `agentId` must be stable across re-renders. If the parent changes
- * `agentId` without unmounting, the hook keeps the original draft ID. Use a
- * `key` prop on the consumer to force remount when `agentId` changes.
+ * The default/legacy chat (no chatId) keeps its original 4-segment storage key
+ * for backward compatibility; a per-chat composer gets the chatId as an extra
+ * segment. chatId is `[a-z0-9-]+`, so a chat key can never collide with the
+ * default key (different segment count).
+ *
+ * IMPORTANT: `agentId`/`chatId` must be stable across re-renders. If the parent
+ * changes them without unmounting, the hook keeps the original draft ID. Use a
+ * `key` prop on the consumer to force remount when either changes.
  */
-export function useDraftId(agentId: string): string {
+export function useDraftId(agentId: string, chatId?: string): string {
   const [draftId] = useState<string>(() => {
-    const key = `pinchy:composer:${agentId}:draftId`;
+    const key = chatId
+      ? `pinchy:composer:${agentId}:${chatId}:draftId`
+      : `pinchy:composer:${agentId}:draftId`;
     const stored = localStorage.getItem(key);
     if (stored) {
       return stored;

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -413,7 +413,9 @@ export function useWsRuntime(
   retryPendingUpload: (localId: string) => void;
 } {
   const { triggerRestart } = useRestart();
-  const draftId = useDraftId(agentId);
+  // Scope the draft id to (agent, chat) so server-side upload staging can't
+  // bleed pending attachments between sibling chats of the same agent (#508).
+  const draftId = useDraftId(agentId, chatId);
   const [messages, setMessages] = useState<WsMessage[]>([]);
   const [isRunning, setIsRunning] = useState(false);
   const [isConnected, setIsConnected] = useState(false);

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -371,7 +371,16 @@ export function shouldReplaceLocalWithServerHistory(
   return lastNonError.status === "sent" && historyMessages.length > prev.length;
 }
 
-export function useWsRuntime(agentId: string): {
+export function useWsRuntime(
+  agentId: string,
+  /**
+   * Optional per-chat identifier (#508). When present it is threaded onto the
+   * `message` and `history` WS frames so the server routes to a distinct
+   * OpenClaw session within this (user, agent) pair. Omitted → the legacy
+   * per-user session key (current/default chat).
+   */
+  chatId?: string
+): {
   runtime: AssistantRuntime;
   isRunning: boolean;
   isConnected: boolean;
@@ -505,9 +514,14 @@ export function useWsRuntime(agentId: string): {
   // so a single stale tick can corrupt the new agent's message list.
   // The react-hooks/purity rule warns against reading refs during render, but
   // here it's the only way to close the race — the timing requirement wins.
-  const [prevAgentId, setPrevAgentId] = useState(agentId);
-  if (prevAgentId !== agentId) {
-    setPrevAgentId(agentId);
+  // Reset on either an agentId OR chatId change (#508). Switching the chat
+  // within the same agent must wipe stale messages and re-load the new chat's
+  // history exactly like an agent switch does — otherwise the previous chat's
+  // transcript would bleed into the new one before the history reconcile lands.
+  const [prevSessionKey, setPrevSessionKey] = useState(`${agentId}\0${chatId ?? ""}`);
+  const sessionKey = `${agentId}\0${chatId ?? ""}`;
+  if (prevSessionKey !== sessionKey) {
+    setPrevSessionKey(sessionKey);
     setMessages(capMessages([]));
     setIsRunning(false);
     setIsDelayed(false);
@@ -652,7 +666,7 @@ export function useWsRuntime(agentId: string): {
         // (which runs in handleHistory) and the history-response send.
         pendingHistoryRef.current = true;
         frameBufferRef.current = [];
-        wsRef.current.send(JSON.stringify({ type: "history", agentId }));
+        wsRef.current.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
       } else {
         connect();
       }
@@ -714,7 +728,8 @@ export function useWsRuntime(agentId: string): {
         // on the (always-sent) history response — no stall, no benefit lost.
         pendingHistoryRef.current = true;
         frameBufferRef.current = [];
-        ws.send(JSON.stringify({ type: "history", agentId }));
+        // #508: scope the history request to the active chat's session.
+        ws.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
 
         // Flush any message that was queued while disconnected/connecting
         if (pendingMessageRef.current) {
@@ -1344,8 +1359,11 @@ export function useWsRuntime(agentId: string): {
       ackTimers.clear();
       wsRef.current?.close();
     };
+    // chatId (#508) is intentionally in the deps: switching the chat must tear
+    // down the old WS and reconnect so the fresh connect() sends a history
+    // frame for the new chat's session key.
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [agentId]);
+  }, [agentId, chatId]);
 
   // Auto-recovery: when OpenClaw becomes reachable again after being unavailable,
   // re-request history so the session is populated with any messages that arrived
@@ -1362,9 +1380,9 @@ export function useWsRuntime(agentId: string): {
     if (wasConnected === fullyConnected) return;
     // Rising edge: was disconnected/unavailable, is now fully connected
     if (fullyConnected && !wasConnected && isHistoryLoaded) {
-      wsRef.current?.send(JSON.stringify({ type: "history", agentId }));
+      wsRef.current?.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
     }
-  }, [fullyConnected, isHistoryLoaded, agentId]);
+  }, [fullyConnected, isHistoryLoaded, agentId, chatId]);
 
   /**
    * Send a JSON-serialised payload over the WebSocket if it's open, otherwise
@@ -1479,6 +1497,7 @@ export function useWsRuntime(agentId: string): {
         content: text,
         ...(attachmentIds.length > 0 && { attachmentIds }),
         agentId,
+        ...(chatId && { chatId }),
         clientMessageId,
       });
 
@@ -1507,7 +1526,7 @@ export function useWsRuntime(agentId: string): {
       }, 10_000);
       pendingAckTimers.current.set(clientMessageId, ackTimer);
     },
-    [agentId, dispatchMessages, dispatchLiveness, sendOrQueue, pendingUploads] // setPendingUploads is stable (useState setter)
+    [agentId, chatId, dispatchMessages, dispatchLiveness, sendOrQueue, pendingUploads] // setPendingUploads is stable (useState setter)
   );
 
   const onRetryContinue = useCallback(
@@ -1534,6 +1553,7 @@ export function useWsRuntime(agentId: string): {
       const payload = JSON.stringify({
         type: "message",
         agentId,
+        ...(chatId && { chatId }),
         content: lastUserMsg.content,
         clientMessageId: lastUserMsg.id,
         isRetry: true,
@@ -1542,7 +1562,7 @@ export function useWsRuntime(agentId: string): {
 
       sendOrQueue(payload);
     },
-    [agentId, messages, dispatchMessages, dispatchLiveness, sendOrQueue]
+    [agentId, chatId, messages, dispatchMessages, dispatchLiveness, sendOrQueue]
   );
 
   const onRetryResend = useCallback(
@@ -1572,6 +1592,7 @@ export function useWsRuntime(agentId: string): {
       const payload = JSON.stringify({
         type: "message",
         agentId,
+        ...(chatId && { chatId }),
         content: failedMsg.content,
         clientMessageId: messageId,
         isRetry: true,
@@ -1586,7 +1607,7 @@ export function useWsRuntime(agentId: string): {
       }, 10_000);
       pendingAckTimers.current.set(messageId, ackTimer);
     },
-    [agentId, messages, dispatchMessages, dispatchLiveness, sendOrQueue]
+    [agentId, chatId, messages, dispatchMessages, dispatchLiveness, sendOrQueue]
   );
 
   // Fire-and-forget: the upload's outcome is driven entirely through the

--- a/packages/web/src/lib/chats/__tests__/generate-chat-id.test.ts
+++ b/packages/web/src/lib/chats/__tests__/generate-chat-id.test.ts
@@ -1,0 +1,18 @@
+import { describe, it, expect } from "vitest";
+import { generateChatId } from "@/lib/chats/generate-chat-id";
+import { chatIdSchema } from "@/lib/schemas/sessions";
+
+describe("generateChatId", () => {
+  it("produces an id that satisfies chatIdSchema", () => {
+    for (let i = 0; i < 50; i++) {
+      const id = generateChatId();
+      expect(chatIdSchema.safeParse(id).success).toBe(true);
+    }
+  });
+
+  it("produces a unique id on each call", () => {
+    const a = generateChatId();
+    const b = generateChatId();
+    expect(a).not.toBe(b);
+  });
+});

--- a/packages/web/src/lib/chats/__tests__/telegram-transcript.test.ts
+++ b/packages/web/src/lib/chats/__tests__/telegram-transcript.test.ts
@@ -1,0 +1,87 @@
+import { describe, it, expect } from "vitest";
+import { mapTelegramTranscript } from "@/lib/chats/telegram-transcript";
+import type { RawHistoryMessage } from "@/lib/chats/telegram-transcript";
+
+describe("mapTelegramTranscript", () => {
+  it("keeps only user/assistant turns and drops tool/system noise", () => {
+    const raw: RawHistoryMessage[] = [
+      { role: "user", content: "hi", timestamp: 1 },
+      { role: "assistant", content: "hello", timestamp: 2 },
+      { role: "tool", content: "tool output", timestamp: 3 },
+      { role: "system", content: "system prompt", timestamp: 4 },
+    ];
+    expect(mapTelegramTranscript(raw).map((m) => m.role)).toEqual(["user", "assistant"]);
+  });
+
+  it("joins the text parts of an array content and ignores non-text parts", () => {
+    const raw: RawHistoryMessage[] = [
+      {
+        role: "assistant",
+        content: [
+          { type: "text", text: "part one" },
+          { type: "image", url: "ignored" },
+          { type: "text", text: "part two" },
+        ],
+        timestamp: 1,
+      },
+    ];
+    expect(mapTelegramTranscript(raw)[0].text).toBe("part one part two");
+  });
+
+  it("strips <final> protocol tags from assistant text", () => {
+    const raw: RawHistoryMessage[] = [
+      { role: "assistant", content: "<final>the answer</final>", timestamp: 1 },
+    ];
+    expect(mapTelegramTranscript(raw)[0].text).toBe("the answer");
+  });
+
+  it("strips OpenClaw's [timestamp] prefix from user messages", () => {
+    const raw: RawHistoryMessage[] = [
+      { role: "user", content: "[2026-06-18 10:00] what's up", timestamp: 1 },
+    ];
+    expect(mapTelegramTranscript(raw)[0].text).toBe("what's up");
+  });
+
+  it("drops messages that are empty after stripping", () => {
+    const raw: RawHistoryMessage[] = [
+      { role: "assistant", content: "<final></final>", timestamp: 1 },
+      { role: "user", content: "real message", timestamp: 2 },
+    ];
+    expect(mapTelegramTranscript(raw).map((m) => m.text)).toEqual(["real message"]);
+  });
+
+  it("drops queued-retry duplicate user messages", () => {
+    // Real OpenClaw user messages carry a leading [timestamp]; the queued-retry
+    // marker follows it. The non-greedy [timestamp] strip removes only the first
+    // bracket, leaving the marker so the startsWith() drop matches.
+    const raw: RawHistoryMessage[] = [
+      {
+        role: "user",
+        content:
+          "[2026-06-18 10:00] [Queued user message that arrived while the previous turn was still active] dup",
+        timestamp: 1,
+      },
+      { role: "user", content: "[2026-06-18 10:01] kept", timestamp: 2 },
+    ];
+    expect(mapTelegramTranscript(raw).map((m) => m.text)).toEqual(["kept"]);
+  });
+
+  it("falls back to timestamp 0 when OpenClaw omits it", () => {
+    const raw: RawHistoryMessage[] = [{ role: "assistant", content: "no time" }];
+    expect(mapTelegramTranscript(raw)[0].timestamp).toBe(0);
+  });
+
+  it("tolerates a null/undefined content part without throwing", () => {
+    // Defensive: OpenClaw doesn't emit null parts today, but a malformed entry
+    // must not crash the read-only mirror (fail soft, not throw).
+    const raw: RawHistoryMessage[] = [
+      {
+        role: "assistant",
+        content: [null, { type: "text", text: "survives" }, undefined] as unknown,
+        timestamp: 1,
+      },
+    ];
+    expect(() => mapTelegramTranscript(raw)).not.toThrow();
+    expect(mapTelegramTranscript(raw)[0].text).toBe("survives");
+  });
+});

--- a/packages/web/src/lib/chats/classify-sessions.ts
+++ b/packages/web/src/lib/chats/classify-sessions.ts
@@ -32,12 +32,26 @@ export type ClassifiedChat = {
 export function classifyUserSessions(
   sessions: RawSession[],
   userId: string,
+  // MUST already be lowercased by the caller. OpenClaw lowercases the principal
+  // segment on storage, and this function compares the raw (lowercased) principal
+  // against this set verbatim — it does not normalize members itself. A peer id
+  // that is not lowercased here will silently never match.
   linkedTelegramPeerIds: ReadonlySet<string>
 ): ClassifiedChat[] {
+  // An empty (or non-string) userId is never a valid identity. Guarding here
+  // stops `ownPrincipal === ""` from matching keys with an empty principal
+  // segment (e.g. `agent:a:direct:`), which would be a cross-user/empty leak.
+  if (typeof userId !== "string" || userId.length === 0) return [];
+
   const ownPrincipal = userId.toLowerCase();
   const result: ClassifiedChat[] = [];
 
   for (const session of sessions) {
+    // `sessions.list` is untyped wire output from OpenClaw. Skip non-conforming
+    // entries (null element, missing/non-string key) instead of throwing — one
+    // bad entry must not nuke the whole list (fail closed, never fail broken).
+    if (!session || typeof session.key !== "string") continue;
+
     const parts = session.key.split(":");
 
     // Only agent direct keys: agent:<agentId>:direct:<principal>[:<chatId>].
@@ -46,6 +60,10 @@ export function classifyUserSessions(
 
     const principal = parts[3];
     const extra = parts.slice(4);
+
+    // An empty principal segment (trailing-colon key) is never a valid
+    // identity, for both the web and Telegram paths. Fail closed.
+    if (!principal) continue;
     const lastInteractionAt = session.lastInteractionAt ?? session.updatedAt ?? 0;
 
     if (principal === ownPrincipal) {

--- a/packages/web/src/lib/chats/classify-sessions.ts
+++ b/packages/web/src/lib/chats/classify-sessions.ts
@@ -1,0 +1,86 @@
+/**
+ * Pure, I/O-free classifier that filters an agent's `sessions.list` output
+ * down to ONLY the chats that belong to the requesting Pinchy user.
+ *
+ * This is the authorization boundary for the Chats feature: `sessions.list`
+ * returns every user's direct sessions for an agent, so a bug here would leak
+ * one user's conversations (web or Telegram) to another. It therefore fails
+ * closed — anything we cannot positively attribute to the requesting user is
+ * excluded.
+ *
+ * Classification is driven entirely by parsing the session KEY. We never trust
+ * a `kind` field: OpenClaw reports `kind: "direct"` even for cron keys.
+ */
+
+export type RawSession = {
+  key: string;
+  sessionId: string;
+  label?: string;
+  lastInteractionAt?: number;
+  updatedAt?: number;
+};
+
+export type ClassifiedChat = {
+  sessionId: string;
+  key: string;
+  origin: "web" | "telegram";
+  writable: boolean;
+  chatId: string | null;
+  lastInteractionAt: number;
+};
+
+export function classifyUserSessions(
+  sessions: RawSession[],
+  userId: string,
+  linkedTelegramPeerIds: ReadonlySet<string>
+): ClassifiedChat[] {
+  const ownPrincipal = userId.toLowerCase();
+  const result: ClassifiedChat[] = [];
+
+  for (const session of sessions) {
+    const parts = session.key.split(":");
+
+    // Only agent direct keys: agent:<agentId>:direct:<principal>[:<chatId>].
+    // Drops :cron:, :subagent:, agent:<id>:main, and anything malformed.
+    if (parts[0] !== "agent" || parts[2] !== "direct") continue;
+
+    const principal = parts[3];
+    const extra = parts.slice(4);
+    const lastInteractionAt = session.lastInteractionAt ?? session.updatedAt ?? 0;
+
+    if (principal === ownPrincipal) {
+      // The user's own web chat. A 4-segment key is a legacy chat with no
+      // chatId; a 5-segment key carries the chatId. More than one extra
+      // segment is malformed — fail closed.
+      if (extra.length > 1) continue;
+      result.push({
+        sessionId: session.sessionId,
+        key: session.key,
+        origin: "web",
+        writable: true,
+        chatId: extra[0] ?? null,
+        lastInteractionAt,
+      });
+      continue;
+    }
+
+    if (linkedTelegramPeerIds.has(principal)) {
+      // A Telegram peer linked to this user. Read-only from the web UI, and
+      // the key must not carry extra segments — fail closed if it does.
+      if (extra.length > 0) continue;
+      result.push({
+        sessionId: session.sessionId,
+        key: session.key,
+        origin: "telegram",
+        writable: false,
+        chatId: null,
+        lastInteractionAt,
+      });
+      continue;
+    }
+
+    // Another user's chat, or an unlinked peer. Exclude.
+  }
+
+  return result;
+}

--- a/packages/web/src/lib/chats/classify-sessions.ts
+++ b/packages/web/src/lib/chats/classify-sessions.ts
@@ -32,10 +32,10 @@ export type ClassifiedChat = {
 export function classifyUserSessions(
   sessions: RawSession[],
   userId: string,
-  // MUST already be lowercased by the caller. OpenClaw lowercases the principal
-  // segment on storage, and this function compares the raw (lowercased) principal
-  // against this set verbatim — it does not normalize members itself. A peer id
-  // that is not lowercased here will silently never match.
+  // The user's linked Telegram peer ids. OpenClaw lowercases the principal
+  // segment on storage, so we compare against a lowercased copy of this set —
+  // callers don't have to pre-normalize (a non-lowercased peer id still matches,
+  // so a future caller can't silently drop a user's Telegram chat).
   linkedTelegramPeerIds: ReadonlySet<string>
 ): ClassifiedChat[] {
   // An empty (or non-string) userId is never a valid identity. Guarding here
@@ -44,6 +44,10 @@ export function classifyUserSessions(
   if (typeof userId !== "string" || userId.length === 0) return [];
 
   const ownPrincipal = userId.toLowerCase();
+  const linkedPeers = new Set<string>();
+  for (const peer of linkedTelegramPeerIds) {
+    if (typeof peer === "string") linkedPeers.add(peer.toLowerCase());
+  }
   const result: ClassifiedChat[] = [];
 
   for (const session of sessions) {
@@ -82,7 +86,7 @@ export function classifyUserSessions(
       continue;
     }
 
-    if (linkedTelegramPeerIds.has(principal)) {
+    if (linkedPeers.has(principal)) {
       // A Telegram peer linked to this user. Read-only from the web UI, and
       // the key must not carry extra segments — fail closed if it does.
       if (extra.length > 0) continue;

--- a/packages/web/src/lib/chats/first-user-message-title.ts
+++ b/packages/web/src/lib/chats/first-user-message-title.ts
@@ -1,0 +1,29 @@
+import { mapTelegramTranscript, type RawHistoryMessage } from "@/lib/chats/telegram-transcript";
+
+/** Max length of a derived chat title before we truncate and append an ellipsis. */
+export const TITLE_MAX_LENGTH = 60;
+
+/**
+ * Derive a human-readable chat title from a session's OpenClaw history by taking
+ * its first user message (#508). Returns `null` when there is no usable user
+ * message, so callers can fall back to a date-stamped label.
+ *
+ * The normalization (drop tool/system turns, join array content, strip
+ * OpenClaw's `[timestamp]` prefix and the `<pinchy:attachments>` block, drop
+ * empties and queued-retry duplicates) is shared with the read-only Telegram
+ * mirror via `mapTelegramTranscript` — so a chat's list title matches the first
+ * line a user would actually read in the transcript, with no separate parser to
+ * drift.
+ */
+export function firstUserMessageTitle(rawMessages: RawHistoryMessage[]): string | null {
+  const firstUser = mapTelegramTranscript(rawMessages).find((m) => m.role === "user");
+  if (!firstUser) return null;
+
+  // mapTelegramTranscript already collapses internal whitespace runs only via
+  // its joins; normalize newlines/tabs so a multi-line message reads as one line.
+  const text = firstUser.text.replace(/\s+/g, " ").trim();
+  if (text.length === 0) return null;
+
+  if (text.length <= TITLE_MAX_LENGTH) return text;
+  return `${text.slice(0, TITLE_MAX_LENGTH).trimEnd()}…`;
+}

--- a/packages/web/src/lib/chats/generate-chat-id.ts
+++ b/packages/web/src/lib/chats/generate-chat-id.ts
@@ -1,0 +1,11 @@
+/**
+ * Mint a fresh, opaque chat id for a new chat (#508). The id becomes the
+ * trailing segment of the OpenClaw session key
+ * (`agent:<agentId>:direct:<userId>:<chatId>`) and the `/chat/<agentId>/<chatId>`
+ * URL, so it must satisfy `chatIdSchema` (lowercase alphanumerics + dashes,
+ * ≤64 chars). `crypto.randomUUID()` already emits lowercase hex + hyphens, so
+ * its output passes that schema as-is — no normalization needed.
+ */
+export function generateChatId(): string {
+  return crypto.randomUUID();
+}

--- a/packages/web/src/lib/chats/telegram-transcript.ts
+++ b/packages/web/src/lib/chats/telegram-transcript.ts
@@ -1,0 +1,82 @@
+import { parseAttachmentBlock } from "@/server/attachment-pipeline";
+import type { TelegramTranscriptMessage } from "@/lib/schemas/sessions";
+
+/**
+ * One raw entry from OpenClaw's `sessions.history` wire output. `content` is
+ * either a plain string or an array of content parts; we treat it as `unknown`
+ * and narrow defensively, mirroring `HistoryMessage` in `client-router.ts`.
+ */
+export type RawHistoryMessage = {
+  role: string;
+  content?: unknown;
+  timestamp?: number;
+};
+
+// OpenClaw marks user messages that arrived while another turn was still active
+// with this prefix and aggregates them. They are duplicates of the original
+// user turn already in history, so the live chat filters them out — we mirror
+// that here. (Kept verbatim in sync with `client-router.ts`.)
+const QUEUED_RETRY_PREFIX =
+  "[Queued user message that arrived while the previous turn was still active]";
+
+/**
+ * Extract the rendered text from one OpenClaw history entry: join the text
+ * parts of an array `content`, or use a string `content` as-is. Identical to
+ * the extraction in `ClientRouter.handleHistory` so the read-only Telegram
+ * mirror renders the same text the live chat would.
+ */
+function extractText(content: unknown): string {
+  if (Array.isArray(content)) {
+    return content
+      .filter((part: { type: string; text?: string }) => part.type === "text" && part.text)
+      .map((part: { text?: string }) => part.text!)
+      .join(" ");
+  }
+  return typeof content === "string" ? content : "";
+}
+
+/**
+ * Map OpenClaw `sessions.history` entries to the minimal, read-only transcript
+ * shape used by the Telegram chat mirror (#508).
+ *
+ * This reuses the exact normalization the live web chat applies in
+ * `ClientRouter.handleHistory`:
+ *   - keep only `user` / `assistant` turns (drop tool/system noise),
+ *   - join array `content` text parts (or use string content),
+ *   - strip `<final>` protocol tags from assistant text,
+ *   - strip OpenClaw's `[timestamp]` prefix from user messages and lift out the
+ *     `<pinchy:attachments>` block via `parseAttachmentBlock`,
+ *   - drop messages that are empty after stripping,
+ *   - drop queued-retry duplicates.
+ *
+ * Unlike the live chat it does NOT surface attachment `files` chips — the
+ * mirror is a static read-only text view — so an attachment-only user message
+ * (no prose) collapses to empty and is dropped, which is acceptable for a
+ * read-only mirror.
+ */
+export function mapTelegramTranscript(
+  rawMessages: RawHistoryMessage[]
+): TelegramTranscriptMessage[] {
+  return rawMessages
+    .filter((msg) => msg.role === "user" || msg.role === "assistant")
+    .map((msg) => {
+      let text = extractText(msg.content);
+
+      // Strip protocol tags from assistant responses.
+      text = text.replace(/<\/?final>/g, "");
+
+      if (msg.role === "user") {
+        // Strip OpenClaw's timestamp prefix, then lift out the attachment block.
+        text = text.replace(/^\[.*?\]\s*/, "");
+        text = parseAttachmentBlock(text).cleanText;
+      }
+
+      return {
+        role: msg.role as "user" | "assistant",
+        text,
+        timestamp: typeof msg.timestamp === "number" ? msg.timestamp : 0,
+      };
+    })
+    .filter((msg) => msg.text.length > 0)
+    .filter((msg) => !(msg.role === "user" && msg.text.startsWith(QUEUED_RETRY_PREFIX)));
+}

--- a/packages/web/src/lib/chats/telegram-transcript.ts
+++ b/packages/web/src/lib/chats/telegram-transcript.ts
@@ -28,8 +28,14 @@ const QUEUED_RETRY_PREFIX =
 function extractText(content: unknown): string {
   if (Array.isArray(content)) {
     return content
-      .filter((part: { type: string; text?: string }) => part.type === "text" && part.text)
-      .map((part: { text?: string }) => part.text!)
+      .filter(
+        (part: { type?: string; text?: string } | null | undefined): part is { text: string } =>
+          part != null &&
+          part.type === "text" &&
+          typeof part.text === "string" &&
+          part.text.length > 0
+      )
+      .map((part) => part.text)
       .join(" ");
   }
   return typeof content === "string" ? content : "";

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -146,9 +146,9 @@ export async function regenerateOpenClawConfig() {
       // *will* run later — true for change-on-change flows (subsequent setting
       // edits, channel pair/unpair, agent CRUD), and boot-inits re-regenerate
       // unconditionally. One-shot actions with no follow-up mutation are the
-      // only blind spot; targeted writes (updateTelegramChannelConfig,
-      // updateIdentityLinks) still throw under EACCES so those callers surface
-      // 5xx and the user can retry.
+      // only blind spot; targeted writes (updateTelegramChannelConfig)
+      // still throw under EACCES so those callers surface 5xx and the user
+      // can retry.
       return;
     }
   }
@@ -1038,15 +1038,6 @@ export async function regenerateOpenClawConfig() {
 
   if (Object.keys(accounts).length > 0) {
     const links = await db.select().from(channelLinks);
-    const identityLinks: Record<string, string[]> = {};
-    for (const link of links) {
-      const identity = `${link.channel}:${link.channelUserId}`;
-      if (!identityLinks[link.userId]) {
-        identityLinks[link.userId] = [identity];
-      } else {
-        identityLinks[link.userId].push(identity);
-      }
-    }
 
     // Build per-user peer bindings for personal agents (e.g. Smithers).
     // Each linked user's DMs are routed to THEIR personal agent, not the
@@ -1140,11 +1131,20 @@ export async function regenerateOpenClawConfig() {
     // assembly above. Overwriting the whole block here would re-enable
     // OpenClaw's default daily session reset whenever telegram is configured,
     // silently losing chat history at 4:00 AM gateway-local time.
+    // #508: per-task session model. We intentionally do NOT emit
+    // `session.identityLinks`. Emitting it made OpenClaw fold a linked
+    // Telegram peer's DMs into the SAME session as the user's web chat
+    // (`agent:<id>:direct:<userId>`), which let a Telegram `/new` wipe web
+    // history and prevented Telegram from surfacing as its own chat. Without
+    // identityLinks each Telegram peer gets its own per-peer session
+    // (`agent:<id>:direct:<peerId>`), which the Chats list shows as a
+    // read-only "Telegram" chat (attributed via channel_links). `dmScope:
+    // "per-peer"` and the reset override stay; the per-user peer bindings
+    // above still route each linked user's DMs to their personal agent.
     const existingSession = (config.session as Record<string, unknown>) ?? {};
     config.session = {
       ...existingSession,
       dmScope: "per-peer",
-      ...(Object.keys(identityLinks).length > 0 && { identityLinks }),
     };
   }
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -381,6 +381,16 @@ export async function regenerateOpenClawConfig() {
   const existingUpdate = (existing.update as Record<string, unknown>) || {};
   const existingCanvasHost = (existing.canvasHost as Record<string, unknown>) || {};
 
+  // #508: identityLinks is no longer Pinchy-owned. Purge any stale value left by
+  // a pre-per-task version so UPGRADES actually un-unify Telegram. We only
+  // STOPPED writing it in 2517a0fb; regenerate spreads the on-disk session,
+  // which would otherwise preserve a baked-in identityLinks forever — OpenClaw
+  // keeps folding the linked Telegram peer's DMs into the web session on exactly
+  // the prod/demo installs that already have the key. We purge ONLY
+  // identityLinks; every other (OC-enriched) session key is preserved.
+  const existingSessionPurged = { ...((existing.session as Record<string, unknown>) || {}) };
+  delete existingSessionPurged.identityLinks;
+
   const config: Record<string, unknown> = {
     gateway,
     // Disable OpenClaw's mDNS announcer. Pinchy always runs OpenClaw inside
@@ -445,9 +455,12 @@ export async function regenerateOpenClawConfig() {
     // Spread existing session fields so OpenClaw-enriched sibling keys are
     // preserved across regenerations (same pattern as gateway, discovery, etc.).
     // Only `reset` is Pinchy-owned; everything else OpenClaw may stamp belongs
-    // to OpenClaw and must survive a config regenerate unchanged.
+    // to OpenClaw and must survive a config regenerate unchanged. `identityLinks`
+    // is stripped above (see `existingSessionPurged`, #508); stripping it here
+    // cascades to the telegram block below, which spreads this already-assembled
+    // `config.session` (not raw `existing.session`), so no second strip is needed.
     session: {
-      ...(existing.session as Record<string, unknown>),
+      ...existingSessionPurged,
       reset: { mode: "idle" as const, idleMinutes: 525600 },
     },
   };

--- a/packages/web/src/lib/openclaw-config/index.ts
+++ b/packages/web/src/lib/openclaw-config/index.ts
@@ -18,6 +18,5 @@ export {
   sanitizeOpenClawConfig,
   seedRestartClassOverridesIfMissing,
   seedGatewayTokenIfMissing,
-  updateIdentityLinks,
   updateTelegramChannelConfig,
 } from "./targeted";

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -33,53 +33,6 @@ export function sanitizeOpenClawConfig(): boolean {
 }
 
 /**
- * Update only session.identityLinks in the config file.
- *
- * Unlike regenerateOpenClawConfig(), this reads the existing config and only
- * modifies session.identityLinks. All other fields (agents.defaults, env,
- * plugins, channels, meta, etc.) are preserved byte-for-byte. This avoids
- * unnecessary diffs that trigger hot-reloads breaking Telegram polling
- * (openclaw#47458).
- *
- * OpenClaw treats identityLinks changes as "dynamic reads" — no channel
- * restart, no hot-reload, just updated in memory.
- */
-export function updateIdentityLinks(identityLinks: Record<string, string[]>): void {
-  const existing = readExistingConfig();
-
-  // Same safety as updateTelegramChannelConfig — see comment there.
-  const existingGateway = existing.gateway as Record<string, unknown> | undefined;
-  if (!existingGateway?.mode) {
-    throw new Error(
-      "[openclaw-config] updateIdentityLinks: existing config has no gateway.mode " +
-        "(likely EACCES race on /openclaw-config/openclaw.json). Retry the request."
-    );
-  }
-
-  const session = (existing.session as Record<string, unknown>) || {};
-  const updatedSession = {
-    ...session,
-    identityLinks,
-  };
-
-  const updated = { ...existing, session: updatedSession };
-
-  // Only write if content actually changed. Format matches OpenClaw's
-  // writeConfigFile output (trimEnd + "\n") so SHA256 hashes line up
-  // for the reload-subsystem dedup. See call site of regenerateOpenClawConfig
-  // for the full rationale.
-  const newContent = JSON.stringify(updated, null, 2).trimEnd() + "\n";
-  try {
-    const current = readFileSync(CONFIG_PATH, "utf-8");
-    if (current === newContent) return;
-  } catch {
-    // File doesn't exist — write it
-  }
-
-  writeConfigAtomic(newContent);
-}
-
-/**
  * Update a single Telegram account in the config (add or remove).
  *
  * Uses OpenClaw's multi-account format: channels.telegram.accounts.<accountId>.

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -47,8 +47,7 @@ export function sanitizeOpenClawConfig(): boolean {
  */
 export function updateTelegramChannelConfig(
   accountId: string | null,
-  account: { botToken: string } | null,
-  identityLinks: Record<string, string[]> | null
+  account: { botToken: string } | null
 ): void {
   const existing = readExistingConfig();
 
@@ -132,13 +131,18 @@ export function updateTelegramChannelConfig(
     existing.bindings = undefined;
   }
 
-  const session = (existing.session as Record<string, unknown>) || {};
+  // #508: identityLinks is no longer Pinchy-owned. Purge any stale value left by
+  // a pre-per-task version unconditionally — this targeted writer spreads the
+  // on-disk `session` block independently of build.ts, so without the strip a
+  // bot connect/disconnect on a prod/demo install that still carries a baked-in
+  // identityLinks would preserve it forever, keeping OpenClaw's unification of
+  // Telegram and the web session alive. We purge ONLY identityLinks; every other
+  // (OC-enriched) session key is preserved.
+  const session = { ...((existing.session as Record<string, unknown>) || {}) };
+  delete session.identityLinks;
   existing.session = {
     ...session,
     dmScope: "per-peer",
-    // null = "don't touch existing identityLinks" (used by bot connect/disconnect).
-    // Non-null = overwrite with provided value (used by link/unlink).
-    ...(identityLinks !== null && { identityLinks }),
   };
 
   const newContent = JSON.stringify(existing, null, 2).trimEnd() + "\n";

--- a/packages/web/src/lib/schemas/sessions.ts
+++ b/packages/web/src/lib/schemas/sessions.ts
@@ -1,19 +1,6 @@
 import { z } from "zod";
 
 /**
- * Body for `POST /api/agents/[agentId]/sessions/compact`.
- *
- * `maxLines` is optional — when omitted, OpenClaw uses its own default
- * compaction threshold. Shared between the route handler (parseRequestBody)
- * and the client component (typed request body via z.infer).
- */
-export const compactSessionSchema = z.object({
-  maxLines: z.number().int().positive().max(100_000).optional(),
-});
-
-export type CompactSessionRequest = z.infer<typeof compactSessionSchema>;
-
-/**
  * Opaque, client-supplied identifier for one chat within a (user, agent)
  * pair. It becomes the trailing segment of the OpenClaw session key
  * (`agent:<agentId>:direct:<userId>:<chatId>`), so it must stay free of the
@@ -25,6 +12,22 @@ export const chatIdSchema = z
   .min(1)
   .max(64)
   .regex(/^[a-z0-9-]+$/);
+
+/**
+ * Body for `POST /api/agents/[agentId]/sessions/compact`.
+ *
+ * `maxLines` is optional — when omitted, OpenClaw uses its own default
+ * compaction threshold. `chatId` (#508) scopes the compaction to one chat's
+ * session; omitted → the default/legacy per-user session. Shared between the
+ * route handler (parseRequestBody) and the client component (typed request
+ * body via z.infer).
+ */
+export const compactSessionSchema = z.object({
+  maxLines: z.number().int().positive().max(100_000).optional(),
+  chatId: chatIdSchema.optional(),
+});
+
+export type CompactSessionRequest = z.infer<typeof compactSessionSchema>;
 
 /**
  * One row in the response of `GET /api/agents/[agentId]/chats` — the user's

--- a/packages/web/src/lib/schemas/sessions.ts
+++ b/packages/web/src/lib/schemas/sessions.ts
@@ -25,3 +25,26 @@ export const chatIdSchema = z
   .min(1)
   .max(64)
   .regex(/^[a-z0-9-]+$/);
+
+/**
+ * One row in the response of `GET /api/agents/[agentId]/chats` — the user's
+ * chats with an agent (#508). Shared between the route's response mapping and
+ * the ChatSwitcher client component so the contract can't silently drift.
+ *
+ * - `chatId` is `null` for the legacy/default chat (the pre-#508 web session
+ *   with no trailing chat segment).
+ * - `origin` is where the chat happens: `web` (this app) or `telegram` (a
+ *   linked Telegram peer, surfaced read-only).
+ * - `writable` is `false` for Telegram chats; the web UI shows them read-only.
+ * - `title` is the human-readable session label, or `null` when unset.
+ * - `lastInteractionAt` is epoch milliseconds; the list is sorted by it
+ *   (most recent first).
+ */
+export type ChatListItem = {
+  chatId: string | null;
+  sessionId: string;
+  origin: "web" | "telegram";
+  writable: boolean;
+  title: string | null;
+  lastInteractionAt: number;
+};

--- a/packages/web/src/lib/schemas/sessions.ts
+++ b/packages/web/src/lib/schemas/sessions.ts
@@ -48,3 +48,23 @@ export type ChatListItem = {
   title: string | null;
   lastInteractionAt: number;
 };
+
+/**
+ * One message in the read-only Telegram transcript mirror returned by
+ * `GET /api/agents/[agentId]/telegram-chat` (#508). Shared between the route's
+ * response mapping and the read-only web view so the contract can't drift.
+ *
+ * This is a deliberately minimal projection of OpenClaw's history entry: the
+ * web view mirrors the user's linked Telegram conversation read-only (no
+ * posting), so it only needs who said what and when. Tool/system turns and
+ * attachment-chip metadata that the live chat carries are dropped here.
+ *
+ * - `role` is `"user"` (the linked Telegram peer) or `"assistant"` (the agent).
+ * - `text` is the rendered message text, with OpenClaw protocol markup removed.
+ * - `timestamp` is epoch milliseconds, or `0` when OpenClaw omits it.
+ */
+export type TelegramTranscriptMessage = {
+  role: "user" | "assistant";
+  text: string;
+  timestamp: number;
+};

--- a/packages/web/src/lib/schemas/sessions.ts
+++ b/packages/web/src/lib/schemas/sessions.ts
@@ -12,3 +12,16 @@ export const compactSessionSchema = z.object({
 });
 
 export type CompactSessionRequest = z.infer<typeof compactSessionSchema>;
+
+/**
+ * Opaque, client-supplied identifier for one chat within a (user, agent)
+ * pair. It becomes the trailing segment of the OpenClaw session key
+ * (`agent:<agentId>:direct:<userId>:<chatId>`), so it must stay free of the
+ * `:` delimiter and other path/whitespace characters. Lowercase alphanumerics
+ * and dashes only (nanoid-compatible), 1–64 chars.
+ */
+export const chatIdSchema = z
+  .string()
+  .min(1)
+  .max(64)
+  .regex(/^[a-z0-9-]+$/);

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -50,8 +50,11 @@ export function parseSessionKey(key: string): ParsedSessionKey | null {
   const scope = match[2];
   if (!agentId || !scope) return null;
 
-  // direct:<userId> → chat session. Preserve userId even if it contains colons.
-  const directMatch = /^direct:(.+)$/.exec(scope);
+  // direct:<userId> → chat session. Capture ONLY the userId segment: the chats
+  // feature appends a trailing chatId (direct:<userId>:<chatId>), and a greedy
+  // capture would fold the chatId into the userId, mis-attributing usage to a
+  // bogus id that never matches the users table. The userId never contains a colon.
+  const directMatch = /^direct:([^:]+)/.exec(scope);
   if (directMatch) {
     return { agentId, userId: directMatch[1], type: "chat" };
   }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -51,6 +51,7 @@ import {
   AttachmentAlreadyAttachedError,
 } from "@/server/attachment-pipeline";
 import { attachmentIdsSchema } from "@/lib/schemas/uploads";
+import { chatIdSchema } from "@/lib/schemas/sessions";
 
 const WS_OPEN = 1;
 const CONNECTION_TIMEOUT_MS = 10_000;
@@ -92,11 +93,19 @@ interface ChatMessage {
   retryReason?: RetryReason;
   /** Two-phase upload IDs from the staged-upload flow. */
   attachmentIds?: string[];
+  /**
+   * Opaque per-chat identifier (#508). Selects which OpenClaw session within
+   * this (user, agent) pair the message routes to. Omitted → the legacy
+   * per-user session key.
+   */
+  chatId?: string;
 }
 
 interface HistoryRequestMessage {
   type: "history";
   agentId: string;
+  /** Per-chat identifier (#508). See ChatMessage.chatId. */
+  chatId?: string;
 }
 
 type BrowserMessage = ChatMessage | HistoryRequestMessage;
@@ -126,6 +135,32 @@ export class ClientRouter {
   private computeSessionKey(agentId: string, chatId?: string): string {
     const base = `agent:${agentId}:direct:${this.userId}`;
     return chatId ? `${base}:${chatId}` : base;
+  }
+
+  /**
+   * Resolve the client-supplied chatId (#508) into the value passed to
+   * computeSessionKey, validating it at the WS trust boundary.
+   *
+   * - No chatId → `{ ok: true, chatId: undefined }` (legacy per-user key).
+   * - Valid chatId → `{ ok: true, chatId }`.
+   * - Invalid chatId → an `INVALID_CHAT_ID` error frame is sent to the client
+   *   and `{ ok: false }` is returned. We do NOT silently fall back to the
+   *   legacy key: a malformed chatId must never route a message (or a history
+   *   read) into the wrong or default conversation.
+   */
+  private resolveChatId(
+    clientWs: WebSocket,
+    chatId: string | undefined
+  ): { ok: true; chatId: string | undefined } | { ok: false } {
+    if (chatId === undefined) {
+      return { ok: true, chatId: undefined };
+    }
+    const parsed = chatIdSchema.safeParse(chatId);
+    if (!parsed.success) {
+      this.sendToClient(clientWs, { type: "error", code: "INVALID_CHAT_ID" });
+      return { ok: false };
+    }
+    return { ok: true, chatId: parsed.data };
   }
 
   async handleMessage(clientWs: WebSocket, message: BrowserMessage): Promise<void> {
@@ -176,7 +211,9 @@ export class ClientRouter {
     }
 
     if (message.type === "history") {
-      return this.handleHistory(clientWs, agent);
+      const resolved = this.resolveChatId(clientWs, message.chatId);
+      if (!resolved.ok) return;
+      return this.handleHistory(clientWs, agent, resolved.chatId);
     }
 
     // Reject legacy attachment shape: clients that still send structured content
@@ -191,7 +228,9 @@ export class ClientRouter {
       return;
     }
 
-    const sessionKey = this.computeSessionKey(message.agentId);
+    const resolvedChat = this.resolveChatId(clientWs, message.chatId);
+    if (!resolvedChat.ok) return;
+    const sessionKey = this.computeSessionKey(message.agentId, resolvedChat.chatId);
 
     const messageId = crypto.randomUUID();
 
@@ -556,9 +595,10 @@ export class ClientRouter {
 
   private async handleHistory(
     clientWs: WebSocket,
-    agent: { id: string; greetingMessage: string }
+    agent: { id: string; greetingMessage: string },
+    chatId?: string
   ): Promise<void> {
-    const sessionKey = this.computeSessionKey(agent.id);
+    const sessionKey = this.computeSessionKey(agent.id, chatId);
 
     // #310 Tier 2b: re-attach this ws to the appropriate listener set
     // BEFORE the history send so any chunks arriving during the await

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -657,9 +657,15 @@ export class ClientRouter {
             if (Array.isArray(msg.content)) {
               content = msg.content
                 .filter(
-                  (part: { type: string; text?: string }) => part.type === "text" && part.text
+                  (
+                    part: { type?: string; text?: string } | null | undefined
+                  ): part is { text: string } =>
+                    part != null &&
+                    part.type === "text" &&
+                    typeof part.text === "string" &&
+                    part.text.length > 0
                 )
-                .map((part: { text?: string }) => part.text!)
+                .map((part) => part.text)
                 .join(" ");
             } else {
               content = typeof msg.content === "string" ? msg.content : "";

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -123,8 +123,9 @@ export class ClientRouter {
     private activeRuns: ActiveRuns = new ActiveRuns()
   ) {}
 
-  private computeSessionKey(agentId: string): string {
-    return `agent:${agentId}:direct:${this.userId}`;
+  private computeSessionKey(agentId: string, chatId?: string): string {
+    const base = `agent:${agentId}:direct:${this.userId}`;
+    return chatId ? `${base}:${chatId}` : base;
   }
 
   async handleMessage(clientWs: WebSocket, message: BrowserMessage): Promise<void> {


### PR DESCRIPTION
Closes #508.

## Summary

Adds a per-agent **"Chats"** overview (header chat-switcher) so users can see and return to their own conversations with an agent, and adopts OpenClaw's native **per-task / explicit-key** session model. This fixes a real production data-loss footgun: an accidental `/new` from **Telegram** (an OpenClaw gateway slash command → `sessions.reset`) used to reset the session that — via `identityLinks` — was **shared** with the web UI, silently making the web chat history unreachable. With per-task sessions, web and Telegram are separate, so a Telegram `/new` can no longer wipe web history.

## What changed

- **chatId session keys:** a web chat = an OpenClaw direct session keyed `agent:<id>:direct:<userId>:<chatId>`. The server builds the key from the **authenticated** userId + an opaque, validated client `chatId` (`chatIdSchema`); threaded through send + history (`client-router.ts`, `use-ws-runtime.ts`).
- **Authorization boundary:** a pure, fail-closed `classifyUserSessions` filters `sessions.list` to the requesting user's own chats only (web chats + their linked Telegram peer via `channel_links`); `GET /api/agents/[id]/chats` returns the list. Excludes cron/subagent/other-users/unlinked.
- **Un-unify Telegram (per-task):** stop emitting `session.identityLinks`, and **purge** any stale value on regenerate so upgrades actually take effect. Telegram becomes its own per-peer session, surfaced **read-only** in web (`/chat/[id]/telegram`, `GET /api/agents/[id]/telegram-chat`) with a "Continue on Telegram" affordance.
- **ChatSwitcher UI:** header dropdown listing the user's chats (optimistic current chat, refetch on open, titles from the first user message, origin badges, read-only marker), `New chat`, routing `/chat/[id]/[chatId]`.
- **Per-chat side-channels:** the compaction action and the composer's upload draft id are both scoped to the active chat, so they can't target/contaminate the default or a sibling chat.
- **Audit/usage safety:** fixed greedy `:direct:` key parsers (audit tool-use + usage-poller) so a chatId no longer mis-attributes rows.

## Behavior change (deployments)

Cross-channel session unification is removed. On upgrade, a deployment's existing unified web+Telegram history stays with the **web** chat; **new** Telegram activity creates a separate read-only Telegram chat. `identityLinks` is verified write-only-to-config (not used for auth), so Telegram allow-listing is unaffected.

## Review fixes (post-review pass)

A multi-reviewer pass found two real correctness bugs (and some polish); all fixed here, TDD:

- **`fix`: compaction targeted the wrong session.** On `/chat/<id>/<chatId>` the header's "Compact conversation" hardcoded the default per-user key, compacting the wrong chat. Now scoped to the active chat (validated chatId; per-key throttle).
- **`fix`: composer upload drafts weren't chat-scoped.** `useDraftId` keyed only on agentId, so two chats of one agent shared a server-side upload staging bucket — a file staged in chat A could appear as a pending attachment in chat B. The draft id is now per-chat.
- **`fix`: optimistic new-chat row showed a far-future time** ("in 292 million years" from the `MAX_SAFE_INTEGER` sort sentinel) → now "Not saved yet".
- **`refactor`: review polish** — Telegram channel badge a11y (distinct accessible name), null-content-part hardening in the transcript/history extraction, classifier self-normalizes the linked-peer set, dropped a dead `isAdmin` prop.
- **`test`: stronger E2E** — the footgun test now asserts the web session's OpenClaw `sessionId` is unchanged across a Telegram `/new` (a reset rotates the id), which is strictly stronger than re-sending; isolation gained a real per-row boundary assertion.

## Test plan

- Unit/RTL: full suite green (6181 passed). New coverage for the classifier (incl. adversarial fail-open/DoS cases), the list route (cross-user + cross-agent isolation), chatId dispatch, the parser fixes, the unification-reversal + upgrade-purge, ChatSwitcher, the Telegram view, the per-chat compaction + draft-id scoping, and the Telegram transcript mapper.
- **E2E (telegram mock stack):** cross-user isolation, **footgun-fixed** (a Telegram `/new` leaves the web chat's session intact), and the Telegram read-only view.
- `tsc`, `lint`, `build`, `test:db` (115 passed) green.

## Test-infra fix in this PR

The new `chats.spec.ts` runs before `telegram-flow.spec.ts` in the same telegram worker and injects Telegram messages, advancing OpenClaw's `getUpdates` offset. `telegram-flow`'s `beforeAll` then called `/control/reset`, which rolled the mock's `updateIdCounter` back to 100 while OpenClaw's long-poll held the higher offset — so the next injected update numbered below that offset was filtered out and the bot appeared silent ("No bot response"). Fixed at the source: the mock keeps `updateIdCounter` **monotonic** across resets (as real Telegram update_ids are), so `resetMockTelegram()` is safe regardless of suite order. (This is the offset/reset hazard previously noted as a flake — it's now fixed, not merely avoided.)

## Deliberate follow-ups (not in this PR)

- LLM-generated chat titles (currently first-user-message, with a date fallback).
- Native "list archived sessions" + clean historical backfill (v1 is forward-only).
- A viewport E2E guard for the header-overflow case.
