### PR TITLE
fix(test): bind fake-ollama context-window test to an ephemeral port

### DIFF
--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-process.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-process.ts
@@ -12,4 +12,11 @@ process.on("SIGINT", () => {
   void shutdown();
 });
 
-void startFakeOllama();
+// startFakeOllama() now rejects on a listen failure (e.g. EADDRINUSE) instead
+// of hanging. Fail the subprocess loudly with a non-zero exit code rather than
+// letting it surface as an unhandled rejection, so the E2E global-setup that
+// spawns this process sees a clean, diagnosable startup failure.
+startFakeOllama().catch((err) => {
+  console.error("[fake-ollama] failed to start:", err);
+  process.exit(1);
+});

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -7,6 +7,7 @@
 // Endpoint used by OpenClaw when routing a chat message:
 //   POST /api/chat   → streaming NDJSON response
 import * as http from "http";
+import type { AddressInfo } from "net";
 
 const MODEL_NAME = "llama3.2";
 // Default response asserted by the integration test suite. The setup-wizard
@@ -852,12 +853,41 @@ export const FAKE_OLLAMA_PDF_ATTACHMENT_READ_TOOL_RESPONSE = PDF_ATTACHMENT_READ
 
 let server: http.Server | null = null;
 
-export function startFakeOllama(): Promise<void> {
-  return new Promise((resolve) => {
-    server = http.createServer(handleRequest);
-    server.listen(FAKE_OLLAMA_PORT, "0.0.0.0", () => {
-      console.log(`[fake-ollama] listening on port ${FAKE_OLLAMA_PORT}`);
-      resolve();
+/**
+ * Start the fake-ollama HTTP server and resolve with the actual bound port.
+ *
+ * @param port  Port to bind. Defaults to the well-known FAKE_OLLAMA_PORT (11435)
+ *   that the Dockerized E2E stack / OpenClaw connect to. Pass 0 for an
+ *   OS-assigned ephemeral port (used by in-process tests so they never collide
+ *   with a concurrent holder of 11435).
+ *
+ * Rejects — rather than hanging on a listen callback that never fires while the
+ * unhandled 'error' event crashes the process — if the port is already in use
+ * (EADDRINUSE) or listen otherwise fails, or if a server is already running.
+ */
+export function startFakeOllama(port: number = FAKE_OLLAMA_PORT): Promise<number> {
+  return new Promise((resolve, reject) => {
+    if (server) {
+      reject(new Error("[fake-ollama] already started; call stopFakeOllama() first"));
+      return;
+    }
+    const s = http.createServer(handleRequest);
+    const onStartupError = (err: Error) => {
+      // listen() failed (e.g. EADDRINUSE) — surface it as a rejection and leave
+      // no half-constructed, never-listening server behind (which would make a
+      // later stopFakeOllama() reject with ERR_SERVER_NOT_RUNNING).
+      server = null;
+      reject(err);
+    };
+    s.once("error", onStartupError);
+    s.listen(port, "0.0.0.0", () => {
+      server = s;
+      s.removeListener("error", onStartupError);
+      // Surface, rather than crash on, any later server-level socket error.
+      s.on("error", (err) => console.error("[fake-ollama] server error:", err));
+      const boundPort = (s.address() as AddressInfo).port;
+      console.log(`[fake-ollama] listening on port ${boundPort}`);
+      resolve(boundPort);
     });
   });
 }

--- a/packages/web/src/__tests__/lib/fake-ollama-context-window.test.ts
+++ b/packages/web/src/__tests__/lib/fake-ollama-context-window.test.ts
@@ -1,10 +1,8 @@
 // @vitest-environment node
 import { describe, it, expect, beforeAll, afterAll } from "vitest";
-import {
-  startFakeOllama,
-  stopFakeOllama,
-  FAKE_OLLAMA_PORT,
-} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+import * as http from "http";
+import type { AddressInfo } from "net";
+import { handleRequest } from "../../../e2e/shared/fake-ollama/fake-ollama-server";
 
 // Regression guard for the OpenClaw 2026.5.28 budget-triggered compaction
 // overflow that turned the "Integration Tests (OpenClaw + Fake Ollama)" suite
@@ -23,15 +21,33 @@ import {
 // keeps the context window from ever being the bottleneck in these short
 // single-turn probes.
 describe("fake-ollama /api/show advertises a realistic context window", () => {
+  let server: http.Server;
+  let baseUrl: string;
+
+  // Bind an ephemeral port (0) and run handleRequest directly, exactly like the
+  // sibling fake-ollama unit tests (fake-ollama-usage, fake-ollama-liveness).
+  // This in-process test only needs to exercise the /api/show branch, so it must
+  // NOT depend on the shared fixed FAKE_OLLAMA_PORT (11435) the way the old
+  // startFakeOllama() singleton did. Under the parallel `pnpm test` run any
+  // concurrent holder of 11435 (a sibling test run, a leftover fake-ollama
+  // process, a local dev stack) turned a clean assertion into an EADDRINUSE that
+  // — because startFakeOllama() registers no `error` handler — hung beforeAll for
+  // the full hook timeout and surfaced as an unhandled error, failing the file.
+  // An OS-assigned ephemeral port cannot collide, so the test is deterministic.
   beforeAll(async () => {
-    await startFakeOllama();
+    server = http.createServer(handleRequest);
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
   });
   afterAll(async () => {
-    await stopFakeOllama();
+    await new Promise<void>((resolve, reject) =>
+      server.close((err) => (err ? reject(err) : resolve()))
+    );
   });
 
   it("reports a real llama context_length so OpenClaw never triggers overflow compaction during probe tests", async () => {
-    const res = await fetch(`http://127.0.0.1:${FAKE_OLLAMA_PORT}/api/show`, {
+    const res = await fetch(`${baseUrl}/api/show`, {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ name: "llama3.2" }),

--- a/packages/web/src/__tests__/lib/fake-ollama-server-lifecycle.test.ts
+++ b/packages/web/src/__tests__/lib/fake-ollama-server-lifecycle.test.ts
@@ -1,0 +1,91 @@
+// @vitest-environment node
+//
+// Hardening coverage for the fake-ollama server lifecycle helpers
+// (startFakeOllama / stopFakeOllama). The Docker E2E stack drives the server as
+// a long-lived subprocess (fake-ollama-process.ts) on the well-known
+// FAKE_OLLAMA_PORT; if that port is ever already bound, startFakeOllama() must
+// fail FAST and LOUD — a rejected promise — rather than hanging on a listen
+// callback that never fires while its unhandled 'error' event crashes the
+// process. (That exact failure mode flaked the context-window unit test and
+// would silently break E2E startup on a port clash.)
+//
+// These in-process tests bind EPHEMERAL ports (0) so they never collide with a
+// concurrent holder of the fixed 11435 themselves.
+import { describe, it, expect, afterEach } from "vitest";
+import * as http from "http";
+import type { AddressInfo } from "net";
+import {
+  startFakeOllama,
+  stopFakeOllama,
+} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+
+/** Bind 0.0.0.0:<ephemeral> and hold it so a subsequent listen on it collides. */
+function occupyPort(): Promise<{ port: number; release: () => Promise<void> }> {
+  return new Promise((resolve) => {
+    const blocker = http.createServer();
+    blocker.listen(0, "0.0.0.0", () => {
+      const { port } = blocker.address() as AddressInfo;
+      resolve({
+        port,
+        release: () => new Promise<void>((res, rej) => blocker.close((e) => (e ? rej(e) : res()))),
+      });
+    });
+  });
+}
+
+afterEach(async () => {
+  // Always release the module singleton between tests so the next test starts
+  // from a clean slate even if a test left it running.
+  await stopFakeOllama();
+});
+
+describe("startFakeOllama / stopFakeOllama lifecycle", () => {
+  it("starts on the requested port and returns the actual bound port", async () => {
+    const port = await startFakeOllama(0);
+    expect(typeof port).toBe("number");
+    expect(port).toBeGreaterThan(0);
+
+    const res = await fetch(`http://127.0.0.1:${port}/api/show`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ name: "llama3.2" }),
+    });
+    expect(res.ok).toBe(true);
+  });
+
+  // Tight timeout: the whole point of the fix is that this rejects promptly
+  // rather than hanging until the default hook/test timeout.
+  it(
+    "rejects with EADDRINUSE instead of hanging when the port is already bound",
+    { timeout: 5000 },
+    async () => {
+      const blocker = await occupyPort();
+      try {
+        await expect(startFakeOllama(blocker.port)).rejects.toMatchObject({
+          code: "EADDRINUSE",
+        });
+      } finally {
+        await blocker.release();
+      }
+    }
+  );
+
+  it("rejects a second start while already running (no silent server leak)", async () => {
+    await startFakeOllama(0);
+    await expect(startFakeOllama(0)).rejects.toThrow(/already started/i);
+  });
+
+  it("leaves no stale server after a failed start, so stop is a clean no-op", async () => {
+    const blocker = await occupyPort();
+    try {
+      await expect(startFakeOllama(blocker.port)).rejects.toMatchObject({
+        code: "EADDRINUSE",
+      });
+    } finally {
+      await blocker.release();
+    }
+    // A failed start must not leave a half-constructed, never-listening server
+    // behind — otherwise stop() rejects with ERR_SERVER_NOT_RUNNING.
+    await expect(stopFakeOllama()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## What

Fixes the flaky unit test `fake-ollama /api/show advertises a realistic context window`, then hardens the shared fake-ollama lifecycle helper that was the underlying cause, so a port conflict can never again turn into a hang + process crash.

Two commits:
1. `fix(test): bind fake-ollama context-window test to an ephemeral port`
2. `fix(test): harden startFakeOllama against port-conflict hangs`

## Root cause

The context-window test bootstrapped the fake server via the `startFakeOllama()` singleton, which binds the **shared fixed `FAKE_OLLAMA_PORT` (11435)**. Under the parallel `pnpm test` run any concurrent holder of 11435 (a sibling test run, a leftover process, a local dev stack) made `listen()` emit `EADDRINUSE`. Because `startFakeOllama()` registered **no `error` handler**:

- the `listen` success callback never fired → `beforeAll` hung for the full **10 s hook timeout**,
- the `EADDRINUSE` event surfaced as an **unhandled error** (crashing the worker),
- the half-constructed, never-listening server left in the singleton then made `afterAll`'s `stopFakeOllama()` reject with `ERR_SERVER_NOT_RUNNING`.

In isolation 11435 is free, so it only flaked in the contention-prone parallel run.

## Changes

**1. Context-window test → ephemeral port.** Runs `handleRequest` on an OS-assigned ephemeral port (0), exactly like the sibling fake-ollama unit tests (`fake-ollama-usage`, `fake-ollama-liveness`). Assertions unchanged — same dispatcher, same `/api/show` response — so coverage is fully preserved; only the fixed-port dependency is removed.

**2. `startFakeOllama()` hardened** (the shared helper still used by the Docker E2E subprocess and Playwright specs):
- **rejects promptly** on a listen failure instead of hanging + crashing on an unhandled `'error'`;
- **rejects a second start** while one is already running, instead of silently leaking the first server;
- **clears the singleton on a failed start**, so `stopFakeOllama()` stays a clean no-op (no more `ERR_SERVER_NOT_RUNNING`);
- accepts an **optional port** (default `FAKE_OLLAMA_PORT`) and **resolves with the actual bound port**, so in-process tests can use port 0 and never collide with a holder of 11435. Backward-compatible: every existing caller uses `await startFakeOllama()` and ignores the return.

`stopFakeOllama()` is unchanged — it already no-ops on a null singleton, which the failed-start cleanup now guarantees. (`server.close()` was measured to resolve in <1 ms even with a pooled keep-alive socket, so `closeAllConnections()` was deliberately **not** added — it would fix no real problem.)

**3. `fake-ollama-process.ts`** (E2E subprocess) now `.catch()`es the start and exits non-zero on failure, rather than turning the new rejection into an unhandled promise rejection.

**4. New unit test `fake-ollama-server-lifecycle.test.ts`** pins all four hardened behaviours. It binds ephemeral ports, so it is itself immune to 11435 contention.

## Verification (deterministic red→green)

| State | Result |
|---|---|
| context-window before fix, 11435 held | ❌ FAIL — 10 s `beforeAll` timeout + `EADDRINUSE` + unhandled error |
| context-window after fix, 11435 *still* held | ✅ PASS (177 ms) |
| lifecycle tests before hardening | ❌ 4 failed (hang + 2 uncaught `EADDRINUSE`) |
| lifecycle tests after hardening | ✅ 4 passed (211 ms) |
| **full suite ×4** (incl. one run with 11435 held by a separate process) | ✅ green each: `494 passed \| 3 skipped`, exit 0 |

`tsc --noEmit`, ESLint and Prettier all clean.