### PR TITLE
fix(pinchy-odoo): audit failed tool calls as failures (+ type-check cleanup)

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -2050,6 +2050,19 @@ describe("error handling", () => {
     );
   });
 
+  it("rejects a non-array `filters` with a clear error instead of forwarding garbage to Odoo", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: "not-an-array",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/filters.*array/i);
+  });
+
   it("returns permission message for Odoo access errors", async () => {
     mockSearchRead.mockRejectedValue(
       new Error("AccessError: no read access on sale.order"),

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1358,6 +1358,23 @@ describe("odoo_count", () => {
     ]);
   });
 
+  it("treats omitted `filters` as an empty domain (match all), not an error", async () => {
+    // asDomain maps undefined/null to [] so an agent that omits filters counts
+    // all records instead of erroring (or forwarding `undefined` to Odoo).
+    mockSearchCount.mockResolvedValue(7);
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+
+    const result = await tool.execute("call-no-filters", {
+      model: "sale.order",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchCount).toHaveBeenCalledWith("sale.order", []);
+    expect(JSON.parse(result.content[0].text).count).toBe(7);
+  });
+
   it("denies count on unpermitted model", async () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_count", agentId)!;
@@ -2063,6 +2080,19 @@ describe("error handling", () => {
     expect(result.content[0].text).toMatch(/filters.*array/i);
   });
 
+  it("attaches details.error on an inline validation error (odoo_describe_model on a non-permitted model)", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_describe_model", agentId)!;
+
+    // stock.move is absent from testPermissions → "not available".
+    const result = await tool.execute("call-1", { model: "stock.move" });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toMatch(
+      /not available/i,
+    );
+  });
+
   it("returns permission message for Odoo access errors", async () => {
     mockSearchRead.mockRejectedValue(
       new Error("AccessError: no read access on sale.order"),
@@ -2377,6 +2407,59 @@ describe("odoo_attach_file", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(
       "does not belong to this Odoo connection",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("attaches details.error when the upload file is missing (ENOENT)", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+    mockStat.mockRejectedValue(
+      Object.assign(new Error("no such file"), { code: "ENOENT" }),
+    );
+
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-enoent", {
+      targetRef,
+      filename: "missing.jpg",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "File not found",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("attaches details.error when the file exceeds the size limit", async () => {
+    const targetRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move",
+      id: 42,
+      label: "INV/2025/0001",
+    });
+    mockStat.mockResolvedValue({ size: 26 * 1024 * 1024 }); // > 25 MB cap
+    mockReadFile.mockResolvedValue(Buffer.from("x"));
+
+    const tools = createApi({ [attachAgentId]: attachAgentConfig });
+    const tool = findTool(tools, "odoo_attach_file", attachAgentId)!;
+
+    const result = await tool.execute("call-toobig", {
+      targetRef,
+      filename: "huge.jpg",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "File too large",
     );
     expect(mockCreate).not.toHaveBeenCalled();
   });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1984,6 +1984,72 @@ describe("error handling", () => {
     expect(result.isError).toBe(true);
   });
 
+  // Audit-integrity contract: OpenClaw strips the MCP `isError` flag before
+  // forwarding tool results to /api/internal/audit/tool-use (OC bug #404), so
+  // the audit endpoint falls back to `result.details.error` to record a
+  // failure. Without it, a failed odoo tool call is logged as outcome=success
+  // (the 2026-06-25 false-success incident: vendor-bill creates threw on an
+  // ambiguous partner, never reached Odoo, yet were audited as success).
+  it("attaches details.error on a client-thrown error so the audit records a failure even when OpenClaw strips isError", async () => {
+    mockSearchRead.mockRejectedValue(new Error("Connection refused"));
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      filters: [],
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "Connection refused",
+    );
+  });
+
+  it("attaches details.error on a permission-denied result", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    // sale.order grants only "read" in testPermissions → create is denied.
+    const result = await tool.execute("call-1", {
+      model: "sale.order",
+      values: { name: "Should not be created" },
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "Permission denied",
+    );
+  });
+
+  it("attaches details.error on an inline validation error (odoo_describe_model without model)", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_describe_model", agentId)!;
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toMatch(
+      /model.*required/i,
+    );
+  });
+
+  it("attaches details.error on an inline validation error (odoo_attach_file invalid filename)", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_attach_file", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      filename: "../../etc/passwd",
+      targetRef: "x",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "Invalid filename",
+    );
+  });
+
   it("returns permission message for Odoo access errors", async () => {
     mockSearchRead.mockRejectedValue(
       new Error("AccessError: no read access on sale.order"),
@@ -2296,7 +2362,9 @@ describe("odoo_attach_file", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect(result.content[0].text).toContain("does not belong to this Odoo connection");
+    expect(result.content[0].text).toContain(
+      "does not belong to this Odoo connection",
+    );
     expect(mockCreate).not.toHaveBeenCalled();
   });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1277,19 +1277,34 @@ async function reportAuthFailure(
   }
 }
 
+/**
+ * Build an MCP-style error result. Every error result MUST carry
+ * `details.error`, not just the `isError` flag: OpenClaw strips `isError`
+ * before forwarding the result to `/api/internal/audit/tool-use` (OC bug
+ * #404), and the audit endpoint then falls back to `result.details.error` to
+ * record `outcome: failure`. Without it, a failed odoo tool call is silently
+ * audited as success. Route ALL error results through this helper so that
+ * invariant cannot be forgotten at an individual call site.
+ */
+function toolError(text: string): {
+  content: ContentBlock[];
+  isError: true;
+  details: { error: string };
+} {
+  return {
+    isError: true,
+    content: [{ type: "text", text }],
+    details: { error: text },
+  };
+}
+
 function permissionDenied(
   operation: string,
   model: string,
-): { content: ContentBlock[]; isError: true } {
-  return {
-    isError: true,
-    content: [
-      {
-        type: "text",
-        text: `Permission denied: ${operation} on ${model} is not allowed for this agent.`,
-      },
-    ],
-  };
+): { content: ContentBlock[]; isError: true; details: { error: string } } {
+  return toolError(
+    `Permission denied: ${operation} on ${model} is not allowed for this agent.`,
+  );
 }
 
 function isOdooAccessError(error: unknown): boolean {
@@ -1306,24 +1321,15 @@ function isOdooAccessError(error: unknown): boolean {
 function errorResult(
   error: unknown,
   context?: { operation?: string; model?: string },
-): { content: ContentBlock[]; isError: true } {
+): { content: ContentBlock[]; isError: true; details: { error: string } } {
   if (isOdooAccessError(error) && context?.model) {
     const op = context.operation ?? "access";
-    return {
-      isError: true,
-      content: [
-        {
-          type: "text",
-          text: `Odoo denied permission to ${op} on ${context.model}. The Odoo user's permissions may have changed since the last sync. An admin can re-sync the connection in Settings > Integrations to update available permissions.`,
-        },
-      ],
-    };
+    return toolError(
+      `Odoo denied permission to ${op} on ${context.model}. The Odoo user's permissions may have changed since the last sync. An admin can re-sync the connection in Settings > Integrations to update available permissions.`,
+    );
   }
   const message = error instanceof Error ? error.message : "Unknown error";
-  return {
-    isError: true,
-    content: [{ type: "text", text: `Error: ${message}` }],
-  };
+  return toolError(`Error: ${message}`);
 }
 
 const plugin = {
@@ -1446,23 +1452,10 @@ const plugin = {
       try {
         const model = params.model;
         if (typeof model !== "string" || model.length === 0) {
-          return {
-            isError: true as const,
-            content: [
-              { type: "text" as const, text: "`model` is required (string)." },
-            ],
-          };
+          return toolError("`model` is required (string).");
         }
         if (!config.permissions[model]) {
-          return {
-            isError: true as const,
-            content: [
-              {
-                type: "text" as const,
-                text: `Model "${model}" is not available for this agent.`,
-              },
-            ],
-          };
+          return toolError(`Model "${model}" is not available for this agent.`);
         }
 
         const rawFields = await withAuthRetry(agentId, config, (client) =>
@@ -2821,15 +2814,9 @@ const plugin = {
               // agent could otherwise pass `../../etc/passwd` and have the
               // plugin attach arbitrary container files to an Odoo record.
               if (!isSafeFilename(filename)) {
-                return {
-                  isError: true as const,
-                  content: [
-                    {
-                      type: "text",
-                      text: `Invalid filename: "${filename}". Must be a plain file name without path components (no "/", no "\\", no "..", no leading ".").`,
-                    },
-                  ],
-                };
+                return toolError(
+                  `Invalid filename: "${filename}". Must be a plain file name without path components (no "/", no "\\", no "..", no leading ".").`,
+                );
               }
 
               const targetRef = params.targetRef as string;
@@ -2873,15 +2860,9 @@ const plugin = {
                     ? String((err as { code: unknown }).code)
                     : "";
                 if (code === "ENOENT") {
-                  return {
-                    isError: true as const,
-                    content: [
-                      {
-                        type: "text",
-                        text: `File not found: ${filename}. Make sure the file was uploaded before calling odoo_attach_file.`,
-                      },
-                    ],
-                  };
+                  return toolError(
+                    `File not found: ${filename}. Make sure the file was uploaded before calling odoo_attach_file.`,
+                  );
                 }
                 throw err;
               }
@@ -2889,15 +2870,9 @@ const plugin = {
               if (fileSize > MAX_ATTACHMENT_BYTES) {
                 const sizeMb = (fileSize / 1024 / 1024).toFixed(1);
                 const maxMb = (MAX_ATTACHMENT_BYTES / 1024 / 1024).toFixed(0);
-                return {
-                  isError: true as const,
-                  content: [
-                    {
-                      type: "text",
-                      text: `File too large: ${filename} is ${sizeMb} MB, max allowed is ${maxMb} MB.`,
-                    },
-                  ],
-                };
+                return toolError(
+                  `File too large: ${filename} is ${sizeMb} MB, max allowed is ${maxMb} MB.`,
+                );
               }
 
               const fileBuffer = await readFile(filePath);

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1,6 +1,6 @@
 import { readFile, stat } from "./io";
 import { basename, extname } from "path";
-import { OdooClient } from "odoo-node";
+import { OdooClient, type OdooDomain } from "odoo-node";
 import { checkPermission, type Permissions } from "./permissions";
 import { decodeRef, encodeRef } from "./integration-ref";
 
@@ -307,7 +307,9 @@ const COMMON_FIELDS = [
   "ref",
 ] as const;
 
-const COMMON_INDEX = new Map(COMMON_FIELDS.map((f, i) => [f, i]));
+const COMMON_INDEX = new Map<string, number>(
+  COMMON_FIELDS.map((f, i) => [f, i]),
+);
 
 export function sortFieldsByPriority(fields: OdooField[]): OdooField[] {
   return [...fields].sort((a, b) => {
@@ -316,6 +318,22 @@ export function sortFieldsByPriority(fields: OdooField[]): OdooField[] {
     if (ia !== ib) return ia - ib;
     return a.name.localeCompare(b.name);
   });
+}
+
+/**
+ * Narrow an untrusted, tool-supplied `filters` value into an Odoo search
+ * domain. A domain is always an array of `[field, op, value]` tuples plus
+ * `&`/`|`/`!` operators; an omitted filter means "match everything" (`[]`).
+ * Reject non-array input early with a clear message instead of forwarding
+ * garbage to Odoo, where it surfaces as an opaque server error. Individual
+ * tuple shapes are left to Odoo to validate.
+ */
+function asDomain(value: unknown): OdooDomain {
+  if (value === undefined || value === null) return [];
+  if (!Array.isArray(value)) {
+    throw new Error("`filters` must be an array (an Odoo search domain).");
+  }
+  return value as OdooDomain;
 }
 
 interface CompactSchemaOptions {
@@ -1687,7 +1705,7 @@ const plugin = {
                   );
                   const records = await client.searchRead(
                     model,
-                    params.filters as unknown[],
+                    asDomain(params.filters),
                     {
                       fields: effectiveFields,
                       limit: params.limit as number | undefined,
@@ -1755,7 +1773,7 @@ const plugin = {
               }
 
               const count = await withAuthRetry(agentId, config, (client) =>
-                client.searchCount(model, params.filters as unknown[]),
+                client.searchCount(model, asDomain(params.filters)),
               );
 
               return {
@@ -1829,7 +1847,7 @@ const plugin = {
               const result = await withAuthRetry(agentId, config, (client) =>
                 client.readGroup(
                   model,
-                  params.filters as unknown[],
+                  asDomain(params.filters),
                   params.fields as string[],
                   params.groupby as string[],
                   {

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -16,6 +16,7 @@ import {
 } from "./helpers";
 import {
   FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_TRIGGER,
+  FAKE_OLLAMA_ODOO_READ_DENIED_TRIGGER,
   FAKE_OLLAMA_PORT,
   startFakeOllama,
   stopFakeOllama,
@@ -332,10 +333,12 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       { model: "sale.order", operation: "read" },
     ]);
 
-    // 7. Allow odoo_list_models — second config regen with the tool in the allow-list.
+    // 7. Allow odoo_list_models (happy-path probe) + odoo_read (failure probe:
+    //    the agent only holds sale.order read, so an odoo_read on res.partner
+    //    hits permissionDenied inside the plugin).
     const patchRes = await pinchyPatch(
       `/api/agents/${dispatchAgentId}`,
-      { allowedTools: ["odoo_list_models"] },
+      { allowedTools: ["odoo_list_models", "odoo_read"] },
       dispatchCookie
     );
     expect(patchRes.status).toBe(200);
@@ -401,5 +404,53 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       deadlineMs: 160_000,
     });
     expect(found).toBe(true);
+  });
+
+  test("a failed odoo tool is audited as outcome=failure, not false-success", async ({
+    page,
+  }, testInfo) => {
+    // Regression guard for the 2026-06-25 false-success incident: a failed
+    // odoo tool call (here permissionDenied) must land in the audit log as
+    // outcome=failure. The plugin returns { isError, details: { error } };
+    // OpenClaw strips isError (#404), so the audit endpoint relies on the
+    // plugin-supplied details.error to record the failure. Before the fix this
+    // exact row was recorded as outcome=success with a green checkmark.
+    testInfo.setTimeout(180_000);
+
+    await loginViaUI(page, getAdminEmail(), getAdminPassword());
+
+    // Capture the cutoff BEFORE dispatch so the poll cannot match a stale row.
+    const since = new Date().toISOString();
+
+    await page.goto(`/chat/${dispatchAgentId}`);
+    await expect(page).toHaveURL(`/chat/${dispatchAgentId}`, { timeout: 10_000 });
+
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(`${FAKE_OLLAMA_ODOO_READ_DENIED_TRIGGER}: read partners`);
+    await input.press("Enter");
+
+    // Poll for a FAILURE-outcome row specifically (status=failure). pollAuditForTool
+    // only proves an entry exists; here the outcome is the whole point.
+    const deadline = Date.now() + 160_000;
+    let foundFailure = false;
+    while (Date.now() < deadline) {
+      const res = await page.request.get(
+        `/api/audit?eventType=tool.odoo_read&status=failure&from=${encodeURIComponent(
+          since
+        )}&limit=10`
+      );
+      if (res.status() === 200) {
+        const audit = (await res.json()) as {
+          entries: Array<{ resource: string | null }>;
+        };
+        if (audit.entries.some((entry) => entry.resource === `agent:${dispatchAgentId}`)) {
+          foundFailure = true;
+          break;
+        }
+      }
+      await new Promise((r) => setTimeout(r, 500));
+    }
+    expect(foundFailure).toBe(true);
   });
 });

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -141,6 +141,13 @@ const CONTEXT_SAVE_USER_TRIGGER = "E2E_CONTEXT_SAVE_USER_TOOL";
 const CONTEXT_SAVE_USER_RESPONSE = "Context saved: coverage probe complete.";
 const ODOO_LIST_MODELS_TRIGGER = "E2E_ODOO_LIST_MODELS_TOOL";
 const ODOO_LIST_MODELS_RESPONSE = "Models listed: coverage probe complete.";
+// Deliberately FAILING odoo call: odoo_read on a model the probe agent lacks
+// permission for (it only holds sale.order read). The call has valid array
+// args so it clears OpenClaw's input-schema check and reaches the plugin,
+// which returns permissionDenied → details.error → audit outcome=failure.
+// Proves a failed odoo tool is no longer recorded as false-success (#404 path).
+const ODOO_READ_DENIED_TRIGGER = "E2E_ODOO_READ_DENIED_TOOL";
+const ODOO_READ_DENIED_RESPONSE = "Read attempted: coverage probe complete.";
 const EMAIL_LIST_TRIGGER = "E2E_EMAIL_LIST_TOOL";
 const EMAIL_LIST_RESPONSE = "Emails listed: coverage probe complete.";
 const EMAIL_SEND_TRIGGER = "E2E_EMAIL_SEND_TOOL";
@@ -196,6 +203,12 @@ const TOOL_TRIGGERS: TriggerConfig[] = [
     response: ODOO_LIST_MODELS_RESPONSE,
     toolName: "odoo_list_models",
     arguments: {},
+  },
+  {
+    trigger: ODOO_READ_DENIED_TRIGGER,
+    response: ODOO_READ_DENIED_RESPONSE,
+    toolName: "odoo_read",
+    arguments: { model: "res.partner", filters: [] },
   },
   {
     trigger: EMAIL_LIST_TRIGGER,
@@ -927,6 +940,7 @@ export const FAKE_OLLAMA_CONTEXT_SAVE_USER_TOOL_TRIGGER = CONTEXT_SAVE_USER_TRIG
 export const FAKE_OLLAMA_CONTEXT_SAVE_USER_TOOL_RESPONSE = CONTEXT_SAVE_USER_RESPONSE;
 export const FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_TRIGGER = ODOO_LIST_MODELS_TRIGGER;
 export const FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_RESPONSE = ODOO_LIST_MODELS_RESPONSE;
+export const FAKE_OLLAMA_ODOO_READ_DENIED_TRIGGER = ODOO_READ_DENIED_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_TRIGGER = EMAIL_LIST_TRIGGER;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_RESPONSE = EMAIL_LIST_RESPONSE;
 export const FAKE_OLLAMA_EMAIL_SEND_TOOL_TRIGGER = EMAIL_SEND_TRIGGER;

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -660,6 +660,37 @@ describe("POST /api/internal/audit/tool-use", () => {
       expect((call.detail.params as Record<string, unknown>).path).toBe("/data/kb/report.md");
     });
 
+    it("keeps params on failure when details carries only an error (no curated fields to suppress)", async () => {
+      // Param-suppression exists to hide CURATED sensitive data (e.g.
+      // pinchy_write replaces content). An error-only `details: { error }` —
+      // which every failed tool now emits so OpenClaw's isError-stripping
+      // (#404) can't mask the failure — must NOT trigger suppression; forensics
+      // need to know what the failed call attempted (the 2026-06-25 incident
+      // hinged on those params).
+      await POST(
+        makeRequest({
+          phase: "end",
+          toolName: "odoo_create",
+          agentId: "agent-1",
+          params: { model: "account.move", values: { move_type: "in_invoice" } },
+          result: {
+            // No isError (OC strips it); only details.error signals failure.
+            content: [{ type: "text", text: "Error: Could not resolve partner_id" }],
+            details: { error: "Error: Could not resolve partner_id" },
+          },
+        })
+      );
+
+      const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
+      expect(call?.outcome).toBe("failure");
+      const detail = call?.detail as Record<string, unknown>;
+      expect(detail.success).toBe(false);
+      expect(detail.error).toMatch(/Could not resolve partner_id/);
+      // params retained for forensics
+      expect(detail).toHaveProperty("params");
+      expect((detail.params as Record<string, unknown>).model).toBe("account.move");
+    });
+
     it("keeps params when result.details is not a plain object", async () => {
       await POST(
         makeRequest({

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -177,7 +177,15 @@ export async function POST(request: NextRequest) {
   if (payload.durationMs !== undefined) detail.durationMs = payload.durationMs;
 
   if (resultDetails) {
-    delete detail.params;
+    // Param-suppression is the PII contract for CURATED details — fields
+    // beyond `error` (e.g. pinchy_write replacing sensitive content with
+    // path/contentHash). An error-only `details: { error }`, which every
+    // failed tool now emits so OpenClaw's isError-stripping (#404) can't mask
+    // the failure, must NOT suppress params: forensics need to know what the
+    // failed call attempted (the 2026-06-25 false-success incident hinged on
+    // those params being lost).
+    const curatesNonErrorFields = Object.keys(resultDetails).some((k) => k !== "error");
+    if (curatesNonErrorFields) delete detail.params;
     Object.assign(detail, resultDetails);
     // Plugins must not override these system fields. Re-apply after merge.
     detail.toolName = payload.toolName;


### PR DESCRIPTION
## Why

On production (2026-06-25) the Penny agent's vendor-bill bookings failed but were logged in the audit trail as **`outcome: success`**. Investigation against Odoo (sequence check + JSON-RPC method logs showed only `account.move.fields_get`, never `create`) confirmed the creates threw during many2one resolution (an ambiguous duplicate supplier partner) and **never reached Odoo** — yet 10 `tool.odoo_create` rows recorded success.

### Root cause
OpenClaw strips the MCP `isError` flag before forwarding tool results to `/api/internal/audit/tool-use` (OC #404). The audit endpoint already falls back to `result.details.error` to detect failure — but `pinchy-odoo`'s `errorResult`/`permissionDenied` (and 5 inline error sites) only set `isError`, never `details.error`. So every failed odoo tool call (create/write/read/delete) was silently audited as success.

## What

1. **Fix:** a `toolError()` helper that always sets `details.error`; all 7 error-result sites route through it. Failed odoo tools now audit as `failure`.
2. **Type cleanup:** 5 pre-existing `tsc` errors (Map key widening, `asDomain()` search-domain guard).
3. **Audit endpoint:** suppress `params` only for *curated* details (fields beyond `error`) — an error-only `details:{error}` must keep params so failure forensics aren't lost (review #2).
4. **E2E:** a fake-LLM trigger drives a permission-denied `odoo_read`; the spec asserts the audit row lands as `outcome=failure` — covers the OpenClaw→audit chain unit tests can't (review #1).
5. **Coverage:** tests for `asDomain` empty-domain default + the remaining inline error sites (review #3/#4).

## Verification
- `pnpm -C packages/plugins/pinchy-odoo test`: **269 green**; `tsc --noEmit`: **clean**.
- Endpoint vitest: **34 green** (incl. params-retained-on-failure).
- E2E spec compiles + is discovered (`playwright --list`); the Docker `odoo-e2e` job runs it in CI.
- prettier + eslint clean on changed files; pre-push web build passes.
- The OpenClaw→`details.error` forwarding was confirmed empirically on prod (pinchy `pdf`/`memory_search` failures already audit as `outcome=failure` via `details.error`).

## Out of scope (tracked separately)
- The genuine **duplicate partner** in Odoo (`div. Restaurants` #127 + `Div. Restaurants` #300) that triggered the resolution failure — **already archived** (#300, via ORM) so name resolution is unambiguous again.
- Penny/Piper were moved off `glm-5.2` (gateway-fragile over ollama-cloud) back to a non-thinking model.