### PR TITLE
fix(ollama): accept OrbStack host aliases; frame ollama.local as deliberate decoupling

### DIFF
--- a/docker-compose.dev.yml
+++ b/docker-compose.dev.yml
@@ -20,11 +20,13 @@ services:
       context: .
       dockerfile: Dockerfile.openclaw
     extra_hosts:
-      # ollama.local is mapped to the Docker host gateway so the OpenClaw
-      # container can reach Ollama on the host. Pinchy's build.ts rewrites
-      # host.docker.internal -> ollama.local in the emitted config because
-      # host.docker.internal is not in OpenClaw 2026.4.27's isLocalBaseUrl
-      # allowlist (*.local is).
+      # ollama.local is mapped to the host gateway so the OpenClaw container can
+      # reach Ollama on the host. Pinchy normalizes every container-host alias
+      # (host.docker.internal, *.orb.internal, ...) -> ollama.local in the
+      # emitted config, which clears OpenClaw's isLocalBaseUrl via the stable
+      # `.local` rule -- a deliberate decoupling from its host-alias allowlist
+      # (which has changed across versions). See
+      # packages/web/src/lib/openclaw-local-url.ts.
       - "ollama.local:host-gateway"
     volumes:
       - ./packages/plugins/pinchy-files:/root/.openclaw/extensions/pinchy-files

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -35,11 +35,13 @@ services:
     expose:
       - "18789"
     extra_hosts:
-      # ollama.local is mapped to the Docker host gateway so the OpenClaw
-      # container can reach Ollama on the host. Pinchy's build.ts rewrites
-      # host.docker.internal -> ollama.local in the emitted config because
-      # host.docker.internal is not in OpenClaw 2026.4.27's isLocalBaseUrl
-      # allowlist (*.local is).
+      # ollama.local is mapped to the host gateway so the OpenClaw container can
+      # reach Ollama on the host. Pinchy normalizes every container-host alias
+      # (host.docker.internal, *.orb.internal, ...) -> ollama.local in the
+      # emitted config, which clears OpenClaw's isLocalBaseUrl via the stable
+      # `.local` rule -- a deliberate decoupling from its host-alias allowlist
+      # (which has changed across versions). See
+      # packages/web/src/lib/openclaw-local-url.ts.
       - "ollama.local:host-gateway"
     volumes:
       - openclaw-config:/root/.openclaw

--- a/docs/src/content/docs/guides/ollama-setup.mdx
+++ b/docs/src/content/docs/guides/ollama-setup.mdx
@@ -262,8 +262,10 @@ agents) with cloud providers (interactive agents).
   `host.docker.internal` was rejected by the local-provider auth path.
 - For non-default URLs, the URL host must be one of: `localhost`,
   `127.0.0.1`, a hostname ending in `.local`, an RFC-1918 private IPv4
