### PR TITLE
perf(docker): multi-stage Dockerfile.openclaw, drop toolchain + npm cache (−38.6%)

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -1,36 +1,63 @@
+# syntax=docker/dockerfile:1
+#
+# Multi-stage build for the Pinchy OpenClaw runtime image.
+#
+# The OpenClaw gateway + Pinchy's plugin runtime deps include native modules
+# (better-sqlite3 and @napi-rs/canvas, both in pinchy-files) that may need to
+# COMPILE from source when a prebuilt binary doesn't match the node:22-slim
+# point release. Compiling needs python3 + build-essential — ~400 MB of
+# toolchain that is pure build-time weight. The single-stage image also shipped
+# the ~300 MB npm download cache (/root/.npm) into production for no runtime
+# benefit.
+#
+# Split it: a `builder` stage carries the toolchain and produces the compiled
+# artifacts (the global openclaw install + four /opt/*-deps bundles, all with
+# their native .node binaries already built). The `runtime` stage starts from a
+# clean node:22-slim and copies ONLY those artifacts, installing just the few
+# apt packages the gateway actually uses at runtime (git, inotify-tools,
+# procps). build-essential, python3 and the npm download cache never reach
+# production. Sibling change: Dockerfile.pinchy (PR #561).
+#
+# Offline-first guarantee (Pinchy ships air-gapped / self-hosted): the runtime
+# stage must need NO network on first boot. start-openclaw.sh's only boot work
+# is local (chmod/chown, copying the /opt/*-deps bundles into the bind-mounted
+# extension dirs, scanning /data) and `openclaw gateway`. OpenClaw 5.x dropped
+# the per-boot `npm install` of plugin runtime deps (symlink model — see
+# config/prewarm-openclaw.sh), so nothing the gateway runs at boot fetches from
+# the network. The global openclaw install is copied verbatim with its deps and
+# prebuilt .node binaries, so the CLI is fully self-contained. The build-time
+# prewarm boot below additionally proves the gateway starts inside this slim
+# stage before the image is ever published.
+
+# ---------------------------------------------------------------------------
+# Stage: builder — toolchain + global openclaw + compiled plugin deps.
+# ---------------------------------------------------------------------------
 # Pull node:22-slim via Google's Docker Hub mirror to avoid Docker Hub
 # anonymous-pull rate limits in CI. mirror.gcr.io is a free, no-auth
 # pull-through cache for `library/*` images on Docker Hub.
-FROM mirror.gcr.io/library/node:22-slim
-
-# Build-time metadata. CI passes --build-arg PINCHY_VERSION + PINCHY_BUILD_SHA;
-# local builds without --build-arg get "dev". OpenClaw's own version is the
-# `openclaw@…` pin below and surfaces via Pinchy's /api/version response.
-ARG PINCHY_VERSION=dev
-ARG PINCHY_BUILD_SHA=dev
-
-LABEL org.opencontainers.image.source="https://github.com/heypinchy/pinchy" \
-      org.opencontainers.image.title="Pinchy OpenClaw runtime" \
-      org.opencontainers.image.description="OpenClaw agent runtime + Pinchy plugin dependencies" \
-      org.opencontainers.image.licenses="AGPL-3.0" \
-      org.opencontainers.image.version="$PINCHY_VERSION" \
-      org.opencontainers.image.revision="$PINCHY_BUILD_SHA"
+FROM mirror.gcr.io/library/node:22-slim AS builder
 
 # python3 + build-essential are needed for native npm modules (better-sqlite3
 # in pinchy-files) to compile from source when the prebuilt binary doesn't
