### PR TITLE
feat(pinchy-files): give pinchy_read a dedicated live-resolved vision model

### DIFF
--- a/packages/plugins/pinchy-files/config-schema.test.ts
+++ b/packages/plugins/pinchy-files/config-schema.test.ts
@@ -21,6 +21,7 @@ const manifest = loadPluginManifest("pinchy-files");
 const REPRESENTATIVE_EMITTED_CONFIG = {
   apiBaseUrl: "http://pinchy:7777",
   gatewayToken: "test-token",
+  visionModel: "ollama-cloud/gemini-3-flash-preview",
   agents: {
     "agent-uuid": {
       allowed_paths: ["/data/knowledge-base"],
@@ -57,6 +58,18 @@ describe("pinchy-files manifest contract", () => {
           write_paths: ["/data/kb"],
         },
       },
+    };
+    const result = validatePluginEntry(manifest, config);
+    if (!result.ok) throw new Error(result.errors.join("\n"));
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts the top-level visionModel field (pinchy_read scanned-page vision)", () => {
+    const config = {
+      apiBaseUrl: "http://pinchy:7777",
+      gatewayToken: "test-token",
+      visionModel: "anthropic/claude-haiku-4-5-20251001",
+      agents: { "agent-1": { allowed_paths: ["/data/kb"] } },
     };
     const result = validatePluginEntry(manifest, config);
     if (!result.ok) throw new Error(result.errors.join("\n"));

--- a/packages/plugins/pinchy-files/config-schema.test.ts
+++ b/packages/plugins/pinchy-files/config-schema.test.ts
@@ -17,7 +17,9 @@ import { loadPluginManifest } from "../../web/src/lib/openclaw-config/plugin-man
 
 const manifest = loadPluginManifest("pinchy-files");
 
-// Mirrors the shape regenerateOpenClawConfig() emits at packages/web/src/lib/openclaw-config/build.ts:260-270.
+// Mirrors the shape regenerateOpenClawConfig() emits for the pinchy-files
+// plugin entry (see the `entries["pinchy-files"]` block in
+// packages/web/src/lib/openclaw-config/build.ts).
 const REPRESENTATIVE_EMITTED_CONFIG = {
   apiBaseUrl: "http://pinchy:7777",
   gatewayToken: "test-token",

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -367,9 +367,15 @@ describe("pinchy_read PDF integration", () => {
     expect(result.content[0].text).not.toContain("<document>");
   });
 
-  it("calls vision API for scanned pages when modelAuth is available", async () => {
-    // Reset the module cache so a fresh PdfCache instance is created.
-    // A previous test may have cached the scanned PDF result without vision.
+  // Shared harness for the scanned-page vision path: fresh module/cache, a
+  // mocked modelAuth + loadConfig runtime, and a globally-mocked fetch returning
+  // `fetchJson`. Returns the tool result and the modelAuth spy so each test can
+  // assert on the dispatched provider and/or extracted text. Restores fetch.
+  async function runScannedPdfVision(opts: {
+    agentModel: string;
+    visionModelOverride?: string;
+    fetchJson: () => Promise<unknown>;
+  }): Promise<{ result: any; mockResolveApiKey: ReturnType<typeof vi.fn> }> {
     vi.resetModules();
     const { rmSync: rm } = await import("fs");
     const cacheSqlite = join(testCacheDir, "pdf-cache.sqlite");
@@ -379,65 +385,52 @@ describe("pinchy_read PDF integration", () => {
 
     const mockResolveApiKey = vi.fn().mockResolvedValue({ apiKey: "test-key" });
     const api = createMockApi({ "agent-1": { allowed_paths: [FIXTURES + "/"] } });
-
-    // Add runtime with modelAuth and config
+    if (opts.visionModelOverride) {
+      (api as any).pluginConfig.visionModel = opts.visionModelOverride;
+    }
     (api as any).runtime = {
       ...api.runtime,
-      modelAuth: {
-        resolveApiKeyForProvider: mockResolveApiKey,
-      },
+      modelAuth: { resolveApiKeyForProvider: mockResolveApiKey },
       config: {
-        loadConfig: () => ({
-          agents: {
-            list: [{ id: "agent-1", model: "anthropic/claude-haiku-4-5-20251001" }],
-          },
-        }),
+        loadConfig: () => ({ agents: { list: [{ id: "agent-1", model: opts.agentModel }] } }),
       },
     };
 
-    // Mock fetch globally to simulate Anthropic API response
     const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
-        content: [{ type: "text", text: "Vision extracted: HWB 234 kWh/m²a" }],
-      }),
-    });
-
+    globalThis.fetch = vi.fn().mockResolvedValue({ ok: true, json: opts.fetchJson });
     try {
       const { default: plugin } = await import("./index");
-      vi.clearAllMocks(); // Clear import-related mocks but keep our fetch mock
-
-      // Re-setup our mocks after clearAllMocks
-      (globalThis.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          content: [{ type: "text", text: "Vision extracted: HWB 234 kWh/m²a" }],
-        }),
-      });
+      vi.clearAllMocks(); // Clear import-related mocks but keep our fetch + auth mocks
+      (globalThis.fetch as any).mockResolvedValue({ ok: true, json: opts.fetchJson });
       mockResolveApiKey.mockResolvedValue({ apiKey: "test-key" });
 
       plugin.register!(api as any);
-
       const readFactory = mockRegisterTool.mock.calls.find(
         (call: any[]) => call[1]?.name === "pinchy_read"
       )?.[0];
       const tool = readFactory({ agentId: "agent-1" });
-
-      const fixturePath = join(FIXTURES, "scanned.pdf");
-      const result = await tool.execute("call-1", { path: fixturePath });
-
-      // resolveApiKeyForProvider should be called with {provider, cfg} object
-      expect(mockResolveApiKey).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: "anthropic" })
-      );
-
-      // The result should contain the vision-extracted text, NOT the fallback
-      expect(result.content[0].text).toContain("HWB 234");
-      expect(result.content[0].text).not.toContain("Unable to extract text");
+      const result = await tool.execute("call-1", { path: join(FIXTURES, "scanned.pdf") });
+      return { result, mockResolveApiKey };
     } finally {
       globalThis.fetch = originalFetch;
     }
