### PR TITLE
refactor(chat): clarify vision-fallback comparator + cover its tiebreak branches

### DIFF
--- a/packages/web/src/__tests__/lib/vision-fallback-preference.test.ts
+++ b/packages/web/src/__tests__/lib/vision-fallback-preference.test.ts
@@ -41,4 +41,25 @@ describe("compareVisionFallbackPreference", () => {
     ]);
     expect(sorted[0]).toBe("anthropic/claude-opus-4");
   });
+
+  it("breaks ties between two models on the same native provider alphabetically", () => {
+    // Native providers carry no curated intra-provider order, so two models on
+    // the same provider fall through to the deterministic alphabetical tiebreak.
+    const sorted = sortedIds([
+      { provider: "anthropic", modelId: "claude-opus-4" },
+      { provider: "anthropic", modelId: "claude-haiku-4" },
+    ]);
+    expect(sorted).toEqual(["anthropic/claude-haiku-4", "anthropic/claude-opus-4"]);
+  });
+
+  it("ranks a provider absent from the preference list (e.g. ollama-local) behind the listed providers", () => {
+    // ollama-local isn't in IMAGE_MODEL_PREFERENCE, so its vision models sort
+    // after every listed provider — including ollama-cloud — in the global
+    // order the resolver uses for its cross-provider last resort.
+    const sorted = sortedIds([
+      { provider: "ollama-local", modelId: "llama3.2-vision" },
+      { provider: "ollama-cloud", modelId: "minimax-m3" },
+    ]);
+    expect(sorted).toEqual(["ollama-cloud/minimax-m3", "ollama-local/llama3.2-vision"]);
+  });
 });

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -182,7 +182,11 @@ function providerImageRank(provider: string): number {
   return idx >= 0 ? idx : IMAGE_MODEL_PREFERENCE.length;
 }
 
-function ollamaCloudVisionRank(provider: string, modelId: string): number {
+// Rank a model WITHIN its provider. Only ollama-cloud carries a curated
+// quality order (`OLLAMA_CLOUD_IMAGE_PREFERENCE`); every other provider returns
+// a constant, so its models fall through to the comparator's alphabetical
+// tiebreak. Uncurated ollama-cloud vision models sort after the curated ones.
+function intraProviderVisionRank(provider: string, modelId: string): number {
   if (provider !== "ollama-cloud") return 0;
   const idx = OLLAMA_CLOUD_IMAGE_PREFERENCE.indexOf(modelId as OllamaCloudModelId);
   return idx >= 0 ? idx : OLLAMA_CLOUD_IMAGE_PREFERENCE.length;
@@ -190,8 +194,9 @@ function ollamaCloudVisionRank(provider: string, modelId: string): number {
 
 /**
  * Comparator (best first) for ordering vision-capable models as per-turn image
- * fallbacks. Mirrors `resolveDefaultImageModel`'s preference so the fallback
- * lands on the same QUALITY order rather than a non-deterministic DB row order:
+ * fallbacks. Mirrors the preference ORDER of `resolveDefaultImageModel` so the
+ * fallback lands on the same quality ranking rather than a non-deterministic DB
+ * row order:
  *
  *   1. Native-vision providers first, in `IMAGE_MODEL_PREFERENCE` order.
  *   2. Within ollama-cloud, the curated `OLLAMA_CLOUD_IMAGE_PREFERENCE` order
@@ -199,9 +204,12 @@ function ollamaCloudVisionRank(provider: string, modelId: string): number {
  *      ranked after the curated ones.
  *   3. Ties broken alphabetically by `provider/modelId` for determinism.
  *
- * This only orders by quality. The tools blocklist (which keeps a tool agent
- * off `gemini-3-flash-preview` even though it tops the curated list) is applied
- * separately by `resolveVisionFallbackModel`.
+ * It mirrors only the ORDER, not `resolveDefaultImageModel`'s live-catalog
+ * gating (`fetchLiveOllamaCloudModelIds`): the candidates fed to this comparator
+ * already come from the `models` table, so they exist by construction — there is
+ * nothing to gate. This also only orders by quality; the tools blocklist (which
+ * keeps a tool agent off `gemini-3-flash-preview` even though it tops the
+ * curated list) is applied separately by `resolveVisionFallbackModel`.
  */
 export function compareVisionFallbackPreference(
   a: { provider: string; modelId: string },
@@ -211,8 +219,8 @@ export function compareVisionFallbackPreference(
   const pb = providerImageRank(b.provider);
   if (pa !== pb) return pa - pb;
 
-  const ma = ollamaCloudVisionRank(a.provider, a.modelId);
-  const mb = ollamaCloudVisionRank(b.provider, b.modelId);
+  const ma = intraProviderVisionRank(a.provider, a.modelId);
+  const mb = intraProviderVisionRank(b.provider, b.modelId);
   if (ma !== mb) return ma - mb;
 
   return `${a.provider}/${a.modelId}`.localeCompare(`${b.provider}/${b.modelId}`);


### PR DESCRIPTION
Review-polish follow-up to the merged image-fallback work ([#598](https://github.com/heypinchy/pinchy/pull/598)). **No behavior change** — naming, docs, and two coverage tests for branches that were live but untested.

## Changes

- **Rename `ollamaCloudVisionRank` → `intraProviderVisionRank`.** The old name read as "only for ollama-cloud", but it's the intra-provider rank for *every* provider — ollama-cloud is just the only one with a curated order (`OLLAMA_CLOUD_IMAGE_PREFERENCE`); the rest return a constant and fall through to the comparator's alphabetical tiebreak. A comment now states this.

- **Clarify the comparator doc.** It mirrors `resolveDefaultImageModel`'s *order*, **not** its live-catalog gating (`fetchLiveOllamaCloudModelIds`). The candidates fed to the comparator already come from the `models` table, so they exist by construction — there's nothing to gate.

- **Two new comparator tests** for the previously-uncovered branches:
  - the alphabetical tiebreak between two models on the *same native provider* (no curated intra-order),
  - a provider absent from `IMAGE_MODEL_PREFERENCE` (`ollama-local`) sorting *behind* the listed providers in the global order the resolver uses for its cross-provider last resort.

  Both verified red with the relevant branch broken (provider-rank fallback / tiebreak), green with it restored.

## Local gates

Unit (6554), integration DB (`test:db`, 132), ESLint, Prettier, `tsc --noEmit` — all green. Branched off latest `main`.