### PR TITLE
fix(release): auto-bump README quick-start pin + fix it to v0.6.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ Honest caveats: Pinchy is young, the integration list is short (Odoo, Gmail, Tel
 ## Quick Start
 
 ```bash
-curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.5.7/docker-compose.yml -o docker-compose.yml
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml
 docker compose up -d
 # Open http://localhost:7777 — the setup wizard creates your admin account
 ```

--- a/scripts/lib/release-logic.mjs
+++ b/scripts/lib/release-logic.mjs
@@ -418,3 +418,33 @@ export function checkReleaseVerification({ verifiedSha, headSha }) {
   }
   return { ok: true, message: `Staging attestation matches HEAD (${h.slice(0, 12)}).` };
 }
+
+/**
+ * Returns README.md contents with the quick-start curl pin updated to the
+ * release tag.
+ *
+ * The README's one-command install pins a concrete
+ * `raw.githubusercontent.com/heypinchy/pinchy/v<X.Y.Z>/docker-compose.yml` URL
+ * so a fresh install is reproducible. Without bumping it here the pin drifts
+ * behind every release — it sat on v0.5.7 through both the v0.5.8 and v0.6.0
+ * releases, so new users pulled a stale compose file. The release tag is created
+ * later in the same release run, so the bumped URL resolves once pushed (same
+ * pattern as the marketplace template pins).
+ *
+ * @param {string} content - raw README.md contents
+ * @param {string} version - release version, no 'v' prefix (e.g. "0.6.0")
+ * @returns {string}
+ * @throws {Error} if the pinned docker-compose URL is missing
+ */
+export function bumpReadmeComposePin(content, version) {
+  const pattern =
+    /(raw\.githubusercontent\.com\/heypinchy\/pinchy\/)v\d+\.\d+\.\d+(\/docker-compose\.yml)/g;
+  if (!pattern.test(content)) {
+    throw new Error(
+      "No pinned docker-compose URL in README.md " +
+        "(raw.githubusercontent.com/heypinchy/pinchy/v<version>/docker-compose.yml). " +
+        "The quick-start install pin moved or was removed — update bumpReadmeComposePin.",
+    );
+  }
+  return content.replace(pattern, `$1v${version}$2`);
+}

--- a/scripts/lib/release-logic.test.mjs
+++ b/scripts/lib/release-logic.test.mjs
@@ -13,6 +13,7 @@ import {
   assertNoStaleUpgradeSections,
   deriveStagingChecklist,
   checkReleaseVerification,
+  bumpReadmeComposePin,
 } from "./release-logic.mjs";
 
 // parseAndValidateVersion
@@ -399,6 +400,45 @@ BAZ=qux
   // Exactly one PINCHY_VERSION= line (not counting the commented one)
   const matches = output.match(/^PINCHY_VERSION=/gm) || [];
   assert.equal(matches.length, 1);
