### PR TITLE
docs(release): note .env.example bump in release.mjs docstring

### DIFF
--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -12,7 +12,7 @@
  *      - upgrading.mdx has a section for the target version
  *      - clean working tree, on main branch, CI green, tag not taken
  *      - pnpm audit --audit-level=high --prod passes (or --skip-audit)
- *   3. Bumps version in root package.json and packages/web/package.json
+ *   3. Bumps version in root package.json, packages/web/package.json, and .env.example
  *   4. Commits, tags, and pushes
  *
  * What to do manually first (see CONTRIBUTING.md):


### PR DESCRIPTION
## What
One-line docstring fix in `scripts/release.mjs`: step 3 now lists `.env.example` alongside `package.json` and `packages/web/package.json`.

## Why
The script actually bumps all three (`bumpEnvExample` + the two `bumpPackageJson` calls), but the header comment's step 3 listed only the two package.json files — making the script's own docstring **less accurate than the `cut-pinchy-release` skill (#531)** that documents the same `.env.example` bump. This aligns the comment with the code.

Comment-only; no behavior change. Surfaced while reviewing #531.