### PR TITLE
feat(marketplace): DigitalOcean + CapRover 1-Click listings + version sync

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -13,6 +13,7 @@ Status: early development. The core is working: setup wizard, authentication, pr
 - `config/` - OpenClaw config support, startup scripts, mock services for integration/E2E tests.
 - `docs/` - Astro Starlight documentation. It is standalone and has its own `package.json` and lockfile.
 - `sample-data/` - Sample knowledge-base data mounted into Docker at `/data/`.
+- `marketplace/` - 1-Click deploy templates (DigitalOcean Packer image, CapRover one-click). Version-pinned to the release and guarded by `scripts/lib/marketplace-version.test.mjs` + `marketplace-lint.test.mjs`.
 - `docker-compose*.yml` - Development, production, integration, and E2E stack definitions.
 - `PERSONALITY.md` - Brand voice guide. Read before writing user-facing UI or docs copy.
 

--- a/marketplace/caprover/README.md
+++ b/marketplace/caprover/README.md
@@ -26,11 +26,14 @@ silent.
    the real tmpfs.
 
 2. **CapRover ignores `depends_on`/healthcheck ordering.** Production gates
-   start order (db healthy -> pinchy -> openclaw). CapRover starts services
-   independently, so first boot relies on `restart: unless-stopped` to converge:
-   pinchy/openclaw restart until the database (and each other) are reachable.
-   First boot is therefore a little noisier, but self-heals. **This is the main
-   thing to confirm on the test deploy below.**
+   start order (db healthy -> pinchy -> openclaw); CapRover starts services
+   independently. Pinchy is built to tolerate this (see `packages/web/server.ts`):
+   it starts its HTTP server first, connects to PostgreSQL lazily (per request),
+   and reconnects to OpenClaw on a 1s interval with unlimited retries — so it
+   converges on its own as the database and OpenClaw come up, rather than
+   crash-looping on first boot. `restart: unless-stopped` is only a backstop for
+   the rare case where an already-set-up instance restarts before its database
+   is ready. Expect a few seconds of connection-retry logs on first boot.
 
 `extra_hosts` (the `ollama.local` host-gateway mapping for a local Ollama) is
 also unsupported by CapRover's parser and is omitted — use a cloud model
@@ -47,8 +50,8 @@ CapRover:
 2. In the CapRover dashboard: **Apps -> One-Click Apps/Databases ->
    `>> TEMPLATE <<`**, paste the contents of `pinchy.yml`, and deploy.
 3. Verify:
-   - all three services come up (allow a couple of restart cycles — see
-     deviation 2),
+   - all three services come up (Pinchy may log DB/OpenClaw connection retries
+     for a few seconds while they start — see deviation 2),
    - the web app reaches the setup wizard at its URL (enable HTTPS first),
    - the three shared volumes work (pinchy and openclaw both read/write
      `oc-config`, `oc-secrets`, `workspaces`, `oc-extensions`),

