### PR TITLE
fix(chat): apply tools blocklist when picking an image-turn fallback model

### DIFF
--- a/docs/src/content/docs/guides/image-attachments.mdx
+++ b/docs/src/content/docs/guides/image-attachments.mdx
@@ -71,7 +71,7 @@ Whether the agent can actually see an image depends on the underlying LLM. As of
 
 You don't have to put your agent on a vision model just to send the occasional screenshot. When you attach an image to an agent whose chat model is **text-only**, Pinchy routes that one turn to a vision-capable model for you — the agent's configured model is left untouched, and the very next text-only message goes straight back to it. Nothing to toggle; the image just works.
 
-Which model handles it: Pinchy prefers a vision model from the **same provider** as your agent's model (so the conversation stays coherent), and falls back to the image model configured for your deployment otherwise. The switch is recorded in the [audit trail](/concepts/audit-trail/) as `chat.image_model_fallback`, so it's always clear which model saw an image.
+Which model handles it: Pinchy prefers a vision model from the **same provider** as your agent's model (so the conversation stays coherent), and falls back to the image model configured for your deployment otherwise. If your agent uses tools, Pinchy only picks a fallback that handles tool calls reliably — so sending a screenshot never costs the agent its tools for that turn. The switch is recorded in the [audit trail](/concepts/audit-trail/) as `chat.image_model_fallback`, so it's always clear which model saw an image.
 
 The only time this can't work is when **no** image-capable model is configured anywhere. Then Pinchy tells you so directly — ask an admin to configure a vision-capable provider (Anthropic, OpenAI, Google, or Ollama Cloud / local Ollama with a vision model). It will never silently drop the image and answer as if it weren't there.
 

--- a/packages/web/src/__tests__/lib/image-fallback.test.ts
+++ b/packages/web/src/__tests__/lib/image-fallback.test.ts
@@ -89,4 +89,20 @@ describe("resolveVisionFallbackModel", () => {
     });
     expect(model).toBe("ollama-cloud/gemini-3-flash-preview");
   });
+
+  it("swaps to a usable cross-provider candidate when every same-provider vision model is blocked for a tool agent — better than blocking", () => {
+    // Same-provider (ollama-cloud) only offers the blocked preview model, but a
+    // usable vision+tools model exists on another provider and no global default
+    // is set. A cross-provider swap beats blocking the user outright.
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/glm-5.2",
+      agentUsesTools: true,
+      candidates: [
+        { id: "ollama-cloud/gemini-3-flash-preview", provider: "ollama-cloud", tools: true },
+        { id: "anthropic/claude-opus-4", provider: "anthropic", tools: true },
+      ],
+      globalDefault: null,
+    });
+    expect(model).toBe("anthropic/claude-opus-4");
+  });
 });

--- a/packages/web/src/__tests__/lib/image-fallback.test.ts
+++ b/packages/web/src/__tests__/lib/image-fallback.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { decideTurnModel } from "@/lib/image-fallback";
+import { decideTurnModel, resolveVisionFallbackModel } from "@/lib/image-fallback";
 
 describe("decideTurnModel", () => {
   it("uses the agent's own model when the turn needs no vision — no image, no swap", () => {
@@ -36,5 +36,57 @@ describe("decideTurnModel", () => {
       visionFallbackModel: null,
     });
     expect(decision).toEqual({ kind: "blocked" });
+  });
+});
+
+describe("resolveVisionFallbackModel", () => {
+  const PREVIEW = {
+    id: "ollama-cloud/gemini-3-flash-preview",
+    provider: "ollama-cloud",
+    tools: true,
+  };
+  const MINIMAX = { id: "ollama-cloud/minimax-m3", provider: "ollama-cloud", tools: true };
+
+  it("skips a tools-blocked preview model when the agent uses tools and picks the next usable same-provider candidate", () => {
+    // The whole bug: gemini-3-flash-preview is seeded tools:true but is on the
+    // tools blocklist (-preview drops thought_signature → upstream 400). A
+    // tool-using agent (e.g. Piper with Odoo tools) must never be routed to it.
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/glm-5.2",
+      agentUsesTools: true,
+      candidates: [PREVIEW, MINIMAX],
+      globalDefault: null,
+    });
+    expect(model).toBe("ollama-cloud/minimax-m3");
+  });
+
+  it("still allows a preview model when the agent does NOT use tools — preview is fine for pure image description", () => {
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/glm-5.2",
+      agentUsesTools: false,
+      candidates: [PREVIEW, MINIMAX],
+      globalDefault: null,
+    });
+    expect(model).toBe("ollama-cloud/gemini-3-flash-preview");
+  });
+
+  it("does not fall back to a tools-blocked global default for a tool-using agent — blocks instead of shipping a 400", () => {
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/glm-5.2",
+      agentUsesTools: true,
+      candidates: [],
+      globalDefault: "ollama-cloud/gemini-3-flash-preview",
+    });
+    expect(model).toBeNull();
+  });
+
+  it("uses a tools-blocked global default when the agent does NOT use tools", () => {
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/glm-5.2",
+      agentUsesTools: false,
+      candidates: [],
+      globalDefault: "ollama-cloud/gemini-3-flash-preview",
+    });
+    expect(model).toBe("ollama-cloud/gemini-3-flash-preview");
   });
 });

