### PR TITLE
fix(chat): refresh conversation title immediately when the first run completes

### DIFF
--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -27,6 +27,9 @@ vi.mock("@/lib/avatar", () => ({
 
 vi.mock("@/components/chat-session-provider", () => ({
   useChatSession: mockUseChatSession,
+  // ChatSwitcher (rendered in the header) reads run-state via this hook to
+  // refresh the chat title when a run completes; idle in these tests.
+  useChatSessionIsRunning: () => false,
 }));
 
 vi.mock("@/hooks/use-chat-status", () => ({

--- a/packages/web/src/components/chat-session-provider.tsx
+++ b/packages/web/src/components/chat-session-provider.tsx
@@ -131,6 +131,23 @@ export function useChatSession(agentId: string, chatId?: string) {
   );
 }
 
+// A shared empty store used as a fallback so run-state reads never throw when a
+// component happens to render outside a ChatSessionProvider (e.g. isolated
+// component tests). It stays empty, so isRunning resolves to false.
+const fallbackStore = createChatSessionStore();
+
+/**
+ * Non-throwing subscription to whether the given chat's run is currently in
+ * flight. Unlike `useChatSession`, returns `false` rather than throwing when
+ * there is no ChatSessionProvider above — so a header component (ChatSwitcher)
+ * can react to run-completion without coupling its render to the provider.
+ */
+export function useChatSessionIsRunning(agentId: string, chatId?: string): boolean {
+  const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
+  const key = chatSessionKey(agentId, chatId);
+  return useStore(store, (s) => s.bundles[key]?.isRunning ?? false);
+}
+
 export function useVisitedAgentIds(): string[] {
   const store = useStoreOrThrow();
   // Serialize to a stable string so useSyncExternalStore snapshot is referentially

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -16,6 +16,8 @@ import { Badge } from "@/components/ui/badge";
 import { apiGet } from "@/lib/api-client";
 import type { ChatListItem } from "@/lib/schemas/sessions";
 import { generateChatId } from "@/lib/chats/generate-chat-id";
+import { useChatSessionIsRunning } from "@/components/chat-session-provider";
+import { useRunCompletionEffect } from "@/hooks/use-run-completion-effect";
 
 interface ChatSwitcherProps {
   agentId: string;
@@ -160,6 +162,13 @@ export function ChatSwitcher({
   // useState so we don't re-set it here (keeps the effect free of a synchronous
   // setState — react-hooks/set-state-in-effect).
   useEffect(() => loadChats(), [loadChats]);
+
+  // Refresh the list the moment the active chat's run finishes, so the server-
+  // derived title (from the first user message) appears immediately. Without
+  // this a brand-new chat keeps showing the agent name in the header until the
+  // dropdown is reopened or the agent is switched.
+  const isRunning = useChatSessionIsRunning(agentId, chatId ?? undefined);
+  useRunCompletionEffect(isRunning, loadChats);
 
   // Re-fetch every time the dropdown opens so sessions created since mount (e.g.
   // by a message just sent in the active chat) appear. The result is discarded

--- a/packages/web/src/hooks/__tests__/use-run-completion-effect.test.ts
+++ b/packages/web/src/hooks/__tests__/use-run-completion-effect.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect, vi } from "vitest";
+import { renderHook } from "@testing-library/react";
+import { useRunCompletionEffect } from "@/hooks/use-run-completion-effect";
+
+// Fires `onComplete` each time a chat run finishes (isRunning true -> false).
+// The ChatSwitcher uses it to refetch the conversation list so the server-
+// derived title appears immediately after the first message, instead of only
+// when the dropdown is reopened or the agent is switched.
+
+describe("useRunCompletionEffect", () => {
+  it("does not fire on mount when idle", () => {
+    const onComplete = vi.fn();
+    renderHook(({ running }) => useRunCompletionEffect(running, onComplete), {
+      initialProps: { running: false },
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("does not fire on mount when it starts mid-run", () => {
+    const onComplete = vi.fn();
+    renderHook(({ running }) => useRunCompletionEffect(running, onComplete), {
+      initialProps: { running: true },
+    });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("does not fire when a run starts (false -> true)", () => {
+    const onComplete = vi.fn();
+    const { rerender } = renderHook(({ running }) => useRunCompletionEffect(running, onComplete), {
+      initialProps: { running: false },
+    });
+    rerender({ running: true });
+    expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("fires once when a run completes (true -> false)", () => {
+    const onComplete = vi.fn();
+    const { rerender } = renderHook(({ running }) => useRunCompletionEffect(running, onComplete), {
+      initialProps: { running: false },
+    });
+    rerender({ running: true });
+    rerender({ running: false });
+    expect(onComplete).toHaveBeenCalledTimes(1);
+  });
+
+  it("fires again on a subsequent run completion", () => {
+    const onComplete = vi.fn();
+    const { rerender } = renderHook(({ running }) => useRunCompletionEffect(running, onComplete), {
+      initialProps: { running: false },
+    });
+    rerender({ running: true });
+    rerender({ running: false });
+    rerender({ running: true });
+    rerender({ running: false });
+    expect(onComplete).toHaveBeenCalledTimes(2);
+  });
+
+  it("calls the latest callback and does not fire on callback identity change alone", () => {
+    const first = vi.fn();
+    const second = vi.fn();
+    const { rerender } = renderHook(({ running, cb }) => useRunCompletionEffect(running, cb), {
+      initialProps: { running: true, cb: first },
+    });
+    // Callback swapped while still running -> no fire.
+    rerender({ running: true, cb: second });
+    expect(first).not.toHaveBeenCalled();
+    expect(second).not.toHaveBeenCalled();
+    // Completion fires only the latest callback.
+    rerender({ running: false, cb: second });
+    expect(second).toHaveBeenCalledTimes(1);
+    expect(first).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/hooks/use-run-completion-effect.ts
+++ b/packages/web/src/hooks/use-run-completion-effect.ts
@@ -1,0 +1,34 @@
+import { useEffect, useRef } from "react";
+
+/**
+ * Run `onComplete` once each time `isRunning` transitions from `true` to
+ * `false` — i.e. a chat run finishes. Never fires on mount (no transition yet)
+ * nor when a run starts.
+ *
+ * Used by the ChatSwitcher to refetch the conversation list when the first
+ * message of a new chat completes: the server derives the conversation title
+ * from that first user message, but the switcher otherwise only refetches on
+ * mount, on dropdown-open, or on an agent switch — so the title would not
+ * appear until the user opened the list or navigated away and back.
+ *
+ * The callback is read through a ref so the effect depends only on `isRunning`
+ * — swapping a non-memoized `onComplete` (common in components) never re-fires
+ * it, and the latest callback is always the one invoked.
+ */
+export function useRunCompletionEffect(isRunning: boolean, onComplete: () => void): void {
+  const wasRunning = useRef(isRunning);
+  const onCompleteRef = useRef(onComplete);
+
+  // Track the latest callback in an effect, not during render (writing a ref
+  // mid-render is disallowed by the react-hooks "refs during render" rule).
+  useEffect(() => {
+    onCompleteRef.current = onComplete;
+  }, [onComplete]);
+
+  useEffect(() => {
+    if (wasRunning.current && !isRunning) {
+      onCompleteRef.current();
+    }
+    wasRunning.current = isRunning;
+  }, [isRunning]);
+}


### PR DESCRIPTION
## Why

Found during v0.7.0 staging testing: after creating an agent and sending the first message, the conversation **title** (server-derived from the first user message) does not appear in the chat header — it keeps showing the agent name until you reopen the chat dropdown or switch agents and come back.

Root cause: `ChatSwitcher` holds the chat list in local state and only refetches on **mount**, **dropdown-open**, and **agent switch** (remount). Nothing refetches when the first run completes, so the freshly-available title isn't picked up. The run-completion signal already exists client-side (`use-ws-runtime` → `setIsRunning(false)`), it just wasn't wired to the switcher.

## Fix

- **`useRunCompletionEffect(isRunning, onComplete)`** — fires `onComplete` once on an `isRunning` true→false transition (never on mount or run-start); reads the callback through a ref so a non-memoized callback never re-fires it.
- **`useChatSessionIsRunning(agentId, chatId?)`** — a non-throwing store read (falls back to an empty store when rendered without a `ChatSessionProvider`, so the header doesn't couple its render to the provider — keeps the existing bare-render `ChatSwitcher` tests valid).
- **`ChatSwitcher`** subscribes to the active chat's run-state and refetches the list when it completes → the title appears immediately.

## Tests

- `use-run-completion-effect.test.ts` (RED→GREEN): mount/idle no-fire, start no-fire, single fire on completion, re-fires on a second run, latest-callback semantics.
- `chat.test.tsx`: mock completeness for the new store hook (assertions unchanged).
- Local: format ✓ · lint (0 errors) ✓ · unit suite (6353) ✓.

Pure UX polish (no correctness/data change). Will confirm on staging (create agent → first message → title appears immediately) before the v0.7.0 cut.

Built on OpenClaw · [heypinchy.com](https://heypinchy.com)