### PR TITLE
feat(release): release:preflight — bespoke staging checklist from upgrade notes

### DIFF
--- a/.claude/skills/cut-pinchy-release/SKILL.md
+++ b/.claude/skills/cut-pinchy-release/SKILL.md
@@ -60,6 +60,15 @@ Two mechanisms now make this impossible:
 
 ## Before you run `pnpm release`
 
+**Step 0 — run the preflight and turn every `[ ]` into a blocking task.** `pnpm release:preflight <version>` prints the gate status plus the **manual** gates the script can't enforce: a release-specific staging checklist **auto-derived from this release's upgrade notes** (the `#### …` subheadings under `### Breaking changes` / `### Upgrade notes`), the standard regression smoke, and the PWA check. This exists because manual gates that live only as prose get silently skipped next to the script's hard gates — that is exactly how v0.6.0 shipped with the staging click-through never done.
+
+So, mechanically:
+
+1. Run `pnpm release:preflight <version>`.
+2. For **each `[ ]`** it prints, create a task (TodoWrite/Task), and make the `pnpm release` task **`blockedBy`** all of them. Do not start the release task while any remain open.
+3. Verify each on the **real `:next` staging instance** (`staging.heypinchy.com`) — it carries the upgrade path + real agents/data; the ephemeral CI E2E stacks don't. The release-specific items are different every release, which is why they're generated from the notes rather than hardcoded.
+4. The preflight then prints the exact `pnpm release <version> --verified=$(git rev-parse HEAD)` command. The `--verified` SHA ties your attestation to the commit you actually tested on staging. (A hard `--verified` gate in `release.mjs` is planned once it can be verified end-to-end against a real staging release; today it's enforced by this task discipline + the preflight echo.)
+
 Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** — that is the canonical, always-current list, so don't re-derive or copy it. The script and CI already enforce the mechanical gates (clean tree, on `main`, CI green, tag free, `upgrading.mdx` section present with both subsections, `pnpm audit --audit-level=high --prod`). The human judgment calls the script _can't_ enforce — verify each against CONTRIBUTING — include:
 
 - All feature/fix PRs for this release merged to `main`; `pnpm outdated` reviewed.
@@ -85,6 +94,7 @@ Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** �
 | "The version bump is just cosmetic"                     | `/api/version` and the public Releases page read it. It IS the shipped version.  |
 | "Deadline — skip the checklist"                         | The checklist is the only thing the script _can't_ enforce.                      |
 | "I can release from this worktree/branch"               | Releases cut from clean `main` only. The script refuses otherwise.               |
+| "`pnpm release` went green, so I'm done"                | Green ≠ verified. The staging click-through + PWA are manual gates the script can't see. Run `release:preflight`, make each `[ ]` a blocking task, verify on `:next` first. |
 
 ## Common mistakes
 

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
     "test": "pnpm --filter @pinchy/web test",
     "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs",
     "release": "node scripts/release.mjs",
+    "release:preflight": "node scripts/release-preflight.mjs",
     "docs:paths": "node scripts/generate-docs-paths.mjs",
     "models:discover": "node scripts/discover-ollama-cloud-models.mjs",
     "models:verify:vision": "node scripts/verify-ollama-cloud-vision.mjs",

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -316,3 +316,105 @@ export function assertNoStaleUpgradeSections(mdx, latestReleasedVersion) {
     );
   }
 }
