### PR TITLE
feat(chat): persist composer draft text across reloads

### DIFF
--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -63,7 +63,7 @@ When you send a message and move to a different page in Pinchy, the chat keeps r
 
 A full page reload does not lose the reply either. Pinchy re-attaches the reloaded chat to the in-flight run through its stable session key, so any output that arrived while the page was reloading still lands in the same bubble and streaming continues. Only a restart of the Pinchy server drops in-flight runs.
 
-An unsent message you've typed is kept too. Each chat holds its own draft, so a message you start in one chat never appears in another — and when you leave a chat and come back, your draft is waiting where you left it. Sending the message clears the draft; so does deleting the text yourself.
+An unsent message you've typed is kept too. Each chat holds its own draft, so a message you start in one chat never appears in another — and your typed text is waiting where you left it when you return, even after a full page reload or closing and reopening the tab. Sending the message clears the draft; so does deleting the text yourself.
 
 Clicking an agent in the sidebar reopens the chat you last had open with that agent on this device, rather than starting from the oldest one. The first time you open an agent on a new device, Pinchy takes you to your most recent conversation with it.
 

--- a/packages/web/src/__tests__/lib/draft-store.test.ts
+++ b/packages/web/src/__tests__/lib/draft-store.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import { getDraft, saveDraft, clearDraft, draftKey } from "@/lib/draft-store";
 
 describe("draftKey", () => {
@@ -74,5 +74,58 @@ describe("draft-store", () => {
     saveDraft("agent-1", { text: "", files: [file] });
     expect(getDraft("agent-1")).toBeDefined();
     expect(getDraft("agent-1")?.files).toHaveLength(1);
+  });
+});
+
+describe("draft-store localStorage persistence (survives reload)", () => {
+  // A fresh module instance models a full page reload: its in-memory Map starts
+  // empty, but jsdom localStorage is shared, so a persisted draft must reappear.
+  beforeEach(() => {
+    localStorage.clear();
+    vi.resetModules();
+  });
+
+  it("recovers the draft text from localStorage after a reload", async () => {
+    const first = await import("@/lib/draft-store");
+    first.saveDraft(first.draftKey("agent-1", "chat-a"), { text: "survive reload", files: [] });
+
+    vi.resetModules();
+    const reloaded = await import("@/lib/draft-store");
+    expect(reloaded.getDraft(reloaded.draftKey("agent-1", "chat-a"))).toEqual({
+      text: "survive reload",
+      files: [],
+    });
+  });
+
+  it("does not resurrect file attachments across a reload (text-only recovery)", async () => {
+    const first = await import("@/lib/draft-store");
+    const file = new File(["x"], "a.txt", { type: "text/plain" });
+    first.saveDraft(first.draftKey("agent-1"), { text: "with file", files: [file] });
+
+    vi.resetModules();
+    const reloaded = await import("@/lib/draft-store");
+    const recovered = reloaded.getDraft(reloaded.draftKey("agent-1"));
+    expect(recovered?.text).toBe("with file");
+    expect(recovered?.files).toEqual([]);
+  });
+
+  it("clears the persisted text so a cleared draft stays gone after a reload", async () => {
+    const first = await import("@/lib/draft-store");
+    first.saveDraft(first.draftKey("agent-1"), { text: "temp", files: [] });
+    first.clearDraft(first.draftKey("agent-1"));
+
+    vi.resetModules();
+    const reloaded = await import("@/lib/draft-store");
+    expect(reloaded.getDraft(reloaded.draftKey("agent-1"))).toBeUndefined();
+  });
+
+  it("removes the persisted text on auto-clear (empty save)", async () => {
+    const first = await import("@/lib/draft-store");
+    first.saveDraft(first.draftKey("agent-1"), { text: "temp", files: [] });
+    first.saveDraft(first.draftKey("agent-1"), { text: "", files: [] });
+
+    vi.resetModules();
+    const reloaded = await import("@/lib/draft-store");
+    expect(reloaded.getDraft(reloaded.draftKey("agent-1"))).toBeUndefined();
   });
 });

--- a/packages/web/src/lib/draft-store.ts
+++ b/packages/web/src/lib/draft-store.ts
@@ -3,7 +3,23 @@ export interface Draft {
   files: File[];
 }
 
