### PR TITLE
fix(auth): reconcile the Secure-cookie flag before the server boots

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -169,7 +169,7 @@ docker compose pull && docker compose up -d && docker image prune -f
 
 Until now, every update could silently sign you out. On HTTPS/domain-locked instances the session cookie's name depended on a value that was computed nondeterministically at startup, so it sometimes changed between container versions and orphaned your existing login. %%PINCHY_VERSION%% pins that decision to the domain-lock state via a stable, persisted flag, so the cookie name no longer changes across restarts.
 
-One transitional effect: **this upgrade signs everyone out one final time** as the cookie name settles onto the stable value. After that, logins persist across updates as expected. Nothing to configure — just sign back in once.
+One transitional effect: **this upgrade may sign you out one final time** as the cookie name settles onto the stable value. The flag is reconciled before the server starts, so the very first boot already uses the stable cookie name — no second sign-out, and Secure cookies are never briefly downgraded. After that, logins persist across updates as expected. Nothing to configure — just sign back in once if prompted.
 
 #### One-click deploys: DigitalOcean Marketplace and CapRover
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -80,5 +80,16 @@ fi
 echo '[pinchy] Running database migrations...'
 su -s /bin/sh pinchy -c 'cd /app/packages/web && pnpm db:migrate'
 
+# Reconcile the Secure-cookie (domain-lock) flag from the DB BEFORE the server
+# starts. auth.ts reads it at module import (eager: server.ts -> ws-auth ->
+# @/lib/auth), which is too early for in-process bootInits to write it. Doing it
+# here — pre-node, after migrations so the settings table exists — means the
+# very first boot after a domain-locked upgrade already issues Secure/`__Secure-`
+# cookies, so the cookie name never flips and users aren't logged out (nor
+# briefly served non-Secure cookies). Non-fatal: a failure degrades to
+# non-Secure cookies (login still works) rather than blocking the boot.
+echo '[pinchy] Reconciling Secure-cookie (domain-lock) flag...'
+su -s /bin/sh pinchy -c 'cd /app/packages/web && node scripts/reconcile-domain-lock-flag.mjs' || true
+
 echo '[pinchy] Starting server...'
 exec su -s /bin/sh pinchy -c 'cd /app/packages/web && exec pnpm start'

--- a/packages/web/scripts/lib/domain-lock-reconciler.mjs
+++ b/packages/web/scripts/lib/domain-lock-reconciler.mjs
@@ -1,0 +1,45 @@
+// Pure core of the pre-boot Secure-cookie reconciler.
+//
+// Better Auth derives the session cookie's `Secure` attribute AND its
+// `__Secure-` NAME prefix from `advanced.useSecureCookies`, evaluated once when
+// auth.ts is imported. That import is EAGER (server.ts -> ws-auth ->
+// @/lib/auth), so it runs before in-process bootInits can write the flag. The
+// flag therefore has to already be on disk at process start. The entrypoint
+// runner (reconcile-domain-lock-flag.mjs) calls this BEFORE `node` starts.
+//
+// This MUST stay byte-for-byte compatible with the writer/reader in
+// src/lib/secure-cookies.ts (same path, same `<domain>\n` body, same 0o600
+// mode). The parity is enforced by domain-lock-reconciler.test.ts.
+
+import { writeFileSync, rmSync, mkdirSync } from "node:fs";
+import { join } from "node:path";
+
+const DOMAIN_LOCK_FILE = ".domain_locked";
+
+/** Absolute path of the flag file inside the persistent secrets volume. */
+export function domainLockFlagPath(secretsDir) {
+  return join(secretsDir, DOMAIN_LOCK_FILE);
+}
+
+/**
+ * Reconcile the synchronous domain-lock flag from the authoritative `domain`
+ * value. A non-empty domain writes the flag (locked = HTTPS/secure mode); a
+ * null/empty domain removes it (insecure mode). Never throws — a failed write
+ * degrades to non-Secure cookies (login still works) rather than crashing the
+ * boot. Returns `{ locked: true|false }` on success, `{ locked: null, warning }`
+ * on a filesystem error.
+ */
+export function reconcileDomainLockFlag({ domain, secretsDir }) {
+  const path = domainLockFlagPath(secretsDir);
+  try {
+    if (typeof domain === "string" && domain.trim().length > 0) {
+      mkdirSync(secretsDir, { recursive: true });
+      writeFileSync(path, `${domain.trim()}\n`, { mode: 0o600 });
+      return { locked: true };
+    }
+    rmSync(path, { force: true });
+    return { locked: false };
+  } catch (err) {
+    return { locked: null, warning: err instanceof Error ? err.message : String(err) };
+  }
+}

