### PR TITLE
ci: align composite action runtimes with workflow group bump (#407)

### DIFF
--- a/.github/actions/capture-e2e-diagnostics/action.yml
+++ b/.github/actions/capture-e2e-diagnostics/action.yml
@@ -94,7 +94,7 @@ runs:
         fi
 
     - name: Upload diagnostics artifact
-      uses: actions/upload-artifact@v4
+      uses: actions/upload-artifact@v7
       with:
         # Include run_attempt so a re-run uploads a fresh artifact instead of
         # colliding with the previous attempt's bundle.

--- a/.github/actions/setup-playwright/action.yml
+++ b/.github/actions/setup-playwright/action.yml
@@ -23,7 +23,7 @@ runs:
 
     - name: Cache Playwright browsers
       id: pw-cache
-      uses: actions/cache@v4
+      uses: actions/cache@v5
       with:
         path: ~/.cache/ms-playwright
         key: pw-${{ runner.os }}-${{ steps.pw-version.outputs.version }}-${{ inputs.browsers }}

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -19,14 +19,14 @@ runs:
   using: composite
   steps:
     - name: Setup pnpm
-      uses: pnpm/action-setup@v4
+      uses: pnpm/action-setup@v6
 
     - name: Setup Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: ${{ inputs.node-version }}
         # Only enable pnpm cache when we're going to actually run
-        # `pnpm install` below — otherwise setup-node@v4's Post-step
+        # `pnpm install` below — otherwise setup-node@v6's Post-step
         # tries to save a never-populated pnpm store and fails with
         # "Path Validation Error: Path(s) specified in the action for
         # caching do(es) not exist", failing the entire job. The CodeQL


### PR DESCRIPTION
## Why

Dependabot's grouped GitHub Actions update ([#407](https://github.com/heypinchy/pinchy/pull/407)) bumped the action references in `.github/workflows/` but **not** the local composite actions under `.github/actions/`. That left four references pinned to versions targeting the deprecated **Node.js 20** runtime, which emits a deprecation annotation on every CI run.

This aligns the composite actions with the exact versions already in use by the top-level workflows after #407.

## Changes

| File | Reference | Before | After |
|------|-----------|--------|-------|
| `.github/actions/setup-playwright/action.yml` | `actions/cache` | `@v4` | `@v5` |
| `.github/actions/capture-e2e-diagnostics/action.yml` | `actions/upload-artifact` | `@v4` | `@v7` |
| `.github/actions/setup-pnpm/action.yml` | `pnpm/action-setup` | `@v4` | `@v6` |
| `.github/actions/setup-pnpm/action.yml` | `actions/setup-node` | `@v4` | `@v6` |

The dated historical comment in `setup-pnpm` (`setup-node@v4 tightened the path check around 2026-05-23`) is intentionally left as `v4` — it's a factual reference to when that behavior was introduced. The present-tense reference describing the active action was updated to `v6`.

## Notes

- Opened from a regular branch (not a `dependabot/*` branch) so CI runs with full repo Actions secrets (DockerHub/license) and can go green — Dependabot PRs run without secrets and fail those jobs.
- Verification target: the **Node.js 20 deprecation annotation** is gone from this run.
- Root cause of the drift: `dependabot.yml` only watches `directory: /` for the `github-actions` ecosystem, so local composite actions under `.github/actions/` aren't auto-updated. Flagged as a separate follow-up.