--- a/packages/web/src/__tests__/lib/vision-fallback-preference.test.ts
+++ b/packages/web/src/__tests__/lib/vision-fallback-preference.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it } from "vitest";
+import { compareVisionFallbackPreference } from "@/lib/openclaw-config/default-media-models";
+
+function sortedIds(candidates: { provider: string; modelId: string }[]): string[] {
+  return [...candidates]
+    .sort(compareVisionFallbackPreference)
+    .map((c) => `${c.provider}/${c.modelId}`);
+}
+
+describe("compareVisionFallbackPreference", () => {
+  it("orders curated ollama-cloud vision models by quality (OLLAMA_CLOUD_IMAGE_PREFERENCE), not alphabetically", () => {
+    // "gemma4:31b" sorts before "minimax-m3" alphabetically, but minimax-m3 is
+    // the higher-quality vision model and ranks ahead of it in the curated list.
+    const sorted = sortedIds([
+      { provider: "ollama-cloud", modelId: "gemma4:31b" },
+      { provider: "ollama-cloud", modelId: "minimax-m3" },
+    ]);
+    expect(sorted).toEqual(["ollama-cloud/minimax-m3", "ollama-cloud/gemma4:31b"]);
+  });
+
+  it("ranks a curated vision model ahead of an uncurated one on the same provider", () => {
+    const sorted = sortedIds([
+      { provider: "ollama-cloud", modelId: "kimi-k2.5" }, // not in the curated list
+      { provider: "ollama-cloud", modelId: "minimax-m3" }, // curated
+    ]);
+    expect(sorted[0]).toBe("ollama-cloud/minimax-m3");
+  });
+
+  it("breaks ties between two uncurated same-provider models alphabetically for determinism", () => {
+    const sorted = sortedIds([
+      { provider: "ollama-cloud", modelId: "ministral-3:14b" },
+      { provider: "ollama-cloud", modelId: "kimi-k2.5" },
+    ]);
+    expect(sorted).toEqual(["ollama-cloud/kimi-k2.5", "ollama-cloud/ministral-3:14b"]);
+  });
+
+  it("prefers a native-vision provider over ollama-cloud", () => {
+    const sorted = sortedIds([
+      { provider: "ollama-cloud", modelId: "minimax-m3" },
+      { provider: "anthropic", modelId: "claude-opus-4" },
+    ]);
+    expect(sorted[0]).toBe("anthropic/claude-opus-4");
+  });
+});

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -4768,12 +4768,14 @@ describe("ClientRouter", () => {
       expect(audit.detail.fallbackModel).toBe("ollama-cloud/minimax-m3");
     });
 