--- a/packages/web/scripts/lib/domain-setting-reader.mjs
+++ b/packages/web/scripts/lib/domain-setting-reader.mjs
@@ -1,0 +1,28 @@
+// Reads the authoritative `domain` setting straight from Postgres, for the
+// pre-boot Secure-cookie reconciler (reconcile-domain-lock-flag.mjs). Uses the
+// same `postgres` client the rest of the entrypoint tooling uses. Kept separate
+// from the pure reconciler so the file logic stays unit-testable while this DB
+// edge is covered by domain-lock-reconciler.integration.test.ts.
+
+import postgres from "postgres";
+
+/**
+ * Return the locked domain (HTTPS/secure mode) or null (insecure mode).
+ *
+ * `domain` is always stored plaintext (settings.encrypted = false; see
+ * lib/settings.ts). A row that is unexpectedly flagged encrypted is treated as
+ * not-locked: the pre-boot context has no key to decrypt it, and degrading to
+ * insecure keeps login working rather than writing ciphertext as a domain.
+ */
+export async function readDomainSetting(url) {
+  const sql = postgres(url, { max: 1, connect_timeout: 10, onnotice: () => {} });
+  try {
+    const rows = await sql`SELECT value, encrypted FROM settings WHERE key = 'domain'`;
+    if (rows.length === 0) return null;
+    const { value, encrypted } = rows[0];
+    if (encrypted) return null;
+    return typeof value === "string" && value.trim().length > 0 ? value : null;
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}

--- a/packages/web/scripts/reconcile-domain-lock-flag.mjs
+++ b/packages/web/scripts/reconcile-domain-lock-flag.mjs
@@ -1,0 +1,42 @@
+#!/usr/bin/env node
+// Entrypoint runner: reconcile the Secure-cookie (domain-lock) flag from the DB
+// BEFORE the Node server starts.
+//
+// Better Auth reads `advanced.useSecureCookies` when auth.ts is imported, which
+// is EAGER (server.ts -> ws-auth -> @/lib/auth) — too early for in-process
+// bootInits to write the flag. Writing it here, pre-node and after migrations,
+// makes the very first boot after a domain-locked upgrade already issue
+// Secure/`__Secure-` cookies: the cookie name never flips, so users are not
+// logged out and the instance is never briefly served non-Secure cookies.
+//
+// All diagnostics go to stderr. ALWAYS exits 0 — a failed reconcile must never
+// block the boot (it degrades to non-Secure cookies; login still works).
+
+import { readDomainSetting } from "./lib/domain-setting-reader.mjs";
+import { reconcileDomainLockFlag } from "./lib/domain-lock-reconciler.mjs";
+
+const log = (msg) => process.stderr.write(`[domain-lock] ${msg}\n`);
+
+const databaseUrl = process.env.DATABASE_URL;
+const secretsDir = process.env.ENCRYPTION_KEY_DIR || "/app/secrets";
+
+if (!databaseUrl) {
+  log("no DATABASE_URL — skipping (Secure-cookie flag left as-is)");
+  process.exit(0);
+}
+
+try {
+  const domain = await readDomainSetting(databaseUrl);
+  const result = reconcileDomainLockFlag({ domain, secretsDir });
+  if (result.warning) {
+    log(`WARNING: could not persist flag: ${result.warning}`);
+  } else if (result.locked) {
+    log(`locked: Secure (__Secure-) cookies ON for ${domain}`);
+  } else {
+    log("unlocked: Secure cookies OFF (no domain set)");
+  }
+} catch (err) {
+  log(`WARNING: ${err instanceof Error ? err.message : err}`);
+}
+
+process.exit(0);

--- a/packages/web/src/__tests__/integration/domain-lock-reconciler.integration.test.ts
+++ b/packages/web/src/__tests__/integration/domain-lock-reconciler.integration.test.ts
@@ -1,0 +1,79 @@
+// Real-Postgres integration test for the pre-boot Secure-cookie reconciler.
+// Exercises the EXACT reader the entrypoint runner uses against a real
+// `settings` table, so a column rename or a change in how `domain` is stored
+// fails here instead of silently shipping non-Secure cookies to production.
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import postgres from "postgres";
+import { readDomainSetting } from "../../../scripts/lib/domain-setting-reader.mjs";
+import {
+  reconcileDomainLockFlag,
+  domainLockFlagPath,
+} from "../../../scripts/lib/domain-lock-reconciler.mjs";
+
+const DB_URL = process.env.DATABASE_URL!; // vitest.integration.config.ts sets this
+
+async function withSql<T>(fn: (sql: ReturnType<typeof postgres>) => Promise<T>): Promise<T> {
+  const sql = postgres(DB_URL, { max: 1, onnotice: () => {} });
+  try {
+    return await fn(sql);
+  } finally {
+    await sql.end({ timeout: 5 });
+  }
+}
+
+async function setDomainRow(value: string | null, encrypted = false): Promise<void> {
+  await withSql(async (sql) => {
+    await sql`DELETE FROM settings WHERE key = 'domain'`;
+    if (value !== null) {
+      await sql`INSERT INTO settings (key, value, encrypted) VALUES ('domain', ${value}, ${encrypted})`;
+    }
+  });
+}
+
+describe("domain-lock reconciler (real Postgres)", () => {
+  let secretsDir: string;
+
+  beforeEach(() => {
+    secretsDir = mkdtempSync(join(tmpdir(), "pinchy-domain-lock-int-"));
+  });
+
+  afterEach(async () => {
+    rmSync(secretsDir, { recursive: true, force: true });
+    await setDomainRow(null);
+  });
+
+  it("reads a locked domain and writes the Secure-cookie flag", async () => {
+    await setDomainRow("staging.example.com");
+
+    const domain = await readDomainSetting(DB_URL);
+    expect(domain).toBe("staging.example.com");
+
+    const result = reconcileDomainLockFlag({ domain, secretsDir });
+    expect(result.locked).toBe(true);
+    expect(readFileSync(domainLockFlagPath(secretsDir), "utf8")).toBe("staging.example.com\n");
+  });
+
+  it("returns null and removes the flag when no domain is set", async () => {
+    await setDomainRow(null);
+
+    const domain = await readDomainSetting(DB_URL);
+    expect(domain).toBe(null);
+
+    const result = reconcileDomainLockFlag({ domain, secretsDir });
+    expect(result.locked).toBe(false);
+    expect(existsSync(domainLockFlagPath(secretsDir))).toBe(false);
+  });
+
+  it("ignores an unexpectedly-encrypted domain row (degrades to insecure)", async () => {
+    // `domain` is always stored plaintext (setSetting default encrypted=false).
+    // If a row is somehow flagged encrypted, the pre-boot reader cannot decrypt
+    // it, so it must report not-locked rather than write ciphertext as a domain.
+    await setDomainRow("Z0FBQUFBQk...ciphertext", true);
+
+    const domain = await readDomainSetting(DB_URL);
+    expect(domain).toBe(null);
+  });
+});

--- a/packages/web/src/__tests__/lib/domain-lock-reconciler.test.ts
+++ b/packages/web/src/__tests__/lib/domain-lock-reconciler.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { mkdtempSync, rmSync, writeFileSync, existsSync, readFileSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import {
+  reconcileDomainLockFlag,
+  domainLockFlagPath,
+} from "../../../scripts/lib/domain-lock-reconciler.mjs";
+import { shouldUseSecureCookies, domainLockFlagPath as readerFlagPath } from "@/lib/secure-cookies";
+
+// The Secure-cookie decision (`useSecureCookies` -> Better Auth's `__Secure-`
+// cookie NAME prefix) is read by auth.ts at MODULE IMPORT, which — via
+// server.ts -> ws-auth -> @/lib/auth — happens BEFORE in-process bootInits can
+// write the flag. So the flag must already be on disk at process start. The
+// entrypoint runner reconciles it from the `domain` DB setting BEFORE `node`
+// starts; this reconciler is its pure, testable core. These tests pin that the
+// reconciler's on-disk output is byte-for-byte what the runtime reader honors.
+
+let dir: string;
+let prev: string | undefined;
+
+beforeEach(() => {
+  dir = mkdtempSync(join(tmpdir(), "pinchy-domain-lock-"));
+  prev = process.env.ENCRYPTION_KEY_DIR;
+});
+
+afterEach(() => {
+  if (prev === undefined) delete process.env.ENCRYPTION_KEY_DIR;
+  else process.env.ENCRYPTION_KEY_DIR = prev;
+  rmSync(dir, { recursive: true, force: true });
+});
+
+describe("reconcileDomainLockFlag", () => {
+  it("writes the flag (secure mode) when a domain is locked", () => {
+    const result = reconcileDomainLockFlag({ domain: "pinchy.example.com", secretsDir: dir });
+    expect(result.locked).toBe(true);
+    expect(existsSync(domainLockFlagPath(dir))).toBe(true);
+    expect(readFileSync(domainLockFlagPath(dir), "utf8")).toBe("pinchy.example.com\n");
+  });
+
+  it("removes the flag (insecure mode) when no domain is set", () => {
+    reconcileDomainLockFlag({ domain: "pinchy.example.com", secretsDir: dir });
+    const result = reconcileDomainLockFlag({ domain: null, secretsDir: dir });
+    expect(result.locked).toBe(false);
+    expect(existsSync(domainLockFlagPath(dir))).toBe(false);
+  });
+
+  it("treats a whitespace-only domain as not locked", () => {
+    const result = reconcileDomainLockFlag({ domain: "   ", secretsDir: dir });
+    expect(result.locked).toBe(false);
+    expect(existsSync(domainLockFlagPath(dir))).toBe(false);
+  });
+
+  it("is idempotent when the flag is already removed", () => {
+    const result = reconcileDomainLockFlag({ domain: null, secretsDir: dir });
+    expect(result.locked).toBe(false);
+    expect(existsSync(domainLockFlagPath(dir))).toBe(false);
+  });
+
+  it("never throws and reports a warning when the secrets dir cannot be created", () => {
+    // Parent is a regular file -> mkdirSync fails with ENOTDIR (terminal). Do
+    // NOT use a /proc/<x> path: on Linux + Node 22 a recursive mkdir of a
+    // non-creatable /proc child infinite-loops in MKDirpSync instead of failing
+    // fast, which previously hung CI for 6h (#558).
+    const blockingFile = join(dir, "blocking-file");
+    writeFileSync(blockingFile, "x");
+    const result = reconcileDomainLockFlag({
+      domain: "pinchy.example.com",
+      secretsDir: join(blockingFile, "secrets"),
+    });
+    expect(result.locked).toBe(null);
+    expect(result.warning).toBeTruthy();
+  });
+});
+
+describe("reconciler <-> runtime reader parity (drift guard)", () => {
+  it("targets the exact path the runtime reader reads", () => {
+    process.env.ENCRYPTION_KEY_DIR = dir;
+    // secure-cookies.ts resolves the path from ENCRYPTION_KEY_DIR; the
+    // reconciler takes it explicitly. They must agree on dir + filename.
+    expect(readerFlagPath()).toBe(domainLockFlagPath(dir));
+  });
+
+  it("a flag written by the reconciler makes shouldUseSecureCookies() true", () => {
+    process.env.ENCRYPTION_KEY_DIR = dir;
+    reconcileDomainLockFlag({ domain: "pinchy.example.com", secretsDir: dir });
+    expect(shouldUseSecureCookies()).toBe(true);
+  });
+
+  it("after the reconciler clears the flag, shouldUseSecureCookies() is false", () => {
+    process.env.ENCRYPTION_KEY_DIR = dir;
+    reconcileDomainLockFlag({ domain: "pinchy.example.com", secretsDir: dir });
+    reconcileDomainLockFlag({ domain: null, secretsDir: dir });
+    expect(shouldUseSecureCookies()).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/entrypoint-runtime-check.test.ts
+++ b/packages/web/src/__tests__/lib/entrypoint-runtime-check.test.ts
@@ -18,3 +18,27 @@ describe("entrypoint.sh plugin runtime check", () => {
     expect(ENTRYPOINT).toMatch(/openclaw-extensions/);
   });
 });
+
+describe("entrypoint.sh Secure-cookie (domain-lock) reconcile", () => {
+  it("runs the domain-lock reconciler before starting the server", () => {
+    expect(ENTRYPOINT).toContain("reconcile-domain-lock-flag.mjs");
+  });
+
+  it("reconciles AFTER migrations (settings table exists) and BEFORE the server boots", () => {
+    // auth.ts reads the flag at import; the server must not start until the
+    // flag reflects the DB `domain` setting, and the settings table must be
+    // migrated first. Order: db:migrate -> reconcile -> pnpm start.
+    const migrate = ENTRYPOINT.indexOf("db:migrate");
+    const reconcile = ENTRYPOINT.indexOf("reconcile-domain-lock-flag.mjs");
+    const start = ENTRYPOINT.lastIndexOf("pnpm start");
+    expect(migrate).toBeGreaterThanOrEqual(0);
+    expect(reconcile).toBeGreaterThan(migrate);
+    expect(start).toBeGreaterThan(reconcile);
+  });
+
+  it("never blocks the boot if the reconcile fails", () => {
+    // The reconcile invocation must be non-fatal (degrades to non-Secure
+    // cookies; login still works) — guarded by a trailing `|| true`.
+    expect(ENTRYPOINT).toMatch(/reconcile-domain-lock-flag\.mjs'\s*\|\|\s*true/);
+  });
+});

--- a/packages/web/src/lib/secure-cookies.ts
+++ b/packages/web/src/lib/secure-cookies.ts
@@ -17,6 +17,14 @@
  * stable across restarts. The DB setting remains the source of truth; this file
  * is a sync cache kept in step on every lock/unlock and on each boot.
  *
+ * Crucially, `auth.ts` imports EAGERLY (server.ts -> ws-auth -> @/lib/auth), so
+ * `shouldUseSecureCookies()` runs before in-process `bootInits()` can backfill
+ * the flag. The Docker entrypoint therefore reconciles the flag from the DB
+ * BEFORE `node` starts (scripts/reconcile-domain-lock-flag.mjs), so the very
+ * first boot after a domain-locked upgrade already reads the correct value —
+ * the in-process `writeDomainLockFlag` calls below are a backfill for dev/test
+ * and any path that skips the entrypoint.
+ *
  * Node-only (uses `fs`). Do NOT import from Edge middleware — use
  * `@/lib/domain-cache`'s `getCachedDomain()` there.
  */

--- a/packages/web/src/lib/skills/index.ts
+++ b/packages/web/src/lib/skills/index.ts
@@ -14,12 +14,18 @@ export function isKnownSkill(id: string): id is SkillId {
   return (KNOWN_SKILLS as readonly string[]).includes(id);
 }
 
-const SKILLS_DIR = join(__dirname);
+// SKILL.md files live in the source tree (src/lib/skills/<id>/SKILL.md) and are
+// copied into the runtime image. Resolve from process.cwd() — the packages/web
+// project root in dev, test, AND production (the image sets WORKDIR
+// /app/packages/web) — NOT __dirname: Next.js rewrites __dirname to a synthetic
+// "/ROOT/…" path in compiled API routes, so a __dirname-relative read ENOENTs in
+// production and broke creating an agent from a skill-bearing template
+// (web-search). versions.ts and skills.test.ts both anchor on process.cwd() too.
+const SKILLS_DIR = join(process.cwd(), "src/lib/skills");
 
-// First-party skill bodies are bundled with the build — they never change
-// at runtime within a process. Cache to avoid re-reading the same file once
-// per agent during `regenerateOpenClawConfig()` (50 agents on the same
-// skill = 50 redundant disk reads without this).
+// Skill bodies never change at runtime within a process. Cache to avoid
+// re-reading the same file once per agent during `regenerateOpenClawConfig()`
+// (50 agents on the same skill = 50 redundant disk reads without this).
 const SKILL_BODY_CACHE = new Map<SkillId, string>();
 
 export function getSkillBody(id: SkillId): string {


### PR DESCRIPTION
## Why

Follow-up hardening of the cookie-stability fix (#558). While verifying the fix on staging against a real upgrade cycle, the login broke after the refresh — root cause:

`auth.ts` reads `advanced.useSecureCookies` (which drives Better Auth's `__Secure-` cookie **name** prefix) **at module import**. That import is **eager** — `server.ts` → `ws-auth` → `@/lib/auth` — so `shouldUseSecureCookies()` runs **before** in-process `bootInits()` can write the domain-lock flag. The flag must already be on disk at process start; `bootInits` only backfills it for the *next* boot.

Consequence on a domain-locked instance upgrading to a flag-introducing release:
1. **Deploy boot:** flag absent → `useSecureCookies=false` → plain cookies → forced logout #1.
2. Runs **non-Secure until the next restart** (could be days).
3. **Next restart:** flag now present → `__Secure-` → forced logout #2, then stable.

So two logouts and a transient Secure-cookie downgrade window — on the exact upgrade that ships the cookie fix. Not something a CISO waves through.

## Fix

Reconcile the flag from the authoritative `domain` DB setting **in the Docker entrypoint** — pre-`node`, after migrations so `settings` exists — so the very first boot already uses the stable cookie name. **At most one final logout, no downgrade window.**

- `scripts/lib/domain-lock-reconciler.mjs` — pure, dependency-free file reconcile (byte-for-byte compatible with `secure-cookies.ts`).
- `scripts/lib/domain-setting-reader.mjs` — reads `domain` via the same `postgres` client the db-password entrypoint tooling uses.
- `scripts/reconcile-domain-lock-flag.mjs` — thin runner, always exits 0 (a failure degrades to non-Secure cookies; login still works).
- `entrypoint.sh` — runs it between `db:migrate` and server start.

The in-process `writeDomainLockFlag` backfill stays for dev/test and any path that skips the entrypoint.

## Tests (TDD)

- **Unit** (`domain-lock-reconciler.test.ts`): write/remove/whitespace/ENOTDIR-no-throw + a drift guard asserting the runtime reader `shouldUseSecureCookies()` honors the reconciler's on-disk output.
- **Integration** (`domain-lock-reconciler.integration.test.ts`, real Postgres): reads a locked domain → writes the flag; no domain → removes it; encrypted row → degrades to insecure.
- **Entrypoint ordering** (`entrypoint-runtime-check.test.ts`): `db:migrate` → reconcile → `pnpm start`, and the reconcile is non-fatal.

Local gates green: format:check, lint (0 errors), unit (6341), integration (127), tsc --noEmit.

## Verification

Will verify on staging against a real v0.6.x → this-build upgrade cycle (no logout for an already-`__Secure-` session; flag correct on boot 1) before the v0.7.0 cut.

Built on OpenClaw · [heypinchy.com](https://heypinchy.com)