### PR TITLE
chore(docs): self-host Umami analytics (tracker → analytics.helmcraft.ai)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -25,7 +25,7 @@ export default defineConfig({
             tag: 'script',
             attrs: {
               defer: true,
-              src: 'https://cloud.umami.is/script.js',
+              src: 'https://analytics.helmcraft.ai/script.js',
               'data-website-id': process.env.UMAMI_WEBSITE_ID,
             },
           },


### PR DESCRIPTION
Switches the docs site (docs.heypinchy.com) analytics from Umami Cloud to our self-hosted, cookieless Umami on our own EU server (`analytics.helmcraft.ai`).

Only the script `src` changes; the `data-website-id` still comes from `UMAMI_WEBSITE_ID` and is unchanged. The destination website already exists in the self-hosted instance with the same id, so tracking flows on the next docs deploy.

Part of the Umami Cloud → self-hosted migration.