### PR TITLE
fix(chat): suppress durable error banner when the inline failure is on screen (#583)

### DIFF
--- a/packages/web/src/__tests__/components/chat-error-banner.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-banner.test.tsx
@@ -10,6 +10,13 @@ vi.mock("@/lib/api-client", () => ({
   apiDelete: (...args: unknown[]) => mockApiDelete(...args),
 }));
 
+// The thread's inline-error signal (#583). Default false so the banner renders
+// as before; the suppression test flips it to true.
+let mockHasInlineError = false;
+vi.mock("@/components/chat-session-provider", () => ({
+  useChatSessionHasInlineError: () => mockHasInlineError,
+}));
+
 const transientRow = {
   id: "err-1",
   agentName: "Penny",
@@ -39,6 +46,7 @@ const providerRejectionRow = {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  mockHasInlineError = false;
   mockApiDelete.mockResolvedValue({ dismissed: true });
 });
 
@@ -69,6 +77,22 @@ describe("ChatErrorBanner", () => {
 
     await waitFor(() => expect(screen.getByText("Smithers couldn't respond")).toBeInTheDocument());
     expect(screen.getByRole("link", { name: /settings > providers/i })).toBeInTheDocument();
+  });
+
+  it("suppresses itself when the thread already shows the inline error for this run (#583)", async () => {
+    // The banner is a fallback for an error the live bubble LOST to reload/
+    // reconnect. When the runtime bundle survives a nav-away/back, the inline
+    // turn-failure bubble is still on screen — rendering the banner too would
+    // duplicate the same failure. With the thread's inline error present, the
+    // banner renders nothing even though an active error exists server-side.
+    mockHasInlineError = true;
+    mockApiGet.mockResolvedValue({ error: transientRow });
+    const { container } = render(<ChatErrorBanner agentId="agent-1" onRetry={vi.fn()} />);
+
+    // Give the mount fetch a chance to resolve; the banner must still be empty.
+    await waitFor(() => expect(mockApiGet).toHaveBeenCalled());
+    expect(screen.queryByText("Penny paused")).not.toBeInTheDocument();
+    expect(container).toBeEmptyDOMElement();
   });
 
   it("dismisses via the API and hides the banner", async () => {

--- a/packages/web/src/__tests__/components/chat-session-provider.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-provider.test.tsx
@@ -4,6 +4,7 @@ import {
   ChatSessionProvider,
   MAX_LIVE_BUNDLES,
   useChatSession,
+  useChatSessionHasInlineError,
   useVisitedAgentIds,
   useVisitedSessions,
   type RuntimeBundle,
@@ -107,6 +108,44 @@ describe("ChatSessionProvider", () => {
     act(() => result.current.publishB(fakeBundle()));
 
     expect(result.current.ids.sort()).toEqual(["agent-A", "agent-B"]);
+  });
+
+  describe("useChatSessionHasInlineError (#583)", () => {
+    it("returns false when the session has no bundle", () => {
+      const { result } = renderHook(() => useChatSessionHasInlineError("agent-1"), { wrapper });
+      expect(result.current).toBe(false);
+    });
+
+    it("reflects the published bundle's hasInlineError flag", () => {
+      const { result } = renderHook(
+        () => ({
+          session: useChatSession("agent-1"),
+          hasInlineError: useChatSessionHasInlineError("agent-1"),
+        }),
+        { wrapper }
+      );
+
+      act(() => result.current.session.publish(fakeBundle({ hasInlineError: true })));
+      expect(result.current.hasInlineError).toBe(true);
+    });
+
+    it("defaults to false when the flag is absent (legacy placeholder bundle)", () => {
+      const { result } = renderHook(
+        () => ({
+          session: useChatSession("agent-1"),
+          hasInlineError: useChatSessionHasInlineError("agent-1"),
+        }),
+        { wrapper }
+      );
+
+      act(() => result.current.session.publish(fakeBundle()));
+      expect(result.current.hasInlineError).toBe(false);
+    });
+
+    it("does not throw outside a ChatSessionProvider (non-throwing fallback)", () => {
+      const { result } = renderHook(() => useChatSessionHasInlineError("agent-1"));
+      expect(result.current).toBe(false);
+    });
   });
 
   it("remove() clears the bundle for that agent", () => {

--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -37,6 +37,9 @@ vi.mock("@/components/chat-session-provider", () => ({
   // ChatSwitcher (rendered in the header) reads run-state via this hook to
   // refresh the chat title when a run completes; idle in these tests.
   useChatSessionIsRunning: () => false,
+  // ChatErrorBanner reads this to suppress itself when the thread already shows
+  // the inline error (#583); no inline error in these tests.
+  useChatSessionHasInlineError: () => false,
 }));
 
 vi.mock("@/hooks/use-chat-status", () => ({

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-inline-error-flag.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-inline-error-flag.test.ts
@@ -1,0 +1,120 @@
+/**
+ * #583: the runtime must report whether the thread currently shows an inline
+ * error bubble, so the durable paused-error banner can suppress itself and act
+ * as a true fallback (rather than rendering the same failure twice after a
+ * nav-away/back). This is the single source of truth the banner reads via
+ * `useChatSessionHasInlineError`.
+ *
+ * Mocks @assistant-ui/react to the identity function so the hook's return
+ * values are observable directly without a real runtime.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: vi.fn() }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+vi.mock("@assistant-ui/react", () => ({
+  useExternalStoreRuntime: (config: unknown) => config,
+  SimpleImageAttachmentAdapter: class {
+    accept = "image/*";
+  },
+  SimpleTextAttachmentAdapter: class {
+    accept = "text/plain";
+  },
+  CompositeAttachmentAdapter: class {
+    accept = "";
+    constructor() {}
+  },
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+describe("useWsRuntime — hasInlineError flag (#583)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    wsInstances = [];
+  });
+  afterEach(() => vi.useRealTimers());
+
+  // The client buffers non-history frames until the history response drains
+  // the Tier 2b buffer, so every test completes the handshake with an (empty)
+  // history frame before driving the failure.
+  function openAndDrain(ws: MockWebSocket) {
+    act(() => ws.simulateOpen());
+    act(() => ws.simulateMessage({ type: "history", messages: [] }));
+  }
+
+  it("is false before any failure", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    openAndDrain(wsInstances[0]!);
+    expect(result.current.hasInlineError).toBe(false);
+  });
+
+  it("becomes true once an error frame injects an inline failure bubble", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    openAndDrain(ws);
+    act(() =>
+      ws.simulateMessage({
+        type: "error",
+        agentName: "Smithers",
+        providerError: "LLM request failed.",
+        messageId: "m1",
+        runId: "r1",
+      })
+    );
+
+    expect(result.current.hasInlineError).toBe(true);
+  });
+
+  it("clears back to false when a successful chunk dismisses the error bubble", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = wsInstances[0]!;
+    openAndDrain(ws);
+    act(() =>
+      ws.simulateMessage({
+        type: "error",
+        agentName: "Smithers",
+        providerError: "LLM request failed.",
+        messageId: "m1",
+        runId: "r1",
+      })
+    );
+    expect(result.current.hasInlineError).toBe(true);
+
+    act(() =>
+      ws.simulateMessage({ type: "chunk", content: "recovered", messageId: "m2", runId: "r2" })
+    );
+    expect(result.current.hasInlineError).toBe(false);
+  });
+});

--- a/packages/web/src/components/chat-error-banner.tsx
+++ b/packages/web/src/components/chat-error-banner.tsx
@@ -2,6 +2,7 @@
 
 import { useEffect, useState } from "react";
 import { apiGet, apiDelete } from "@/lib/api-client";
+import { useChatSessionHasInlineError } from "@/components/chat-session-provider";
 import { ChatErrorMessage, type ChatError } from "@/components/assistant-ui/chat-error-message";
 import type { TransientReason } from "@/lib/schemas/chat-frames";
 import { Button } from "@/components/ui/button";
@@ -65,6 +66,13 @@ export function ChatErrorBanner({
 }) {
   const [error, setError] = useState<ActiveError | null>(null);
 
+  // #583: the banner is a FALLBACK for a failure the live bubble lost to a
+  // reload/reconnect. When the runtime bundle survives a nav-away/back, the
+  // inline turn-failure bubble is still on screen — so suppress the banner to
+  // avoid showing the same failure twice. The thread is the single source of
+  // truth; the banner only fills in when no inline error is present.
+  const hasInlineError = useChatSessionHasInlineError(agentId, chatId ?? undefined);
+
   useEffect(() => {
     let cancelled = false;
     const url = chatId
@@ -82,7 +90,7 @@ export function ChatErrorBanner({
     };
   }, [agentId, chatId]);
 
-  if (!error) return null;
+  if (!error || hasInlineError) return null;
 
   const handleDismiss = () => {
     const id = error.id;

--- a/packages/web/src/components/chat-session-mounts.tsx
+++ b/packages/web/src/components/chat-session-mounts.tsx
@@ -95,6 +95,7 @@ function ChatSessionInstance({ agentId, chatId }: { agentId: string; chatId?: st
       isDelayed: bundle.isDelayed,
       reconnectExhausted: bundle.reconnectExhausted,
       payloadRejected: bundle.payloadRejected,
+      hasInlineError: bundle.hasInlineError,
       onRetryContinue,
       onRetryResend,
       lastError,
@@ -118,6 +119,7 @@ function ChatSessionInstance({ agentId, chatId }: { agentId: string; chatId?: st
     bundle.isDelayed,
     bundle.reconnectExhausted,
     bundle.payloadRejected,
+    bundle.hasInlineError,
     bundle.pendingUploads,
   ]);
 

--- a/packages/web/src/components/chat-session-provider.tsx
+++ b/packages/web/src/components/chat-session-provider.tsx
@@ -33,6 +33,13 @@ export interface RuntimeBundle {
   isDelayed: boolean;
   reconnectExhausted: boolean;
   payloadRejected: boolean;
+  /**
+   * The thread currently shows an inline turn-failure bubble (#583). Optional
+   * so the placeholder bundle and legacy publishers stay valid; absent ≙ false.
+   * Read by the durable paused-error banner to suppress itself when the same
+   * failure is already on screen inline, making the banner a true fallback.
+   */
+  hasInlineError?: boolean;
   onRetryContinue: (reason: "orphan" | "partial_stream_failure" | "send_failure") => void;
   onRetryResend: (messageId: string) => void;
   lastError: string | null;
@@ -146,6 +153,19 @@ export function useChatSessionIsRunning(agentId: string, chatId?: string): boole
   const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
   const key = chatSessionKey(agentId, chatId);
   return useStore(store, (s) => s.bundles[key]?.isRunning ?? false);
+}
+
+/**
+ * Non-throwing subscription to whether the given chat's thread currently shows
+ * an inline turn-failure bubble (#583). Mirrors `useChatSessionIsRunning`'s
+ * fallback-store pattern so the durable paused-error banner — which lives
+ * outside the runtime — can suppress itself when the failure is already
+ * visible inline, without coupling its render to the provider.
+ */
+export function useChatSessionHasInlineError(agentId: string, chatId?: string): boolean {
+  const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
+  const key = chatSessionKey(agentId, chatId);
+  return useStore(store, (s) => s.bundles[key]?.hasInlineError ?? false);
 }
 
 export function useVisitedAgentIds(): string[] {

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -405,6 +405,12 @@ export function useWsRuntime(
   hasInitialContent: boolean;
   reconnectExhausted: boolean;
   payloadRejected: boolean;
+  /**
+   * True while an inline turn-failure bubble is in the thread (#583). Lets the
+   * durable paused-error banner suppress itself as a fallback rather than
+   * duplicate a failure that is already visible inline.
+   */
+  hasInlineError: boolean;
   onRetryContinue: (reason: "orphan" | "partial_stream_failure" | "send_failure") => void;
   onRetryResend: (messageId: string) => void;
   pendingUploads: PendingUpload[];
@@ -1921,6 +1927,10 @@ export function useWsRuntime(
     isOpenClawConnected,
     reconnectExhausted,
     payloadRejected,
+    // #583: whether an inline turn-failure bubble is currently in the thread.
+    // The durable paused-error banner reads this (via the published bundle) to
+    // suppress itself when the same failure is already shown inline.
+    hasInlineError: messages.some((m) => m.error),
     onRetryContinue,
     onRetryResend,
     pendingUploads,


### PR DESCRIPTION
## What

The durable "paused" error banner and the inline turn-failure bubble showed the **same failure twice** — once at the top of the chat (banner) and once in the thread (bubble) — after navigating away and back, or after a reconnect that preserved the runtime bundle.

The banner is meant to be a **fallback**: it re-surfaces a failure the live bubble *lost* to a reload/reconnect. When the runtime bundle survives, the inline bubble is still on screen, so the banner is redundant.

## Fix

The thread is the single source of truth for a live failure:
- `useWsRuntime` publishes `hasInlineError` = `messages.some((m) => m.error)`.
- It's threaded through the `RuntimeBundle` (optional; absent ≙ false, so the placeholder bundle and legacy publishers stay valid) and `chat-session-mounts`.
- A new non-throwing `useChatSessionHasInlineError(agentId, chatId)` hook — mirroring `useChatSessionIsRunning`'s fallback-store pattern — lets `ChatErrorBanner`, which lives outside the runtime, read the flag and `return null` when an inline error is already on screen.

Net effect: the banner only fills in when **no** inline error is present (the live bubble was genuinely lost). No duplicate.

## Tests (TDD)
- `use-ws-runtime-inline-error-flag.test.ts` — the runtime sets `hasInlineError` from thread messages.
- `chat-session-provider.test.tsx` — `useChatSessionHasInlineError` returns the bundle flag, falls back to `false` outside a provider.
- `chat-error-banner.test.tsx` — the banner suppresses itself when an inline error is present, renders when none is.
- `chat.test.tsx` — mock completeness for the new hook.

Full unit suite green (6361 passed); lint 0 errors; tsc clean; prettier clean.

Closes #583
