### PR TITLE
fix(chat): honest hint for OpenClaw's generic provider-rejection envelope (#584)

### DIFF
--- a/packages/web/src/__tests__/api/agent-active-error.test.ts
+++ b/packages/web/src/__tests__/api/agent-active-error.test.ts
@@ -93,6 +93,36 @@ describe("/api/agents/[agentId]/active-error", () => {
       expect(mockGetActive).toHaveBeenCalledWith("agent:agent-1:direct:user-1");
     });
 
+    it("includes a role-appropriate hint for the generic provider-rejection envelope (#584)", async () => {
+      // The durable banner shows no hint of its own; without one, a provider
+      // rejection reads like a malformed-request bug. The server computes the
+      // hint from providerError + role so the banner can point an admin at
+      // their provider configuration.
+      mockGetSession.mockResolvedValueOnce({ user: { id: "user-1", role: "admin" } });
+      mockGetActive.mockResolvedValueOnce({
+        ...activeRow,
+        errorClass: "unknown",
+        transientReason: null,
+        providerError: "LLM request failed: provider rejected the request schema or tool payload.",
+      });
+      const res = await GET(getRequest(), ctx as never);
+      const body = await res.json();
+      expect(body.error.hint).toBe("Go to Settings > Providers to check your API configuration.");
+    });
+
+    it("computes the member hint from the caller's role", async () => {
+      // Default session role is `member`; non-admins can't fix provider config.
+      mockGetActive.mockResolvedValueOnce({
+        ...activeRow,
+        errorClass: "unknown",
+        transientReason: null,
+        providerError: "LLM request failed: provider rejected the request schema or tool payload.",
+      });
+      const res = await GET(getRequest(), ctx as never);
+      const body = await res.json();
+      expect(body.error.hint).toBe("Please contact your administrator.");
+    });
+
     it("scopes the lookup to the chatId when provided", async () => {
       mockGetActive.mockResolvedValueOnce(null);
       await GET(

--- a/packages/web/src/__tests__/components/chat-error-banner.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-banner.test.tsx
@@ -22,6 +22,21 @@ const transientRow = {
   createdAt: "2026-06-18T09:38:43Z",
 };
 
+// A durable provider-rejection: OpenClaw's generic catch-all, classified
+// `unknown`, carrying the server-computed admin hint (#584).
+const providerRejectionRow = {
+  id: "err-2",
+  agentName: "Smithers",
+  model: null,
+  errorClass: "unknown",
+  transientReason: null,
+  providerError: "LLM request failed: provider rejected the request schema or tool payload.",
+  sideEffects: false,
+  clientMessageId: "cm-2",
+  createdAt: "2026-06-24T09:21:00Z",
+  hint: "Go to Settings > Providers to check your API configuration.",
+};
+
 beforeEach(() => {
   vi.clearAllMocks();
   mockApiDelete.mockResolvedValue({ dismissed: true });
@@ -43,6 +58,17 @@ describe("ChatErrorBanner", () => {
     expect(screen.getByText(/rate-limiting/i)).toBeInTheDocument();
     expect(screen.getByTestId("side-effects-warning")).toBeInTheDocument();
     expect(mockApiGet).toHaveBeenCalledWith("/api/agents/agent-1/active-error?chatId=chat-7");
+  });
+
+  it("surfaces the server hint for a durable provider-rejection (#584)", async () => {
+    // Without a hint the banner shows the bare "...schema or tool payload"
+    // wording, which reads like a malformed-request bug. The server-computed
+    // admin hint must render the actionable "Settings > Providers" link.
+    mockApiGet.mockResolvedValue({ error: providerRejectionRow });
+    render(<ChatErrorBanner agentId="agent-1" onRetry={vi.fn()} />);
+
+    await waitFor(() => expect(screen.getByText("Smithers couldn't respond")).toBeInTheDocument());
+    expect(screen.getByRole("link", { name: /settings > providers/i })).toBeInTheDocument();
   });
 
   it("dismisses via the API and hides the banner", async () => {

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -43,6 +43,31 @@ describe("getErrorHint", () => {
     );
   });
 
+  describe("generic OpenClaw provider-rejection envelope → role-based hint (#584)", () => {
+    // Ground truth from staging audit (2026-06-24): when a provider rejects a
+    // run for an account-side reason (e.g. depleted credit), OpenClaw collapses
+    // the cause into this exact generic catch-all and emits it as the error
+    // chunk text. The distinguishing reason never reaches Pinchy, so we can't
+    // honestly classify it (audit class stays `unknown`) — but we CAN stop
+    // showing it bare and point an admin at their provider configuration.
+    const genericEnvelope =
+      "LLM request failed: provider rejected the request schema or tool payload.";
+
+    it("should return admin hint for the generic provider-rejection envelope", () => {
+      expect(getErrorHint(genericEnvelope, "admin")).toBe(PROVIDER_SETTINGS_HINT);
+    });
+
+    it("should return member hint for the generic provider-rejection envelope", () => {
+      expect(getErrorHint(genericEnvelope, "member")).toBe("Please contact your administrator.");
+    });
+
+    it("should match case-insensitively", () => {
+      expect(getErrorHint("PROVIDER REJECTED THE REQUEST SCHEMA OR TOOL PAYLOAD", "admin")).toBe(
+        PROVIDER_SETTINGS_HINT
+      );
+    });
+  });
+
   describe("unrecognized errors → null", () => {
     it("should return null for unrecognized errors", () => {
       expect(getErrorHint("Something completely unexpected", "admin")).toBeNull();

--- a/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
@@ -5,6 +5,7 @@ import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { directSessionKey } from "@/lib/session-key";
 import { getActiveChatSessionError, dismissChatSessionError } from "@/server/chat-session-errors";
+import { getErrorHint } from "@/server/error-hints";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -34,6 +35,10 @@ export const GET = withAuth<RouteContext>(async (request, { params }, session) =
           errorClass: row.errorClass,
           transientReason: row.transientReason,
           providerError: row.providerError,
+          // The banner renders no hint of its own; derive the same role-gated
+          // guidance the live error frame gets (client-router) so a durable
+          // provider-rejection points an admin at their provider config (#584).
+          hint: getErrorHint(row.providerError, session.user.role),
           sideEffects: row.sideEffects,
           clientMessageId: row.clientMessageId,
           createdAt: row.createdAt,

--- a/packages/web/src/components/chat-error-banner.tsx
+++ b/packages/web/src/components/chat-error-banner.tsx
@@ -17,6 +17,8 @@ interface ActiveError {
   sideEffects: boolean;
   clientMessageId: string | null;
   createdAt: string;
+  /** Role-gated guidance computed server-side from providerError (#584). */
+  hint: string | null;
 }
 
 const TRANSIENT_REASONS: TransientReason[] = ["rate_limit", "overloaded", "timeout", "unavailable"];
@@ -37,7 +39,11 @@ function toChatError(error: ActiveError): ChatError {
       },
     };
   }
-  return { agentName: error.agentName, providerError: error.providerError };
+  return {
+    agentName: error.agentName,
+    providerError: error.providerError,
+    hint: error.hint,
+  };
 }
 
 /**

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -1,4 +1,8 @@
-import { TRANSIENT_PATTERN, PROVIDER_CONFIG_PATTERN } from "@/server/error-patterns";
+import {
+  TRANSIENT_PATTERN,
+  PROVIDER_CONFIG_PATTERN,
+  PROVIDER_REJECTED_GENERIC_PATTERN,
+} from "@/server/error-patterns";
 
 export const PROVIDER_SETTINGS_HINT = "Go to Settings > Providers to check your API configuration.";
 
@@ -10,6 +14,16 @@ export function getErrorHint(errorText: string, userRole: string): string | null
   }
 
   if (PROVIDER_CONFIG_PATTERN.test(errorText)) {
+    return userRole === "admin" ? PROVIDER_SETTINGS_HINT : "Please contact your administrator.";
+  }
+
+  // OpenClaw's generic provider-rejection catch-all (#584). The real cause —
+  // most often a provider-account issue like depleted credit or an invalid
+  // key — never reaches Pinchy in the chunk text, so the audit class stays
+  // honest (`unknown`). The bare wording reads like a malformed-request bug;
+  // pointing an admin at their provider configuration is the most actionable
+  // honest guidance we can give without asserting a cause we can't prove.
+  if (PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText)) {
     return userRole === "admin" ? PROVIDER_SETTINGS_HINT : "Please contact your administrator.";
   }
 

--- a/packages/web/src/server/error-patterns.ts
+++ b/packages/web/src/server/error-patterns.ts
@@ -48,3 +48,18 @@ export const PROVIDER_CONFIG_PATTERN =
  * before we widen this anchor.
  */
 export const HTTP_5XX_PATTERN = /HTTP\s+(5\d\d)\b/i;
+
+/**
+ * OpenClaw's generic failover catch-all. When a provider rejects a run for a
+ * reason OpenClaw collapses (verified on staging: depleted credit surfaces as
+ * this string, not "credit balance too low"), the error chunk carries exactly
+ * this wording and nothing else — the distinguishing cause stays in OpenClaw's
+ * internal failover decision and never reaches Pinchy (issue #584). Because the
+ * real cause is unknowable from this text, it must NOT widen
+ * `PROVIDER_CONFIG_PATTERN` (that would assert an unproven cause in the
+ * append-only audit trail). It is used only by the user-facing hint to stop
+ * showing the bare wording — which reads like a malformed-request bug — and
+ * instead point an admin at their provider configuration.
+ */
+export const PROVIDER_REJECTED_GENERIC_PATTERN =
+  /provider rejected the request schema or tool payload/i;


### PR DESCRIPTION
## What

When an LLM provider rejects a run for an account-side reason (e.g. Anthropic "Your credit balance is too low"), the chat error surface showed the bare, misleading wording **"LLM request failed: provider rejected the request schema or tool payload."** with no guidance — in both the live bubble and the durable paused-error banner. It reads like Pinchy sent a malformed request.

This recognizes that generic OpenClaw catch-all and surfaces an honest, role-gated provider-config hint:
- **Admin** → "Go to Settings > Providers to check your API configuration." (rendered as the existing actionable link).
- **Member** → "Please contact your administrator."

The durable banner previously rendered **no hint at all**; the `active-error` route now computes the same hint the live frame already gets, so both surfaces agree.

## Ground-truth investigation (why this is the honest fix, not the one the issue proposed)

Issue #584 proposed classifying from "the WS-level `FailoverError` errorMessage (which contains 'credit balance too low')". I verified this is **not achievable in Pinchy**:

1. **Type system** — the normalized `ChatChunk` error variant in `openclaw-node` carries `{ type, text, runId }` only. No `errorCode`, no `reason`.
2. **openclaw-node source** — the error chunk text is built from `data.error` of the gateway `lifecycle.error` event (`index.mjs:435`); every other field of the event payload is discarded.
3. **Staging audit log (ground truth, 2026-06-24)** — the `chat.agent_error` rows for this failure stored exactly `error_class=unknown`, `providerError="LLM request failed: provider rejected the request schema or tool payload."`. The billing wording is **absent** — it lives only in OpenClaw's internal failover decision. (One minute later the same provider returned a real `HTTP 401`, which Pinchy *did* classify correctly as `provider_config` — so the pass-through works when OpenClaw gives us a meaningful string.)

Because the distinguishing cause never reaches Pinchy, the audit class **deliberately stays `unknown`** rather than asserting an unproven billing cause in the append-only, HMAC-signed trail. We change only the user-facing hint, not the audit label.

## The real fix is upstream

The full resolution (distinguishing billing/quota/policy from a genuine schema rejection) requires OpenClaw to preserve the underlying provider error — or a structured `reason` — in the failover error chunk instead of collapsing it to a generic envelope. Built on OpenClaw (https://heypinchy.com) — happy to file that upstream if useful; flagging it here so #584 can track the dependency.

## Tests (TDD, all RED→GREEN)
- `error-hints.test.ts` — generic envelope → admin/member hint, case-insensitive.
- `agent-active-error.test.ts` — route includes a role-appropriate `hint` for the generic envelope.
- `chat-error-banner.test.tsx` — durable banner renders the Settings > Providers link for a provider-rejection.

Full unit suite green (6359 passed); lint 0 errors; tsc clean; prettier clean.

Refs #584