-# match the current node:22-slim point release. Without them the image build
-# fails intermittently whenever the upstream base image bumps Node.js.
-RUN apt-get update && apt-get install -y \
-      git \
-      inotify-tools \
-      procps \
+# match the current node:22-slim point release. They live ONLY in this builder
+# stage and never reach the runtime image, which is the whole point of the
+# split. Without them the build fails intermittently whenever the upstream base
+# image bumps Node.js.
+RUN apt-get update && apt-get install -y --no-install-recommends \
       python3 \
       build-essential \
     && rm -rf /var/lib/apt/lists/*
 
+# The drift guard (openclaw-version-pin-drift.test.ts) greps for this exact
+# `npm install -g openclaw@<version>` line to keep the runtime version in
+# lockstep with packages/web/package.json (which feeds /api/version). Keep the
+# literal form unchanged.
 RUN npm install -g openclaw@2026.6.8
 
-# Install pinchy-files plugin dependencies (native modules must be built in the container)
+# Install pinchy-files plugin dependencies (native modules must be built here).
+# Each bundle's node_modules is copied into /opt/<plugin>-deps so the runtime
+# stage can grab a clean, fully-built tree. The npm download cache stays in this
+# builder stage (it lives in /root/.npm, which is never copied to runtime).
 COPY packages/plugins/pinchy-files/package.json /tmp/pinchy-files/package.json
 RUN cd /tmp/pinchy-files && npm install --omit=dev && \
     mkdir -p /opt/pinchy-files-deps && \
@@ -58,12 +85,71 @@ RUN cd /tmp/pinchy-email && npm install --omit=dev && \
     cp -r /tmp/pinchy-email/node_modules /opt/pinchy-email-deps/ && \
     rm -rf /tmp/pinchy-email
 
+# ---------------------------------------------------------------------------
+# Stage: runtime — slim image with only what the gateway runs.
+# ---------------------------------------------------------------------------
+# Must be the LAST stage: CI builds with `-f Dockerfile.openclaw` and no
+# `--target`, so Docker publishes the final stage. Keep `runtime` last.
+FROM mirror.gcr.io/library/node:22-slim AS runtime
+
+# Build-time metadata. CI passes --build-arg PINCHY_VERSION + PINCHY_BUILD_SHA;
+# local builds without --build-arg get "dev". OpenClaw's own version is the
+# `openclaw@…` pin above and surfaces via Pinchy's /api/version response.
+ARG PINCHY_VERSION=dev
+ARG PINCHY_BUILD_SHA=dev
+
+LABEL org.opencontainers.image.source="https://github.com/heypinchy/pinchy" \
+      org.opencontainers.image.title="Pinchy OpenClaw runtime" \
+      org.opencontainers.image.description="OpenClaw agent runtime + Pinchy plugin dependencies" \
+      org.opencontainers.image.licenses="AGPL-3.0" \
+      org.opencontainers.image.version="$PINCHY_VERSION" \
+      org.opencontainers.image.revision="$PINCHY_BUILD_SHA"
+
+# Runtime-only apt deps. start-openclaw.sh uses inotifywait (inotify-tools) on
+# the secrets dir, pkill/ps (procps) to manage the gateway process, and git is
+# used by OpenClaw for plugin/runtime operations. build-essential and python3
+# are intentionally absent — the native modules were already compiled in the
+# builder stage and ship as prebuilt .node binaries.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+      git \
+      inotify-tools \
+      procps \
+    && rm -rf /var/lib/apt/lists/*
+
+# The global openclaw install (built in the builder stage). Its native modules
+# ship as prebuilt .node binaries, so no toolchain is needed to run them — we
+# copy the install verbatim instead of re-running `npm install -g` here. That
+# keeps the ~300 MB npm download cache out of this stage entirely.
+#   - /usr/local/lib/node_modules/openclaw is the package tree.
+COPY --from=builder /usr/local/lib/node_modules /usr/local/lib/node_modules
+
+# Recreate the CLI symlink rather than COPYing it. `COPY --from` DEREFERENCES
+# symlinks, so `COPY .../bin/openclaw` would copy openclaw.mjs's *contents* to
+# /usr/local/bin/openclaw — turning the launcher into a plain file. The loader
+# resolves its build output via `new URL("./dist/entry.js", import.meta.url)`,
+# which would then point at /usr/local/bin/dist/entry.js (nonexistent) and the
+# gateway would die at boot with "missing dist/entry.(m)js (build output)".
+# A symlink keeps import.meta.url anchored at the package dir, where dist/ lives.
+RUN ln -s ../lib/node_modules/openclaw/openclaw.mjs /usr/local/bin/openclaw
+
+# Pre-built plugin runtime dependency bundles from the builder stage. These
+# carry the already-compiled native .node binaries (better-sqlite3 +
+# @napi-rs/canvas in pinchy-files-deps), so no toolchain is needed here.
+# start-openclaw.sh copies them into each plugin's node_modules on boot.
+COPY --from=builder /opt/pinchy-files-deps /opt/pinchy-files-deps
+COPY --from=builder /opt/pinchy-odoo-deps /opt/pinchy-odoo-deps
+COPY --from=builder /opt/pinchy-web-deps /opt/pinchy-web-deps
+COPY --from=builder /opt/pinchy-email-deps /opt/pinchy-email-deps
+
 # Pre-warm the bundled-plugin runtime-deps cache. Rationale and full
 # behaviour live in config/prewarm-openclaw.sh; in short: boot the
 # gateway once at build time so the npm install of ~15 plugin runtime
 # deps lands in /root/.openclaw/plugin-runtime-deps/ before any user
 # starts the container. Saves ~48s of `[plugins] staging bundled
-# runtime deps` on first boot, observed on 2-vCPU staging.
+# runtime deps` on first boot, observed on 2-vCPU staging. On OpenClaw
+# 5.x (symlink model) the per-boot install is gone, so this boot also
+# serves as a smoke test that the gateway starts in this slim runtime
+# stage — the offline-first guarantee in this file's header relies on it.
 COPY config/openclaw-prewarm.json /tmp/openclaw-prewarm.json
 COPY config/prewarm-openclaw.sh /tmp/prewarm-openclaw.sh
 RUN chmod +x /tmp/prewarm-openclaw.sh && \


### PR DESCRIPTION
## What

Make `Dockerfile.openclaw` a multi-stage build, the same treatment `Dockerfile.pinchy` got in #561. The single-stage image shipped the full native-module build toolchain (`python3` + `build-essential`) **and** the ~300 MB npm download cache (`/root/.npm`) into production for no runtime benefit.

- **builder** stage: `python3` + `build-essential`, the global `openclaw@2026.6.8` install, and the four `/opt/*-deps` plugin runtime-dep bundles (with their native `.node` binaries already compiled).
- **runtime** stage: clean `node:22-slim`, copies only the built artifacts, and installs only the apt packages the gateway uses at boot (`git`, `inotify-tools`, `procps`). `build-essential`, `python3`, and the npm cache never reach the runtime image.

The `openclaw@2026.6.8` install line is kept literal (the `openclaw-version-pin-drift.test.ts` guard greps for it), and `runtime` is the last stage so CI's no-`--target` `docker build -f Dockerfile.openclaw` publishes it. The prewarm step, healthcheck, volume layout, `/pinchy-docs`, and `ENTRYPOINT` are unchanged — the runtime `/root/.openclaw` seed is byte-identical to the single-stage image.

### One reconciliation fix worth calling out

The draft this started from `COPY --from=builder /usr/local/bin/openclaw …`. That is broken: `COPY --from` **dereferences** symlinks, so it copies `openclaw.mjs`'s *contents* to `/usr/local/bin/openclaw`, turning the launcher into a plain file. The loader resolves its build output via `new URL("./dist/entry.js", import.meta.url)`, which then points at `/usr/local/bin/dist/entry.js` (nonexistent) and the gateway dies at boot with `missing dist/entry.(m)js (build output)`. The fix is to recreate the symlink with `RUN ln -s …` so `import.meta.url` stays anchored at the package dir. (This is exactly why the original draft "never successfully built".)

## Before / after (local, arm64)

| image | bytes | size |
|---|---|---|
| baseline (single-stage `main`) | 1,603,378,151 | 1.6 GB |
| slim (this PR) | 983,791,161 | 984 MB |

**−619,586,990 bytes (~591 MiB), −38.6 %.**

## Offline-first verification (the #561 lesson)

#561 broke offline startup because the fresh runtime stage didn't pre-warm a cache the entrypoint needed at boot. Pinchy is offline-first (air-gapped / self-hosted is a product promise), so I verified the slim runtime needs **no network** on first boot. All commands run with `--network none`:

**1. CLI + native module loads**
```
docker run --rm --network none --entrypoint sh pinchy-openclaw:slim -c '
  openclaw --version
  node -e "const p=require(\"/opt/pinchy-files-deps/node_modules/better-sqlite3\"); const db=new p(\":memory:\"); console.log(db.prepare(\"select 1 as ok\").get().ok===1?\"better-sqlite3 OK\":\"FAIL\")"
  node -e "const c=require(\"/opt/pinchy-files-deps/node_modules/@napi-rs/canvas\"); c.createCanvas(8,8).getContext(\"2d\"); console.log(\"@napi-rs/canvas OK\")"
'
```
Output:
```
OpenClaw 2026.6.8 (844f405)
better-sqlite3 OK
@napi-rs/canvas OK
```

**2. Full gateway boot, no network** (token config, same shape the build-time prewarm uses):
```
[gateway] http server listening (7 plugins: browser, canvas, device-pair, file-transfer, memory-core, phone-control, talk-voice; 1.1s)
[gateway] ready
```

**3. Toolchain / cache actually gone, runtime tools present** (`--network none`):
```
git /usr/bin/git | inotifywait /usr/bin/inotifywait | pkill /usr/bin/pkill | ps /usr/bin/ps | node /usr/local/bin/node | bash /usr/bin/bash
gcc absent | cc absent | make absent | python3 absent
/root/.npm absent
```

The build-time prewarm boot (`config/prewarm-openclaw.sh`) also runs inside the slim runtime stage and reports `gateway ready after 3s` — so the gateway is proven to start in the slim image before it's ever published. On OpenClaw 5.x the per-boot `npm install` of plugin runtime deps is gone (symlink model), so nothing the entrypoint runs at boot fetches from the network; the global openclaw install is copied verbatim with its deps and prebuilt `.node` binaries.

> Note: with the bare image's stock `config/openclaw.json` (`bind: lan`, **no** auth token) OpenClaw refuses to bind — but the baseline image behaves identically; in real deployments Pinchy writes `gateway.auth.token` before boot. This is config-driven, not a slimming regression.

## Runtime validation

End-to-end behavior of this image is covered by CI's E2E jobs — Telegram, Odoo, Email, and Web E2E all run against `Dockerfile.openclaw` (`docker-compose.e2e.yml` builds the `openclaw` service from it, asserted by `e2e-compose-build-coverage.test.ts`). The `openclaw-version-pin-drift.test.ts` guard still passes (verified locally against the new Dockerfile).

Sibling of #561.

---
Draft until CI (incl. the E2E jobs that exercise this image) is green.