+  }
+
+  it("calls vision API for scanned pages when modelAuth is available", async () => {
+    const { result, mockResolveApiKey } = await runScannedPdfVision({
+      agentModel: "anthropic/claude-haiku-4-5-20251001",
+      fetchJson: async () => ({
+        content: [{ type: "text", text: "Vision extracted: HWB 234 kWh/m²a" }],
+      }),
+    });
+
+    // resolveApiKeyForProvider should be called with {provider, cfg} object
+    expect(mockResolveApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "anthropic" })
+    );
+    // The result should contain the vision-extracted text, NOT the fallback
+    expect(result.content[0].text).toContain("HWB 234");
+    expect(result.content[0].text).not.toContain("Unable to extract text");
   });
 
   it("prefers the pluginConfig.visionModel over the agent's own chat model for vision", async () => {
@@ -445,62 +438,21 @@ describe("pinchy_read PDF integration", () => {
     // visionModel pointing at google. Vision must dispatch to GOOGLE — proving
     // scanned-page description is decoupled from the (possibly text-only) chat
     // model and uses the live-resolved visionModel instead.
-    vi.resetModules();
-    const { rmSync: rm } = await import("fs");
-    const cacheSqlite = join(testCacheDir, "pdf-cache.sqlite");
-    rm(cacheSqlite, { force: true });
-    rm(cacheSqlite + "-wal", { force: true });
-    rm(cacheSqlite + "-shm", { force: true });
-
-    const mockResolveApiKey = vi.fn().mockResolvedValue({ apiKey: "test-key" });
-    const api = createMockApi({ "agent-1": { allowed_paths: [FIXTURES + "/"] } });
-    (api as any).pluginConfig.visionModel = "google/gemini-2.5-flash";
-    (api as any).runtime = {
-      ...api.runtime,
-      modelAuth: { resolveApiKeyForProvider: mockResolveApiKey },
-      config: {
-        loadConfig: () => ({
-          agents: { list: [{ id: "agent-1", model: "anthropic/claude-haiku-4-5-20251001" }] },
-        }),
-      },
-    };
-
-    const originalFetch = globalThis.fetch;
-    globalThis.fetch = vi.fn().mockResolvedValue({
-      ok: true,
-      json: async () => ({
+    const { mockResolveApiKey } = await runScannedPdfVision({
+      agentModel: "anthropic/claude-haiku-4-5-20251001",
+      visionModelOverride: "google/gemini-2.5-flash",
+      fetchJson: async () => ({
         candidates: [{ content: { parts: [{ text: "Vision via google" }] } }],
       }),
     });
 
-    try {
-      const { default: plugin } = await import("./index");
-      vi.clearAllMocks();
-      (globalThis.fetch as any).mockResolvedValue({
-        ok: true,
-        json: async () => ({
-          candidates: [{ content: { parts: [{ text: "Vision via google" }] } }],
-        }),
-      });
-      mockResolveApiKey.mockResolvedValue({ apiKey: "test-key" });
-
-      plugin.register!(api as any);
-      const readFactory = mockRegisterTool.mock.calls.find(
-        (call: any[]) => call[1]?.name === "pinchy_read"
-      )?.[0];
-      const tool = readFactory({ agentId: "agent-1" });
-      await tool.execute("call-1", { path: join(FIXTURES, "scanned.pdf") });
-
-      // The override (google) wins over the agent's anthropic model.
-      expect(mockResolveApiKey).toHaveBeenCalledWith(
-        expect.objectContaining({ provider: "google" })
-      );
-      expect(mockResolveApiKey).not.toHaveBeenCalledWith(
-        expect.objectContaining({ provider: "anthropic" })
-      );
-    } finally {
-      globalThis.fetch = originalFetch;
-    }
+    // The override (google) wins over the agent's anthropic model.
+    expect(mockResolveApiKey).toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "google" })
+    );
+    expect(mockResolveApiKey).not.toHaveBeenCalledWith(
+      expect.objectContaining({ provider: "anthropic" })
+    );
   });
 
   it("uses cache for repeated PDF reads", async () => {

--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -440,6 +440,69 @@ describe("pinchy_read PDF integration", () => {
     }
   });
 
+  it("prefers the pluginConfig.visionModel over the agent's own chat model for vision", async () => {
+    // The agent's chat model is anthropic, but Pinchy emitted a dedicated
+    // visionModel pointing at google. Vision must dispatch to GOOGLE — proving
+    // scanned-page description is decoupled from the (possibly text-only) chat
+    // model and uses the live-resolved visionModel instead.
+    vi.resetModules();
+    const { rmSync: rm } = await import("fs");
+    const cacheSqlite = join(testCacheDir, "pdf-cache.sqlite");
+    rm(cacheSqlite, { force: true });
+    rm(cacheSqlite + "-wal", { force: true });
+    rm(cacheSqlite + "-shm", { force: true });
+
+    const mockResolveApiKey = vi.fn().mockResolvedValue({ apiKey: "test-key" });
+    const api = createMockApi({ "agent-1": { allowed_paths: [FIXTURES + "/"] } });
+    (api as any).pluginConfig.visionModel = "google/gemini-2.5-flash";
+    (api as any).runtime = {
+      ...api.runtime,
+      modelAuth: { resolveApiKeyForProvider: mockResolveApiKey },
+      config: {
+        loadConfig: () => ({
+          agents: { list: [{ id: "agent-1", model: "anthropic/claude-haiku-4-5-20251001" }] },
+        }),
+      },
+    };
+
+    const originalFetch = globalThis.fetch;
+    globalThis.fetch = vi.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({
+        candidates: [{ content: { parts: [{ text: "Vision via google" }] } }],
+      }),
+    });
+
+    try {
+      const { default: plugin } = await import("./index");
+      vi.clearAllMocks();
+      (globalThis.fetch as any).mockResolvedValue({
+        ok: true,
+        json: async () => ({
+          candidates: [{ content: { parts: [{ text: "Vision via google" }] } }],
+        }),
+      });
+      mockResolveApiKey.mockResolvedValue({ apiKey: "test-key" });
+
+      plugin.register!(api as any);
+      const readFactory = mockRegisterTool.mock.calls.find(
+        (call: any[]) => call[1]?.name === "pinchy_read"
+      )?.[0];
+      const tool = readFactory({ agentId: "agent-1" });
+      await tool.execute("call-1", { path: join(FIXTURES, "scanned.pdf") });
+
+      // The override (google) wins over the agent's anthropic model.
+      expect(mockResolveApiKey).toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "google" })
+      );
+      expect(mockResolveApiKey).not.toHaveBeenCalledWith(
+        expect.objectContaining({ provider: "anthropic" })
+      );
+    } finally {
+      globalThis.fetch = originalFetch;
+    }
+  });
+
   it("uses cache for repeated PDF reads", async () => {
     const fixturePath = join(FIXTURES, "text-only.pdf");
     const api = createMockApi({ "agent-1": { allowed_paths: [FIXTURES + "/"] } });

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -106,7 +106,11 @@ interface PluginApi {
      * against the live `/v1/models` catalog and emitted into plugin config.
      * Decouples vision from the agent's chat model (which may be text-only) and
      * is kept fresh by Pinchy's self-heal/background-refresh, so it never points
-     * at a retired model. Falls back to the agent's own model when absent.
+     * at a retired model.
+     *
+     * Absent only when no vision provider is configured at all — in that case
+     * the plugin falls back to the agent's own model, which is likely text-only,
+     * so scanned-page vision may simply be unavailable (same as before).
      */
     visionModel?: string;
   };
@@ -226,7 +230,11 @@ const plugin = {
     const apiBaseUrl = api.pluginConfig?.apiBaseUrl;
     const gatewayToken = api.pluginConfig?.gatewayToken;
     // Pinchy-resolved, live-checked vision model for scanned pages. Preferred
-    // over the agent's (possibly text-only) chat model when present.
+    // over the agent's (possibly text-only) chat model when present. Captured
+    // here at register() time, exactly like apiBaseUrl/gatewayToken above — so
+    // a self-heal/background-refresh that rewrites this value takes effect only
+    // once OpenClaw re-registers the plugin on config hot-reload (verified by
+    // the dispatch E2E), not mid-process.
     const visionModelOverride = api.pluginConfig?.visionModel;
 
     // Capture runtime APIs for vision (direct LLM API calls for scanned pages)

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -101,6 +101,14 @@ interface PluginApi {
     agents?: Record<string, AgentFileConfig>;
     apiBaseUrl?: string;
     gatewayToken?: string;
+    /**
+     * Dedicated vision model for scanned-page description, resolved by Pinchy
+     * against the live `/v1/models` catalog and emitted into plugin config.
+     * Decouples vision from the agent's chat model (which may be text-only) and
+     * is kept fresh by Pinchy's self-heal/background-refresh, so it never points
+     * at a retired model. Falls back to the agent's own model when absent.
+     */
+    visionModel?: string;
   };
   registerTool: (
     factory: (ctx: PluginToolContext) => AgentTool | null,
@@ -217,6 +225,9 @@ const plugin = {
     const agentConfigs = api.pluginConfig?.agents ?? {};
     const apiBaseUrl = api.pluginConfig?.apiBaseUrl;
     const gatewayToken = api.pluginConfig?.gatewayToken;
+    // Pinchy-resolved, live-checked vision model for scanned pages. Preferred
+    // over the agent's (possibly text-only) chat model when present.
+    const visionModelOverride = api.pluginConfig?.visionModel;
 
     // Capture runtime APIs for vision (direct LLM API calls for scanned pages)
     const modelAuth = (api as any).runtime?.modelAuth as {
@@ -348,11 +359,14 @@ const plugin = {
                   const cfg = loadConfig();
                   const agentInfo = resolveAgentInfo(cfg, agentId);
                   resolvedAgentName = agentInfo.name;
-                  if (agentInfo.model) {
+                  // Prefer Pinchy's dedicated, live-resolved vision model; fall
+                  // back to the agent's own model only when none was emitted.
+                  const visionModel = visionModelOverride ?? agentInfo.model;
+                  if (visionModel) {
                     visionConfig = createVisionConfig({
                       modelAuth,
                       cfg,
-                      model: agentInfo.model,
+                      model: visionModel,
                     });
                   }
                 }

--- a/packages/plugins/pinchy-files/openclaw.plugin.json
+++ b/packages/plugins/pinchy-files/openclaw.plugin.json
@@ -11,6 +11,7 @@
     "properties": {
       "apiBaseUrl": { "type": "string" },
       "gatewayToken": { "type": "string" },
+      "visionModel": { "type": "string" },
       "agents": {
         "type": "object",
         "additionalProperties": {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1398,6 +1398,50 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
+  it("emits a live-resolved visionModel into pinchy-files config (decoupled from the agent's chat model)", async () => {
+    const existingConfig = {
+      gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-files" } },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existingConfig));
+    // ollama-cloud-only stack: the agent's chat model may be text-only, so the
+    // vision model must come from the dedicated live-resolved pick, not the
+    // agent model.
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "kb-agent-id",
+          name: "Invoice Reader",
+          model: "ollama-cloud/glm-4.7", // text-only chat model
+          templateId: "knowledge-base",
+          pluginConfig: { "pinchy-files": { allowed_paths: ["/data/invoices/"] } },
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    await regenerateOpenClawConfig();
+
+    // Setting a provider key triggers an extra (secrets/profiles) write, so
+    // pick the openclaw config write by content (the one carrying `plugins`)
+    // rather than assuming a call index.
+    const config = mockedWriteFileSync.mock.calls
+      .map((c) => {
+        try {
+          return JSON.parse(c[1] as string);
+        } catch {
+          return null;
+        }
+      })
+      .find((c) => c && c.plugins);
+    expect(config.plugins.entries["pinchy-files"].config.visionModel).toBe(
+      "ollama-cloud/gemini-3-flash-preview"
+    );
+  });
+
   it("injects workspace/uploads into pinchy-files.allowed_paths for every agent", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -547,12 +547,20 @@ export async function regenerateOpenClawConfig() {
   // /api/internal/usage/record. Unlike pinchy-context which only exposes
   // per-agent `agents`, pinchy-files adds the two top-level keys alongside.
   if (pluginConfigs["pinchy-files"]) {
+    // Dedicated vision model for pinchy_read's scanned-page description. Same
+    // best-live-vision-model resolution as the (legacy) built-in image tool,
+    // but consumed by our own plugin — so it works on every provider/version
+    // and, resolved against the live /v1/models catalog, never points at a
+    // retired model. Omitted when no vision provider is configured; the plugin
+    // then falls back to the agent's own model.
+    const visionModel = await resolveDefaultImageModel();
     entries["pinchy-files"] = {
       enabled: true,
       config: {
         apiBaseUrl:
           process.env.PINCHY_INTERNAL_URL || `http://pinchy:${process.env.PORT || "7777"}`,
         gatewayToken: gatewayTokenString,
+        ...(visionModel ? { visionModel } : {}),
         agents: pluginConfigs["pinchy-files"],
       },
     };

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -551,8 +551,10 @@ export async function regenerateOpenClawConfig() {
     // best-live-vision-model resolution as the (legacy) built-in image tool,
     // but consumed by our own plugin — so it works on every provider/version
     // and, resolved against the live /v1/models catalog, never points at a
-    // retired model. Omitted when no vision provider is configured; the plugin
-    // then falls back to the agent's own model.
+    // retired model. This is a single provider-default pick (e.g. Anthropic →
+    // Haiku), NOT the per-agent chat model — matching the old pdfModel/imageModel
+    // behaviour. Omitted when no vision provider is configured; the plugin then
+    // falls back to the agent's own model.
     const visionModel = await resolveDefaultImageModel();
     entries["pinchy-files"] = {
       enabled: true,


### PR DESCRIPTION
## Why

Follow-up to #588. `pinchy_read` describes scanned PDF/image pages by calling a vision model — but it used **the agent's own chat model** ([index.ts](packages/plugins/pinchy-files/index.ts)). On an ollama-cloud stack that chat model is often **text-only**, so scanned-document vision quietly had no usable model. Since #588 already routes PDF *and* image attachments through `pinchy_read`, this is the path that actually runs in production for the invoice-reading agents (Penny, Piper) — and their PDFs are scanned receipts.

This decouples `pinchy_read`'s vision from the chat model and pins it to a dedicated, **live-resolved** vision model that can't point at a retired model.

Built on [OpenClaw](https://docs.openclaw.ai); part of [Pinchy](https://heypinchy.com)'s self-hosted governance layer.

## What

- `regenerateOpenClawConfig` emits a `visionModel` into the `pinchy-files` plugin config — the best live vision-verified model, resolved via the same `resolveDefaultImageModel` path that #588 made live-availability-aware (so it degrades to the curated fallback offline and never pins a retired model). Omitted when no vision provider is configured.
- The plugin prefers `pluginConfig.visionModel` over the agent's chat model for scanned-page description; falls back to the agent model only when none was emitted.
- Manifest `configSchema` + `config-schema.test.ts` kept in sync (the 3-place drift contract).

## Tests

- `openclaw-config.test.ts` — a text-only-chat-model agent on ollama-cloud still gets a live `visionModel` (`gemini-3-flash-preview`) in plugin config.
- `pinchy-files/index.test.ts` — vision dispatches to the emitted `visionModel`'s provider (google), **not** the agent's (anthropic), proving the decoupling.
- `config-schema.test.ts` — `visionModel` accepted by the manifest schema.
- Full web suite green (**6496 passed**), tsc clean, ESLint 0 errors, Prettier clean.

## Next (separate follow-up PR, intentionally not here)

This makes `pinchy_read`'s vision robust **without** yet removing OpenClaw's built-in `pdf`/`image` tools. Removing them entirely (stop emitting `pdfModel`/`imageModel`) is the next step — it's a behaviour change that needs the E2E/OpenClaw stack to confirm `pinchy_read` covers every case the built-ins did, plus a ~180-line resolver-test extraction. Also queued: a background catalog-refresh (proactive self-heal) and a scheduled CI drift job against the Ollama deprecation table.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
