### PR TITLE
feat(models): add kimi-k2.7-code to the Ollama Cloud catalog

### DIFF
--- a/packages/web/src/__tests__/lib/model-vision.integration.test.ts
+++ b/packages/web/src/__tests__/lib/model-vision.integration.test.ts
@@ -64,6 +64,15 @@ describe("Ollama cloud vision models (from DB seed)", () => {
     expect(isModelVisionCapable("ollama-cloud/qwen3.5:397b")).toBe(false);
   });
 
+  it("returns FALSE for kimi-k2.7-code (library claims vision, live API 500s)", () => {
+    // Unlike its kimi-k2.5/2.6 siblings (vision-capable above), the -code
+    // variant's library page claims image input (MoonViT) but the live
+    // `/v1/chat/completions` returns HTTP 500 on image_url payloads (probed
+    // 2026-06-25, 2 rounds). Flagged vision:false so it's never picked for
+    // images — its value is reliable tools, not vision.
+    expect(isModelVisionCapable("ollama-cloud/kimi-k2.7-code")).toBe(false);
+  });
+
   it("returns true for every ministral-3 variant", () => {
     expect(isModelVisionCapable("ollama-cloud/ministral-3:3b")).toBe(true);
     expect(isModelVisionCapable("ollama-cloud/ministral-3:8b")).toBe(true);

--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -131,9 +131,30 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     // of gemma4:31b, which we already carry with verified vision. Vision could
     // not be re-confirmed (the image endpoint was returning blanket 5xx that
     // day). They stay out until a deliberate multi-run + vision re-evaluation.
+    //
+    // Re-triaged 2026-06-25 (v0.7.x catalog sweep): ollama.com/library/gemma3
+    // now lists only vision — no "tools" tag at all — so the family isn't even
+    // a tool candidate any more. No tag → not added (every Pinchy agent uses
+    // tools); the prior multi-turn-500 evidence stands.
     for (const id of ["gemma3:4b", "gemma3:12b", "gemma3:27b"]) {
       expect(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS).not.toContain(id);
     }
+  });
+
+  it("includes kimi-k2.7-code with reasoning, text-only, 256K context", () => {
+    // Added 2026-06-25 (v0.7.x catalog sweep). ollama.com/library/kimi-k2.7-code
+    // lists tools + thinking + vision (image/video via MoonViT), 256K context.
+    // Tools verified empirically 4/4 rounds against /v1/chat/completions
+    // (structured tool_call + clean multi-turn follow-up) — no multi-turn-500
+    // regression, unlike its kimi-k2-thinking sibling. Vision is flagged false:
+    // the live endpoint returns HTTP 500 on image_url payloads (2 rounds), so
+    // the library "vision" tag is a lie here, same shape as qwen3.5:397b.
+    const m = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((x) => x.id === "kimi-k2.7-code");
+    expect(m).toBeDefined();
+    expect(m!.reasoning).toBe(true);
+    expect(m!.vision).toBe(false);
+    expect(m!.contextWindow).toBe(262144);
+    expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("kimi-k2.7-code")).toBe(false);
   });
 
   it("every model declares vision and carries no dead capability fields", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1868,6 +1868,7 @@ describe("regenerateOpenClawConfig", () => {
         "gpt-oss:20b",
         "kimi-k2.5",
         "kimi-k2.6",
+        "kimi-k2.7-code",
         "minimax-m2.1",
         "minimax-m2.5",
         "minimax-m2.7",
@@ -1930,6 +1931,7 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["gemma4:31b"]).toBe(262144);
     expect(ctx["kimi-k2.5"]).toBe(262144);
     expect(ctx["kimi-k2.6"]).toBe(262144);
+    expect(ctx["kimi-k2.7-code"]).toBe(262144);
     expect(ctx["ministral-3:3b"]).toBe(262144);
     expect(ctx["ministral-3:8b"]).toBe(262144);
     expect(ctx["ministral-3:14b"]).toBe(262144);
@@ -2002,6 +2004,10 @@ describe("regenerateOpenClawConfig", () => {
     expect(byId["deepseek-v3.2"].input).toEqual(["text"]);
     expect(byId["devstral-small-2:24b"].input).toEqual(["text"]);
     expect(byId["qwen3.5:397b"].input).toEqual(["text"]);
+    // kimi-k2.7-code: library page claims image input (MoonViT), but the live
+    // /v1/chat/completions returns HTTP 500 on image_url payloads (probed
+    // 2026-06-25, 2 rounds) — text-only, unlike its kimi-k2.5/2.6 siblings.
+    expect(byId["kimi-k2.7-code"].input).toEqual(["text"]);
     // 2026-06 additions: both are text-only lines (no image input tag, and
     // vision is never assumed without an empirical probe).
     expect(byId["nemotron-3-ultra"].input).toEqual(["text"]);
@@ -2025,6 +2031,7 @@ describe("regenerateOpenClawConfig", () => {
       "gpt-oss:120b",
       "kimi-k2.5",
       "kimi-k2.6",
+      "kimi-k2.7-code",
       "minimax-m2.5",
       "minimax-m2.7",
       "minimax-m3",

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -296,6 +296,7 @@ describe("fetchProviderModels", () => {
             { id: "kimi-k2-thinking" },
             { id: "kimi-k2.5" },
             { id: "kimi-k2.6" },
+            { id: "kimi-k2.7-code" },
             { id: "minimax-m2.1" },
             { id: "minimax-m2.5" },
             { id: "minimax-m2.7" },
@@ -347,6 +348,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
+        "ollama-cloud/kimi-k2.7-code",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",
@@ -372,7 +374,7 @@ describe("fetchProviderModels", () => {
     expect(ids).not.toContain("ollama-cloud/qwen3-next:80b");
     // minimax-m3 was added to the allowlist (vision + tools confirmed live).
     expect(ids).toContain("ollama-cloud/minimax-m3");
-    expect(ids).toHaveLength(31);
+    expect(ids).toHaveLength(32);
 
     // Tool-broken models are filtered out (probed 2026-06-12: gemma3:4b leaks
     // pseudo tool calls as text, gemma3:12b serves HTTP 500, gemma3:27b
@@ -421,7 +423,7 @@ describe("fetchProviderModels", () => {
     const ids = ollama!.models.map((m) => m.id);
     // kimi-k2-thinking removed from allowlist (#305 — Ollama Cloud returns HTTP 500 for this model)
     expect(ids).not.toContain("ollama-cloud/kimi-k2-thinking");
-    expect(ids).toHaveLength(31);
+    expect(ids).toHaveLength(32);
     expect(ids).toEqual(
       expect.arrayContaining([
         "ollama-cloud/deepseek-v3.1:671b",
@@ -440,6 +442,7 @@ describe("fetchProviderModels", () => {
         "ollama-cloud/gpt-oss:120b",
         "ollama-cloud/kimi-k2.5",
         "ollama-cloud/kimi-k2.6",
+        "ollama-cloud/kimi-k2.7-code",
         "ollama-cloud/minimax-m2.1",
         "ollama-cloud/minimax-m2.5",
         "ollama-cloud/minimax-m2.7",

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -175,6 +175,19 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: true,
   },
   {
+    // Tools verified 4/4 rounds (structured tool_call + clean multi-turn,
+    // 2026-06-25) — reliably tool-capable, no multi-turn-500 regression. The
+    // library page lists "vision" (image/video via MoonViT), but the live
+    // /v1/chat/completions returns HTTP 500 on image_url payloads (2026-06-25,
+    // 2 rounds), so vision:false — the page lies and we never hand it an image.
+    // `reasoning:true` from the library "thinking" tag (kimi-k2.5/2.6 parity).
+    id: "kimi-k2.7-code",
+    contextWindow: 262144,
+    maxTokens: 8192,
+    reasoning: true,
+    vision: false,
+  },
+  {
     id: "minimax-m2.1",
     contextWindow: 204800,
     maxTokens: 8192,


### PR DESCRIPTION
## What

Catalog sweep for the v0.7.x line (`pnpm models:discover`, 2026-06-25). No upstream removals; four `ADDED` candidates triaged against their library pages + live probes (key principle: **the library tags lie — every flag is set from what the live API does**).

### Added: `kimi-k2.7-code`
- **Tools: verified 4/4 rounds** against the live `/v1/chat/completions` — structured `tool_call` + clean multi-turn follow-up each round. No multi-turn-500 regression (the failure mode that got `kimi-k2-thinking` removed in #305).
- **Vision: flagged `false`.** The library page claims image input (MoonViT), but the live endpoint returns **HTTP 500 on `image_url` payloads** (probed 2×). Same "page lies" shape as `qwen3.5:397b`. Its value is reliable tools, not vision.
- `reasoning: true` from the thinking tag, consistent with `kimi-k2.5`/`2.6`. Context 256K (262144).
- **Not a tier default** — the kimi family is deliberately avoided for tier picks (`v0.5.3` silent-500 history, see `providers/ollama-cloud.ts`). It's available for manual selection, exactly like `kimi-k2.5`/`2.6`.

### Not added: `gemma3:4b` / `12b` / `27b`
The `ollama.com/library/gemma3` page **no longer carries a `tools` tag at all** (only vision) — so the family isn't even a candidate; every Pinchy agent uses tools. The prior multi-turn-500 evidence still stands. The existing exclusion test records the 2026-06-25 re-triage.

## Derived sites
No tier-pick / families / blocklist / image-preference change (kimi avoided for defaults; `vision:false` ⇒ not an image fallback). Drift tests updated: `provider-models` (count 31→32 + lists + served mock), `openclaw-config` (written list, contextWindow, `input`, `reasoning`), the dated empirical assertions in `ollama-cloud-models`, and a `model-vision.integration` negative case.

## Gates
`tsc` clean · `test:scripts` green · full unit suite (6479) green · `test:db` (132, incl. vision-integration) green · lint 0 errors · prettier clean.
