### PR TITLE
fix(web): fall back to visible text when Readability under-extracts a page

### DIFF
--- a/docs/src/content/docs/guides/web-search-setup.mdx
+++ b/docs/src/content/docs/guides/web-search-setup.mdx
@@ -49,6 +49,10 @@ Adding a connection does not give any agent web access. You must explicitly enab
 If no Brave Search API key is configured, you'll see an info banner in the Web Search section pointing you to Settings → Integrations.
 :::
 
+:::note[What the page fetcher can read]
+**Fetch web pages** reads a page's static HTML — it does not run JavaScript. Most sites work, but if a page renders its content client-side (a JavaScript single-page app) or sits behind anti-bot protection, a static fetch returns no usable text. In that case the agent reports that the page may be client-side rendered, blocked, or simply have little text — rather than returning raw markup. Point the agent at a more text-friendly URL where one exists.
+:::
+
 ## 4. Configure per-agent filters
 
 When you enable web search tools for an agent, additional filter options appear below the checkboxes. These let you control what the agent can search and fetch. Restrictions apply to **both** Search the web and Fetch web pages.

--- a/packages/plugins/pinchy-web/web-fetch.test.ts
+++ b/packages/plugins/pinchy-web/web-fetch.test.ts
@@ -10,7 +10,8 @@ vi.mock("node:dns/promises", () => ({
 }));
 
 // Import after mock setup
-const { webFetch, pinnedLookup, readBodyCapped } = await import("./web-fetch.js");
+const { webFetch, pinnedLookup, readBodyCapped, extractReadableContent, visibleTextFromHtml } =
+  await import("./web-fetch.js");
 
 // Build a Response whose body streams the given byte chunks, to exercise
 // readBodyCapped's streaming cap path (the text() fallback is used elsewhere).
