### PR TITLE
Harden release upgrade-notes flow + prep v0.6.0 notes

### DIFF
--- a/.claude/skills/cut-pinchy-release/SKILL.md
+++ b/.claude/skills/cut-pinchy-release/SKILL.md
@@ -42,6 +42,22 @@ A `gh release create` shortcut now fails the workflow **before any artifact exis
 - **Build-time guard** — `scripts/assert-package-version.mjs <tag>` runs before the image build; fails if `package.json` / `packages/web/package.json` don't match the tag.
 - **Runtime guard** — the `end-user-install-published` job smoke-tests `/api/version` against the tag on the _published_ image.
 
+## The upgrade-notes section auto-finalizes (since v0.6.0, the v0.5.8 incident)
+
+`upgrading.mdx` is cumulative: one `## Upgrading from v<prev> to <target>` section per release. During development the **current** section is written with the `%%PINCHY_VERSION%%` placeholder (heading and body), because the next version number isn't known yet. `docs/scripts/inject-version.sh` resolves that placeholder to the **build-time** version — so only the single newest section may carry it; every older section must already be **concrete** (`to vX.Y.Z`).
+
+The v0.5.8 release forgot to freeze its section: the heading stayed `from v0.5.7 to %%PINCHY_VERSION%%` and the body kept literal placeholders. That's a silent time-bomb — the v0.5.8 notes render fine for v0.5.8, then mis-render as the next version's the moment newer docs build. v0.6.0's release prep had to repair it.
+
+Two mechanisms now make this impossible:
+
+- **Auto-finalize in the release commit.** `pnpm release X.Y.Z` calls `finalizeUpgradeSection()` (`scripts/lib/release-logic.mjs`): it freezes the current `from v<prev> to %%PINCHY_VERSION%%` section — heading **and** body placeholders — to `vX.Y.Z`, and includes the edited `upgrading.mdx` in the `chore: release vX.Y.Z` commit. So the release script now touches **four** files, not three: `.env.example`, `package.json`, `packages/web/package.json`, **and** `docs/src/content/docs/guides/upgrading.mdx`.
+- **Freshness guard in CI.** `scripts/lib/upgrading-mdx-freshness.test.mjs` (via `assertNoStaleUpgradeSections`, run in `pnpm test:scripts`) fails any PR where a released version's section still carries `%%PINCHY_VERSION%%`, where two sections carry it, or where the placeholder section's `from` doesn't equal `package.json#version` (the latest released version). The preamble / "Standard upgrade" display placeholder is out of scope.
+
+**What this means for you when cutting a release:**
+
+- You only write the **new** `## Upgrading from v<prev> to %%PINCHY_VERSION%%` section (with `%%PINCHY_VERSION%%` placeholders is fine and preferred). The script freezes it for you at release time.
+- After a release lands, the **first** upgrade-affecting change should add a fresh `## Upgrading from v<just-released> to %%PINCHY_VERSION%%` section for the next cycle. If nobody does, the next release's gate fails loudly at the start (no `from v<just-released>` section) — which is the safety net, not a surprise.
+
 ## Before you run `pnpm release`
 
 Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** — that is the canonical, always-current list, so don't re-derive or copy it. The script and CI already enforce the mechanical gates (clean tree, on `main`, CI green, tag free, `upgrading.mdx` section present with both subsections, `pnpm audit --audit-level=high --prod`). The human judgment calls the script _can't_ enforce — verify each against CONTRIBUTING — include:
@@ -50,7 +66,7 @@ Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** �
 - `Dockerfile.openclaw` version bumped if OpenClaw was upgraded.
 - Model-resolver spot-check if models or templates changed.
 - **Ollama Cloud catalog** → run the `update-ollama-cloud-models` skill every release to refresh the catalog.
