### PR TITLE
feat(transcript): Pinchy-owned conversation transcript (robust Telegram mirror)

### DIFF
--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -40,6 +40,7 @@ COPY packages/web packages/web
 COPY packages/plugins/pinchy-files/openclaw.plugin.json packages/plugins/pinchy-files/
 COPY packages/plugins/pinchy-context/openclaw.plugin.json packages/plugins/pinchy-context/
 COPY packages/plugins/pinchy-audit/openclaw.plugin.json packages/plugins/pinchy-audit/
+COPY packages/plugins/pinchy-transcript/openclaw.plugin.json packages/plugins/pinchy-transcript/
 COPY packages/plugins/pinchy-docs/openclaw.plugin.json packages/plugins/pinchy-docs/
 COPY packages/plugins/pinchy-email/openclaw.plugin.json packages/plugins/pinchy-email/
 COPY packages/plugins/pinchy-odoo/openclaw.plugin.json packages/plugins/pinchy-odoo/
@@ -61,6 +62,7 @@ WORKDIR /app/packages/web
 COPY packages/plugins/pinchy-files /app/pinchy-plugins/pinchy-files
 COPY packages/plugins/pinchy-context /app/pinchy-plugins/pinchy-context
 COPY packages/plugins/pinchy-audit /app/pinchy-plugins/pinchy-audit
+COPY packages/plugins/pinchy-transcript /app/pinchy-plugins/pinchy-transcript
 COPY packages/plugins/pinchy-docs /app/pinchy-plugins/pinchy-docs
 COPY packages/plugins/pinchy-odoo /app/pinchy-plugins/pinchy-odoo
 COPY packages/plugins/pinchy-web /app/pinchy-plugins/pinchy-web

--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -30,6 +30,7 @@ services:
       - ./packages/plugins/pinchy-files:/root/.openclaw/extensions/pinchy-files
       - ./packages/plugins/pinchy-context:/root/.openclaw/extensions/pinchy-context
       - ./packages/plugins/pinchy-audit:/root/.openclaw/extensions/pinchy-audit
+      - ./packages/plugins/pinchy-transcript:/root/.openclaw/extensions/pinchy-transcript
       - ./packages/plugins/pinchy-odoo:/root/.openclaw/extensions/pinchy-odoo
       - ./packages/plugins/pinchy-web:/root/.openclaw/extensions/pinchy-web
       - ./packages/plugins/pinchy-email:/root/.openclaw/extensions/pinchy-email

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -52,7 +52,7 @@ done
 # we fail loud here instead. List MUST stay in sync with KNOWN_PINCHY_PLUGINS
 # in packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts; drift is
 # caught by entrypoint-runtime-check.test.ts.
-EXPECTED_PLUGINS="pinchy-files pinchy-context pinchy-audit pinchy-docs pinchy-email pinchy-odoo pinchy-web"
+EXPECTED_PLUGINS="pinchy-files pinchy-context pinchy-audit pinchy-transcript pinchy-docs pinchy-email pinchy-odoo pinchy-web"
 MISSING=""
 for plugin in $EXPECTED_PLUGINS; do
   if [ ! -d "/openclaw-extensions/$plugin" ]; then

