### PR TITLE
fix(plugins): preserve plugin node_modules across a pinchy-only restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -516,6 +516,55 @@ jobs:
           fi
           echo "Clean startup verified (restarts=$RESTART_COUNT, connection_errors=$ERROR_COUNT)"
 
+      - name: Verify plugins load + deps survive a pinchy-only restart (PR #275 regression)
+        run: |
+          # External-dep plugins' node_modules are installed ONLY by the
+          # OpenClaw container (start-openclaw.sh) from baked /opt/<plugin>-deps
+          # bundles — the pinchy image ships plugin SOURCE with no node_modules.
+          # PR #275 made pinchy's per-boot source sync `rm -rf; cp -r`, which
+          # wiped those deps on every pinchy restart, so a pinchy-only recreate
+          # (openclaw left running) broke pinchy-web / pinchy-files /
+          # pinchy-odoo with "Cannot find module". A fresh full-stack boot
+          # happens to order correctly, which is why CI never caught it. This
+          # reproduces the partial restart and asserts the deps survive.
+          set -e
+          DEP_PLUGINS="pinchy-web pinchy-files pinchy-odoo pinchy-email"
+
+          echo "== assert no plugin failed to load on initial boot =="
+          if docker compose logs openclaw 2>&1 | grep -E "failed to (load|initialize)|Cannot find module"; then
+            echo "::error::a Pinchy plugin failed to load (missing runtime dep in the openclaw image?)"
+            docker compose logs openclaw | tail -80
+            exit 1
+          fi
+
+          assert_deps() {
+            for p in $DEP_PLUGINS; do
+              # Only plugins the openclaw image bundled deps for must have node_modules.
+              if docker compose exec -T openclaw sh -c "test -d /opt/$p-deps"; then
+                if ! docker compose exec -T openclaw sh -c "test -d /root/.openclaw/extensions/$p/node_modules"; then
+                  echo "::error::$p/node_modules missing $1 — the plugin source sync wiped OpenClaw-installed deps"
+                  exit 1
+                fi
+              fi
+            done
+            echo "all bundled-plugin node_modules present $1"
+          }
+          assert_deps "(initial boot)"
+
+          echo "== pinchy-only recreate: re-runs the source sync, openclaw left running =="
+          docker compose up -d --no-deps --force-recreate pinchy
+          for i in $(seq 1 30); do
+            curl -sf http://localhost:7777/api/health >/dev/null 2>&1 && break
+            if [ "$i" -eq 30 ]; then
+              echo "::error::pinchy did not become healthy after recreate"
+              docker compose logs pinchy | tail -40
+              exit 1
+            fi
+            sleep 2
+          done
+          assert_deps "(after pinchy-only recreate)"
+          echo "Plugin deps survived a pinchy-only restart"
+
       # Regression guard for the openclaw-node deviceToken bug that broke the
       # v0.4.1 demo. Pinchy had been running fine; an upgrade recreated both
       # containers, gateway.auth.token got regenerated (race between Pinchy's

--- a/Dockerfile.pinchy
+++ b/Dockerfile.pinchy
@@ -186,6 +186,9 @@ RUN groupadd -r -g 999 pinchy && useradd -r -u 999 -g pinchy -d /app pinchy
 RUN mkdir -p /app/secrets /openclaw-config/workspaces && chown -R pinchy:pinchy /app /app/secrets /openclaw-config/workspaces
 
 COPY entrypoint.sh /entrypoint.sh
-RUN chmod +x /entrypoint.sh
+# Plugin-source sync helper the entrypoint runs on every boot. Extracted from
+# entrypoint.sh so its node_modules-preservation invariant is unit-testable.
+COPY config/sync-plugins.sh /sync-plugins.sh
+RUN chmod +x /entrypoint.sh /sync-plugins.sh
 
 ENTRYPOINT ["/entrypoint.sh"]

--- a/config/sync-plugins.sh
+++ b/config/sync-plugins.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Sync Pinchy plugin SOURCE from the image into the shared openclaw-extensions
+# volume, on every pinchy-container start. Extracted from entrypoint.sh so the
+# node_modules-preservation invariant below is unit-testable
+# (see packages/web/src/__tests__/lib/sync-plugins.test.ts).
+#
+# The named Docker volume is only seeded from the image on first creation;
+# upgrades leave stale content from the previous image, so we re-sync each boot.
+#
+# CRITICAL — never touch node_modules. Plugin node_modules are installed ONLY by
+# the OpenClaw container's start-openclaw.sh (install_plugin_deps) from baked
+# /opt/<plugin>-deps bundles; the pinchy image ships plugin SOURCE with NO
+# node_modules. Before PR #275 the sync was a non-destructive overlay; #275
+# changed it to `rm -rf "$dst"; cp -r`, which — because the image source has no
+# node_modules — made `diff` ALWAYS differ and wiped the OpenClaw-installed deps.
+# On a pinchy-only restart (deps not reinstalled until openclaw restarts) the
+# three external-dep plugins (pinchy-web/@mozilla/readability,
+# pinchy-files/mammoth, pinchy-odoo/odoo-node) then fail to load with
+# "Cannot find module". So: exclude node_modules from the change-detection AND
+# from the deletion — one writer (openclaw), zero deleters.
+#
+# Idempotent: untouched source means no spurious inotify events for OpenClaw's
+# plugin watcher (which would otherwise re-init the plugin runtime every boot).
+
+PLUGIN_SRC_ROOT="${PLUGIN_SRC_ROOT:-/app/pinchy-plugins}"
+PLUGIN_DST_ROOT="${PLUGIN_DST_ROOT:-/openclaw-extensions}"
+
+for plugin_src in "$PLUGIN_SRC_ROOT"/*/; do
+  [ -d "$plugin_src" ] || continue
+  plugin_name=$(basename "$plugin_src")
+  plugin_dst="$PLUGIN_DST_ROOT/$plugin_name"
+  if [ ! -d "$plugin_dst" ] || ! diff -rq --exclude=node_modules "$plugin_src" "$plugin_dst" >/dev/null 2>&1; then
+    mkdir -p "$plugin_dst"
+    # Replace only stale SOURCE entries; never delete node_modules.
+    find "$plugin_dst" -mindepth 1 -maxdepth 1 ! -name node_modules -exec rm -rf {} +
+    cp -r "$plugin_src". "$plugin_dst"/
+    echo "[entrypoint] synced plugin: $plugin_name"
+  fi
+done

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -27,24 +27,15 @@ fi
 # it can enter the directory and rename files atomically.
 chown pinchy:pinchy /openclaw-secrets 2>/dev/null || true
 
-# Refresh plugin directories on every startup. The named Docker volume
-# (openclaw-extensions) is only initialised from the image on first creation;
-# subsequent upgrades leave stale content from the previous image.
-#
-# Critically idempotent: we only re-copy a plugin if its directory is missing
-# or differs from the image. Untouched files mean no spurious inotify events
-# for OpenClaw's plugin watcher (which would otherwise cause it to re-init the
-# plugin runtime on every container start, blocking the event loop for tens
-# of seconds — see Telegram E2E investigation for the failure mode).
-for plugin_src in /app/pinchy-plugins/*/; do
-  plugin_name=$(basename "$plugin_src")
-  plugin_dst="/openclaw-extensions/$plugin_name"
-  if [ ! -d "$plugin_dst" ] || ! diff -rq "$plugin_src" "$plugin_dst" >/dev/null 2>&1; then
-    rm -rf "$plugin_dst"
-    cp -r "$plugin_src" "$plugin_dst"
-    echo "[entrypoint] synced plugin: $plugin_name"
-  fi
-done
+# Refresh plugin SOURCE in the shared openclaw-extensions volume on every
+# startup (the named volume is only seeded from the image on first creation;
+# upgrades otherwise keep stale content from the previous image). The sync
+# PRESERVES each plugin's node_modules: those are installed solely by the
+# OpenClaw container (start-openclaw.sh) from baked /opt/<plugin>-deps bundles
+# and are the only copy, so a pinchy-only restart must never wipe them. Logic +
+# its regression test live in config/sync-plugins.sh / sync-plugins.test.ts
+# (guards the PR #275 regression that wiped deps and broke plugin load).
+sh /sync-plugins.sh
 
 # Verify every Pinchy plugin shipped in the image landed in the shared
 # extensions volume. If a Dockerfile.pinchy COPY line is missing, OpenClaw

--- a/packages/web/src/__tests__/lib/entrypoint-runtime-check.test.ts
+++ b/packages/web/src/__tests__/lib/entrypoint-runtime-check.test.ts
@@ -42,3 +42,26 @@ describe("entrypoint.sh Secure-cookie (domain-lock) reconcile", () => {
     expect(ENTRYPOINT).toMatch(/reconcile-domain-lock-flag\.mjs'\s*\|\|\s*true/);
   });
 });
