### PR TITLE
docs(glossary): add sourced authority signals to GEO target-query pages

### DIFF
--- a/docs/src/content/docs/glossary/ai-agent-audit-trail.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-audit-trail.mdx
@@ -52,6 +52,8 @@ An AI agent is different from a chatbot: it takes _actions_. It can write a reco
 
 Without an audit trail, "the agent did something" stays vague. With one, it becomes "this user asked this agent to take this action at this time, and here is the signed record."
 
+Regulators are starting to require exactly this. The EU AI Act obliges high-risk AI systems to automatically record events over their lifetime for traceability ([Article 12, record-keeping](https://artificialintelligenceact.eu/article/12/)), and breaching the high-risk obligations can cost up to €15 million or 3% of worldwide annual turnover. An audit trail is how an organization produces those records when an authority, or its own security team, asks for them.
+
 ## What a good audit trail records
 
 | Field                  | Why it matters                                |

--- a/docs/src/content/docs/glossary/ai-agent-governance.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-governance.mdx
@@ -46,6 +46,8 @@ The defining property is that these controls are **enforced in code, outside the
 
 Agents have moved from answering questions to taking actions in real systems. A chatbot that drafts text needs little governance. An agent that can write to your ERP, send email, or act for multiple people needs all of it. The shift from _answer_ to _act_ is exactly the point where governance stops being optional.
 
+The market is already feeling the gap. Gartner predicts that [over 40% of agentic AI projects will be canceled by the end of 2027](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027), citing escalating costs, unclear business value, and inadequate risk controls. The production side shows the inverse: in Databricks' [2026 State of AI Agents report](https://www.databricks.com/resources/ebook/state-of-ai-agents), companies that put governance in place moved 12x more AI projects into production. Governance is increasingly what separates an agent that ships from one that stalls.
+
 ## The four components
 
 1. **Identity.** Each person is a real account, not a shared login or token. Without identity, nothing below can attribute or restrict by user.

--- a/docs/src/content/docs/glossary/ai-agent-permissions.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-permissions.mdx
@@ -58,6 +58,8 @@ A prompt is a request, not a boundary. Two ways it fails as a control:
 1. **Prompt injection.** A malicious document or message can talk the model out of its instructions.
 2. **Drift.** A model can simply not follow an instruction reliably.
 
+Prompt injection is not a fringe concern. It ranks first, as LLM01, in the [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/), holding the top spot for the second consecutive edition. A boundary that the single most prevalent attack against language models can switch off is not a boundary.
+
 Real permissions live in code, outside the model. If a tool is not granted, the agent cannot call it, regardless of what the prompt or the user says. The model decides _whether_ to use a granted tool; it can never reach an ungranted one.
 
 ## Granularity that matters


### PR DESCRIPTION
## What

Adds one on-topic, primary-source-verified statistic (with an authoritative citation link) to each of the three glossary pages that target our top GEO queries:

- **`/glossary/ai-agent-governance/`** — Gartner: [>40% of agentic AI projects canceled by end of 2027](https://www.gartner.com/en/newsroom/press-releases/2025-06-25-gartner-predicts-over-40-percent-of-agentic-ai-projects-will-be-canceled-by-end-of-2027) (escalating costs, unclear value, inadequate risk controls) + Databricks [2026 State of AI Agents](https://www.databricks.com/resources/ebook/state-of-ai-agents): governance → 12x more projects in production.
- **`/glossary/ai-agent-permissions/`** — OWASP: prompt injection = LLM01, #1 in the [OWASP Top 10 for LLM Applications](https://owasp.org/www-project-top-10-for-large-language-model-applications/) for the second consecutive edition.
- **`/glossary/ai-agent-audit-trail/`** — EU AI Act [Article 12 record-keeping](https://artificialintelligenceact.eu/article/12/) obligation for high-risk systems; high-risk breaches up to €15M or 3% of worldwide turnover.

## Why

The three pages were structurally strong (citation-first definitions, FAQ schema, comparison tables) but failed the AI-SEO "statistics with sources cited" extractability check — zero stats, zero external citations. The Princeton GEO study (KDD 2024) ranks **citing sources (+40%)** and **adding statistics (+37%)** as the two highest-impact levers for being cited by answer engines. This adds exactly those, on the exact pages we want cited, without creating any new page.

## Fact-fidelity notes (counter-metric 1)

- All four figures re-verified against primary sources on **2026-06-19**.
- **EU AI Act tier corrected:** record-keeping / high-risk obligations fall under the **€15M / 3%** tier (Art. 99), **not** the €35M / 7% tier, which applies only to prohibited practices (Art. 5). The internal research note generalized the 7% ceiling; this PR uses the correct tier for a logging/audit obligation.
- Gartner phrasing uses their own words ("inadequate risk controls"), not a "weak governance" paraphrase.

## Verification

- `cd docs && pnpm install --frozen-lockfile && pnpm build` → green (MDX parses).
- `prettier 3.x --config packages/web/.prettierrc --check` on all three files → "All matched files use Prettier code style!"
- No new pages; FAQ JSON-LD schemas untouched; "In Pinchy" feature claims unchanged.

🤖 Drafted by the GEO marketing agent — review + merge gated to Clemens.