### PR TITLE
ci(links): exclude the private heypinchy/website repo from lychee

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2014,7 +2014,11 @@ jobs:
           # --accept treats transient server responses (rate-limit + 5xx, e.g.
           # GitHub returning a 504 during a brief outage) as OK so they don't
           # red-light unrelated PRs. Genuinely broken links (404/410) still fail.
-          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org' --exclude 'star-history\\.com'"
+          # github.com/heypinchy/website is excluded because it's a SEPARATE
+          # PRIVATE repo: the job's GITHUB_TOKEN is scoped to this repo only, so
+          # lychee gets a 404 even though the link is valid for maintainers. The
+          # release docs intentionally cross-reference it.
+          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'github\\.com/heypinchy/website' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org' --exclude 'star-history\\.com'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## What does this PR do?

The release-checklist docs added in #-recent commits (`CONTRIBUTING.md`, `.claude/skills/cut-pinchy-release/SKILL.md`) cross-reference the separate marketing-website repo at `https://github.com/heypinchy/website`.

That repo is **private**, and the **Check links** job's `GITHUB_TOKEN` is scoped to this repo only — so `lychee` gets a **404** and red-lights `main` itself **plus every open PR**, even though the link is perfectly valid for maintainers.

This excludes that URL from the link check, exactly the way `localhost` and other not-anonymously-verifiable URLs already are. Genuine 404/410s elsewhere still fail the job.

## Type of change

- [x] 🔧 Tooling / CI

## Checklist

- [x] My code follows the project's style (prettier-clean)
- [x] All existing tests pass (CI-config only, no code change)

## Note

This is a focused fix kept out of the larger hardening PR #579 on purpose — it's a `main`-level CI breakage that affects all PRs, so it should land on `main` independently. Once merged, open PRs go green on their next Check-links run (the job runs against the PR's merge with `main`).