+
+describe("plugin-source sync preserves node_modules (PR #275 regression guard)", () => {
+  const SYNC_PLUGINS = readFileSync(resolve(REPO_ROOT, "config/sync-plugins.sh"), "utf8");
+
+  it("entrypoint delegates the plugin-source sync to sync-plugins.sh", () => {
+    expect(ENTRYPOINT).toContain("/sync-plugins.sh");
+  });
+
+  it("excludes node_modules from change-detection", () => {
+    // node_modules is installed by the OpenClaw container, not shipped in the
+    // image source. Including it in the diff makes the sync ALWAYS differ and
+    // re-run, which is what destroyed the deps in #275.
+    expect(SYNC_PLUGINS).toMatch(/diff\b[^\n]*--exclude=node_modules/);
+  });
+
+  it("replaces stale source without ever deleting node_modules", () => {
+    // The fix: delete only non-node_modules entries, never `rm -rf` the whole
+    // plugin dir (the #275 bug that wiped OpenClaw-installed deps and broke
+    // pinchy-web / pinchy-files / pinchy-odoo on a pinchy-only restart).
+    expect(SYNC_PLUGINS).toMatch(/!\s+-name\s+node_modules/);
+    expect(SYNC_PLUGINS).not.toMatch(/rm\s+-rf\s+"\$plugin_dst"/);
+  });
+});