+/**
+ * In-memory layer: holds the full draft (text + File objects) for the lifetime of
+ * the page. `File` objects are not serializable, so attachments live ONLY here and
+ * are session-scoped — they survive in-app navigation but not a reload. That is an
+ * acceptable limit: composer attachments are pre-upload local files, and no chat
+ * product resurrects unsent file attachments across a reload.
+ */
 const drafts = new Map<string, Draft>();
+
+/**
+ * Durable layer: the draft TEXT is mirrored to localStorage so it survives a full
+ * reload and a mobile tab eviction (the in-memory Map does not). Text is the part
+ * users actually lose and ask to keep; the in-memory Map stays the authoritative
+ * source within a session (it also carries the files), and localStorage is the
+ * fallback consulted only when the Map has no entry (i.e. after a reload).
+ */
+const TEXT_PREFIX = "pinchy:composer:draft:";
 
 /**
  * Store key for one composer draft, scoped to a single (agent, chat) pair (#508).
@@ -21,17 +37,31 @@ export function draftKey(agentId: string, chatId?: string | null): string {
 }
 
 export function getDraft(key: string): Draft | undefined {
-  return drafts.get(key);
+  const inMemory = drafts.get(key);
+  if (inMemory) return inMemory;
+  // Map miss (e.g. immediately after a reload) — recover the persisted text.
+  if (typeof localStorage === "undefined") return undefined;
+  const text = localStorage.getItem(TEXT_PREFIX + key);
+  return text ? { text, files: [] } : undefined;
 }
 
 export function saveDraft(key: string, draft: Draft): void {
   if (!draft.text && draft.files.length === 0) {
-    drafts.delete(key);
+    clearDraft(key);
     return;
   }
   drafts.set(key, draft);
+  if (typeof localStorage === "undefined") return;
+  // Only text is durable; a files-only draft has nothing serializable to persist.
+  if (draft.text) {
+    localStorage.setItem(TEXT_PREFIX + key, draft.text);
+  } else {
+    localStorage.removeItem(TEXT_PREFIX + key);
+  }
 }
 
 export function clearDraft(key: string): void {
   drafts.delete(key);
+  if (typeof localStorage === "undefined") return;
+  localStorage.removeItem(TEXT_PREFIX + key);
 }


### PR DESCRIPTION
## Why

Follow-up to the per-chat composer draft work (#589). That store was **in-memory only**, so a full page reload — or a mobile tab eviction while you'd typed but not sent — lost the text. That's the exact "switched apps, my prompt is gone" failure users hit (documented for ChatGPT's iOS app), and per-conversation draft persistence that survives a reload is the table-stakes bar set by Slack/WhatsApp/Telegram/Gmail.

## What changed

The draft store becomes a small hybrid:

- **In-memory `Map`** — still the authoritative in-session source; carries the full draft including `File` attachments, survives in-app navigation.
- **localStorage (text only)** — the draft **text** is mirrored per `(agentId, chatId)` and consulted as a fallback when the map is empty (i.e. just after a reload). Because `DraftPersistence` already saves on every composer change, the text is persisted continuously — which also covers the mobile blur/eviction case **without** a separate `visibilitychange` handler.

**File attachments stay session-scoped on purpose:** `File` objects aren't serializable, and no chat product resurrects unsent attachments across a reload. Text is the part users actually lose and ask to keep.

No component changes — `DraftPersistence` calls `getDraft`/`saveDraft`/`clearDraft` as before; persistence is now transparent.

## Tests (TDD)

`draft-store.test.ts` gains a "survives reload" block that models a reload with `vi.resetModules()` (fresh module = empty map, shared localStorage):
- recovers the draft text after a reload;
- does **not** resurrect file attachments (text-only recovery);
- a cleared draft, and an auto-cleared (emptied) draft, stay gone after a reload.

The real-composer `draft-persistence.test.tsx` and the rest of the suite pass unchanged (per-chat isolation, restore-on-return, clear-on-send/delete).

Docs: `chat-states.mdx` notes the typed text now survives a reload / tab reopen.

## Verification

- Full web unit suite: 6478 passed, 13 skipped, 0 failed.
- `tsc --noEmit` (fresh), ESLint (0 errors), Prettier — clean.
- Pre-push `next build` passed.

Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com).