### PR TITLE
docs(glossary): link the two free tools from the matching glossary pages

### DIFF
--- a/docs/src/content/docs/glossary/ai-agent-governance.mdx
+++ b/docs/src/content/docs/glossary/ai-agent-governance.mdx
@@ -57,6 +57,8 @@ The market is already feeling the gap. Gartner predicts that [over 40% of agenti
 
 Miss any one and the others leak. Perfect permissions with shared logins lose attribution. A perfect audit trail of an agent that can do anything is just a detailed record of an incident.
 
+To see where your own setup stands across these four layers, try the free [AI agent governance maturity self-assessment](https://heypinchy.com/governance-maturity-assessment): four questions, scored against the model above, and your answers never leave your browser.
+
 ## Enforced in code, not in a prompt
 
 A prompt is a request. Prompt injection and model drift mean an agent can be talked or nudged out of its instructions. Governance controls sit outside the model: if a user lacks the role, they cannot reach the agent; if a tool is not granted, the agent cannot call it; every action is recorded in a tamper-evident audit trail. The model operates _within_ the boundary, never defines it.

--- a/docs/src/content/docs/glossary/what-is-openclaw.mdx
+++ b/docs/src/content/docs/glossary/what-is-openclaw.mdx
@@ -68,6 +68,8 @@ Pinchy is an [AI agent platform](/glossary/ai-agent-platform/) built on top of O
 
 Learn more at the [OpenClaw project](https://github.com/openclaw/openclaw) and the [OpenClaw documentation](https://docs.openclaw.ai).
 
+Running OpenClaw yourself? The free [OpenClaw security self-check](https://heypinchy.com/openclaw-security-check) walks the common exposure opt-outs (gateway binding, authentication, containment) in six questions. It is a questionnaire, so you never paste a secret or any config, and your answers never leave your browser.
+
 ## Related terms
 
 - [What is an AI agent platform?](/glossary/ai-agent-platform/)


### PR DESCRIPTION
**Draft — closes the docs half of the free tools' Definition of Done.**

The two client-side free tools (governance maturity self-assessment, OpenClaw security self-check) were brought to DoD on the website in [heypinchy/website#63](https://github.com/heypinchy/website/pull/63) (precise zero-data claims + inbound links + llms.txt). Their DoD also requires being **linkable from the docs** — this PR adds that.

Two **contextual** links (deliberately not a templated block on every glossary page — that's the templated-content anti-pattern):
- `glossary/ai-agent-governance` → the [governance maturity self-assessment](https://heypinchy.com/governance-maturity-assessment), placed right after the four-layers / "miss any one and the others leak" passage (the tool *is* the interactive version of that model).
- `glossary/what-is-openclaw` → the [OpenClaw security self-check](https://heypinchy.com/openclaw-security-check), for the run-it-yourself reader.

Wording note: uses the precise **"your answers never leave your browser"** (not the absolute "nothing is sent") — the site loads a Umami pageview, so the absolute would be an overclaim; this matches the correction made in website#63.

Verification: `cd docs && pnpm build` green (56 pages); no em-dashes added; pre-commit prettier clean.