### PR TITLE
fix(openclaw): bump runtime 2026.6.5 → 2026.6.8 (latest)

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -28,7 +28,7 @@ RUN apt-get update && apt-get install -y \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
-RUN npm install -g openclaw@2026.6.5
+RUN npm install -g openclaw@2026.6.8
 
 # Install pinchy-files plugin dependencies (native modules must be built in the container)
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json

--- a/docs/src/content/docs/architecture.mdx
+++ b/docs/src/content/docs/architecture.mdx
@@ -221,7 +221,7 @@ For the full details, see [Audit Trail](/concepts/audit-trail/).
 
 OpenClaw runs as a separate Docker container. Pinchy communicates with it via `openclaw-node` (the official Node.js client) over WebSocket on port 18789. The browser never connects to OpenClaw directly.
 
-The current pin pair is **`openclaw@2026.6.5`** in `Dockerfile.openclaw` and **`openclaw-node@0.12.1`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
+The current pin pair is **`openclaw@2026.6.8`** in `Dockerfile.openclaw` and **`openclaw-node@0.13.0`** as a Pinchy dependency, which together advertise protocol v4 on the gateway handshake. Earlier OpenClaw versions ran protocol v3; the v4 cut-over is permanent from OpenClaw 2026.5.12 onward.
 
 ### Config generation
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -92,7 +92,7 @@
     "eslint-config-next": "16.2.6",
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.6.5",
+    "openclaw": "2026.6.8",
     "prettier": "^3.8.3",
     "sharp": "^0.34.5",
     "tailwindcss": "^4.3.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -359,8 +359,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       openclaw:
-        specifier: 2026.6.5
-        version: 2026.6.5
+        specifier: 2026.6.8
+        version: 2026.6.8
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -5329,8 +5329,8 @@ packages:
     resolution: {integrity: sha512-hEU3kO3G2do36IrfFqEENoXsmcMzWbm5cDtzRZTV4CFRe7qG4nvFJSy57IejGcHEL7xNoyUmyb+rGChOxbcnFg==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.6.5:
-    resolution: {integrity: sha512-sRgF0TexfRcJX8Eg0lcL6Jj0YdZbSxUbbp8EbG+qo3v6TtVayE6tKPEs3oCKD7YfYe2C/8Qg26HUxTnycd44ZQ==}
+  openclaw@2026.6.8:
+    resolution: {integrity: sha512-iziR8fi69+ojrtX7FYYvTpkGcVnmyLpIhvchgt5LFkkdHVWw973XAAekKVZ3/xQJ5FG4NwgHkXL0LLTrgsNOSQ==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -11166,7 +11166,7 @@ snapshots:
 
   json-schema-to-ts@3.1.1:
     dependencies:
-      '@babel/runtime': 7.29.2
+      '@babel/runtime': 7.29.7
       ts-algebra: 2.0.0
 
   json-schema-traverse@0.4.1: {}
@@ -11949,7 +11949,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.6.5:
+  openclaw@2026.6.8:
     dependencies:
       '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
       '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)


### PR DESCRIPTION
## Summary

Bumps the OpenClaw runtime pin from **`2026.6.5` → `2026.6.8`** (npm `latest`, released 2026-06-16). Surfaces via `GET /api/version`. Per `AGENTS.md`, an OpenClaw upgrade is a pre-release checklist item for the next release (v0.7.0).

Touches the same four files every OpenClaw bump touches:

- `Dockerfile.openclaw` — the `openclaw@X` runtime install
- `packages/web/package.json` — `devDependencies.openclaw` (drives `NEXT_PUBLIC_OPENCLAW_VERSION` → `/api/version`; kept in lockstep by `openclaw-version-pin-drift.test.ts`)
- `pnpm-lock.yaml`
- `docs/src/content/docs/architecture.mdx` — the documented pin pair (also corrects a stale `openclaw-node@0.12.1` → `0.13.0`, matching `package.json`)

## Changelog review (2026.6.6 + 2026.6.8) — bugfix/additive for Pinchy

- **Tool calling:** safer OpenAI/Anthropic tool-schema recovery and quarantine of *unreadable* / post-hook schemas — hardening of malformed input, **not** a contract change. Pinchy's plugin tool schemas are well-formed (manifest-tools-drift + plugin-tool-coverage guards green; schemas are validated against OpenAI's strict validator).
- **Models:** GLM-5.2 and Claude Haiku 4.5 catalog entries added; provider-qualified model IDs normalized across OpenRouter/Vertex. Additive — `model-resolver` tests green.
- **Web search default change** (key-free providers are now explicit opt-ins instead of auto-fallback): **Pinchy is unaffected** — `pinchy-web` registers its own `pinchy_web_search` tool backed by Brave with an explicit API key, not OpenClaw's built-in provider auto-selection.
- **Vision/image:** the `chat.send` → `imageModel` offload mechanism is unchanged; Pinchy's own `image-fallback` path is independent.
- **Security:** broad fail-closed hardening across sandbox / MCP / browser / channel / exec-approval paths — good for an enterprise deployment.
- `#92510` (require admin for HTTP session/model override surfaces) does not affect Pinchy: per-turn model overrides go over the WebSocket `chat.send` path with the gateway token, not an HTTP override surface.

`openclaw-node` stays at `0.13.0` (already advertises protocol v4; unchanged).

## Validation

Local:
- `pnpm test` — **6190 passed**, incl. `openclaw-version-pin-drift`, `model-resolver/*`, `manifest-tools-drift`, `plugin-tool-coverage`, `auth-config-consistency`.
- `pnpm -C packages/web test:db` — **115 passed**.
- Built `Dockerfile.openclaw@2026.6.8`: `npm install -g openclaw@2026.6.8` + the prewarm gateway boot succeed; the full production stack (`Dockerfile.pinchy` + openclaw) comes up **healthy** running **OpenClaw 2026.6.8 (844f405)**, with Pinchy↔gateway connectivity confirmed via the `/api/internal/openclaw-config-ready` healthcheck.
- `prettier --check` clean on changed files; pre-push `@pinchy/web` build passed.

Tool-call round-trip:
- The **live tool-dispatch round-trip** (fake-ollama → OpenClaw → `docs_list` / `pinchy_save_user_context` / `pinchy_ls` / `pinchy_read` audit entries) is exercised by the CI **`integration`** job (`build-image` → `test:integration` against the freshly-built 2026.6.8 image). A local run of `agent-chat.spec.ts` was blocked only by an OrbStack host-port-forward artifact on this multi-stack dev box (the seed's `localhost:5435` connection), unrelated to the bump — the production stack itself ran healthy on 2026.6.8 throughout. CI runs this in a clean single-stack runner.

## Upgrade notes

None needed — an OpenClaw runtime bump is transparent to operators (same image pull), consistent with prior bumps (`2026.5.28 → 2026.6.1 → 2026.6.5`), which added no `upgrading.mdx` section.