-- `docs/src/content/docs/guides/upgrading.mdx` has a new `## Upgrading from v<prev> to %%PINCHY_VERSION%%` section containing `### Breaking changes` (write "None." if none) and `### Upgrade notes`. The script aborts without it.
+- `docs/src/content/docs/guides/upgrading.mdx` has a new `## Upgrading from v<prev> to %%PINCHY_VERSION%%` section containing `### Breaking changes` (write "None." if none) and `### Upgrade notes`. The script aborts without it, **freezes the placeholder for you** at release time, and a CI guard rejects stale placeholders — see "The upgrade-notes section auto-finalizes" above.
 - Staging (`:next`) click-through + PWA install check.
 
 ## After the release

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -238,7 +238,7 @@ ssh root@<staging-host> "cd /opt/pinchy && docker compose pull && docker compose
 
 The `docker image prune -f` step removes the previous `:next` image that `pull` left dangling. Staging cycles `:next` many times per day, so without it the root volume fills up within a release window (see [#370](https://github.com/heypinchy/pinchy/issues/370)).
 
-Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.6.0.
+Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.7.0.
 
 **Use synthetic data in staging.** Do not restore prod dumps — unnecessary privacy surface.
 
@@ -329,7 +329,7 @@ Every push to `main` triggers the **Pre-release** workflow, which builds and pub
 ssh root@<staging-ip> "cd /opt/pinchy && docker compose pull && docker compose up -d && docker image prune -f"
 ```
 
-Run this manually before each pre-release click-through. Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.6.0.
+Run this manually before each pre-release click-through. Auto-deploy on every push to `main` is tracked in [issue #184](https://github.com/heypinchy/pinchy/issues/184) and lands in v0.7.0.
 
 ### Saving cost between releases
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -149,7 +149,53 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
-## Upgrading from v0.5.7 to %%PINCHY_VERSION%%
+## Upgrading from v0.5.8 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+#### Telegram and web no longer share one conversation
+
+Pinchy now uses **per-chat sessions**. Web and Telegram are separate OpenClaw sessions instead of being folded into one. Previously, an agent linked to a Telegram peer merged that peer's DMs into the user's web chat — which is why a Telegram `/new` could wipe web history. Starting with %%PINCHY_VERSION%%, each Telegram peer gets its own session and shows up as a read-only chat in the agent's Chats list.
+
+- **No action required.** The stale link is removed automatically the next time the OpenClaw config is regenerated (any settings save, or the first boot after the upgrade). Permissions are unaffected — the Chats list and Telegram allow-listing read channel links directly, not the removed setting.
+- **Where your history goes.** Your existing web conversation keeps everything under its current session, including Telegram messages that were previously merged in. Telegram starts a fresh, separate thread from the upgrade onward — so a Telegram chat that suddenly looks empty isn't lost; its past messages live in the web conversation.
+
+### Upgrade notes
+
+The standard flow applies:
+
+```bash
+cd /opt/pinchy
+sed -i 's/PINCHY_VERSION=v0.5.8/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+#### Multiple chats per agent
+
+Each agent now keeps a list of separate conversations per user. A **chat switcher** in the chat header lets you start a new chat, jump between existing ones, and see the current one at a glance. Chat titles are derived from the first message you send, so the list stays scannable. New chats show a "Not saved yet" marker until the first message lands.
+
+#### Telegram conversations are visible as read-only chats
+
+When an agent is connected to Telegram, each linked peer's conversation appears in the Chats list as a **read-only** transcript. You can read what was said over Telegram from the web UI; replying still happens in Telegram. This makes Telegram activity auditable from the same place as web chats.
+
+#### Sturdier streaming and reconnects
+
+Backgrounding a chat tab mid-reply, reloading during a stream, or reconnecting while a run is still in flight no longer corrupts the message list. The chat view keeps a stable in-flight assistant slot across reconnects and discards stale pre-history buffers, so resume, timeout, and full-reload transitions land cleanly. Nothing to configure.
+
+#### Usage analytics read retry
+
+Reading OpenClaw session files for usage analytics now retries transient `EACCES` errors instead of failing the request, so per-user/per-turn usage numbers stay reliable under concurrent writes.
+
+#### Dependencies
+
+- **openclaw-node 0.13.0** (was 0.12.1) and **odoo-node 0.3.0** (was 0.2.0) — client-library bumps bundled into the images; no operator action.
+- **hono override raised to ≥ 4.12.25** — a transitive web-framework dependency, bumped to clear a published advisory. Build/runtime dependency only.
+
+#### Database migrations
+
+None this release.
+
+## Upgrading from v0.5.7 to v0.5.8
 
 ### Breaking changes
 
@@ -161,13 +207,13 @@ The standard flow applies:
 
 ```bash
 cd /opt/pinchy
-sed -i 's/PINCHY_VERSION=v0.5.7/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+sed -i 's/PINCHY_VERSION=v0.5.7/PINCHY_VERSION=v0.5.8/' .env
 docker compose pull && docker compose up -d && docker image prune -f
 ```
 
 #### Automatic migration off the default database password
 
-The default `pinchy_dev` database password is public in our repository, so running on it was never real protection. Starting with %%PINCHY_VERSION%%, installations that never set `DB_PASSWORD` are migrated automatically on their first boot after the upgrade: Pinchy generates a strong password, persists it in the `pinchy-secrets` Docker volume (the same place the encryption key already lives), and applies it to PostgreSQL — no action required, no downtime beyond the normal upgrade restart.
+The default `pinchy_dev` database password is public in our repository, so running on it was never real protection. Starting with v0.5.8, installations that never set `DB_PASSWORD` are migrated automatically on their first boot after the upgrade: Pinchy generates a strong password, persists it in the `pinchy-secrets` Docker volume (the same place the encryption key already lives), and applies it to PostgreSQL — no action required, no downtime beyond the normal upgrade restart.
 
 - **If you set `DB_PASSWORD` in `.env`:** nothing changes. Your value always wins — and if you ever set it without updating PostgreSQL itself, Pinchy now applies it for you on the next boot instead of failing to connect.
 - **If you never set `DB_PASSWORD`:** the migration runs once, invisibly. Settings → Security shows the database password as _Auto-generated (Docker volume)_, and `GET /api/health` reports `"db_password": "generated"`.

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -196,3 +196,123 @@ export function extractUpgradeNotes(mdx, prevVersion, targetVersion) {
 
   return body.trim().replace(/%%PINCHY_VERSION%%/g, `v${targetVersion}`);
 }
+
+/**
+ * Freezes the in-progress upgrade-notes section at release time.
+ *
+ * During development the newest section is written as
+ * `## Upgrading from v<prev> to %%PINCHY_VERSION%%`, and its body may use
+ * `%%PINCHY_VERSION%%` too (e.g. "Starting with %%PINCHY_VERSION%% …"). Once the
+ * version is known, this replaces every `%%PINCHY_VERSION%%` occurrence WITHIN
+ * that one section (heading + body, sliced to the next `## ` heading) with
+ * `v<target>` and returns the rewritten mdx.
+ *
+ * Why it exists: the v0.5.8 release shipped without freezing its section, so the
+ * heading stayed `from v0.5.7 to %%PINCHY_VERSION%%` and the body kept literal
+ * placeholders. Because docs/scripts/inject-version.sh resolves
+ * `%%PINCHY_VERSION%%` to the *current* build version, those v0.5.8 notes would
+ * mis-render as the next release's. The release script calls this so the miss is
+ * structurally impossible going forward.
+ *
+ * Everything outside the matched section is left byte-for-byte: older,
+ * already-concrete entries, and the preamble / "Standard upgrade" section whose
+ * `%%PINCHY_VERSION%%` is an intentional build-time "latest version" display.
+ *
+ * @param {string} mdx
+ * @param {string} prevVersion - no leading 'v' (e.g. "0.5.8")
+ * @param {string} targetVersion - no leading 'v' (e.g. "0.6.0")
+ * @returns {string} mdx with the matched section frozen; unchanged if the
+ *   heading already uses a concrete target or no matching section exists.
+ */
+export function finalizeUpgradeSection(mdx, prevVersion, targetVersion) {
+  const headingPattern = new RegExp(
+    `^##\\s+Upgrading\\s+from\\s+v${escapeRegex(prevVersion)}\\s+to\\s+%%PINCHY_VERSION%%\\s*$`,
+    "m",
+  );
+  const match = headingPattern.exec(mdx);
+  if (!match) return mdx;
+
+  const sectionStart = match.index;
+  const afterHeading = sectionStart + match[0].length;
+  const remainder = mdx.slice(afterHeading);
+  const nextHeading = /^## /m.exec(remainder);
+  const sectionEnd = nextHeading
+    ? afterHeading + nextHeading.index
+    : mdx.length;
+
+  const before = mdx.slice(0, sectionStart);
+  const section = mdx.slice(sectionStart, sectionEnd);
+  const after = mdx.slice(sectionEnd);
+
+  return before + section.replace(/%%PINCHY_VERSION%%/g, `v${targetVersion}`) + after;
+}
+
+/**
+ * Asserts upgrading.mdx carries no stale `%%PINCHY_VERSION%%` in a released
+ * version's section. CI guard (run from scripts/lib/upgrading-mdx-freshness.test.mjs)
+ * against the exact drift that shipped in v0.5.8.
+ *
+ * Invariant enforced:
+ *  - At most ONE `## Upgrading from vX to %%PINCHY_VERSION%%` section may exist
+ *    (the current/in-progress one). Two means a prior release never froze.
+ *  - If one exists, its `from` version must equal the latest released version
+ *    (root package.json#version). A lagging `from` means the previous release
+ *    forgot to freeze its notes.
+ *  - A frozen (concrete-headed `to vY`) section must not keep `%%PINCHY_VERSION%%`
+ *    anywhere in its body.
+ *
+ * Scope: only `## Upgrading from vX to …` sections are inspected. The preamble
+ * and the "Standard upgrade" section legitimately render `%%PINCHY_VERSION%%` as
+ * a build-time "latest version" display, so they are out of scope.
+ *
+ * @param {string} mdx
+ * @param {string} latestReleasedVersion - no leading 'v' (e.g. "0.5.8")
+ * @throws {Error} on a stale, lagging, or duplicated placeholder section
+ */
+export function assertNoStaleUpgradeSections(mdx, latestReleasedVersion) {
+  const latest = parseAndValidateVersion(latestReleasedVersion);
+  const headingRe =
+    /^##\s+Upgrading\s+from\s+v(\d+\.\d+\.\d+)\s+to\s+(v\d+\.\d+\.\d+|%%PINCHY_VERSION%%)\s*$/gm;
+
+  const matches = [];
+  let m;
+  while ((m = headingRe.exec(mdx)) !== null) {
+    matches.push({ from: m[1], to: m[2], index: m.index, headingLen: m[0].length });
+  }
+
+  const placeholderSections = [];
+  for (const s of matches) {
+    const afterHeading = s.index + s.headingLen;
+    const remainder = mdx.slice(afterHeading);
+    const nextHeading = /^## /m.exec(remainder);
+    const body = remainder.slice(0, nextHeading ? nextHeading.index : remainder.length);
+
+    if (s.to === "%%PINCHY_VERSION%%") {
+      placeholderSections.push(s);
+    } else if (body.includes("%%PINCHY_VERSION%%")) {
+      throw new Error(
+        `Stale %%PINCHY_VERSION%% in the frozen "Upgrading from v${s.from} to v${s.to}" section body.\n` +
+          `Frozen sections must use the concrete version — replace %%PINCHY_VERSION%% with v${s.to} there.`,
+      );
+    }
+  }
+
+  if (placeholderSections.length > 1) {
+    const froms = placeholderSections.map((s) => `v${s.from}`).join(", ");
+    throw new Error(
+      `Multiple in-progress upgrade sections still use %%PINCHY_VERSION%% (${froms}).\n` +
+        `Only the current section (from v${latest}) may — freeze the older one to its released version.`,
+    );
+  }
+
+  if (placeholderSections.length === 1 && placeholderSections[0].from !== latest) {
+    const from = placeholderSections[0].from;
+    throw new Error(
+      `Stale upgrade-notes section: "Upgrading from v${from} to %%PINCHY_VERSION%%", ` +
+        `but the latest released version is v${latest}.\n` +
+        `A prior release forgot to freeze its notes. Change that heading to ` +
+        `"## Upgrading from v${from} to v${latest}" (and freeze its body placeholders), ` +
+        `then add a fresh "## Upgrading from v${latest} to %%PINCHY_VERSION%%" section.`,
+    );
+  }
+}

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -9,6 +9,8 @@ import {
   extractUpgradeNotes,
   bumpEnvExample,
   assertVersionMatchesTag,
+  finalizeUpgradeSection,
+  assertNoStaleUpgradeSections,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -395,4 +397,169 @@ BAZ=qux
   // Exactly one PINCHY_VERSION= line (not counting the commented one)
   const matches = output.match(/^PINCHY_VERSION=/gm) || [];
   assert.equal(matches.length, 1);
+});
+
+// finalizeUpgradeSection — freezes the in-progress section at release time so
+// the v0.5.8 "section left on %%PINCHY_VERSION%%" miss can't recur.
+
+test("finalizeUpgradeSection freezes the heading placeholder to v<target>", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
+    "Standard upgrade.",
+  ].join("\n");
+  const out = finalizeUpgradeSection(mdx, "0.5.8", "0.6.0");
+  assert.match(out, /^## Upgrading from v0\.5\.8 to v0\.6\.0$/m);
+  assert.doesNotMatch(out, /%%PINCHY_VERSION%%/);
+});
+
+test("finalizeUpgradeSection freezes body placeholders within the section too", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
+    "Starting with %%PINCHY_VERSION%% the thing changes.",
+    "",
+    "```bash",
+    "sed -i 's/PINCHY_VERSION=v0.5.8/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env",
+    "```",
+  ].join("\n");
+  const out = finalizeUpgradeSection(mdx, "0.5.8", "0.6.0");
+  assert.match(out, /Starting with v0\.6\.0 the thing changes\./);
+  assert.match(out, /PINCHY_VERSION=v0\.6\.0/);
+  assert.doesNotMatch(out, /%%PINCHY_VERSION%%/);
+});
+
+test("finalizeUpgradeSection leaves older concrete sections untouched", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "Current notes.",
+    "",
+    "## Upgrading from v0.5.7 to v0.5.8",
+    "",
+    "Older notes mentioning v0.5.8.",
+  ].join("\n");
+  const out = finalizeUpgradeSection(mdx, "0.5.8", "0.6.0");
+  assert.match(out, /## Upgrading from v0\.5\.7 to v0\.5\.8/);
+  assert.match(out, /Older notes mentioning v0\.5\.8\./);
+});
+
+test("finalizeUpgradeSection does not touch placeholders outside the matched section (preamble)", () => {
+  const mdx = [
+    "## Standard upgrade",
+    "",
+    "Bump to PINCHY_VERSION=%%PINCHY_VERSION%% (build-time display).",
+    "",
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "Current section.",
+  ].join("\n");
+  const out = finalizeUpgradeSection(mdx, "0.5.8", "0.6.0");
+  // The build-time display placeholder in "Standard upgrade" must survive.
+  assert.match(out, /PINCHY_VERSION=%%PINCHY_VERSION%% \(build-time display\)/);
+  // The version section heading is frozen.
+  assert.match(out, /## Upgrading from v0\.5\.8 to v0\.6\.0/);
+});
+
+test("finalizeUpgradeSection is a no-op when the heading already uses a concrete target", () => {
+  const mdx = "## Upgrading from v0.5.8 to v0.6.0\n\nAlready concrete.\n";
+  assert.equal(finalizeUpgradeSection(mdx, "0.5.8", "0.6.0"), mdx);
+});
+
+test("finalizeUpgradeSection is a no-op when no matching section exists", () => {
+  const mdx = "## Upgrading from v0.5.6 to v0.5.7\n\nUnrelated.\n";
+  assert.equal(finalizeUpgradeSection(mdx, "0.5.8", "0.6.0"), mdx);
+});
+
+// assertNoStaleUpgradeSections — CI guard against unfrozen / drifted sections.
+
+test("assertNoStaleUpgradeSections passes when the single placeholder section matches latest", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "Current.",
+    "",
+    "## Upgrading from v0.5.7 to v0.5.8",
+    "",
+    "Older.",
+  ].join("\n");
+  assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.5.8"));
+});
+
+test("assertNoStaleUpgradeSections passes with zero placeholder sections (post-release state)", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to v0.6.0",
+    "",
+    "Frozen current.",
+    "",
+    "## Upgrading from v0.5.7 to v0.5.8",
+    "",
+    "Older.",
+  ].join("\n");
+  assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.6.0"));
+});
+
+test("assertNoStaleUpgradeSections throws when the placeholder section's 'from' lags the latest tag (the v0.5.8 miss)", () => {
+  const mdx = [
+    "## Upgrading from v0.5.7 to %%PINCHY_VERSION%%",
+    "",
+    "These are really v0.5.8 notes that were never frozen.",
+  ].join("\n");
+  assert.throws(
+    () => assertNoStaleUpgradeSections(mdx, "0.5.8"),
+    /stale upgrade-notes section/i,
+  );
+});
+
+test("assertNoStaleUpgradeSections throws on two placeholder sections", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "Current.",
+    "",
+    "## Upgrading from v0.5.7 to %%PINCHY_VERSION%%",
+    "",
+    "Unfrozen older.",
+  ].join("\n");
+  assert.throws(
+    () => assertNoStaleUpgradeSections(mdx, "0.5.8"),
+    /multiple in-progress upgrade sections/i,
+  );
+});
+
+test("assertNoStaleUpgradeSections throws when a frozen (concrete) section body still has a placeholder", () => {
+  const mdx = [
+    "## Upgrading from v0.5.7 to v0.5.8",
+    "",
+    "Starting with %%PINCHY_VERSION%% something happens.",
+  ].join("\n");
+  assert.throws(
+    () => assertNoStaleUpgradeSections(mdx, "0.5.8"),
+    /stale %%PINCHY_VERSION%%/i,
+  );
+});
+
+test("assertNoStaleUpgradeSections ignores placeholders outside version sections (preamble / Standard upgrade)", () => {
+  const mdx = [
+    "## Standard upgrade",
+    "",
+    "Bump to PINCHY_VERSION=%%PINCHY_VERSION%% (build-time display).",
+    "",
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "Current.",
+  ].join("\n");
+  assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.5.8"));
 });