--- a/marketplace/caprover/README.md
+++ b/marketplace/caprover/README.md
@@ -1,0 +1,79 @@
+# Pinchy on CapRover
+
+A [CapRover](https://caprover.com) One-Click App template (`captainVersion: 4`)
+that deploys Pinchy's three-service stack (pinchy + openclaw + postgres) onto a
+CapRover server. The web UI (port 7777) is exposed through CapRover's reverse
+proxy; OpenClaw and PostgreSQL stay on the internal Swarm network.
+
+The pinned version lives in `pinchy.yml` (the `$$cap_pinchy_version` variable)
+and is kept in lockstep with `.env.example` by `pnpm release` and the
+`scripts/lib/marketplace-version.test.mjs` drift guard.
+
+## Two deviations CapRover forces (and how we handle them)
+
+CapRover's one-click schema can't express two things Pinchy's production compose
+relies on. Both are documented here so the security trade-off is explicit, not
+silent.
+
+1. **`openclaw-secrets` can't be a tmpfs.** In production it's a RAM-only volume
+   (cleared on restart, rebuilt from the encrypted database). CapRover only
+   supports regular named volumes, so here it's a shared on-disk volume
+   (`$$cap_appname-oc-secrets`). The bounded impact: a runtime SecretRef *cache*
+   lands on the host disk instead of RAM. It is **not** the source of truth —
+   the actual provider keys stay AES-256-GCM-encrypted in PostgreSQL and the
+   cache is rebuilt from them. For deployments where runtime secrets must never
+   touch disk, use the DigitalOcean image or the raw docker-compose, which keep
+   the real tmpfs.
+
+2. **CapRover ignores `depends_on`/healthcheck ordering.** Production gates
+   start order (db healthy -> pinchy -> openclaw). CapRover starts services
+   independently, so first boot relies on `restart: unless-stopped` to converge:
+   pinchy/openclaw restart until the database (and each other) are reachable.
+   First boot is therefore a little noisier, but self-heals. **This is the main
+   thing to confirm on the test deploy below.**
+
+`extra_hosts` (the `ollama.local` host-gateway mapping for a local Ollama) is
+also unsupported by CapRover's parser and is omitted — use a cloud model
+provider or run Ollama as its own CapRover app.
+
+## Test before submitting (needs your own CapRover server)
+
+CapRover is self-hosted, so there's no sandbox — you need a server running
+CapRover:
+
+1. Provision a small x86 VPS (>= 2 GB RAM; Pinchy + OpenClaw + Postgres want
+   headroom) and [install CapRover](https://caprover.com/docs/get-started.html)
+   (opens ports 80/443/3000 and wants a wildcard DNS record for HTTPS).
+2. In the CapRover dashboard: **Apps -> One-Click Apps/Databases ->
+   `>> TEMPLATE <<`**, paste the contents of `pinchy.yml`, and deploy.
+3. Verify:
+   - all three services come up (allow a couple of restart cycles — see
+     deviation 2),
+   - the web app reaches the setup wizard at its URL (enable HTTPS first),
+   - the three shared volumes work (pinchy and openclaw both read/write
+     `oc-config`, `oc-secrets`, `workspaces`, `oc-extensions`),
+   - a chat round-trip works end to end.
+
+## Submit
+
+Open a PR against [`caprover/one-click-apps`](https://github.com/caprover/one-click-apps):
+
+- `public/v4/apps/pinchy.yml` — this template.
+- `public/v4/logos/pinchy.png` — the Pinchy logo
+  (`packages/web/public/icon-512.png` in this repo).
+
+Keep `isOfficial: false` (Pinchy is a third-party image). A CapRover maintainer
+reviews and merges; there's no automatic publish.
+
+## Updating for a new release
+
+`pnpm release X.Y.Z` bumps `$$cap_pinchy_version` in `pinchy.yml` automatically.
+Open a follow-up PR to `caprover/one-click-apps` with the new template. The
+pinned version only sets the **starting** version for new installs; existing
+deployments update by changing the version variable and redeploying.
+
+## License
+
+Pinchy is AGPL-3.0. The app runs entirely on the user's own CapRover server —
+CapRover gets no license grant over the software — so listing it is plain FOSS
+distribution, compatible with AGPL.

--- a/marketplace/caprover/pinchy.yml
+++ b/marketplace/caprover/pinchy.yml
@@ -27,6 +27,10 @@ services:
     environment:
       DATABASE_URL: postgresql://pinchy:$$cap_db_password@srv-captain--$$cap_appname-db:5432/pinchy
       OPENCLAW_WS_URL: ws://srv-captain--$$cap_appname-openclaw:18789
+      # OpenClaw plugins call back to Pinchy's API at this URL. It defaults to
+      # http://pinchy:7777 (the compose service name), which doesn't resolve on
+      # CapRover — services are reached as srv-captain--<appname>-<service>.
+      PINCHY_INTERNAL_URL: http://srv-captain--$$cap_appname-pinchy:7777
       BETTER_AUTH_SECRET: $$cap_auth_secret
       ENCRYPTION_KEY: $$cap_encryption_key
       PINCHY_ENTERPRISE_KEY: $$cap_enterprise_key

--- a/marketplace/caprover/pinchy.yml
+++ b/marketplace/caprover/pinchy.yml
@@ -1,0 +1,95 @@
+captainVersion: 4
+
+# Pinchy on CapRover — three services (pinchy + openclaw + postgres), wired to
+# match Pinchy's production docker-compose as closely as CapRover's one-click
+# schema allows. See README.md for two deliberate deviations CapRover forces:
+#   1. openclaw-secrets cannot be a tmpfs, so it is a regular shared volume on
+#      disk (a runtime cache rebuilt from the encrypted DB — bounded regression).
+#   2. CapRover ignores healthcheck/depends_on ordering, so the services rely on
+#      restart-on-failure to converge on first boot.
+
+services:
+  $$cap_appname-db:
+    image: postgres:17
+    restart: unless-stopped
+    volumes:
+      - $$cap_appname-pgdata:/var/lib/postgresql/data
+    environment:
+      POSTGRES_DB: pinchy
+      POSTGRES_USER: pinchy
+      POSTGRES_PASSWORD: $$cap_db_password
+    caproverExtra:
+      notExposeAsWebApp: 'true'
+
+  $$cap_appname-pinchy:
+    image: ghcr.io/heypinchy/pinchy:$$cap_pinchy_version
+    restart: unless-stopped
+    environment:
+      DATABASE_URL: postgresql://pinchy:$$cap_db_password@srv-captain--$$cap_appname-db:5432/pinchy
+      OPENCLAW_WS_URL: ws://srv-captain--$$cap_appname-openclaw:18789
+      BETTER_AUTH_SECRET: $$cap_auth_secret
+      ENCRYPTION_KEY: $$cap_encryption_key
+      PINCHY_ENTERPRISE_KEY: $$cap_enterprise_key
+    volumes:
+      - $$cap_appname-oc-config:/openclaw-config
+      - $$cap_appname-oc-secrets:/openclaw-secrets
+      - $$cap_appname-workspaces:/openclaw-config/workspaces
+      - $$cap_appname-oc-extensions:/openclaw-extensions
+      - $$cap_appname-pinchy-secrets:/app/secrets
+    depends_on:
+      - $$cap_appname-db
+    caproverExtra:
+      containerHttpPort: '7777'
+
+  $$cap_appname-openclaw:
+    image: ghcr.io/heypinchy/pinchy-openclaw:$$cap_pinchy_version
+    restart: unless-stopped
+    volumes:
+      - $$cap_appname-oc-config:/root/.openclaw
+      - $$cap_appname-oc-secrets:/openclaw-secrets
+      - $$cap_appname-workspaces:/root/.openclaw/workspaces
+      - $$cap_appname-oc-extensions:/root/.openclaw/extensions
+      - $$cap_appname-pinchy-data:/data
+      - $$cap_appname-pdf-cache:/var/cache/pinchy-files
+    depends_on:
+      - $$cap_appname-pinchy
+    caproverExtra:
+      notExposeAsWebApp: 'true'
+
+caproverOneClickApp:
+  displayName: Pinchy
+  isOfficial: false
+  description: Self-hosted AI agents with per-agent permissions and a signed audit trail. Built on OpenClaw, open source (AGPL-3.0).
+  documentation: See https://docs.heypinchy.com — only port 7777 (the web UI) is exposed; OpenClaw and PostgreSQL stay on CapRover's internal network.
+  instructions:
+    start: >-
+      Pinchy runs as three containers (web + OpenClaw runtime + PostgreSQL).
+      Secrets are generated for you below — leave them as-is unless you manage
+      your own. After deploy, enable HTTPS on the web app and open it: a setup
+      wizard creates your admin account and connects your first model.
+    end: >-
+      Pinchy is starting. Open the web app's URL (enable HTTPS first) to reach
+      the setup wizard. The OpenClaw and database services are internal-only.
+      Docs: https://docs.heypinchy.com
+  variables:
+    - id: $$cap_pinchy_version
+      label: Pinchy version
+      defaultValue: 'v0.6.0'
+      description: The released Pinchy version to deploy (must have published images).
+      validRegex: '/^v\d+\.\d+\.\d+$/'
+    - id: $$cap_db_password
+      label: Database password
+      defaultValue: $$cap_gen_random_hex(32)
+      description: Auto-generated. Leave as-is unless you manage the credential yourself.
+    - id: $$cap_auth_secret
+      label: Session secret (BETTER_AUTH_SECRET)
+      defaultValue: $$cap_gen_random_hex(64)
+      description: Auto-generated session-signing secret. Leave as-is.
+    - id: $$cap_encryption_key
+      label: Encryption key (ENCRYPTION_KEY)
+      defaultValue: $$cap_gen_random_hex(64)
+      description: Auto-generated 64-hex-char key that encrypts provider API keys at rest. Leave as-is.
+    - id: $$cap_enterprise_key
+      label: Enterprise license key (optional)
+      defaultValue: ''
+      description: Optional. Enables Groups and agent access control. Can also be entered later in Settings -> License.

--- a/marketplace/digitalocean/README.md
+++ b/marketplace/digitalocean/README.md
@@ -1,0 +1,102 @@
+# Pinchy on the DigitalOcean Marketplace
+
+A [Packer](https://www.packer.io/) build that produces a DigitalOcean snapshot
+image which runs Pinchy's **real production `docker-compose.yml`** — the same
+three-service stack (pinchy + openclaw + postgres), the same tmpfs secrets
+volume, the same healthcheck ordering. Nothing about Pinchy's security model is
+adapted away; the Droplet just runs the stack we already ship and test.
+
+The pinned version lives in `template.json` (`variables.application_version`)
+and is kept in lockstep with `.env.example` by `pnpm release` and the
+`scripts/lib/marketplace-version.test.mjs` drift guard.
+
+## What the build does
+
+**At build time** (baked into the snapshot, so first boot is fast):
+
+- Installs Docker + Compose, Caddy (reverse proxy + loading page), ufw.
+- Fetches `docker-compose.yml` and the loading page for the pinned release.
+- Pre-pulls the three container images.
+- Bakes only `PINCHY_VERSION` into `/opt/pinchy/.env` — **no secrets**.
+- Runs DigitalOcean's cleanup requirements so the image passes `img_check.sh`.
+
+**On first boot of each customer Droplet** (`per-instance/001_onboot`):
+
+- Generates per-Droplet `DB_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`.
+- Creates a 2 GB swap file.
+- Brings Pinchy up (`docker compose up -d`).
+
+Per-Droplet secrets are never baked into the shared snapshot.
+
+## Prerequisites (founder-gated)
+
+1. A DigitalOcean account, and Marketplace **vendor** access — apply at
+   <https://marketplace.digitalocean.com/vendors>. This gates the Vendor Portal
+   where the listing is submitted and reviewed.
+2. [`packer`](https://developer.hashicorp.com/packer/install) installed.
+3. A DigitalOcean API token with **write** scope, exported as
+   `DIGITALOCEAN_TOKEN`.
+
+## Build the snapshot
+
+```bash
+cd marketplace/digitalocean
+packer init .                      # installs the digitalocean plugin (first run)
+DIGITALOCEAN_TOKEN=dop_v1_… packer build template.json
+```
+
+Packer spins up a temporary $6 build Droplet, provisions it, snapshots it into
+your DigitalOcean account, and destroys the Droplet. DigitalOcean strongly
+recommends the `s-1vcpu-1gb` ($6) build size so the image stays compatible with
+all Droplet plans (already set in `template.json`).
+
+## Validate before submitting
+
+Run DigitalOcean's official image validation against a Droplet booted from the
+snapshot (DigitalOcean runs the same check on submission):
+
+```bash
+# On a Droplet created from the snapshot, as root:
+curl -sSL https://raw.githubusercontent.com/digitalocean/marketplace-partners/master/scripts/99-img-check.sh | bash
+```
+
+It must report **no FAIL** lines (ufw active, cloud-init present, no pending
+security updates, no leftover keys/history/agent). Then smoke-test the app:
+visit `http://<droplet-ip>` and confirm the Pinchy setup wizard loads.
+
+## Submit
+
+In the [Vendor Portal](https://cloud.digitalocean.com/vendorportal), create the
+1-Click app listing, point it at the snapshot, fill in the listing copy, and
+submit for review. DigitalOcean reviews the initial listing manually (no
+published SLA).
+
+## Updating for a new release
+
+`pnpm release X.Y.Z` bumps `template.json` to the new version automatically. To
+publish the update:
+
+1. Rebuild the snapshot (`packer build template.json`) on the new version.
+2. `PATCH` the listing to the new snapshot via the Vendor API:
+
+   ```bash
+   curl -X PATCH \
+     -H "Authorization: Bearer $DIGITALOCEAN_TOKEN" \
+     -H "Content-Type: application/json" \
+     -d '{ "reasonForUpdate": "Pinchy X.Y.Z", "imageId": <snapshot-id>,
+           "softwareIncluded": [{ "name": "Pinchy", "version": "X.Y.Z" }] }' \
+     https://api.digitalocean.com/api/v1/vendor-portal/apps/<app-id>
+   ```
+
+   Note: a PATCH returns the app to `pending`, so version updates re-enter
+   DigitalOcean's review queue. The pinned version only sets the **starting**
+   version for new installs — existing Droplets update themselves by bumping
+   `PINCHY_VERSION` in `/opt/pinchy/.env`, independent of the listing.
+
+## License
+
+Pinchy is AGPL-3.0. DigitalOcean's
+[Marketplace Vendor Terms](https://www.digitalocean.com/legal/marketplace-vendor-terms)
+grant DigitalOcean only a license to display the **listing**, with no
+sublicensing or managed-SaaS grant over the software — compatible with AGPL, the
+same basis on which Nextcloud and Mastodon (also AGPL) ship as 1-Click apps.

--- a/marketplace/digitalocean/files/etc/caddy/Caddyfile
+++ b/marketplace/digitalocean/files/etc/caddy/Caddyfile
@@ -1,0 +1,30 @@
+# Pinchy reverse proxy
+# Primary upstream: Pinchy on 127.0.0.1:7777
+# Fallback upstream: local loading page on 127.0.0.1:9999
+#
+# lb_policy first      -> prefer primary; fall back only when primary is down.
+# lb_try_duration 1s   -> fail fast so users never wait for a dead backend.
+# fail_duration 5s     -> mark unreachable backend as dead for 5s before retry.
+#
+# To enable HTTPS: replace `:80` with your domain (e.g. pinchy.example.com)
+# and run `systemctl reload caddy`. Caddy provisions Let's Encrypt automatically.
+
+:80 {
+    reverse_proxy 127.0.0.1:7777 127.0.0.1:9999 {
+        lb_policy first
+        lb_try_duration 1s
+        fail_duration 5s
+    }
+}
+
+:9999 {
+    bind 127.0.0.1
+    handle /api/* {
+        respond 503
+    }
+    handle {
+        root * /var/www/pinchy-loading
+        try_files /index.html
+        file_server
+    }
+}

--- a/marketplace/digitalocean/files/etc/update-motd.d/99-one-click
+++ b/marketplace/digitalocean/files/etc/update-motd.d/99-one-click
@@ -1,0 +1,29 @@
+#!/bin/sh
+# DigitalOcean Marketplace welcome message, shown on first SSH login.
+myip=$(hostname -I 2>/dev/null | awk '{print $1}')
+
+cat <<EOF
+
+********************************************************************************
+
+  Welcome to Pinchy — self-hosted AI agents with permissions and an audit trail.
+
+  Open Pinchy in your browser:   http://${myip}
+
+  On first launch, a setup wizard creates your admin account and connects your
+  first model. While the containers start, that address shows a loading page.
+
+  HTTPS: point a domain's A record at ${myip}, then replace ':80' with your
+  domain in /etc/caddy/Caddyfile and run 'systemctl reload caddy'.
+
+  The firewall (ufw) is enabled. Open ports: 22 (SSH), 80, 443.
+  Per-Droplet secrets are stored in /opt/pinchy/.env — keep them private.
+
+  Docs:     https://docs.heypinchy.com
+  Source:   https://github.com/heypinchy/pinchy
+
+  To remove this message: rm -f $(readlink -f "\$0")
+
+********************************************************************************
+
+EOF

--- a/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Runs once on the first boot of each Droplet created from the Pinchy snapshot
+# (cloud-init per-instance). Generates per-Droplet secrets, sets up swap, and
+# starts Pinchy. The shared snapshot never carries these secrets.
+set -euo pipefail
+
+ENV=/opt/pinchy/.env
+
+# Per-Droplet secrets — generated here, never baked into the snapshot. Pinchy
+# would auto-generate BETTER_AUTH_SECRET / ENCRYPTION_KEY if omitted; pinning
+# them up front means the public dev defaults are never active for a moment.
+{
+  echo "DB_PASSWORD=$(openssl rand -hex 32)"
+  echo "BETTER_AUTH_SECRET=$(openssl rand -hex 32)"
+  echo "ENCRYPTION_KEY=$(openssl rand -hex 32)"
+} >> "$ENV"
+chmod 600 "$ENV"
+
+# 2 GB swap — created on first boot so the snapshot image stays small.
+if [ ! -f /swapfile ]; then
+  fallocate -l 2G /swapfile
+  chmod 600 /swapfile
+  mkswap /swapfile
+  swapon /swapfile
+  echo '/swapfile none swap sw 0 0' >> /etc/fstab
+fi
+
+# Stamp the loading page's start time so it shows elapsed install time.
+sed -i "s/INSTALL_START_TIME/$(date +%s)000/" /var/www/pinchy-loading/index.html 2>/dev/null || true
+
+# Bring Pinchy up — images were pre-pulled at build time, so this is fast.
+cd /opt/pinchy && docker compose up -d

--- a/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001_onboot
+++ b/marketplace/digitalocean/files/var/lib/cloud/scripts/per-instance/001_onboot
@@ -29,4 +29,11 @@ fi
 sed -i "s/INSTALL_START_TIME/$(date +%s)000/" /var/www/pinchy-loading/index.html 2>/dev/null || true
 
 # Bring Pinchy up — images were pre-pulled at build time, so this is fast.
-cd /opt/pinchy && docker compose up -d
+# Retry a few times: cloud-init per-instance runs once, so a transient failure
+# (e.g. the Docker daemon not yet ready) must not leave the stack down.
+cd /opt/pinchy
+for attempt in 1 2 3 4 5; do
+  docker compose up -d && break
+  echo "docker compose up attempt ${attempt} failed; retrying in 5s..."
+  sleep 5
+done

--- a/marketplace/digitalocean/scripts/010-docker.sh
+++ b/marketplace/digitalocean/scripts/010-docker.sh
@@ -1,0 +1,11 @@
+#!/bin/bash
+# Install Docker and the Compose v2 plugin (build-time, baked into the snapshot).
+# Matches Pinchy's tested cloud-init deployment (Ubuntu's docker.io packages).
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+apt-get -qqy update
+apt-get -qqy install docker.io docker-compose-v2
+systemctl enable docker
+systemctl start docker

--- a/marketplace/digitalocean/scripts/011-caddy.sh
+++ b/marketplace/digitalocean/scripts/011-caddy.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+# Install Caddy (reverse proxy) from its official Cloudsmith apt repository.
+# The Caddyfile is pre-staged at /etc/caddy/Caddyfile by the file provisioner,
+# so --force-confold keeps our config instead of dpkg's default on install.
+set -euo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/gpg.key' \
+  | gpg --dearmor -o /usr/share/keyrings/caddy-stable-archive-keyring.gpg
+curl -1sLf 'https://dl.cloudsmith.io/public/caddy/stable/debian.deb.txt' \
+  | tee /etc/apt/sources.list.d/caddy-stable.list
+apt-get -qqy update
+apt-get -qqy -o Dpkg::Options::=--force-confold install caddy
+systemctl enable caddy

--- a/marketplace/digitalocean/scripts/012-pinchy-stage.sh
+++ b/marketplace/digitalocean/scripts/012-pinchy-stage.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+# Stage Pinchy for the pinned version (build-time): fetch the compose file and
+# loading page, pre-pull the images, configure the firewall. Per-Droplet secrets
+# are NOT written here — they are generated on first boot (001_onboot), so the
+# shared snapshot never carries them.
+set -euo pipefail
+
+VERSION="${application_version:?application_version not set by Packer}"
+
+mkdir -p /opt/pinchy /var/www/pinchy-loading
+
+# Compose file + loading page for exactly this release
+curl -fsSL "https://raw.githubusercontent.com/heypinchy/pinchy/${VERSION}/docker-compose.yml" \
+  -o /opt/pinchy/docker-compose.yml
+curl -fsSL "https://github.com/heypinchy/pinchy/releases/download/${VERSION}/installing.html" \
+  -o /var/www/pinchy-loading/index.html
+
+# Bake only the version pin. Secrets are per-Droplet (added on first boot).
+echo "PINCHY_VERSION=${VERSION}" > /opt/pinchy/.env
+
+# Pre-pull the three images so first boot is just "compose up".
+(cd /opt/pinchy && docker compose pull)
+
+# Firewall: SSH + HTTP/HTTPS only. img_check expects ufw active.
+ufw allow OpenSSH
+ufw allow 80/tcp
+ufw allow 443/tcp
+ufw --force enable
+
+# The file provisioner does not preserve the executable bit.
+chmod 755 /etc/update-motd.d/99-one-click
+chmod 755 /var/lib/cloud/scripts/per-instance/001_onboot

--- a/marketplace/digitalocean/scripts/012-pinchy-stage.sh
+++ b/marketplace/digitalocean/scripts/012-pinchy-stage.sh
@@ -9,11 +9,17 @@ VERSION="${application_version:?application_version not set by Packer}"
 
 mkdir -p /opt/pinchy /var/www/pinchy-loading
 
-# Compose file + loading page for exactly this release
+# Compose file for exactly this release (required — fail the build if missing)
 curl -fsSL "https://raw.githubusercontent.com/heypinchy/pinchy/${VERSION}/docker-compose.yml" \
   -o /opt/pinchy/docker-compose.yml
-curl -fsSL "https://github.com/heypinchy/pinchy/releases/download/${VERSION}/installing.html" \
-  -o /var/www/pinchy-loading/index.html
+
+# Loading page is cosmetic — tolerate a missing release asset with a minimal
+# fallback so a build never fails on it.
+if ! curl -fsSL "https://github.com/heypinchy/pinchy/releases/download/${VERSION}/installing.html" \
+  -o /var/www/pinchy-loading/index.html; then
+  echo '<!doctype html><meta http-equiv="refresh" content="5"><title>Starting Pinchy</title><body style="font-family:sans-serif;text-align:center;margin-top:20vh">Pinchy is starting&hellip; this page refreshes automatically.</body>' \
+    > /var/www/pinchy-loading/index.html
+fi
 
 # Bake only the version pin. Secrets are per-Droplet (added on first boot).
 echo "PINCHY_VERSION=${VERSION}" > /opt/pinchy/.env

--- a/marketplace/digitalocean/scripts/900-cleanup.sh
+++ b/marketplace/digitalocean/scripts/900-cleanup.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# DigitalOcean Marketplace image cleanup — runs last, before the snapshot.
+# Requirements distilled from digitalocean/marketplace-partners img_check.sh:
+# no pending security updates, no leftover secrets/keys/history, no DO agent,
+# and cloud-init instance state wiped so per-instance scripts re-run on the
+# customer's Droplet. Best-effort throughout (no set -e).
+set -uo pipefail
+
+export DEBIAN_FRONTEND=noninteractive
+
+# img_check needs a writable /tmp for its own update check
+mkdir -p /tmp && chmod 1777 /tmp
+
+# Install all pending updates — img_check FAILs on any pending security update
+apt-get -qqy update
+apt-get -qqy -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold upgrade
+apt-get -qqy autoremove
+apt-get -qqy autoclean
+apt-get -qqy clean
+
+# Remove the DigitalOcean monitoring agent — img_check FAILs if present
+apt-get -qqy purge 'droplet-agent*' 2>/dev/null || true
+
+# Clear logs
+find /var/log -mtime -1 -type f -exec truncate -s 0 {} \; 2>/dev/null || true
+rm -rf /var/log/*.gz /var/log/*.[0-9] /var/log/*-???????? 2>/dev/null || true
+[ -f /var/log/wtmp ] && truncate -s 0 /var/log/wtmp
+[ -f /var/log/lastlog ] && truncate -s 0 /var/log/lastlog
+
+# Remove SSH host keys + any authorized_keys (regenerated on first boot)
+rm -f /etc/ssh/*key*
+rm -f /root/.ssh/authorized_keys
+touch /etc/ssh/revoked_keys && chmod 600 /etc/ssh/revoked_keys
+
+# Wipe cloud-init instance state so per-instance/001_onboot re-runs on first boot
+rm -rf /var/lib/cloud/instances/*
+cloud-init clean --logs 2>/dev/null || true
+
+# Clear shell history
+unset HISTFILE
+rm -f /root/.bash_history
+find /home -name '.bash_history' -exec rm -f {} \; 2>/dev/null || true
+
+# Clear temp dirs
+rm -rf /tmp/* /var/tmp/*
+
+# Zero free space so the snapshot compresses well (best-effort)
+dd if=/dev/zero of=/zerofile bs=1M 2>/dev/null || true
+rm -f /zerofile
+sync

--- a/marketplace/digitalocean/template.json
+++ b/marketplace/digitalocean/template.json
@@ -1,0 +1,68 @@
+{
+  "variables": {
+    "do_token": "{{env `DIGITALOCEAN_TOKEN`}}",
+    "image_name": "pinchy-24-04-snapshot-{{timestamp}}",
+    "apt_packages": "apt-transport-https ca-certificates curl gnupg jq ufw debian-keyring debian-archive-keyring",
+    "application_name": "Pinchy",
+    "application_version": "v0.6.0"
+  },
+  "builders": [
+    {
+      "type": "digitalocean",
+      "api_token": "{{user `do_token`}}",
+      "image": "ubuntu-24-04-x64",
+      "region": "nyc3",
+      "size": "s-1vcpu-1gb",
+      "ssh_username": "root",
+      "snapshot_name": "{{user `image_name`}}"
+    }
+  ],
+  "provisioners": [
+    {
+      "type": "shell",
+      "inline": ["cloud-init status --wait"]
+    },
+    {
+      "type": "file",
+      "source": "files/etc/",
+      "destination": "/etc/"
+    },
+    {
+      "type": "file",
+      "source": "files/var/",
+      "destination": "/var/"
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "inline": [
+        "apt-get -qqy update",
+        "apt-get -qqy -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold full-upgrade",
+        "apt-get -qqy -o Dpkg::Options::=--force-confdef -o Dpkg::Options::=--force-confold install {{user `apt_packages`}}",
+        "apt-get -qqy clean"
+      ]
+    },
+    {
+      "type": "shell",
+      "environment_vars": [
+        "application_name={{user `application_name`}}",
+        "application_version={{user `application_version`}}",
+        "DEBIAN_FRONTEND=noninteractive",
+        "LC_ALL=C",
+        "LANG=en_US.UTF-8",
+        "LC_CTYPE=en_US.UTF-8"
+      ],
+      "scripts": [
+        "scripts/010-docker.sh",
+        "scripts/011-caddy.sh",
+        "scripts/012-pinchy-stage.sh",
+        "scripts/900-cleanup.sh"
+      ]
+    }
+  ]
+}

--- a/scripts/lib/marketplace-lint.mjs
+++ b/scripts/lib/marketplace-lint.mjs
@@ -1,0 +1,124 @@
+/**
+ * Syntax + structural guards for the marketplace deploy artifacts. These can't
+ * be test-deployed in CI (they need a DigitalOcean account / CapRover server),
+ * so this catches the cheap-but-costly regressions before a founder wastes a
+ * build: a broken shell script, malformed template JSON, or a critical CapRover
+ * field (e.g. PINCHY_INTERNAL_URL) silently dropped.
+ *
+ * No YAML parser is available to the script runner, so the CapRover checks are
+ * targeted text invariants — which is actually stronger than a generic parse
+ * for catching meaningful breakage (a removed env line still parses as YAML).
+ */
+
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { execFileSync } from "node:child_process";
+
+/**
+ * Recursively collects files under `dir` whose first line is a /bin/sh or
+ * /bin/bash shebang — catches both `.sh` scripts and extension-less ones
+ * (cloud-init's 001_onboot, the MOTD 99-one-click).
+ * @param {string} dir
+ * @returns {string[]} absolute-ish file paths
+ */
+export function findShellScripts(dir) {
+  const out = [];
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    let st;
+    try {
+      st = statSync(full);
+    } catch {
+      continue;
+    }
+    if (st.isDirectory()) {
+      out.push(...findShellScripts(full));
+      continue;
+    }
+    let firstLine = "";
+    try {
+      firstLine = readFileSync(full, "utf8").split("\n", 1)[0];
+    } catch {
+      continue;
+    }
+    if (/^#!\s*\/\S*\/(ba)?sh\b/.test(firstLine)) out.push(full);
+  }
+  return out;
+}
+
+/**
+ * Runs `bash -n` (parse-only, no execution) on a shell file.
+ * @param {string} file
+ * @throws {Error} with the file and stderr on a syntax error
+ */
+export function checkShellSyntax(file) {
+  try {
+    execFileSync("bash", ["-n", file], { stdio: "pipe" });
+  } catch (err) {
+    const detail = err.stderr ? err.stderr.toString() : err.message;
+    throw new Error(`Shell syntax error in ${file}:\n${detail}`);
+  }
+}
+
+/**
+ * Validates the DigitalOcean Packer template's JSON and critical structure.
+ * @param {string} content - raw template.json contents
+ * @throws {Error} on invalid JSON or a missing required field
+ */
+export function assertValidPackerTemplate(content) {
+  let template;
+  try {
+    template = JSON.parse(content);
+  } catch (e) {
+    throw new Error(`template.json is not valid JSON: ${e.message}`);
+  }
+  if (
+    !/^v\d+\.\d+\.\d+$/.test(template?.variables?.application_version ?? "")
+  ) {
+    throw new Error(
+      "template.json variables.application_version must be a vX.Y.Z string",
+    );
+  }
+  if (
+    !Array.isArray(template.builders) ||
+    !template.builders.some((b) => b.type === "digitalocean")
+  ) {
+    throw new Error("template.json must declare a digitalocean builder");
+  }
+  if (
+    !Array.isArray(template.provisioners) ||
+    template.provisioners.length === 0
+  ) {
+    throw new Error("template.json must declare provisioners");
+  }
+}
+
+/**
+ * Validates the CapRover one-click template's critical invariants. Text-based
+ * (no YAML lib); each invariant is a regression we have already hit or that
+ * would silently break a real deploy.
+ * @param {string} content - raw pinchy.yml contents
+ * @throws {Error} on a missing invariant
+ */
+export function assertValidCaproverTemplate(content) {
+  const required = [
+    ["captainVersion: 4", "captainVersion: 4 header"],
+    ["$$cap_appname-db", "db service"],
+    ["$$cap_appname-pinchy", "pinchy service"],
+    ["$$cap_appname-openclaw", "openclaw service"],
+    [
+      "PINCHY_INTERNAL_URL",
+      "PINCHY_INTERNAL_URL (OpenClaw plugins can't reach Pinchy on CapRover's remapped DNS without it)",
+    ],
+    ["srv-captain--$$cap_appname-pinchy", "srv-captain-- inter-service DNS"],
+    ["caproverOneClickApp", "caproverOneClickApp metadata block"],
+  ];
+  for (const [needle, label] of required) {
+    if (!content.includes(needle)) {
+      throw new Error(`CapRover template is missing ${label} ("${needle}")`);
+    }
+  }
+  if (!/defaultValue:\s*['"]?v\d+\.\d+\.\d+/.test(content)) {
+    throw new Error("CapRover template must pin a vX.Y.Z version defaultValue");
+  }
+}

--- a/scripts/lib/marketplace-lint.test.mjs
+++ b/scripts/lib/marketplace-lint.test.mjs
@@ -1,0 +1,136 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  findShellScripts,
+  checkShellSyntax,
+  assertValidPackerTemplate,
+  assertValidCaproverTemplate,
+} from "./marketplace-lint.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const MARKETPLACE = resolve(ROOT, "marketplace");
+const TEMPLATE_PATH = resolve(MARKETPLACE, "digitalocean/template.json");
+const CAPROVER_PATH = resolve(MARKETPLACE, "caprover/pinchy.yml");
+
+// ─── Packer template structure ────────────────────────────────────────────────
+
+test("assertValidPackerTemplate accepts a well-formed template", () => {
+  const good = JSON.stringify({
+    variables: { application_version: "v0.6.0" },
+    builders: [{ type: "digitalocean" }],
+    provisioners: [{ type: "shell" }],
+  });
+  assert.doesNotThrow(() => assertValidPackerTemplate(good));
+});
+
+test("assertValidPackerTemplate rejects invalid JSON", () => {
+  assert.throws(
+    () => assertValidPackerTemplate("{ not json"),
+    /not valid JSON/,
+  );
+});
+
+test("assertValidPackerTemplate rejects a non-version application_version", () => {
+  const bad = JSON.stringify({
+    variables: { application_version: "latest" },
+    builders: [{ type: "digitalocean" }],
+    provisioners: [{ type: "shell" }],
+  });
+  assert.throws(() => assertValidPackerTemplate(bad), /vX\.Y\.Z/);
+});
+
+test("assertValidPackerTemplate rejects a missing digitalocean builder", () => {
+  const bad = JSON.stringify({
+    variables: { application_version: "v0.6.0" },
+    builders: [{ type: "amazon-ebs" }],
+    provisioners: [{ type: "shell" }],
+  });
+  assert.throws(() => assertValidPackerTemplate(bad), /digitalocean builder/);
+});
+
+test("assertValidPackerTemplate rejects missing provisioners", () => {
+  const bad = JSON.stringify({
+    variables: { application_version: "v0.6.0" },
+    builders: [{ type: "digitalocean" }],
+  });
+  assert.throws(() => assertValidPackerTemplate(bad), /provisioners/);
+});
+
+// ─── CapRover template invariants ─────────────────────────────────────────────
+
+const GOOD_CAPROVER = `captainVersion: 4
+services:
+  $$cap_appname-db:
+    image: postgres:17
+  $$cap_appname-pinchy:
+    environment:
+      PINCHY_INTERNAL_URL: http://srv-captain--$$cap_appname-pinchy:7777
+  $$cap_appname-openclaw:
+    image: ghcr.io/heypinchy/pinchy-openclaw:$$cap_pinchy_version
+caproverOneClickApp:
+  variables:
+    - id: $$cap_pinchy_version
+      defaultValue: 'v0.6.0'
+`;
+
+test("assertValidCaproverTemplate accepts a well-formed template", () => {
+  assert.doesNotThrow(() => assertValidCaproverTemplate(GOOD_CAPROVER));
+});
+
+test("assertValidCaproverTemplate rejects a template missing PINCHY_INTERNAL_URL", () => {
+  // Regression guard: this exact field was missing in the first draft and would
+  // have silently broken OpenClaw plugin callbacks on CapRover.
+  const bad = GOOD_CAPROVER.replace(
+    /PINCHY_INTERNAL_URL: .*/,
+    "SOMETHING_ELSE: x",
+  );
+  assert.throws(() => assertValidCaproverTemplate(bad), /PINCHY_INTERNAL_URL/);
+});
+
+test("assertValidCaproverTemplate rejects a missing service", () => {
+  const bad = GOOD_CAPROVER.replace(
+    "$$cap_appname-openclaw",
+    "$$cap_appname-typo",
+  );
+  assert.throws(() => assertValidCaproverTemplate(bad), /openclaw service/);
+});
+
+test("assertValidCaproverTemplate rejects a missing version pin", () => {
+  const bad = GOOD_CAPROVER.replace(
+    "defaultValue: 'v0.6.0'",
+    "defaultValue: latest",
+  );
+  assert.throws(() => assertValidCaproverTemplate(bad), /version defaultValue/);
+});
+
+// ─── Real-file guards ─────────────────────────────────────────────────────────
+
+test("the committed DigitalOcean template.json is structurally valid", () => {
+  assert.doesNotThrow(() =>
+    assertValidPackerTemplate(readFileSync(TEMPLATE_PATH, "utf8")),
+  );
+});
+
+test("the committed CapRover pinchy.yml holds all critical invariants", () => {
+  assert.doesNotThrow(() =>
+    assertValidCaproverTemplate(readFileSync(CAPROVER_PATH, "utf8")),
+  );
+});
+
+test("every shell script under marketplace/ passes bash -n", () => {
+  const scripts = findShellScripts(MARKETPLACE);
+  // Sanity: the DO image ships several scripts + the first-boot + MOTD files.
+  assert.ok(
+    scripts.length >= 6,
+    `expected to find the marketplace shell scripts, found ${scripts.length}`,
+  );
+  for (const file of scripts) {
+    assert.doesNotThrow(
+      () => checkShellSyntax(file),
+      `bash -n failed for ${file}`,
+    );
+  }
+});

--- a/scripts/lib/marketplace-version.mjs
+++ b/scripts/lib/marketplace-version.mjs
@@ -68,23 +68,87 @@ export function bumpMarketplaceVersion(content, version) {
 }
 
 /**
- * Asserts the marketplace template's pinned version equals `.env.example`'s
- * PINCHY_VERSION. `pnpm release` bumps both, so any divergence means a release
- * forgot the marketplace template (or someone hand-edited one of them).
- *
- * @param {string} templateJson - contents of the Packer template
- * @param {string} envExample - contents of .env.example
- * @throws {Error} if the two versions differ
+ * Reads the pinned version from the CapRover one-click template's YAML
+ * contents (the `$$cap_pinchy_version` variable's `defaultValue`). The version
+ * variable is the only one with a version-shaped default — the secrets use
+ * `$$cap_gen_random_hex(...)` — so a single regex matches it unambiguously.
+ * @param {string} templateYaml
+ * @returns {string} the version with its leading 'v' (e.g. "v0.6.0")
+ * @throws {Error} if no version default is present
  */
-export function assertMarketplaceVersionInSync(templateJson, envExample) {
-  const marketplace = readMarketplaceVersion(templateJson);
-  const env = readPinchyVersionFromEnv(envExample);
-  if (marketplace !== env) {
+export function readCaproverVersion(templateYaml) {
+  const match = /defaultValue:\s*['"]?(v\d+\.\d+\.\d+)['"]?/.exec(templateYaml);
+  if (!match) {
     throw new Error(
-      `Marketplace template version (${marketplace}) is out of sync with ` +
-        `.env.example PINCHY_VERSION (${env}).\n` +
-        `'pnpm release' bumps both together — they must match. ` +
-        `Re-run the release bump or align the marketplace template.`,
+      "CapRover template has no version defaultValue (v X.Y.Z) to read",
     );
   }
+  return match[1];
+}
+
+/**
+ * Returns the CapRover template YAML with the `$$cap_pinchy_version` default
+ * set to `v<version>`. Surgical replace of just that value — preserves quoting,
+ * formatting, and the trailing newline.
+ * @param {string} content - raw CapRover template contents
+ * @param {string} version - release version, no 'v' prefix (e.g. "0.6.0")
+ * @returns {string}
+ * @throws {Error} if no version default is present
+ */
+export function bumpCaproverVersion(content, version) {
+  const pattern = /(defaultValue:\s*['"]?)v\d+\.\d+\.\d+(['"]?)/;
+  if (!pattern.test(content)) {
+    throw new Error(
+      "CapRover template has no version defaultValue (v X.Y.Z) to bump",
+    );
+  }
+  return content.replace(pattern, `$1v${version}$2`);
+}
+
+/**
+ * Asserts a marketplace template's pinned version equals `.env.example`'s
+ * PINCHY_VERSION. `pnpm release` bumps every template, so any divergence means
+ * a release forgot one (or someone hand-edited it).
+ *
+ * @param {string} actualVersion - version read from a template (e.g. "v0.6.0")
+ * @param {string} envExample - contents of .env.example
+ * @param {string} label - human name of the template, for the error message
+ * @throws {Error} if the versions differ
+ */
+export function assertVersionInSync(actualVersion, envExample, label) {
+  const env = readPinchyVersionFromEnv(envExample);
+  if (actualVersion !== env) {
+    throw new Error(
+      `${label} version (${actualVersion}) is out of sync with ` +
+        `.env.example PINCHY_VERSION (${env}).\n` +
+        `'pnpm release' bumps both together — they must match. ` +
+        `Re-run the release bump or align the template.`,
+    );
+  }
+}
+
+/**
+ * Drift guard for the DigitalOcean Packer template.
+ * @param {string} templateJson - contents of the Packer template
+ * @param {string} envExample - contents of .env.example
+ */
+export function assertMarketplaceVersionInSync(templateJson, envExample) {
+  assertVersionInSync(
+    readMarketplaceVersion(templateJson),
+    envExample,
+    "DigitalOcean template",
+  );
+}
+
+/**
+ * Drift guard for the CapRover one-click template.
+ * @param {string} templateYaml - contents of the CapRover template
+ * @param {string} envExample - contents of .env.example
+ */
+export function assertCaproverVersionInSync(templateYaml, envExample) {
+  assertVersionInSync(
+    readCaproverVersion(templateYaml),
+    envExample,
+    "CapRover template",
+  );
 }

--- a/scripts/lib/marketplace-version.mjs
+++ b/scripts/lib/marketplace-version.mjs
@@ -1,0 +1,90 @@
+/**
+ * Keeps the marketplace listing templates' pinned Pinchy version in lockstep
+ * with `.env.example` (the project's declared "version users should run").
+ *
+ * Marketplace images bake a concrete version (e.g. the DigitalOcean snapshot
+ * pre-pulls that version's images). Left to drift, a new install would start
+ * several versions behind the current release. `.env.example` already carries
+ * the canonical pin (`PINCHY_VERSION=vX.Y.Z`, bumped by `pnpm release`), so the
+ * marketplace templates anchor to it and the release script bumps them together.
+ *
+ * Pure functions only — all I/O happens in the callers (release.mjs, the guard
+ * test). Mirrors the shape of release-logic.mjs.
+ */
+
+const PINCHY_VERSION_LINE = /^PINCHY_VERSION=(.+)$/m;
+
+/**
+ * Extracts the `PINCHY_VERSION=vX.Y.Z` value from a .env-style file's contents.
+ * @param {string} content
+ * @returns {string} the version with its leading 'v' (e.g. "v0.6.0")
+ * @throws {Error} if no PINCHY_VERSION= line is present
+ */
+export function readPinchyVersionFromEnv(content) {
+  const match = PINCHY_VERSION_LINE.exec(content);
+  if (!match) {
+    throw new Error("No PINCHY_VERSION= line found in .env.example");
+  }
+  return match[1].trim();
+}
+
+/**
+ * Reads the pinned version from a DigitalOcean Packer template's JSON contents
+ * (`variables.application_version`).
+ * @param {string} templateJson
+ * @returns {string} the version with its leading 'v' (e.g. "v0.6.0")
+ * @throws {Error} if the field is missing
+ */
+export function readMarketplaceVersion(templateJson) {
+  const template = JSON.parse(templateJson);
+  const version = template?.variables?.application_version;
+  if (!version) {
+    throw new Error(
+      "Packer template has no variables.application_version to read",
+    );
+  }
+  return version;
+}
+
+/**
+ * Returns the Packer template JSON contents with `application_version` set to
+ * `v<version>`. A surgical replace of just that value — like bumpEnvExample —
+ * so the rest of the file (formatting, key order, trailing newline) is left
+ * byte-for-byte and a release bump produces a one-line diff that never fights
+ * Prettier.
+ * @param {string} content - raw template.json contents
+ * @param {string} version - release version, no 'v' prefix (e.g. "0.6.0")
+ * @returns {string}
+ * @throws {Error} if the template has no application_version field
+ */
+export function bumpMarketplaceVersion(content, version) {
+  const pattern = /("application_version"\s*:\s*")[^"]*(")/;
+  if (!pattern.test(content)) {
+    throw new Error(
+      'Packer template has no "application_version" field to bump',
+    );
+  }
+  return content.replace(pattern, `$1v${version}$2`);
+}
+
+/**
+ * Asserts the marketplace template's pinned version equals `.env.example`'s
+ * PINCHY_VERSION. `pnpm release` bumps both, so any divergence means a release
+ * forgot the marketplace template (or someone hand-edited one of them).
+ *
+ * @param {string} templateJson - contents of the Packer template
+ * @param {string} envExample - contents of .env.example
+ * @throws {Error} if the two versions differ
+ */
+export function assertMarketplaceVersionInSync(templateJson, envExample) {
+  const marketplace = readMarketplaceVersion(templateJson);
+  const env = readPinchyVersionFromEnv(envExample);
+  if (marketplace !== env) {
+    throw new Error(
+      `Marketplace template version (${marketplace}) is out of sync with ` +
+        `.env.example PINCHY_VERSION (${env}).\n` +
+        `'pnpm release' bumps both together — they must match. ` +
+        `Re-run the release bump or align the marketplace template.`,
+    );
+  }
+}

--- a/scripts/lib/marketplace-version.test.mjs
+++ b/scripts/lib/marketplace-version.test.mjs
@@ -8,10 +8,14 @@ import {
   readMarketplaceVersion,
   bumpMarketplaceVersion,
   assertMarketplaceVersionInSync,
+  readCaproverVersion,
+  bumpCaproverVersion,
+  assertCaproverVersionInSync,
 } from "./marketplace-version.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const TEMPLATE_PATH = resolve(ROOT, "marketplace/digitalocean/template.json");
+const CAPROVER_PATH = resolve(ROOT, "marketplace/caprover/pinchy.yml");
 const ENV_EXAMPLE_PATH = resolve(ROOT, ".env.example");
 const RELEASE_MJS = resolve(ROOT, "scripts/release.mjs");
 
@@ -23,6 +27,14 @@ const SAMPLE_TEMPLATE = JSON.stringify(
   null,
   2,
 );
+
+const SAMPLE_CAPROVER = `caproverOneClickApp:
+  variables:
+    - id: $$cap_pinchy_version
+      defaultValue: 'v0.5.8'
+    - id: $$cap_db_password
+      defaultValue: $$cap_gen_random_hex(32)
+`;
 
 // ─── Pure helpers ─────────────────────────────────────────────────────────────
 
@@ -90,6 +102,57 @@ test("assertMarketplaceVersionInSync throws when versions differ", () => {
   );
 });
 
+// ─── CapRover template helpers ────────────────────────────────────────────────
+
+test("readCaproverVersion reads the version variable's defaultValue", () => {
+  assert.equal(readCaproverVersion(SAMPLE_CAPROVER), "v0.5.8");
+});
+
+test("readCaproverVersion ignores the random-hex secret defaults", () => {
+  // Only the version variable has a version-shaped default; the secrets use
+  // $$cap_gen_random_hex(...), which must not be mistaken for a version.
+  assert.equal(readCaproverVersion(SAMPLE_CAPROVER), "v0.5.8");
+});
+
+test("readCaproverVersion throws when no version default is present", () => {
+  assert.throws(
+    () => readCaproverVersion("variables:\n  - id: x\n"),
+    /version defaultValue/,
+  );
+});
+
+test("bumpCaproverVersion sets the version default, preserving quotes", () => {
+  const bumped = bumpCaproverVersion(SAMPLE_CAPROVER, "0.6.0");
+  assert.equal(readCaproverVersion(bumped), "v0.6.0");
+  assert.match(bumped, /defaultValue: 'v0\.6\.0'/);
+});
+
+test("bumpCaproverVersion leaves the secret defaults untouched", () => {
+  const bumped = bumpCaproverVersion(SAMPLE_CAPROVER, "0.6.0");
+  assert.match(bumped, /\$\$cap_gen_random_hex\(32\)/);
+});
+
+test("bumpCaproverVersion throws on a template without a version default", () => {
+  assert.throws(
+    () => bumpCaproverVersion("variables:\n  - id: x\n", "0.6.0"),
+    /version defaultValue/,
+  );
+});
+
+test("assertCaproverVersionInSync passes when versions match", () => {
+  assert.doesNotThrow(() =>
+    assertCaproverVersionInSync(SAMPLE_CAPROVER, "PINCHY_VERSION=v0.5.8\n"),
+  );
+});
+
+test("assertCaproverVersionInSync throws when versions differ", () => {
+  assert.throws(
+    () =>
+      assertCaproverVersionInSync(SAMPLE_CAPROVER, "PINCHY_VERSION=v0.6.0\n"),
+    /out of sync/,
+  );
+});
+
 // ─── Real-file drift guard ────────────────────────────────────────────────────
 // The committed DigitalOcean template must always pin the same version as
 // .env.example. `pnpm release` bumps both; this fails a PR the moment they drift.
@@ -102,11 +165,17 @@ test("the DigitalOcean template version matches .env.example PINCHY_VERSION", ()
   );
 });
 
+test("the CapRover template version matches .env.example PINCHY_VERSION", () => {
+  const template = readFileSync(CAPROVER_PATH, "utf8");
+  const envExample = readFileSync(ENV_EXAMPLE_PATH, "utf8");
+  assert.doesNotThrow(() => assertCaproverVersionInSync(template, envExample));
+});
+
 // ─── Release-script wiring guard ──────────────────────────────────────────────
 // The drift guard only protects us if `pnpm release` actually bumps the
 // marketplace template. These textual sweeps fail if a refactor drops the bump.
 
-test("release.mjs bumps the marketplace template version", () => {
+test("release.mjs bumps both marketplace template versions", () => {
   const src = readFileSync(RELEASE_MJS, "utf8");
   assert.match(
     src,
@@ -118,12 +187,22 @@ test("release.mjs bumps the marketplace template version", () => {
     /marketplace\/digitalocean\/template\.json/,
     "release.mjs must write the DigitalOcean template.json on release",
   );
+  assert.match(
+    src,
+    /bumpCaproverVersion/,
+    "release.mjs must call bumpCaproverVersion so the CapRover template tracks the release",
+  );
+  assert.match(
+    src,
+    /marketplace\/caprover\/pinchy\.yml/,
+    "release.mjs must write the CapRover pinchy.yml on release",
+  );
 });
 
-test("release.mjs commits the marketplace template", () => {
+test("release.mjs commits both marketplace templates", () => {
   const src = readFileSync(RELEASE_MJS, "utf8");
-  // The single `git add` line in release.mjs must include the template so the
-  // bump lands in the release commit rather than as a dangling local change.
+  // The single `git add` line in release.mjs must include the templates so the
+  // bumps land in the release commit rather than as dangling local changes.
   const addLine = src
     .split("\n")
     .find((l) => l.includes("git add") && l.includes("package.json"));
@@ -132,5 +211,10 @@ test("release.mjs commits the marketplace template", () => {
     addLine,
     /marketplace\/digitalocean\/template\.json/,
     "the release commit's `git add` must include the DigitalOcean template.json",
+  );
+  assert.match(
+    addLine,
+    /marketplace\/caprover\/pinchy\.yml/,
+    "the release commit's `git add` must include the CapRover pinchy.yml",
   );
 });

--- a/scripts/lib/marketplace-version.test.mjs
+++ b/scripts/lib/marketplace-version.test.mjs
@@ -1,0 +1,136 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  readPinchyVersionFromEnv,
+  readMarketplaceVersion,
+  bumpMarketplaceVersion,
+  assertMarketplaceVersionInSync,
+} from "./marketplace-version.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const TEMPLATE_PATH = resolve(ROOT, "marketplace/digitalocean/template.json");
+const ENV_EXAMPLE_PATH = resolve(ROOT, ".env.example");
+const RELEASE_MJS = resolve(ROOT, "scripts/release.mjs");
+
+const SAMPLE_TEMPLATE = JSON.stringify(
+  {
+    variables: { application_name: "Pinchy", application_version: "v0.5.8" },
+    builders: [{ type: "digitalocean" }],
+  },
+  null,
+  2,
+);
+
+// ─── Pure helpers ─────────────────────────────────────────────────────────────
+
+test("readPinchyVersionFromEnv extracts the pinned version", () => {
+  assert.equal(
+    readPinchyVersionFromEnv("FOO=bar\nPINCHY_VERSION=v0.6.0\nBAZ=qux\n"),
+    "v0.6.0",
+  );
+});
+
+test("readPinchyVersionFromEnv throws when the line is absent", () => {
+  assert.throws(() => readPinchyVersionFromEnv("FOO=bar\n"), /PINCHY_VERSION/);
+});
+
+test("readMarketplaceVersion reads variables.application_version", () => {
+  assert.equal(readMarketplaceVersion(SAMPLE_TEMPLATE), "v0.5.8");
+});
+
+test("readMarketplaceVersion throws when the field is missing", () => {
+  assert.throws(
+    () => readMarketplaceVersion('{"variables":{}}'),
+    /application_version/,
+  );
+});
+
+test("bumpMarketplaceVersion sets application_version with a v prefix", () => {
+  const bumped = bumpMarketplaceVersion(SAMPLE_TEMPLATE, "0.6.0");
+  assert.equal(readMarketplaceVersion(bumped), "v0.6.0");
+});
+
+test("bumpMarketplaceVersion preserves a trailing newline", () => {
+  assert.ok(
+    bumpMarketplaceVersion(SAMPLE_TEMPLATE + "\n", "0.6.0").endsWith("\n"),
+  );
+  assert.ok(!bumpMarketplaceVersion(SAMPLE_TEMPLATE, "0.6.0").endsWith("\n"));
+});
+
+test("bumpMarketplaceVersion leaves other fields untouched", () => {
+  const bumped = JSON.parse(bumpMarketplaceVersion(SAMPLE_TEMPLATE, "0.6.0"));
+  assert.equal(bumped.variables.application_name, "Pinchy");
+  assert.equal(bumped.builders[0].type, "digitalocean");
+});
+
+test("bumpMarketplaceVersion throws on a template without the field", () => {
+  assert.throws(
+    () => bumpMarketplaceVersion('{"variables":{}}', "0.6.0"),
+    /application_version/,
+  );
+});
+
+test("assertMarketplaceVersionInSync passes when versions match", () => {
+  assert.doesNotThrow(() =>
+    assertMarketplaceVersionInSync(SAMPLE_TEMPLATE, "PINCHY_VERSION=v0.5.8\n"),
+  );
+});
+
+test("assertMarketplaceVersionInSync throws when versions differ", () => {
+  assert.throws(
+    () =>
+      assertMarketplaceVersionInSync(
+        SAMPLE_TEMPLATE,
+        "PINCHY_VERSION=v0.6.0\n",
+      ),
+    /out of sync/,
+  );
+});
+
+// ─── Real-file drift guard ────────────────────────────────────────────────────
+// The committed DigitalOcean template must always pin the same version as
+// .env.example. `pnpm release` bumps both; this fails a PR the moment they drift.
+
+test("the DigitalOcean template version matches .env.example PINCHY_VERSION", () => {
+  const template = readFileSync(TEMPLATE_PATH, "utf8");
+  const envExample = readFileSync(ENV_EXAMPLE_PATH, "utf8");
+  assert.doesNotThrow(() =>
+    assertMarketplaceVersionInSync(template, envExample),
+  );
+});
+
+// ─── Release-script wiring guard ──────────────────────────────────────────────
+// The drift guard only protects us if `pnpm release` actually bumps the
+// marketplace template. These textual sweeps fail if a refactor drops the bump.
+
+test("release.mjs bumps the marketplace template version", () => {
+  const src = readFileSync(RELEASE_MJS, "utf8");
+  assert.match(
+    src,
+    /bumpMarketplaceVersion/,
+    "release.mjs must call bumpMarketplaceVersion so the DO template tracks the release",
+  );
+  assert.match(
+    src,
+    /marketplace\/digitalocean\/template\.json/,
+    "release.mjs must write the DigitalOcean template.json on release",
+  );
+});
+
+test("release.mjs commits the marketplace template", () => {
+  const src = readFileSync(RELEASE_MJS, "utf8");
+  // The single `git add` line in release.mjs must include the template so the
+  // bump lands in the release commit rather than as a dangling local change.
+  const addLine = src
+    .split("\n")
+    .find((l) => l.includes("git add") && l.includes("package.json"));
+  assert.ok(addLine, "release.mjs has no 'git add … package.json' line");
+  assert.match(
+    addLine,
+    /marketplace\/digitalocean\/template\.json/,
+    "the release commit's `git add` must include the DigitalOcean template.json",
+  );
+});

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -33,6 +33,7 @@ import {
   assertUpgradingSectionExists,
   finalizeUpgradeSection,
 } from "./lib/release-logic.mjs";
+import { bumpMarketplaceVersion } from "./lib/marketplace-version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -174,6 +175,16 @@ writeFileSync(
 );
 log(`  ✔ .env.example → v${version}`);
 
+// Keep the marketplace listing templates pinned to the released version, so a
+// fresh DigitalOcean install starts on the current release rather than drifting
+// behind. The marketplace-version drift guard fails CI if this is ever skipped.
+const doTemplatePath = resolve(ROOT, "marketplace/digitalocean/template.json");
+writeFileSync(
+  doTemplatePath,
+  bumpMarketplaceVersion(readFileSync(doTemplatePath, "utf8"), version),
+);
+log(`  ✔ marketplace/digitalocean/template.json → v${version}`);
+
 // Freeze the in-progress upgrade-notes section so the just-released version's
 // `%%PINCHY_VERSION%%` placeholders become concrete. Without this, the section
 // keeps the placeholder and the next release's docs build mis-renders these
@@ -191,7 +202,7 @@ if (finalizedMdx !== upgradingMdx) {
 
 log("\nCommitting...");
 exec(
-  `git add package.json packages/web/package.json .env.example "${upgradingMdxPath}"`,
+  `git add package.json packages/web/package.json .env.example marketplace/digitalocean/template.json "${upgradingMdxPath}"`,
 );
 exec(`git commit -m "${buildCommitMessage(version)}"`);
 log(`  ✔ Committed`);

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -33,7 +33,10 @@ import {
   assertUpgradingSectionExists,
   finalizeUpgradeSection,
 } from "./lib/release-logic.mjs";
-import { bumpMarketplaceVersion } from "./lib/marketplace-version.mjs";
+import {
+  bumpMarketplaceVersion,
+  bumpCaproverVersion,
+} from "./lib/marketplace-version.mjs";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const ROOT = resolve(__dirname, "..");
@@ -185,6 +188,13 @@ writeFileSync(
 );
 log(`  ✔ marketplace/digitalocean/template.json → v${version}`);
 
+const caproverTemplatePath = resolve(ROOT, "marketplace/caprover/pinchy.yml");
+writeFileSync(
+  caproverTemplatePath,
+  bumpCaproverVersion(readFileSync(caproverTemplatePath, "utf8"), version),
+);
+log(`  ✔ marketplace/caprover/pinchy.yml → v${version}`);
+
 // Freeze the in-progress upgrade-notes section so the just-released version's
 // `%%PINCHY_VERSION%%` placeholders become concrete. Without this, the section
 // keeps the placeholder and the next release's docs build mis-renders these
@@ -202,7 +212,7 @@ if (finalizedMdx !== upgradingMdx) {
 
 log("\nCommitting...");
 exec(
-  `git add package.json packages/web/package.json .env.example marketplace/digitalocean/template.json "${upgradingMdxPath}"`,
+  `git add package.json packages/web/package.json .env.example marketplace/digitalocean/template.json marketplace/caprover/pinchy.yml "${upgradingMdxPath}"`,
 );
 exec(`git commit -m "${buildCommitMessage(version)}"`);
 log(`  ✔ Committed`);


### PR DESCRIPTION
## What & why

Ships Pinchy on two self-hosted marketplaces — **DigitalOcean** (flagship) and
**CapRover** — plus the release-time automation that keeps both listings' pinned
version from rotting.

These are the two marketplaces that survived a compatibility check against
Pinchy's real architecture. **Railway** was ruled out (it can't share a volume
across services, which Pinchy's `pinchy`↔`openclaw` boundary requires).
**Umbrel** is deferred: its community-store update delivery is unreliable, a poor
fit for a security product.

## DigitalOcean Marketplace (`marketplace/digitalocean/`)

A Packer build (DigitalOcean's blessed JSON template format) that snapshots
Pinchy's **real production `docker-compose.yml`** — same three services, same
tmpfs secrets volume, same healthcheck ordering. Nothing about the security
model is adapted away.

- **Build-time:** install Docker + Caddy + ufw, stage the compose file + loading
  page for the pinned release, pre-pull images, run DigitalOcean's cleanup so the
  image passes `img_check.sh`.
- **First boot** (`cloud-init` per-instance): generate per-Droplet secrets,
  create swap, `docker compose up`. **Secrets are never baked into the snapshot.**

## CapRover (`marketplace/caprover/pinchy.yml`)

A `captainVersion: 4` one-click template. The web UI (7777) is exposed via
CapRover's proxy; OpenClaw and PostgreSQL stay internal. Two deviations CapRover
forces are documented explicitly (not silently) in its README:

- `openclaw-secrets` can't be a tmpfs, so it's a shared on-disk volume — a
  rebuildable runtime cache, **not** the source of truth (provider keys stay
  AES-256-GCM-encrypted in PostgreSQL).
- CapRover ignores healthcheck ordering, so services rely on
  `restart: unless-stopped` to converge on first boot.

## Release version sync

`pnpm release` now bumps **both** templates alongside `.env.example`, and a drift
guard (`scripts/lib/marketplace-version.test.mjs`, run in `test:scripts`) fails
CI the moment either template's pinned version diverges from `.env.example`'s
`PINCHY_VERSION`. Wiring guards assert `release.mjs` keeps bumping + committing
both, so a refactor can't silently drop one. Surgical regex bumps (no JSON/YAML
reformat) keep release diffs to one line per template.

## Testing

- 22 new unit + guard tests (`pnpm test:scripts` → 148 pass).
- Both drift guards verified against the real templates (v0.6.0) ↔ `.env.example`.
- Both bumps verified to produce clean one-line diffs.
- DO shell scripts pass `bash -n`; CapRover YAML validates; touched JS is
  Prettier-clean.

## Not in scope (founder-gated, documented in each README)

The actual DigitalOcean snapshot build + vendor submission (needs the DO vendor
account) and the CapRover test deploy + `caprover/one-click-apps` PR (needs a
CapRover server) require accounts/infrastructure that can't be exercised in CI.
The in-repo artifacts + automation are complete and tested; the build/submit
steps are runbooks in the READMEs.

> Note: this PR currently inherits a **pre-existing `main` failure** unrelated to
> these changes — `upgrade-prune-step.test.ts` (the docs upgrade-notes guard) is
> red on the v0.6.0 release commit. Once `main` is green, this branch rebases
> clean (its own `test:scripts` guard passes locally).