-  (`192.168.*`, `10.*`, `172.16-31.*`), or one of Docker's host aliases
-  (`host.docker.internal`, `gateway.docker.internal`).
+  (`192.168.*`, `10.*`, `172.16-31.*`), or one of the recognized container-host
+  aliases (`host.docker.internal`, `gateway.docker.internal`, and OrbStack's
+  `docker.orb.internal` / `host.orb.internal`) — all auto-rewritten to
+  `ollama.local`.
 - **Upgrading from `http://ollama:11434`?** Earlier docs recommended the
   bare service name, which fails the check above. Switch to
   [option B](#b-ollama-as-a-docker-service) — add an `ollama.docker.local`

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2269,12 +2269,13 @@ describe("regenerateOpenClawConfig", () => {
     expect(config.models.providers["ollama"].baseUrl).toBe("http://ollama.local:11434/v1");
   });
 
-  it("rewrites all known Docker host aliases to ollama.local", async () => {
-    // Docker exposes the host under multiple aliases depending on platform
-    // and version: gateway.docker.internal (alternative), docker.for.mac.*
-    // (legacy Mac), docker.for.win.* (legacy Windows). All are Docker host
-    // aliases that must reach the host machine — none are in OpenClaw's
-    // isLocalBaseUrl allowlist, so all need the same ollama.local rewrite.
+  it("rewrites all known container-host aliases to ollama.local", async () => {
+    // The host is exposed under several aliases depending on the runtime:
+    // gateway.docker.internal, docker.for.mac.* / docker.for.win.* (legacy
+    // Docker Desktop), and docker.orb.internal / host.orb.internal (OrbStack).
+    // All are normalized to ollama.local regardless of whether OpenClaw's
+    // isLocalBaseUrl happens to accept a given alias today — that's the
+    // deliberate decoupling from OpenClaw's host-alias allowlist churn.
     vi.mocked(fetchOllamaLocalModelsFromUrl).mockResolvedValue([
       {
         id: "ollama/qwen2.5:7b",
@@ -2289,6 +2290,8 @@ describe("regenerateOpenClawConfig", () => {
       "http://gateway.docker.internal:11434",
       "http://docker.for.mac.host.internal:11434",
       "http://docker.for.win.host.internal:11434",
+      "http://docker.orb.internal:11434",
+      "http://host.orb.internal:11434",
     ];
 
     for (const url of aliases) {

--- a/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
@@ -6,19 +6,20 @@ import {
 } from "@/lib/openclaw-local-url";
 
 /**
- * Drift guard for the shared 1:1 port of OpenClaw's `isLocalBaseUrl` predicate.
- * The mirror is documented and pinned to OpenClaw 2026.4.27 — these tests pin
- * the exact behavior so a future maintainer can't silently change a boundary
- * (e.g. tighten the 172.16–172.31 RFC1918 range) without a red test.
- *
- * See `openclaw-config.test.ts` for the dual that re-exports the same helper
- * as a config-generation drift guard.
- *
- * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump)
+ * Tests for the local-Ollama URL handling. `isOpenClawLocalBaseUrl` is a
+ * deliberate STABLE SUBSET of OpenClaw's `isLocalBaseUrl` (only loopback,
+ * `.local`, and RFC1918 private IPv4 — conventions OpenClaw won't drop), so it
+ * can only ever be a SAFE subset: it never accepts a host OpenClaw would
+ * reject. Container-host aliases are handled separately by `DOCKER_HOST_ALIASES`
+ * (Pinchy-owned), which `build.ts#rewriteOllamaHostForOpenClaw` normalizes to
+ * `ollama.local` — passing OpenClaw via the rock-stable `.local` rule and
+ * decoupling us from its host-alias allowlist churn. So this set does NOT need
+ * re-verifying against OpenClaw on every bump; it only grows when we choose to
+ * support a new container runtime's host alias.
  */
 describe("openclaw-local-url", () => {
   describe("DOCKER_HOST_ALIASES", () => {
-    it("contains exactly the four Docker host aliases that get rewritten to ollama.local in build.ts", () => {
+    it("contains the Docker + OrbStack host aliases that get rewritten to ollama.local in build.ts", () => {
       // Source of truth lives in @/lib/openclaw-local-url; mirrored by
       // build.ts#rewriteOllamaHostForOpenClaw. If a new alias is added,
       // both the rewrite map AND this drift guard must be updated.
@@ -26,10 +27,22 @@ describe("openclaw-local-url", () => {
         [
           "docker.for.mac.host.internal",
           "docker.for.win.host.internal",
+          "docker.orb.internal",
           "gateway.docker.internal",
           "host.docker.internal",
+          "host.orb.internal",
         ].sort()
       );
+    });
+
+    it("accepts the OrbStack host aliases (normalized to ollama.local at emit)", () => {
+      // OrbStack's host aliases are NOT in OpenClaw's allowlist directly, but
+      // the rewrite normalizes them to ollama.local, so they must validate at
+      // save time rather than being falsely rejected.
+      expect(isOpenClawCompatibleOllamaUrl("http://docker.orb.internal:11434")).toBe(true);
+      expect(isOpenClawCompatibleOllamaUrl("http://host.orb.internal:11434")).toBe(true);
+      // …while a bare service name that ISN'T a known alias stays rejected.
+      expect(isOpenClawCompatibleOllamaUrl("http://ollama:11434")).toBe(false);
     });
 
     it("is immutable in practice (ReadonlySet contract)", () => {

--- a/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-local-url.test.ts
@@ -20,9 +20,10 @@ import {
 describe("openclaw-local-url", () => {
   describe("DOCKER_HOST_ALIASES", () => {
     it("contains the Docker + OrbStack host aliases that get rewritten to ollama.local in build.ts", () => {
-      // Source of truth lives in @/lib/openclaw-local-url; mirrored by
-      // build.ts#rewriteOllamaHostForOpenClaw. If a new alias is added,
-      // both the rewrite map AND this drift guard must be updated.
+      // Single source of truth lives in @/lib/openclaw-local-url and is
+      // IMPORTED by build.ts#rewriteOllamaHostForOpenClaw (not duplicated), so
+      // adding an alias to the set is all that's needed — the rewrite picks it
+      // up automatically. This test just pins the set's exact membership.
       expect([...DOCKER_HOST_ALIASES].sort()).toEqual(
         [
           "docker.for.mac.host.internal",

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -61,10 +61,12 @@ export const DEFAULT_DOCS_PUBLIC_BASE_URL = "https://docs.heypinchy.com";
 
 /**
  * Rewrites the user-supplied Ollama URL so OpenClaw's `isLocalBaseUrl` check
- * passes (see model-auth-CsyLGY9m.js:111 in OpenClaw 2026.4.27). Docker host
- * aliases (see DOCKER_HOST_ALIASES) get rewritten to `ollama.local`; private
- * IPv4, `*.local`, `localhost`, etc. are already on the allowlist and pass
- * through unchanged.
+ * passes. Container-host aliases (see `DOCKER_HOST_ALIASES`) get normalized to
+ * `ollama.local` — which clears the check via the rock-stable `.local` rule and
+ * decouples us from OpenClaw's host-alias allowlist churn (see the
+ * `DOCKER_HOST_ALIASES` doc for the full rationale — this is load-bearing, not a
+ * version workaround). Private IPv4, `*.local`, `localhost`, etc. are stable
+ * allowlist entries and pass through unchanged.
  *
  * Also appends `/v1` so pi-ai's openai-completions provider hits Ollama's
  * OpenAI-compatible endpoint at `/v1/chat/completions` (pi-ai appends

--- a/packages/web/src/lib/openclaw-local-url.ts
+++ b/packages/web/src/lib/openclaw-local-url.ts
@@ -1,35 +1,57 @@
 /**
- * Mirror of OpenClaw's `isLocalBaseUrl` predicate
- * (model-auth-CsyLGY9m.js:111-118 + isPrivateIpv4Host:120-126). OpenClaw
- * does not export the function through any of its public subpath exports,
- * so we re-implement it here as a 1:1 port and use it both at save time
- * (providers.ts → reject unsupported hosts before they hit the DB) and as
- * a drift guard in openclaw-config.test.ts.
+ * A deliberately CONSERVATIVE subset of OpenClaw's `isLocalBaseUrl` predicate,
+ * used at save time (providers.ts → reject unsupported hosts before they hit
+ * the DB). OpenClaw doesn't export the function, so we re-implement only the
+ * parts that are CONVENTIONS — loopback, `.local` (mDNS / RFC 6762), and
+ * RFC1918 private IPv4. Those have been in every OpenClaw version and won't
+ * drop, so this subset can only ever be a SAFE predictor: anything it accepts,
+ * OpenClaw accepts too (no false acceptance → no surprise runtime "No API key"
+ * failure).
  *
- * If upstream changes the allowlist, this mirror won't auto-detect it —
- * anyone bumping the `openclaw` version pin should grep for
- * `OPENCLAW_ISLOCAL_PIN` and re-verify the predicate, then update the
- * docs in ollama-setup.mdx if the allowlist semantics changed.
+ * It intentionally does NOT mirror OpenClaw's volatile container-host aliases
+ * (`host.docker.internal`, `*.orb.internal`, …). Those are handled by
+ * `DOCKER_HOST_ALIASES` + the `ollama.local` rewrite (see below), which
+ * decouples us from OpenClaw's allowlist churn. So — unlike a 1:1 port — this
+ * does NOT need re-verifying against OpenClaw on every version bump; the worst
+ * case is a soft, correctable false REJECTION of an alias we haven't listed,
+ * never a hard false acceptance.
  *
- * OPENCLAW_ISLOCAL_PIN: 2026.4.27 (re-verify on bump; see PR #279)
+ * Verified safe-subset-of against OpenClaw 2026.6.8 (`src/agents/model-auth.ts`
+ * `isLocalBaseUrl`). See PR #279 for the original derivation.
  */
 
 /**
- * Docker host aliases that all resolve to "the host machine running
- * Docker". None of them pass OpenClaw's `isLocalBaseUrl` allowlist
- * directly, but `build.ts#rewriteOllamaHostForOpenClaw` rewrites every
- * one of them to `ollama.local` before the URL ever lands in the
- * emitted `openclaw.json`. The save-time validator accepts these as
- * "would pass after rewrite" so users can paste the placeholder URL
- * (`host.docker.internal:11434`) without seeing a spurious rejection.
+ * Container-host aliases that all resolve to "the host machine running the
+ * container runtime" (Docker Desktop, plain Docker on Linux, OrbStack).
+ * `build.ts#rewriteOllamaHostForOpenClaw` rewrites every one of them to
+ * `ollama.local` before the URL lands in the emitted `openclaw.json`, and the
+ * save-time validator accepts them as "would pass after rewrite" so users can
+ * paste the placeholder (`host.docker.internal:11434`) without a spurious
+ * rejection.
  *
- * Kept in sync with `DOCKER_HOST_ALIASES` in openclaw-config/build.ts.
+ * Why normalize them all to `ollama.local` instead of passing the alias
+ * through? Because `ollama.local` clears OpenClaw's `isLocalBaseUrl` via the
+ * `.local` (mDNS / RFC 6762) rule — the single most stable entry in that
+ * allowlist — which **decouples Pinchy from OpenClaw's host-alias allowlist
+ * churn**. OpenClaw has changed which Docker aliases it accepts more than once
+ * (2026.4.27 had none of these; 2026.6.x added `host.docker.internal` +
+ * `*.orb.internal`). Relying on a specific alias being in that allowlist would
+ * make a routine OpenClaw bump able to break local Ollama for every self-hoster
+ * with a "No API key" error. So this rewrite is a deliberate, load-bearing
+ * decoupling — NOT a version-specific workaround to be "cleaned up" later.
+ *
+ * This list is Pinchy-owned (it grows only when we choose to support a new
+ * runtime's alias) and is kept in sync with the rewrite in
+ * openclaw-config/build.ts.
  */
 export const DOCKER_HOST_ALIASES: ReadonlySet<string> = new Set([
   "host.docker.internal",
   "gateway.docker.internal",
   "docker.for.mac.host.internal",
   "docker.for.win.host.internal",
+  // OrbStack's native host aliases (Docker Desktop alternative).
+  "docker.orb.internal",
+  "host.orb.internal",
 ]);
 
 function isPrivateIpv4Host(host: string): boolean {


### PR DESCRIPTION
## Context

While prepping the OpenClaw 2026.6.8 bump (#541) I flagged the `ollama.local` host-rewrite as "probably obsolete" — OpenClaw added `host.docker.internal` to its `isLocalBaseUrl` allowlist, so in theory Pinchy could store it directly and drop the rewrite. This PR is the result of critically evaluating that cleanup **and reversing it.**

## Why dropping the rewrite would be *less* robust

`build.ts#rewriteOllamaHostForOpenClaw` normalizes every container-host alias to `ollama.local`, which clears OpenClaw's `isLocalBaseUrl` via the **`.local` (mDNS / RFC 6762) rule** — the single most stable entry in that allowlist. That makes Pinchy **immune to OpenClaw's host-alias allowlist churn**, which is real: 2026.4.27 had *none* of these aliases; 2026.6.x added `host.docker.internal` + `*.orb.internal`.

Dropping the rewrite would **couple** Pinchy to OpenClaw's exact, third-party, *private* allowlist — so a routine OpenClaw bump that ever tightened it would break local Ollama for **every self-hoster** with an opaque `No API key found for provider 'ollama'`. The rewrite also (a) appends `/v1` (essential, kept) and (b) covers 3 legacy + 2 OrbStack aliases OpenClaw does **not** accept natively. So the rewrite is a deliberate, load-bearing decoupling — not a version workaround.

## What this PR actually does (the real defect + hardening)

The only genuine defect from the stale mirror was a **false rejection** of OrbStack's native aliases (`docker.orb.internal` / `host.orb.internal`) at save time.

- **Fix:** add `docker.orb.internal` + `host.orb.internal` to `DOCKER_HOST_ALIASES` (normalized to `ollama.local` like the rest).
- **Reframe the mirror** (`isOpenClawLocalBaseUrl`) as a deliberate **safe subset** of `isLocalBaseUrl` — only loopback / `.local` / RFC1918, all stable conventions. A subset can only ever false-*reject* (soft, correctable), never false-*accept* (hard runtime failure). So it does **not** need re-verifying against OpenClaw on every bump.
- **Refresh the stale `2026.4.27` comments** (`openclaw-local-url.ts`, `build.ts`, prod + dev compose) to document the decoupling rationale — so a future maintainer (or AI) doesn't "clean it up" and reintroduce the coupling.

## Verification
- `pnpm -C packages/web test` — 6228 passed (incl. updated `openclaw-local-url` + the `rewrites all container-host aliases` config test now covering OrbStack).
- `tsc --noEmit` clean; prettier clean.
- The safe-subset claim is verified against OpenClaw 2026.6.8 `src/agents/model-auth.ts#isLocalBaseUrl`.
- No change to the working rewrite / compose / runtime semantics — purely additive (2 aliases) + documentation.