--- a/scripts/lib/upgrading-mdx-freshness.test.mjs
+++ b/scripts/lib/upgrading-mdx-freshness.test.mjs
@@ -1,0 +1,29 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import { assertNoStaleUpgradeSections } from "./release-logic.mjs";
+
+// CI guard: the real docs/src/content/docs/guides/upgrading.mdx must not carry a
+// stale `%%PINCHY_VERSION%%` left over from a release that forgot to freeze its
+// section (the v0.5.8 miss). The "latest released version" is root
+// package.json#version — on main it always equals the most recently released
+// tag because `pnpm release` bumps it in the release commit.
+//
+// Runs in `pnpm test:scripts` (wired into the CI `quality` job), so any future
+// drift fails a PR instead of silently rotting until the next docs build.
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..", "..");
+
+test("upgrading.mdx has no stale %%PINCHY_VERSION%% section vs package.json version", () => {
+  const pkgVersion = JSON.parse(
+    readFileSync(resolve(ROOT, "package.json"), "utf8"),
+  ).version;
+  const mdx = readFileSync(
+    resolve(ROOT, "docs/src/content/docs/guides/upgrading.mdx"),
+    "utf8",
+  );
+  assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, pkgVersion));
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -31,6 +31,7 @@ import {
   buildTagName,
   buildCommitMessage,
   assertUpgradingSectionExists,
+  finalizeUpgradeSection,
 } from "./lib/release-logic.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -173,10 +174,25 @@ writeFileSync(
 );
 log(`  ✔ .env.example → v${version}`);
 
