### PR TITLE
fix(web): fail-closed tool allowlist instead of partial deny-list (#605)

### DIFF
--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -58,7 +58,7 @@ Powerful tools let the agent **change state outside the conversation** — write
 
 Powerful integration tools (Odoo write/delete, email draft/send) are covered in their own sections below.
 
-Pinchy does **not** expose a shell-execution tool or an unrestricted "read any file" tool. OpenClaw's native filesystem and shell groups are denied by default at config-generation time — see [How permissions reach OpenClaw](#how-permissions-reach-openclaw) below. If you need shell-style automation, do it through a custom OpenClaw plugin so the actions are bounded by the plugin's contract.
+Pinchy does **not** expose a shell-execution tool or an unrestricted "read any file" tool. OpenClaw's native filesystem and shell tools are never added to an agent's allow-list, so they stay unreachable — see [How permissions reach OpenClaw](#how-permissions-reach-openclaw) below. If you need shell-style automation, do it through a custom OpenClaw plugin so the actions are bounded by the plugin's contract.
 
 ## The Permissions tab
 
@@ -86,11 +86,11 @@ See the [Mount Data Directories](/guides/mount-data-directories/) guide for inst
 
 ## How permissions reach OpenClaw
 
-Pinchy controls what tools an agent can use. OpenClaw's native tools (shell, file system, web) are not exposed directly — Pinchy replaces them with its own sandboxed tools and integration tools. This gives Pinchy full control over what each agent can do.
+Pinchy controls what tools an agent can use. OpenClaw's native tools (shell, file system, raw web, the built-in browser) are not exposed directly — Pinchy replaces them with its own sandboxed and integration tools. This gives Pinchy full control over what each agent can do.
 
-Under the hood, Pinchy converts its allow-list into a deny-list at config generation time using `computeDeniedGroups()`. This function takes the list of tool IDs an admin has enabled and returns all tool groups that should be blocked. The result is written into each agent's `tools.deny` array in the OpenClaw config.
+Under the hood, Pinchy emits a **fail-closed allow-list** into each agent's OpenClaw config. The `computeAllowedTools()` function returns exactly the Pinchy plugin tools plus a small set of read-only built-ins (memory search, PDF and image reading, session status), and Pinchy writes that set into the agent's `tools.allow` array — with no tool profile set, so OpenClaw treats it as an absolute allow-list. Every other built-in is therefore denied by default, **including tools added in future OpenClaw versions**: shell execution, raw file access, the native web and browser tools, scheduling (`cron`), gateway control, cross-session spawning, outbound messaging, and the media generators.
 
-This conversion runs automatically whenever the OpenClaw config is regenerated — admins never interact with the deny-list directly.
+This is the same fail-closed principle as the per-agent allow-list above, applied one layer down at the runtime boundary: rather than chasing a deny-list that must be revisited on every OpenClaw upgrade, Pinchy lists only what it trusts and denies the rest by default. It runs automatically whenever the OpenClaw config is regenerated — admins never interact with it directly. Per-agent tool gating still happens inside each Pinchy plugin, which only registers the tools an agent is permitted to use; the allow-list is the outer boundary that keeps everything else out.
 
 ## Integration tools
 
@@ -168,12 +168,13 @@ After creating an agent, you can change its permissions at any time via the Perm
 
 ## Defense in depth
 
-Pinchy does not rely on any single layer for security. Four layers work together:
+Pinchy does not rely on any single layer for security. Five layers work together:
 
 1. **Docker volumes** — only directories explicitly mounted into the container are accessible at all
 2. **Allow-list enforcement** — only tools an admin explicitly enables are available to the agent
-3. **Plugin path validation** — the `pinchy-files` plugin checks every requested path against the agent's allowed directories
-4. **Symlink resolution** — paths are resolved to their real location before validation, preventing symlink-based escapes
+3. **Runtime tool allow-list** — Pinchy emits an absolute `tools.allow` to OpenClaw, so built-ins Pinchy never surfaces (shell, raw file access, `cron`, gateway control, the native browser, …) are unreachable even if a plugin or future OpenClaw version would otherwise expose them
+4. **Plugin path validation** — the `pinchy-files` plugin checks every requested path against the agent's allowed directories
+5. **Symlink resolution** — paths are resolved to their real location before validation, preventing symlink-based escapes
 
 If any one layer fails, the others still prevent unauthorized access.
 

--- a/packages/web/e2e/integration/21-tool-allowlist.spec.ts
+++ b/packages/web/e2e/integration/21-tool-allowlist.spec.ts
@@ -1,0 +1,92 @@
+// packages/web/e2e/integration/21-tool-allowlist.spec.ts
+//
+// Runtime read-side guard for the fail-closed tool allowlist (#605).
+//
+// Pinchy emits `agents.list[].tools.allow` (no profile) so OpenClaw resolves an
+// absolute allowlist: only Pinchy plugin tools + a few read-only built-ins
+// (memory/pdf/image/session_status) reach the model; every other built-in is
+// denied — cron, gateway, message, nodes, subagents, sessions_*, raw exec/fs/
+// web, the native browser. The unit emitter test proves Pinchy WRITES that
+// shape; this spec proves OpenClaw HONORS it at runtime by inspecting the tool
+// list OpenClaw actually advertises to the model (captured by the fake Ollama).
+//
+// Without this, a future OpenClaw change to allow-resolution semantics could
+// silently re-expose forbidden built-ins and only this real round-trip would
+// catch it. See also tool-registry.test.ts (emit-layer drift guard).
+import { test, expect } from "@playwright/test";
+import { FAKE_OLLAMA_PORT, FAKE_OLLAMA_RESPONSE } from "../shared/fake-ollama/fake-ollama-server";
+import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
+
+const TOOLS_SEEN_URL = `http://localhost:${FAKE_OLLAMA_PORT}/__pinchy_fake_ollama/tools-seen`;
+
+// Built-ins a governed Pinchy agent must NEVER be offered. If any of these ever
+// shows up in OpenClaw's advertised tool list, the allowlist has regressed.
+const FORBIDDEN_BUILTINS = [
+  "exec",
+  "process",
+  "code_execution",
+  "read",
+  "write",
+  "edit",
+  "apply_patch",
+  "web_fetch",
+  "web_search",
+  "browser",
+  "canvas",
+  "cron",
+  "gateway",
+  "message",
+  "nodes",
+  "subagents",
+  "sessions_spawn",
+  "image_generate",
+];
+
+test.describe("Tool allowlist — fail-closed at runtime (#605)", () => {
+  test("OpenClaw advertises only allowlisted tools to the model", async ({ page, request }) => {
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+    await page.goto(`/chat/${agentId}`);
+    await waitForOpenClawConnected(page);
+
+    // Drive one full model round-trip so OpenClaw advertises this agent's tools.
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10000 });
+    await input.fill("Hello, are you there?");
+    await input.press("Enter");
+    await expect(page.getByText(FAKE_OLLAMA_RESPONSE).first()).toBeVisible({ timeout: 30000 });
+
+    // The fake Ollama records the union of every tool OpenClaw advertised.
+    // Poll until populated (the final advertise may land just after the reply).
+    let toolsSeen: string[] = [];
+    await expect
+      .poll(
+        async () => {
+          const res = await request.get(TOOLS_SEEN_URL);
+          if (!res.ok()) return 0;
+          toolsSeen = (await res.json()).tools as string[];
+          return toolsSeen.length;
+        },
+        { timeout: 30000, message: "OpenClaw never advertised any tools to the model" }
+      )
+      .toBeGreaterThan(0);
+
+    // (1) Fail-closed: not one forbidden built-in may be advertised.
+    for (const forbidden of FORBIDDEN_BUILTINS) {
+      expect(toolsSeen, `forbidden built-in "${forbidden}" must not be advertised`).not.toContain(
+        forbidden
+      );
+    }
+
+    // (2) Allowlist still lets governed tools through (not accidentally empty):
+    //     memory_search is an intended read-only built-in present for every agent.
+    expect(toolsSeen).toContain("memory_search");
+
+    // (3) At least one Pinchy plugin tool reaches the model — proves plugin
+    //     tools survive the allowlist, not just the built-in helpers.
+    expect(
+      toolsSeen.some((t) => t.startsWith("pinchy_") || t.startsWith("docs_")),
+      `expected a Pinchy plugin tool among advertised tools: ${toolsSeen.join(", ")}`
+    ).toBe(true);
+  });
+});

