### PR TITLE
fix(chat): per-chat composer drafts + reopen last-viewed chat

### DIFF
--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -63,6 +63,10 @@ When you send a message and move to a different page in Pinchy, the chat keeps r
 
 A full page reload does not lose the reply either. Pinchy re-attaches the reloaded chat to the in-flight run through its stable session key, so any output that arrived while the page was reloading still lands in the same bubble and streaming continues. Only a restart of the Pinchy server drops in-flight runs.
 
+An unsent message you've typed is kept too. Each chat holds its own draft, so a message you start in one chat never appears in another — and when you leave a chat and come back, your draft is waiting where you left it. Sending the message clears the draft; so does deleting the text yourself.
+
+Clicking an agent in the sidebar reopens the chat you last had open with that agent on this device, rather than starting from the oldest one. The first time you open an agent on a new device, Pinchy takes you to your most recent conversation with it.
+
 ## Paused: agent errors survive a reload
 
 Some agent errors are only temporary — the model provider is rate-limiting requests, is overloaded, timed out, or is briefly unavailable. When one of these interrupts a run, the chat shows an error bubble that names the actual cause (we don't label everything a "rate limit").

--- a/packages/web/e2e/integration/16-in-app-navigation-persists-chat.spec.ts
+++ b/packages/web/e2e/integration/16-in-app-navigation-persists-chat.spec.ts
@@ -118,15 +118,18 @@ test.describe("In-app navigation chat persistence (#199)", () => {
   //
   // 2. "Composer draft survives in-app navigation"
   //    The composer state in @assistant-ui/react is internal to the
-  //    AssistantRuntime. While the runtime instance survives the
-  //    consumer's unmount/remount (proven by runtime-stability.test.tsx),
-  //    the composer's textarea value is not preserved by the runtime in
-  //    the version we use; the textarea reads its initial value as ""
-  //    on every mount. Until that's fixed upstream (or we wrap the
-  //    composer with our own draft cache), claiming "draft survives
-  //    navigation" would be a false promise — so this test was removed
-  //    along with the corresponding line in
-  //    docs/explanation/chat-states.mdx.
+  //    AssistantRuntime, and the textarea reads its initial value as ""
+  //    on every mount — so the runtime alone does NOT carry a draft across
+  //    a consumer remount. Pinchy therefore wraps the composer with its own
+  //    per-(agent,chat) draft cache (the DraftPersistence component +
+  //    draft-store), which restores the draft on mount and clears it on send
+  //    or manual delete. That behaviour — per-chat isolation (no bleed),
+  //    restore-on-return, and clear-on-empty — is pinned against the REAL
+  //    assistant-ui composer in
+  //    src/components/assistant-ui/__tests__/draft-persistence.test.tsx,
+  //    which is the right level: the draft is pure client state and does not
+  //    cross OpenClaw, so an E2E here would add no coverage the component
+  //    test doesn't already give deterministically.
   //
   // 3. "Sidebar pulse dot stays visible after navigating to /agents"
   //    The user-visible feature relies on Next.js client-side navigation

--- a/packages/web/e2e/integration/20-last-chat-reopen.spec.ts
+++ b/packages/web/e2e/integration/20-last-chat-reopen.spec.ts
@@ -1,0 +1,53 @@
+import { test, expect } from "@playwright/test";
+import { login, getSmithersAgentId } from "./helpers";
+
+// End-to-end guard for "reopen the chat I last had open" (#508).
+//
+// The unit tests cover each seam (Chat records the last-viewed chat, the sidebar
+// resolves the link from localStorage, the default route redirects as a fallback).
+// This pins the seams together through real navigation: visit a named chat, leave
+// to another page, then the agent's sidebar link must point back to that chat —
+// not the bare /chat/<agentId> that lands on the oldest/default chat.
+//
+// Deliberately OpenClaw-independent: the assertion is purely the resolved link and
+// the resulting URL, so there is no streaming/timing flake surface. localStorage is
+// written by <Chat> on mount (before it gates on the runtime), so the named chat
+// need not have a server session.
+test.describe("Reopen last-viewed chat (#508)", () => {
+  test("the agent sidebar link returns to the chat last viewed on this device", async ({
+    browser,
+  }) => {
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+
+    const namedChatId = "e2e-last-chat";
+
+    // Visit a named chat — <Chat> records it as this agent's last-viewed chat.
+    await page.goto(`/chat/${agentId}/${namedChatId}`);
+    await expect
+      .poll(() => page.evaluate((aid) => localStorage.getItem(`pinchy:lastChat:${aid}`), agentId), {
+        timeout: 15000,
+      })
+      .toBe(namedChatId);
+
+    // Leave to a non-chat page; the sidebar stays mounted in the app layout.
+    await page.goto("/usage");
+
+    // The agent's sidebar link must resolve to the last-viewed chat, not the bare
+    // /chat/<agentId> (which would land on the oldest/default chat).
+    const agentLink = page.locator(`a[href^="/chat/${agentId}"]`).first();
+    await expect(agentLink).toHaveAttribute("href", `/chat/${agentId}/${namedChatId}`, {
+      timeout: 15000,
+    });
+
+    // Clicking it lands on that chat (the named route renders directly, no redirect).
+    await agentLink.click();
+    await expect(page).toHaveURL((url) => url.pathname === `/chat/${agentId}/${namedChatId}`, {
+      timeout: 15000,
+    });
+
+    await ctx.close();
+  });
+});

--- a/packages/web/src/__tests__/app/chat-page.test.tsx
+++ b/packages/web/src/__tests__/app/chat-page.test.tsx
@@ -5,8 +5,19 @@ const mockNotFound = vi.fn(() => {
   throw new Error("NOT_FOUND");
 });
 
+const mockRedirect = vi.fn((url: string) => {
+  throw new Error(`REDIRECT:${url}`);
+});
+
 vi.mock("next/navigation", () => ({
   notFound: () => mockNotFound(),
+  redirect: (url: string) => mockRedirect(url),
+}));
+
+const mockSessionsList = vi.fn();
+
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ sessions: { list: mockSessionsList } }),
 }));
 
 const dbSelectMock = {
@@ -90,6 +101,8 @@ describe("ChatPage", () => {
     dbSelectMock.from.mockReturnValue({ where: dbSelectMock.where });
     mockGetUserGroupIds.mockResolvedValue([]);
     mockGetAgentGroupIds.mockResolvedValue([]);
+    // Default: no other sessions → no redirect, render the default chat.
+    mockSessionsList.mockResolvedValue({ sessions: [] });
   });
 
   it("calls notFound when a non-admin user tries to access another user's personal agent", async () => {
@@ -288,5 +301,65 @@ describe("ChatPage", () => {
     render(result);
 
     expect(capturedChatProps.avatarUrl).toBe("data:image/svg+xml;utf8,mock-my-seed");
+  });
+
+  it("redirects to the most-recently-interacted named chat (#508)", async () => {
+    const sharedAgent = { id: "agent-2", name: "Shared Agent", ownerId: null, isPersonal: false };
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([sharedAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {});
+    mockSessionsList.mockResolvedValue({
+      sessions: [
+        { key: "agent:agent-2:direct:user-1", sessionId: "s-default", lastInteractionAt: 100 },
+        { key: "agent:agent-2:direct:user-1:chat-x", sessionId: "s-x", lastInteractionAt: 200 },
+      ],
+    });
+
+    await expect(
+      ChatPage({
+        params: Promise.resolve({ agentId: "agent-2" }),
+        searchParams: Promise.resolve({}),
+      })
+    ).rejects.toThrow("REDIRECT:/chat/agent-2/chat-x");
+
+    expect(mockRedirect).toHaveBeenCalledWith("/chat/agent-2/chat-x");
+  });
+
+  it("does NOT redirect when ?keep is set (explicit default chat)", async () => {
+    const sharedAgent = { id: "agent-2", name: "Shared Agent", ownerId: null, isPersonal: false };
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([sharedAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {});
+    mockSessionsList.mockResolvedValue({
+      sessions: [
+        { key: "agent:agent-2:direct:user-1:chat-x", sessionId: "s-x", lastInteractionAt: 200 },
+      ],
+    });
+
+    const result = await ChatPage({
+      params: Promise.resolve({ agentId: "agent-2" }),
+      searchParams: Promise.resolve({ keep: "1" }),
+    });
+    render(result);
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("mock-chat")).toBeInTheDocument();
+  });
+
+  it("renders the default chat when OpenClaw is unreachable", async () => {
+    const sharedAgent = { id: "agent-2", name: "Shared Agent", ownerId: null, isPersonal: false };
+    mockRequireAuth.mockResolvedValue({ user: { id: "user-1", role: "member" } });
+    dbSelectMock.where.mockResolvedValue([sharedAgent]);
+    mockAssertAgentAccess.mockImplementation(() => {});
+    mockSessionsList.mockRejectedValue(new Error("openclaw down"));
+
+    const result = await ChatPage({
+      params: Promise.resolve({ agentId: "agent-2" }),
+      searchParams: Promise.resolve({}),
+    });
+    render(result);
+
+    expect(mockRedirect).not.toHaveBeenCalled();
+    expect(screen.getByTestId("mock-chat")).toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -4,10 +4,17 @@ import "@testing-library/jest-dom";
 import { Chat } from "@/components/chat";
 import type { Agent } from "@/components/agent-list";
 
-const { mockGetAgent, mockUseChatStatus, mockUseChatSession } = vi.hoisted(() => ({
-  mockGetAgent: vi.fn() as ReturnType<typeof vi.fn>,
-  mockUseChatStatus: vi.fn(),
-  mockUseChatSession: vi.fn(),
+const { mockGetAgent, mockUseChatStatus, mockUseChatSession, mockRecordLastChat } = vi.hoisted(
+  () => ({
+    mockGetAgent: vi.fn() as ReturnType<typeof vi.fn>,
+    mockUseChatStatus: vi.fn(),
+    mockUseChatSession: vi.fn(),
+    mockRecordLastChat: vi.fn(),
+  })
+);
+
+vi.mock("@/lib/last-chat-store", () => ({
+  recordLastChat: (...args: unknown[]) => mockRecordLastChat(...args),
 }));
 
 vi.mock("@/components/agents-provider", () => ({
@@ -127,6 +134,16 @@ describe("Chat", () => {
   it("calls useChatSession without a chatId for the legacy/default chat", () => {
     render(<Chat agentId="agent-1" agentName="Smithers" />);
     expect(mockUseChatSession).toHaveBeenCalledWith("agent-1", undefined);
+  });
+
+  it("records the viewed chat as last-opened for this agent (#508)", () => {
+    render(<Chat agentId="agent-1" agentName="Smithers" chatId="chat-x" />);
+    expect(mockRecordLastChat).toHaveBeenCalledWith("agent-1", "chat-x");
+  });
+
+  it("records the default chat (no chatId) so the last-chat pointer is cleared (#508)", () => {
+    render(<Chat agentId="agent-1" agentName="Smithers" />);
+    expect(mockRecordLastChat).toHaveBeenCalledWith("agent-1", undefined);
   });
 
   describe("status indicator colors and labels", () => {

--- a/packages/web/src/__tests__/components/sidebar.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar.test.tsx
@@ -83,6 +83,7 @@ describe("AppSidebar", () => {
     vi.clearAllMocks();
     mockUsePathname.mockReturnValue("/chat/1");
     setAgents([]);
+    localStorage.clear();
   });
 
   afterEach(() => {
@@ -325,6 +326,39 @@ describe("AppSidebar", () => {
       renderSidebar(false);
       const activeButton = screen.getByRole("link", { name: /beta/i }).closest("[data-active]");
       expect(activeButton).toHaveAttribute("data-active", "true");
+    });
+  });
+
+  describe("last-viewed chat link (#508)", () => {
+    const agents: Agent[] = [
+      {
+        id: "agent-1",
+        name: "Alpha",
+        model: "anthropic/claude-sonnet-4-6",
+        isPersonal: false,
+        tagline: null,
+        avatarSeed: null,
+      },
+    ];
+
+    it("links the agent to the chat last viewed on this device", async () => {
+      localStorage.setItem("pinchy:lastChat:agent-1", "chat-xyz");
+      setAgents(agents);
+      renderSidebar(false);
+
+      await waitFor(() => {
+        expect(screen.getByRole("link", { name: /alpha/i })).toHaveAttribute(
+          "href",
+          "/chat/agent-1/chat-xyz"
+        );
+      });
+    });
+
+    it("falls back to the bare agent chat when nothing is recorded (server resolves the default)", () => {
+      setAgents(agents);
+      renderSidebar(false);
+      // No localStorage entry → the default route resolves the most-recent chat.
+      expect(screen.getByRole("link", { name: /alpha/i })).toHaveAttribute("href", "/chat/agent-1");
     });
   });
 

--- a/packages/web/src/__tests__/lib/draft-store.test.ts
+++ b/packages/web/src/__tests__/lib/draft-store.test.ts
@@ -1,5 +1,33 @@
 import { describe, it, expect, beforeEach } from "vitest";
-import { getDraft, saveDraft, clearDraft } from "@/lib/draft-store";
+import { getDraft, saveDraft, clearDraft, draftKey } from "@/lib/draft-store";
+
+describe("draftKey", () => {
+  it("scopes a draft to a single (agent, chat) pair", () => {
+    // The bare agentId is the key for the default/legacy chat (chatId omitted)
+    // — byte-identical to the pre-per-chat key so existing drafts don't move.
+    expect(draftKey("agent-1")).toBe("agent-1");
+    expect(draftKey("agent-1", "chat-a")).toBe("agent-1:chat-a");
+  });
+
+  it("never collides across chats of the same agent", () => {
+    expect(draftKey("agent-1", "chat-a")).not.toBe(draftKey("agent-1", "chat-b"));
+    // The default chat key can't collide with a per-chat key (segment count).
+    expect(draftKey("agent-1")).not.toBe(draftKey("agent-1", "chat-a"));
+  });
+
+  it("isolates drafts between two chats of the same agent (the bleed bug)", () => {
+    saveDraft(draftKey("agent-1", "chat-a"), { text: "draft A", files: [] });
+    saveDraft(draftKey("agent-1", "chat-b"), { text: "draft B", files: [] });
+
+    expect(getDraft(draftKey("agent-1", "chat-a"))?.text).toBe("draft A");
+    expect(getDraft(draftKey("agent-1", "chat-b"))?.text).toBe("draft B");
+    // The default chat of the same agent stays empty — no bleed from a sibling.
+    expect(getDraft(draftKey("agent-1"))).toBeUndefined();
+
+    clearDraft(draftKey("agent-1", "chat-a"));
+    clearDraft(draftKey("agent-1", "chat-b"));
+  });
+});
 
 describe("draft-store", () => {
   beforeEach(() => {

--- a/packages/web/src/__tests__/lib/last-chat-store.test.ts
+++ b/packages/web/src/__tests__/lib/last-chat-store.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import { recordLastChat, getLastChat } from "@/lib/last-chat-store";
+
+describe("last-chat-store", () => {
+  beforeEach(() => localStorage.clear());
+
+  it("returns null when no chat has been recorded for an agent", () => {
+    expect(getLastChat("agent-1")).toBeNull();
+  });
+
+  it("records and returns the last viewed chat id per agent", () => {
+    recordLastChat("agent-1", "chat-a");
+    expect(getLastChat("agent-1")).toBe("chat-a");
+  });
+
+  it("scopes the last viewed chat per agent (no bleed across agents)", () => {
+    recordLastChat("agent-1", "chat-a");
+    recordLastChat("agent-2", "chat-b");
+    expect(getLastChat("agent-1")).toBe("chat-a");
+    expect(getLastChat("agent-2")).toBe("chat-b");
+  });
+
+  it("overwrites the previous chat when a newer one is viewed", () => {
+    recordLastChat("agent-1", "chat-a");
+    recordLastChat("agent-1", "chat-b");
+    expect(getLastChat("agent-1")).toBe("chat-b");
+  });
+
+  it("clears the entry when the default/legacy chat is viewed (chatId null)", () => {
+    // Viewing the default chat removes any stored pointer so the sidebar falls
+    // back to the most-recently-interacted chat instead of pinning the default.
+    recordLastChat("agent-1", "chat-a");
+    recordLastChat("agent-1", null);
+    expect(getLastChat("agent-1")).toBeNull();
+  });
+
+  it("treats undefined chatId the same as the default chat (clears)", () => {
+    recordLastChat("agent-1", "chat-a");
+    recordLastChat("agent-1", undefined);
+    expect(getLastChat("agent-1")).toBeNull();
+  });
+});

--- a/packages/web/src/__tests__/lib/select-most-recent-chat.test.ts
+++ b/packages/web/src/__tests__/lib/select-most-recent-chat.test.ts
@@ -1,0 +1,55 @@
+import { describe, it, expect } from "vitest";
+import { selectMostRecentWebChatId } from "@/lib/chats/select-most-recent-chat";
+import type { ClassifiedChat } from "@/lib/chats/classify-sessions";
+
+function web(chatId: string | null, lastInteractionAt: number): ClassifiedChat {
+  return {
+    sessionId: `s-${chatId ?? "default"}`,
+    key: "k",
+    origin: "web",
+    writable: true,
+    chatId,
+    lastInteractionAt,
+  };
+}
+function telegram(lastInteractionAt: number): ClassifiedChat {
+  return {
+    sessionId: "s-tg",
+    key: "k",
+    origin: "telegram",
+    writable: false,
+    chatId: null,
+    lastInteractionAt,
+  };
+}
+
+describe("selectMostRecentWebChatId", () => {
+  it("returns null when there are no chats", () => {
+    expect(selectMostRecentWebChatId([])).toBeNull();
+  });
+
+  it("returns null when the only chat is the default/legacy chat", () => {
+    // chatId null → the default chat; redirecting there would loop, so render it.
+    expect(selectMostRecentWebChatId([web(null, 100)])).toBeNull();
+  });
+
+  it("returns the chatId of the single named chat", () => {
+    expect(selectMostRecentWebChatId([web("chat-a", 100)])).toBe("chat-a");
+  });
+
+  it("returns the most-recently-interacted named chat", () => {
+    expect(
+      selectMostRecentWebChatId([web("chat-old", 100), web("chat-new", 200), web("chat-mid", 150)])
+    ).toBe("chat-new");
+  });
+
+  it("returns null when the default chat is the most recent (render default, no redirect)", () => {
+    expect(selectMostRecentWebChatId([web("chat-a", 100), web(null, 200)])).toBeNull();
+  });
+
+  it("ignores telegram chats and picks the most recent WEB chat", () => {
+    // The most recent chat overall is a read-only Telegram mirror; clicking the
+    // agent must not land there — pick the most recent web chat instead.
+    expect(selectMostRecentWebChatId([telegram(300), web("chat-a", 200)])).toBe("chat-a");
+  });
+});

--- a/packages/web/src/app/(app)/chat/[agentId]/page.tsx
+++ b/packages/web/src/app/(app)/chat/[agentId]/page.tsx
@@ -2,13 +2,16 @@ import type { Metadata } from "next";
 import { db } from "@/db";
 import { activeAgents } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { notFound } from "next/navigation";
+import { notFound, redirect } from "next/navigation";
 import { Chat } from "@/components/chat";
 import { requireAuth } from "@/lib/require-auth";
 import { assertAgentAccess, effectiveVisibility } from "@/lib/agent-access";
 import { getUserGroupIds, getAgentGroupIds } from "@/lib/groups";
 import { getLicenseState } from "@/lib/enterprise";
 import { getAgentAvatarSvg } from "@/lib/avatar";
+import { getOpenClawClient } from "@/server/openclaw-client";
+import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import { selectMostRecentWebChatId } from "@/lib/chats/select-most-recent-chat";
 
 export async function generateMetadata({
   params,
@@ -25,7 +28,13 @@ export async function generateMetadata({
   return { title: agent?.name ?? "Chat" };
 }
 
-export default async function ChatPage({ params }: { params: Promise<{ agentId: string }> }) {
+export default async function ChatPage({
+  params,
+  searchParams,
+}: {
+  params: Promise<{ agentId: string }>;
+  searchParams?: Promise<{ keep?: string }>;
+}) {
   const { agentId } = await params;
   const session = await requireAuth();
   const userId = session.user.id!;
@@ -53,6 +62,32 @@ export default async function ChatPage({ params }: { params: Promise<{ agentId: 
   } catch {
     notFound();
   }
+
+  // Where should a bare /chat/<agentId> land? (#508) The user's most-recently-
+  // interacted chat — the sidebar links here when this device has no recorded
+  // last-viewed chat. The switcher opens the legacy/default chat explicitly with
+  // `?keep`, which skips the redirect so that chat stays reachable.
+  const sp = searchParams ? await searchParams : {};
+  let mostRecentChatId: string | null = null;
+  if (sp.keep === undefined) {
+    try {
+      const raw = (await getOpenClawClient().sessions.list({})) as
+        | { sessions?: RawSession[] }
+        | undefined;
+      const sessionsArr = Array.isArray(raw?.sessions) ? raw.sessions : [];
+      const scoped = sessionsArr.filter(
+        (s) => typeof s?.key === "string" && s.key.split(":")[1] === agentId
+      );
+      // Only web chats are a valid landing target, so no Telegram peers needed.
+      const classified = classifyUserSessions(scoped, userId, new Set());
+      mostRecentChatId = selectMostRecentWebChatId(classified);
+    } catch {
+      // OpenClaw unreachable — render the default chat rather than failing.
+      mostRecentChatId = null;
+    }
+  }
+  // redirect() throws NEXT_REDIRECT, so it must run OUTSIDE the try/catch above.
+  if (mostRecentChatId) redirect(`/chat/${agentId}/${mostRecentChatId}`);
 
   const avatarUrl = getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name });
   const isAdmin = userRole === "admin";

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -200,7 +200,7 @@ describe("ChatSwitcher", () => {
     expect(push).toHaveBeenCalledWith("/chat/agent-1/chat-abc");
   });
 
-  it("selecting the default chat (chatId null) pushes /chat/<agentId>", async () => {
+  it("selecting the default chat (chatId null) pushes /chat/<agentId>?keep (no redirect)", async () => {
     const user = userEvent.setup();
     mockChats(allChats);
     render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
@@ -209,7 +209,9 @@ describe("ChatSwitcher", () => {
     const fallback = new Date(legacyChat.lastInteractionAt).toLocaleDateString();
     await user.click(within(menu).getByText(`Chat from ${fallback}`));
 
-    expect(push).toHaveBeenCalledWith("/chat/agent-1");
+    // `?keep` marks this as an explicit choice of the legacy/default chat so the
+    // default route renders it instead of redirecting to the most-recent chat (#508).
+    expect(push).toHaveBeenCalledWith("/chat/agent-1?keep=1");
   });
 
   it("selecting a Telegram chat pushes /chat/<agentId>/telegram (the read-only mirror)", async () => {

--- a/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
@@ -14,7 +14,7 @@
 // so a dependency change that breaks the draft contract shows up HERE.
 
 import { describe, it, expect, beforeEach } from "vitest";
-import { render, screen, fireEvent, act } from "@testing-library/react";
+import { render, screen, fireEvent, act, waitFor } from "@testing-library/react";
 import { useEffect, type FC } from "react";
 import {
   AssistantRuntimeProvider,
@@ -26,9 +26,30 @@ import {
 } from "@assistant-ui/react";
 import { DraftPersistence } from "@/components/assistant-ui/thread";
 import { AgentIdContext, ChatIdContext } from "@/components/chat";
-import { getDraft, clearDraft, draftKey } from "@/lib/draft-store";
+import { getDraft, saveDraft, clearDraft, draftKey } from "@/lib/draft-store";
 
 const AGENT = "agent-1";
+
+// Minimal attachment adapter so the runtime accepts addAttachment during restore.
+// Mirrors the shape of Pinchy's real adapter: a composer attachment that carries
+// the original File and is ready to send.
+const testAttachmentAdapter = {
+  accept: "*",
+  async add({ file }: { file: File }) {
+    return {
+      id: file.name,
+      type: "document" as const,
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: { type: "requires-action" as const, reason: "composer-send" as const },
+    };
+  },
+  async send(attachment: { id: string; name: string; file: File }) {
+    return { ...attachment, status: { type: "complete" as const } };
+  },
+  async remove() {},
+};
 
 let composerApi: ComposerRuntime | null = null;
 const CaptureComposer: FC = () => {
@@ -49,6 +70,7 @@ const Harness: FC<{ chatId: string | null }> = ({ chatId }) => {
     isRunning: false,
     convertMessage: (m: ThreadMessageLike) => m,
     onNew: async () => {},
+    adapters: { attachments: testAttachmentAdapter },
   });
   return (
     <AgentIdContext.Provider value={AGENT}>
@@ -133,5 +155,25 @@ describe("DraftPersistence (per-chat composer draft)", () => {
 
     expect(composerApi!.getState().text).toBe("");
     expect(getDraft(draftKey(AGENT, "chat-a"))).toBeUndefined();
+  });
+
+  it("restores a file attachment without clobbering the stored draft mid-restore", async () => {
+    const file = new File(["data"], "report.pdf", { type: "application/pdf" });
+    saveDraft(draftKey(AGENT, "chat-a"), { text: "see attached", files: [file] });
+
+    render(<Harness chatId="chat-a" />);
+
+    // Attachment restore is async — wait for the file to land in the composer.
+    await waitFor(() => {
+      expect(composerApi!.getState().attachments).toHaveLength(1);
+    });
+    expect(composerApi!.getState().attachments[0].name).toBe("report.pdf");
+    expect(composerApi!.getState().text).toBe("see attached");
+
+    // A persist firing while attachments were still being re-added must NOT have
+    // written a partial (text-only) set over the complete stored draft.
+    const stored = getDraft(draftKey(AGENT, "chat-a"));
+    expect(stored?.files).toHaveLength(1);
+    expect(stored?.text).toBe("see attached");
   });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
@@ -1,0 +1,137 @@
+// Behavioural guard for the composer draft cache, rendered against the REAL
+// assistant-ui composer (no mock) and the REAL in-memory draft store.
+//
+// Bug history: the composer draft was keyed by agentId alone, so a draft typed
+// in one chat surfaced in a sibling chat of the same agent ("bleed"), survived a
+// send, and reappeared after being deleted (the "resurrection"). The fix keys
+// the draft per (agentId, chatId), persists on every composer change, and lets
+// the empty-auto-clear in saveDraft handle both send and manual deletion.
+//
+// Why a real-dependency test and not a mock: the sibling thread.test.tsx mocks
+// @assistant-ui/react wholesale, so DraftPersistence's reliance on the live
+// composer runtime (subscribe / setText / getState) is invisible there. This
+// file renders the real ComposerPrimitive against a real useExternalStoreRuntime
+// so a dependency change that breaks the draft contract shows up HERE.
+
+import { describe, it, expect, beforeEach } from "vitest";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+import { useEffect, type FC } from "react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  useComposerRuntime,
+  useExternalStoreRuntime,
+  type ThreadMessageLike,
+  type ComposerRuntime,
+} from "@assistant-ui/react";
+import { DraftPersistence } from "@/components/assistant-ui/thread";
+import { AgentIdContext, ChatIdContext } from "@/components/chat";
+import { getDraft, clearDraft, draftKey } from "@/lib/draft-store";
+
+const AGENT = "agent-1";
+
+let composerApi: ComposerRuntime | null = null;
+const CaptureComposer: FC = () => {
+  const composer = useComposerRuntime();
+  useEffect(() => {
+    composerApi = composer;
+  }, [composer]);
+  return null;
+};
+
+// Mirrors the production tree: DraftPersistence lives inside the composer of a
+// runtime created per (agent, chat). Each mount gets its OWN runtime, exactly
+// like production where switching chats remounts <Chat> against that chat's
+// background runtime.
+const Harness: FC<{ chatId: string | null }> = ({ chatId }) => {
+  const runtime = useExternalStoreRuntime({
+    messages: [] as ThreadMessageLike[],
+    isRunning: false,
+    convertMessage: (m: ThreadMessageLike) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AgentIdContext.Provider value={AGENT}>
+      <ChatIdContext.Provider value={chatId}>
+        <AssistantRuntimeProvider runtime={runtime}>
+          <ComposerPrimitive.Root>
+            <CaptureComposer />
+            <DraftPersistence />
+            <ComposerPrimitive.Input aria-label="Message input" />
+          </ComposerPrimitive.Root>
+        </AssistantRuntimeProvider>
+      </ChatIdContext.Provider>
+    </AgentIdContext.Provider>
+  );
+};
+
+function type(text: string) {
+  const textarea = screen.getByRole("textbox") as HTMLTextAreaElement;
+  act(() => {
+    fireEvent.change(textarea, { target: { value: text } });
+  });
+}
+
+describe("DraftPersistence (per-chat composer draft)", () => {
+  beforeEach(() => {
+    clearDraft(draftKey(AGENT));
+    clearDraft(draftKey(AGENT, "chat-a"));
+    clearDraft(draftKey(AGENT, "chat-b"));
+    composerApi = null;
+  });
+
+  it("saves the draft under the (agent, chat) key as the user types", () => {
+    render(<Harness chatId="chat-a" />);
+    type("hello from A");
+
+    expect(getDraft(draftKey(AGENT, "chat-a"))?.text).toBe("hello from A");
+    // No bleed onto the agent-level or sibling keys.
+    expect(getDraft(draftKey(AGENT))).toBeUndefined();
+    expect(getDraft(draftKey(AGENT, "chat-b"))).toBeUndefined();
+  });
+
+  it("does NOT bleed a draft into a sibling chat of the same agent", () => {
+    const { unmount } = render(<Harness chatId="chat-a" />);
+    type("hello from A");
+    unmount();
+
+    // Switch to a different chat of the SAME agent — its composer must be empty.
+    render(<Harness chatId="chat-b" />);
+    expect(composerApi!.getState().text).toBe("");
+    expect(getDraft(draftKey(AGENT, "chat-b"))).toBeUndefined();
+    // Chat A's draft is untouched.
+    expect(getDraft(draftKey(AGENT, "chat-a"))?.text).toBe("hello from A");
+  });
+
+  it("restores the draft when returning to the same chat", () => {
+    const first = render(<Harness chatId="chat-a" />);
+    type("draft to keep");
+    first.unmount();
+
+    render(<Harness chatId="chat-a" />);
+    expect(composerApi!.getState().text).toBe("draft to keep");
+  });
+
+  it("clears the draft when the composer is emptied (manual delete sticks)", () => {
+    render(<Harness chatId="chat-a" />);
+    type("oops");
+    expect(getDraft(draftKey(AGENT, "chat-a"))?.text).toBe("oops");
+
+    // Delete the text — the cleared state must persist, not resurrect.
+    type("");
+    expect(getDraft(draftKey(AGENT, "chat-a"))).toBeUndefined();
+  });
+
+  it("clears the draft on send", async () => {
+    render(<Harness chatId="chat-a" />);
+    type("send me");
+    expect(getDraft(draftKey(AGENT, "chat-a"))?.text).toBe("send me");
+
+    await act(async () => {
+      await composerApi!.send();
+    });
+
+    expect(composerApi!.getState().text).toBe("");
+    expect(getDraft(draftKey(AGENT, "chat-a"))).toBeUndefined();
+  });
+});

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -125,6 +125,8 @@ vi.mock("@assistant-ui/react", () => ({
 vi.mock("@/lib/draft-store", () => ({
   getDraft: vi.fn(() => null),
   saveDraft: vi.fn(),
+  draftKey: (agentId: string, chatId?: string | null) =>
+    chatId ? `${agentId}:${chatId}` : agentId,
 }));
 
 vi.mock("@/lib/api-client", () => ({
@@ -187,6 +189,7 @@ vi.mock("@/components/chat", async () => {
   return {
     AgentAvatarContext: React.createContext<string | null>(null),
     AgentIdContext: React.createContext<string | null>(null),
+    ChatIdContext: React.createContext<string | null>(null),
     AgentModelContext: React.createContext<string | null>(null),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),
     RetryContinueContext: React.createContext<() => void>(() => {}),

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -38,6 +38,7 @@ import {
 import { type FC, useState, useEffect, useRef, useContext } from "react";
 import {
   AgentIdContext,
+  ChatIdContext,
   AgentNameContext,
   RetryResendContext,
   RetryContinueContext,
@@ -52,7 +53,7 @@ import type { PendingUpload } from "@/hooks/use-ws-runtime";
 import { RetryButton } from "@/components/chat/retry-button";
 import { DuplicateRetryConfirm } from "@/components/chat/duplicate-retry-confirm";
 import { useComposerRuntime } from "@assistant-ui/react";
-import { getDraft, saveDraft } from "@/lib/draft-store";
+import { getDraft, saveDraft, draftKey } from "@/lib/draft-store";
 
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
@@ -246,34 +247,45 @@ export const ThreadWelcome: FC = () => {
   );
 };
 
-const DraftPersistence: FC = () => {
+/**
+ * Persists the composer draft (text + attachments) per chat (#508), scoped to the
+ * current (agentId, chatId) so a draft never bleeds into a sibling chat of the
+ * same agent. It saves on every composer change rather than only on unmount: an
+ * unmount-only save closes over stale state and races the next chat's restore
+ * during navigation (the deleted-draft resurrection). Because `saveDraft`
+ * auto-clears an empty composer, both a send (assistant-ui empties the composer)
+ * and a manual delete clear the draft with no extra special case.
+ */
+export const DraftPersistence: FC = () => {
   const agentId = useContext(AgentIdContext);
+  const chatId = useContext(ChatIdContext);
   const composerRuntime = useComposerRuntime({ optional: true });
-  const runtimeRef = useRef(composerRuntime);
-
-  useEffect(() => {
-    runtimeRef.current = composerRuntime;
-  }, [composerRuntime]);
 
   useEffect(() => {
     if (!agentId || !composerRuntime) return;
+    const key = draftKey(agentId, chatId);
 
-    const draft = getDraft(agentId);
+    // Restore this chat's draft on mount.
+    const draft = getDraft(key);
     if (draft) {
       composerRuntime.setText(draft.text);
       draft.files.forEach((file) => composerRuntime.addAttachment(file));
     }
 
-    return () => {
-      const rt = runtimeRef.current;
-      if (!rt) return;
-      const state = rt.getState();
+    const persist = () => {
+      const state = composerRuntime.getState();
       const files = state.attachments
         .filter((a): a is typeof a & { file: File } => "file" in a && a.file instanceof File)
         .map((a) => a.file);
-      saveDraft(agentId, { text: state.text, files });
+      saveDraft(key, { text: state.text, files });
     };
-  }, [agentId, composerRuntime]);
+    const unsubscribe = composerRuntime.subscribe(persist);
+
+    return () => {
+      persist(); // flush the latest state before this chat's composer unmounts
+      unsubscribe();
+    };
+  }, [agentId, chatId, composerRuntime]);
 
   return null;
 };

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -255,6 +255,11 @@ export const ThreadWelcome: FC = () => {
  * during navigation (the deleted-draft resurrection). Because `saveDraft`
  * auto-clears an empty composer, both a send (assistant-ui empties the composer)
  * and a manual delete clear the draft with no extra special case.
+ *
+ * `addAttachment` is async, so attachment restore completes after a tick. We gate
+ * `persist` behind a `restored` flag and only subscribe once restore has settled,
+ * so a notification fired while attachments are still being re-added can never
+ * write a partial file set back over the complete stored draft.
  */
 export const DraftPersistence: FC = () => {
   const agentId = useContext(AgentIdContext);
@@ -265,25 +270,41 @@ export const DraftPersistence: FC = () => {
     if (!agentId || !composerRuntime) return;
     const key = draftKey(agentId, chatId);
 
-    // Restore this chat's draft on mount.
-    const draft = getDraft(key);
-    if (draft) {
-      composerRuntime.setText(draft.text);
-      draft.files.forEach((file) => composerRuntime.addAttachment(file));
-    }
+    let cancelled = false;
+    let restored = false;
+    let unsubscribe: (() => void) | undefined;
 
     const persist = () => {
+      if (!restored) return; // never clobber the stored draft mid-restore
       const state = composerRuntime.getState();
       const files = state.attachments
         .filter((a): a is typeof a & { file: File } => "file" in a && a.file instanceof File)
         .map((a) => a.file);
       saveDraft(key, { text: state.text, files });
     };
-    const unsubscribe = composerRuntime.subscribe(persist);
+
+    // Restore this chat's draft, then start persisting. With no attachments this
+    // runs synchronously, so the common text-only path subscribes before the user
+    // can type; attachments add a short async window during which persist stays a
+    // no-op (guarded above).
+    const restore = async () => {
+      const draft = getDraft(key);
+      if (draft) {
+        composerRuntime.setText(draft.text);
+        for (const file of draft.files) {
+          await composerRuntime.addAttachment(file);
+          if (cancelled) return;
+        }
+      }
+      restored = true;
+      unsubscribe = composerRuntime.subscribe(persist);
+    };
+    void restore();
 
     return () => {
-      persist(); // flush the latest state before this chat's composer unmounts
-      unsubscribe();
+      cancelled = true;
+      persist(); // flush the latest state (no-op if restore hasn't settled)
+      unsubscribe?.();
     };
   }, [agentId, chatId, composerRuntime]);
 

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -212,7 +212,10 @@ export function ChatSwitcher({
       router.push(`/chat/${agentId}/telegram`);
       return;
     }
-    router.push(item.chatId ? `/chat/${agentId}/${item.chatId}` : `/chat/${agentId}`);
+    // The legacy/default chat (chatId null) is opened explicitly with `?keep` so
+    // the default route renders it instead of redirecting to the most-recent
+    // chat (#508) — otherwise picking it here would bounce to another chat.
+    router.push(item.chatId ? `/chat/${agentId}/${item.chatId}` : `/chat/${agentId}?keep=1`);
   }
 
   return (

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -17,6 +17,7 @@ import { ChatSwitcher } from "@/components/chat-switcher";
 import { Badge } from "@/components/ui/badge";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { type ChatStatus, useChatStatus } from "@/hooks/use-chat-status";
+import { recordLastChat } from "@/lib/last-chat-store";
 
 function getStatusIndicator(status: ChatStatus): { colorClass: string; label: string } {
   switch (status.kind) {
@@ -144,6 +145,14 @@ export function Chat({
   const displayIsPersonal = liveAgent?.isPersonal ?? isPersonal;
 
   const { bundle: chatBundle, publish } = useChatSession(agentId, chatId);
+
+  // Remember this as the chat the user last had open for this agent (#508), so
+  // clicking the agent in the sidebar returns here instead of the oldest chat.
+  // Per-device by design (localStorage). Viewing the default chat (no chatId)
+  // clears the pointer so the sidebar falls back to the most recent chat.
+  useEffect(() => {
+    recordLastChat(agentId, chatId);
+  }, [agentId, chatId]);
 
   // Register this (agent, chat) with the provider on first mount so
   // ChatSessionMounts spins up a hidden runtime instance.

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -2,6 +2,8 @@
 
 import Link from "next/link";
 import { usePathname } from "next/navigation";
+import { useMemo, useSyncExternalStore } from "react";
+import { getLastChat } from "@/lib/last-chat-store";
 import { BarChart3, Bug, ClipboardList, Plus, Settings } from "lucide-react";
 import { LogoutButton } from "@/components/logout-button";
 import { useAgentsContext } from "@/components/agents-provider";
@@ -26,10 +28,44 @@ interface AppSidebarProps {
   isAdmin: boolean;
 }
 
+// localStorage has no same-tab change event; a cross-tab write fires "storage".
+// Same-tab updates are picked up because navigating re-renders the sidebar
+// (usePathname), which re-runs the snapshot read below.
+function subscribeLastChats(callback: () => void) {
+  if (typeof window === "undefined") return () => {};
+  window.addEventListener("storage", callback);
+  return () => window.removeEventListener("storage", callback);
+}
+
 export function AppSidebar({ isAdmin }: AppSidebarProps) {
   const pathname = usePathname();
   const { sortedAgents } = useAgentsContext();
   const { authFailedCount } = useIntegrationHealth(isAdmin);
+
+  // Resolve each agent's link to the chat last viewed on THIS device (#508), so
+  // clicking an agent returns the user where they left off instead of the oldest
+  // chat. Read via useSyncExternalStore (not an effect) so the server snapshot is
+  // empty — links fall back to the bare /chat/<agentId>, where the server resolves
+  // the most-recent chat — and the client reads localStorage without a hydration
+  // mismatch or a synchronous setState. The snapshot is a JSON string so its
+  // identity stays stable (Object.is) between renders when nothing changed.
+  const agentIds = sortedAgents.map((a) => a.id);
+  const serializedLastChats = useSyncExternalStore(
+    subscribeLastChats,
+    () => {
+      const map: Record<string, string> = {};
+      for (const id of agentIds) {
+        const last = getLastChat(id);
+        if (last) map[id] = last;
+      }
+      return JSON.stringify(map);
+    },
+    () => "{}"
+  );
+  const lastChatById = useMemo(
+    () => JSON.parse(serializedLastChats) as Record<string, string>,
+    [serializedLastChats]
+  );
 
   return (
     <Sidebar>
@@ -47,6 +83,8 @@ export function AppSidebar({ isAdmin }: AppSidebarProps) {
             <SidebarMenu>
               {sortedAgents.map((agent) => {
                 const isActive = pathname.startsWith(`/chat/${agent.id}`);
+                const lastChat = lastChatById[agent.id];
+                const href = lastChat ? `/chat/${agent.id}/${lastChat}` : `/chat/${agent.id}`;
                 return (
                   <SidebarMenuItem key={agent.id}>
                     <SidebarMenuButton
@@ -59,7 +97,7 @@ export function AppSidebar({ isAdmin }: AppSidebarProps) {
                           : ""
                       }`}
                     >
-                      <Link href={`/chat/${agent.id}`}>
+                      <Link href={href}>
                         {/* eslint-disable-next-line @next/next/no-img-element */}
                         <img
                           src={getAgentAvatarSvg({

--- a/packages/web/src/lib/chats/select-most-recent-chat.ts
+++ b/packages/web/src/lib/chats/select-most-recent-chat.ts
@@ -1,0 +1,22 @@
+import type { ClassifiedChat } from "@/lib/chats/classify-sessions";
+
+/**
+ * Pick the chat to open when a user clicks an agent and has no recorded
+ * last-viewed chat on this device (#508) — the most-recently-interacted WEB chat.
+ *
+ * Returns its `chatId`, or `null` when the caller should render the default/legacy
+ * chat instead. `null` is returned when there are no web chats, OR when the most
+ * recent web chat IS the default chat (chatId null): the default chat has no
+ * chatId to redirect to, and redirecting `/chat/<agentId>` back to itself would
+ * loop. Telegram chats are read-only mirrors and never a landing target, so they
+ * are excluded from the recency comparison.
+ */
+export function selectMostRecentWebChatId(classified: ClassifiedChat[]): string | null {
+  const mostRecentWeb = classified
+    .filter((c) => c.origin === "web")
+    .reduce<ClassifiedChat | null>(
+      (best, c) => (best === null || c.lastInteractionAt > best.lastInteractionAt ? c : best),
+      null
+    );
+  return mostRecentWeb?.chatId ?? null;
+}

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -5,18 +5,33 @@ export interface Draft {
 
 const drafts = new Map<string, Draft>();
 
-export function getDraft(agentId: string): Draft | undefined {
-  return drafts.get(agentId);
+/**
+ * Store key for one composer draft, scoped to a single (agent, chat) pair (#508).
+ *
+ * A draft belongs to ONE chat, never to the agent as a whole — otherwise a draft
+ * typed in one chat surfaces in a sibling chat of the same agent (the cross-session
+ * bleed bug). When `chatId` is omitted the key is the bare `agentId`, byte-identical
+ * to the pre-per-chat key, so the default/legacy chat keeps its existing entry.
+ *
+ * Mirrors `chatSessionKey` in chat-session-provider.tsx (same `(agent, chat)` →
+ * key shape); kept local so the draft store stays a standalone, dependency-free lib.
+ */
+export function draftKey(agentId: string, chatId?: string | null): string {
+  return chatId ? `${agentId}:${chatId}` : agentId;
 }
 
-export function saveDraft(agentId: string, draft: Draft): void {
+export function getDraft(key: string): Draft | undefined {
+  return drafts.get(key);
+}
+
+export function saveDraft(key: string, draft: Draft): void {
   if (!draft.text && draft.files.length === 0) {
-    drafts.delete(agentId);
+    drafts.delete(key);
     return;
   }
-  drafts.set(agentId, draft);
+  drafts.set(key, draft);
 }
 
-export function clearDraft(agentId: string): void {
-  drafts.delete(agentId);
+export function clearDraft(key: string): void {
+  drafts.delete(key);
 }

--- a/packages/web/src/lib/last-chat-store.ts
+++ b/packages/web/src/lib/last-chat-store.ts
@@ -1,0 +1,32 @@
+"use client";
+
+/**
+ * Per-device memory of the chat a user last had open for each agent (#508).
+ *
+ * Clicking an agent in the sidebar should return the user to the chat they were
+ * last in on this device — not the oldest/default chat. We store the last-VIEWED
+ * chat id (not last-interacted) in localStorage, keyed per agent, so the choice
+ * is per-device by design: different devices can have different chats open.
+ *
+ * The default/legacy chat has no chatId; viewing it CLEARS the pointer rather
+ * than storing a sentinel, so the sidebar falls back to the server-resolved
+ * most-recently-interacted chat. The default chat has no distinct, non-redirecting
+ * URL of its own, and if it is genuinely the user's most active chat the fallback
+ * lands there anyway.
+ */
+const KEY_PREFIX = "pinchy:lastChat:";
+
+export function recordLastChat(agentId: string, chatId: string | null | undefined): void {
+  if (typeof localStorage === "undefined") return;
+  const key = KEY_PREFIX + agentId;
+  if (chatId) {
+    localStorage.setItem(key, chatId);
+  } else {
+    localStorage.removeItem(key);
+  }
+}
+
+export function getLastChat(agentId: string): string | null {
+  if (typeof localStorage === "undefined") return null;
+  return localStorage.getItem(KEY_PREFIX + agentId);
+}


### PR DESCRIPTION
## Why

Two related production annoyances when working across multiple chats of the same agent:

1. **A draft bled across chats, survived sending, and resurrected after deletion.** Typing in one chat showed the same text in another chat of the same agent; the text persisted even after it was sent elsewhere; and deleting it then switching chats brought it back.
2. **Clicking an agent always opened the oldest (default) chat**, discarding whichever chat you last had open — most visible after switching chats within an agent, leaving, and coming back.

## Root cause

1. The composer draft was keyed by `agentId` alone (it predates per-chat sessions, #508) and was only saved on unmount. So every chat of an agent shared one draft entry; nothing cleared it on send; and during a chat switch the new composer restored the still-present stale draft before the old one's unmount-cleanup persisted the cleared state (a remount race) — the resurrection.
2. The sidebar link was hardcoded to `/chat/<agentId>` (the legacy/default chat, i.e. the oldest), and nothing remembered the last-viewed chat.

## What changed

**Draft fix**
- Key drafts per `(agentId, chatId)` via `draftKey()`.
- `DraftPersistence` saves on every composer change (not only on unmount). `saveDraft` already auto-clears an empty composer, so a send (assistant-ui empties the composer) and a manual delete both clear the draft — no special case, no race.
- The app-owned draft cache stays: assistant-ui does not redisplay composer text across a consumer remount in this version, so deleting it would regress drafts. It is corrected, not removed.

**Last-chat fix**
- Remember the last-viewed chat per `(user, agent)` in `localStorage` — per device by design (different devices can have different chats open).
- The sidebar resolves each agent's link to that chat via `useSyncExternalStore` (SSR-empty → no hydration mismatch, no synchronous setState-in-effect).
- When a device has no record yet, the default `/chat/<agentId>` route redirects to the most-recently-interacted web chat. The switcher opens the legacy/default chat explicitly with `?keep` so it stays reachable without bouncing.

## Tests (TDD)

- `draft-store.test.ts` — per-chat key isolation.
- `draft-persistence.test.tsx` — rendered against the **real** assistant-ui composer: per-chat isolation (no bleed), restore-on-return, clear-on-send, clear-on-delete. This is the level a mock cannot cover (catches a dependency regression).
- `last-chat-store.test.ts`, `select-most-recent-chat.test.ts` — last-viewed store + most-recent selection.
- `chat-page.test.tsx` — default-route redirect, `?keep` opt-out, OpenClaw-unreachable fallback.
- `sidebar.test.tsx`, `chat-switcher.test.tsx` — link resolution + explicit default-chat URL.

Docs: `chat-states.mdx` now documents per-chat draft persistence and last-chat reopen.

## Verification

- Full web unit suite: 6471 passed, 13 skipped, 0 failed.
- `tsc --noEmit` (fresh), ESLint (0 errors), Prettier check — all clean.
- Pre-push `next build` (authoritative prod typecheck) passed.

Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com).