### PR TITLE
chore(release): v0.7.0 prep — upgrade notes + cut-release runbook hardening

### DIFF
--- a/.claude/skills/cut-pinchy-release/SKILL.md
+++ b/.claude/skills/cut-pinchy-release/SKILL.md
@@ -80,9 +80,12 @@ Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** �
 
 ## After the release
 
-1. **Watch the Release workflow.** `gh run watch "$(gh run list --workflow Release --limit 1 --json databaseId --jq '.[0].databaseId')"`. A failure means the release is **not installable** — do not announce until green. Recovery steps are in CONTRIBUTING.md § "If the release workflow fails".
-2. **Tags are immutable — never force-update a tag.** A broken release is fixed with a _patch release_, not a re-push.
-3. **Re-check deployment overrides.** Any long-running deployment that pins a `docker-compose.override.yml` (to work around upstream bugs not yet fixed) should be reviewed after each release — the upstream fix may have shipped in this release, in which case drop the override.
+1. **Watch BOTH post-tag runs to a _verified_ green — never trust a watch's exit code.** The tag push starts the **Release** workflow (images + GitHub Release) **and** a fresh **CI** run on the new `chore: release` commit. That commit carries new content the pre-release CI never saw — the version bumps and the **auto-finalized `upgrading.mdx`** — which is exactly how v0.6.0 turned `main` red (the finalize removed the `%%PINCHY_VERSION%%` placeholder a test anchored on). So a green pre-release CI does **not** mean the release commit is green.
+   - `gh run watch <id>` and `gh pr checks --watch` **routinely exit 0 prematurely**: right after a push no checks are registered yet (zero-checks race), and staged `needs:` jobs (E2E) only start after the build job. The watch exiting is not proof.
+   - **Confirm the authoritative signal instead:** `gh run view <id> --json status,conclusion` → `completed` / `success` with no failed jobs; and for a PR, `gh pr view <n> --json mergeStateStatus` → `CLEAN` (not `UNSTABLE`/`BLOCKING`). Only then merge/announce. A Release-workflow failure means the release is **not installable** — recovery in CONTRIBUTING.md § "If the release workflow fails".
+2. **Red CI: classify transient vs. real before reacting.** Is `main` green for the same check? A crash in **Node/pnpm internals** during dependency download (e.g. an undici `assert(!this.paused)`), a **6h runner stall**, or a **fresh OSV advisory** are infrastructure → a rerun is the correct response. A failure in our own test/build logic is real → fix it, don't blind-rerun. (Flaky _tests we own_ get fixed at the root, never papered over with reruns.)
+3. **Tags are immutable — never force-update a tag.** A broken release is fixed with a _patch release_, not a re-push.
+4. **Re-check deployment overrides.** Any long-running deployment that pins a `docker-compose.override.yml` (to work around upstream bugs not yet fixed) should be reviewed after each release — the upstream fix may have shipped in this release, in which case drop the override.
 
 ## Red flags — STOP
 
@@ -95,6 +98,9 @@ Work through **every** item in **CONTRIBUTING.md § "Pre-release checklist"** �
 | "Deadline — skip the checklist"                         | The checklist is the only thing the script _can't_ enforce.                      |
 | "I can release from this worktree/branch"               | Releases cut from clean `main` only. The script refuses otherwise.               |
 | "`pnpm release` went green, so I'm done"                | Green ≠ verified. The staging click-through + PWA are manual gates the script can't see. Run `release:preflight`, make each `[ ]` a blocking task, verify on `:next` first. |
+| "The watch exited 0, so CI is green"                    | `gh run/pr checks --watch` exits early when checks register late (right after a push) or stage in via `needs:`. Confirm `conclusion: success` + `mergeStateStatus: CLEAN` before merging/announcing. |
+| "Pre-release CI was green, so the release commit is fine" | The `chore: release` commit adds the version bumps + the auto-finalized `upgrading.mdx`. Watch the fresh CI run on that commit too — v0.6.0 turned main red exactly here. |
+| "CI is red — rerun it"                                  | Classify first. Infra (Node/pnpm crash, runner stall, fresh OSV) with `main` green → rerun. Our own test/build → real, fix it. |
 
 ## Common mistakes
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -149,6 +149,54 @@ If you need to roll back after an upgrade:
   backup step matters.
 </Aside>
 
