### PR TITLE
fix(models): harden ollama-cloud model resolution against upstream retirement + runtime self-heal

### DIFF
--- a/packages/web/src/__tests__/lib/model-retirement.test.ts
+++ b/packages/web/src/__tests__/lib/model-retirement.test.ts
@@ -1,0 +1,44 @@
+import { describe, it, expect } from "vitest";
+import { isRetiredModelError } from "@/lib/model-retirement";
+
+describe("isRetiredModelError", () => {
+  it("matches the HTTP 410 retired error we saw in production", () => {
+    // Real audit row from pinchy.heypinchy.com (2026-06-24):
+    expect(
+      isRetiredModelError(
+        new Error(
+          'PDF model failed (ollama-cloud/qwen3-vl:235b-instruct): 410 "qwen3-vl:235b-instruct was retired at 2026-06-16 00:00:00 -0700 PDT"'
+        )
+      )
+    ).toBe(true);
+  });
+
+  it("matches an Unknown model error", () => {
+    expect(
+      isRetiredModelError(new Error("Unknown model: ollama-cloud/gemini-2-preview-0514"))
+    ).toBe(true);
+  });
+
+  it("matches model_not_found (OpenAI-style) and a plain string", () => {
+    expect(isRetiredModelError("model_not_found")).toBe(true);
+    expect(isRetiredModelError({ message: "the model was retired" })).toBe(true);
+  });
+
+  it("does NOT match a capability error (400 image not enabled) — re-resolve won't fix it", () => {
+    expect(
+      isRetiredModelError(
+        new Error(
+          'PDF model failed (ollama-cloud/devstral-small-2:24b): 400 "Image input is not enabled for this model"'
+        )
+      )
+    ).toBe(false);
+  });
+
+  it("does NOT match unrelated errors or empty input", () => {
+    expect(isRetiredModelError(new Error("Local media file not found"))).toBe(false);
+    expect(isRetiredModelError(new Error("Expected PDF but got image/webp"))).toBe(false);
+    expect(isRetiredModelError(undefined)).toBe(false);
+    expect(isRetiredModelError(null)).toBe(false);
+    expect(isRetiredModelError("")).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -111,8 +111,23 @@ vi.mock("@/lib/provider-models", () => {
     "ollama-cloud": "ollama-cloud/gemini-3-flash-preview",
     "ollama-local": "",
   };
+  // Default "live" catalog: all three ollama-cloud image-preference models are
+  // present. Individual tests override this to simulate an upstream retirement
+  // (a model dropping out of /v1/models).
+  const fetchProviderModels = vi.fn(async () => [
+    {
+      id: "ollama-cloud",
+      name: "Ollama Cloud",
+      models: [
+        { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini-3-flash-preview" },
+        { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
+        { id: "ollama-cloud/gemma4:31b", name: "gemma4:31b" },
+      ],
+    },
+  ]);
   return {
     getDefaultModel: vi.fn(async (provider: string) => defaults[provider] ?? ""),
+    fetchProviderModels,
     fetchOllamaLocalModelsFromUrl: vi.fn().mockResolvedValue([]),
   };
 });
@@ -141,8 +156,9 @@ import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-con
 import { getPendingConfigPushCount, _resetConfigPushState } from "@/lib/openclaw-config/push-state";
 import { db } from "@/db";
 import { getSetting } from "@/lib/settings";
-import { fetchOllamaLocalModelsFromUrl } from "@/lib/provider-models";
+import { fetchOllamaLocalModelsFromUrl, fetchProviderModels } from "@/lib/provider-models";
 
+const mockedFetchProviderModels = vi.mocked(fetchProviderModels);
 const mockedWriteFileSync = vi.mocked(writeFileSync);
 const mockedReadFileSync = vi.mocked(readFileSync);
 const mockedExistsSync = vi.mocked(existsSync);
@@ -6998,5 +7014,45 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
 
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
     expect(config.agents.defaults.imageModel.primary).toBe("google/gemini-2.5-flash");
+  });
+
+  it("skips a preferred ollama-cloud image model that is no longer in the live catalog", async () => {
+    // The v0.5.8 incident: `gemini-3-flash-preview` would normally win, but if
+    // Ollama retires it upstream it drops out of /v1/models. The resolver must
+    // NOT pin the dead model — it falls through to the next LIVE preference.
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    mockedFetchProviderModels.mockResolvedValueOnce([
+      {
+        id: "ollama-cloud",
+        name: "Ollama Cloud",
+        // gemini-3-flash-preview retired upstream → absent here.
+        models: [
+          { id: "ollama-cloud/minimax-m3", name: "minimax-m3" },
+          { id: "ollama-cloud/gemma4:31b", name: "gemma4:31b" },
+        ],
+      },
+    ]);
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.imageModel.primary).toBe("ollama-cloud/minimax-m3");
+  });
+
+  it("emits no imageModel when no preferred ollama-cloud model is live", async () => {
+    // Every vision-verified preference has been retired upstream. Better to
+    // emit no imageModel (built-in image tool simply doesn't register) than to
+    // pin a dead model that 410s on every call.
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    mockedFetchProviderModels.mockResolvedValueOnce([
+      { id: "ollama-cloud", name: "Ollama Cloud", models: [] },
+    ]);
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents?.defaults?.imageModel).toBeUndefined();
   });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -7055,4 +7055,17 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
     expect(config.agents?.defaults?.imageModel).toBeUndefined();
   });