+// Freeze the in-progress upgrade-notes section so the just-released version's
+// `%%PINCHY_VERSION%%` placeholders become concrete. Without this, the section
+// keeps the placeholder and the next release's docs build mis-renders these
+// notes as that version's (the v0.5.8 miss). No-op if the author already wrote
+// a concrete `to v${version}` heading.
+const finalizedMdx = finalizeUpgradeSection(upgradingMdx, prevVersion, version);
+if (finalizedMdx !== upgradingMdx) {
+  writeFileSync(upgradingMdxPath, finalizedMdx);
+  log(`  ✔ upgrading.mdx → froze v${prevVersion}→%%PINCHY_VERSION%% section to v${version}`);
+} else {
+  log(`  ✔ upgrading.mdx → section already concrete (nothing to freeze)`);
+}
+
 // ─── Commit, tag, push ────────────────────────────────────────────────────────
 
 log("\nCommitting...");
-exec("git add package.json packages/web/package.json .env.example");
+exec(
+  `git add package.json packages/web/package.json .env.example "${upgradingMdxPath}"`,
+);
 exec(`git commit -m "${buildCommitMessage(version)}"`);
 log(`  ✔ Committed`);
 


### PR DESCRIPTION
## Why

Cutting the next release surfaced two problems in the upgrade-notes flow:

1. **The v0.5.8 release never froze its upgrade-notes section.** The heading still read `## Upgrading from v0.5.7 to %%PINCHY_VERSION%%` and the body kept literal `%%PINCHY_VERSION%%` placeholders. `docs/scripts/inject-version.sh` resolves that placeholder to the **build-time** version, so those v0.5.8 notes would mis-render as the next release's the moment newer docs build. Silent doc rot.
2. **No section existed for the next release**, so `pnpm release` would have aborted at the upgrade-notes gate.

This PR fixes the rot, drafts the v0.6.0 notes, and hardens the process so the finalization miss can't recur. It's the prerequisite for cutting **v0.6.0**.

## What

**Process hardening (`fix(release)`)**
- `finalizeUpgradeSection()` freezes the current `from v<prev> to %%PINCHY_VERSION%%` section (heading **and** body placeholders) to the released version. `release.mjs` now writes it into the `chore: release` commit — so a release touches **four** files, not three (`+ upgrading.mdx`).
- `assertNoStaleUpgradeSections()` + `scripts/lib/upgrading-mdx-freshness.test.mjs` (runs in `pnpm test:scripts`, CI `quality` job) reject: a released section that still carries `%%PINCHY_VERSION%%`, two placeholder sections, or a placeholder section whose `from` lags `package.json#version`. Preamble/"Standard upgrade" display placeholders are out of scope.

