### PR TITLE
fix(openclaw): converge device-pairing approval on the live requestId (setup-wizard E2E flake)

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -158,6 +158,10 @@ RUN chmod +x /tmp/prewarm-openclaw.sh && \
 
 COPY config/openclaw.json /root/.openclaw/openclaw.json
 COPY config/start-openclaw.sh /start-openclaw.sh
+# Device-pairing auto-approver invoked per tick by start-openclaw.sh. Kept as a
+# separate Node module so its requestId-churn convergence is unit-testable
+# (config/__tests__/auto-approve-once.test.mjs) instead of embedded bash.
+COPY config/auto-approve-once.mjs /auto-approve-once.mjs
 RUN chmod +x /start-openclaw.sh
 
 # Bake Pinchy's user-facing docs into the image so Smithers' docs_list /

--- a/config/__tests__/auto-approve-once.test.mjs
+++ b/config/__tests__/auto-approve-once.test.mjs
@@ -1,0 +1,153 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  parseLatestRequestId,
+  approveLatestOnce,
+} from "../auto-approve-once.mjs";
+
+/**
+ * Fake `openclaw devices` gateway that reproduces the production requestId
+ * churn: while a device-pairing request is pending, Pinchy keeps reconnecting
+ * (exponential backoff) and every reconnect makes OpenClaw mint a *fresh*
+ * pairing requestId, superseding the previous one. So the id discovered by
+ * `--latest` can already be stale by the time `approve <id>` runs, and the
+ * gateway then rejects it with "unknown requestId".
+ *
+ * `churn` = how many of the first approve attempts race a concurrent reconnect
+ * (rotate the pending id and reject the approve). After the churn budget is
+ * spent the pending id stabilises and the matching approve succeeds.
+ */
+function makeFakeGateway({ initialId = "req-1", churn = 0 } = {}) {
+  const state = {
+    currentId: initialId,
+    churnRemaining: churn,
+    counter: 1,
+    approveCalls: [],
+    approvedId: null,
+  };
+  const exec = (args) => {
+    if (args.includes("--latest")) {
+      if (state.currentId === null) {
+        return { code: 1, stdout: JSON.stringify({}), stderr: "" };
+      }
+      return {
+        code: 1,
+        stdout: JSON.stringify({
+          selected: { requestId: state.currentId },
+          approveCommand: `openclaw devices approve ${state.currentId}`,
+        }),
+        stderr: "",
+      };
+    }
+    // Explicit approve: `["devices", "approve", <id>, "--json"]`.
+    const id = args[2];
+    state.approveCalls.push(id);
+    if (state.churnRemaining > 0) {
+      // A concurrent Pinchy reconnect replaced the pending request after we
+      // discovered it but before this approve landed.
+      state.churnRemaining -= 1;
+      state.counter += 1;
+      state.currentId = `req-${state.counter}`;
+      return { code: 1, stdout: "", stderr: "unknown requestId" };
+    }
+    if (id === state.currentId) {
+      state.approvedId = id;
+      return {
+        code: 0,
+        stdout: JSON.stringify({
+          requestId: id,
+          device: { deviceId: "dev-1" },
+        }),
+        stderr: "",
+      };
+    }
+    return { code: 1, stdout: "", stderr: "unknown requestId" };
+  };
+  return { state, exec };
+}
+
+test("parseLatestRequestId reads selected.requestId from --json output", () => {
+  assert.equal(
+    parseLatestRequestId(JSON.stringify({ selected: { requestId: "req-9" } })),
+    "req-9",
+  );
+});
+
+test("parseLatestRequestId returns null when nothing is pending", () => {
+  assert.equal(parseLatestRequestId(JSON.stringify({})), null);
+  assert.equal(
+    parseLatestRequestId("No pending device pairing requests to approve"),
+    null,
+  );
+  assert.equal(parseLatestRequestId(""), null);
+  assert.equal(parseLatestRequestId(undefined), null);
+});
+
+test("parseLatestRequestId falls back to the explicit approve-command hint", () => {
+  assert.equal(
+    parseLatestRequestId(
+      "Approve this exact request with: openclaw devices approve req-abc==",
+    ),
+    "req-abc==",
+  );
+});
+
+test("parseLatestRequestId recovers the id from approveCommand when selected is absent", () => {
+  // Defensive: if a future --json shape omits selected.requestId but still
+  // carries the approveCommand hint, the regex fallback must still find the id.
+  assert.equal(
+    parseLatestRequestId(
+      JSON.stringify({ approveCommand: "openclaw devices approve req-xyz" }),
+    ),
+    "req-xyz",
+  );
+});
+
+test("approveLatestOnce converges on the live request despite requestId churn", () => {
+  const { state, exec } = makeFakeGateway({ initialId: "req-1", churn: 2 });
+  const result = approveLatestOnce({ exec, log: () => {}, maxAttempts: 6 });
+  assert.equal(result.outcome, "approved");
+  assert.equal(result.requestId, state.approvedId);
+  // 1 initial attempt + 2 re-discoveries after the churned rejections.
+  assert.equal(state.approveCalls.length, 3);
+});
+
+test("approveLatestOnce without a retry budget fails under churn (reproduces the flake)", () => {
+  const { exec } = makeFakeGateway({ initialId: "req-1", churn: 2 });
+  const result = approveLatestOnce({ exec, log: () => {}, maxAttempts: 1 });
+  assert.equal(result.outcome, "exhausted");
+});
+
+test("approveLatestOnce reports no-pending when the queue is empty", () => {
+  const exec = (args) => {
+    if (args.includes("--latest"))
+      return { code: 1, stdout: JSON.stringify({}), stderr: "" };
+    throw new Error("approve must not run when nothing is pending");
+  };
+  const result = approveLatestOnce({ exec, log: () => {}, maxAttempts: 6 });
+  assert.equal(result.outcome, "no-pending");
+});
+
+test("approveLatestOnce stops early when Pinchy has already connected", () => {
+  let latestCalls = 0;
+  const exec = (args) => {
+    if (args.includes("--latest")) {
+      latestCalls += 1;
+      return {
+        code: 1,
+        stdout: JSON.stringify({ selected: { requestId: "req-1" } }),
+        stderr: "",
+      };
+    }
+    return { code: 1, stdout: "", stderr: "unknown requestId" };
+  };
+  const result = approveLatestOnce({
+    exec,
+    log: () => {},
+    isDone: () => true,
+    maxAttempts: 6,
+  });
+  assert.equal(result.outcome, "done");
+  assert.equal(latestCalls, 0);
+});