-    it("picks the vision fallback deterministically, independent of the catalog's row order", async () => {
+    it("picks the highest-quality vision fallback, independent of catalog row order and alphabetical order", async () => {
       // listVisionCandidates queries the models table without an ORDER BY, so
-      // Postgres can return rows in any order. The fallback must still resolve
-      // deterministically — the alphabetically-first usable same-provider model
-      // — not whatever the DB happened to hand back first. Rows here arrive in
-      // reverse-alphabetical order to prove the resolver re-sorts them.
+      // Postgres can return rows in any order. The fallback must resolve by
+      // QUALITY (OLLAMA_CLOUD_IMAGE_PREFERENCE ranks minimax-m3 above gemma4:31b)
+      // — not by DB row order, and not alphabetically. The rows here are ordered
+      // so that both "first row" (gemma4:31b) and "alphabetically first"
+      // (gemma4:31b < minimax-m3) would pick the WRONG model if quality were
+      // ignored, so a minimax-m3 result proves the preference sort.
       mockFindFirst.mockResolvedValue({
         ...defaultAgent,
         model: "ollama-cloud/glm-5.2",
@@ -4782,8 +4784,8 @@ describe("ClientRouter", () => {
       mockIsModelVisionCapable.mockReturnValue(false);
       mockMaterializeAttachments.mockResolvedValue(imageAttachment());
       mockListVisionModels.mockResolvedValue([
-        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
         { provider: "ollama-cloud", modelId: "gemma4:31b", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
       ]);
       mockChat.mockReturnValue(okStream());
 
@@ -4796,7 +4798,7 @@ describe("ClientRouter", () => {
 
       const [, options] = mockChat.mock.calls[0];
       expect(options.provider).toBe("ollama-cloud");
-      expect(options.model).toBe("gemma4:31b");
+      expect(options.model).toBe("minimax-m3");
     });
 
     it("sends a vision_unavailable error and does not dispatch when no vision model is configured anywhere", async () => {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -4768,6 +4768,37 @@ describe("ClientRouter", () => {
       expect(audit.detail.fallbackModel).toBe("ollama-cloud/minimax-m3");
     });
 
+    it("picks the vision fallback deterministically, independent of the catalog's row order", async () => {
+      // listVisionCandidates queries the models table without an ORDER BY, so
+      // Postgres can return rows in any order. The fallback must still resolve
+      // deterministically — the alphabetically-first usable same-provider model
+      // — not whatever the DB happened to hand back first. Rows here arrive in
+      // reverse-alphabetical order to prove the resolver re-sorts them.
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/glm-5.2",
+        allowedTools: ["odoo_search_read"],
+      });
+      mockIsModelVisionCapable.mockReturnValue(false);
+      mockMaterializeAttachments.mockResolvedValue(imageAttachment());
+      mockListVisionModels.mockResolvedValue([
+        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "gemma4:31b", vision: true, tools: true },
+      ]);
+      mockChat.mockReturnValue(okStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "What is in this image?",
+        attachmentIds: [ATTACHMENT_ID],
+        agentId: "agent-1",
+      });
+
+      const [, options] = mockChat.mock.calls[0];
+      expect(options.provider).toBe("ollama-cloud");
+      expect(options.model).toBe("gemma4:31b");
+    });
+
     it("sends a vision_unavailable error and does not dispatch when no vision model is configured anywhere", async () => {
       mockFindFirst.mockResolvedValue(TEXT_ONLY_AGENT);
       mockIsModelVisionCapable.mockReturnValue(false);

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -4730,6 +4730,44 @@ describe("ClientRouter", () => {
       expect(audit.outcome).toBe("success");
     });
 
+    it("does not route a tool-using agent's image turn to a tools-blocked preview model — picks the next usable same-provider vision model", async () => {
+      // Piper's exact shape: a text-only agent (GLM 5.2) that uses tools (Odoo),
+      // on an ollama-cloud stack. The seeder marks every ollama-cloud model
+      // tools:true, so the catalog hands back gemini-3-flash-preview first —
+      // but it is on the tools blocklist (-preview drops thought_signature →
+      // provider rejects the tool payload with a 400, pinchy#344/#338). The
+      // fallback must skip it and take the next usable vision+tools model.
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/glm-5.2",
+        allowedTools: ["odoo_search_read"],
+      });
+      mockIsModelVisionCapable.mockReturnValue(false);
+      mockMaterializeAttachments.mockResolvedValue(imageAttachment());
+      mockListVisionModels.mockResolvedValue([
+        { provider: "ollama-cloud", modelId: "gemini-3-flash-preview", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
+      ]);
+      mockChat.mockReturnValue(okStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "What is in this image?",
+        attachmentIds: [ATTACHMENT_ID],
+        agentId: "agent-1",
+      });
+
+      const [, options] = mockChat.mock.calls[0];
+      expect(options.provider).toBe("ollama-cloud");
+      expect(options.model).toBe("minimax-m3");
+
+      const audit = mockAppendAuditLog.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.eventType === "chat.image_model_fallback");
+      expect(audit).toBeDefined();
+      expect(audit.detail.fallbackModel).toBe("ollama-cloud/minimax-m3");
+    });
+
     it("sends a vision_unavailable error and does not dispatch when no vision model is configured anywhere", async () => {
       mockFindFirst.mockResolvedValue(TEXT_ONLY_AGENT);
       mockIsModelVisionCapable.mockReturnValue(false);

--- a/packages/web/src/lib/image-fallback.ts
+++ b/packages/web/src/lib/image-fallback.ts
@@ -1,4 +1,6 @@
 import { requiredCapabilityForFile } from "@/lib/attachment-capability";
+import { isBlocked } from "@/lib/model-resolver/blocklist";
+import type { ModelCapability } from "@/lib/model-resolver/types";
 
 /**
  * Per-turn image-model fallback decision.
@@ -60,6 +62,17 @@ export type VisionCandidate = {
  * system-wide default (or any remaining candidate) — a cross-provider swap is a
  * better outcome than blocking the user outright.
  *
+ * Before any of that, every candidate (and the global default) is filtered
+ * through the SAME tools blocklist the model picker and agent-model validation
+ * already enforce. Without this, a tool-using agent's image turn could be routed
+ * to a model the rest of Pinchy forbids — exactly what happened to text-only
+ * agents on an ollama-cloud stack: the seeder marks every cloud model
+ * `tools: true`, so `gemini-3-flash-preview` (vision + tools, but blocklisted
+ * because `-preview` drops `thought_signature` and the provider rejects the
+ * tool payload with a 400 — pinchy#344/#338) was picked first and crashed the
+ * turn. The blocklist only forbids it WHEN tools are required, so a chat-only
+ * agent can still use a preview model for pure image description.
+ *
  * `candidates` are passed in caller-defined preference order.
  */
 export function resolveVisionFallbackModel(params: {
@@ -68,10 +81,13 @@ export function resolveVisionFallbackModel(params: {
   candidates: VisionCandidate[];
   globalDefault: string | null;
 }): string | null {
+  const requiredCaps: ModelCapability[] = params.agentUsesTools ? ["vision", "tools"] : ["vision"];
+  const usable = params.candidates.filter((c) => !isBlocked(c.id, requiredCaps));
+
   const slashIdx = params.agentModel.indexOf("/");
   const agentProvider = slashIdx > 0 ? params.agentModel.slice(0, slashIdx) : "";
 
-  const sameProvider = params.candidates.filter((c) => c.provider === agentProvider);
+  const sameProvider = usable.filter((c) => c.provider === agentProvider);
   if (sameProvider.length > 0) {
     if (params.agentUsesTools) {
       return (sameProvider.find((c) => c.tools) ?? sameProvider[0]).id;
@@ -79,8 +95,10 @@ export function resolveVisionFallbackModel(params: {
     return sameProvider[0].id;
   }
 
-  if (params.globalDefault) return params.globalDefault;
-  if (params.candidates.length > 0) return params.candidates[0].id;
+  if (params.globalDefault && !isBlocked(params.globalDefault, requiredCaps)) {
+    return params.globalDefault;
+  }
+  if (usable.length > 0) return usable[0].id;
   return null;
 }
 

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -176,3 +176,44 @@ export async function resolveDefaultImageModel(): Promise<string | null> {
   }
   return null;
 }
+
+function providerImageRank(provider: string): number {
+  const idx = IMAGE_MODEL_PREFERENCE.indexOf(provider as ProviderName);
+  return idx >= 0 ? idx : IMAGE_MODEL_PREFERENCE.length;
+}
+
+function ollamaCloudVisionRank(provider: string, modelId: string): number {
+  if (provider !== "ollama-cloud") return 0;
+  const idx = OLLAMA_CLOUD_IMAGE_PREFERENCE.indexOf(modelId as OllamaCloudModelId);
+  return idx >= 0 ? idx : OLLAMA_CLOUD_IMAGE_PREFERENCE.length;
+}
+
+/**
+ * Comparator (best first) for ordering vision-capable models as per-turn image
+ * fallbacks. Mirrors `resolveDefaultImageModel`'s preference so the fallback
+ * lands on the same QUALITY order rather than a non-deterministic DB row order:
+ *
+ *   1. Native-vision providers first, in `IMAGE_MODEL_PREFERENCE` order.
+ *   2. Within ollama-cloud, the curated `OLLAMA_CLOUD_IMAGE_PREFERENCE` order
+ *      (e.g. `minimax-m3` ahead of `gemma4:31b`), with uncurated vision models
+ *      ranked after the curated ones.
+ *   3. Ties broken alphabetically by `provider/modelId` for determinism.
+ *
+ * This only orders by quality. The tools blocklist (which keeps a tool agent
+ * off `gemini-3-flash-preview` even though it tops the curated list) is applied
+ * separately by `resolveVisionFallbackModel`.
+ */
+export function compareVisionFallbackPreference(
+  a: { provider: string; modelId: string },
+  b: { provider: string; modelId: string }
+): number {
+  const pa = providerImageRank(a.provider);
+  const pb = providerImageRank(b.provider);
+  if (pa !== pb) return pa - pb;
+
+  const ma = ollamaCloudVisionRank(a.provider, a.modelId);
+  const mb = ollamaCloudVisionRank(b.provider, b.modelId);
+  if (ma !== mb) return ma - mb;
+
+  return `${a.provider}/${a.modelId}`.localeCompare(`${b.provider}/${b.modelId}`);
+}

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -51,6 +51,7 @@ import { eq } from "drizzle-orm";
 import { isModelVisionCapable } from "@/lib/model-vision";
 import { resolveImageTurnModel, type VisionCandidate } from "@/lib/image-fallback";
 import { readExistingConfig } from "@/lib/openclaw-config/write";
+import { compareVisionFallbackPreference } from "@/lib/openclaw-config/default-media-models";
 import {
   type ProcessedWorkspaceRef,
   buildAttachmentBlock,
@@ -1814,21 +1815,20 @@ export class ClientRouter {
 
 /**
  * Vision-capable models from the catalog, used as fallback candidates for an
- * image turn on a text-only agent. Sorted by `provider/modelId` so the resolver
- * gets a STABLE order to layer same-provider preference on top of: the query has
- * no `ORDER BY` and `models.id` is a random UUID, so Postgres' natural row order
- * is non-deterministic — without this sort, which usable model an image turn
- * lands on could vary between identical requests.
+ * image turn on a text-only agent. Sorted best-first by
+ * `compareVisionFallbackPreference` so the resolver layers same-provider
+ * preference on a QUALITY order — the same order `resolveDefaultImageModel`
+ * uses — rather than Postgres' natural row order: the query has no `ORDER BY`
+ * and `models.id` is a random UUID, so without this sort which usable model an
+ * image turn lands on would be non-deterministic.
  */
 async function listVisionCandidates(): Promise<VisionCandidate[]> {
   const rows = await db.select().from(models).where(eq(models.vision, true));
-  return rows
-    .map((m) => ({
-      id: `${m.provider}/${m.modelId}`,
-      provider: m.provider,
-      tools: m.tools ?? false,
-    }))
-    .sort((a, b) => a.id.localeCompare(b.id));
+  return rows.sort(compareVisionFallbackPreference).map((m) => ({
+    id: `${m.provider}/${m.modelId}`,
+    provider: m.provider,
+    tools: m.tools ?? false,
+  }));
 }
 
 /**

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -1814,16 +1814,21 @@ export class ClientRouter {
 
 /**
  * Vision-capable models from the catalog, used as fallback candidates for an
- * image turn on a text-only agent. Returned in the catalog's natural order; the
- * resolver layers same-provider preference on top.
+ * image turn on a text-only agent. Sorted by `provider/modelId` so the resolver
+ * gets a STABLE order to layer same-provider preference on top of: the query has
+ * no `ORDER BY` and `models.id` is a random UUID, so Postgres' natural row order
+ * is non-deterministic — without this sort, which usable model an image turn
+ * lands on could vary between identical requests.
  */
 async function listVisionCandidates(): Promise<VisionCandidate[]> {
   const rows = await db.select().from(models).where(eq(models.vision, true));
-  return rows.map((m) => ({
-    id: `${m.provider}/${m.modelId}`,
-    provider: m.provider,
-    tools: m.tools ?? false,
-  }));
+  return rows
+    .map((m) => ({
+      id: `${m.provider}/${m.modelId}`,
+      provider: m.provider,
+      tools: m.tools ?? false,
+    }))
+    .sort((a, b) => a.id.localeCompare(b.id));
 }
 
 /**


### PR DESCRIPTION
## Problem

A text-only agent that uses tools — e.g. a sales agent on **GLM 5.2** with Odoo tools — crashes when you attach an image. The UI shows the amber *"This model doesn't support image input"* hint (correct: GLM 5.2 is `vision: false`), then the turn fails with **"LLM request failed: provider rejected the request schema or tool payload."**

Pinchy already offloads an image turn on a text-only agent to a vision-capable model for that one turn (`resolveImageTurnModel` → `resolveVisionFallbackModel`). The bug is in *which* model it picks:

- The seeder marks **every** ollama-cloud model `tools: true`.
- So `resolveVisionFallbackModel` picks the first vision+tools candidate in catalog order — `ollama-cloud/gemini-3-flash-preview`.
- That `-preview` model drops `thought_signature` over ollama-cloud's OpenAI-compat surface, so the provider rejects the tool payload with a 400 (pinchy#344/#338).

The tools blocklist (`model-resolver/blocklist.ts`) already forbids exactly this model for tool slots — but only in the **model picker**, **agent-model validation**, and the **settings warning**. The image fallback, the one path that selects a model *on the user's behalf*, never consulted it.

The error-classifier signature confirms the path: a 400 mentioning `thought_signature` classifies as `upstream_format_error` / `schema_rejection`, which is what produced the user-facing wording — not GLM 5.2's own *"this model does not support image input"* (a different 400). So the fallback ran and picked the wrong model.

## Fix

`resolveVisionFallbackModel` now filters candidates **and** the global default through the same blocklist, with capabilities derived from the turn:

- agent uses tools → require `["vision", "tools"]` (skips `-preview`)
- agent is chat-only → require `["vision"]` (a preview model is still fine for pure image description)

For Piper this lands on the next usable same-provider vision+tools model (e.g. `minimax-m3`) and the turn runs cleanly, Odoo tools intact. If only blocklisted models exist and no usable cross-provider default, it blocks with the existing `vision_unavailable` message rather than shipping a guaranteed 400.

No new config or per-agent setting: this is the existing automatic fallback doing the right thing. Nothing for the user to toggle.

## Tests (Unit + Integration)

- `image-fallback.test.ts` — `resolveVisionFallbackModel` skips a tools-blocked preview for tool-using agents, still allows it for chat-only agents, and won't fall back to a blocklisted global default for a tool-using agent.
- `client-router.test.ts` — integration test reproducing Piper's exact shape (GLM 5.2 + Odoo tools + image): the dispatched turn goes to `minimax-m3`, not `gemini-3-flash-preview`, and the `chat.image_model_fallback` audit reflects it.
- Verified both layers go red with the fix disabled, green with it restored.

## Docs

Updated the image-attachments guide: a tool-using agent's image fallback is one that handles tool calls reliably.

## Local gates

Unit (6483), integration DB (`test:db`, 131), ESLint, Prettier, `tsc --noEmit` — all green. Rebased on latest `main`.