**Docs (`docs(upgrading)`)**
- Froze the stale section to `## Upgrading from v0.5.7 to v0.5.8` (done with the new `finalizeUpgradeSection`, dog-fooded).
- Added `## Upgrading from v0.5.8 to %%PINCHY_VERSION%%` for v0.6.0. **Breaking change:** web and Telegram are now separate per-chat sessions (the #508 un-unification — fixes the Telegram `/new` wiping web history). No action required; stale `session.identityLinks` purge on regenerate.
- Deferred the CONTRIBUTING `#184 auto-deploy "lands in v0.6.0"` note to v0.7.0.

**Skill** — documented the auto-finalize behaviour + freshness guard in `cut-pinchy-release`.

## Verification
- `pnpm test:scripts` — 126 pass (incl. new finalize/guard unit tests + the real-file freshness guard).
- `pnpm -C packages/web exec vitest run` on the two docs tests that read `upgrading.mdx` — 10 pass.
- CI docs prettier check (`prettier --check "docs/src/**/*.{mdx,md}"`) — clean.
- Dry-run: the gate finds the v0.6.0 section, `finalizeUpgradeSection` freezes it at release time leaving only the preamble display placeholder, and the post-release file passes the freshness guard at v0.6.0.

## Follow-up (not in this PR)
- Cut v0.6.0 via `pnpm release 0.6.0` once this is on `main` and CI is green.
- Move the 3 open issues on the v0.6.0 milestone (#184, #183, #175) to a new v0.7.0 milestone.