+});
+
+// bumpReadmeComposePin — keeps the README quick-start curl pin on the released
+// tag so a fresh one-command install is reproducible. Orphaned before this:
+// the pin sat on v0.5.7 through the v0.5.8 and v0.6.0 releases.
+
+test("bumpReadmeComposePin updates the pinned docker-compose tag, preserves the rest", () => {
+  const input = `## Quick Start
+
+\`\`\`bash
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.5.7/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+\`\`\`
+`;
+  const expected = `## Quick Start
+
+\`\`\`bash
+curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml
+docker compose up -d
+\`\`\`
+`;
+  assert.equal(bumpReadmeComposePin(input, "0.6.0"), expected);
+});
+
+test("bumpReadmeComposePin throws when the pinned docker-compose URL is missing", () => {
+  const input = `## Quick Start\n\nNo pinned compose URL here.\n`;
+  assert.throws(
+    () => bumpReadmeComposePin(input, "0.6.0"),
+    /No pinned docker-compose URL in README\.md/,
+  );
+});
+
+test("bumpReadmeComposePin replaces any prior version, not just a specific one", () => {
+  const input =
+    "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.4.12/docker-compose.yml -o docker-compose.yml\n";
+  assert.equal(
+    bumpReadmeComposePin(input, "0.6.0"),
+    "curl https://raw.githubusercontent.com/heypinchy/pinchy/v0.6.0/docker-compose.yml -o docker-compose.yml\n",
+  );
 });
 
 // finalizeUpgradeSection — freezes the in-progress section at release time so

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -32,6 +32,7 @@ import {
   buildCommitMessage,
   assertUpgradingSectionExists,
   finalizeUpgradeSection,
+  bumpReadmeComposePin,
 } from "./lib/release-logic.mjs";
 import {
   bumpMarketplaceVersion,
@@ -165,6 +166,7 @@ log("\nBumping versions...");
 const rootPkgPath = resolve(ROOT, "package.json");
 const webPkgPath = resolve(ROOT, "packages/web/package.json");
 const envExamplePath = resolve(ROOT, ".env.example");
+const readmePath = resolve(ROOT, "README.md");
 
 writeFileSync(rootPkgPath, bumpPackageJson(readFileSync(rootPkgPath, "utf8"), version));
 log(`  ✔ package.json → ${version}`);
@@ -177,6 +179,15 @@ writeFileSync(
   bumpEnvExample(readFileSync(envExamplePath, "utf8"), version),
 );
 log(`  ✔ .env.example → v${version}`);
+
+// Keep the README quick-start curl pin on the released tag so the
+// one-command install is reproducible and never drifts behind (it sat on
+// v0.5.7 through the v0.5.8 and v0.6.0 releases before this).
+writeFileSync(
+  readmePath,
+  bumpReadmeComposePin(readFileSync(readmePath, "utf8"), version),
+);
+log(`  ✔ README.md quick-start pin → v${version}`);
 
 // Keep the marketplace listing templates pinned to the released version, so a
 // fresh DigitalOcean install starts on the current release rather than drifting
@@ -212,7 +223,7 @@ if (finalizedMdx !== upgradingMdx) {
 
 log("\nCommitting...");
 exec(
-  `git add package.json packages/web/package.json .env.example marketplace/digitalocean/template.json marketplace/caprover/pinchy.yml "${upgradingMdxPath}"`,
+  `git add package.json packages/web/package.json .env.example README.md marketplace/digitalocean/template.json marketplace/caprover/pinchy.yml "${upgradingMdxPath}"`,
 );
 exec(`git commit -m "${buildCommitMessage(version)}"`);
 log(`  ✔ Committed`);


### PR DESCRIPTION
## Problem

The README quick-start installs a **version-pinned** compose file:

```bash
curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/vX.Y.Z/docker-compose.yml -o docker-compose.yml
```

Nothing bumped that pin, so it drifted: it sat on **v0.5.7** through the v0.5.8 **and** v0.6.0 releases. Every new user running the documented one-command install pulled a two-releases-stale compose file. (`scripts/release.mjs` bumps `package.json`, `.env.example`, and the marketplace templates, but never the README pin.)

## Fix (root-cause, not a one-off bump)

- **New pure fn `bumpReadmeComposePin(content, version)`** in `scripts/lib/release-logic.mjs`, same idiom as `bumpEnvExample` — regex replace, and it **throws if the pin is missing** so a moved/removed URL fails the release loudly instead of silently drifting again.
- **TDD**: 3 tests (update + preserve, throw-on-missing, any-prior-version).
- **Wired into `release.mjs`** alongside the other bumps, and added `README.md` to the release commit's `git add`.
- **Bumped the live README pin v0.5.7 → v0.6.0** (current latest) now.

The tag is created later in the same release run, so the bumped URL resolves once pushed — same pattern as the marketplace template pins.

## Verification

- `node --check scripts/release.mjs` ✓
- release-logic + release-version-guards + assert-package-version suites: **67/67 green**
- `bumpReadmeComposePin` applied to the real README is idempotent on v0.6.0 and bumps arbitrary versions correctly
- `scripts/**` and root `README.md` are outside the repo's prettier scope (CI format:check covers only `packages/web` + `docs/src` + `.github`), and the additions match the surrounding file style

🤖 Drafted by the GEO marketing agent while clearing the open items from today's run (the stale README pin was flagged during the glossary/GEO work). Review + merge gated to Clemens.