### PR TITLE
fix(web): deny OpenClaw group:ui so the native browser tool isn't silently reachable

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -671,7 +671,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "anthropic/claude-opus-4-7",
       workspace: "/root/.openclaw/workspaces/uuid-agent-1",
       tools: {
-        deny: ["group:runtime", "group:fs", "group:web", "image_generate"],
+        deny: ["group:runtime", "group:fs", "group:web", "group:ui", "image_generate"],
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },
@@ -686,7 +686,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "openai/gpt-5.4",
       workspace: "/root/.openclaw/workspaces/uuid-agent-2",
       tools: {
-        deny: ["group:runtime", "group:fs", "group:web", "image_generate"],
+        deny: ["group:runtime", "group:fs", "group:web", "group:ui", "image_generate"],
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -165,6 +165,54 @@ describe("computeDeniedGroups", () => {
   });
 });
 
+describe("deny-list drift guard vs OpenClaw built-in tool groups", () => {
+  // OpenClaw built-in tool → group membership, transcribed from
+  // docs/gateway/config-tools.md (OpenClaw 2026.6.8). Re-check on every OpenClaw
+  // upgrade: if a powerful built-in is added or moves group, update this fixture
+  // — which forces a conscious decision about whether Pinchy denies it. This is
+  // the guard that would have caught `browser` (group:ui) being reachable while
+  // only group:runtime/fs/web were denied.
+  const OPENCLAW_TOOL_GROUPS: Record<string, readonly string[]> = {
+    "group:runtime": ["exec", "process", "code_execution"],
+    "group:fs": ["read", "write", "edit", "apply_patch"],
+    "group:web": ["web_search", "x_search", "web_fetch"],
+    "group:ui": ["browser", "canvas"],
+  };
+
+  // Built-in tools a governed Pinchy agent must NEVER reach: code execution, raw
+  // filesystem, raw web access, the real browser, and the canvas. Pinchy exposes
+  // none of these — it ships permissioned, audited pinchy_* equivalents instead.
+  const MUST_DENY_BUILTINS = [
+    "exec",
+    "process",
+    "code_execution",
+    "read",
+    "write",
+    "edit",
+    "apply_patch",
+    "web_search",
+    "x_search",
+    "web_fetch",
+    "browser",
+    "canvas",
+  ] as const;
+
+  it("denies (by group or standalone) every built-in a governed agent must never reach", () => {
+    const denied = new Set(computeDeniedGroups([]));
+    for (const tool of MUST_DENY_BUILTINS) {
+      const group = Object.entries(OPENCLAW_TOOL_GROUPS).find(([, tools]) =>
+        tools.includes(tool)
+      )?.[0];
+      const covered = denied.has(tool) || (group !== undefined && denied.has(group));
+      expect(covered, `built-in "${tool}" (group ${group ?? "none"}) must be denied`).toBe(true);
+    }
+  });
+
+  it("denies group:ui so the native `browser` and `canvas` tools are unreachable", () => {
+    expect(computeDeniedGroups([])).toContain("group:ui");
+  });
+});
+
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -884,8 +884,11 @@ export async function regenerateOpenClawConfig() {
   //     has no phone integration.
   //
   // Plugins we keep on (despite Pinchy not using them yet):
-  //   - browser: planned feature; gated by tool-registry deny-list anyway
-  //     so users can't reach it without admin opt-in.
+  //   - browser: planned feature. The `browser`/`canvas` tools live in
+  //     OpenClaw's `group:ui`, which the tool-registry deny-list denies for
+  //     every agent (see ALL_GROUPS + the drift guard), so the plugin can load
+  //     here without any agent reaching the real browser until we add an
+  //     explicit per-agent opt-in.
   //   - memory-core: activation.onStartup=false; lazy and free at startup.
   //   - talk-voice: leaf TTS-voice picker; tiny, future voice work.
   // Bundled OpenClaw extensions that Pinchy depends on but that aren't

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -222,7 +222,12 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
   },
 ];
 
-const ALL_GROUPS = ["group:runtime", "group:fs", "group:web"] as const;
+// OpenClaw built-in tool groups Pinchy denies for every agent because it
+// exposes no tool from them (it ships permissioned, audited pinchy_* equivalents
+// instead). `group:ui` covers the native `browser` and `canvas` tools — denying
+// it keeps the real browser behind a future per-agent opt-in rather than
+// silently available (see the deny-list drift guard in tool-registry.test.ts).
+const ALL_GROUPS = ["group:runtime", "group:fs", "group:web", "group:ui"] as const;
 
 // `pdf` and `image` are deliberately NOT in this list. They are read-only
 // vision/document tools that respect `tools.fs.workspaceOnly`, and they


### PR DESCRIPTION
## Problem

OpenClaw's native `browser` (and `canvas`) tools live in tool group **`group:ui`** (per `docs/gateway/config-tools.md`, OpenClaw 2026.6.8). Pinchy's per-agent deny-list `computeDeniedGroups` denied `group:runtime` / `group:fs` / `group:web` + `image_generate` — but **not `group:ui`**. So the real browser was never gated for any agent, even though Pinchy exposes no `browser`/`canvas` tool. The `build.ts` comment explicitly (and wrongly) claimed the deny-list already covered it.

**Severity: latent, not actively exploitable today** — the production image ships no Chromium, so the tool would fail at runtime. But that's an accident, not a control, and it must be a real gate before we add a governed browser feature (#602).

This was found while reviewing #601.

## Fix

- Add `group:ui` to `ALL_GROUPS` so every agent's `tools.deny` covers `browser` + `canvas`.
- **Drift guard** (`tool-registry.test.ts`): transcribes OpenClaw's built-in tool→group membership and asserts every built-in a governed agent must never reach (`exec`, `read`, `web_fetch`, `browser`, `canvas`, …) is denied — by group or standalone. This would have caught `browser` slipping through, and forces a conscious decision when a future OpenClaw upgrade adds or moves a powerful built-in.
- Correct the `build.ts` comment to describe the actual gating mechanism.
- Update the two exact `tools.deny` assertions in `openclaw-config.test.ts` to include `group:ui`.

## Tests

- TDD: drift guard written first (red — `browser`/`canvas` uncovered), then `group:ui` added (green).
- Full web unit suite: **6554 passed, 13 skipped, 0 failures**.

## Notes

Denying `group:ui` is safe: Pinchy exposes neither `browser` nor `canvas`. Prerequisite for #602 (governed real-browser feature).

Built on OpenClaw (https://docs.openclaw.ai). Pinchy: https://heypinchy.com