### PR TITLE
fix(screenshots): clean marketing captures — hide banners, single-row usage stats, realistic seed

### DIFF
--- a/docs/src/content/docs/guides/usage-dashboard.mdx
+++ b/docs/src/content/docs/guides/usage-dashboard.mdx
@@ -37,7 +37,7 @@ Not every token an agent burns comes from a user message. Pinchy labels each usa
 - **System** — tokens spent on background work Pinchy triggers on the agent's behalf, such as onboarding interviews or scheduled jobs. No human sent these messages.
 - **Plugin** — tokens spent _inside_ a tool call. For example, when an agent asks the `pinchy-files` plugin to read a PDF, the plugin may call a vision model to extract text from scanned pages. Those vision calls are billed to the agent but show up under Plugin, not Chat.
 
-Cards for each bucket only appear when that bucket has non-zero usage, so a fresh instance only shows Chat until background or plugin work kicks in.
+The breakdown only appears once at least two sources have non-zero usage — a lone card (for example "Chat" before any background or plugin work kicks in) would just repeat the Total Tokens figure, so Pinchy hides it until the split actually tells you something. Each card then shows only the buckets that have usage.
 
 ### Filters
 

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -98,6 +98,15 @@ describe("EnterpriseBanner", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Trial: 1 day remaining.");
   });
 
