### PR TITLE
fix(skills): resolve SKILL.md from process.cwd(), not __dirname (prod agent-create crash)

### DIFF
--- a/packages/web/src/lib/skills/index.ts
+++ b/packages/web/src/lib/skills/index.ts
@@ -14,12 +14,18 @@ export function isKnownSkill(id: string): id is SkillId {
   return (KNOWN_SKILLS as readonly string[]).includes(id);
 }
 
-const SKILLS_DIR = join(__dirname);
+// SKILL.md files live in the source tree (src/lib/skills/<id>/SKILL.md) and are
+// copied into the runtime image. Resolve from process.cwd() — the packages/web
+// project root in dev, test, AND production (the image sets WORKDIR
+// /app/packages/web) — NOT __dirname: Next.js rewrites __dirname to a synthetic
+// "/ROOT/…" path in compiled API routes, so a __dirname-relative read ENOENTs in
+// production and broke creating an agent from a skill-bearing template
+// (web-search). versions.ts and skills.test.ts both anchor on process.cwd() too.
+const SKILLS_DIR = join(process.cwd(), "src/lib/skills");
 
-// First-party skill bodies are bundled with the build — they never change
-// at runtime within a process. Cache to avoid re-reading the same file once
-// per agent during `regenerateOpenClawConfig()` (50 agents on the same
-// skill = 50 redundant disk reads without this).
+// Skill bodies never change at runtime within a process. Cache to avoid
+// re-reading the same file once per agent during `regenerateOpenClawConfig()`
+// (50 agents on the same skill = 50 redundant disk reads without this).
 const SKILL_BODY_CACHE = new Map<SkillId, string>();
 
 export function getSkillBody(id: SkillId): string {


### PR DESCRIPTION
**0.7.0 release-blocker.** Creating an agent from a skill-bearing template (the new **Market & News Monitor** template → `web-search` skill) fails in production.

## Root cause (ground truth from the staging container log)
```
⨯ ENOENT: open '/ROOT/packages/web/src/lib/skills/web-search/SKILL.md'
    at src/lib/skills/index.ts:33 (readFileSync)  ← src/app/api/agents/route.ts:302
```
`getSkillBody()` resolved `SKILL.md` via `join(__dirname, …)`. The Next.js bundler rewrites `__dirname` to a synthetic `/ROOT/…` path in compiled API routes, so the read pointed at a nonexistent path. Dev/test never caught it because `__dirname` is the real source path there — which is exactly why the staging click-through gate exists.

## Fix
Anchor `SKILLS_DIR` on `process.cwd()` (the `packages/web` project root in dev, test, **and** the runtime image — the Dockerfile sets `WORKDIR /app/packages/web` and copies the whole `src` tree, SKILL.md included). This mirrors `versions.ts` and `skills.test.ts`, which already anchor on `process.cwd()`. One-line change.

## Verification
- `skills.test.ts` (incl. the `getSkillBody` contract test) green; `tsc --noEmit` clean.
- Prerequisites verified: SKILL.md is shipped (`COPY … /packages/web/src`), runtime cwd is `/app/packages/web`.
- **Definitive:** will rebuild the prod image and re-test agent creation from the Market & News Monitor template on staging before merging into the 0.7.0 cut.

## Follow-up (separate)
A unit test can't catch this class (vitest `__dirname` is real). Tracking an E2E guard that creates a skill-bearing-template agent against the prod image — the test that would have caught it.