### PR TITLE
fix(test): make upgrade-prune check survive the release auto-finalize (red main)

### DIFF
--- a/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
+++ b/packages/web/src/__tests__/docs/upgrade-prune-step.test.ts
@@ -75,15 +75,17 @@ describe("upgrade flow includes Docker image disk-hygiene step (#370)", () => {
   });
 
   it("latest version-specific upgrade one-liner pipes through prune", () => {
-    // The %%PINCHY_VERSION%% section ships in the active release notes.
-    // It must show the same hygiene step as the Standard upgrade flow so
-    // copy-paste deployments stay consistent. We match the heading version
-    // pattern agnostically so this test survives each release bump without
-    // hand-editing — the `%%PINCHY_VERSION%%` placeholder is the stable
-    // anchor that identifies the current section.
+    // The newest upgrade-notes section must show the same hygiene step as the
+    // Standard upgrade flow so copy-paste deployments stay consistent. The
+    // anchor is the FIRST `## Upgrading from …` heading — sections are listed
+    // newest-first — whether it still carries the `%%PINCHY_VERSION%%`
+    // placeholder (mid-development) or was frozen to a concrete version by the
+    // release script's auto-finalize step (right after a release). Anchoring on
+    // the placeholder alone broke on every release commit, when the current
+    // section has just been frozen and no placeholder section exists yet.
     const currentSection = sectionBetween(
       upgrading,
-      /^##\s+Upgrading from v[\d.]+ to %%PINCHY_VERSION%%\s*$/m,
+      /^##\s+Upgrading from v[\d.]+ to (?:v[\d.]+|%%PINCHY_VERSION%%)\s*$/m,
       /^##\s+Upgrading from /m
     );
     expect(currentSection, "current-version upgrade section not found").toBeDefined();


### PR DESCRIPTION
## Why — main is red

The v0.6.0 release commit (`chore: release v0.6.0`) turned `main` red. The only failing test:

```
FAIL src/__tests__/docs/upgrade-prune-step.test.ts
  > latest version-specific upgrade one-liner pipes through prune
  AssertionError: current-version upgrade section not found: expected undefined to be defined  (:89)
```

**Root cause — interaction with the new auto-finalize:** PR #537 taught `pnpm release` to *freeze* the current `## Upgrading from v<prev> to %%PINCHY_VERSION%%` section to a concrete version in the release commit. That's correct (it kills the v0.5.8 doc-rot class). But this test anchored "the latest upgrade section" on the `%%PINCHY_VERSION%%` placeholder heading — which no longer exists right after a release, when the section has just been frozen to `to v0.6.0`. So the anchor matched nothing.

This is a gap in #537's verification: I ran this test in the *pre-finalize* state (placeholder present → passed) but not in the *post-finalize* state.

## Fix

Anchor on the **first** `## Upgrading from …` heading (sections are listed newest-first), matching either form:

```
/^##\s+Upgrading from v[\d.]+ to (?:v[\d.]+|%%PINCHY_VERSION%%)\s*$/m
```

The `docker image prune` assertion is unchanged — this is not a weakening, it makes the section-finder robust to both lifecycle states (mid-development placeholder *and* freshly-frozen concrete).

## Verification
- Reproduced red on post-finalize `main` (`expected undefined to be defined` at :89), green after the fix.
- Confirmed the new anchor resolves the correct section in **both** states (dev/placeholder and post-release/concrete) — no regression to mid-development coverage.