--- a/packages/plugins/pinchy-transcript/config-schema.test.ts
+++ b/packages/plugins/pinchy-transcript/config-schema.test.ts
@@ -1,0 +1,30 @@
+// @vitest-environment node
+import { describe, it, expect } from "vitest";
+import { validatePluginEntry } from "../../web/src/lib/openclaw-config/plugin-schema";
+import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-manifest-loader";
+
+const manifest = loadPluginManifest("pinchy-transcript");
+
+// Mirrors build.ts — pinchy-transcript has no per-agent config, just credentials.
+const REPRESENTATIVE_EMITTED_CONFIG = {
+  apiBaseUrl: "http://pinchy:7777",
+  gatewayToken: "test-token",
+};
+
+describe("pinchy-transcript manifest contract", () => {
+  it("validates the config shape that regenerateOpenClawConfig() writes", () => {
+    const result = validatePluginEntry(manifest, REPRESENTATIVE_EMITTED_CONFIG);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("requires apiBaseUrl and gatewayToken", () => {
+    expect(validatePluginEntry(manifest, {}).ok).toBe(false);
+    expect(validatePluginEntry(manifest, { apiBaseUrl: "x" }).ok).toBe(false);
+    expect(validatePluginEntry(manifest, { gatewayToken: "x" }).ok).toBe(false);
+  });
+
+  it("uses additionalProperties: false", () => {
+    expect((manifest.configSchema as Record<string, unknown>).additionalProperties).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-transcript/index.test.ts
+++ b/packages/plugins/pinchy-transcript/index.test.ts
@@ -1,0 +1,173 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import plugin, {
+  buildPayload,
+  parseDirectSessionKey,
+  surrogateId,
+  postChannelMessage,
+} from "./index";
+
+const SK = "agent:agent-1:direct:tg-peer-111";
+
+describe("parseDirectSessionKey", () => {
+  it("parses a direct session key into agentId + peer", () => {
+    expect(parseDirectSessionKey(SK)).toEqual({ agentId: "agent-1", peer: "tg-peer-111" });
+  });
+  it("rejects non-direct scopes and garbage", () => {
+    expect(parseDirectSessionKey("agent:a:group:g")).toBeNull();
+    expect(parseDirectSessionKey("nope")).toBeNull();
+    expect(parseDirectSessionKey(undefined)).toBeNull();
+  });
+});
+
+describe("buildPayload", () => {
+  const base = {
+    channel: "telegram",
+    sessionKey: SK,
+    direction: "inbound" as const,
+    content: "  Hello over Telegram  ",
+    messageId: "msg-42",
+    sentAt: 1700000000000,
+  };
+
+  it("builds an inbound telegram payload: peer from key, trimmed content, messageId as externalId", () => {
+    expect(buildPayload(base)).toEqual({
+      channel: "telegram",
+      sessionKey: SK,
+      peerId: "tg-peer-111",
+      direction: "inbound",
+      externalId: "msg-42",
+      content: "Hello over Telegram",
+      sentAt: 1700000000000,
+    });
+  });
+
+  it("falls back to a deterministic surrogate externalId when messageId is absent", () => {
+    const p = buildPayload({ ...base, messageId: undefined });
+    expect(p?.externalId).toBe(surrogateId("inbound", "Hello over Telegram", 1700000000000));
+    // Stable across calls so retries dedup.
+    expect(buildPayload({ ...base, messageId: undefined })?.externalId).toBe(p?.externalId);
+  });
+
+  it("skips non-mirrored channels", () => {
+    expect(buildPayload({ ...base, channel: "discord" })).toBeNull();
+    expect(buildPayload({ ...base, channel: undefined })).toBeNull();
+  });
+
+  it("skips non-direct sessions (group/other scopes are not mirrored)", () => {
+    expect(buildPayload({ ...base, sessionKey: "agent:a:group:g" })).toBeNull();
+  });
+
+  it("skips empty / whitespace-only content", () => {
+    expect(buildPayload({ ...base, content: "   " })).toBeNull();
+    expect(buildPayload({ ...base, content: undefined })).toBeNull();
+  });
+});
+
+describe("postChannelMessage", () => {
+  const cfg = { apiBaseUrl: "http://pinchy:7777/", gatewayToken: "tok" };
+  const payload = {
+    channel: "telegram",
+    sessionKey: SK,
+    peerId: "tg-peer-111",
+    direction: "inbound" as const,
+    externalId: "msg-42",
+    content: "hi",
+    sentAt: 1,
+  };
+
+  beforeEach(() => vi.restoreAllMocks());
+  afterEach(() => vi.restoreAllMocks());
+
+  it("POSTs to the capture endpoint with bearer auth and the payload", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+
+    await postChannelMessage(cfg, undefined, payload);
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const [url, init] = fetchMock.mock.calls[0];
+    // Trailing slash on apiBaseUrl is normalized away.
+    expect(url).toBe("http://pinchy:7777/api/internal/channel-messages");
+    expect((init as RequestInit).method).toBe("POST");
+    expect((init as { headers: Record<string, string> }).headers.Authorization).toBe("Bearer tok");
+    expect(JSON.parse((init as { body: string }).body)).toEqual(payload);
+  });
+
+  it("does NOT retry a 4xx (our bug — server keeps rejecting)", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 400 });
+    vi.stubGlobal("fetch", fetchMock);
+    await postChannelMessage(cfg, undefined, payload); // returns, no throw
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it("retries a 5xx and throws after exhausting retries", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(postChannelMessage(cfg, undefined, payload)).rejects.toThrow();
+    expect(fetchMock).toHaveBeenCalledTimes(3); // 1 + MAX_RETRIES(2)
+  });
+});
+
+describe("plugin.register", () => {
+  const cfg = { apiBaseUrl: "http://pinchy:7777", gatewayToken: "tok" };
+
+  function fakeApi() {
+    const handlers: Record<string, (e: unknown, c: unknown) => Promise<void> | void> = {};
+    return {
+      pluginConfig: cfg,
+      logger: { warn: vi.fn() },
+      on: (name: string, h: (e: unknown, c: unknown) => Promise<void> | void) => {
+        handlers[name] = h;
+      },
+      handlers,
+    };
+  }
+
+  beforeEach(() => vi.restoreAllMocks());
+
+  it("captures an inbound telegram message via message_received", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+    const api = fakeApi();
+    plugin.register(api as never);
+
+    await api.handlers["message_received"](
+      { content: "Hi from TG", messageId: "m1", sessionKey: SK, timestamp: 1700000000000 },
+      { channelId: "telegram" }
+    );
+
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const body = JSON.parse(fetchMock.mock.calls[0][1].body);
+    expect(body).toMatchObject({ direction: "inbound", peerId: "tg-peer-111", content: "Hi from TG" });
+  });
+
+  it("captures a delivered outbound reply but SKIPS a failed delivery", async () => {
+    const fetchMock = vi.fn().mockResolvedValue({ ok: true, status: 200 });
+    vi.stubGlobal("fetch", fetchMock);
+    const api = fakeApi();
+    plugin.register(api as never);
+
+    await api.handlers["message_sent"](
+      { content: "reply", messageId: "m2", sessionKey: SK, success: true },
+      { channelId: "telegram" }
+    );
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    expect(JSON.parse(fetchMock.mock.calls[0][1].body)).toMatchObject({ direction: "outbound" });
+
+    fetchMock.mockClear();
+    await api.handlers["message_sent"](
+      { content: "undelivered", messageId: "m3", sessionKey: SK, success: false },
+      { channelId: "telegram" }
+    );
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it("does not register hooks when config is missing", () => {
+    const api = fakeApi();
+    api.pluginConfig = undefined as never;
+    plugin.register(api as never);
+    expect(Object.keys(api.handlers)).toHaveLength(0);
+    expect(api.logger.warn).toHaveBeenCalled();
+  });
+});

--- a/packages/plugins/pinchy-transcript/index.test.ts
+++ b/packages/plugins/pinchy-transcript/index.test.ts
@@ -30,11 +30,10 @@ describe("buildPayload", () => {
     sentAt: 1700000000000,
   };
 
-  it("builds an inbound telegram payload: peer from key, trimmed content, messageId as externalId", () => {
+  it("builds an inbound telegram payload: trimmed content, messageId as externalId (peer derived server-side)", () => {
     expect(buildPayload(base)).toEqual({
       channel: "telegram",
       sessionKey: SK,
-      peerId: "tg-peer-111",
       direction: "inbound",
       externalId: "msg-42",
       content: "Hello over Telegram",
@@ -69,7 +68,6 @@ describe("postChannelMessage", () => {
   const payload = {
     channel: "telegram",
     sessionKey: SK,
-    peerId: "tg-peer-111",
     direction: "inbound" as const,
     externalId: "msg-42",
     content: "hi",
@@ -139,7 +137,7 @@ describe("plugin.register", () => {
 
     expect(fetchMock).toHaveBeenCalledTimes(1);
     const body = JSON.parse(fetchMock.mock.calls[0][1].body);
-    expect(body).toMatchObject({ direction: "inbound", peerId: "tg-peer-111", content: "Hi from TG" });
+    expect(body).toMatchObject({ direction: "inbound", sessionKey: SK, content: "Hi from TG" });
   });
 
   it("captures a delivered outbound reply but SKIPS a failed delivery", async () => {

--- a/packages/plugins/pinchy-transcript/index.ts
+++ b/packages/plugins/pinchy-transcript/index.ts
@@ -60,8 +60,8 @@ interface PluginApi {
 
 interface CaptureChannelMessage {
   channel: string;
+  // agentId + peer are derived server-side from sessionKey (single source of truth).
   sessionKey: string;
-  peerId: string;
   direction: "inbound" | "outbound";
   externalId: string;
   content: string;
@@ -162,15 +162,15 @@ function buildPayload(args: {
 }): CaptureChannelMessage | null {
   const { channel, sessionKey, direction, content, messageId, sentAt } = args;
   if (!channel || !CAPTURED_CHANNELS.has(channel)) return null;
-  const direct = parseDirectSessionKey(sessionKey);
-  if (!direct) return null;
+  // Only mirror DIRECT (1:1) conversations; the endpoint re-derives agent+peer
+  // from this same key, so we just gate on it being a valid direct session.
+  if (!parseDirectSessionKey(sessionKey)) return null;
   const text = (content ?? "").trim();
   if (!text) return null;
 
   return {
     channel,
     sessionKey: sessionKey!,
-    peerId: direct.peer,
     direction,
     externalId: messageId ?? surrogateId(direction, text, sentAt),
     content: text,

--- a/packages/plugins/pinchy-transcript/index.ts
+++ b/packages/plugins/pinchy-transcript/index.ts
@@ -71,8 +71,12 @@ interface CaptureChannelMessage {
 // Channels whose direct conversations Pinchy mirrors. Widen to add Slack etc.
 const CAPTURED_CHANNELS = new Set(["telegram"]);
 
+// Strip trailing slashes without a regex: `/\/+$/` trips CodeQL's
+// js/polynomial-redos heuristic. A linear scan is unambiguously safe.
 function normalizeBaseUrl(url: string): string {
-  return url.replace(/\/+$/, "");
+  let end = url.length;
+  while (end > 0 && url.charCodeAt(end - 1) === 47 /* "/" */) end--;
+  return url.slice(0, end);
 }
 
 /**

--- a/packages/plugins/pinchy-transcript/index.ts
+++ b/packages/plugins/pinchy-transcript/index.ts
@@ -1,0 +1,230 @@
+/**
+ * pinchy-transcript — captures inbound/outbound channel messages into Pinchy's
+ * durable `channel_messages` store (via POST /api/internal/channel-messages), so
+ * the read-only conversation mirror renders from Pinchy's own record instead of
+ * OpenClaw's session-scoped chat.history. That makes the mirror robust against
+ * OpenClaw session semantics (/new resets, the daily reset, compaction, id
+ * rotation) and aligns the conversation record with Pinchy's audit/governance
+ * model.
+ *
+ * v1 captures DIRECT (1:1) Telegram conversations — the only channel Pinchy
+ * mirrors today. The schema, endpoint, and this plugin are channel-agnostic, so
+ * extending to Slack/WhatsApp is just widening CAPTURED_CHANNELS.
+ */
+
+interface PluginConfig {
+  apiBaseUrl: string;
+  gatewayToken: string;
+}
+
+interface PluginLogger {
+  warn?: (message: string) => void;
+}
+
+// Channel-message hook shapes (OpenClaw plugin SDK 2026.6.x). Only the fields
+// this plugin reads are typed; the SDK objects carry more.
+interface MessageHookContext {
+  channelId?: string;
+  sessionKey?: string;
+  senderId?: string;
+}
+
+interface MessageReceivedEvent {
+  content?: string;
+  from?: string;
+  senderId?: string;
+  sessionKey?: string;
+  messageId?: string;
+  timestamp?: number;
+}
+
+interface MessageSentEvent {
+  to?: string;
+  content?: string;
+  success?: boolean;
+  sessionKey?: string;
+  messageId?: string;
+}
+
+interface PluginApi {
+  pluginConfig?: PluginConfig;
+  logger?: PluginLogger;
+  on: (
+    hookName: "message_received" | "message_sent",
+    handler: (
+      event: MessageReceivedEvent | MessageSentEvent,
+      ctx: MessageHookContext
+    ) => Promise<void> | void
+  ) => void;
+}
+
+interface CaptureChannelMessage {
+  channel: string;
+  sessionKey: string;
+  peerId: string;
+  direction: "inbound" | "outbound";
+  externalId: string;
+  content: string;
+  sentAt: number;
+}
+
+// Channels whose direct conversations Pinchy mirrors. Widen to add Slack etc.
+const CAPTURED_CHANNELS = new Set(["telegram"]);
+
+function normalizeBaseUrl(url: string): string {
+  return url.replace(/\/+$/, "");
+}
+
+/**
+ * Parse `agent:<agentId>:direct:<peer>` → { agentId, peer }. Returns null for
+ * any key that isn't a DIRECT session (group/other scopes are not mirrored).
+ * Telegram direct keys carry no trailing chat segment, so `peer` is the final
+ * segment.
+ */
+function parseDirectSessionKey(
+  sessionKey: string | undefined
+): { agentId: string; peer: string } | null {
+  if (!sessionKey) return null;
+  const m = /^agent:([^:]+):direct:([^:]+)$/.exec(sessionKey);
+  return m ? { agentId: m[1], peer: m[2] } : null;
+}
+
+// Small deterministic hash for the surrogate externalId used when a channel
+// hook omits a message id. Stable across retries so dedup still works.
+function djb2(str: string): string {
+  let h = 5381;
+  for (let i = 0; i < str.length; i++) h = (h * 33) ^ str.charCodeAt(i);
+  return (h >>> 0).toString(36);
+}
+
+function surrogateId(direction: string, content: string, sentAt: number): string {
+  return `surrogate:${direction}:${sentAt}:${djb2(content)}`;
+}
+
+const MAX_RETRIES = 2;
+
+async function postChannelMessage(
+  cfg: PluginConfig,
+  logger: PluginLogger | undefined,
+  payload: CaptureChannelMessage
+): Promise<void> {
+  const endpoint = `${normalizeBaseUrl(cfg.apiBaseUrl)}/api/internal/channel-messages`;
+  let lastError: Error | undefined;
+
+  for (let attempt = 0; attempt <= MAX_RETRIES; attempt++) {
+    try {
+      const res = await fetch(endpoint, {
+        method: "POST",
+        headers: {
+          "Content-Type": "application/json",
+          Authorization: `Bearer ${cfg.gatewayToken}`,
+        },
+        body: JSON.stringify(payload),
+      });
+      // 2xx = stored (or idempotently skipped). 4xx = our bug; don't retry a
+      // request the server will keep rejecting. 5xx = transient; retry.
+      if (res.ok) return;
+      if (res.status < 500) {
+        logger?.warn?.(
+          `[pinchy-transcript] capture rejected (${res.status}) for ${payload.direction} ${payload.channel} message; dropping`
+        );
+        return;
+      }
+      lastError = new Error(`capture endpoint returned ${res.status}`);
+    } catch (error) {
+      lastError = error instanceof Error ? error : new Error(String(error));
+    }
+
+    if (attempt < MAX_RETRIES) {
+      logger?.warn?.(
+        `[pinchy-transcript] capture failed (attempt ${attempt + 1}/${MAX_RETRIES + 1}), retrying: ${lastError?.message}`
+      );
+    }
+  }
+  throw lastError;
+}
+
+/**
+ * Build a capture payload from a channel message, or null if it should be
+ * skipped: non-mirrored channel, non-direct session, or empty content.
+ */
+function buildPayload(args: {
+  channel: string | undefined;
+  sessionKey: string | undefined;
+  direction: "inbound" | "outbound";
+  content: string | undefined;
+  messageId: string | undefined;
+  sentAt: number;
+}): CaptureChannelMessage | null {
+  const { channel, sessionKey, direction, content, messageId, sentAt } = args;
+  if (!channel || !CAPTURED_CHANNELS.has(channel)) return null;
+  const direct = parseDirectSessionKey(sessionKey);
+  if (!direct) return null;
+  const text = (content ?? "").trim();
+  if (!text) return null;
+
+  return {
+    channel,
+    sessionKey: sessionKey!,
+    peerId: direct.peer,
+    direction,
+    externalId: messageId ?? surrogateId(direction, text, sentAt),
+    content: text,
+    sentAt,
+  };
+}
+
+const plugin = {
+  id: "pinchy-transcript",
+  name: "Pinchy Transcript",
+  description: "Captures channel conversation messages into Pinchy's durable transcript store.",
+  configSchema: {
+    validate: (value: unknown) => {
+      if (value && typeof value === "object" && "apiBaseUrl" in value && "gatewayToken" in value) {
+        return { ok: true as const, value };
+      }
+      return { ok: false as const, errors: ["Missing required keys in config"] };
+    },
+  },
+
+  register(api: PluginApi) {
+    const cfg = api.pluginConfig;
+    if (!cfg?.apiBaseUrl || !cfg?.gatewayToken) {
+      api.logger?.warn?.("[pinchy-transcript] plugin config is missing apiBaseUrl or gatewayToken");
+      return;
+    }
+
+    api.on("message_received", async (event, ctx) => {
+      const e = event as MessageReceivedEvent;
+      const payload = buildPayload({
+        channel: ctx.channelId,
+        sessionKey: e.sessionKey ?? ctx.sessionKey,
+        direction: "inbound",
+        content: e.content,
+        messageId: e.messageId,
+        sentAt: typeof e.timestamp === "number" ? e.timestamp : Date.now(),
+      });
+      if (payload) await postChannelMessage(cfg, api.logger, payload);
+    });
+
+    api.on("message_sent", async (event, ctx) => {
+      const e = event as MessageSentEvent;
+      // Only record replies that were actually delivered to the channel.
+      if (e.success === false) return;
+      const payload = buildPayload({
+        channel: ctx.channelId,
+        sessionKey: e.sessionKey ?? ctx.sessionKey,
+        direction: "outbound",
+        content: e.content,
+        messageId: e.messageId,
+        // message_sent carries no timestamp; stamp at delivery time.
+        sentAt: Date.now(),
+      });
+      if (payload) await postChannelMessage(cfg, api.logger, payload);
+    });
+  },
+};
+
+// Exported for unit tests; the default export is the plugin OpenClaw loads.
+export { buildPayload, parseDirectSessionKey, surrogateId, postChannelMessage };
+export default plugin;

--- a/packages/plugins/pinchy-transcript/openclaw.plugin.json
+++ b/packages/plugins/pinchy-transcript/openclaw.plugin.json
@@ -1,0 +1,21 @@
+{
+  "id": "pinchy-transcript",
+  "name": "Pinchy Transcript",
+  "description": "Captures channel conversation messages into Pinchy's durable transcript store.",
+  "activation": {
+    "onStartup": true
+  },
+  "configSchema": {
+    "type": "object",
+    "additionalProperties": false,
+    "properties": {
+      "apiBaseUrl": {
+        "type": "string"
+      },
+      "gatewayToken": {
+        "type": "string"
+      }
+    },
+    "required": ["apiBaseUrl", "gatewayToken"]
+  }
+}

--- a/packages/plugins/pinchy-transcript/package.json
+++ b/packages/plugins/pinchy-transcript/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "@pinchy/pinchy-transcript",
+  "version": "0.1.0",
+  "private": true,
+  "type": "module",
+  "scripts": {
+    "test": "vitest run",
+    "test:watch": "vitest"
+  },
+  "devDependencies": {
+    "typescript": "^6.0.3",
+    "vitest": "^4.1.7"
+  }
+}

--- a/packages/web/drizzle/0040_fresh_ultimates.sql
+++ b/packages/web/drizzle/0040_fresh_ultimates.sql
@@ -1,0 +1,15 @@
+CREATE TABLE "channel_messages" (
+	"id" text PRIMARY KEY NOT NULL,
+	"agent_id" text NOT NULL,
+	"channel" text NOT NULL,
+	"peer_id" text NOT NULL,
+	"direction" text NOT NULL,
+	"external_id" text NOT NULL,
+	"content" text NOT NULL,
+	"sent_at" timestamp NOT NULL,
+	"recorded_at" timestamp DEFAULT now() NOT NULL
+);
+--> statement-breakpoint
+ALTER TABLE "channel_messages" ADD CONSTRAINT "channel_messages_agent_id_agents_id_fk" FOREIGN KEY ("agent_id") REFERENCES "public"."agents"("id") ON DELETE cascade ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "channel_messages_agent_channel_peer_idx" ON "channel_messages" USING btree ("agent_id","channel","peer_id","sent_at");--> statement-breakpoint
+CREATE UNIQUE INDEX "channel_messages_dedup_uniq" ON "channel_messages" USING btree ("channel","agent_id","peer_id","direction","external_id");

--- a/packages/web/drizzle/meta/0040_snapshot.json
+++ b/packages/web/drizzle/meta/0040_snapshot.json
@@ -1,0 +1,1976 @@
+{
+  "id": "93b9f88d-d059-43e5-a8e7-ee654dc6a83e",
+  "prevId": "8085d2df-aafd-440f-8beb-d46942515cbf",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -281,6 +281,13 @@
       "when": 1781544172048,
       "tag": "0039_faithful_tyger_tiger",
       "breakpoints": true
+    },
+    {
+      "idx": 40,
+      "version": "7",
+      "when": 1781789770668,
+      "tag": "0040_fresh_ultimates",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -344,11 +344,17 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
     await expect(page.getByTestId("telegram-chat-header")).toBeVisible({ timeout: 30000 });
     await expect(page.getByTestId("telegram-channel-indicator")).toBeVisible();
 
-    // The transcript renders with at least one message (seeded above). The peer
-    // was linked + chatted in the previous test; the read-only mirror reads the
-    // server-derived session for user A's own peer.
+    // The transcript renders with at least one message. The peer chatted in the
+    // previous test, then sent `/new`. This asserts the message SURVIVES that
+    // reset in the mirror — which is only true because the `pinchy-transcript`
+    // plugin captured the inbound/outbound messages into Pinchy's own
+    // `channel_messages` store (message_received / message_sent hooks), so the
+    // read-only mirror renders from Pinchy's durable record rather than
+    // OpenClaw's session-scoped chat.history (which `/new` empties). This is the
+    // regression the Pinchy-owned-transcript work fixed: pre-reset history stays
+    // visible, matching what the user still sees in Telegram.
     await expect(page.getByTestId("telegram-transcript")).toBeVisible({ timeout: 30000 });
-    await expect(page.getByTestId("telegram-message-0")).toBeVisible();
+    await expect(page.getByTestId("telegram-message-0")).toBeVisible({ timeout: 15000 });
 
     // NO composer: the read-only view renders no message input. assistant-ui's
     // composer textarea (present on the live chat) must be absent here.

--- a/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
@@ -22,7 +22,8 @@ vi.mock("@/lib/agent-access", () => ({
 vi.mock("drizzle-orm", () => ({
   and: (...a: unknown[]) => a,
   eq: (...a: unknown[]) => a,
-  asc: (...a: unknown[]) => a,
+  // desc tags its argument so the test can assert newest-first ordering.
+  desc: (col: unknown) => ({ __desc: col }),
 }));
 
 // Schema sentinels: the route only needs object identity to pick the table.
@@ -48,6 +49,7 @@ let messageRows: unknown[];
 let messagesFail = false;
 const fromCalls: unknown[] = [];
 const messagesWhereArgs: unknown[] = [];
+const messagesOrderBy: unknown[] = [];
 vi.mock("@/db", async () => {
   const schema = (await import("@/db/schema")) as {
     channelLinks: unknown;
@@ -60,7 +62,10 @@ vi.mock("@/db", async () => {
         if (isMessages) messagesWhereArgs.push(...a);
         return chain;
       },
-      orderBy: () => chain,
+      orderBy: (...a: unknown[]) => {
+        if (isMessages) messagesOrderBy.push(...a);
+        return chain;
+      },
       limit: () => chain,
       then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) => {
         if (isMessages && messagesFail) return reject?.(new Error("db down"));
@@ -103,6 +108,7 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
     vi.clearAllMocks();
     fromCalls.length = 0;
     messagesWhereArgs.length = 0;
+    messagesOrderBy.length = 0;
     messagesFail = false;
     mockGetSession.mockResolvedValue({
       user: { id: "user-1", email: "user@test.com", role: "member" },
@@ -110,10 +116,12 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
     mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
     // This user has one linked Telegram peer (mixed case to prove lowercasing).
     linkRows = [{ channel: "telegram", userId: "user-1", channelUserId: "TG-Peer-111" }];
-    // Pinchy-owned transcript: inbound→user, outbound→assistant, chronological.
+    // Pinchy-owned transcript. The route queries newest-first (desc + limit) to
+    // render the most RECENT messages, so the mock returns rows newest-first;
+    // the route must reverse them back to chronological order for rendering.
     messageRows = [
-      { direction: "inbound", content: "Hello from Telegram", sentAt: new Date(1000) },
       { direction: "outbound", content: "Hi there!", sentAt: new Date(2000) },
+      { direction: "inbound", content: "Hello from Telegram", sentAt: new Date(1000) },
     ];
     mockGetSetting.mockResolvedValue("smithers_bot");
 
@@ -142,6 +150,10 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
     const { channelMessages } = (await import("@/db/schema")) as { channelMessages: unknown };
     expect(fromCalls).toContain(channelMessages);
 
+    // Recency: the query orders newest-first (desc) + limit, so a long
+    // conversation shows the most RECENT backlog, not the oldest. The mock
+    // returns rows newest-first; the response must be chronological (reversed).
+    expect(messagesOrderBy).toContainEqual({ __desc: expect.anything() });
     const body = await res.json();
     expect(body.messages).toEqual([
       { role: "user", text: "Hello from Telegram", timestamp: 1000 },

--- a/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-chat.test.ts
@@ -17,24 +17,70 @@ vi.mock("@/lib/agent-access", () => ({
   getAgentWithAccess: (...args: unknown[]) => mockGetAgentWithAccess(...args),
 }));
 
-const mockHistory = vi.fn();
-vi.mock("@/server/openclaw-client", () => ({
-  getOpenClawClient: () => ({ sessions: { history: mockHistory } }),
+// drizzle expression builders are no-ops here — the mocked query chain ignores
+// them and returns fixed rows per table.
+vi.mock("drizzle-orm", () => ({
+  and: (...a: unknown[]) => a,
+  eq: (...a: unknown[]) => a,
+  asc: (...a: unknown[]) => a,
 }));
 
-// `db.select().from().where()` returns the linked channel rows for THIS user.
-const mockWhere = vi.fn();
-vi.mock("@/db", () => ({
-  db: {
-    select: vi.fn().mockReturnValue({
-      from: vi.fn().mockReturnValue({
-        where: (...args: unknown[]) => mockWhere(...args),
-      }),
-    }),
+// Schema sentinels: the route only needs object identity to pick the table.
+vi.mock("@/db/schema", () => ({
+  channelLinks: { __table: "channel_links", channel: {}, userId: {} },
+  channelMessages: {
+    __table: "channel_messages",
+    direction: {},
+    content: {},
+    sentAt: {},
+    agentId: {},
+    channel: {},
+    peerId: {},
   },
 }));
 
-// `getSetting("telegram_bot_username:<agentId>")` resolves the bot username.
+// Two queries run: channel_links (peer lookup) then channel_messages (transcript).
+// The chain is awaitable (`then`) and chainable (`where/orderBy/limit`) so both
+// the `.where()`-terminated links query and the `.limit()`-terminated messages
+// query resolve to the right rows by table identity.
+let linkRows: unknown[];
+let messageRows: unknown[];
+let messagesFail = false;
+const fromCalls: unknown[] = [];
+const messagesWhereArgs: unknown[] = [];
+vi.mock("@/db", async () => {
+  const schema = (await import("@/db/schema")) as {
+    channelLinks: unknown;
+    channelMessages: unknown;
+  };
+  const makeChain = (table: unknown) => {
+    const isMessages = table === schema.channelMessages;
+    const chain: Record<string, unknown> = {
+      where: (...a: unknown[]) => {
+        if (isMessages) messagesWhereArgs.push(...a);
+        return chain;
+      },
+      orderBy: () => chain,
+      limit: () => chain,
+      then: (resolve: (v: unknown) => unknown, reject?: (e: unknown) => unknown) => {
+        if (isMessages && messagesFail) return reject?.(new Error("db down"));
+        return resolve(isMessages ? messageRows : linkRows);
+      },
+    };
+    return chain;
+  };
+  return {
+    db: {
+      select: () => ({
+        from: (table: unknown) => {
+          fromCalls.push(table);
+          return makeChain(table);
+        },
+      }),
+    },
+  };
+});
+
 const mockGetSetting = vi.fn();
 vi.mock("@/lib/settings", () => ({
   getSetting: (...args: unknown[]) => mockGetSetting(...args),
@@ -43,34 +89,10 @@ vi.mock("@/lib/settings", () => ({
 // ── Helpers ──────────────────────────────────────────────────────────────
 
 function makeRequest() {
-  return new NextRequest("http://localhost/api/agents/agent-1/telegram-chat", {
-    method: "GET",
-  });
+  return new NextRequest("http://localhost/api/agents/agent-1/telegram-chat", { method: "GET" });
 }
 
 const ctx = { params: Promise.resolve({ agentId: "agent-1" }) };
-
-/**
- * A realistic OpenClaw `sessions.history` payload mixing the shapes the live
- * web chat already normalizes: a user turn with OpenClaw's `[timestamp]`
- * prefix, an assistant turn wrapped in `<final>` tags, and tool/system noise
- * that must be dropped.
- */
-function transcriptPayload() {
-  return {
-    messages: [
-      { role: "user", content: "[2026-06-16T10:00:00Z] Hello from Telegram", timestamp: 1000 },
-      {
-        role: "assistant",
-        content: [{ type: "text", text: "<final>Hi there!</final>" }],
-        timestamp: 2000,
-      },
-      // tool/system noise the read-only view drops, exactly like the live chat
-      { role: "tool", content: "tool result blob", timestamp: 1500 },
-      { role: "system", content: "system prompt", timestamp: 500 },
-    ],
-  };
-}
 
 // ── Tests ──────────────────────────────────────────────────────────────────
 
@@ -79,26 +101,29 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
+    fromCalls.length = 0;
+    messagesWhereArgs.length = 0;
+    messagesFail = false;
     mockGetSession.mockResolvedValue({
       user: { id: "user-1", email: "user@test.com", role: "member" },
     });
     mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
-    // This user has one linked Telegram peer (note mixed case to prove lowercasing).
-    mockWhere.mockResolvedValue([
-      { channel: "telegram", userId: "user-1", channelUserId: "TG-Peer-111" },
-    ]);
-    mockHistory.mockResolvedValue(transcriptPayload());
+    // This user has one linked Telegram peer (mixed case to prove lowercasing).
+    linkRows = [{ channel: "telegram", userId: "user-1", channelUserId: "TG-Peer-111" }];
+    // Pinchy-owned transcript: inbound→user, outbound→assistant, chronological.
+    messageRows = [
+      { direction: "inbound", content: "Hello from Telegram", sentAt: new Date(1000) },
+      { direction: "outbound", content: "Hi there!", sentAt: new Date(2000) },
+    ];
     mockGetSetting.mockResolvedValue("smithers_bot");
 
-    const mod = await import("@/app/api/agents/[agentId]/telegram-chat/route");
-    GET = mod.GET;
+    GET = (await import("@/app/api/agents/[agentId]/telegram-chat/route")).GET;
   });
 
   it("returns 401 when unauthenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(401);
-    expect(mockHistory).not.toHaveBeenCalled();
   });
 
   it("propagates the access decision from getAgentWithAccess (403/404)", async () => {
@@ -107,15 +132,15 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
     );
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(403);
-    expect(mockHistory).not.toHaveBeenCalled();
   });
 
-  it("resolves the session key from the authed user's link and returns mapped messages", async () => {
+  it("renders the Pinchy-owned transcript: inbound→user, outbound→assistant, in order", async () => {
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
 
-    // Session key is server-derived: agent:<agentId>:direct:<lowercased peerId>.
-    expect(mockHistory).toHaveBeenCalledWith("agent:agent-1:direct:tg-peer-111", expect.anything());
+    // Reads from Pinchy's own channel_messages store, NOT OpenClaw.
+    const { channelMessages } = (await import("@/db/schema")) as { channelMessages: unknown };
+    expect(fromCalls).toContain(channelMessages);
 
     const body = await res.json();
     expect(body.messages).toEqual([
@@ -125,35 +150,41 @@ describe("GET /api/agents/[agentId]/telegram-chat", () => {
   });
 
   it("returns 404 when the authed user has no linked Telegram conversation", async () => {
-    mockWhere.mockResolvedValueOnce([]);
+    linkRows = [];
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(404);
     const body = await res.json();
     expect(body.error).toBe("No linked Telegram conversation");
-    // Never hit OpenClaw without a resolved peer.
-    expect(mockHistory).not.toHaveBeenCalled();
+    // Never query the transcript without a resolved peer.
+    const { channelMessages } = (await import("@/db/schema")) as { channelMessages: unknown };
+    expect(fromCalls).not.toContain(channelMessages);
   });
 
-  it("derives the peer from the AUTHED user only — a second user gets THEIR peer, never the first user's", async () => {
-    // A different authed user with their OWN, different link.
+  it("empty transcript renders as an empty message list (still 200)", async () => {
+    messageRows = [];
+    const res = await GET(makeRequest(), ctx as never);
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.messages).toEqual([]);
+  });
+
+  it("derives the peer from the AUTHED user only — a second user's transcript query uses THEIR peer, never the first user's", async () => {
     mockGetSession.mockResolvedValueOnce({
       user: { id: "user-2", email: "other@test.com", role: "member" },
     });
-    mockWhere.mockResolvedValueOnce([
-      { channel: "telegram", userId: "user-2", channelUserId: "tg-peer-222" },
-    ]);
+    linkRows = [{ channel: "telegram", userId: "user-2", channelUserId: "tg-peer-222" }];
 
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(200);
 
-    // The session key uses user-2's peer (222), NOT user-1's peer (111).
-    expect(mockHistory).toHaveBeenCalledWith("agent:agent-1:direct:tg-peer-222", expect.anything());
-    const calledKey = mockHistory.mock.calls[0][0] as string;
-    expect(calledKey).not.toContain("tg-peer-111");
+    // The transcript query is keyed by user-2's peer (222), never user-1's (111).
+    const where = JSON.stringify(messagesWhereArgs);
+    expect(where).toContain("tg-peer-222");
+    expect(where).not.toContain("tg-peer-111");
   });
 
-  it("returns 502 when OpenClaw sessions.history fails", async () => {
-    mockHistory.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
+  it("returns 502 (retryable) when the transcript query fails", async () => {
+    messagesFail = true;
     const res = await GET(makeRequest(), ctx as never);
     expect(res.status).toBe(502);
   });

--- a/packages/web/src/__tests__/api/internal-channel-messages.test.ts
+++ b/packages/web/src/__tests__/api/internal-channel-messages.test.ts
@@ -1,0 +1,92 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const mockValidateGatewayToken = vi.fn();
+vi.mock("@/lib/gateway-auth", () => ({
+  validateGatewayToken: (...args: unknown[]) => mockValidateGatewayToken(...args),
+}));
+
+const mockOnConflictDoNothing = vi.fn();
+const mockValues = vi.fn().mockReturnValue({ onConflictDoNothing: mockOnConflictDoNothing });
+const mockInsert = vi.fn().mockReturnValue({ values: mockValues });
+vi.mock("@/db", () => ({
+  db: { insert: (...args: unknown[]) => mockInsert(...args) },
+}));
+
+// channelMessages is referenced as the insert target; a sentinel is enough.
+vi.mock("@/db/schema", () => ({ channelMessages: { __table: "channel_messages" } }));
+
+function makeRequest(body: unknown) {
+  return new NextRequest("http://localhost/api/internal/channel-messages", {
+    method: "POST",
+    headers: { "content-type": "application/json", authorization: "Bearer tok" },
+    body: JSON.stringify(body),
+  });
+}
+
+const validBody = {
+  channel: "telegram",
+  sessionKey: "agent:agent-1:direct:TG-Peer-111",
+  peerId: "TG-Peer-111",
+  direction: "inbound",
+  externalId: "msg-42",
+  content: "Hello over Telegram",
+  sentAt: 1700000000000,
+};
+
+describe("POST /api/internal/channel-messages", () => {
+  let POST: typeof import("@/app/api/internal/channel-messages/route").POST;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    mockValidateGatewayToken.mockReturnValue(true);
+    mockOnConflictDoNothing.mockResolvedValue(undefined);
+    POST = (await import("@/app/api/internal/channel-messages/route")).POST;
+  });
+
+  it("returns 401 when the gateway token is invalid", async () => {
+    mockValidateGatewayToken.mockReturnValueOnce(false);
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(401);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 on an invalid body", async () => {
+    const res = await POST(makeRequest({ ...validBody, direction: "sideways" }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("returns 400 when sessionKey is not an agent session key", async () => {
+    const res = await POST(makeRequest({ ...validBody, sessionKey: "not-a-session" }));
+    expect(res.status).toBe(400);
+    expect(mockInsert).not.toHaveBeenCalled();
+  });
+
+  it("derives agentId from sessionKey, lowercases the peer, and upserts idempotently", async () => {
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(200);
+
+    expect(mockValues).toHaveBeenCalledTimes(1);
+    const values = mockValues.mock.calls[0][0];
+    expect(values).toMatchObject({
+      agentId: "agent-1", // derived from sessionKey, NOT trusted from body
+      channel: "telegram",
+      peerId: "tg-peer-111", // lowercased to match channel_links + read route
+      direction: "inbound",
+      externalId: "msg-42",
+      content: "Hello over Telegram",
+    });
+    expect(values.sentAt).toBeInstanceOf(Date);
+    expect((values.sentAt as Date).getTime()).toBe(1700000000000);
+
+    // Idempotent capture: retries / duplicate hook fires must not double-insert.
+    expect(mockOnConflictDoNothing).toHaveBeenCalledTimes(1);
+  });
+
+  it("returns 503 (retryable) when the DB write fails", async () => {
+    mockOnConflictDoNothing.mockRejectedValueOnce(new Error("db down"));
+    const res = await POST(makeRequest(validBody));
+    expect(res.status).toBe(503);
+  });
+});

--- a/packages/web/src/__tests__/api/internal-channel-messages.test.ts
+++ b/packages/web/src/__tests__/api/internal-channel-messages.test.ts
@@ -26,8 +26,8 @@ function makeRequest(body: unknown) {
 
 const validBody = {
   channel: "telegram",
+  // agentId + peer are derived from this; the body carries no peerId.
   sessionKey: "agent:agent-1:direct:TG-Peer-111",
-  peerId: "TG-Peer-111",
   direction: "inbound",
   externalId: "msg-42",
   content: "Hello over Telegram",
@@ -57,13 +57,15 @@ describe("POST /api/internal/channel-messages", () => {
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it("returns 400 when sessionKey is not an agent session key", async () => {
-    const res = await POST(makeRequest({ ...validBody, sessionKey: "not-a-session" }));
-    expect(res.status).toBe(400);
+  it("returns 400 for a non-direct or malformed sessionKey", async () => {
+    for (const sessionKey of ["not-a-session", "agent:agent-1:group:g", "agent:agent-1:direct:"]) {
+      const res = await POST(makeRequest({ ...validBody, sessionKey }));
+      expect(res.status, sessionKey).toBe(400);
+    }
     expect(mockInsert).not.toHaveBeenCalled();
   });
 
-  it("derives agentId from sessionKey, lowercases the peer, and upserts idempotently", async () => {
+  it("derives BOTH agentId and peer from sessionKey, lowercases the peer, and upserts idempotently", async () => {
     const res = await POST(makeRequest(validBody));
     expect(res.status).toBe(200);
 
@@ -72,7 +74,7 @@ describe("POST /api/internal/channel-messages", () => {
     expect(values).toMatchObject({
       agentId: "agent-1", // derived from sessionKey, NOT trusted from body
       channel: "telegram",
-      peerId: "tg-peer-111", // lowercased to match channel_links + read route
+      peerId: "tg-peer-111", // ALSO derived from sessionKey (no body peerId), lowercased
       direction: "inbound",
       externalId: "msg-42",
       content: "Hello over Telegram",

--- a/packages/web/src/__tests__/integrations/template-integration-coverage.test.ts
+++ b/packages/web/src/__tests__/integrations/template-integration-coverage.test.ts
@@ -78,6 +78,7 @@ const SCHEMA_SYNC_COVERAGES: ReadonlyArray<SchemaSyncCoverage> = [
 const NO_SCHEMA_REQUIRED: ReadonlyArray<KnownPinchyPlugin> = [
   // Internal plugins — no external schema sync, no per-template schema declaration.
   "pinchy-audit",
+  "pinchy-transcript",
   "pinchy-context",
   "pinchy-docs",
   "pinchy-files",

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -5558,6 +5558,7 @@ describe("restart-state integration", () => {
       "pinchy-audit",
       "telegram",
       "pinchy-files",
+      "pinchy-transcript",
       "document-extract",
     ]);
   });
@@ -6000,6 +6001,7 @@ describe("restart-state integration", () => {
         "pinchy-docs",
         "telegram",
         "pinchy-files",
+        "pinchy-transcript",
         "document-extract",
       ]);
     }

--- a/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
@@ -1,5 +1,5 @@
 import { NextResponse } from "next/server";
-import { and, asc, eq } from "drizzle-orm";
+import { and, desc, eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { getSetting } from "@/lib/settings";
@@ -63,7 +63,9 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
           eq(channelMessages.peerId, peerId)
         )
       )
-      .orderBy(asc(channelMessages.sentAt))
+      // Newest-first + limit so a long conversation renders the most RECENT
+      // HISTORY_LIMIT messages (a chat backlog), not the oldest ones.
+      .orderBy(desc(channelMessages.sentAt))
       .limit(HISTORY_LIMIT);
   } catch {
     // Transient DB error. 502 so the client surfaces a retryable "couldn't load
@@ -71,7 +73,8 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
     return NextResponse.json({ error: "Failed to load Telegram conversation" }, { status: 502 });
   }
 
-  const messages: TelegramTranscriptMessage[] = rows.map((row) => ({
+  // Reverse the newest-first query result back to chronological order for display.
+  const messages: TelegramTranscriptMessage[] = rows.reverse().map((row) => ({
     role: row.direction === "inbound" ? "user" : "assistant",
     text: row.content,
     timestamp: row.sentAt.getTime(),

--- a/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/telegram-chat/route.ts
@@ -1,28 +1,30 @@
 import { NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
+import { and, asc, eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
-import { getOpenClawClient } from "@/server/openclaw-client";
 import { getSetting } from "@/lib/settings";
 import { db } from "@/db";
-import { channelLinks } from "@/db/schema";
-import { mapTelegramTranscript, type RawHistoryMessage } from "@/lib/chats/telegram-transcript";
+import { channelLinks, channelMessages } from "@/db/schema";
+import type { TelegramTranscriptMessage } from "@/lib/schemas/sessions";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
-// How many trailing history entries to fetch for the read-only mirror. Matches
-// a reasonable chat backlog without pulling an unbounded transcript.
+// How many trailing messages to render in the read-only mirror. Matches a
+// reasonable chat backlog without pulling an unbounded transcript.
 const HISTORY_LIMIT = 200;
 
 /**
  * Read-only mirror of the requesting user's linked Telegram conversation with
- * this agent (#508). Pinchy mirrors Telegram into the web UI read-only — there
- * is no posting from here — so this only fetches and projects the transcript.
+ * this agent (#508). Pinchy renders this from its OWN durable `channel_messages`
+ * store (captured by the `pinchy-transcript` plugin), NOT from OpenClaw's
+ * session-scoped `chat.history` — so the mirror reflects what the user actually
+ * sees in Telegram (where messages persist across resets) and is immune to
+ * OpenClaw session semantics (`/new`, the daily reset, compaction, id rotation).
  *
  * The Telegram peer is SERVER-DERIVED from the authed user's `channel_links`
- * row; the client never supplies it. That is the authorization boundary: a
- * user can only ever read the session keyed to their own linked peer, so one
- * user's transcript can never leak to another.
+ * row; the client never supplies it. That is the authorization boundary: a user
+ * can only ever read messages keyed to their own linked peer, so one user's
+ * transcript can never leak to another.
  */
 // audit-exempt: read-only telegram transcript mirror — no state change.
 export const GET = withAuth<RouteContext>(async (_request, { params }, session) => {
@@ -34,8 +36,7 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
   const userId = session.user.id!;
 
   // The authed user's Telegram peer. One Telegram link per user, so the first
-  // (and only) row is the peer. Lowercased to match OpenClaw's stored principal
-  // segment — the classifier's contract (see classify-sessions.ts).
+  // (and only) row is the peer. Lowercased to match the stored `peer_id`.
   const links = await db
     .select()
     .from(channelLinks)
@@ -46,27 +47,39 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
     return NextResponse.json({ error: "No linked Telegram conversation" }, { status: 404 });
   }
 
-  // Per-task session model: the Telegram conversation is a SEPARATE OpenClaw
-  // session from the web chat, keyed by the user's Telegram peer id.
-  const sessionKey = `agent:${agentId}:direct:${peerId}`;
-
-  let raw: { messages?: RawHistoryMessage[] } | undefined;
+  let rows: { direction: string; content: string; sentAt: Date }[];
   try {
-    raw = (await getOpenClawClient().sessions.history(sessionKey, { limit: HISTORY_LIMIT })) as
-      | { messages?: RawHistoryMessage[] }
-      | undefined;
+    rows = await db
+      .select({
+        direction: channelMessages.direction,
+        content: channelMessages.content,
+        sentAt: channelMessages.sentAt,
+      })
+      .from(channelMessages)
+      .where(
+        and(
+          eq(channelMessages.agentId, agentId),
+          eq(channelMessages.channel, "telegram"),
+          eq(channelMessages.peerId, peerId)
+        )
+      )
+      .orderBy(asc(channelMessages.sentAt))
+      .limit(HISTORY_LIMIT);
   } catch {
-    // OpenClaw unreachable / mid-reconnect. 502 (not 500) so the client can
-    // surface a retryable "couldn't load conversation" toast.
+    // Transient DB error. 502 so the client surfaces a retryable "couldn't load
+    // conversation" toast rather than a hard failure.
     return NextResponse.json({ error: "Failed to load Telegram conversation" }, { status: 502 });
   }
 
-  const messages = mapTelegramTranscript(raw?.messages ?? []);
+  const messages: TelegramTranscriptMessage[] = rows.map((row) => ({
+    role: row.direction === "inbound" ? "user" : "assistant",
+    text: row.content,
+    timestamp: row.sentAt.getTime(),
+  }));
 
   // "Continue on Telegram" deep link. The bot username is persisted per agent
-  // as `telegram_bot_username:<agentId>` when an admin connects the bot (see
-  // the agent telegram channel route). Null when this agent has no bot
-  // configured — the UI falls back gracefully.
+  // as `telegram_bot_username:<agentId>` when an admin connects the bot. Null
+  // when this agent has no bot configured — the UI falls back gracefully.
   const botUsername = await getSetting(`telegram_bot_username:${agentId}`);
   const botDeepLink = botUsername ? `https://t.me/${botUsername}` : null;
 

--- a/packages/web/src/app/api/internal/channel-messages/route.ts
+++ b/packages/web/src/app/api/internal/channel-messages/route.ts
@@ -1,0 +1,73 @@
+import { NextRequest, NextResponse } from "next/server";
+import { validateGatewayToken } from "@/lib/gateway-auth";
+import { parseRequestBody } from "@/lib/api-validation";
+import { captureChannelMessageSchema } from "@/lib/schemas/channel-messages";
+import { db } from "@/db";
+import { channelMessages } from "@/db/schema";
+
+/**
+ * Extract the agent id from a session key (`agent:<agentId>:...`). The agent is
+ * derived from the session, never trusted from the body — see the schema doc.
+ */
+function agentIdFromSessionKey(sessionKey: string): string | undefined {
+  return /^agent:([^:]+):/.exec(sessionKey)?.[1];
+}
+
+/**
+ * Capture sink for the `pinchy-transcript` plugin. Records one inbound/outbound
+ * channel message into Pinchy's durable `channel_messages` store so the
+ * read-only conversation mirror renders from Pinchy's own record instead of
+ * OpenClaw's session-scoped transcript (robust against /new resets, the daily
+ * reset, compaction, and id rotation).
+ *
+ * Idempotent: the unique index (channel, agent_id, peer_id, direction,
+ * external_id) plus ON CONFLICT DO NOTHING means the plugin can safely retry or
+ * double-fire a hook without ever double-inserting.
+ *
+ * audit-exempt: high-volume internal transcript ingestion. The captured rows
+ * ARE the conversation record; emitting a separate audit entry per message
+ * would bloat the audit log with no added accountability (the plugin is the
+ * only, gateway-token-authed caller, mirroring /api/internal/audit/tool-use).
+ */
+// audit-exempt: high-volume internal transcript ingestion; the captured rows are
+// the conversation record, so a per-message audit entry adds no accountability.
+export async function POST(request: NextRequest) {
+  if (!validateGatewayToken(request.headers)) {
+    return NextResponse.json({ error: "Unauthorized" }, { status: 401 });
+  }
+
+  const parsed = await parseRequestBody(captureChannelMessageSchema, request);
+  if ("error" in parsed) return parsed.error;
+  const payload = parsed.data;
+
+  const agentId = agentIdFromSessionKey(payload.sessionKey);
+  if (!agentId) {
+    return NextResponse.json(
+      { error: "sessionKey must be of the form agent:<agentId>:..." },
+      { status: 400 }
+    );
+  }
+
+  try {
+    await db
+      .insert(channelMessages)
+      .values({
+        agentId,
+        channel: payload.channel,
+        // Lowercased to match channel_links.channelUserId and the direct-session
+        // peer segment the read route derives.
+        peerId: payload.peerId.toLowerCase(),
+        direction: payload.direction,
+        externalId: payload.externalId,
+        content: payload.content,
+        sentAt: new Date(payload.sentAt),
+      })
+      .onConflictDoNothing();
+  } catch {
+    // Transient DB error. 503 (not 500) so the plugin's retry loop treats it as
+    // retryable and re-delivers the message rather than dropping it.
+    return NextResponse.json({ error: "Failed to record channel message" }, { status: 503 });
+  }
+
+  return NextResponse.json({ success: true });
+}

--- a/packages/web/src/app/api/internal/channel-messages/route.ts
+++ b/packages/web/src/app/api/internal/channel-messages/route.ts
@@ -6,11 +6,15 @@ import { db } from "@/db";
 import { channelMessages } from "@/db/schema";
 
 /**
- * Extract the agent id from a session key (`agent:<agentId>:...`). The agent is
- * derived from the session, never trusted from the body — see the schema doc.
+ * Parse `agent:<agentId>:direct:<peer>` → { agentId, peer }. Both the agent and
+ * the peer are derived from the session key, never trusted from the body — so a
+ * buggy/compromised plugin can't mis-attribute a message, and the stored peer
+ * stays consistent with the read route's `channel_links`-derived peer. Returns
+ * null for any non-direct session (group/other scopes are not mirrored).
  */
-function agentIdFromSessionKey(sessionKey: string): string | undefined {
-  return /^agent:([^:]+):/.exec(sessionKey)?.[1];
+function parseDirectSessionKey(sessionKey: string): { agentId: string; peer: string } | null {
+  const m = /^agent:([^:]+):direct:([^:]+)$/.exec(sessionKey);
+  return m ? { agentId: m[1], peer: m[2] } : null;
 }
 
 /**
@@ -40,10 +44,10 @@ export async function POST(request: NextRequest) {
   if ("error" in parsed) return parsed.error;
   const payload = parsed.data;
 
-  const agentId = agentIdFromSessionKey(payload.sessionKey);
-  if (!agentId) {
+  const session = parseDirectSessionKey(payload.sessionKey);
+  if (!session) {
     return NextResponse.json(
-      { error: "sessionKey must be of the form agent:<agentId>:..." },
+      { error: "sessionKey must be of the form agent:<agentId>:direct:<peer>" },
       { status: 400 }
     );
   }
@@ -52,11 +56,11 @@ export async function POST(request: NextRequest) {
     await db
       .insert(channelMessages)
       .values({
-        agentId,
+        agentId: session.agentId,
         channel: payload.channel,
-        // Lowercased to match channel_links.channelUserId and the direct-session
-        // peer segment the read route derives.
-        peerId: payload.peerId.toLowerCase(),
+        // Lowercased to match channel_links.channelUserId and the peer the read
+        // route derives.
+        peerId: session.peer.toLowerCase(),
         direction: payload.direction,
         externalId: payload.externalId,
         content: payload.content,

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -257,6 +257,60 @@ export const channelLinks = pgTable(
   ]
 );
 
+/**
+ * Durable per-channel conversation transcript owned by Pinchy (#541 follow-up).
+ *
+ * Pinchy captures inbound/outbound channel messages via the `pinchy-transcript`
+ * OpenClaw plugin (message_received / message_sent hooks) and stores them here,
+ * so the read-only conversation mirror renders from Pinchy's own record instead
+ * of OpenClaw's session-scoped `chat.history`. That makes the mirror robust
+ * against OpenClaw session semantics — `/new` resets, the 4 AM daily reset,
+ * compaction, and id rotation no longer blank the view — and aligns the
+ * conversation record with Pinchy's audit/governance model.
+ *
+ * `peerId` is the channel-side user id (e.g. the Telegram peer), lowercased to
+ * match `channel_links.channelUserId` and the `agent:<id>:direct:<peer>`
+ * session-key segment. `externalId` is the channel's own message id (or a
+ * deterministic surrogate when the hook omits one) and is the idempotency key:
+ * the capture endpoint upserts on (channel, agentId, peerId, direction,
+ * externalId) so retries / duplicate hook fires never double-insert.
+ */
+export const channelMessages = pgTable(
+  "channel_messages",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    agentId: text("agent_id")
+      .notNull()
+      .references(() => agents.id, { onDelete: "cascade" }),
+    channel: text("channel").notNull(),
+    peerId: text("peer_id").notNull(),
+    direction: text("direction").notNull(),
+    externalId: text("external_id").notNull(),
+    content: text("content").notNull(),
+    sentAt: timestamp("sent_at").notNull(),
+    recordedAt: timestamp("recorded_at").notNull().defaultNow(),
+  },
+  (table) => [
+    // Read path: one user's transcript for (agent, channel, peer), chronological.
+    index("channel_messages_agent_channel_peer_idx").on(
+      table.agentId,
+      table.channel,
+      table.peerId,
+      table.sentAt
+    ),
+    // Idempotent capture: a given channel message is recorded once per direction.
+    uniqueIndex("channel_messages_dedup_uniq").on(
+      table.channel,
+      table.agentId,
+      table.peerId,
+      table.direction,
+      table.externalId
+    ),
+  ]
+);
+
 export const settings = pgTable("settings", {
   key: text("key").primaryKey(),
   value: text("value").notNull(),

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -558,6 +558,18 @@ export async function regenerateOpenClawConfig() {
     },
   };
 
+  // Always include pinchy-transcript and keep it enabled. It captures inbound/
+  // outbound channel messages (message_received / message_sent hooks) into
+  // Pinchy's durable transcript store so the read-only conversation mirror
+  // survives OpenClaw session resets.
+  entries["pinchy-transcript"] = {
+    enabled: true,
+    config: {
+      apiBaseUrl: process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
+      gatewayToken: gatewayTokenString,
+    },
+  };
+
   // Note: pinchy-files is always included (workspace uploads) — per-agent paths are built above.
 
   // Collect Odoo integration configs for agents with integration permissions

--- a/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
@@ -1,6 +1,7 @@
 import pinchyFilesManifest from "../../../../plugins/pinchy-files/openclaw.plugin.json";
 import pinchyContextManifest from "../../../../plugins/pinchy-context/openclaw.plugin.json";
 import pinchyAuditManifest from "../../../../plugins/pinchy-audit/openclaw.plugin.json";
+import pinchyTranscriptManifest from "../../../../plugins/pinchy-transcript/openclaw.plugin.json";
 import pinchyDocsManifest from "../../../../plugins/pinchy-docs/openclaw.plugin.json";
 import pinchyEmailManifest from "../../../../plugins/pinchy-email/openclaw.plugin.json";
 import pinchyOdooManifest from "../../../../plugins/pinchy-odoo/openclaw.plugin.json";
@@ -10,6 +11,7 @@ export const KNOWN_PINCHY_PLUGINS = [
   "pinchy-files",
   "pinchy-context",
   "pinchy-audit",
+  "pinchy-transcript",
   "pinchy-docs",
   "pinchy-email",
   "pinchy-odoo",
@@ -29,6 +31,7 @@ export const INTERNAL_PLUGINS = [
   "pinchy-context",
   "pinchy-docs",
   "pinchy-audit",
+  "pinchy-transcript",
 ] as const satisfies readonly KnownPinchyPlugin[];
 
 // Compile-time exhaustiveness check: every known plugin must appear in exactly
@@ -55,6 +58,7 @@ const MANIFESTS: Record<KnownPinchyPlugin, PluginManifest> = {
   "pinchy-files": pinchyFilesManifest as unknown as PluginManifest,
   "pinchy-context": pinchyContextManifest as unknown as PluginManifest,
   "pinchy-audit": pinchyAuditManifest as unknown as PluginManifest,
+  "pinchy-transcript": pinchyTranscriptManifest as unknown as PluginManifest,
   "pinchy-docs": pinchyDocsManifest as unknown as PluginManifest,
   "pinchy-email": pinchyEmailManifest as unknown as PluginManifest,
   "pinchy-odoo": pinchyOdooManifest as unknown as PluginManifest,

--- a/packages/web/src/lib/schemas/channel-messages.ts
+++ b/packages/web/src/lib/schemas/channel-messages.ts
@@ -6,18 +6,18 @@ import { z } from "zod";
  * message. Gateway-token authed. The plugin is the only caller; this schema is
  * shared so the plugin's payload and the route's parser can never drift.
  *
- * `agentId` is intentionally NOT in the body: it is derived server-side from
- * `sessionKey` (the single source of truth, matching the audit endpoint), so a
- * compromised/buggy plugin can't mis-attribute a message to an arbitrary agent
- * by spoofing an agentId field — the agent is whatever the session is keyed to.
+ * Neither `agentId` nor `peerId` is in the body: BOTH are derived server-side
+ * from `sessionKey` (`agent:<agentId>:direct:<peer>`), the single source of
+ * truth — so a compromised/buggy plugin can't mis-attribute a message to an
+ * arbitrary agent or peer by spoofing a field. The attribution is whatever the
+ * session is keyed to, and it stays consistent with the read route (which
+ * derives the peer from `channel_links`).
  */
 export const captureChannelMessageSchema = z.object({
   /** Channel id from the hook, e.g. "telegram". */
   channel: z.string().trim().min(1),
-  /** `agent:<agentId>:direct:<peer>` — agentId is parsed from this. */
+  /** `agent:<agentId>:direct:<peer>` — agentId AND peer are parsed from this. */
   sessionKey: z.string().trim().min(1),
-  /** Channel-side user id (e.g. the Telegram peer). Lowercased on store. */
-  peerId: z.string().trim().min(1),
   /** "inbound" = user→agent, "outbound" = agent→user. */
   direction: z.enum(["inbound", "outbound"]),
   /** Channel message id, or a deterministic surrogate. The idempotency key. */

--- a/packages/web/src/lib/schemas/channel-messages.ts
+++ b/packages/web/src/lib/schemas/channel-messages.ts
@@ -1,0 +1,31 @@
+import { z } from "zod";
+
+/**
+ * Body for `POST /api/internal/channel-messages` — the capture endpoint the
+ * `pinchy-transcript` OpenClaw plugin calls for every inbound/outbound channel
+ * message. Gateway-token authed. The plugin is the only caller; this schema is
+ * shared so the plugin's payload and the route's parser can never drift.
+ *
+ * `agentId` is intentionally NOT in the body: it is derived server-side from
+ * `sessionKey` (the single source of truth, matching the audit endpoint), so a
+ * compromised/buggy plugin can't mis-attribute a message to an arbitrary agent
+ * by spoofing an agentId field — the agent is whatever the session is keyed to.
+ */
+export const captureChannelMessageSchema = z.object({
+  /** Channel id from the hook, e.g. "telegram". */
+  channel: z.string().trim().min(1),
+  /** `agent:<agentId>:direct:<peer>` — agentId is parsed from this. */
+  sessionKey: z.string().trim().min(1),
+  /** Channel-side user id (e.g. the Telegram peer). Lowercased on store. */
+  peerId: z.string().trim().min(1),
+  /** "inbound" = user→agent, "outbound" = agent→user. */
+  direction: z.enum(["inbound", "outbound"]),
+  /** Channel message id, or a deterministic surrogate. The idempotency key. */
+  externalId: z.string().trim().min(1),
+  /** Message text. Empty/whitespace-only messages are not captured. */
+  content: z.string().min(1),
+  /** Epoch milliseconds the message was sent on the channel. */
+  sentAt: z.number().int().nonnegative(),
+});
+
+export type CaptureChannelMessage = z.infer<typeof captureChannelMessageSchema>;

--- a/packages/web/src/test-helpers/integration/setup.ts
+++ b/packages/web/src/test-helpers/integration/setup.ts
@@ -21,6 +21,7 @@ const APPLICATION_TABLES = [
   "agent_connection_permissions",
   "integration_connections",
   "channel_links",
+  "channel_messages",
   "agent_groups",
   "user_groups",
   "invite_groups",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -144,6 +144,15 @@ importers:
         specifier: ^4.1.7
         version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
 
+  packages/plugins/pinchy-transcript:
+    devDependencies:
+      typescript:
+        specifier: ^6.0.3
+        version: 6.0.3
+      vitest:
+        specifier: ^4.1.7
+        version: 4.1.7(@opentelemetry/api@1.9.1)(@types/node@25.9.1)(jsdom@29.1.1(@noble/hashes@2.0.1))(vite@8.0.16(@types/node@25.9.1)(esbuild@0.28.1)(jiti@2.7.0)(tsx@4.22.3)(yaml@2.9.0))
+
   packages/plugins/pinchy-web:
     dependencies:
       '@mozilla/readability':


### PR DESCRIPTION
## Why

While prepping the OpenClaw `2026.6.5 → 2026.6.8` bump (#541), the Telegram E2E `chats.spec.ts › Telegram read-only view` started failing deterministically on 2026.6.8. Root cause (source-verified at both OpenClaw tags): the read-only Telegram mirror read OpenClaw's **session-scoped** `chat.history`, which a `/new` reset empties. So after a `/new`, the web mirror went blank — diverging from Telegram itself, where the messages still exist (the Bot API can't delete history; `/new` only resets the agent's context).

UX research (ChatGPT/Claude "new chat" preserves history; omnichannel inboxes own the full transcript; Telegram can't delete messages) confirmed the mirror **should** keep showing the conversation across resets. The robust fix is architectural: **Pinchy owns the conversation transcript** instead of depending on OpenClaw's ephemeral session storage. This also aligns the conversation record with Pinchy's audit/governance model and makes the mirror immune to *every* OpenClaw session-lifecycle event (`/new`, the 4 AM daily reset, compaction, id rotation), not just this one.

## What

A durable, channel-agnostic, Pinchy-owned transcript:

- **`channel_messages` table** (migration `0040`) — `(agent_id, channel, peer_id, direction, external_id, content, sent_at)`, idempotent unique index on `(channel, agent_id, peer_id, direction, external_id)`, chronological read index, `on delete cascade` per agent.
- **`pinchy-transcript` plugin** (hooks-only, modeled on `pinchy-audit`) — registers `message_received` + `message_sent`, captures inbound/outbound Telegram messages, POSTs them to Pinchy with retry. Durability is plugin-owned (idempotent sink keyed by message id) because the SDK's observation hooks are best-effort fire-and-forget.
- **`POST /api/internal/channel-messages`** — gateway-token-authed capture sink. `agentId` is derived from `sessionKey` (never trusted from the body); idempotent upsert; 503 on transient DB error so the plugin retries.
- **`GET /api/agents/[agentId]/telegram-chat`** now reads the mirror from `channel_messages` instead of OpenClaw `chat.history`. Same `channel_links` per-user auth boundary; identical response shape (frontend unchanged).
- Full plugin wiring kept every drift guard green: `KNOWN_PINCHY_PLUGINS` / `INTERNAL_PLUGINS` / manifests, `build.ts` always-on emission, `Dockerfile.pinchy` staging, `docker-compose.dev.yml` mount, `entrypoint.sh` runtime check, integration truncate list.

## Verification

- `pnpm -C packages/web test` — **6223 passed** (incl. capture endpoint, read mirror, all plugin/wiring drift guards, openclaw-config order assertions).
- `pnpm -C packages/web test:db` — **115 passed** (migration `0040` applies; `channel_messages` truncated between tests).
- `pinchy-transcript` plugin unit tests — **16 passed** (capture/filter/retry/idempotency/hook flow).
- `tsc --noEmit` clean.
- **CI E2E (telegram)** exercises the end-to-end path: a Telegram message is captured by `pinchy-transcript` → stored → the read-only mirror still shows it **after `/new`** (`chats.spec.ts`, the regression this fixes).

## Relationship to #541

This is the prerequisite for the OpenClaw bump: it removes the Telegram-mirror regression that the bump surfaced. Merge this first, then #541 rebases cleanly and its CI goes green.

## Deliberate follow-ups (not blocking)

- **Backfill**: existing conversations start empty at deploy (capture is going-forward). A one-time seed from current `chat.history` per linked peer can close the transition gap.
- **Live refresh**: the read-only view is a one-shot fetch; now that the store is reliable, a periodic refresh would make it a live mirror.
- **Unlink retention**: messages are kept on Telegram unlink (governance record); hard-delete is a separate admin/GDPR action.