+  it("exposes a stable data-testid so screenshot tooling can hide it", async () => {
+    // The screenshot capture pipeline hides this banner via a CSS selector on
+    // [data-testid="enterprise-banner"]. Keep the hook stable so a refactor
+    // can't silently re-expose the "Buy Pinchy Pro" trial promo in marketing
+    // screenshots.
+    await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 23 }));
+    expect(screen.getByRole("alert").getAttribute("data-testid")).toBe("enterprise-banner");
+  });
+
   it("shows the trial-expired banner with a pricing CTA and no re-trial button", async () => {
     const expiresAt = new Date("2026-06-01T00:00:00.000Z");
     await renderWithStatus(

--- a/packages/web/src/__tests__/components/enterprise-banner.test.tsx
+++ b/packages/web/src/__tests__/components/enterprise-banner.test.tsx
@@ -98,13 +98,20 @@ describe("EnterpriseBanner", () => {
     expect(screen.getByRole("alert")).toHaveTextContent("Trial: 1 day remaining.");
   });
 
-  it("exposes a stable data-testid so screenshot tooling can hide it", async () => {
-    // The screenshot capture pipeline hides this banner via a CSS selector on
-    // [data-testid="enterprise-banner"]. Keep the hook stable so a refactor
-    // can't silently re-expose the "Buy Pinchy Pro" trial promo in marketing
-    // screenshots.
-    await renderWithStatus(statusJson({ state: "trial", type: "trial", daysRemaining: 23 }));
-    expect(screen.getByRole("alert").getAttribute("data-testid")).toBe("enterprise-banner");
+  it("wraps all banner bars in a single stable data-testid hook", async () => {
+    // The screenshot capture pipeline hides this region via a CSS selector on
+    // [data-testid="enterprise-banner"]. The hook must stay a SINGLE element
+    // even when several bars stack (trial + seat pressure), so it's a reliable,
+    // unambiguous handle (getByTestId) and a refactor can't silently re-expose
+    // the "Buy Pinchy Pro" promo in marketing screenshots.
+    await renderWithStatus(
+      statusJson({ state: "trial", type: "trial", daysRemaining: 23, seatsUsed: 11, maxUsers: 10 })
+    );
+    // Two bars render (trial + seat pressure)…
+    expect(screen.getAllByRole("alert").length).toBeGreaterThanOrEqual(2);
+    // …but exactly one test-id wrapper contains them.
+    const hook = screen.getByTestId("enterprise-banner");
+    expect(hook).toContainElement(screen.getByText("Trial: 23 days remaining."));
   });
 
   it("shows the trial-expired banner with a pricing CTA and no re-trial button", async () => {

--- a/packages/web/src/__tests__/components/insecure-banner.test.tsx
+++ b/packages/web/src/__tests__/components/insecure-banner.test.tsx
@@ -45,6 +45,16 @@ describe("InsecureBanner", () => {
     expect(banner.className).toContain("text-amber-950");
   });
 
+  it("exposes a stable data-testid so screenshot tooling can hide it", async () => {
+    // The screenshot capture pipeline hides this banner via a CSS selector on
+    // [data-testid="insecure-banner"]. Keep the hook stable so a refactor can't
+    // silently re-expose the "not secured" warning in marketing screenshots.
+    vi.mocked(isInsecureMode).mockResolvedValue(true);
+    const Component = await InsecureBanner({ isAdmin: true });
+    render(Component);
+    expect(screen.getByRole("alert").getAttribute("data-testid")).toBe("insecure-banner");
+  });
+
   it("should show 'contact administrator' for non-admins", async () => {
     vi.mocked(isInsecureMode).mockResolvedValue(true);
     const Component = await InsecureBanner({ isAdmin: false });

--- a/packages/web/src/__tests__/components/usage-dashboard.test.tsx
+++ b/packages/web/src/__tests__/components/usage-dashboard.test.tsx
@@ -290,6 +290,58 @@ describe("UsageDashboard", () => {
       expect(screen.queryByText("System Tokens")).not.toBeInTheDocument();
       expect(screen.queryByText("Plugin Tokens")).not.toBeInTheDocument();
     });
+
+    it("suppresses the source breakdown when only one source has tokens", async () => {
+      // Best practice (Anthropic/OpenAI usage dashboards): a lone source card
+      // just duplicates "Total Tokens" — e.g. Chat == Total when system/plugin
+      // are zero. The per-source breakdown only earns its space once it
+      // distinguishes >= 2 sources.
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: { inputTokens: "500000", outputTokens: "700000", cost: "3.50" },
+          system: { inputTokens: "0", outputTokens: "0", cost: "0" },
+          plugin: { inputTokens: "0", outputTokens: "0", cost: "0" },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Total Tokens")).toBeInTheDocument();
+      });
+
+      expect(screen.queryByText("Chat Tokens")).not.toBeInTheDocument();
+      expect(screen.queryByText("System Tokens")).not.toBeInTheDocument();
+      expect(screen.queryByText("Plugin Tokens")).not.toBeInTheDocument();
+    });
+  });
+
+  describe("stat card layout", () => {
+    it("keeps every visible stat card in a single row (columns track card count)", async () => {
+      // Regression guard for the screenshot/desktop layout: a hardcoded
+      // grid-cols-3 wrapped a 4th+ card onto a second row, pushing the chart
+      // off-screen. The grid must size its column count to the number of
+      // visible cards so they always sit in one row.
+      mockBothEndpoints({
+        agents: mockSummaryResponse.agents,
+        totals: {
+          chat: { inputTokens: "500000", outputTokens: "700000", cost: "3.50" },
+          system: { inputTokens: "50000", outputTokens: "10000", cost: "0.40" },
+          plugin: { inputTokens: "100000", outputTokens: "20000", cost: "0.92" },
+        },
+      });
+      render(<UsageDashboard />);
+
+      await waitFor(() => {
+        expect(screen.getByText("Chat Tokens")).toBeInTheDocument();
+      });
+
+      // Total Tokens, Estimated Cost, Chat, System, Plugin = 5 cards
+      // (this mock carries no cache tokens).
+      const grid = screen.getByTestId("usage-stat-grid");
+      expect(grid.children).toHaveLength(5);
+      expect(grid.style.getPropertyValue("--stat-cols")).toBe("5");
+    });
   });
 
   it("should display agent table with agent names and formatted values", async () => {

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -137,11 +137,7 @@ function BannerBar({ banner, onDismiss }: { banner: Banner; onDismiss: (key: str
   const toneClass =
     banner.tone === "warn" ? "bg-amber-500 text-white" : "bg-muted text-foreground border-b";
   return (
-    <div
-      role="alert"
-      data-testid="enterprise-banner"
-      className={`relative px-8 py-2 text-sm text-center ${toneClass}`}
-    >
+    <div role="alert" className={`relative px-8 py-2 text-sm text-center ${toneClass}`}>
       {banner.message}{" "}
       {banner.links.map((link, i) => (
         <span key={link.href}>
@@ -215,11 +211,14 @@ export function EnterpriseBanner({ isAdmin }: { isAdmin: boolean }) {
 
   if (banners.length === 0) return null;
 
+  // Single, stable hook for the screenshot pipeline to hide the whole region
+  // (it can hold several stacked bars). The plain wrapper doesn't affect the
+  // full-width block layout of the bars.
   return (
-    <>
+    <div data-testid="enterprise-banner">
       {banners.map((banner) => (
         <BannerBar key={banner.key} banner={banner} onDismiss={dismiss} />
       ))}
-    </>
+    </div>
   );
 }

--- a/packages/web/src/components/enterprise-banner.tsx
+++ b/packages/web/src/components/enterprise-banner.tsx
@@ -137,7 +137,11 @@ function BannerBar({ banner, onDismiss }: { banner: Banner; onDismiss: (key: str
   const toneClass =
     banner.tone === "warn" ? "bg-amber-500 text-white" : "bg-muted text-foreground border-b";
   return (
-    <div role="alert" className={`relative px-8 py-2 text-sm text-center ${toneClass}`}>
+    <div
+      role="alert"
+      data-testid="enterprise-banner"
+      className={`relative px-8 py-2 text-sm text-center ${toneClass}`}
+    >
       {banner.message}{" "}
       {banner.links.map((link, i) => (
         <span key={link.href}>

--- a/packages/web/src/components/insecure-banner.tsx
+++ b/packages/web/src/components/insecure-banner.tsx
@@ -9,6 +9,7 @@ export async function InsecureBanner({ isAdmin }: { isAdmin: boolean }) {
   return (
     <div
       role="alert"
+      data-testid="insecure-banner"
       className="flex items-center justify-center gap-2 bg-amber-500 px-4 py-2 text-sm text-amber-950"
     >
       <ShieldAlert className="size-4 shrink-0" />

--- a/packages/web/src/components/usage-dashboard.tsx
+++ b/packages/web/src/components/usage-dashboard.tsx
@@ -312,6 +312,40 @@ export function UsageDashboard({
 
   const hasData = (summary?.agents?.length ?? 0) > 0;
 
+  // Headline KPI cards plus an optional per-source breakdown. Following the
+  // pattern established by the Anthropic/OpenAI usage dashboards, the breakdown
+  // only appears once it distinguishes >= 2 sources — a lone source card would
+  // just duplicate "Total Tokens" (e.g. Chat == Total when system/plugin are
+  // zero). The grid then lays every visible card out in a single row
+  // (--stat-cols) so the chart below is never pushed off-screen.
+  const sourceCards = [
+    { label: "Chat Tokens", bucket: chatBucket },
+    { label: "System Tokens", bucket: systemBucket },
+    { label: "Plugin Tokens", bucket: pluginBucket },
+  ].filter((s) => s.bucket.tokens > 0);
+  const showBreakdown = Boolean(summary?.totals) && sourceCards.length >= 2;
+
+  const statCards: { label: string; value: React.ReactNode; subtitle?: React.ReactNode }[] = [
+    {
+      label: "Total Tokens",
+      value: formatTokens(totalTokens),
+      subtitle: <FormattedCost value={totalCost} />,
+    },
+    { label: "Estimated Cost", value: <FormattedCost value={totalCost} /> },
+  ];
+  if (totalCacheTokens > 0) {
+    statCards.push({ label: "Cache Tokens", value: formatTokens(totalCacheTokens) });
+  }
+  if (showBreakdown) {
+    for (const { label, bucket } of sourceCards) {
+      statCards.push({
+        label,
+        value: formatTokens(bucket.tokens),
+        subtitle: <FormattedCost value={bucket.cost} />,
+      });
+    }
+  }
+
   function handleRetry() {
     setError(null);
     setSummary(null);
@@ -413,37 +447,14 @@ export function UsageDashboard({
         <p>No usage data available.</p>
       ) : (
         <>
-          <div className="grid grid-cols-3 gap-2 sm:gap-3">
-            <StatCard
-              label="Total Tokens"
-              value={formatTokens(totalTokens)}
-              subtitle={<FormattedCost value={totalCost} />}
-            />
-            <StatCard label="Estimated Cost" value={<FormattedCost value={totalCost} />} />
-            {totalCacheTokens > 0 && (
-              <StatCard label="Cache Tokens" value={formatTokens(totalCacheTokens)} />
-            )}
-            {summary?.totals && chatBucket.tokens > 0 && (
-              <StatCard
-                label="Chat Tokens"
-                value={formatTokens(chatBucket.tokens)}
-                subtitle={<FormattedCost value={chatBucket.cost} />}
-              />
-            )}
-            {summary?.totals && systemBucket.tokens > 0 && (
-              <StatCard
-                label="System Tokens"
-                value={formatTokens(systemBucket.tokens)}
-                subtitle={<FormattedCost value={systemBucket.cost} />}
-              />
-            )}
-            {summary?.totals && pluginBucket.tokens > 0 && (
-              <StatCard
-                label="Plugin Tokens"
-                value={formatTokens(pluginBucket.tokens)}
-                subtitle={<FormattedCost value={pluginBucket.cost} />}
-              />
-            )}
+          <div
+            data-testid="usage-stat-grid"
+            className="grid grid-cols-3 gap-2 sm:gap-3 sm:[grid-template-columns:repeat(var(--stat-cols),minmax(0,1fr))]"
+            style={{ "--stat-cols": statCards.length } as React.CSSProperties}
+          >
+            {statCards.map((c) => (
+              <StatCard key={c.label} label={c.label} value={c.value} subtitle={c.subtitle} />
+            ))}
           </div>
 
           <Card>

--- a/screenshots/README.md
+++ b/screenshots/README.md
@@ -36,6 +36,38 @@ npx playwright test screenshots/capture.ts
 | `user-management.png` | User list & roles |
 | `groups.png` | Group-based access control |
 
+### Full window vs. focused variants
+
+Every capture is the **full 1280×720 app window** — the docs
+(`docs.heypinchy.com`) use these so readers see *where* a feature lives.
+
+Marketing pages shrink images hard (especially on 375px mobile), where a full
+window becomes an unreadable slice. For the screens that appear large on the
+marketing site we additionally capture a **focused element screenshot** of the
+relevant panel, written to `output/focus/<name>.png` (same base name, `focus/`
+subdir). These are **additive** — the full-window files are never replaced.
+
+| Focused file | Element captured |
+|------|-------------|
+| `focus/agent-settings-permissions.png` | Content region (`<main>`, no sidebar/banner) |
+| `focus/audit-trail.png` | Content region (`<main>`, no sidebar/banner) |
+| `focus/usage-dashboard.png` | Content region (`<main>`, no sidebar/banner) |
+| `focus/groups.png` | Content region (`<main>`, no sidebar/banner) |
+| `focus/user-management.png` | Content region (`<main>`, no sidebar/banner) |
+
+The selector is the only tuning knob — pass it as the 3rd arg to
+`screenshot(page, name, selector)`. All five use `main` (the shadcn
+`SidebarInset`): a fixed, viewport-sized box that drops the sidebar and the
+already-hidden banners, so focused shots are about legibility, not banner
+removal. Tighter per-panel selectors (e.g. just a tab panel's allow-list) are
+possible but `main` is what we ship — element-screenshotting a tall panel
+inside the scroll container hit Playwright stability timeouts, whereas `main`'s
+fixed box is reliable.
+
+Both variants ship in the `pinchy-screenshots` artifact (the upload is
+recursive over `screenshots/output/`), so the website's `pull-screenshots.yml`
+receives the `focus/` subdir automatically.
+
 ## Environment variables
 
 | Variable | Default | Description |

--- a/screenshots/capture.ts
+++ b/screenshots/capture.ts
@@ -43,6 +43,20 @@ async function login(page: Page) {
 async function screenshot(page: Page, name: string) {
   const dir = path.dirname(path.join(OUTPUT_DIR, name));
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
+  // Hide the warning/promo banners so marketing screenshots show the app the
+  // way a domain-locked, licensed production instance does: the amber
+  // "instance is not secured" warning and the "Buy Pinchy Pro" trial banner.
+  // We hide rather than configure these away: locking a real domain would
+  // silence the warning but also turns on the host-check (403 for localhost)
+  // and Secure cookies (rejected over HTTP), breaking the capture run; the
+  // trial banner is inherent to the trial license CI mints for screenshots.
+  // Injected here, after the page has loaded (head exists) — an addInitScript
+  // runs before document.documentElement exists and silently throws, leaving
+  // the banners visible. There is no CSP to block the injected <style>.
+  await page.addStyleTag({
+    content:
+      '[data-testid="insecure-banner"],[data-testid="enterprise-banner"]{display:none !important}',
+  });
   await page.screenshot({ path: `${OUTPUT_DIR}/${name}`, fullPage: false });
 }
 
@@ -58,17 +72,6 @@ test.describe("Feature screenshots", () => {
   test.use({ viewport: VIEWPORT, deviceScaleFactor: 2 });
 
   test.beforeEach(async ({ page }) => {
-    // Hide the "instance is not secured" banner. Locking a domain would silence
-    // it for real, but that also flips on the host-check (403 for localhost) and
-    // Secure cookies (rejected over HTTP), which breaks the capture run. Hiding
-    // the banner in the tooling yields the same view a properly domain-locked
-    // production instance shows, without that fallout. Runs before every
-    // navigation; documentElement always exists this early.
-    await page.addInitScript(() => {
-      const style = document.createElement("style");
-      style.textContent = '[data-testid="insecure-banner"]{display:none !important}';
-      document.documentElement.appendChild(style);
-    });
     await login(page);
   });
 

--- a/screenshots/capture.ts
+++ b/screenshots/capture.ts
@@ -58,6 +58,17 @@ test.describe("Feature screenshots", () => {
   test.use({ viewport: VIEWPORT, deviceScaleFactor: 2 });
 
   test.beforeEach(async ({ page }) => {
+    // Hide the "instance is not secured" banner. Locking a domain would silence
+    // it for real, but that also flips on the host-check (403 for localhost) and
+    // Secure cookies (rejected over HTTP), which breaks the capture run. Hiding
+    // the banner in the tooling yields the same view a properly domain-locked
+    // production instance shows, without that fallout. Runs before every
+    // navigation; documentElement always exists this early.
+    await page.addInitScript(() => {
+      const style = document.createElement("style");
+      style.textContent = '[data-testid="insecure-banner"]{display:none !important}';
+      document.documentElement.appendChild(style);
+    });
     await login(page);
   });
 

--- a/screenshots/capture.ts
+++ b/screenshots/capture.ts
@@ -40,7 +40,17 @@ async function login(page: Page) {
   await page.context().storageState({ path: STORAGE_STATE });
 }
 
-async function screenshot(page: Page, name: string) {
+/**
+ * Capture a screenshot to OUTPUT_DIR/<name>.
+ *
+ * Without `target`, captures the full 1280x720 window (the docs consumer wants
+ * this — readers see where a feature lives in the app). With a `target`
+ * selector, captures just that element: a focused, legible panel for the
+ * marketing site, which shrinks images hard (especially on 375px mobile). Both
+ * variants are produced additively from the same loaded page — never replace
+ * the full shots, other consumers depend on them.
+ */
+async function screenshot(page: Page, name: string, target?: string) {
   const dir = path.dirname(path.join(OUTPUT_DIR, name));
   if (!fs.existsSync(dir)) fs.mkdirSync(dir, { recursive: true });
   // Hide the warning/promo banners so marketing screenshots show the app the
@@ -57,7 +67,15 @@ async function screenshot(page: Page, name: string) {
     content:
       '[data-testid="insecure-banner"],[data-testid="enterprise-banner"]{display:none !important}',
   });
-  await page.screenshot({ path: `${OUTPUT_DIR}/${name}`, fullPage: false });
+  const out = `${OUTPUT_DIR}/${name}`;
+  if (target) {
+    // .first() guards against nested matches; animations:"disabled" freezes
+    // CSS/Web animations so the element's box settles (element screenshots
+    // wait for a stable bounding box, unlike page.screenshot).
+    await page.locator(target).first().screenshot({ path: out, animations: "disabled" });
+  } else {
+    await page.screenshot({ path: out, fullPage: false });
+  }
 }
 
 // Get agent ID from API
@@ -79,6 +97,8 @@ test.describe("Feature screenshots", () => {
     await page.goto(`${BASE_URL}/audit`);
     await page.waitForTimeout(2000);
     await screenshot(page, "audit-trail.png");
+    // Focused: the content region (<main>) drops the sidebar + banners.
+    await screenshot(page, "focus/audit-trail.png", "main");
   });
 
   test("02 chat interface", async ({ page }) => {
@@ -150,6 +170,8 @@ test.describe("Feature screenshots", () => {
       }
     }
     await screenshot(page, "agent-settings-permissions.png");
+    // Focused: the content region (<main>) drops the sidebar + banners.
+    await screenshot(page, "focus/agent-settings-permissions.png", "main");
   });
 
   test("agent settings - web search", async ({ page }) => {
@@ -207,6 +229,8 @@ test.describe("Feature screenshots", () => {
     }
     await page.waitForTimeout(1500);
     await screenshot(page, "user-management.png");
+    // Focused: the content region (<main>) drops the sidebar + banners.
+    await screenshot(page, "focus/user-management.png", "main");
   });
 
   test("groups", async ({ page }) => {
@@ -220,12 +244,16 @@ test.describe("Feature screenshots", () => {
     }
     await page.waitForTimeout(1500);
     await screenshot(page, "groups.png");
+    // Focused: the content region (<main>) drops the sidebar + banners.
+    await screenshot(page, "focus/groups.png", "main");
   });
 
   test("usage dashboard", async ({ page }) => {
     await page.goto(`${BASE_URL}/usage`);
     await page.waitForTimeout(2500);
     await screenshot(page, "usage-dashboard.png");
+    // Focused: the content region (<main>) drops the sidebar + banners.
+    await screenshot(page, "focus/usage-dashboard.png", "main");
   });
 
   test("agent settings - telegram", async ({ page }) => {

--- a/screenshots/seed.sh
+++ b/screenshots/seed.sh
@@ -465,7 +465,13 @@ BEGIN
       ) VALUES (
         day_date + (floor(random() * 43200) || ' seconds')::INTERVAL,
         user_ids[u_idx], agent_ids[a_idx], agent_names[a_idx],
-        'agent:' || agent_ids[a_idx] || ':user-' || lower(user_ids[u_idx]),
+        -- Use the real per-user chat session key (agent:<id>:direct:<userId>).
+        -- The summary API classifies usage into chat/system/plugin buckets from
+        -- this key (agent:%:direct:% => chat). The old ':user-' format matched
+        -- none of those patterns, so every seeded row fell through to "system",
+        -- making the dashboard show a redundant "System Tokens == Total Tokens"
+        -- card. With the correct key the demo data reads as genuine chat usage.
+        'agent:' || agent_ids[a_idx] || ':direct:' || user_ids[u_idx],
         agent_models[a_idx], inp, outp,
         floor(random() * inp * 0.3)::INTEGER,
         floor(random() * inp * 0.1)::INTEGER,


### PR DESCRIPTION
## Why

Marketing screenshots had three problems, all visible in the captured `usage-dashboard.png`:

1. The amber **"Your Pinchy instance is not secured"** banner showed on every screenshot — alarming and pointless for marketing.
2. The usage dashboard's stat cards were hardcoded to `grid-cols-3`, so a 4th card wrapped to a second row and **pushed the chart off-screen** at the 1280×720 capture viewport.
3. The dashboard showed a redundant **"System Tokens" card equal to "Total Tokens"** — the seed wrote session keys the summary API couldn't classify as chat, so all usage fell through to the `system` bucket.

A capture run also surfaced a fourth issue: the **"Buy Pinchy Pro" trial banner** (inherent to the trial license CI mints), which the local instance never shows.

## What

- **Hide both banners in the capture tooling** (`screenshots/capture.ts`). Locking a real domain would silence the warning but also turns on the host-check (403 for localhost) and Secure cookies (rejected over HTTP), breaking the capture run — so we hide instead, via an `addStyleTag` injected from the `screenshot()` helper *after* the page loads. (`addInitScript` runs before `document.documentElement` exists and throws.) `InsecureBanner` and `EnterpriseBanner` each get a stable `data-testid` hook, guarded by a unit test.
- **Single-row stat grid** (`usage-dashboard.tsx`): the grid's column count now tracks the number of visible cards, so 3–6 cards always sit in one row from `sm` up and never push the chart down.
- **Suppress single-source breakdown**: following the Anthropic/OpenAI usage-dashboard convention, the per-source breakdown only appears once it distinguishes ≥2 sources — a lone "Chat"/"System" card just duplicates "Total Tokens".
- **Fix the seed** (`screenshots/seed.sh`): use the real `agent:<id>:direct:<userId>` session key so demo usage classifies as genuine chat instead of falling through to `system`.
- **Docs** updated to describe the ≥2-source rule.

## Verification

- TDD: failing tests first, then implementation (single-source suppression, stat-grid column count, both banner `data-testid` hooks).
- Full web unit suite green (6073 passed), ESLint + `tsc` clean.
- Tailwind compile checked: the dynamic-column arbitrary class generates correctly and overrides `grid-cols-3` from 640px up.
- **Real CI capture run confirmed visually**: no banners, 3 stat cards in one row, full "Daily Token Usage" chart.

Screenshots are regenerated and deployed by the `Screenshots` workflow (no PNGs committed here).