+
+  it("emits no imageModel when the live catalog has no ollama-cloud provider at all", async () => {
+    // Defensive: if /v1/models fetch yields no ollama-cloud entry (and the
+    // FALLBACK didn't kick in), the live id set is empty → no pick, no pin.
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    mockedFetchProviderModels.mockResolvedValueOnce([]);
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents?.defaults?.imageModel).toBeUndefined();
+  });
 });

--- a/packages/web/src/__tests__/server/attachment-pipeline.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline.test.ts
@@ -157,9 +157,9 @@ describe("buildAttachmentBlock", () => {
   });
 
   // The previous implementation silently fell back to a vague "the
-  // appropriate built-in tool" string for any MIME outside PDF/image. That
+  // appropriate built-in tool" string for any MIME outside the allowlist. That
   // would leave the agent guessing on a future MIME we forgot to wire.
-  it("throws when given a MIME type with no registered built-in tool", async () => {
+  it("throws when given a MIME type with no registered tool", async () => {
     const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
     expect(() =>
       buildAttachmentBlock([
@@ -172,7 +172,7 @@ describe("buildAttachmentBlock", () => {
           reused: false,
         },
       ])
-    ).toThrow(/no built-in tool/i);
+    ).toThrow(/no tool registered/i);
   });
 });
 

--- a/packages/web/src/__tests__/server/attachment-pipeline.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline.test.ts
@@ -60,6 +60,27 @@ describe("buildAttachmentBlock", () => {
     expect(block).not.toContain("analyze with `pdf`");
   });
 