+## Upgrading from v0.6.0 to %%PINCHY_VERSION%%
+
+### Breaking changes
+
+None.
+
+### Upgrade notes
+
+The standard flow applies:
+
+```bash
+cd /opt/pinchy
+sed -i 's/PINCHY_VERSION=v0.6.0/PINCHY_VERSION=%%PINCHY_VERSION%%/' .env
+docker compose pull && docker compose up -d && docker image prune -f
+```
+
+#### One-click deploys: DigitalOcean Marketplace and CapRover
+
+Spinning up a fresh Pinchy is now a one-click affair on two more platforms: a **DigitalOcean Marketplace** 1-Click image and a **CapRover** one-click app template. Existing installs need nothing here — this only adds new install paths. Both templates are version-pinned to the release.
+
+#### Agent skills
+
+Agents now carry a **skills** allowlist (migration `0042` adds the column, defaulting to none). This release lays the foundation plus a web-search skill pilot and a market-monitor template. Existing agents are unaffected until you assign skills in their settings.
+
+#### Pinchy-owned chat transcript
+
+Pinchy now mirrors conversations into its own store (`channel_messages`) via the `pinchy-transcript` plugin, instead of relying solely on OpenClaw's session-scoped history. The transcript is immune to `/new`, daily resets, and compaction, and backs the read-only channel views. Nothing to configure; the mirror starts filling from the upgrade onward.
+
+#### Durable "paused" error banner
+
+When an agent run fails, the chat now shows a **persistent banner above the composer** with honest, cause-specific wording, instead of a transient message that vanishes on reload. The active error is stored (`chat_session_errors`), exposed via GET/dismiss endpoints, and swept once resolved. Reload-safe; nothing to configure.
+
+#### Audit detail sheet
+
+The audit entry-detail sheet is wider and its JSON payload is now one-click copyable — easier to pull a full audit record for review or an incident report.
+
+#### Dependencies
+
+- **OpenClaw 2026.6.8** (was 2026.6.5) — picked up via `Dockerfile.openclaw`, surfaced in `GET /api/version`. Same protocol train; backward-compatible patch bump. The runtime image is now a slimmer multi-stage build (faster pulls), with no behavioural change.
+
+### Database migrations
+
+Three additive migrations run automatically on startup — no manual steps, nothing you'd miss:
+
+- `0040` — `channel_messages` table (the Pinchy-owned transcript mirror).
+- `0041` — `chat_session_errors` table (the durable paused-error banner).
+- `0042` — adds the `skills` column to `agents` (defaults to empty) for the agent-skills allowlist.
+
 ## Upgrading from v0.5.8 to v0.6.0
 
 ### Breaking changes


### PR DESCRIPTION
Release prep for **v0.7.0** (cutting from green `main`; the cookie fix #559 is deferred to 0.7.1 due to a CI-only vitest exit-hang unrelated to its code — tracked separately).

## What
- **`docs(upgrading)`**: new `## Upgrading from v0.6.0 to %%PINCHY_VERSION%%` section covering the release's features — one-click DigitalOcean/CapRover deploys, the agent-skills foundation, the Pinchy-owned chat transcript mirror (`channel_messages`), the durable paused error banner (`chat_session_errors`), the audit detail sheet — plus OpenClaw 2026.6.8 and the three additive migrations (0040/0041/0042). Breaking changes: none. The release script freezes the placeholder to the concrete version at tag time.
- **`docs(release)`**: hardens the `cut-pinchy-release` skill with the operational lessons from the v0.6.0/v0.6.1 work — watch BOTH post-tag runs (Release workflow + the fresh CI on the `chore: release` commit) and verify `conclusion=success` + `mergeStateStatus=CLEAN` rather than trusting a `--watch` exit; classify red CI as transient-vs-real before reacting.

## Why version 0.7.0 (not a patch)
51 commits since v0.6.0 incl. 16 features and 3 additive DB migrations (two new tables + an `agents.skills` column) — new capabilities → minor bump per SemVer.

## Verification
- `pnpm test:scripts` freshness guard green; release-gate dry-run confirms the v0.6.0→0.7.0 section is found, finalizes cleanly (only the preamble placeholder remains), and the post-release file stays freshness-clean at 0.7.0.
- `prettier --check` on docs clean; `upgrade-prune-step` test green (newest section carries the prune hygiene step).
- Docs/skill only — no source or test changes.

After merge: `release:preflight 0.7.0` → staging verification → `pnpm release 0.7.0`.