+
+/**
+ * Derives a release-specific "verify on staging" checklist from the target
+ * upgrade-notes section.
+ *
+ * The release-specific verification is bespoke every time — what to click
+ * through depends on what actually changed. That list already exists: it's the
+ * `#### …` subheadings under `### Breaking changes` and `### Upgrade notes` of
+ * this release's section. This turns each into a checklist item, flagging the
+ * ones under Breaking changes (which deserve the closest look). A "None."
+ * Breaking-changes subsection simply has no `####` and yields no items.
+ *
+ * Only the target section is scanned (sliced to the next `## ` heading), so a
+ * later release's subheadings never leak in. If the section has no `####`
+ * subheadings at all, a single generic item is returned so the operator still
+ * verifies the notes rather than getting an empty list.
+ *
+ * @param {string} mdx
+ * @param {string} prevVersion - no leading 'v'
+ * @param {string} targetVersion - no leading 'v'
+ * @returns {Array<{title: string, breaking: boolean}>}
+ */
+export function deriveStagingChecklist(mdx, prevVersion, targetVersion) {
+  const heading = new RegExp(
+    `^##\\s+Upgrading\\s+from\\s+v${escapeRegex(prevVersion)}\\s+to\\s+(v${escapeRegex(targetVersion)}|%%PINCHY_VERSION%%)\\s*$`,
+    "m",
+  );
+  const m = heading.exec(mdx);
+  if (!m) return [];
+
+  const remainder = mdx.slice(m.index + m[0].length);
+  const nextH2 = /^## /m.exec(remainder);
+  const sectionBody = remainder.slice(0, nextH2 ? nextH2.index : remainder.length);
+
+  const subRe = /^###\s+(.+?)\s*$/gm;
+  const subs = [];
+  let sm;
+  while ((sm = subRe.exec(sectionBody)) !== null) {
+    subs.push({ name: sm[1].trim(), index: sm.index, len: sm[0].length });
+  }
+
+  const items = [];
+  for (let i = 0; i < subs.length; i++) {
+    const bodyStart = subs[i].index + subs[i].len;
+    const bodyEnd = i + 1 < subs.length ? subs[i + 1].index : sectionBody.length;
+    const body = sectionBody.slice(bodyStart, bodyEnd);
+    const breaking = /^breaking changes$/i.test(subs[i].name);
+    const hRe = /^####\s+(.+?)\s*$/gm;
+    let hm;
+    while ((hm = hRe.exec(body)) !== null) {
+      items.push({ title: hm[1].trim(), breaking });
+    }
+  }
+
+  if (items.length === 0) {
+    return [
+      {
+        title: `Verify the changes described in the v${targetVersion} upgrade notes`,
+        breaking: false,
+      },
+    ];
+  }
+  return items;
+}
+
+/**
+ * Checks a staging attestation against the commit being released.
+ *
+ * The release-specific staging verification can't be made fraud-proof, but it
+ * can be anchored to the exact code: the operator passes the SHA they verified
+ * on staging (`:next` builds the tip of main), and it must match HEAD — the
+ * commit about to be tagged. A short SHA that prefixes HEAD is accepted
+ * (`git rev-parse --short`). Returns a result rather than throwing so callers
+ * decide whether to warn or hard-fail.
+ *
+ * @param {{verifiedSha?: string, headSha?: string}} args
+ * @returns {{ok: boolean, message: string}}
+ */
+export function checkReleaseVerification({ verifiedSha, headSha }) {
+  const v = (verifiedSha || "").trim().toLowerCase();
+  const h = (headSha || "").trim().toLowerCase();
+  if (!v) {
+    return {
+      ok: false,
+      message:
+        "No staging attestation provided. Verify this commit on staging, then pass --verified=$(git rev-parse HEAD).",
+    };
+  }
+  if (v.length < 7) {
+    return {
+      ok: false,
+      message: `Attestation SHA "${verifiedSha}" is too short — pass at least 7 chars (use $(git rev-parse HEAD)).`,
+    };
+  }
+  if (!(h.startsWith(v) || v.startsWith(h))) {
+    return {
+      ok: false,
+      message: `Attestation SHA ${verifiedSha} does not match HEAD ${headSha} — you verified a different commit than you're releasing.`,
+    };
+  }
+  return { ok: true, message: `Staging attestation matches HEAD (${h.slice(0, 12)}).` };
+}

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -11,6 +11,8 @@ import {
   assertVersionMatchesTag,
   finalizeUpgradeSection,
   assertNoStaleUpgradeSections,
+  deriveStagingChecklist,
+  checkReleaseVerification,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -562,4 +564,143 @@ test("assertNoStaleUpgradeSections ignores placeholders outside version sections
     "Current.",
   ].join("\n");
   assert.doesNotThrow(() => assertNoStaleUpgradeSections(mdx, "0.5.8"));
+});
+
+// deriveStagingChecklist — turns the target section's `####` subheadings into a
+// release-specific "verify on staging" checklist (the bespoke gate). Breaking
+// changes are flagged; "None." breaking changes yield no breaking items.
+
+const CHECKLIST_MDX = [
+  "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+  "",
+  "### Breaking changes",
+  "",
+  "#### Telegram and web no longer share one conversation",
+  "",
+  "Body.",
+  "",
+  "### Upgrade notes",
+  "",
+  "#### Multiple chats per agent",
+  "",
+  "Body.",
+  "",
+  "#### Sturdier streaming and reconnects",
+  "",
+  "Body.",
+  "",
+  "## Upgrading from v0.5.7 to v0.5.8",
+  "",
+  "#### Older feature (must NOT leak into the v0.6.0 checklist)",
+].join("\n");
+
+test("deriveStagingChecklist extracts #### subheadings as items, flagging breaking ones", () => {
+  const items = deriveStagingChecklist(CHECKLIST_MDX, "0.5.8", "0.6.0");
+  assert.deepEqual(items, [
+    { title: "Telegram and web no longer share one conversation", breaking: true },
+    { title: "Multiple chats per agent", breaking: false },
+    { title: "Sturdier streaming and reconnects", breaking: false },
+  ]);
+});
+
+test("deriveStagingChecklist does not leak a later section's subheadings", () => {
+  const items = deriveStagingChecklist(CHECKLIST_MDX, "0.5.8", "0.6.0");
+  assert.ok(!items.some((i) => /Older feature/.test(i.title)));
+});
+
+test("deriveStagingChecklist yields no breaking items when Breaking changes is 'None.'", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
+    "#### A nice improvement",
+    "",
+    "Body.",
+  ].join("\n");
+  const items = deriveStagingChecklist(mdx, "0.5.8", "0.6.0");
+  assert.deepEqual(items, [{ title: "A nice improvement", breaking: false }]);
+});
+
+test("deriveStagingChecklist falls back to a generic item when there are no #### subheadings", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to %%PINCHY_VERSION%%",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
+    "Standard upgrade — just bump and pull.",
+  ].join("\n");
+  const items = deriveStagingChecklist(mdx, "0.5.8", "0.6.0");
+  assert.equal(items.length, 1);
+  assert.equal(items[0].breaking, false);
+  assert.match(items[0].title, /upgrade notes/i);
+});
+
+test("deriveStagingChecklist returns [] when the target section is missing", () => {
+  const mdx = "## Upgrading from v0.5.6 to v0.5.7\n\n#### Unrelated\n";
+  assert.deepEqual(deriveStagingChecklist(mdx, "0.5.8", "0.6.0"), []);
+});
+
+test("deriveStagingChecklist works on a concrete (post-finalize) target heading too", () => {
+  const mdx = [
+    "## Upgrading from v0.5.8 to v0.6.0",
+    "",
+    "### Breaking changes",
+    "",
+    "None.",
+    "",
+    "### Upgrade notes",
+    "",
+    "#### A feature",
+    "",
+    "Body.",
+  ].join("\n");
+  const items = deriveStagingChecklist(mdx, "0.5.8", "0.6.0");
+  assert.deepEqual(items, [{ title: "A feature", breaking: false }]);
+});
+
+// checkReleaseVerification — ties the staging attestation to the exact commit.
+
+test("checkReleaseVerification ok when verified SHA matches HEAD", () => {
+  const r = checkReleaseVerification({
+    verifiedSha: "abc1234def567",
+    headSha: "abc1234def567",
+  });
+  assert.equal(r.ok, true);
+});
+
+test("checkReleaseVerification accepts a short verified SHA that prefixes HEAD", () => {
+  const r = checkReleaseVerification({
+    verifiedSha: "abc1234",
+    headSha: "abc1234def5678901234",
+  });
+  assert.equal(r.ok, true);
+});
+
+test("checkReleaseVerification fails on SHA mismatch", () => {
+  const r = checkReleaseVerification({
+    verifiedSha: "abc1234",
+    headSha: "def9999000",
+  });
+  assert.equal(r.ok, false);
+  assert.match(r.message, /match|head/i);
+});
+
+test("checkReleaseVerification fails when no attestation is provided", () => {
+  const r = checkReleaseVerification({ verifiedSha: "", headSha: "abc1234def" });
+  assert.equal(r.ok, false);
+  assert.match(r.message, /--verified|attestation|staging/i);
+});
+
+test("checkReleaseVerification rejects a too-short verified SHA", () => {
+  const r = checkReleaseVerification({ verifiedSha: "abc", headSha: "abc1234def567" });
+  assert.equal(r.ok, false);
 });