+  it("routes images to `pinchy_read`, not OpenClaw's built-in `image` tool", async () => {
+    // The built-in `image` tool only registers when Pinchy emits `imageModel`,
+    // which is auto-resolved and dies when the upstream model is retired (the
+    // same class of failure that broke the `pdf` tool, #501). pinchy_read reads
+    // image files as image content blocks via the runtime modelAuth API and
+    // works on every provider/model — so images route through it too.
+    const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
+    const block = buildAttachmentBlock([
+      {
+        relativePath: "uploads/receipt.png",
+        absolutePath: "/root/.openclaw/workspaces/test/uploads/receipt.png",
+        mimeType: "image/png",
+        sizeBytes: 30_000,
+        contentHash: "c".repeat(64),
+        reused: false,
+      },
+    ]);
+    expect(block).toContain("analyze with `pinchy_read`");
+    expect(block).not.toContain("analyze with `image`");
+  });
+
   it("returns empty string when no uploads", async () => {
     const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
     expect(buildAttachmentBlock([])).toBe("");
@@ -108,9 +129,11 @@ describe("buildAttachmentBlock", () => {
         reused: false,
       },
     ]);
-    // Must reference the actual built-in tool names
-    expect(block).toMatch(/\bpdf\b/);
-    expect(block).toMatch(/\bimage\b/);
+    // Both PDF and image attachments route through pinchy_read (the built-in
+    // pdf/image tools are no longer registered — see model-resilience work).
+    expect(block.match(/analyze with `pinchy_read`/g)).toHaveLength(2);
+    expect(block).not.toContain("analyze with `pdf`");
+    expect(block).not.toContain("analyze with `image`");
     // Must use the absolute workspace path (not relative)
     expect(block).toContain("/root/.openclaw/workspaces/agent-1/uploads/invoice.pdf");
     expect(block).toContain("/root/.openclaw/workspaces/agent-1/uploads/photo.png");

--- a/packages/web/src/__tests__/server/model-self-heal.test.ts
+++ b/packages/web/src/__tests__/server/model-self-heal.test.ts
@@ -1,0 +1,24 @@
+import { describe, it, expect } from "vitest";
+import { shouldSelfHeal } from "@/server/model-self-heal";
+
+const COOLDOWN = 5 * 60 * 1000;
+
+describe("shouldSelfHeal", () => {
+  it("triggers on a retired-model error when the cooldown has elapsed", () => {
+    const err = new Error('410 "qwen3-vl:235b-instruct was retired"');
+    expect(shouldSelfHeal(err, 0, COOLDOWN, COOLDOWN)).toBe(true);
+  });
+
+  it("does NOT re-trigger within the cooldown window (burst debounce)", () => {
+    const err = new Error("Unknown model: ollama-cloud/foo");
+    const lastHeal = 1_000_000;
+    // 30s later — a retirement makes every dispatch fail; must not regenerate
+    // config on each one.
+    expect(shouldSelfHeal(err, lastHeal, lastHeal + 30_000, COOLDOWN)).toBe(false);
+  });
+
+  it("does NOT trigger for a non-retirement error even past the cooldown", () => {
+    const err = new Error("Local media file not found");
+    expect(shouldSelfHeal(err, 0, 10 * COOLDOWN, COOLDOWN)).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/server/model-self-heal.test.ts
+++ b/packages/web/src/__tests__/server/model-self-heal.test.ts
@@ -1,5 +1,19 @@
-import { describe, it, expect } from "vitest";
-import { shouldSelfHeal } from "@/server/model-self-heal";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("@/lib/openclaw-config", () => ({
+  regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
+}));
+vi.mock("@/lib/provider-models", () => ({
+  resetCache: vi.fn(),
+}));
+
+import {
+  shouldSelfHeal,
+  maybeSelfHealOnModelError,
+  _resetSelfHealState,
+} from "@/server/model-self-heal";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { resetCache } from "@/lib/provider-models";
 
 const COOLDOWN = 5 * 60 * 1000;
 
@@ -20,5 +34,39 @@ describe("shouldSelfHeal", () => {
   it("does NOT trigger for a non-retirement error even past the cooldown", () => {
     const err = new Error("Local media file not found");
     expect(shouldSelfHeal(err, 0, 10 * COOLDOWN, COOLDOWN)).toBe(false);
+  });
+});
+
+describe("maybeSelfHealOnModelError", () => {
+  beforeEach(() => {
+    _resetSelfHealState();
+    vi.clearAllMocks();
+  });
+
+  it("busts the provider-models cache BEFORE regenerating, so re-resolution fetches a fresh /v1/models", async () => {
+    const healed = await maybeSelfHealOnModelError(
+      new Error('410 "qwen3-vl:235b-instruct was retired"')
+    );
+    expect(healed).toBe(true);
+    expect(resetCache).toHaveBeenCalledTimes(1);
+    expect(regenerateOpenClawConfig).toHaveBeenCalledTimes(1);
+    // Order matters: a stale 1h cache would otherwise re-pick the dead model.
+    expect(vi.mocked(resetCache).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(regenerateOpenClawConfig).mock.invocationCallOrder[0]
+    );
+  });
+
+  it("debounces a burst — a second retirement error within the cooldown does not regenerate again", async () => {
+    await maybeSelfHealOnModelError(new Error("Unknown model: ollama-cloud/foo"));
+    const second = await maybeSelfHealOnModelError(new Error("Unknown model: ollama-cloud/foo"));
+    expect(second).toBe(false);
+    expect(regenerateOpenClawConfig).toHaveBeenCalledTimes(1);
+  });
+
+  it("does nothing for a non-retirement error", async () => {
+    const healed = await maybeSelfHealOnModelError(new Error("Local media file not found"));
+    expect(healed).toBe(false);
+    expect(resetCache).not.toHaveBeenCalled();
+    expect(regenerateOpenClawConfig).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/lib/model-retirement.ts
+++ b/packages/web/src/lib/model-retirement.ts
@@ -18,6 +18,12 @@
  * model" — re-resolving doesn't fix a model that exists but lacks a capability;
  * that's the curated-list's job, not self-heal's.
  */
+// Patterns are intentionally broad. The only consumer is the self-heal path,
+// where a false positive is cheap (one debounced, idempotent config
+// regeneration) but a false negative is costly (a genuinely retired model
+// keeps 410ing with no heal). So we bias toward catching retirements — e.g.
+// bare `410` matches even when the body doesn't say "retired". `\b410\b`
+// won't fire on substrings like "410ms" (no word boundary before "ms").
 const RETIREMENT_PATTERNS: readonly RegExp[] = [
   /\b410\b/,
   /\bretired\b/i,

--- a/packages/web/src/lib/model-retirement.ts
+++ b/packages/web/src/lib/model-retirement.ts
@@ -1,0 +1,40 @@
+/**
+ * Classify whether an error from an OpenClaw tool/model dispatch indicates the
+ * configured model is no longer AVAILABLE upstream (retired / unknown), as
+ * opposed to a transient or capability error.
+ *
+ * Motivation: providers retire models without advance notice (Ollama Cloud
+ * documents a deprecation table but no notice window and no RSS/webhook —
+ * https://docs.ollama.com/cloud). When a configured model is retired, every
+ * dispatch fails the same way (e.g. HTTP 410 "qwen3-vl:235b-instruct was
+ * retired"). OpenClaw has no fallback resolver, so Pinchy self-heals: a
+ * retired-model error triggers a config regeneration, which re-resolves media
+ * models against the live `/v1/models` catalog (see `default-media-models.ts`).
+ *
+ * We deliberately match AVAILABILITY signals only:
+ *   - HTTP 410 ("retired"/"gone")
+ *   - "Unknown model" / "model_not_found" / HTTP 404 on a model id
+ * and NOT capability errors like 400 "Image input is not enabled for this
+ * model" — re-resolving doesn't fix a model that exists but lacks a capability;
+ * that's the curated-list's job, not self-heal's.
+ */
+const RETIREMENT_PATTERNS: readonly RegExp[] = [
+  /\b410\b/,
+  /\bretired\b/i,
+  /\bunknown model\b/i,
+  /\bmodel[_ ]not[_ ]found\b/i,
+  /\bno longer available\b/i,
+];
+
+export function isRetiredModelError(error: unknown): boolean {
+  const message =
+    error instanceof Error
+      ? error.message
+      : typeof error === "string"
+        ? error
+        : error && typeof error === "object" && "message" in error
+          ? String((error as { message: unknown }).message)
+          : "";
+  if (!message) return false;
+  return RETIREMENT_PATTERNS.some((re) => re.test(message));
+}

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -1,6 +1,6 @@
 import { PROVIDERS, type ProviderName } from "@/lib/providers";
 import { getSetting } from "@/lib/settings";
-import { getDefaultModel } from "@/lib/provider-models";
+import { getDefaultModel, fetchProviderModels } from "@/lib/provider-models";
 import { isModelVisionCapable } from "@/lib/model-vision";
 import { ensureModelCapabilityCacheLoaded } from "@/lib/model-capabilities/cache";
 import {
@@ -120,9 +120,40 @@ export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   "gemma4:31b",
 ];
 
-function pickOllamaCloudImageModel(): string | null {
+/**
+ * Bare ollama-cloud model ids that are currently LIVE — i.e. present in the
+ * provider's `/v1/models` catalog right now.
+ *
+ * `fetchProviderModels` already intersects the live `/v1/models` response with
+ * the curated tool-capable set and, on a fetch failure, falls back to the full
+ * curated list (`FALLBACK_MODELS`). So this is "live ∩ curated, degrading to
+ * curated when offline" — exactly the availability signal we want, without a
+ * second network call. We strip the `ollama-cloud/` prefix to compare against
+ * the bare catalog ids in `OLLAMA_CLOUD_IMAGE_PREFERENCE`.
+ */
+async function fetchLiveOllamaCloudModelIds(): Promise<Set<string>> {
+  const providers = await fetchProviderModels();
+  const oc = providers.find((p) => p.id === "ollama-cloud");
+  if (!oc) return new Set();
+  return new Set(oc.models.map((m) => m.id.replace(/^ollama-cloud\//, "")));
+}
+
+/**
+ * Pick the best vision-verified ollama-cloud image model that is BOTH curated
+ * (empirically vision-capable) AND currently live in the catalog.
+ *
+ * The live-availability gate is the fix for the v0.5.8 incident: the resolver
+ * used to pick a model purely from the static curated list, so when Ollama
+ * retired `qwen3-vl:235b-instruct` upstream (HTTP 410) the dead model stayed
+ * pinned in `openclaw.json` until the next Pinchy upgrade. Intersecting with
+ * the live `/v1/models` catalog means a retired model is skipped immediately —
+ * the resolver falls through to the next live preference (`minimax-m3` …).
+ */
+async function pickOllamaCloudImageModel(): Promise<string | null> {
+  const liveIds = await fetchLiveOllamaCloudModelIds();
   for (const id of OLLAMA_CLOUD_IMAGE_PREFERENCE) {
-    if (TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.some((m) => m.id === id)) {
+    const curated = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.some((m) => m.id === id);
+    if (curated && liveIds.has(id)) {
       return `ollama-cloud/${id}`;
     }
   }
@@ -135,7 +166,7 @@ export async function resolveDefaultImageModel(): Promise<string | null> {
     const key = await getSetting(PROVIDERS[provider].settingsKey);
     if (!key) continue;
     if (provider === "ollama-cloud") {
-      const picked = pickOllamaCloudImageModel();
+      const picked = await pickOllamaCloudImageModel();
       if (picked) return picked;
       continue;
     }

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -273,7 +273,13 @@ function toolNameForMime(mimeType: string): string {
   // pdfModel points at — so it fails "Unknown model" for the common case
   // (v0.5.8 staging finding; OpenClaw upstream issue filed separately).
   if (mimeType === "application/pdf") return "`pinchy_read`";
-  if (mimeType.startsWith("image/")) return "`image`";
+  // Images route through pinchy_read too, NOT OpenClaw's built-in `image`
+  // tool. That tool only registers when Pinchy emits `imageModel`, which is
+  // auto-resolved against the live vision-capable models and dies when the
+  // upstream model is retired (HTTP 410) — the same failure class that broke
+  // the `pdf` tool (#501). pinchy_read reads images as image content blocks
+  // via the runtime modelAuth API and works on every provider/model/version.
+  if (mimeType.startsWith("image/")) return "`pinchy_read`";
   // Text formats (CSV, Markdown, JSON, YAML, plain text) are workspace files
   // read via the pinchy_read plugin tool rather than an OpenClaw built-in.
   if (

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -254,44 +254,42 @@ export async function materializeAttachments(
   return { chatAttachments, workspaceRefs };
 }
 
+// Text formats analyzed as workspace files. PDFs and images are handled by
+// the prefix/exact checks in toolNameForMime.
+const PINCHY_READ_TEXT_MIMES = new Set([
+  "text/plain",
+  "text/csv",
+  "text/markdown",
+  "application/json",
+  "text/yaml",
+]);
+
 /**
- * Resolve the built-in OpenClaw tool name for a given attachment MIME type.
+ * Resolve the tool an attachment of `mimeType` should be analyzed with.
  *
- * Throws if a MIME type slips through that's outside the documented set —
- * the upload hint must be specific (which built-in tool to call), and a
- * silent fallback ("the appropriate built-in tool") would leave the agent
- * guessing. If a new attachment type is whitelisted, this function must be
- * updated in the same change.
+ * Every supported type routes through pinchy-files' own `pinchy_read` — a
+ * plugin tool, NOT an OpenClaw built-in. It has a full PDF subsystem
+ * (pdf-extract for the text layer; pdf-vision for scanned pages), reads images
+ * as image content blocks, and resolves credentials through the runtime
+ * modelAuth API, so it works on every provider/model/version. We deliberately
+ * do NOT use OpenClaw's built-in `pdf`/`image` tools: they only register when
+ * Pinchy emits `pdfModel`/`imageModel`, which is auto-resolved and 410s when
+ * the upstream model is retired (v0.5.8 incident, #501).
+ *
+ * Throws on a MIME outside the documented set — the upload hint must be
+ * specific, and a silent fallback would leave the agent guessing. If a new
+ * attachment type is whitelisted, update this allowlist in the same change.
  */
 function toolNameForMime(mimeType: string): string {
-  // PDFs are read via pinchy-files' own `pinchy_read`, which has a full,
-  // tested PDF subsystem (pdf-extract for the text layer; pdf-vision for
-  // scanned pages) and resolves credentials through the runtime modelAuth
-  // API. We deliberately do NOT use OpenClaw's built-in `pdf` tool: it
-  // resolves its model only against the per-agent models.json catalog, which
-  // never contains the built-in providers (anthropic/openai/google) a typical
-  // pdfModel points at — so it fails "Unknown model" for the common case
-  // (v0.5.8 staging finding; OpenClaw upstream issue filed separately).
-  if (mimeType === "application/pdf") return "`pinchy_read`";
-  // Images route through pinchy_read too, NOT OpenClaw's built-in `image`
-  // tool. That tool only registers when Pinchy emits `imageModel`, which is
-  // auto-resolved against the live vision-capable models and dies when the
-  // upstream model is retired (HTTP 410) — the same failure class that broke
-  // the `pdf` tool (#501). pinchy_read reads images as image content blocks
-  // via the runtime modelAuth API and works on every provider/model/version.
-  if (mimeType.startsWith("image/")) return "`pinchy_read`";
-  // Text formats (CSV, Markdown, JSON, YAML, plain text) are workspace files
-  // read via the pinchy_read plugin tool rather than an OpenClaw built-in.
   if (
-    mimeType === "text/plain" ||
-    mimeType === "text/csv" ||
-    mimeType === "text/markdown" ||
-    mimeType === "application/json" ||
-    mimeType === "text/yaml"
-  )
+    mimeType === "application/pdf" ||
+    mimeType.startsWith("image/") ||
+    PINCHY_READ_TEXT_MIMES.has(mimeType)
+  ) {
     return "`pinchy_read`";
+  }
   throw new Error(
-    `attachment-pipeline: no built-in tool registered for MIME ${mimeType}. ` +
+    `attachment-pipeline: no tool registered for MIME ${mimeType}. ` +
       `Update toolNameForMime() when adding a new attachment type.`
   );
 }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -1802,6 +1802,12 @@ export class ClientRouter {
     // Self-heal: if this error means the agent's model was retired upstream
     // (HTTP 410 / "Unknown model"), regenerate config so it re-resolves to a
     // live model. Fire-and-forget + debounced + never throws.
+    //
+    // Scope: this hook covers the CHAT-model path (an agent pinned to a model
+    // that was retired). The built-in pdf/image tools hit the same failure on
+    // their own dispatch path, but Pinchy is removing those in favour of
+    // pinchy_read (#501 follow-up), so we don't wire self-heal into the
+    // tool-dispatch audit path here.
     void maybeSelfHealOnModelError(args.providerError);
   }
 }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -15,6 +15,7 @@ import { getLicenseState } from "@/lib/enterprise";
 import { buildMemoryPromptBlock } from "@/lib/memory-prompt";
 import { appendAuditLog, safeProviderError } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
+import { maybeSelfHealOnModelError } from "@/server/model-self-heal";
 import { ActiveRuns } from "@/server/active-runs";
 import { iterateUntilAborted } from "@/server/abortable-stream";
 import { NEVER_DISCONNECTS, type DisconnectSignal } from "@/server/openclaw-disconnect-signal";
@@ -1797,6 +1798,11 @@ export class ClientRouter {
     } catch (err) {
       recordAuditFailure(err, auditEntry);
     }
+
+    // Self-heal: if this error means the agent's model was retired upstream
+    // (HTTP 410 / "Unknown model"), regenerate config so it re-resolves to a
+    // live model. Fire-and-forget + debounced + never throws.
+    void maybeSelfHealOnModelError(args.providerError);
   }
 }
 

--- a/packages/web/src/server/model-self-heal.ts
+++ b/packages/web/src/server/model-self-heal.ts
@@ -1,5 +1,6 @@
 import { isRetiredModelError } from "@/lib/model-retirement";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { resetCache } from "@/lib/provider-models";
 
 /**
  * Runtime self-heal: when a chat/tool dispatch fails because the configured
@@ -42,6 +43,12 @@ export async function maybeSelfHealOnModelError(error: unknown): Promise<boolean
   if (!shouldSelfHeal(error, lastHealAtMs, now)) return false;
   lastHealAtMs = now;
   try {
+    // Bust the 1h provider-models cache FIRST. `regenerateOpenClawConfig`
+    // re-resolves media models via `fetchProviderModels`, which is cached for
+    // an hour — without this reset the re-resolution would read stale data
+    // that still lists the just-retired model and re-pin it, making the heal a
+    // no-op until the cache expired.
+    resetCache();
     await regenerateOpenClawConfig();
     console.log(
       "[pinchy] Self-heal: regenerated OpenClaw config after a retired-model dispatch error"

--- a/packages/web/src/server/model-self-heal.ts
+++ b/packages/web/src/server/model-self-heal.ts
@@ -1,0 +1,59 @@
+import { isRetiredModelError } from "@/lib/model-retirement";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+
+/**
+ * Runtime self-heal: when a chat/tool dispatch fails because the configured
+ * model was retired upstream (HTTP 410 / "Unknown model"), regenerate the
+ * OpenClaw config. `regenerateOpenClawConfig` re-resolves media models against
+ * the LIVE `/v1/models` catalog (see `default-media-models.ts`) and skips the
+ * write when nothing changed — so a retired model is swapped for a live one
+ * without waiting for the next Pinchy upgrade or restart.
+ *
+ * OpenClaw has no fallback resolver of its own, so this is Pinchy's job. The
+ * regeneration is debounced: a retirement makes EVERY dispatch fail the same
+ * way, and we must not regenerate config (and trigger an OC hot-reload) on
+ * every error in a burst.
+ */
+const SELF_HEAL_COOLDOWN_MS = 5 * 60 * 1000; // 5 minutes
+
+let lastHealAtMs = 0;
+
+/**
+ * Pure decision: should a retired-model error trigger a regeneration now?
+ * Exposed for testing without faking timers or the heavy regenerate call.
+ */
+export function shouldSelfHeal(
+  error: unknown,
+  lastHealMs: number,
+  nowMs: number,
+  cooldownMs: number = SELF_HEAL_COOLDOWN_MS
+): boolean {
+  if (!isRetiredModelError(error)) return false;
+  return nowMs - lastHealMs >= cooldownMs;
+}
+
+/**
+ * Best-effort: if `error` signals a retired model and we're past the cooldown,
+ * regenerate config. Never throws — a self-heal failure must not break the
+ * caller's error-handling path. Returns true when a regeneration ran.
+ */
+export async function maybeSelfHealOnModelError(error: unknown): Promise<boolean> {
+  const now = Date.now();
+  if (!shouldSelfHeal(error, lastHealAtMs, now)) return false;
+  lastHealAtMs = now;
+  try {
+    await regenerateOpenClawConfig();
+    console.log(
+      "[pinchy] Self-heal: regenerated OpenClaw config after a retired-model dispatch error"
+    );
+    return true;
+  } catch (err) {
+    console.error("[pinchy] Self-heal config regeneration failed:", err);
+    return false;
+  }
+}
+
+/** Test hook — reset the debounce clock between cases. */
+export function _resetSelfHealState(): void {
+  lastHealAtMs = 0;
+}


### PR DESCRIPTION
## Why

Production (`pinchy.heypinchy.com`, ollama-cloud-only stack) hit repeated PDF failures. The audit log shows the root cause:

```
tool.pdf  failure  PDF model failed (ollama-cloud/qwen3-vl:235b-instruct):
410 "qwen3-vl:235b-instruct was retired at 2026-06-16"
```

Ollama Cloud **retired** the auto-resolved vision model. Pinchy had pinned it in `openclaw.json` from a static curated list, so every PDF/image read 410'd until the next upgrade + restart. This has happened **three times** (`devstral-small-2` 400, `gemini-2-preview` "Unknown model", `qwen3-vl` 410). Ollama publishes a deprecation table at https://docs.ollama.com/cloud but gives **no advance-notice window and no RSS/webhook**, and `/v1/models` exposes availability but **not** capabilities — so the model list drifts out from under us.

This PR hardens model resolution so a retired model can no longer break agents, and self-heals at runtime instead of waiting for an upgrade. Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com)'s self-hosted governance layer.

## What

1. **Live-availability-aware resolution** — `resolveDefaultImageModel`'s ollama-cloud pick is now intersected with the live `/v1/models` catalog (via `fetchProviderModels`, which already degrades to the curated `FALLBACK` list offline). A model that's been retired upstream is skipped immediately; the resolver falls through to the next live, vision-verified preference. **Capability** flags stay empirically curated (Ollama's endpoints mislabel vision), only **availability** is taken live.

2. **Runtime self-heal** — a dispatch error classified as a retirement (`410` / `Unknown model` / `model_not_found`) triggers a debounced `regenerateOpenClawConfig()`, which re-resolves against the live catalog. OpenClaw has no fallback resolver of its own, so this is Pinchy's job.

3. **Images route via `pinchy_read`** — image attachments no longer depend on OpenClaw's built-in `image` tool (which only registers when `imageModel` is emitted and dies on a retired model, same failure class). `pinchy_read` reads images via the runtime `modelAuth` API and works on every provider/version — same treatment PDFs already got in #500.

## Tests

- `model-retirement.test.ts` — classifier matches the real production 410/`Unknown model` rows, rejects capability errors (400 "image not enabled") and noise.
- `model-self-heal.test.ts` — pure debounce/decision logic (retirement + cooldown).
- `openclaw-config.test.ts` — a retired preferred model is skipped for a live one; no `imageModel` emitted when none are live.
- `attachment-pipeline.test.ts` — images route to `pinchy_read`, never the built-in `image` tool.
- Full web unit suite green (**6352 passed**), `tsc` clean, ESLint 0 errors, Prettier clean.

The `client-router` self-heal call site (one fire-and-forget line) and the actual OpenClaw hot-reload are exercised first in CI/staging — the decision logic it depends on is unit-tested.

## Deliberately scoped out (follow-ups)

This is the resilience core. Tracked for a focused follow-up PR because they need the running OpenClaw/E2E stack to verify, or are larger behavior changes:

- **Fully remove** the built-in `pdf`/`image` tools (stop emitting `pdfModel`/`imageModel`) and give `pinchy_read` a dedicated live-resolved `visionModel` via plugin config (today it uses the agent's chat model, which may be text-only). Needs the plugin-boundary manifest sync + E2E.
- **Background refresh** — a scheduled `regenerateOpenClawConfig()` (LiteLLM-style ~6h) so a deployment self-heals even with no chat traffic.
- **CI drift job** — diff the curated list against `/v1/models` **and** the deprecation table, opening a migration issue (retired→replacement).
- Docs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