@@ -60,6 +61,12 @@ describe("webFetch", () => {
     vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
+
+  // Routing/SSRF/redirect tests care only about isError, not the body. Use a
+  // body with enough real text to clear extractReadableContent's empty-content
+  // guard, so these tests stay decoupled from content-extraction behaviour.
+  const ROUTING_FIXTURE =
+    "<html><body><article><p>This is an ordinary web page whose body carries enough readable prose for the extractor to treat it as genuine content.</p></article></body></html>";
 
   function mockHtmlResponse(html: string, status = 200) {
     fetchMock.mockResolvedValue({
@@ -114,7 +121,7 @@ describe("webFetch", () => {
 
   describe("domain filtering", () => {
     it("allows URL matching allowedDomains", async () => {
-      mockHtmlResponse("<html><body><p>Content</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://github.com/foo", {
         allowedDomains: ["github.com"],
@@ -136,7 +143,7 @@ describe("webFetch", () => {
     });
 
     it("allows subdomains of allowedDomains", async () => {
-      mockHtmlResponse("<html><body><p>Docs</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://docs.github.com/foo", {
         allowedDomains: ["github.com"],
@@ -157,7 +164,7 @@ describe("webFetch", () => {
     });
 
     it("matches allowedDomains case-insensitively", async () => {
-      mockHtmlResponse("<html><body><p>hi</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
       const result = await webFetch("https://GitHub.com/user/repo", {
         allowedDomains: ["github.com"],
       });
@@ -165,7 +172,7 @@ describe("webFetch", () => {
     });
 
     it("treats a trailing-dot hostname as matching allowedDomains", async () => {
-      mockHtmlResponse("<html><body><p>hi</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
       const result = await webFetch("https://github.com./user/repo", {
         allowedDomains: ["github.com"],
       });
@@ -173,7 +180,7 @@ describe("webFetch", () => {
     });
 
     it("allows any public URL when no domain config is set", async () => {
-      mockHtmlResponse("<html><body><p>Any content</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://any-site.example.org/page");
 
@@ -270,7 +277,7 @@ describe("webFetch", () => {
     it("allows IPv4-mapped IPv6 wrapping a public IPv4 (::ffff:8.8.8.8)", async () => {
       resolve4Mock.mockResolvedValue([]);
       resolve6Mock.mockResolvedValue(["::ffff:8.8.8.8"]);
-      mockHtmlResponse("<html><body><p>OK</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://example.com/page");
 
@@ -349,7 +356,7 @@ describe("webFetch", () => {
         .mockResolvedValueOnce(["93.184.216.34"]) // guard sees public
         .mockResolvedValueOnce(["10.0.0.5"]); // a second resolution would see private
       resolve6Mock.mockResolvedValue([]);
-      mockHtmlResponse("<html><body><p>Safe</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://example.com/page");
 
@@ -373,7 +380,7 @@ describe("webFetch", () => {
       resolve6Mock.mockClear();
 
       // No DNS to rebind — the URL itself names the destination address.
-      mockHtmlResponse("<html><body><p>Direct</p></body></html>");
+      mockHtmlResponse(ROUTING_FIXTURE);
 
       const result = await webFetch("https://93.184.216.34/page");
 
@@ -548,5 +555,96 @@ describe("webFetch", () => {
       // cap = 100 * 8 = 800 bytes ≈ 1 chunk, so we stop far before the 100-chunk end.
       expect(chunksPulled).toBeLessThan(5);
     });
+  });
+});
+
+describe("extractReadableContent", () => {
+  // A JavaScript single-page-app shell: the real content is rendered client-side,
+  // so the static HTML carries no readable prose (the zaruba-edv.at case). The
+  // old code fell back to `?? text` and shipped ~50KB of raw markup to the agent
+  // with isError unset — an honest, distinct error is required instead.
+  it("flags a client-side-rendered shell instead of returning raw HTML markup", () => {
+    const spa = `<!DOCTYPE html><html dir="ltr" lang="en"><head><title>App</title>
+      <meta name="app-name" content="export_website"></head>
+      <body><div id="root"></div><script>window.__APP__=1;</script></body></html>`;
+
+    const result = extractReadableContent(spa, "text/html", 50000);
+
+    expect(result.isError).toBe(true);
+    expect(result.content).not.toContain("<");
+    expect(result.content).not.toContain("DOCTYPE");
+    // Honest empty-state: names client-side rendering as ONE possibility...
+    expect(result.content.toLowerCase()).toMatch(/client-side|javascript|single-page/);
+    // ...without asserting it as the sole cause (a short static page is also possible).
+    expect(result.content.toLowerCase()).toMatch(/little text|or simply|little textual/);
+  });
+
+  // A content-rich marketing/landing page with no <article> element. Readability
+  // grabs only a fragment of such pages (the ambersearch.de case: 1048 of 5241
+  // visible chars), so we must fall back to the full visible text — keeping the
+  // first AND last section — rather than to a fragment or raw markup.
+  it("returns full visible text when Readability under-extracts a non-article page", () => {
+    const sections = Array.from(
+      { length: 14 },
+      (_, i) => `<section><div>Heading ${i}</div><div>Distinct marketing line number ${i}.</div></section>`,
+    ).join("");
+    const html = `<!DOCTYPE html><html><head><title>Marketing</title></head><body><header>Home Pricing Login</header>${sections}</body></html>`;
+
+    const result = extractReadableContent(html, "text/html", 50000);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).not.toContain("<");
+    expect(result.content).toContain("Distinct marketing line number 0.");
+    expect(result.content).toContain("Distinct marketing line number 13.");
+    // Header chrome survives only on the visible-text branch (Readability strips
+    // nav), proving the fallback ran rather than Readability capturing the page.
+    expect(result.content).toContain("Pricing");
+  });
+
+  // A well-structured article: Readability's clean extraction is preferred over
+  // the raw visible text (which would include nav/footer chrome).
+  it("uses Readability's clean text for a well-structured article", () => {
+    const para =
+      "<p>This is a substantial paragraph of genuine article prose that Readability recognises as the main body of the document.</p>";
+    const html = `<html><body><nav>Home About Contact</nav><article><h1>Headline</h1>${para.repeat(5)}</article><footer>Footer chrome junk</footer></body></html>`;
+
+    const result = extractReadableContent(html, "text/html", 50000);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toContain("substantial paragraph of genuine article prose");
+    expect(result.content).not.toContain("<");
+  });
+
+  // Script/style code must never leak into the visible-text fallback, even when
+  // the closing tag is irregular (e.g. `</script >` with a space). Regex tag
+  // stripping misses these (CodeQL js/bad-tag-filter); DOM parsing does not.
+  it("strips script and style code from visible text despite irregular closing tags", () => {
+    const html = `<!DOCTYPE html><html><head><style>.brand{color:#f00}</style ></head>
+      <body><div>Hello world visible content</div>
+      <script>window.SECRET_TOKEN = "leakme12345";</script >
+      <div>second visible block</div></body></html>`;
+
+    const out = visibleTextFromHtml(html);
+
+    expect(out).toContain("Hello world visible content");
+    expect(out).not.toContain("SECRET_TOKEN");
+    expect(out).not.toContain("leakme12345");
+    expect(out).not.toContain("color:#f00");
+  });
+
+  it("truncates extracted text at maxChars with a marker", () => {
+    const html = `<html><body><article><p>${"word ".repeat(400)}</p></article></body></html>`;
+
+    const result = extractReadableContent(html, "text/html", 100);
+
+    expect(result.content.length).toBeLessThanOrEqual(100 + "\n\n[truncated]".length);
+    expect(result.content).toContain("[truncated]");
+  });
+
+  it("returns non-HTML content unchanged", () => {
+    const result = extractReadableContent("plain text body", "text/plain", 50000);
+
+    expect(result.isError).toBeFalsy();
+    expect(result.content).toBe("plain text body");
   });
 });

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -175,6 +175,88 @@ export async function readBodyCapped(res: Response, maxBytes: number): Promise<s
   return new TextDecoder("utf-8").decode(Buffer.concat(chunks));
 }
 
+// Below this many characters of extracted text we treat a 200 response as
+// having no usable content. Tuned to flag SPA shells and anti-bot challenge
+// pages (a handful of visible chars, e.g. zaruba-edv.at's "ZARUBA-EDV") while
+// letting genuinely short pages through (an example.com-sized page is ~100+).
+const MIN_READABLE_CHARS = 25;
+// Readability gives cleaner output than the raw visible text, but on non-article
+// pages (marketing / landing pages like ambersearch.de) it captures only a
+// fragment. Keep its result only when it covers at least this share of the
+// page's visible text; otherwise fall back to the full visible text.
+const READABILITY_KEEP_RATIO = 0.5;
+
+function collapseWhitespace(s: string): string {
+  return s.replace(/\s+/g, " ").trim();
+}
+
+// Recover human-visible text from HTML by parsing the DOM and dropping
+// non-content elements, then reading the body's text. This is the fallback when
+// Readability misfires: it rescues content-rich non-article pages, and by
+// yielding almost nothing on a client-rendered shell it lets us report an honest
+// error instead of dumping raw markup at the agent (the pre-fix `?? text`
+// behaviour returned ~50KB of tags for SPA pages). DOM parsing (not regex tag
+// stripping) is used so script/style code can't leak through irregular closing
+// tags like `</script >` (CodeQL js/bad-tag-filter).
+export function visibleTextFromHtml(html: string): string {
+  const { document } = parseHTML(html);
+  for (const el of document.querySelectorAll("script, style, noscript, template")) {
+    el.remove();
+  }
+  const root = document.body ?? document.documentElement;
+  return collapseWhitespace(root?.textContent ?? "");
+}
+
+function capText(s: string, maxChars: number): string {
+  return s.length > maxChars ? s.slice(0, maxChars) + "\n\n[truncated]" : s;
+}
+
+/**
+ * Turn a fetched body into the text the agent should read.
+ *
+ * For HTML we prefer Readability's article extraction, but fall back to the
+ * full visible text when Readability returns null or captures only a fragment
+ * (common on SPA shells and marketing pages). If even the visible text is
+ * essentially empty, the page is client-rendered or blocked, so we surface that
+ * as an error rather than returning unusable markup.
+ */
+export function extractReadableContent(
+  text: string,
+  contentType: string,
+  maxChars: number,
+): { content: string; isError?: boolean } {
+  if (!contentType.includes("text/html")) {
+    return { content: capText(text, maxChars) };
+  }
+
+  const { document } = parseHTML(text);
+  const article = new Readability(document).parse();
+  const readable = collapseWhitespace(article?.textContent ?? "");
+  const visible = visibleTextFromHtml(text);
+
+  // Deliberate trade-off: when Readability captured too little we take the full
+  // visible text, accepting some nav/footer chrome in exchange for completeness.
+  // For non-article pages (marketing/landing) that is the right call; for a
+  // chrome-heavy article it can be noisier than Readability's clean extraction.
+  const chosen =
+    readable.length >= Math.max(MIN_READABLE_CHARS, visible.length * READABILITY_KEEP_RATIO)
+      ? readable
+      : visible;
+
+  if (chosen.length < MIN_READABLE_CHARS) {
+    return {
+      content:
+        "Fetched the page, but it returned almost no readable text. It may be " +
+        "rendered client-side (a JavaScript single-page app), blocked by anti-bot " +
+        "protection, or simply contain little text. A static fetch cannot read " +
+        "client-rendered content.",
+      isError: true,
+    };
+  }
+
+  return { content: capText(chosen, maxChars) };
+}
+
 export async function webFetch(
   url: string,
   config: WebFetchConfig = {},
@@ -294,22 +376,7 @@ export async function webFetch(
     }
     const text = await readBodyCapped(res, maxBodyBytes);
 
-    // Extract readable content
-    let extracted: string;
-    if (contentType.includes("text/html")) {
-      const { document } = parseHTML(text);
-      const reader = new Readability(document);
-      const article = reader.parse();
-      extracted = article?.textContent ?? text;
-    } else {
-      extracted = text;
-    }
-
-    if (extracted.length > maxChars) {
-      extracted = extracted.slice(0, maxChars) + "\n\n[truncated]";
-    }
-
-    return { content: extracted };
+    return extractReadableContent(text, contentType, maxChars);
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err);
     return { content: `Failed to fetch URL: ${message}`, isError: true };


### PR DESCRIPTION
## Problem

`pinchy_web_fetch` reported `success: true` while handing the agent unusable content for two common page types. Both were reproduced by running the **real** `webFetch` pipeline against the live URLs a user reported (Piper could not read them):

- **JavaScript single-page-app shells** (e.g. Canva-hosted `zaruba-edv.at`): Readability returns `null`, and the old code fell back to `?? text` — ~50KB of raw HTML markup (`<!DOCTYPE…><title>…>`).
- **Content-rich marketing pages** (`ambersearch.de`): the content is fully server-rendered and arrives intact, but Readability captures only a fragment — measured **1048 of 5241** visible chars, dropping the hero and most sections.

In both cases `isError` was unset, so the audit row showed `success: true` despite the agent getting nothing useful.

## Fix

`extractReadableContent()` (extracted from `webFetch` and unit-tested directly):

1. Keeps Readability's clean output **only** when it covers a real share of the page's visible text (`READABILITY_KEEP_RATIO`).
2. Otherwise falls back to a tag-stripped **visible-text** extraction instead of raw HTML markup.
3. If even that is essentially empty (`< MIN_READABLE_CHARS`), returns `isError: true` with an honest "client-side rendered or blocked" message — so the agent can tell the user *why*, instead of dumping markup.

## Verified against the real pages

| URL | before | after |
|---|---|---|
| example.com | 111 chars clean | 111 chars (unchanged) |
| zaruba-edv.at | ~50KB raw markup, `success` | `isError` + honest SPA message |
| ambersearch.de | 1048-char fragment | **5241 chars**, full content |

## Tests

- 5 new `extractReadableContent` tests: SPA shell → honest error (no raw markup), non-article page → full visible text (first + last section survive), well-structured article → Readability's clean text, truncation, non-HTML passthrough.
- Routing/SSRF/redirect tests decoupled from content via a realistic fixture — **assertions unchanged** (not weakened).
- Full `pinchy-web` suite: 80/80 green. No type errors in changed code.

## Docs

Added a "What the page fetcher can read" note to `web-search-setup.mdx` explaining the static-HTML / no-JavaScript limitation.

## Notes / follow-ups (not in this PR)

While verifying, I found that OpenClaw's native `browser` tool lives in `group:ui`, which Pinchy's per-agent deny-list does **not** deny (the `build.ts:887` comment assumes it does). A real-browser feature + closing that gap are tracked separately for discussion.