--- a/scripts/release-preflight.mjs
+++ b/scripts/release-preflight.mjs
@@ -1,0 +1,160 @@
+#!/usr/bin/env node
+/**
+ * Pinchy release preflight (advisory)
+ *
+ * Usage: pnpm release:preflight <version> [--verified=<sha>]
+ *   e.g. pnpm release:preflight 0.7.0
+ *
+ * Prints, before you cut a release:
+ *   1. Auto-checked gates (branch, clean tree, tag free, upgrade-notes section,
+ *      CI status) — the same hard gates `pnpm release` enforces, surfaced early.
+ *   2. The MANUAL gates that the release script CANNOT enforce — and that get
+ *      silently skipped if they live only as prose. Each is printed as an
+ *      unchecked `[ ]` item to be verified on staging (:next) before releasing:
+ *        - a release-specific checklist DERIVED FROM THIS RELEASE'S UPGRADE NOTES
+ *          (the bespoke part — different every release),
+ *        - the standard regression smoke,
+ *        - the PWA install check.
+ *
+ * This is advisory output — it never mutates anything and always exits 0. The
+ * forcing function is the cut-release skill: turn every `[ ]` below into a
+ * blocking task and make the `pnpm release` task depend on them.
+ *
+ * After verifying on staging, cut with:
+ *   pnpm release <version> --verified=$(git rev-parse HEAD)
+ */
+
+import { execSync } from "node:child_process";
+import { readFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+import {
+  parseAndValidateVersion,
+  buildTagName,
+  assertUpgradingSectionExists,
+  deriveStagingChecklist,
+  checkReleaseVerification,
+} from "./lib/release-logic.mjs";
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const ROOT = resolve(__dirname, "..");
+
+function tryExec(cmd) {
+  try {
+    return { ok: true, out: execSync(cmd, { cwd: ROOT, encoding: "utf8", stdio: ["pipe", "pipe", "pipe"] }).trim() };
+  } catch (e) {
+    return { ok: false, out: (e.stdout || e.message || "").toString().trim() };
+  }
+}
+
+const out = (s = "") => process.stdout.write(`${s}\n`);
+const mark = (ok) => (ok === true ? "✓" : ok === false ? "✗" : "❓");
+
+// ─── Argument ────────────────────────────────────────────────────────────────
+
+const input = process.argv[2];
+const verifiedArg = (process.argv.find((a) => a.startsWith("--verified=")) || "").split("=")[1];
+if (!input) {
+  process.stderr.write("Usage: pnpm release:preflight <version> [--verified=<sha>]\n");
+  process.exit(1);
+}
+
+let version;
+try {
+  version = parseAndValidateVersion(input);
+} catch (e) {
+  process.stderr.write(`✖ ${e.message}\n`);
+  process.exit(1);
+}
+const tag = buildTagName(version);
+
+const prevTag = tryExec("git describe --tags --abbrev=0");
+const prevVersion = prevTag.ok ? prevTag.out.replace(/^v/, "") : null;
+
+out(`\nRelease preflight — ${tag}${prevVersion ? ` (from v${prevVersion})` : ""}\n`);
+
+// ─── Auto-checked gates ───────────────────────────────────────────────────────
+
+const branch = tryExec("git branch --show-current");
+const status = tryExec("git status --porcelain");
+const tags = tryExec("git tag --list");
+
+let upgradeNotesOk = false;
+let upgradeNotesMsg = "";
+if (prevVersion) {
+  try {
+    const mdx = readFileSync(
+      resolve(ROOT, "docs/src/content/docs/guides/upgrading.mdx"),
+      "utf8",
+    );
+    assertUpgradingSectionExists(mdx, prevVersion, version);
+    upgradeNotesOk = true;
+  } catch (e) {
+    upgradeNotesMsg = e.message.split("\n")[0];
+  }
+} else {
+  upgradeNotesMsg = "no previous tag found (cannot resolve the 'from' version)";
+}
+
+const ci = tryExec(
+  'gh run list --branch main --workflow CI --limit 1 --json conclusion --jq ".[0].conclusion"',
+);
+const ciState = !ci.ok ? null : ci.out === "success" ? true : false;
+
+out("Auto-checked (also enforced by `pnpm release`):");
+out(`  ${mark(branch.out === "main")} on main branch${branch.out === "main" ? "" : ` (on: ${branch.out || "?"})`}`);
+out(`  ${mark(status.ok && status.out === "")} working tree clean`);
+out(`  ${mark(tags.ok && !tags.out.split("\n").includes(tag))} tag ${tag} is free`);
+out(`  ${mark(upgradeNotesOk)} upgrade-notes section present${upgradeNotesOk ? "" : ` — ${upgradeNotesMsg}`}`);
+out(`  ${mark(ciState)} CI green on main${ciState === null ? " (could not query gh — check manually)" : ci.out ? ` (${ci.out})` : ""}`);
+
+// ─── Manual gates — verify on staging, then check each off ────────────────────
+
+out("");
+out("Manual gates — verify on staging (:next) and CHECK EACH OFF before `pnpm release`:");
+out("(the skill turns each `[ ]` into a blocking task that `pnpm release` waits on)");
+
+out("");
+out("  Release-specific (from this release's upgrade notes):");
+let checklist = [];
+if (prevVersion) {
+  try {
+    const mdx = readFileSync(
+      resolve(ROOT, "docs/src/content/docs/guides/upgrading.mdx"),
+      "utf8",
+    );
+    checklist = deriveStagingChecklist(mdx, prevVersion, version);
+  } catch {
+    // handled below by the empty-list branch
+  }
+}
+if (checklist.length === 0) {
+  out("    (!) no upgrade-notes section resolved — write it first; nothing to verify yet");
+} else {
+  for (const item of checklist) {
+    out(`    [ ] ${item.breaking ? "[BREAKING] " : ""}${item.title}`);
+  }
+}
+
+out("");
+out("  Standard regression smoke:");
+out("    [ ] Smithers chat round-trip");
+out("    [ ] One live integration");
+out("    [ ] One custom agent with existing chat history");
+
+out("");
+out("  PWA install check (manifest fields are already CI-gated):");
+out("    [ ] Chrome desktop: install icon appears, opens a standalone window");
+out("    [ ] iOS Safari: Share → Add to Home Screen opens full-screen with splash");
+
+// ─── Attestation echo ─────────────────────────────────────────────────────────
+
+out("");
+const head = tryExec("git rev-parse HEAD");
+if (verifiedArg !== undefined) {
+  const v = checkReleaseVerification({ verifiedSha: verifiedArg, headSha: head.out });
+  out(`Attestation: ${mark(v.ok)} ${v.message}`);
+} else if (head.ok) {
+  out(`After verifying on staging, cut with:\n  pnpm release ${version} --verified=${head.out.slice(0, 12)}`);
+}
+out("");


### PR DESCRIPTION
## Why

Follow-up to the release hardening (#537). v0.6.0 shipped with the manual staging click-through never done — because manual gates that live only as prose in CONTRIBUTING get silently skipped next to the script's hard gates. The fix isn't more prose; it's making the manual gate **generated, surfaced, and task-shaped**.

Key insight (from the design discussion): the release-specific staging verification is **bespoke every release** — what to click through depends on what changed. A fixed automated smoke can't cover it. But that list already exists: it's the `#### …` subheadings of this release's upgrade-notes section.

## What

**`pnpm release:preflight <version>`** (`scripts/release-preflight.mjs`, advisory — never mutates, always exits 0) prints:
- **Auto-checked gates** (branch, clean tree, tag free, upgrade-notes section present, CI on main) — the same hard gates `pnpm release` enforces, surfaced early.
- **Release-specific staging checklist**, auto-derived from the upgrade notes (`deriveStagingChecklist`): each `#### …` under `### Breaking changes` / `### Upgrade notes` becomes a `[ ]` item, breaking ones flagged `[BREAKING]`.
- The **standard regression smoke** + **PWA** manual items.
- The exact `pnpm release <version> --verified=$(git rev-parse HEAD)` command. `checkReleaseVerification` ties the attestation SHA to the commit under test.

**Skill** (`cut-pinchy-release`): now leads with *run the preflight, turn every `[ ]` into a blocking task, make the `pnpm release` task `blockedBy` them, verify on the real `:next` staging instance*. Adds a "green ≠ verified" red flag.

## Scope notes
- **PWA manifest checks already exist** as a CI gate (`__tests__/lib/pwa/manifest.test.ts`: `display:standalone`, any+maskable icons, icon existence, start_url/scope) — so the deterministic PWA part is already covered; only the manual install gesture remains.
- **Basic smoke runs against the real staging instance**, not a CI fresh-stack — CI already runs full E2E (Setup Wizard, agent-chat, Telegram/Odoo/Email) on ephemeral stacks every run; staging uniquely exercises the upgrade path + real data.
- **The hard `--verified` gate in `release.mjs` is deliberately deferred** to an egress-capable follow-up where it can be verified end-to-end against a real staging release — shipping an unverified gate into the release-critical script is exactly what turned main red on the v0.6.0 release commit. Today the attestation is enforced by the task discipline + preflight echo.

## Verification
- `pnpm test:scripts` — 137 pass (+11: `deriveStagingChecklist`, `checkReleaseVerification`).
- Ran `release:preflight` end-to-end; `deriveStagingChecklist` on the real v0.6.0 notes yields the expected 7-item checklist with the Telegram breaking change flagged; `--verified` self-check confirmed for match / short-prefix / mismatch.