--- a/packages/web/src/__tests__/lib/sync-plugins.test.ts
+++ b/packages/web/src/__tests__/lib/sync-plugins.test.ts
@@ -1,0 +1,94 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, writeFileSync, readFileSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// config/sync-plugins.sh is the pinchy-container entrypoint's plugin-source
+// sync, extracted so it is testable. CRITICAL invariant (regressed in PR #275):
+// it must refresh plugin SOURCE in the shared openclaw-extensions volume WITHOUT
+// wiping each plugin's node_modules. Those node_modules are installed by the
+// OpenClaw container's start-openclaw.sh (install_plugin_deps) from baked
+// /opt/<plugin>-deps bundles and are the ONLY copy — the pinchy image ships no
+// node_modules. The old `rm -rf "$dst"; cp -r` wiped them, so a pinchy-only
+// restart (deps not re-installed until openclaw restarts) broke pinchy-web /
+// pinchy-files / pinchy-odoo at load time ("Cannot find module").
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const SCRIPT = resolve(REPO_ROOT, "config/sync-plugins.sh");
+
+let root: string;
+let srcRoot: string;
+let dstRoot: string;
+
+function runSync(): void {
+  execFileSync("sh", [SCRIPT], {
+    env: { ...process.env, PLUGIN_SRC_ROOT: srcRoot, PLUGIN_DST_ROOT: dstRoot },
+    stdio: "pipe",
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "pinchy-sync-plugins-"));
+  srcRoot = join(root, "image-src");
+  dstRoot = join(root, "volume-dst");
+  mkdirSync(srcRoot, { recursive: true });
+  mkdirSync(dstRoot, { recursive: true });
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("sync-plugins.sh", () => {
+  it("preserves an existing plugin's node_modules across a source re-sync", () => {
+    // Image source (no node_modules — never shipped) with NEW source content.
+    mkdirSync(join(srcRoot, "pinchy-web"), { recursive: true });
+    writeFileSync(join(srcRoot, "pinchy-web", "index.ts"), "new source\n");
+
+    // Volume already populated by a prior boot: openclaw-installed deps + stale
+    // source that differs from the image.
+    mkdirSync(join(dstRoot, "pinchy-web", "node_modules", "@mozilla", "readability"), {
+      recursive: true,
+    });
+    writeFileSync(
+      join(dstRoot, "pinchy-web", "node_modules", "@mozilla", "readability", "index.js"),
+      "DEP MARKER\n"
+    );
+    writeFileSync(join(dstRoot, "pinchy-web", "index.ts"), "old source\n");
+    writeFileSync(join(dstRoot, "pinchy-web", "stale-removed.ts"), "gone next sync\n");
+
+    runSync();
+
+    // The dependency the OpenClaw container installed MUST survive.
+    expect(
+      existsSync(join(dstRoot, "pinchy-web", "node_modules", "@mozilla", "readability", "index.js"))
+    ).toBe(true);
+    // Source is refreshed to the image version.
+    expect(readFileSync(join(dstRoot, "pinchy-web", "index.ts"), "utf8")).toBe("new source\n");
+    // Stale source the image no longer ships is removed.
+    expect(existsSync(join(dstRoot, "pinchy-web", "stale-removed.ts"))).toBe(false);
+  });
+
+  it("creates a fresh plugin dir from source on first boot (empty volume)", () => {
+    mkdirSync(join(srcRoot, "pinchy-context"), { recursive: true });
+    writeFileSync(join(srcRoot, "pinchy-context", "index.ts"), "ctx\n");
+
+    runSync();
+
+    expect(readFileSync(join(dstRoot, "pinchy-context", "index.ts"), "utf8")).toBe("ctx\n");
+  });
+
+  it("does not re-sync (preserves node_modules) when source is unchanged", () => {
+    mkdirSync(join(srcRoot, "pinchy-web"), { recursive: true });
+    writeFileSync(join(srcRoot, "pinchy-web", "index.ts"), "same\n");
+    mkdirSync(join(dstRoot, "pinchy-web", "node_modules"), { recursive: true });
+    writeFileSync(join(dstRoot, "pinchy-web", "node_modules", "marker"), "keep\n");
+    writeFileSync(join(dstRoot, "pinchy-web", "index.ts"), "same\n");
+
+    runSync();
+
+    expect(existsSync(join(dstRoot, "pinchy-web", "node_modules", "marker"))).toBe(true);
+    expect(readFileSync(join(dstRoot, "pinchy-web", "index.ts"), "utf8")).toBe("same\n");
+  });
+});


### PR DESCRIPTION
## Why

Found while verifying v0.7.0 on staging: the **Market & News Monitor** agent said it would search the web, then produced nothing. Root cause (confirmed on staging + via a 6-agent investigation): **`pinchy-web`, `pinchy-files` and `pinchy-odoo` failed to load** in the OpenClaw container — `Cannot find module '@mozilla/readability'` / `mammoth` / `odoo-node` — so `pinchy_web_search` was never registered and never offered to the model.

Those plugins' `node_modules` are installed **solely by the OpenClaw container** (`start-openclaw.sh` → `install_plugin_deps`, from baked `/opt/<plugin>-deps` bundles). The pinchy image ships plugin **source with no `node_modules`**. Since **PR #275** the pinchy entrypoint synced source with `rm -rf "$dst"; cp -r` — and because the image source has no `node_modules`, the `diff -rq` **always** reported a difference once OpenClaw had populated deps, so **every pinchy restart wiped the deps**. `install_plugin_deps` only re-runs at openclaw container start, so a **pinchy-only recreate** (`up -d pinchy`, `up -d --no-deps pinchy`, `restart pinchy`) wiped the deps with nothing to restore them.

**Not a blocker for the documented upgrade** (`docker compose pull && up -d` bumps both images via one `PINCHY_VERSION` and recreates both, so openclaw re-layers deps; CapRover/DO templates pin both to one version too). It IS a real operator footgun and a latent fragility — and it bit staging.

## Fix

Extract the sync into `config/sync-plugins.sh` and make it `node_modules`-safe:
- exclude `node_modules` from the change-detection `diff`,
- delete only non-`node_modules` entries (`find … ! -name node_modules`) before copying source.

One writer of `node_modules` (openclaw), zero deleters. Idempotency (no spurious inotify re-init) is preserved.

## Guardrails (the gap that let this ship)

- **`sync-plugins.test.ts`** — behavioral test: `node_modules` survives a re-sync; first-boot create; idempotent no-op.
- **`entrypoint-runtime-check.test.ts`** — assert the `--exclude=node_modules` + `! -name node_modules` guards and that the destructive `rm -rf "$plugin_dst"` is gone.
- **`ci.yml` docker-smoke** — reproduce a pinchy-only recreate and assert (a) no plugin `failed to load`/`Cannot find module` and (b) every bundled plugin keeps its `node_modules`. CI previously only greped for `blocked plugin candidate`, so a missing-dep load failure produced a **green** run.

## Verification

Local: format ✓ · lint (0 errors) ✓ · unit suite (6347) ✓ · `sync-plugins.test.ts` RED→GREEN. Will verify on staging with a deliberate `docker compose up -d --no-deps --force-recreate pinchy` (deps survive) before the v0.7.0 cut.

Built on OpenClaw · [heypinchy.com](https://heypinchy.com)