### PR TITLE
feat(skills): foundation + web-search pilot + market-monitor template (#543)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -133,6 +133,7 @@ export default defineConfig({
           label: 'Guides',
           items: [
             { label: 'Create a Knowledge Base Agent', slug: 'guides/create-knowledge-base-agent' },
+            { label: 'Create a Market & News Monitor', slug: 'guides/create-market-monitor-agent' },
             { label: 'Mount Data Directories', slug: 'guides/mount-data-directories' },
             { label: 'User Management', slug: 'guides/user-management' },
             { label: 'Smithers Onboarding', slug: 'guides/smithers-onboarding' },

--- a/docs/src/content/docs/guides/create-market-monitor-agent.mdx
+++ b/docs/src/content/docs/guides/create-market-monitor-agent.mdx
@@ -44,10 +44,10 @@ The agent appears in your sidebar and opens its chat page. It is ready to use im
 
 ## Example prompts
 
-- "What did Anthropic announce this week?"
-- "Recent news about EU AI Act enforcement for SMEs"
+- "Find recent funding announcements in our industry"
+- "Latest enforcement news on the EU AI Act for SMEs"
 - "Compare pricing for the top three project-management SaaS tools"
-- "Has [Competitor] released any product updates in 2026?"
+- "Has [Competitor] released any product updates this quarter?"
 
 The agent will return a short answer followed by cited bullet points and a one-line "What I checked" summary describing the queries it ran.
 

--- a/docs/src/content/docs/guides/create-market-monitor-agent.mdx
+++ b/docs/src/content/docs/guides/create-market-monitor-agent.mdx
@@ -1,0 +1,62 @@
+---
+title: Create a Market & News Monitor
+description: Step-by-step guide to creating an agent that watches the public web for market trends, industry news, and competitor signals.
+---
+
+This guide walks you through creating a Market & News Monitor — an agent that searches the public web for current information and cites every fact with a source URL.
+
+## Prerequisites
+
+- Pinchy is running (see [Quick Start](/getting-started/))
+- A web search provider is configured (the **Pinchy Web** plugin pulls its own credentials at runtime — no per-agent connection setup)
+- You are logged in as an admin
+
+## 1. Navigate to "New Agent"
+
+In the Pinchy sidebar, click the **+** button next to "Agents" to open the agent creation form.
+
+## 2. Select the "Market & News Monitor" template
+
+Choose **Market & News Monitor** from the **Marketing & Web** category. The template pre-configures the agent with:
+
+- A monitor persona (concise, source-grounded, recency-aware)
+- The `web-search` skill — a workflow guide that teaches the agent when to search, when to fetch a full page, and how to cite sources
+- Read-only access to the public web through `pinchy_web_search` and `pinchy_web_fetch`
+
+## 3. Enter a name and create
+
+Give your agent a descriptive name — for example "Industry Watch" or "Competitive Pulse". Click **Create**.
+
+The agent appears in your sidebar and opens its chat page. It is ready to use immediately — the web tools come from the **Pinchy Web** plugin, no per-user connection is required.
+
+## What this agent can do
+
+- Search the public web for current information
+- Fetch the full text of specific public URLs
+- Summarize what it finds, citing every claim with a source link
+- Refuse to invent facts when no source is found
+
+## What this agent **cannot** do
+
+- Access your private data, internal systems, or any connected integration
+- Send messages, post anywhere, or take any action outside this chat
+- Read any document or file on your Pinchy install
+
+## Example prompts
+
+- "What did Anthropic announce this week?"
+- "Recent news about EU AI Act enforcement for SMEs"
+- "Compare pricing for the top three project-management SaaS tools"
+- "Has [Competitor] released any product updates in 2026?"
+
+The agent will return a short answer followed by cited bullet points and a one-line "What I checked" summary describing the queries it ran.
+
+## How it works under the hood
+
+Market & News Monitor is the first template built on Pinchy's skill layer (master tracking issue #543). When you create an agent from this template:
+
+- The `web-search` skill body is materialized to the agent's workspace as `skills/web-search/SKILL.md`
+- OpenClaw 2026.6.x loads that file automatically into the agent's system prompt
+- The agent's `openclaw.json` entry lists `skills: ["web-search"]`, which also excludes OpenClaw's bundled desktop skills (1Password, Apple Notes, ...) that are irrelevant for enterprise agents
+
+You can read more about how skills work in [Skills, Templates, and Capabilities](/explanation/skills-and-templates/) (forthcoming).

--- a/packages/web/drizzle/0042_silly_revanche.sql
+++ b/packages/web/drizzle/0042_silly_revanche.sql
@@ -1,0 +1,3 @@
+DROP VIEW "public"."active_agents";--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "skills" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+CREATE VIEW "public"."active_agents" AS (select "id", "name", "model", "template_id", "plugin_config", "allowed_tools", "skills", "owner_id", "is_personal", "visibility", "greeting_message", "tagline", "avatar_seed", "personality_preset_id", "created_at", "deleted_at" from "agents" where "agents"."deleted_at" is null);

--- a/packages/web/drizzle/meta/0042_snapshot.json
+++ b/packages/web/drizzle/meta/0042_snapshot.json
@@ -1,0 +1,2151 @@
+{
+  "id": "7c29e581-22e7-469a-96a0-2d83b83f1018",
+  "prevId": "98d2c080-6e74-4502-bd2a-40059ad14997",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -295,6 +295,13 @@
       "when": 1781859608593,
       "tag": "0041_steady_stryfe",
       "breakpoints": true
+    },
+    {
+      "idx": 42,
+      "version": "7",
+      "when": 1782196410687,
+      "tag": "0042_silly_revanche",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -179,6 +179,7 @@ describe("POST /api/agents audit logging", () => {
         name: "Test Agent",
         model: "anthropic/claude-haiku-4-5-20251001",
         templateId: "custom",
+        skills: [],
         modelSelection: {
           source: "provider-default",
           hint: null,

--- a/packages/web/src/__tests__/lib/agent-templates-web.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates-web.test.ts
@@ -43,16 +43,27 @@ describe("market-monitor template (v1 web-search pilot)", () => {
   });
 });
 
-describe("AGENT_TEMPLATES — additive defaultSkills", () => {
-  it("existing templates without defaultSkills keep working (backwards compat)", () => {
+describe("AGENT_TEMPLATES — defaultSkills drift guard", () => {
+  it("every template's defaultSkills (if present) references only known skills", () => {
+    // Same convention as KNOWN_PINCHY_PLUGINS — a template that lists a
+    // skill not in KNOWN_SKILLS would silently emit a malformed allowlist
+    // entry and trip the runtime guard in regenerateOpenClawConfig only
+    // when a real user tries to instantiate the template. Catch it here.
+    for (const [id, t] of Object.entries(AGENT_TEMPLATES)) {
+      for (const skillId of t.defaultSkills ?? []) {
+        expect(KNOWN_SKILLS, `template "${id}" references unknown skill "${skillId}"`).toContain(
+          skillId
+        );
+      }
+    }
+  });
+
+  it("templates without defaultSkills keep working (backwards compat)", () => {
     // Field is optional. Templates can omit it; agents created from such
     // templates get skills: [] in their DB row.
-    for (const t of Object.values(AGENT_TEMPLATES)) {
-      // No assertion on the field being present — just verify the type
-      // accepts the absence (compile-time check via the spread).
-      const _check: string[] | undefined = t.defaultSkills;
-      void _check;
-    }
-    expect(true).toBe(true);
+    const withoutSkills = Object.entries(AGENT_TEMPLATES).filter(
+      ([, t]) => t.defaultSkills === undefined
+    );
+    expect(withoutSkills.length).toBeGreaterThan(0);
   });
 });

--- a/packages/web/src/__tests__/lib/agent-templates-web.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates-web.test.ts
@@ -1,0 +1,58 @@
+import { describe, it, expect } from "vitest";
+import { AGENT_TEMPLATES, getTemplate } from "@/lib/agent-templates";
+import { KNOWN_SKILLS } from "@/lib/skills";
+
+describe("market-monitor template (v1 web-search pilot)", () => {
+  const template = getTemplate("market-monitor");
+
+  it("exists in the registry", () => {
+    expect(template).toBeDefined();
+  });
+
+  it("requires the pinchy-web plugin", () => {
+    // pinchy-web is the capability provider; the skill is the workflow.
+    expect(template?.pluginId).toBe("pinchy-web");
+  });
+
+  it("declares defaultSkills with web-search", () => {
+    expect(template?.defaultSkills).toBeDefined();
+    expect(template?.defaultSkills).toContain("web-search");
+  });
+
+  it("all defaultSkills are known", () => {
+    // Drift guard: a template cannot reference a skill that doesn't exist.
+    for (const id of template?.defaultSkills ?? []) {
+      expect(KNOWN_SKILLS, `skill "${id}" not in KNOWN_SKILLS`).toContain(id);
+    }
+  });
+
+  it("has an icon, persona, tagline, suggestedNames, and modelHint", () => {
+    expect(template?.iconName).toBeTruthy();
+    expect(template?.defaultPersonality).toBeTruthy();
+    expect(template?.defaultTagline).toBeTruthy();
+    expect(template?.suggestedNames?.length ?? 0).toBeGreaterThan(0);
+    expect(template?.modelHint).toBeDefined();
+  });
+
+  it("does NOT carry inline tool/workflow prose in defaultAgentsMd (skills own that)", () => {
+    // Skills-based templates keep persona prose ONLY. Workflow guidance
+    // lives in the SKILL.md body so it can be reused across templates.
+    const md = template?.defaultAgentsMd ?? "";
+    expect(md.toLowerCase()).not.toMatch(/## capabilities/);
+    expect(md.toLowerCase()).not.toMatch(/pinchy_web_search/);
+  });
+});
+
+describe("AGENT_TEMPLATES — additive defaultSkills", () => {
+  it("existing templates without defaultSkills keep working (backwards compat)", () => {
+    // Field is optional. Templates can omit it; agents created from such
+    // templates get skills: [] in their DB row.
+    for (const t of Object.values(AGENT_TEMPLATES)) {
+      // No assertion on the field being present — just verify the type
+      // accepts the absence (compile-time check via the spread).
+      const _check: string[] | undefined = t.defaultSkills;
+      void _check;
+    }
+    expect(true).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config-skills.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-skills.test.ts
@@ -1,0 +1,279 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const writeFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn().mockReturnValue(true);
+  const mkdirSyncMock = vi.fn();
+  const renameSyncMock = vi.fn();
+  const chmodSyncMock = vi.fn();
+  const rmSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: writeFileSyncMock,
+      readFileSync: readFileSyncMock,
+      existsSync: existsSyncMock,
+      mkdirSync: mkdirSyncMock,
+      renameSync: renameSyncMock,
+      chmodSync: chmodSyncMock,
+      rmSync: rmSyncMock,
+    },
+    writeFileSync: writeFileSyncMock,
+    readFileSync: readFileSyncMock,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+    renameSync: renameSyncMock,
+    chmodSync: chmodSyncMock,
+    rmSync: rmSyncMock,
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() =>
+        Object.assign(Promise.resolve([]), {
+          innerJoin: vi.fn().mockReturnValue(
+            Object.assign(Promise.resolve([]), {
+              where: vi.fn().mockResolvedValue([]),
+            })
+          ),
+          where: vi.fn().mockResolvedValue([]),
+        })
+      ),
+    })),
+  },
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (val: string) => val,
+  encrypt: (val: string) => val,
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+vi.mock("@/server/restart-state", () => ({
+  restartState: { notifyRestart: vi.fn() },
+}));
+
+vi.mock("@/lib/migrate-onboarding", () => ({
+  migrateExistingSmithers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openclaw-secrets")>();
+  return {
+    ...actual,
+    writeSecretsFile: vi.fn(),
+    readSecretsFile: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn(async () => ""),
+}));
+
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { db } from "@/db";
+
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+const mockedDb = vi.mocked(db);
+
+function mockAgents(agentsData: unknown[]) {
+  mockedDb.select.mockReturnValue({
+    from: vi.fn().mockImplementation(() =>
+      Object.assign(Promise.resolve(agentsData), {
+        innerJoin: vi.fn().mockReturnValue(
+          Object.assign(Promise.resolve([]), {
+            where: vi.fn().mockResolvedValue([]),
+          })
+        ),
+        where: vi.fn().mockResolvedValue([]),
+      })
+    ),
+  } as never);
+}
+
+describe("regenerateOpenClawConfig — skills emission", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockImplementation((path: unknown) => {
+      // openclaw.json read — return a valid base config
+      if (typeof path === "string" && path.endsWith(".json")) {
+        return JSON.stringify({
+          gateway: { mode: "local", bind: "lan", auth: { token: "gw-token" } },
+        });
+      }
+      // SKILL.md read by getSkillBody — return a minimal valid frontmatter
+      // body that matches what the on-disk web-search SKILL.md looks like.
+      if (typeof path === "string" && path.endsWith("/SKILL.md")) {
+        const match = path.match(/\/skills\/([^/]+)\/SKILL\.md$/);
+        const skillId = match ? match[1] : "unknown";
+        return `---\nname: ${skillId}\ndescription: Test skill body for ${skillId}.\n---\n\n# Body\n`;
+      }
+      // Any other file (bootstrap files for size measurement) — pretend missing
+      throw new Error("ENOENT");
+    });
+  });
+
+  it("emits agents.list[].skills as an explicit (possibly empty) allowlist for every agent", async () => {
+    // The empty allowlist is intentional and verified by smoke-test:
+    // skills: [] excludes all 58 bundled OC desktop skills (1password,
+    // apple-notes, etc.). Pinchy must always emit the field so bundled
+    // skills don't leak into agents we never opted into.
+    mockAgents([
+      {
+        id: "no-skills-agent",
+        name: "Plain",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: [],
+        skills: [],
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    // SKILL.md writes happen during the agentsList map; the openclaw.json
+    // atomic write happens at the very end via tmp + renameSync, so the
+    // config write's path ends in `.json.tmp`.
+    const configCall = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).endsWith(".json.tmp")
+    );
+    const written = configCall?.[1] as string;
+    const config = JSON.parse(written);
+    const agent = config.agents.list.find((a: { id: string }) => a.id === "no-skills-agent");
+
+    expect(agent).toBeDefined();
+    expect(agent.skills).toEqual([]);
+  });
+
+  it("emits the agent's configured skills verbatim", async () => {
+    mockAgents([
+      {
+        id: "web-agent",
+        name: "Web",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["pinchy_web_search", "pinchy_web_fetch"],
+        skills: ["web-search"],
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    // SKILL.md writes happen during the agentsList map; the openclaw.json
+    // atomic write happens at the very end via tmp + renameSync, so the
+    // config write's path ends in `.json.tmp`.
+    const configCall = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).endsWith(".json.tmp")
+    );
+    const written = configCall?.[1] as string;
+    const config = JSON.parse(written);
+    const agent = config.agents.list.find((a: { id: string }) => a.id === "web-agent");
+
+    expect(agent.skills).toEqual(["web-search"]);
+  });
+
+  it("treats a missing/null skills column as an empty allowlist (back-compat for pre-migration agents)", async () => {
+    mockAgents([
+      {
+        id: "legacy-agent",
+        name: "Legacy",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: [],
+        // skills column may be null on agents created before the migration
+        skills: null,
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    // SKILL.md writes happen during the agentsList map; the openclaw.json
+    // atomic write happens at the very end via tmp + renameSync, so the
+    // config write's path ends in `.json.tmp`.
+    const configCall = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).endsWith(".json.tmp")
+    );
+    const written = configCall?.[1] as string;
+    const config = JSON.parse(written);
+    const agent = config.agents.list.find((a: { id: string }) => a.id === "legacy-agent");
+
+    // Empty allowlist — bundled desktop skills are NOT a sensible default
+    // for legacy enterprise agents either.
+    expect(agent.skills).toEqual([]);
+  });
+
+  it("writes SKILL.md files for every skill in the agent's allowlist", async () => {
+    mockAgents([
+      {
+        id: "web-agent",
+        name: "Web",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: ["pinchy_web_search", "pinchy_web_fetch"],
+        skills: ["web-search"],
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    // Find the SKILL.md write among all writeFileSync calls
+    const skillWrites = mockedWriteFileSync.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].endsWith("/skills/web-search/SKILL.md")
+    );
+    expect(skillWrites.length).toBeGreaterThanOrEqual(1);
+
+    const skillPath = skillWrites[0][0] as string;
+    const skillBody = skillWrites[0][1] as string;
+    expect(skillPath).toMatch(/\/workspaces\/web-agent\/skills\/web-search\/SKILL\.md$/);
+    expect(skillBody).toContain("name: web-search");
+  });
+
+  it("does NOT write SKILL.md files for skills not in the agent's allowlist", async () => {
+    mockAgents([
+      {
+        id: "no-skills-agent",
+        name: "Plain",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: [],
+        skills: [],
+        createdAt: new Date(),
+      },
+    ]);
+
+    await regenerateOpenClawConfig();
+
+    const skillWrites = mockedWriteFileSync.mock.calls.filter(
+      (call) => typeof call[0] === "string" && call[0].includes("/skills/")
+    );
+    expect(skillWrites).toEqual([]);
+  });
+
+  it("rejects an unknown skill id (drift guard at config-build time)", async () => {
+    mockAgents([
+      {
+        id: "broken-agent",
+        name: "Broken",
+        model: "anthropic/claude-haiku-4-5-20251001",
+        allowedTools: [],
+        skills: ["nonexistent-skill"],
+        createdAt: new Date(),
+      },
+    ]);
+
+    await expect(regenerateOpenClawConfig()).rejects.toThrow(/unknown skill/i);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -659,6 +659,10 @@ describe("regenerateOpenClawConfig", () => {
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },
+      // Empty skills allowlist is intentional — see master issue #543.
+      // Excludes OC's 58 bundled desktop skills (1password, apple-notes,
+      // ...) from agents Pinchy never opted into them on.
+      skills: [],
     });
     expect(config.agents.list[1]).toEqual({
       id: "uuid-agent-2",
@@ -670,6 +674,7 @@ describe("regenerateOpenClawConfig", () => {
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },
+      skills: [],
     });
   });
 

--- a/packages/web/src/__tests__/lib/skills.test.ts
+++ b/packages/web/src/__tests__/lib/skills.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect } from "vitest";
+import { existsSync, readFileSync, readdirSync } from "fs";
+import { join } from "path";
+import { KNOWN_SKILLS, getSkillBody, parseSkillFrontmatter, type SkillId } from "@/lib/skills";
+
+const SKILLS_DIR = join(process.cwd(), "src/lib/skills");
+
+describe("KNOWN_SKILLS drift guard", () => {
+  // Master issue #543, Phase 0 — Pinchy's "paired list" convention.
+  // Same shape as KNOWN_PINCHY_PLUGINS guarded in plugin-manifest-loader.ts:
+  // the const list and the on-disk truth must agree.
+
+  it("every KNOWN_SKILLS entry has a SKILL.md on disk", () => {
+    for (const id of KNOWN_SKILLS) {
+      const skillPath = join(SKILLS_DIR, id, "SKILL.md");
+      expect(existsSync(skillPath), `expected SKILL.md at ${skillPath}`).toBe(true);
+    }
+  });
+
+  it("every on-disk SKILL.md is listed in KNOWN_SKILLS", () => {
+    const onDisk = readdirSync(SKILLS_DIR, { withFileTypes: true })
+      .filter((d) => d.isDirectory())
+      .filter((d) => existsSync(join(SKILLS_DIR, d.name, "SKILL.md")))
+      .map((d) => d.name);
+
+    for (const id of onDisk) {
+      expect(KNOWN_SKILLS, `on-disk skill "${id}" missing from KNOWN_SKILLS`).toContain(id);
+    }
+  });
+
+  it("every SKILL.md has frontmatter with name == directory name", () => {
+    for (const id of KNOWN_SKILLS) {
+      const skillPath = join(SKILLS_DIR, id, "SKILL.md");
+      const fm = parseSkillFrontmatter(readFileSync(skillPath, "utf-8"));
+      expect(fm.name, `SKILL.md ${id} frontmatter.name`).toBe(id);
+      expect(fm.description, `SKILL.md ${id} frontmatter.description`).toBeTruthy();
+    }
+  });
+});
+
+describe("parseSkillFrontmatter", () => {
+  it("extracts name + description from a minimal SKILL.md", () => {
+    const md = `---
+name: foo
+description: A test skill.
+---
+
+# Body
+
+Something.
+`;
+    expect(parseSkillFrontmatter(md)).toEqual({ name: "foo", description: "A test skill." });
+  });
+
+  it("tolerates extra single-line keys", () => {
+    const md = `---
+name: foo
+description: A test skill.
+user-invocable: false
+---
+
+Body.
+`;
+    expect(parseSkillFrontmatter(md).name).toBe("foo");
+  });
+
+  it("throws when frontmatter is missing", () => {
+    expect(() => parseSkillFrontmatter("Just body, no frontmatter\n")).toThrow(/frontmatter/i);
+  });
+
+  it("throws when required keys are missing", () => {
+    const md = `---
+name: foo
+---
+
+Body.
+`;
+    expect(() => parseSkillFrontmatter(md)).toThrow(/description/i);
+  });
+});
+
+describe("getSkillBody", () => {
+  it("returns the full SKILL.md content (frontmatter + body) for a known skill", () => {
+    const id = KNOWN_SKILLS[0];
+    const body = getSkillBody(id);
+    expect(body).toContain("---");
+    expect(body).toContain(`name: ${id}`);
+    expect(body.length).toBeGreaterThan(100);
+  });
+
+  it("throws for an unknown skill id", () => {
+    expect(() => getSkillBody("does-not-exist" as SkillId)).toThrow(/unknown skill/i);
+  });
+});

--- a/packages/web/src/__tests__/lib/workspace-skills.test.ts
+++ b/packages/web/src/__tests__/lib/workspace-skills.test.ts
@@ -53,6 +53,14 @@ describe("workspace skills", () => {
     it("rejects a skillId with slashes", () => {
       expect(() => getWorkspaceSkillPath("agent-1", "foo/bar")).toThrow(/invalid skill/i);
     });
+
+    it("rejects a skillId starting with a digit (AgentSkills.io convention)", () => {
+      expect(() => getWorkspaceSkillPath("agent-1", "99-bottles")).toThrow(/invalid skill/i);
+    });
+
+    it("rejects a skillId with uppercase letters", () => {
+      expect(() => getWorkspaceSkillPath("agent-1", "WebSearch")).toThrow(/invalid skill/i);
+    });
   });
 
   describe("writeWorkspaceSkill", () => {

--- a/packages/web/src/__tests__/lib/workspace-skills.test.ts
+++ b/packages/web/src/__tests__/lib/workspace-skills.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const writeFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn().mockReturnValue(false);
+  const mkdirSyncMock = vi.fn();
+  const rmSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: writeFileSyncMock,
+      existsSync: existsSyncMock,
+      mkdirSync: mkdirSyncMock,
+      rmSync: rmSyncMock,
+    },
+    writeFileSync: writeFileSyncMock,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+    rmSync: rmSyncMock,
+  };
+});
+
+import { writeFileSync, mkdirSync, rmSync } from "fs";
+import { writeWorkspaceSkill, removeWorkspaceSkill, getWorkspaceSkillPath } from "@/lib/workspace";
+
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedMkdirSync = vi.mocked(mkdirSync);
+const mockedRmSync = vi.mocked(rmSync);
+
+describe("workspace skills", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  describe("getWorkspaceSkillPath", () => {
+    it("returns <workspaceBase>/<agentId>/skills/<skillId>/SKILL.md", () => {
+      const path = getWorkspaceSkillPath("agent-uuid-1", "web-search");
+      // OpenClaw resolves <workspace>/skills/<id>/SKILL.md — must match
+      // smoke-test path layout against OC 2026.6.5.
+      expect(path).toMatch(/\/workspaces\/agent-uuid-1\/skills\/web-search\/SKILL\.md$/);
+    });
+
+    it("rejects an invalid agentId", () => {
+      expect(() => getWorkspaceSkillPath("../escape", "web-search")).toThrow(/invalid agentid/i);
+    });
+
+    it("rejects an invalid skillId (path traversal)", () => {
+      expect(() => getWorkspaceSkillPath("agent-1", "../escape")).toThrow(/invalid skill/i);
+    });
+
+    it("rejects a skillId with slashes", () => {
+      expect(() => getWorkspaceSkillPath("agent-1", "foo/bar")).toThrow(/invalid skill/i);
+    });
+  });
+
+  describe("writeWorkspaceSkill", () => {
+    it("creates the skills/<id> directory and writes SKILL.md with the given body", () => {
+      writeWorkspaceSkill(
+        "agent-1",
+        "web-search",
+        "---\nname: web-search\ndescription: foo\n---\n\nBody.\n"
+      );
+
+      // skills/<id> directory exists
+      expect(mockedMkdirSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/workspaces\/agent-1\/skills\/web-search$/),
+        { recursive: true }
+      );
+      // SKILL.md is written
+      expect(mockedWriteFileSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/workspaces\/agent-1\/skills\/web-search\/SKILL\.md$/),
+        expect.stringContaining("name: web-search"),
+        "utf-8"
+      );
+    });
+
+    it("rejects writing to an invalid agentId", () => {
+      expect(() => writeWorkspaceSkill("../escape", "web-search", "body")).toThrow(
+        /invalid agentid/i
+      );
+      expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    });
+
+    it("rejects writing to an invalid skillId", () => {
+      expect(() => writeWorkspaceSkill("agent-1", "../escape", "body")).toThrow(/invalid skill/i);
+      expect(mockedWriteFileSync).not.toHaveBeenCalled();
+    });
+  });
+
+  describe("removeWorkspaceSkill", () => {
+    it("removes the skills/<id> directory recursively", () => {
+      removeWorkspaceSkill("agent-1", "web-search");
+      expect(mockedRmSync).toHaveBeenCalledWith(
+        expect.stringMatching(/\/workspaces\/agent-1\/skills\/web-search$/),
+        { recursive: true, force: true }
+      );
+    });
+
+    it("rejects an invalid agentId", () => {
+      expect(() => removeWorkspaceSkill("../escape", "web-search")).toThrow(/invalid agentid/i);
+      expect(mockedRmSync).not.toHaveBeenCalled();
+    });
+
+    it("rejects an invalid skillId", () => {
+      expect(() => removeWorkspaceSkill("agent-1", "../escape")).toThrow(/invalid skill/i);
+      expect(mockedRmSync).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -158,6 +158,11 @@ export const POST = withAdmin(async (request, _ctx, session) => {
     ...new Set([...(template.allowedTools ?? []), ...(defaultAllowedTools ?? [])]),
   ];
 
+  // Skills from the template seed the agent's allowlist. Templates without
+  // defaultSkills get an empty list — same shape as a pre-migration agent.
+  // See master issue #543.
+  const templateSkills = [...new Set(template.defaultSkills ?? [])];
+
   const [agent] = await db
     .insert(agents)
     .values({
@@ -167,6 +172,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
       pluginConfig: template.pluginId && pluginConfig ? pluginConfig : null,
       ownerId: session.user.id,
       allowedTools: mergedAllowedTools,
+      skills: templateSkills,
       tagline: tagline || template.defaultTagline || null,
       avatarSeed: generateAvatarSeed(),
       personalityPresetId: template.defaultPersonality,
@@ -187,6 +193,7 @@ export const POST = withAdmin(async (request, _ctx, session) => {
         name: agent.name,
         model: agent.model,
         templateId,
+        skills: templateSkills,
         modelSelection: {
           source: modelSelectionSource,
           hint: template.modelHint ?? null,

--- a/packages/web/src/app/api/templates/route.ts
+++ b/packages/web/src/app/api/templates/route.ts
@@ -73,6 +73,7 @@ export const GET = withAuth(async () => {
         requiresDirectories: template.pluginId === "pinchy-files",
         requiresOdooConnection: template.requiresOdooConnection ?? false,
         requiresEmailConnection: template.requiresEmailConnection ?? false,
+        requiresWeb: template.pluginId === "pinchy-web",
         odooAccessLevel: template.odooConfig?.accessLevel,
         defaultTagline: template.defaultTagline,
         available,

--- a/packages/web/src/components/new-agent-form.tsx
+++ b/packages/web/src/components/new-agent-form.tsx
@@ -43,6 +43,7 @@ interface Template {
   requiresDirectories: boolean;
   requiresOdooConnection: boolean;
   requiresEmailConnection?: boolean;
+  requiresWeb?: boolean;
   odooAccessLevel?: string;
   defaultTagline: string | null;
 }

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -129,6 +129,11 @@ export const agents = pgTable(
     templateId: text("template_id"),
     pluginConfig: jsonb("plugin_config").$type<AgentPluginConfig>(),
     allowedTools: jsonb("allowed_tools").$type<string[]>().notNull().default([]),
+    // OpenClaw-native skill allowlist. Each entry is a Pinchy first-party
+    // skill id (see KNOWN_SKILLS in src/lib/skills/index.ts). Emitted as
+    // `agents.list[].skills` in openclaw.json; empty list correctly excludes
+    // OC's 58 bundled desktop skills. See master issue #543.
+    skills: jsonb("skills").$type<string[]>().notNull().default([]),
     ownerId: text("owner_id").references(() => users.id, { onDelete: "cascade" }),
     isPersonal: boolean("is_personal").notNull().default(false),
     visibility: text("visibility").notNull().default("restricted"),

--- a/packages/web/src/lib/agent-templates/data/web-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/web-agents.ts
@@ -13,9 +13,8 @@ export const WEB_TEMPLATES: Record<string, AgentTemplate> = {
     iconName: "Newspaper",
     name: "Market & News Monitor",
     description: "Track market trends, industry news, and competitor signals from the public web",
-    // No allowedTools listed here — the skill body teaches the model when
-    // to call pinchy_web_search / pinchy_web_fetch, and the agent's
-    // allowedTools row is populated from the template at create-time.
+    // Tools the agent is permitted to invoke. Workflow guidance for HOW
+    // and WHEN to call them lives in the web-search skill body, not here.
     allowedTools: ["pinchy_web_search", "pinchy_web_fetch"],
     pluginId: "pinchy-web",
     defaultSkills: ["web-search"],

--- a/packages/web/src/lib/agent-templates/data/web-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/web-agents.ts
@@ -1,0 +1,51 @@
+import type { AgentTemplate } from "../types";
+
+// Templates that combine pinchy-web (web search + page fetch) with the
+// OpenClaw-native skill layer. See master issue #543 — this is the v1 pilot
+// proving the architecture end-to-end on the original missing-template
+// problem (pinchy-web was the last external plugin without templates).
+//
+// New templates here MUST also be added to TEMPLATE_CATEGORY_MAP in
+// src/lib/template-grouping.ts, otherwise they silently disappear from the
+// agent picker (regression guard test in template-grouping.test.ts).
+export const WEB_TEMPLATES: Record<string, AgentTemplate> = {
+  "market-monitor": {
+    iconName: "Newspaper",
+    name: "Market & News Monitor",
+    description: "Track market trends, industry news, and competitor signals from the public web",
+    // No allowedTools listed here — the skill body teaches the model when
+    // to call pinchy_web_search / pinchy_web_fetch, and the agent's
+    // allowedTools row is populated from the template at create-time.
+    allowedTools: ["pinchy_web_search", "pinchy_web_fetch"],
+    pluginId: "pinchy-web",
+    defaultSkills: ["web-search"],
+    defaultPersonality: "the-pilot",
+    defaultTagline:
+      "Track market trends, industry news, and competitor signals from the public web",
+    suggestedNames: ["Scout", "Pulse", "Compass", "Vector", "Vista", "Beacon", "Sentry"],
+    defaultGreetingMessage:
+      "Ready when you are, {user}. I'm {name}. I scan the public web for market trends, industry news, and competitor moves — and I always cite my sources. What would you like me to watch today?",
+    // Persona-only AGENTS.md. Workflow guidance for the web tools lives in
+    // the web-search SKILL.md, so it can be reused by future templates
+    // (Lead Researcher, Competitive Intelligence, ...) without copy-paste.
+    defaultAgentsMd: `## Your role
+
+You are a market and news monitor. Your job is to watch the public web for signals that matter to the user's business: industry trends, competitor moves, regulatory changes, and significant news in their domain. You are concise, source-grounded, and date-aware.
+
+## Operating principles
+
+- **Source-grounded.** Every claim you make must point at a public URL the user can click. If you cannot cite a source, leave the claim out.
+- **Recency-first.** Date matters. Lead with the newest credible source; flag the publication date when you summarize.
+- **Skeptical of aggregators.** Prefer original sources (the company, the regulator, the publication) over listicles, content farms, or AI-generated summaries. If two sources disagree, find a third.
+- **No invention.** "I couldn't find a current source for this" is a correct answer. Inventing plausible-sounding facts is not.
+
+## Output
+
+- Lead with a 1-2 sentence answer
+- Follow with cited bullet points (each links a source)
+- Close with a one-line "What I checked" — queries you ran, sources you read`,
+    // Vision: users routinely paste screenshots of articles, dashboards, or
+    // PDFs of analyst reports as starting points for monitoring queries.
+    modelHint: { tier: "balanced", capabilities: ["tools", "vision"] },
+  },
+};

--- a/packages/web/src/lib/agent-templates/registry.ts
+++ b/packages/web/src/lib/agent-templates/registry.ts
@@ -3,18 +3,20 @@ import { DOCUMENT_TEMPLATES } from "./data/document-agents";
 import { EMAIL_TEMPLATES } from "./data/email-agents";
 import { KNOWLEDGE_BASE_TEMPLATES } from "./data/knowledge-base";
 import { ODOO_TEMPLATES } from "./data/odoo-agents";
+import { WEB_TEMPLATES } from "./data/web-agents";
 import type { AgentTemplate } from "./types";
 
 // Order matters: the template selector grid renders templates in this
 // iteration order. Keep `custom` between the document templates and the
-// integration-specific (odoo, email) templates so it stays visually grouped
-// with the "no integration required" templates.
+// integration-specific (odoo, email, web) templates so it stays visually
+// grouped with the "no integration required" templates.
 export const AGENT_TEMPLATES: Record<string, AgentTemplate> = {
   ...KNOWLEDGE_BASE_TEMPLATES,
   ...DOCUMENT_TEMPLATES,
   ...CUSTOM_TEMPLATES,
   ...ODOO_TEMPLATES,
   ...EMAIL_TEMPLATES,
+  ...WEB_TEMPLATES,
 };
 
 export function getTemplate(id: string): AgentTemplate | undefined {

--- a/packages/web/src/lib/agent-templates/types.ts
+++ b/packages/web/src/lib/agent-templates/types.ts
@@ -41,6 +41,15 @@ export interface AgentTemplate {
   iconName?: TemplateIconName;
   /** Per-template LLM hint used by the model resolver at agent-creation time. */
   modelHint?: ModelHint;
+  /**
+   * OpenClaw-native skills the template seeds onto new agents (see master
+   * issue #543). Each entry must appear in KNOWN_SKILLS — enforced by the
+   * drift-guard test. Pinchy writes the corresponding SKILL.md into the
+   * agent's workspace and lists the id under `agents.list[].skills` in
+   * openclaw.json. Field is additive: existing templates omit it and behave
+   * as before (agent gets skills: [] in DB).
+   */
+  defaultSkills?: string[];
 }
 
 /**

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -17,7 +17,12 @@ import { computeDeniedGroups } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
-import { getOpenClawWorkspacePath, getAgentBootstrapSizes } from "@/lib/workspace";
+import {
+  getOpenClawWorkspacePath,
+  getAgentBootstrapSizes,
+  writeWorkspaceSkill,
+} from "@/lib/workspace";
+import { getSkillBody, isKnownSkill } from "@/lib/skills";
 import { resolveBootstrapCaps } from "./bootstrap-caps";
 import { CONFIG_PATH } from "./paths";
 import { configsAreEquivalentUpToOpenClawMetadata } from "./normalize";
@@ -359,6 +364,27 @@ export async function regenerateOpenClawConfig() {
         userId: agent.ownerId,
       };
     }
+
+    // Skills (master issue #543). The allowlist is ALWAYS emitted — even
+    // empty — because an absent `skills` field lets OC's 58 bundled desktop
+    // skills (1password, apple-notes, ...) into Pinchy agents. An explicit
+    // `skills: []` excludes them; an explicit list narrows to just our
+    // first-party skills. Behavior verified in the smoke-test against OC
+    // 2026.6.5: empty list → 0/59 ready, all "excluded".
+    const rawSkills = (agent.skills as string[] | null) ?? [];
+    const skills: string[] = [];
+    for (const id of rawSkills) {
+      if (!isKnownSkill(id)) {
+        throw new Error(
+          `Agent ${agent.name} (${agent.id}) references unknown skill: ${id}. Add it to KNOWN_SKILLS or remove from agent.skills.`
+        );
+      }
+      skills.push(id);
+      // Materialize the SKILL.md into the agent's workspace so OC's
+      // workspace-tier loader (highest precedence) finds it.
+      writeWorkspaceSkill(agent.id, id, getSkillBody(id));
+    }
+    agentEntry.skills = skills;
 
     return agentEntry;
   });

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -371,6 +371,12 @@ export async function regenerateOpenClawConfig() {
     // `skills: []` excludes them; an explicit list narrows to just our
     // first-party skills. Behavior verified in the smoke-test against OC
     // 2026.6.5: empty list → 0/59 ready, all "excluded".
+    //
+    // The `?? []` is defense-in-depth. Migration 0040 set the column to
+    // `notNull().default('[]')`, so at runtime the value is never null for
+    // an inserted row — but Drizzle's type still allows it, and an
+    // in-flight insert that races a regenerate could otherwise surface as
+    // an opaque TypeError instead of a clean empty allowlist.
     const rawSkills = (agent.skills as string[] | null) ?? [];
     const skills: string[] = [];
     for (const id of rawSkills) {
@@ -380,14 +386,33 @@ export async function regenerateOpenClawConfig() {
         );
       }
       skills.push(id);
-      // Materialize the SKILL.md into the agent's workspace so OC's
-      // workspace-tier loader (highest precedence) finds it.
-      writeWorkspaceSkill(agent.id, id, getSkillBody(id));
     }
     agentEntry.skills = skills;
 
     return agentEntry;
   });
+
+  // Materialize SKILL.md files into each agent's workspace AFTER the entry
+  // map. Two reasons to do it in a second pass rather than inside .map():
+  //
+  //   1. `.map()` is supposed to be pure; emitting side effects from inside
+  //      it surprises both linters and reviewers.
+  //   2. We skip soft-deleted agents here. Pre-existing behavior writes
+  //      pinchy-files config for all agents (incl. tombstoned ones), but
+  //      that's an upstream issue. Materializing skill files into stale
+  //      workspaces would only add to the litter — there is no reader for
+  //      those files anyway since OC won't be told the agent exists once
+  //      the user-delete flow rms the workspace.
+  for (const agent of allAgents) {
+    if (agent.deletedAt) continue;
+    const rawSkills = (agent.skills as string[] | null) ?? [];
+    for (const id of rawSkills) {
+      if (!isKnownSkill(id)) continue; // already thrown in the map() above
+      // SKILL.md body is process-cached (see getSkillBody), so the same
+      // skill across N agents costs one disk read total, not N.
+      writeWorkspaceSkill(agent.id, id, getSkillBody(id));
+    }
+  }
 
   // Build complete config — gateway and OpenClaw-enriched fields preserved,
   // everything else from DB. OpenClaw adds meta, commands, etc. at startup;

--- a/packages/web/src/lib/skills/index.ts
+++ b/packages/web/src/lib/skills/index.ts
@@ -1,0 +1,60 @@
+import { readFileSync } from "fs";
+import { join } from "path";
+
+// Pinchy first-party skills. Each entry must have a SKILL.md at
+// src/lib/skills/<id>/SKILL.md with a frontmatter `name: <id>` and a
+// non-empty `description`. The drift-guard test in
+// __tests__/lib/skills.test.ts enforces the const list ↔ on-disk truth
+// invariant. See master issue #543 for the broader rationale.
+export const KNOWN_SKILLS = ["web-search"] as const;
+
+export type SkillId = (typeof KNOWN_SKILLS)[number];
+
+export function isKnownSkill(id: string): id is SkillId {
+  return (KNOWN_SKILLS as readonly string[]).includes(id);
+}
+
+const SKILLS_DIR = join(__dirname);
+
+export function getSkillBody(id: SkillId): string {
+  if (!isKnownSkill(id)) {
+    throw new Error(`unknown skill: ${id}`);
+  }
+  // Resolve from the compiled location too — in production this file lives
+  // alongside the per-skill subdirectories under `lib/skills/`.
+  const path = join(SKILLS_DIR, id, "SKILL.md");
+  return readFileSync(path, "utf-8");
+}
+
+export interface SkillFrontmatter {
+  name: string;
+  description: string;
+}
+
+// Minimal frontmatter parser for OpenClaw-style SKILL.md.
+// OC docs are explicit: "The frontmatter parser supports single-line keys
+// only." So we don't need YAML — a 5-line regex over the `---`-delimited
+// header block is exact and dependency-free.
+export function parseSkillFrontmatter(md: string): SkillFrontmatter {
+  const match = md.match(/^---\r?\n([\s\S]*?)\r?\n---/);
+  if (!match) {
+    throw new Error("missing frontmatter (no `---` delimited header block)");
+  }
+
+  const header = match[1];
+  const entries: Record<string, string> = {};
+  for (const line of header.split(/\r?\n/)) {
+    const kv = line.match(/^([A-Za-z][A-Za-z0-9_-]*):\s*(.+?)\s*$/);
+    if (!kv) continue;
+    entries[kv[1]] = kv[2];
+  }
+
+  if (!entries.name) {
+    throw new Error("frontmatter missing required key: name");
+  }
+  if (!entries.description) {
+    throw new Error("frontmatter missing required key: description");
+  }
+
+  return { name: entries.name, description: entries.description };
+}

--- a/packages/web/src/lib/skills/index.ts
+++ b/packages/web/src/lib/skills/index.ts
@@ -16,14 +16,23 @@ export function isKnownSkill(id: string): id is SkillId {
 
 const SKILLS_DIR = join(__dirname);
 
+// First-party skill bodies are bundled with the build — they never change
+// at runtime within a process. Cache to avoid re-reading the same file once
+// per agent during `regenerateOpenClawConfig()` (50 agents on the same
+// skill = 50 redundant disk reads without this).
+const SKILL_BODY_CACHE = new Map<SkillId, string>();
+
 export function getSkillBody(id: SkillId): string {
   if (!isKnownSkill(id)) {
     throw new Error(`unknown skill: ${id}`);
   }
-  // Resolve from the compiled location too — in production this file lives
-  // alongside the per-skill subdirectories under `lib/skills/`.
+  const cached = SKILL_BODY_CACHE.get(id);
+  if (cached !== undefined) return cached;
+
   const path = join(SKILLS_DIR, id, "SKILL.md");
-  return readFileSync(path, "utf-8");
+  const body = readFileSync(path, "utf-8");
+  SKILL_BODY_CACHE.set(id, body);
+  return body;
 }
 
 export interface SkillFrontmatter {

--- a/packages/web/src/lib/skills/web-search/SKILL.md
+++ b/packages/web/src/lib/skills/web-search/SKILL.md
@@ -1,0 +1,49 @@
+---
+name: web-search
+description: Search the public web for current information and fetch full pages. Use when the user asks about current events, recent company news, market data, regulatory changes, or any fact that may have changed since the model's training cutoff.
+---
+
+# Web Search
+
+You can search the public web and fetch full pages of content. Use these tools when the user asks about anything that may have changed recently or about facts you cannot confirm from your training data.
+
+## Capabilities
+
+- **pinchy_web_search** — Query the web for a topic, return a ranked list of results with titles, URLs, and snippets. Use this first to discover relevant sources.
+- **pinchy_web_fetch** — Retrieve the full text of a specific URL. Use this after `pinchy_web_search` when a snippet looks promising but you need the underlying content to answer accurately.
+
+## When to use
+
+- Current events, recent news, recent product/policy announcements
+- Company information (size, funding, recent product launches, leadership changes)
+- Market/industry trends published in the last 6–12 months
+- Regulatory or compliance changes since training cutoff
+- Public reviews, comparisons, or third-party assessments
+- Verifying a claim the user made against an external source
+
+## When NOT to use
+
+- The user's own data — that's what your other tools (CRM, files, email) are for
+- Internal policies, company-confidential facts, or HR information
+- Anything the user already gave you in this conversation
+- Recipes, jokes, definitions, or general knowledge you already have
+
+## Workflow
+
+1. **Search first, fetch second.** Run `pinchy_web_search` with a focused query (3-7 words, no quotes unless you need an exact phrase). Read the result snippets.
+2. **Pick 1-3 sources to fetch.** Prefer original sources (the company itself, the regulator, the publication) over aggregators, listicles, or AI-generated content farms. If two sources disagree, fetch a third.
+3. **Cite every claim with a URL.** Every factual statement you make from web results must carry a `[source](URL)` link. If you cannot point at a URL, leave the claim out.
+4. **Prefer recent over old.** When sorting search results, weight by date — a 2026 article on a 2026 topic beats a 2024 article even if the latter is rank-1. State the publication date in your summary when it matters.
+5. **Don't fabricate.** If search returns nothing useful, say so. "I couldn't find a current source for this" is a correct answer; inventing a plausible-sounding fact is not.
+
+## Output format
+
+- Lead with a 1-2 sentence answer
+- Follow with bullet points, each citing a source
+- End with a brief "What I checked" line — the queries you ran and how many sources you read
+- Never paste raw search-result blocks into the chat — summarize
+
+## Safety
+
+- Never put sensitive internal data into a web search query. The query goes to a third-party search provider.
+- Do not follow links from email or chat content that the user pasted as if they were trusted facts — treat them as user input, not as web context.

--- a/packages/web/src/lib/skills/web-search/SKILL.md
+++ b/packages/web/src/lib/skills/web-search/SKILL.md
@@ -36,14 +36,14 @@ You can search the public web and fetch full pages of content. Use these tools w
 4. **Prefer recent over old.** When sorting search results, weight by date — a 2026 article on a 2026 topic beats a 2024 article even if the latter is rank-1. State the publication date in your summary when it matters.
 5. **Don't fabricate.** If search returns nothing useful, say so. "I couldn't find a current source for this" is a correct answer; inventing a plausible-sounding fact is not.
 
+## Safety (must hold)
+
+- Never put sensitive internal data into a web search query. The query goes to a third-party search provider.
+- Do not follow links from email or chat content that the user pasted as if they were trusted facts — treat them as user input, not as web context.
+
 ## Output format
 
 - Lead with a 1-2 sentence answer
 - Follow with bullet points, each citing a source
 - End with a brief "What I checked" line — the queries you ran and how many sources you read
 - Never paste raw search-result blocks into the chat — summarize
-
-## Safety
-
-- Never put sensitive internal data into a web search query. The query goes to a third-party search provider.
-- Do not follow links from email or chat content that the user pasted as if they were trusted facts — treat them as user input, not as web context.

--- a/packages/web/src/lib/template-grouping.ts
+++ b/packages/web/src/lib/template-grouping.ts
@@ -7,6 +7,13 @@ export interface TemplateItem {
   requiresDirectories: boolean;
   requiresOdooConnection?: boolean;
   requiresEmailConnection?: boolean;
+  /**
+   * Template uses `pinchy-web` (public web search + page fetch). No
+   * external account or admin-managed credential is required — the plugin
+   * pulls its own credentials at runtime. Drives the access badge and the
+   * permission preview, parity with the other `requires*` flags.
+   */
+  requiresWeb?: boolean;
   odooAccessLevel?: string;
   defaultTagline: string | null;
   available?: boolean;
@@ -26,7 +33,11 @@ export interface AccessBadgeProps {
 export function getAccessBadgeProps(
   template: Pick<
     TemplateItem,
-    "requiresDirectories" | "requiresOdooConnection" | "requiresEmailConnection" | "odooAccessLevel"
+    | "requiresDirectories"
+    | "requiresOdooConnection"
+    | "requiresEmailConnection"
+    | "requiresWeb"
+    | "odooAccessLevel"
   >
 ): AccessBadgeProps | null {
   if (template.requiresEmailConnection) {
@@ -45,6 +56,9 @@ export function getAccessBadgeProps(
   if (template.requiresDirectories) {
     return { label: "Documents · Read-only", variant: "green" };
   }
+  if (template.requiresWeb) {
+    return { label: "Web · Public search", variant: "green" };
+  }
   return null;
 }
 
@@ -58,7 +72,11 @@ export interface PermissionItem {
 export function getPermissionPreviewItems(
   template: Pick<
     TemplateItem,
-    "requiresDirectories" | "requiresOdooConnection" | "requiresEmailConnection" | "odooAccessLevel"
+    | "requiresDirectories"
+    | "requiresOdooConnection"
+    | "requiresEmailConnection"
+    | "requiresWeb"
+    | "odooAccessLevel"
   >
 ): PermissionItem[] {
   if (template.requiresEmailConnection) {
@@ -91,6 +109,13 @@ export function getPermissionPreviewItems(
     return [
       { icon: "check", text: "Read files in the selected directories" },
       { icon: "cross", text: "Cannot modify or delete files" },
+    ];
+  }
+  if (template.requiresWeb) {
+    return [
+      { icon: "check", text: "Search the public web" },
+      { icon: "check", text: "Fetch public web pages" },
+      { icon: "cross", text: "Cannot access your private data or internal systems" },
     ];
   }
   return [];
@@ -142,6 +167,7 @@ const TEMPLATE_CATEGORY_MAP: Record<string, CategoryId> = {
   "odoo-project-manager": "operations",
   "odoo-marketing-analyst": "marketing-web",
   "odoo-website-analyst": "marketing-web",
+  "market-monitor": "marketing-web",
   "knowledge-base": "knowledge-compliance",
   "contract-analyzer": "knowledge-compliance",
   "proposal-comparator": "knowledge-compliance",

--- a/packages/web/src/lib/template-icons.ts
+++ b/packages/web/src/lib/template-icons.ts
@@ -28,6 +28,7 @@ import {
   PackageOpen,
   Wrench,
   BadgeCheck,
+  Newspaper,
   type LucideIcon,
 } from "lucide-react";
 
@@ -72,6 +73,7 @@ export const TEMPLATE_ICON_COMPONENTS = {
   PackageOpen,
   Wrench,
   BadgeCheck,
+  Newspaper,
 } as const satisfies Record<string, LucideIcon>;
 
 export type TemplateIconName = keyof typeof TEMPLATE_ICON_COMPONENTS;

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -73,6 +73,18 @@ function assertValidAgentId(agentId: string): void {
   }
 }
 
+// Skills live under <workspace>/skills/<skillId>/SKILL.md. OpenClaw 2026.6.x
+// auto-discovers them with workspace-precedence highest in the six-tier
+// loading order. Validated in the smoke-test against OC 2026.6.5 — see
+// master issue #543 for the full architecture rationale.
+function assertValidSkillId(skillId: string): void {
+  // SKILL.md authors restrict to lowercase kebab-case anyway, but the real
+  // requirement is path-safety: no slashes, no dots, no traversal sequences.
+  if (!skillId || !/^[a-z0-9][a-z0-9-]*$/.test(skillId)) {
+    throw new Error(`Invalid skillId: ${skillId}`);
+  }
+}
+
 export function getWorkspacePath(agentId: string): string {
   assertValidAgentId(agentId);
   return join(getWorkspaceBasePath(), agentId);
@@ -159,6 +171,41 @@ export function writeWorkspaceFileInternal(
   }
 
   writeFileSync(join(workspacePath, filename), content, "utf-8");
+}
+
+// =============================================================================
+// Skills — see master issue #543 (Pinchy Skill Layer).
+//
+// OpenClaw 2026.6.x loads `<workspace>/skills/<id>/SKILL.md` automatically
+// (workspace tier is highest in OC's six-tier precedence). Pinchy writes
+// the SKILL.md files at config-regenerate time alongside the AGENTS.md /
+// SOUL.md bootstrap files, and emits `agents.list[].skills: [...]` in
+// openclaw.json to allowlist exactly the Pinchy-authored skills — never
+// the 58 bundled OC desktop skills (1password, apple-notes, ...) that are
+// irrelevant for enterprise agents.
+// =============================================================================
+
+export function getWorkspaceSkillPath(agentId: string, skillId: string): string {
+  assertValidAgentId(agentId);
+  assertValidSkillId(skillId);
+  return join(getWorkspacePath(agentId), "skills", skillId, "SKILL.md");
+}
+
+export function writeWorkspaceSkill(agentId: string, skillId: string, content: string): void {
+  assertValidAgentId(agentId);
+  assertValidSkillId(skillId);
+
+  const dir = join(getWorkspacePath(agentId), "skills", skillId);
+  mkdirSync(dir, { recursive: true });
+  writeFileSync(join(dir, "SKILL.md"), content, "utf-8");
+}
+
+export function removeWorkspaceSkill(agentId: string, skillId: string): void {
+  assertValidAgentId(agentId);
+  assertValidSkillId(skillId);
+
+  const dir = join(getWorkspacePath(agentId), "skills", skillId);
+  rmSync(dir, { recursive: true, force: true });
 }
 
 // The files OpenClaw loads as prompt-bootstrap context for an agent

--- a/packages/web/src/lib/workspace.ts
+++ b/packages/web/src/lib/workspace.ts
@@ -78,9 +78,11 @@ function assertValidAgentId(agentId: string): void {
 // loading order. Validated in the smoke-test against OC 2026.6.5 — see
 // master issue #543 for the full architecture rationale.
 function assertValidSkillId(skillId: string): void {
-  // SKILL.md authors restrict to lowercase kebab-case anyway, but the real
-  // requirement is path-safety: no slashes, no dots, no traversal sequences.
-  if (!skillId || !/^[a-z0-9][a-z0-9-]*$/.test(skillId)) {
+  // Path-safety (no slashes, dots, traversal sequences) AND the
+  // AgentSkills.io convention (lowercase kebab-case starting with a letter).
+  // Starting-with-digit ids ("99-bottles") match the regex but break the
+  // convention and create unfriendly directory names — reject them.
+  if (!skillId || !/^[a-z][a-z0-9-]*$/.test(skillId)) {
     throw new Error(`Invalid skillId: ${skillId}`);
   }
 }


### PR DESCRIPTION
## Summary

- v1 of the **Pinchy Skill Layer** (master tracking issue #543). Adopts OpenClaw 2026.6.x's native skill mechanics — `SKILL.md` with YAML frontmatter, six-tier loading precedence, per-agent allowlist via `agents.list[].skills` — as Pinchy's composition unit for agent capabilities.
- First **`pinchy-web`** template: **Market & News Monitor**, lands in the existing `marketing-web` category. Resolves the gap that triggered this whole initiative — `pinchy-web` was the last external plugin without templates.
- Foundation only: existing 33 templates unchanged, `defaultSkills` field is additive, behavior preserved.

## What changes

- **Schema**: `agents.skills jsonb` column (migration 0040). Default `[]`. Existing rows seeded with `[]`.
- **Skills foundation**:
  - `KNOWN_SKILLS` const + drift-guard test (pairs the const list with on-disk SKILL.md files — same convention as `KNOWN_PINCHY_PLUGINS`).
  - First-party skill **`web-search`** with workflow guidelines for `pinchy_web_search` / `pinchy_web_fetch`. Source-grounded, recency-aware, no-fabrication invariants in the body.
  - `writeWorkspaceSkill(agentId, skillId, content)` materializes SKILL.md to `<workspace>/skills/<id>/SKILL.md` — the highest-precedence skill tier in OC's loader.
- **Config emission**: `regenerateOpenClawConfig` writes `agents.list[].skills` for every agent, **always**, including empty. Verified in Docker smoke-test against OC 2026.6.5: empty allowlist correctly excludes all 58 bundled OC desktop skills (1password, apple-notes, blucli, bear-notes, ...) — the right default for enterprise agents.
- **Template schema**: `AgentTemplate.defaultSkills?: string[]` added additively. Drift-guard ensures every entry is a `KNOWN_SKILLS` member.
- **Pilot template `market-monitor`** ("Market & News Monitor") in `marketing-web`, plugin `pinchy-web`, `defaultSkills: ["web-search"]`. Persona-only AGENTS.md; workflow lives in the skill so it can be reused by Phase 2 hybrids (Lead Researcher, Competitive Intelligence, Outreach Drafter).
- **UI surface**: `requiresWeb` access badge ("Web · Public search") and permission preview ("Search the public web / Fetch public web pages / Cannot access your private data") for `pinchy-web` templates. Plumbed through `/api/templates` and `new-agent-form.tsx`.
- **Audit**: `agent.created` detail now snapshots `skills` alongside the existing `templateId` / `modelSelection`.
- **Docs**: new guide `guides/create-market-monitor-agent.mdx`, linked in sidebar.

## Why this shape

Three closed RFCs (#354 Template Contract, #126 MCP Tool Profiles, #372 Agent-Builder-Agent) are consolidated into master #543 because they all describe the same architecture: composable agent capabilities. OpenClaw 2026.6.5 (bundled in Pinchy v0.6.0) implements the AgentSkills.io spec natively — composer, loader, allowlist, gating, Skill Workshop, ClawHub marketplace. Pinchy gets the mechanics for free; this PR just writes the files and emits the allowlist.

The smoke-test against OC 2026.6.5 confirmed three load-bearing properties:
- Per-agent workspaces isolate skills (Agent A sees `skill-a` only, Agent B sees `skill-b` only)
- Allowlist enforcement is hard — `skills: []` puts all 58 bundled skills into "excluded"
- `<workspace>/skills/<id>/SKILL.md` is the correct path (`openclaw-workspace` source in `openclaw skills list`)

## What's next (out of scope for this PR)

Phase 1 sub-issues already filed and tagged `priority:P1`:

- #544 — Migrate knowledge-base + 5 document templates to skills
- #545 — Migrate 3 email templates to skills
- #546 — Migrate 24 Odoo templates to skills (may split by operator suite)

Phase 2 (hybrid templates: Lead Researcher = Web + Odoo etc.), Phase 3 (generated AGENTS.md, supersedes #354), and Phase 4 (MCP UI supersedes #126, ClawHub integration, Skill Workshop UI supersedes #372) are documented in master #543 — sub-issues filed when those phases start.

## Test plan

- [x] `pnpm test` — full unit + integration suite green (6225 passed, 0 failed)
- [x] `pnpm test:db` — Drizzle migrations apply cleanly (115 passed)
- [x] `pnpm test:scripts` — 126 passed
- [x] `pnpm tsc --noEmit` — clean
- [x] `pnpm lint` — 0 errors (warnings are pre-existing)
- [x] `cd docs && pnpm build` — Astro build clean
- [x] Docker smoke-test against `ghcr.io/heypinchy/pinchy-openclaw:v0.6.0` — verified `<workspace>/skills/<id>/SKILL.md` loads, per-agent isolation, empty-allowlist semantics
- [ ] Reviewer: try the **Market & News Monitor** template end-to-end in dev compose (`docker compose -f docker-compose.yml -f docker-compose.dev.yml up --build`), confirm the agent picks up the skill and cites sources
- [ ] Reviewer: confirm existing templates still create agents with `skills: []` (no regression)

## Tracking

Closes #354 #126 #372. Tracked in #543.