--- a/config/auto-approve-once.mjs
+++ b/config/auto-approve-once.mjs
@@ -1,0 +1,141 @@
+#!/usr/bin/env node
+// Approve the *live* OpenClaw device-pairing request for Pinchy — once per call.
+//
+// Why this exists (the setup-wizard E2E flake):
+// Pinchy connects to the gateway from a non-loopback container IP, so OpenClaw
+// requires operator-side device pairing. While that pairing is pending, Pinchy
+// keeps reconnecting (exponential backoff, maxReconnectAttempts: Infinity), and
+// *every* reconnect makes OpenClaw mint a fresh pairing requestId, superseding
+// the previous one.
+//
+// `openclaw devices approve --latest` is preview-only: it prints the pending
+// requestId and exits 1 *without* approving, so we must approve with a second,
+// explicit `openclaw devices approve <id>` call. Each call loads the full
+// plugin system (seconds). The old bash loop discovered the id in one call and
+// approved it in a *separate* call, then slept 5 s before retrying — leaving a
+// multi-second window in which a reconnect could churn the id. The explicit
+// approve then referenced a requestId the gateway no longer had pending and was
+// rejected with INVALID_REQUEST "unknown requestId" (or "device pairing
+// approval denied" on the operator.admin scope-upgrade round). OpenClaw's CLI
+// has a same-device-replacement recovery, but it only engages for errors whose
+// message contains "pairing required" — not for these two — so the approve just
+// failed and the device could stay unapproved long enough that Pinchy never
+// connected within the wizard's settle/health budget → E2E timeout.
+//
+// This script collapses discover+approve into one process and, on a stale-id
+// rejection, re-discovers and re-approves *immediately* (a tight bounded retry)
+// instead of losing a whole ~13 s outer tick — so it converges on whatever
+// request is actually pending right now. The bash outer loop in
+// start-openclaw.sh still owns cadence, the token gate, the connected-signal
+// stop condition, and the 5-minute safety cap.
+//
+// Covered by config/__tests__/auto-approve-once.test.mjs.
+
+import { spawnSync } from "node:child_process";
+import { existsSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+
+// Bounded burst per invocation. With ~1/3 of attempts racing a reconnect, 6
+// attempts drives the per-tick miss probability to ~(1/3)^6 ≈ 0.0014 while
+// staying well under the outer loop's 5-minute safety cap. Tunable via env.
+const DEFAULT_MAX_ATTEMPTS =
+  Number(process.env.PINCHY_APPROVE_MAX_ATTEMPTS) || 6;
+
+const SIGNAL_PATH =
+  process.env.PINCHY_DEVICE_APPROVED_SIGNAL ||
+  "/root/.openclaw/pinchy-device-approved";
+
+/**
+ * Extract the pending pairing requestId from `openclaw devices approve --latest`
+ * output. Prefers the structured `--json` shape ({ selected: { requestId } });
+ * falls back to the human-readable "openclaw devices approve <id>" hint. Returns
+ * null when nothing is pending or the id can't be found.
+ */
+export function parseLatestRequestId(output) {
+  if (!output) return null;
+  const text = String(output);
+  let id = null;
+  try {
+    id = JSON.parse(text)?.selected?.requestId ?? null;
+  } catch {
+    // Not JSON — fall through to the text-hint parser below.
+  }
+  if (typeof id === "string" && id.trim()) return id.trim();
+  // Fallback: the human-readable "openclaw devices approve <id>" hint, which
+  // also appears as `approveCommand` inside the --json payload.
+  const match = text.match(/openclaw devices approve\s+([A-Za-z0-9_=-]+)/);
+  return match ? match[1] : null;
+}
+
+/**
+ * Discover and approve the currently-pending device-pairing request, retrying
+ * on stale-id rejections by re-discovering the live requestId.
+ *
+ * @param {object} deps
+ * @param {(args: string[]) => {code: number, stdout: string, stderr: string}} deps.exec
+ *        Runs `openclaw <args>` and returns its result.
+ * @param {(msg: string) => void} [deps.log]
+ * @param {() => boolean} [deps.isDone] Returns true once Pinchy has connected.
+ * @param {number} [deps.maxAttempts]
+ * @returns {{outcome: "approved"|"no-pending"|"exhausted"|"done", requestId: string|null}}
+ */
+export function approveLatestOnce({
+  exec,
+  log = () => {},
+  isDone = () => false,
+  maxAttempts = DEFAULT_MAX_ATTEMPTS,
+} = {}) {
+  let attempts = 0;
+  let lastId = null;
+  while (attempts < maxAttempts) {
+    if (isDone()) return { outcome: "done", requestId: lastId };
+
+    const latest = exec(["devices", "approve", "--latest", "--json"]);
+    const id =
+      parseLatestRequestId(latest?.stdout) ??
+      parseLatestRequestId(latest?.stderr);
+    if (!id) return { outcome: "no-pending", requestId: lastId };
+
+    lastId = id;
+    attempts += 1;
+
+    const approve = exec(["devices", "approve", id, "--json"]);
+    if (approve && approve.code === 0) {
+      log(`approved device pairing request ${id}`);
+      return { outcome: "approved", requestId: id };
+    }
+
+    const detail =
+      (approve?.stderr || approve?.stdout || "").trim() || "no detail";
+    log(`approve of ${id} failed (${detail}); re-discovering live request`);
+  }
+  return { outcome: "exhausted", requestId: lastId };
+}
+
+function realExec(args) {
+  const result = spawnSync("openclaw", args, { encoding: "utf8" });
+  return {
+    code: typeof result.status === "number" ? result.status : 1,
+    stdout: result.stdout ?? "",
+    stderr: result.stderr ?? "",
+  };
+}
+
+function main() {
+  const result = approveLatestOnce({
+    exec: realExec,
+    log: (msg) => console.log(`[auto-approve] ${msg}`),
+    isDone: () => existsSync(SIGNAL_PATH),
+  });
+  if (result.outcome === "exhausted") {
+    console.log(
+      `[auto-approve] no approval landed this tick (last id ${result.requestId ?? "none"}); outer loop will retry`,
+    );
+  }
+  // Always exit 0: the bash outer loop owns cadence and the connected-signal
+  // success check, so a nonzero exit here would only be swallowed by `|| true`.
+}
+
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/config/auto-approve-once.mjs
+++ b/config/auto-approve-once.mjs
@@ -27,7 +27,7 @@
 // instead of losing a whole ~13 s outer tick — so it converges on whatever
 // request is actually pending right now. The bash outer loop in
 // start-openclaw.sh still owns cadence, the token gate, the connected-signal
-// stop condition, and the 5-minute safety cap.
+// stop condition, and the overall pairing safety cap.
 //
 // Covered by config/__tests__/auto-approve-once.test.mjs.
 
@@ -35,11 +35,19 @@ import { spawnSync } from "node:child_process";
 import { existsSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 
-// Bounded burst per invocation. With ~1/3 of attempts racing a reconnect, 6
-// attempts drives the per-tick miss probability to ~(1/3)^6 ≈ 0.0014 while
-// staying well under the outer loop's 5-minute safety cap. Tunable via env.
+// Bounded burst per invocation: re-discover + re-approve a handful of times so
+// a couple of reconnect-driven requestId rotations are absorbed within a single
+// tick, then hand back to the outer loop. The outer loop in start-openclaw.sh
+// owns the overall pairing deadline; this only caps one tick's work. Tunable
+// via env.
 const DEFAULT_MAX_ATTEMPTS =
   Number(process.env.PINCHY_APPROVE_MAX_ATTEMPTS) || 6;
+
+// Per-CLI-call timeout. Each `openclaw devices` invocation loads the full plugin
+// system, so allow generous headroom — but never block the tick forever on a
+// stalled call (a hung discover/approve would otherwise wedge the whole burst).
+const CLI_TIMEOUT_MS =
+  Number(process.env.PINCHY_APPROVE_CLI_TIMEOUT_MS) || 30000;
 
 const SIGNAL_PATH =
   process.env.PINCHY_DEVICE_APPROVED_SIGNAL ||
@@ -113,7 +121,13 @@ export function approveLatestOnce({
 }
 
 function realExec(args) {
-  const result = spawnSync("openclaw", args, { encoding: "utf8" });
+  const result = spawnSync("openclaw", args, {
+    encoding: "utf8",
+    timeout: CLI_TIMEOUT_MS,
+  });
+  // A timeout (or signal kill) leaves status === null; map any non-numeric exit
+  // to a failure so approveLatestOnce re-discovers rather than treating it as a
+  // successful approve.
   return {
     code: typeof result.status === "number" ? result.status : 1,
     stdout: result.stdout ?? "",

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -184,25 +184,30 @@ auto_approve_devices() {
             sleep 5
             continue
         fi
-        # `openclaw devices approve --latest` is preview-only since 2026.4.10.
-        # It prints the requestId but exits with code 1 without approving.
-        # We parse the requestId from the output and approve explicitly.
+        # Approve the *live* pending request, tracking requestId churn.
         #
-        # In OpenClaw 5.x, scope upgrades (operator.pairing → operator.admin)
-        # from non-loopback clients trigger a second approval round that the
-        # CLI cannot approve via WebSocket (it would need operator.admin itself,
-        # causing infinite scope-upgrade loops). The fix: omit --url so the CLI
-        # reads the gateway URL from openclaw.json and, on WS rejection, falls
-        # back to direct local-file approval (shouldUseLocalPairingFallback).
-        # The local fallback bypasses WebSocket auth entirely and writes the
-        # approval directly into /root/.openclaw/ — safe because this script
-        # runs inside the OpenClaw container with the same filesystem.
-        local approve_output request_id
-        approve_output=$(openclaw devices approve --latest 2>&1 || true)
-        request_id=$(echo "$approve_output" | grep -oE 'openclaw devices approve [a-zA-Z0-9_=-]+' | awk '{print $NF}' || true)
-        if [ -n "$request_id" ]; then
-            openclaw devices approve "$request_id" >/dev/null 2>&1 || true
-        fi
+        # `openclaw devices approve --latest` is preview-only: it prints the
+        # pending requestId and exits 1 without approving, so the id must be
+        # approved with a second, explicit `approve <id>` call. While pairing is
+        # pending Pinchy keeps reconnecting (exponential backoff), and every
+        # reconnect makes OpenClaw mint a fresh requestId — so the discovered id
+        # can already be stale by the time a separate approve call lands, and the
+        # gateway rejects it with "unknown requestId" (or "device pairing
+        # approval denied" on the operator.admin scope-upgrade round). The old
+        # two-step bash discover→approve left a multi-second window for that
+        # churn and then slept 5 s before retrying, so the device could stay
+        # unapproved long enough that Pinchy never connected within the
+        # setup-wizard E2E budget (the flake; CI run 28011331943).
+        #
+        # auto-approve-once.mjs collapses discover+approve into one process and
+        # re-discovers immediately on a stale-id failure, converging on whatever
+        # request is actually pending now. It omits --url so the CLI resolves the
+        # loopback gateway from openclaw.json (and can fall back to direct
+        # local-file approval for the operator.admin scope upgrade). The outer
+        # loop here still owns cadence, the token gate, the connected-signal stop
+        # condition, and the 5-minute safety cap.
+        # Covered by config/__tests__/auto-approve-once.test.mjs.
+        node /auto-approve-once.mjs || true
         elapsed=$((elapsed + 5))
         sleep 5
     done

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -202,10 +202,10 @@ auto_approve_devices() {
         # auto-approve-once.mjs collapses discover+approve into one process and
         # re-discovers immediately on a stale-id failure, converging on whatever
         # request is actually pending now. It omits --url so the CLI resolves the
-        # loopback gateway from openclaw.json (and can fall back to direct
-        # local-file approval for the operator.admin scope upgrade). The outer
-        # loop here still owns cadence, the token gate, the connected-signal stop
-        # condition, and the 5-minute safety cap.
+        # gateway from openclaw.json and connects over loopback — which is what
+        # lets the in-container CLI authenticate as a trusted operator to approve
+        # the operator.admin request. The outer loop here still owns cadence, the
+        # token gate, the connected-signal stop condition, and the safety cap.
         # Covered by config/__tests__/auto-approve-once.test.mjs.
         node /auto-approve-once.mjs || true
         elapsed=$((elapsed + 5))

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter @pinchy/web dev",
     "build": "pnpm --filter @pinchy/web build",
     "test": "pnpm --filter @pinchy/web test",
-    "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs",
+    "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs config/__tests__/*.test.mjs",
     "release": "node scripts/release.mjs",
     "release:preflight": "node scripts/release-preflight.mjs",
     "docs:paths": "node scripts/generate-docs-paths.mjs",


### PR DESCRIPTION
## Problem

The **Setup Wizard E2E** job is intermittently flaky (passes on most main runs, fails sporadically — e.g. CI run 28011331943 on #559, whose diff touches nothing pairing-related, confirming pre-existing flakiness).

From the openclaw container log during a failing run, the device-pairing approval handshake fails repeatedly (~every 13s):

- `device.pair.approve … errorCode=INVALID_REQUEST errorMessage=device pairing approval denied`
- `device.pair.approve … errorCode=INVALID_REQUEST errorMessage=unknown requestId`
- occasional `[ws] closed before connect … reason=connect failed`

…so the wizard times out waiting for Pinchy to connect to OpenClaw.

## Root cause (verified against the openclaw@2026.6.8 source)

The auto-approver in `config/start-openclaw.sh` had a TOCTOU race:

1. It discovered the pending `requestId` with `openclaw devices approve --latest` (preview-only — prints the id and exits 1 **without** approving).
2. It then approved it with a **separate** `openclaw devices approve <id>` call.

Each CLI call reloads the full plugin system (seconds). Meanwhile Pinchy reconnects with exponential backoff (`scopes: ["operator.admin"]`, `maxReconnectAttempts: Infinity`), and **every reconnect makes OpenClaw mint a fresh pairing requestId**, superseding the previous one. The discovered id was often stale by approve-time → the gateway rejected it with `unknown requestId` (or `device pairing approval denied` on the operator.admin scope-upgrade round).

OpenClaw's CLI has a `same-device-replacement` recovery, but it only engages for errors whose message contains `"pairing required"` — **not** for these two — so the approve simply failed, and the old loop then slept 5s before retrying. Under CI load the discover→approve window widens and the loop/reconnect cadences drift, so the device can stay unapproved long enough that Pinchy never connects within the wizard's settle/health budget.

## Fix

Collapse discover+approve into one process (`config/auto-approve-once.mjs`) and **re-discover immediately on a stale-id failure** (a tight, bounded retry), converging on whatever request is actually pending *now* instead of losing a whole ~13s outer tick.

- No timeout bumps, no retry-marking.
- The bash outer loop still owns cadence, the token gate, the connected-signal stop condition, and the 5-minute safety cap.
- Uses `--json` for robust id parsing (with a text-hint fallback), avoiding the old `grep`/`awk` fragility.
- Checks the connected-signal between attempts so it stops the moment Pinchy pairs (respects the "don't hammer the CLI / kill Telegram polling" constraint).

## Verification

- ✅ **Deterministic unit test** (`config/__tests__/auto-approve-once.test.mjs`, 8 cases, run via `test:scripts` in CI): reproduces the requestId churn and proves convergence — and that the old single-shot-per-tick behaviour fails (`maxAttempts: 1` → `exhausted`).
- ✅ Full `test:scripts` suite green; drift guards (`openclaw-version-pin-drift`, `e2e-compose-build-coverage`) green.
- ✅ openclaw image builds with the change; in-container smoke: `node /auto-approve-once.mjs` runs in the real image, handles the bootstrap (no-token) edge gracefully, exits 0 in ~2s (no hang), and the real CLI accepts `--latest --json`.
- The full Setup Wizard E2E runs in this PR's CI (`setup-wizard-e2e` job). It couldn't be run locally because it requires host port 7777, which was held by a parallel dev stack.

Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com).