--- a/packages/web/e2e/integration/zz-tool-allowlist.spec.ts
+++ b/packages/web/e2e/integration/zz-tool-allowlist.spec.ts
@@ -26,7 +26,9 @@ import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 const TOOLS_SEEN_URL = `http://localhost:${FAKE_OLLAMA_PORT}/__pinchy_fake_ollama/tools-seen`;
 
 // Built-ins a governed Pinchy agent must NEVER be offered. If any of these ever
-// shows up in OpenClaw's advertised tool list, the allowlist has regressed.
+// shows up in OpenClaw's advertised tool list, the allowlist has regressed. Kept
+// in parity with MUST_NOT_ALLOW_BUILTINS in tool-registry.test.ts (the emit-layer
+// drift guard) so the runtime guard covers the same dangerous built-in set.
 const FORBIDDEN_BUILTINS = [
   "exec",
   "process",
@@ -37,6 +39,7 @@ const FORBIDDEN_BUILTINS = [
   "apply_patch",
   "web_fetch",
   "web_search",
+  "x_search",
   "browser",
   "canvas",
   "cron",
@@ -45,7 +48,11 @@ const FORBIDDEN_BUILTINS = [
   "nodes",
   "subagents",
   "sessions_spawn",
+  "sessions_send",
   "image_generate",
+  "music_generate",
+  "video_generate",
+  "tts",
 ];
 
 test.describe("Tool allowlist — fail-closed at runtime (#605)", () => {

--- a/packages/web/e2e/integration/zz-tool-allowlist.spec.ts
+++ b/packages/web/e2e/integration/zz-tool-allowlist.spec.ts
@@ -1,4 +1,4 @@
-// packages/web/e2e/integration/21-tool-allowlist.spec.ts
+// packages/web/e2e/integration/zz-tool-allowlist.spec.ts
 //
 // Runtime read-side guard for the fail-closed tool allowlist (#605).
 //
@@ -13,8 +13,14 @@
 // Without this, a future OpenClaw change to allow-resolution semantics could
 // silently re-expose forbidden built-ins and only this real round-trip would
 // catch it. See also tool-registry.test.ts (emit-layer drift guard).
+//
+// `zz-` prefix on purpose: this spec posts a message into Smithers' shared
+// conversation, and `agent-chat.spec.ts` asserts a *pristine* single response
+// with a non-`.last()` locator. The integration suite runs serially
+// (workers:1), so running last keeps that assumption intact — every spec that
+// tolerates accumulated history already uses `.last()`/`.first()`.
 import { test, expect } from "@playwright/test";
-import { FAKE_OLLAMA_PORT, FAKE_OLLAMA_RESPONSE } from "../shared/fake-ollama/fake-ollama-server";
+import { FAKE_OLLAMA_PORT } from "../shared/fake-ollama/fake-ollama-server";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
 const TOOLS_SEEN_URL = `http://localhost:${FAKE_OLLAMA_PORT}/__pinchy_fake_ollama/tools-seen`;
@@ -50,14 +56,15 @@ test.describe("Tool allowlist — fail-closed at runtime (#605)", () => {
     await waitForOpenClawConnected(page);
 
     // Drive one full model round-trip so OpenClaw advertises this agent's tools.
+    // We don't assert on the reply text (other specs own the happy path) — the
+    // tools-seen poll below is the synchronization point.
     const input = page.getByPlaceholder(/send a message/i);
     await expect(input).toBeVisible({ timeout: 10000 });
     await input.fill("Hello, are you there?");
     await input.press("Enter");
-    await expect(page.getByText(FAKE_OLLAMA_RESPONSE).first()).toBeVisible({ timeout: 30000 });
 
     // The fake Ollama records the union of every tool OpenClaw advertised.
-    // Poll until populated (the final advertise may land just after the reply).
+    // Poll until populated (the advertise lands when OpenClaw calls the model).
     let toolsSeen: string[] = [];
     await expect
       .poll(

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -10,6 +10,22 @@ import * as http from "http";
 import type { AddressInfo } from "net";
 
 const MODEL_NAME = "llama3.2";
+
+// Union of every tool name OpenClaw has advertised to the model across all
+// chat requests this process has served. Lets a test assert the *effective*
+// per-agent tool policy OpenClaw resolved from Pinchy's emitted config —
+// the read-side proof of the fail-closed allowlist (#605): a forbidden
+// built-in (cron/exec/gateway/browser) must never appear here. Union (not
+// last-seen) makes the assertion immune to request ordering across agents.
+const advertisedToolNames = new Set<string>();
+
+function recordAdvertisedTools(payload: Record<string, unknown>): void {
+  const tools = Array.isArray(payload.tools) ? payload.tools : [];
+  for (const tool of tools) {
+    const name = (tool as { function?: { name?: unknown } })?.function?.name;
+    if (typeof name === "string") advertisedToolNames.add(name);
+  }
+}
 // Default response asserted by the integration test suite. The setup-wizard
 // E2E container overrides this via FAKE_OLLAMA_RESPONSE so its spec can
 // assert the same canonical "Sure, happy to help..." reply as the other
@@ -679,6 +695,15 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
     return;
   }
 
+  // Read-side probe for the #605 tool-allowlist guard: returns the union of
+  // every tool name OpenClaw has advertised to the model so far. A test asserts
+  // forbidden built-ins never appear and the agent's own tools do.
+  if (method === "GET" && url === "/__pinchy_fake_ollama/tools-seen") {
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify({ tools: [...advertisedToolNames].sort() }));
+    return;
+  }
+
   if (method === "GET" && url === "/api/tags") {
     res.writeHead(200, { "Content-Type": "application/json" });
     res.end(
@@ -718,6 +743,7 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
 
   if (method === "POST" && url === "/api/chat") {
     const payload = await readJsonBody(req);
+    recordAdvertisedTools(payload);
     const messages = Array.isArray(payload.messages) ? payload.messages : [];
     const lastUserMessage = [...messages]
       .reverse()
@@ -840,6 +866,7 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
 
   if (method === "POST" && url === "/v1/chat/completions") {
     const payload = await readJsonBody(req);
+    recordAdvertisedTools(payload);
     const messages = Array.isArray(payload.messages) ? payload.messages : [];
     const lastUserMessage = [...messages]
       .reverse()

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { isOpenClawLocalBaseUrl } from "@/lib/openclaw-local-url";
+import { computeAllowedTools } from "@/lib/tool-registry";
 
 vi.mock("@/lib/model-vision", () => ({
   isModelVisionCapable: vi.fn((modelId: string) => {
@@ -671,7 +672,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "anthropic/claude-opus-4-7",
       workspace: "/root/.openclaw/workspaces/uuid-agent-1",
       tools: {
-        deny: ["group:runtime", "group:fs", "group:web", "group:ui", "image_generate"],
+        allow: computeAllowedTools(),
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },
@@ -686,7 +687,7 @@ describe("regenerateOpenClawConfig", () => {
       model: "openai/gpt-5.4",
       workspace: "/root/.openclaw/workspaces/uuid-agent-2",
       tools: {
-        deny: ["group:runtime", "group:fs", "group:web", "group:ui", "image_generate"],
+        allow: computeAllowedTools(),
         fs: { workspaceOnly: true },
       },
       heartbeat: { every: "0m" },
@@ -757,17 +758,18 @@ describe("regenerateOpenClawConfig", () => {
     expect(agentEntry.tools.fs).toEqual({ workspaceOnly: true });
   });
 
-  // Locks the combined chat-attachment security contract (PR #316 review #3):
+  // Locks the combined chat-attachment security contract (PR #316 review #3),
+  // re-expressed for the fail-closed allowlist posture (#605):
   //
   //   1. `pdf` and `image` MUST be available to every agent — they're the
   //      built-in tools the upload hint instructs the agent to call. If
-  //      either ends up in `tools.deny`, the entire attachment feature
+  //      either is missing from `tools.allow`, the entire attachment feature
   //      silently breaks: the agent receives a path it cannot read.
   //
-  //   2. `image_generate` MUST remain denied. It produces new content
-  //      (token cost, output side-effects) and belongs behind explicit
+  //   2. `image_generate` MUST stay out of the allowlist. It produces new
+  //      content (token cost, output side-effects) and belongs behind explicit
   //      admin opt-in. This is the explicit boundary documented in
-  //      tool-registry.ts § STANDALONE_DENY.
+  //      tool-registry.ts § INTENDED_BUILTIN_TOOLS.
   //
   //   3. `tools.fs.workspaceOnly === true` MUST be set. Without it, `pdf`
   //      and `image` have unrestricted host-filesystem access — an agent
@@ -777,7 +779,7 @@ describe("regenerateOpenClawConfig", () => {
   // confined to the workspace, but cannot generate new content without
   // admin permission. Regression in any one of them silently changes the
   // security posture for every Pinchy install.
-  it("locks the chat-attachment security contract: pdf/image allowed + workspace-confined + image_generate denied", async () => {
+  it("locks the chat-attachment security contract: pdf/image allowed + workspace-confined + image_generate excluded", async () => {
     const agentsData = [
       {
         id: "security-contract-agent",
@@ -795,14 +797,14 @@ describe("regenerateOpenClawConfig", () => {
     const agentEntry = config.agents.list.find(
       (a: { id: string }) => a.id === "security-contract-agent"
     );
-    const deny = (agentEntry.tools?.deny ?? []) as string[];
+    const allow = (agentEntry.tools?.allow ?? []) as string[];
 
-    // (1) pdf/image MUST be reachable (NOT in the deny list).
-    expect(deny).not.toContain("pdf");
-    expect(deny).not.toContain("image");
+    // (1) pdf/image MUST be reachable (present in the allowlist).
+    expect(allow).toContain("pdf");
+    expect(allow).toContain("image");
 
-    // (2) image_generate MUST stay denied (admin-only).
-    expect(deny).toContain("image_generate");
+    // (2) image_generate MUST stay out of the allowlist (admin-only).
+    expect(allow).not.toContain("image_generate");
 
     // (3) workspace confinement MUST be active.
     expect(agentEntry.tools.fs).toEqual({ workspaceOnly: true });
@@ -1267,7 +1269,7 @@ describe("regenerateOpenClawConfig", () => {
     });
   });
 
-  it("should deny all groups for agents with only safe tools", async () => {
+  it("emits a fail-closed allowlist (not a deny list) for agents with only safe tools", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([
         {
@@ -1291,13 +1293,19 @@ describe("regenerateOpenClawConfig", () => {
     const kbAgent = config.agents.list.find((a: { id: string }) => a.id === "kb-agent-id");
 
     expect(kbAgent.tools).toBeDefined();
-    expect(kbAgent.tools.deny).toContain("group:runtime");
-    expect(kbAgent.tools.deny).toContain("group:fs");
-    expect(kbAgent.tools.deny).toContain("group:web");
-    expect(kbAgent.tools.allow).toBeUndefined();
+    // Allowlist posture: tools.allow is set, tools.deny is gone entirely.
+    expect(kbAgent.tools.allow).toBeDefined();
+    expect(kbAgent.tools.deny).toBeUndefined();
+    // The agent's own filesystem tools are inside the allowlist.
+    expect(kbAgent.tools.allow).toContain("pinchy_ls");
+    expect(kbAgent.tools.allow).toContain("pinchy_read");
+    // Fail-closed: raw runtime/fs/web/ui + automation built-ins stay out.
+    for (const blocked of ["exec", "read", "write", "web_fetch", "browser", "cron", "gateway"]) {
+      expect(kbAgent.tools.allow).not.toContain(blocked);
+    }
   });
 
-  it("should deny all groups for agents with empty allowedTools", async () => {
+  it("emits a fail-closed allowlist for agents with empty allowedTools", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([
         {
@@ -1319,9 +1327,13 @@ describe("regenerateOpenClawConfig", () => {
     const customAgent = config.agents.list.find((a: { id: string }) => a.id === "custom-agent-id");
 
     expect(customAgent.tools).toBeDefined();
-    expect(customAgent.tools.deny).toContain("group:runtime");
-    expect(customAgent.tools.deny).toContain("group:fs");
-    expect(customAgent.tools.deny).toContain("group:web");
+    expect(customAgent.tools.allow).toBeDefined();
+    expect(customAgent.tools.deny).toBeUndefined();
+    // Even with no Pinchy tools granted, the agent never reaches powerful
+    // built-ins — the allowlist is fail-closed against the whole built-in set.
+    for (const blocked of ["exec", "read", "write", "web_fetch", "browser", "cron", "gateway"]) {
+      expect(customAgent.tools.allow).not.toContain(blocked);
+    }
   });
 
   it("should include pinchy-files plugin config for agents with safe tools", async () => {

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -3,7 +3,7 @@ import {
   TOOL_REGISTRY,
   getToolById,
   getToolsByCategory,
-  computeDeniedGroups,
+  computeAllowedTools,
   getOdooTools,
   getOdooToolsForAccessLevel,
   detectOdooAccessLevel,
@@ -11,6 +11,7 @@ import {
   getEmailToolsForOperations,
   detectEmailOperations,
 } from "@/lib/tool-registry";
+import { getAllPinchyPluginToolNames } from "@/lib/openclaw-config/plugin-manifest-loader";
 
 describe("TOOL_REGISTRY", () => {
   it("contains safe tools", () => {
@@ -134,55 +135,103 @@ describe("getToolsByCategory", () => {
   });
 });
 
-describe("computeDeniedGroups", () => {
-  it("does not deny the OpenClaw built-in `pdf` tool — it powers chat-attachment PDF reading", () => {
-    const denied = computeDeniedGroups([]);
-    expect(denied).not.toContain("pdf");
+describe("computeAllowedTools", () => {
+  it("allows the OpenClaw built-in `pdf` tool — it powers chat-attachment PDF reading", () => {
+    expect(computeAllowedTools()).toContain("pdf");
   });
 
-  it("does not deny the OpenClaw built-in `image` tool — same reason for image attachments", () => {
-    const denied = computeDeniedGroups([]);
-    expect(denied).not.toContain("image");
+  it("allows the OpenClaw built-in `image` tool — same reason for image attachments", () => {
+    expect(computeAllowedTools()).toContain("image");
   });
 
-  it("still denies `image_generate` (write/output tool, requires explicit opt-in)", () => {
-    const denied = computeDeniedGroups([]);
-    expect(denied).toContain("image_generate");
+  it("allows memory_search/memory_get (bundled memory-core plugin powers agent memory)", () => {
+    const allowed = computeAllowedTools();
+    expect(allowed).toContain("memory_search");
+    expect(allowed).toContain("memory_get");
   });
 
-  it("always returns the base group deny list", () => {
-    const denied = computeDeniedGroups([]);
-    expect(denied).toContain("group:runtime");
-    expect(denied).toContain("group:fs");
-    expect(denied).toContain("group:web");
+  it("allows session_status (read-only self-status, the baseline `minimal` tool)", () => {
+    expect(computeAllowedTools()).toContain("session_status");
   });
 
-  it("returns same deny list even when tool IDs are passed (forward compat)", () => {
-    const denied = computeDeniedGroups(["pinchy_ls", "odoo_create"]);
-    expect(denied).not.toContain("pdf");
-    expect(denied).not.toContain("image");
-    expect(denied).toContain("image_generate");
+  it("does NOT allow `image_generate` (produces new content, requires explicit opt-in)", () => {
+    expect(computeAllowedTools()).not.toContain("image_generate");
+  });
+
+  it("includes every Pinchy plugin tool from the manifests (no plugin tool silently blocked)", () => {
+    const allowed = new Set(computeAllowedTools());
+    for (const tool of getAllPinchyPluginToolNames()) {
+      expect(allowed.has(tool), `plugin tool "${tool}" must be in the allowlist`).toBe(true);
+    }
+  });
+
+  it("is fail-closed: never allows raw runtime/fs/web/ui or other powerful built-ins", () => {
+    const allowed = new Set(computeAllowedTools());
+    const mustNeverAllow = [
+      "exec",
+      "process",
+      "code_execution",
+      "read",
+      "write",
+      "edit",
+      "apply_patch",
+      "web_search",
+      "x_search",
+      "web_fetch",
+      "browser",
+      "canvas",
+      "cron",
+      "gateway",
+      "message",
+      "nodes",
+      "subagents",
+      "sessions_spawn",
+      "sessions_send",
+      "tts",
+      "music_generate",
+      "video_generate",
+    ];
+    for (const tool of mustNeverAllow) {
+      expect(allowed.has(tool), `built-in "${tool}" must NOT be in the allowlist`).toBe(false);
+    }
   });
 });
 
-describe("deny-list drift guard vs OpenClaw built-in tool groups", () => {
+describe("allow-list drift guard vs OpenClaw built-in tool groups", () => {
   // OpenClaw built-in tool → group membership, transcribed from
   // docs/gateway/config-tools.md (OpenClaw 2026.6.8). Re-check on every OpenClaw
   // upgrade: if a powerful built-in is added or moves group, update this fixture
-  // — which forces a conscious decision about whether Pinchy denies it. This is
-  // the guard that would have caught `browser` (group:ui) being reachable while
-  // only group:runtime/fs/web were denied.
+  // — which forces a conscious decision about whether the allowlist should keep
+  // excluding it. Because Pinchy now emits an ALLOWlist (not a deny list), any
+  // new built-in is denied by default; this guard exists to prove the dangerous
+  // ones stay out and the intended read-only ones stay in.
   const OPENCLAW_TOOL_GROUPS: Record<string, readonly string[]> = {
     "group:runtime": ["exec", "process", "code_execution"],
     "group:fs": ["read", "write", "edit", "apply_patch"],
     "group:web": ["web_search", "x_search", "web_fetch"],
     "group:ui": ["browser", "canvas"],
+    "group:automation": ["heartbeat_respond", "cron", "gateway"],
+    "group:messaging": ["message"],
+    "group:nodes": ["nodes"],
+    "group:media": ["image", "image_generate", "music_generate", "video_generate", "tts"],
+    // group:sessions — subagents/session spawning/cross-session messaging.
+    "group:sessions": [
+      "sessions_list",
+      "sessions_history",
+      "sessions_send",
+      "sessions_spawn",
+      "sessions_yield",
+      "subagents",
+      "session_status",
+    ],
   };
 
   // Built-in tools a governed Pinchy agent must NEVER reach: code execution, raw
-  // filesystem, raw web access, the real browser, and the canvas. Pinchy exposes
-  // none of these — it ships permissioned, audited pinchy_* equivalents instead.
-  const MUST_DENY_BUILTINS = [
+  // filesystem/web, the real browser/canvas, scheduling + gateway control,
+  // cross-session/agent fan-out, outbound messaging/nodes, and content
+  // generators. Pinchy exposes none of these — it ships permissioned, audited
+  // pinchy_* equivalents (or governs them through its own config) instead.
+  const MUST_NOT_ALLOW_BUILTINS = [
     "exec",
     "process",
     "code_execution",
@@ -195,21 +244,46 @@ describe("deny-list drift guard vs OpenClaw built-in tool groups", () => {
     "web_fetch",
     "browser",
     "canvas",
+    "cron",
+    "gateway",
+    "message",
+    "nodes",
+    "subagents",
+    "sessions_spawn",
+    "sessions_send",
+    "image_generate",
+    "music_generate",
+    "video_generate",
+    "tts",
   ] as const;
 
-  it("denies (by group or standalone) every built-in a governed agent must never reach", () => {
-    const denied = new Set(computeDeniedGroups([]));
-    for (const tool of MUST_DENY_BUILTINS) {
+  // The ONLY non-Pinchy tools the allowlist may contain (read-only / attachment
+  // helpers). Anything else from group:media etc. must stay out.
+  const INTENDED_BUILTINS = ["memory_search", "memory_get", "pdf", "image", "session_status"];
+
+  it("excludes every built-in a governed agent must never reach", () => {
+    const allowed = new Set(computeAllowedTools());
+    for (const tool of MUST_NOT_ALLOW_BUILTINS) {
       const group = Object.entries(OPENCLAW_TOOL_GROUPS).find(([, tools]) =>
         tools.includes(tool)
       )?.[0];
-      const covered = denied.has(tool) || (group !== undefined && denied.has(group));
-      expect(covered, `built-in "${tool}" (group ${group ?? "none"}) must be denied`).toBe(true);
+      expect(
+        allowed.has(tool),
+        `built-in "${tool}" (group ${group ?? "none"}) must be excluded from the allowlist`
+      ).toBe(false);
     }
   });
 
-  it("denies group:ui so the native `browser` and `canvas` tools are unreachable", () => {
-    expect(computeDeniedGroups([])).toContain("group:ui");
+  it("excludes the native browser/canvas (group:ui) — preserves the #603 boundary", () => {
+    const allowed = computeAllowedTools();
+    expect(allowed).not.toContain("browser");
+    expect(allowed).not.toContain("canvas");
+  });
+
+  it("allows no non-Pinchy tool beyond the intended read-only built-ins", () => {
+    const pluginTools = new Set(getAllPinchyPluginToolNames());
+    const nonPinchy = computeAllowedTools().filter((t) => !pluginTools.has(t));
+    expect(nonPinchy.sort()).toEqual([...INTENDED_BUILTINS].sort());
   });
 });
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -13,7 +13,7 @@ import {
   channelLinks,
 } from "@/db/schema";
 import { getSetting } from "@/lib/settings";
-import { computeDeniedGroups } from "@/lib/tool-registry";
+import { computeAllowedTools } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
@@ -299,18 +299,25 @@ export async function regenerateOpenClawConfig() {
       );
     }
 
-    // Compute denied tool groups from allowed tools
+    // Fail-closed tool policy: emit an explicit allowlist (`tools.allow`) of
+    // exactly the Pinchy plugin tools plus the intentionally-allowed read-only
+    // built-ins (memory, pdf, image, session_status — see computeAllowedTools).
+    // With no `tools.profile` set, OpenClaw treats `allow` as an absolute
+    // allowlist (full ∩ allow), so every other built-in is denied by default,
+    // including ones added in future OpenClaw versions: cron, gateway, message,
+    // nodes, subagents, sessions_*, the media generators, raw exec/fs/web, and
+    // the native browser/canvas. Per-agent tool gating still happens inside each
+    // plugin's config; this allowlist is the outer boundary. Verified live
+    // against OpenClaw 2026.6.8 — `allow` matches tool names (not plugin ids,
+    // groups, or wildcards) and a profile would intersect the allowlist to ∅.
+    // See issue #605.
+    //
+    // `tools.fs.workspaceOnly` confines the built-in `pdf`/`image` tools to the
+    // agent's own workspace; without it they would have unrestricted
+    // host-filesystem access (CISO-review note, PR #316).
     const allowedTools = (agent.allowedTools as string[]) || [];
-    const deniedGroups = computeDeniedGroups(allowedTools);
-    if (deniedGroups.length > 0) {
-      agentEntry.tools = { deny: deniedGroups };
-    }
-
-    // Confine the built-in `pdf` and `image` tools to the agent's own
-    // workspace directory. Without this, the tools would have unrestricted
-    // host-filesystem access. See CISO-review note in PR #316.
     agentEntry.tools = {
-      ...((agentEntry.tools as Record<string, unknown>) ?? {}),
+      allow: computeAllowedTools(),
       fs: { workspaceOnly: true },
     };
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -218,7 +218,8 @@ export async function regenerateOpenClawConfig() {
   const pinchyDefaults: Record<string, unknown> = {
     // Disable OpenClaw's native pre-compaction memory flush. The flush hard-codes
     // the built-in `read`/`write` tools (OpenClaw's MEMORY_FLUSH_ALLOWED_TOOL_NAMES),
-    // which Pinchy denies via `group:fs` for every agent (see tool-registry.ts).
+    // which Pinchy never adds to any agent's tool allowlist (see computeAllowedTools
+    // in tool-registry.ts — the native fs tools are denied by omission).
     // It therefore runs with zero tools, flails through "tool not found" attempts,
     // returns NO_REPLY, and consumes the user's inbound turn — on production it
     // silently dropped a Telegram receipt image. Pinchy already owns memory
@@ -262,7 +263,7 @@ export async function regenerateOpenClawConfig() {
     pinchyDefaults.imageModel = { primary: imageModel };
   }
 
-  // Build agents list with OpenClaw-side workspace paths, tools.deny, and plugin configs
+  // Build agents list with OpenClaw-side workspace paths, tools.allow, and plugin configs
   const pluginConfigs: Record<string, Record<string, Record<string, unknown>>> = {};
   let contextPluginAgents: Record<string, { tools: string[]; userId: string }> | undefined;
 
@@ -892,10 +893,10 @@ export async function regenerateOpenClawConfig() {
   //
   // Plugins we keep on (despite Pinchy not using them yet):
   //   - browser: planned feature. The `browser`/`canvas` tools live in
-  //     OpenClaw's `group:ui`, which the tool-registry deny-list denies for
-  //     every agent (see ALL_GROUPS + the drift guard), so the plugin can load
-  //     here without any agent reaching the real browser until we add an
-  //     explicit per-agent opt-in.
+  //     OpenClaw's `group:ui` and are excluded from the fail-closed allowlist
+  //     (computeAllowedTools omits them; see the drift guard in
+  //     tool-registry.test.ts), so the plugin can load here without any agent
+  //     reaching the real browser until we add an explicit per-agent opt-in.
   //   - memory-core: activation.onStartup=false; lazy and free at startup.
   //   - talk-voice: leaf TTS-voice picker; tiny, future voice work.
   // Bundled OpenClaw extensions that Pinchy depends on but that aren't

--- a/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
+++ b/packages/web/src/lib/openclaw-config/plugin-manifest-loader.ts
@@ -52,6 +52,7 @@ export interface PluginManifest {
   name: string;
   description?: string;
   configSchema: Record<string, unknown>;
+  contracts?: { tools?: string[] };
 }
 
 const MANIFESTS: Record<KnownPinchyPlugin, PluginManifest> = {
@@ -71,4 +72,23 @@ export function loadPluginManifest(id: KnownPinchyPlugin): PluginManifest {
     throw new Error(`Unknown Pinchy plugin id: ${id}`);
   }
   return manifest;
+}
+
+/**
+ * The union of every tool name declared by a Pinchy plugin manifest
+ * (`contracts.tools`), deduplicated and sorted. This is the source of truth for
+ * the per-agent tool allowlist (see `computeAllowedTools` in tool-registry.ts):
+ * because the allowlist is derived from the manifests, adding a tool to a
+ * plugin automatically widens the allowlist — no second list to keep in sync.
+ * Plugins with no tools (pinchy-audit, pinchy-transcript — hooks only) simply
+ * contribute nothing.
+ */
+export function getAllPinchyPluginToolNames(): string[] {
+  const names = new Set<string>();
+  for (const id of KNOWN_PINCHY_PLUGINS) {
+    for (const tool of MANIFESTS[id].contracts?.tools ?? []) {
+      names.add(tool);
+    }
+  }
+  return [...names].sort();
 }

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -1,3 +1,5 @@
+import { getAllPinchyPluginToolNames } from "@/lib/openclaw-config/plugin-manifest-loader";
+
 export interface ToolDefinition {
   id: string;
   label: string;
@@ -222,20 +224,29 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
   },
 ];
 
-// OpenClaw built-in tool groups Pinchy denies for every agent because it
-// exposes no tool from them (it ships permissioned, audited pinchy_* equivalents
-// instead). `group:ui` covers the native `browser` and `canvas` tools — denying
-// it keeps the real browser behind a future per-agent opt-in rather than
-// silently available (see the deny-list drift guard in tool-registry.test.ts).
-const ALL_GROUPS = ["group:runtime", "group:fs", "group:web", "group:ui"] as const;
-
-// `pdf` and `image` are deliberately NOT in this list. They are read-only
-// vision/document tools that respect `tools.fs.workspaceOnly`, and they
-// power Pinchy's chat-attachment feature: the upload-hint instructs the
-// agent to call them with the workspace path. `image_generate` stays denied
-// because it produces new content (token cost, output side-effects) and
-// belongs behind explicit admin opt-in.
-const STANDALONE_DENY = ["image_generate"] as const;
+// OpenClaw built-in (or bundled-plugin) tools Pinchy intentionally keeps
+// reachable, on top of the Pinchy plugin tools. Everything NOT in the emitted
+// allowlist is denied — so this list is the complete set of non-Pinchy tools an
+// agent may use:
+//   - memory_search / memory_get: the bundled `memory-core` plugin powers
+//     Pinchy's agent-memory feature (see memory-prompt.ts). They are
+//     plugin-owned, so they must be allowed by NAME — `group:memory` does NOT
+//     match them (verified against OpenClaw 2026.6.8).
+//   - pdf / image: read-only vision/document tools that respect
+//     `tools.fs.workspaceOnly`. They power chat attachments: the upload hint
+//     tells the agent to call them with the workspace path.
+//   - session_status: read-only self-status (the baseline `minimal` profile).
+// Notably ABSENT (hence denied): image_generate / music_generate /
+// video_generate / tts (produce new content — admin-only), the native
+// browser/canvas (group:ui), cron, gateway, message, nodes, subagents,
+// sessions_*, and raw exec/fs/web.
+const INTENDED_BUILTIN_TOOLS = [
+  "memory_search",
+  "memory_get",
+  "pdf",
+  "image",
+  "session_status",
+] as const;
 
 export function getToolById(id: string): ToolDefinition | undefined {
   return TOOL_REGISTRY.find((t) => t.id === id);
@@ -246,13 +257,21 @@ export function getToolsByCategory(category: "safe" | "powerful"): ToolDefinitio
 }
 
 /**
- * Compute which OpenClaw tool groups and standalone tools to deny.
- * Since no Pinchy-managed tool maps to an OpenClaw group or standalone tool,
- * this always returns the full deny list. The parameter is kept for forward
- * compatibility.
+ * Compute the fail-closed tool allowlist emitted per agent as `tools.allow`.
+ *
+ * With no `tools.profile` set, OpenClaw treats `allow` as an absolute allowlist
+ * (effective = full ∩ allow), so anything not listed here is denied — including
+ * built-ins added in future OpenClaw versions. The list is every Pinchy plugin
+ * tool (derived from the manifests, so it can't drift) plus the intentionally
+ * allowed read-only built-ins.
+ *
+ * The same superset is emitted for every agent: per-agent tool gating already
+ * happens inside each plugin's own config (the plugin only registers the tools
+ * that agent is permitted), so listing a tool an agent lacks is a harmless
+ * no-match. This allowlist is the OUTER boundary against built-ins.
  */
-export function computeDeniedGroups(_allowedToolIds: string[]): string[] {
-  return [...ALL_GROUPS, ...STANDALONE_DENY];
+export function computeAllowedTools(): string[] {
+  return [...getAllPinchyPluginToolNames(), ...INTENDED_BUILTIN_TOOLS];
 }
 
 // --- Email operation helpers ---


### PR DESCRIPTION
## What & why

Closes #605 (follows #603). Pinchy emitted only a partial **deny-list** per agent — `tools.deny: [group:runtime, group:fs, group:web, group:ui, image_generate]` with **no `tools.allow`/profile**. An unset OpenClaw profile means `full`, so every governed agent effectively ran *"full minus those five"* — leaving powerful, **Pinchy-unaudited** built-ins reachable: `cron`, `gateway`, `message`, `nodes`, `subagents`/`sessions_spawn`, `sessions_send`, and the `tts`/`music_generate`/`video_generate` generators. Same bug class as #603 (browser/`group:ui`), but broader.

This flips to a **fail-closed allowlist**: emit `tools.allow` of exactly the Pinchy plugin tools (derived from the plugin manifests, so it can't drift) plus a small set of read-only built-ins (`memory_search`/`memory_get`, `pdf`, `image`, `session_status`), with **no profile**. OpenClaw then resolves an absolute allowlist (`full ∩ allow`), so everything else — **including built-ins added in future OpenClaw versions** — is denied by default. Per-agent tool gating still happens inside each plugin's own config; this allowlist is the outer boundary.

## Verified live against OpenClaw 2026.6.8

Before writing code I reproduced the semantics against a standalone gateway (`openclaw agent --local` + a capture model server recording the advertised `tools`):

- `tools.allow` by **tool name** (no profile) = absolute fail-closed allowlist. ✓
- Plugin IDs (`"pinchy-web"`, `"memory-core"`), `group:memory`, and **wildcards** (`memory_*`) **do not match** — must list tool names. (memory tools are plugin-owned → allowed by name.)
- `profile: "minimal"` + `allow` **intersects to ∅** → would break every agent. Hence **allow-only, no profile**.
- The old deny-only posture live-leaked `cron, gateway, message, nodes, subagents, sessions_*, tts, …` — the vuln, reproduced.

## Changes

- **tool-registry**: `computeDeniedGroups()` → `computeAllowedTools()`; `INTENDED_BUILTIN_TOOLS`; plugin tools via new `getAllPinchyPluginToolNames()` (reads manifest `contracts.tools` → self-maintaining).
- **build**: emit `tools.allow` + `fs.workspaceOnly` (drop `tools.deny`).
- **tests**: deny drift guard → **allow drift guard** (forbidden built-ins excluded, plugin tools + intended built-ins included); `openclaw-config` assertions updated to the allow shape. Net test count up (7 → 10 unit; +1 e2e).
- **e2e**: new integration spec asserts the tool list OpenClaw advertises to the model **excludes** forbidden built-ins and **includes** the agent's tools, via a new fake-ollama `tools-seen` probe (runtime read-side guard, verified by CI against real Dockerized OpenClaw).
- **docs**: rewrite *"How permissions reach OpenClaw"* for the allowlist posture; add the runtime allow-list as a defense-in-depth layer.

## Test plan

- [x] `pnpm -C packages/web test` — 6557 passed, 13 pre-existing skips
- [x] tsc `--noEmit` clean, eslint 0 errors, prettier clean
- [x] OpenClaw allow/profile semantics verified live (standalone 2026.6.8)
- [ ] CI integration `21-tool-allowlist` e2e (real OpenClaw round-trip)

Built on OpenClaw (https://docs.openclaw.ai). Pinchy: https://heypinchy.com