### PR TITLE
fix(chat): last-chat link staleness + context-overflow hint (v0.8.0 staging findings)

### DIFF
--- a/packages/web/src/__tests__/components/sidebar.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar.test.tsx
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
-import { render, screen, waitFor } from "@testing-library/react";
+import { render, screen, waitFor, act } from "@testing-library/react";
+import { recordLastChat } from "@/lib/last-chat-store";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AppSidebar } from "@/components/sidebar";
@@ -360,6 +361,28 @@ describe("AppSidebar", () => {
       renderSidebar(false);
       // No localStorage entry → the default route resolves the most-recent chat.
       expect(screen.getByRole("link", { name: /alpha/i })).toHaveAttribute("href", "/chat/agent-1");
+    });
+
+    it("refreshes the link on a same-tab write without navigating (#508 staleness regression)", async () => {
+      setAgents(agents);
+      renderSidebar(false);
+      // No record yet → bare link.
+      expect(screen.getByRole("link", { name: /alpha/i })).toHaveAttribute("href", "/chat/agent-1");
+
+      // The open chat records itself in THIS tab — localStorage fires no `storage`
+      // event and the pathname does not change. The store's same-tab notifier must
+      // still refresh the resolved link; otherwise the sidebar stays one render
+      // behind and reopens an older chat.
+      act(() => {
+        recordLastChat("agent-1", "chat-new");
+      });
+
+      await waitFor(() => {
+        expect(screen.getByRole("link", { name: /alpha/i })).toHaveAttribute(
+          "href",
+          "/chat/agent-1/chat-new"
+        );
+      });
     });
   });
 

--- a/packages/web/src/__tests__/lib/last-chat-store.test.ts
+++ b/packages/web/src/__tests__/lib/last-chat-store.test.ts
@@ -1,5 +1,5 @@
-import { describe, it, expect, beforeEach } from "vitest";
-import { recordLastChat, getLastChat } from "@/lib/last-chat-store";
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { recordLastChat, getLastChat, subscribeLastChat } from "@/lib/last-chat-store";
 
 describe("last-chat-store", () => {
   beforeEach(() => localStorage.clear());
@@ -38,5 +38,24 @@ describe("last-chat-store", () => {
     recordLastChat("agent-1", "chat-a");
     recordLastChat("agent-1", undefined);
     expect(getLastChat("agent-1")).toBeNull();
+  });
+
+  // Regression: the sidebar resolves agent links via useSyncExternalStore, which
+  // only re-reads when a subscriber is notified. localStorage fires no same-tab
+  // `storage` event, so without an in-module notifier the sidebar link goes stale
+  // (one render behind recordLastChat's effect) and reopens an OLDER chat.
+  it("notifies same-tab subscribers on record and on clear", () => {
+    const listener = vi.fn();
+    const unsubscribe = subscribeLastChat(listener);
+
+    recordLastChat("agent-1", "chat-a");
+    expect(listener).toHaveBeenCalledTimes(1);
+
+    recordLastChat("agent-1", null);
+    expect(listener).toHaveBeenCalledTimes(2);
+
+    unsubscribe();
+    recordLastChat("agent-1", "chat-b");
+    expect(listener).toHaveBeenCalledTimes(2);
   });
 });

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -1,5 +1,11 @@
 import { describe, it, expect } from "vitest";
-import { getErrorHint, PROVIDER_SETTINGS_HINT } from "@/server/error-hints";
+import {
+  getErrorHint,
+  presentProviderError,
+  PROVIDER_SETTINGS_HINT,
+  CONTEXT_OVERFLOW_HINT,
+  CONTEXT_OVERFLOW_MESSAGE,
+} from "@/server/error-hints";
 
 describe("getErrorHint", () => {
   describe("provider/config errors → role-based hint", () => {
@@ -96,14 +102,45 @@ describe("getErrorHint", () => {
       expect(getErrorHint("You exceeded your current quota", "admin")).toBe(PROVIDER_SETTINGS_HINT);
     });
 
-    it("should return null for 'context window exceeded' (model capability, not config)", () => {
-      // Context-window overflow is a model-capability issue: the user should
-      // swap to a larger-context model or trim the input. Telling them to
-      // "check your API configuration" would be misleading. Keeping bare
-      // `exceeded` out of PROVIDER_CONFIG_PATTERN is what makes this fall
-      // through to `null` (no hint) instead.
-      expect(getErrorHint("context window exceeded for this prompt", "admin")).toBeNull();
-      expect(getErrorHint("context window exceeded for this prompt", "member")).toBeNull();
+    it("should NOT misroute 'context window exceeded' to the provider-config hint", () => {
+      // Context-window overflow is a model-capability/length issue, not a
+      // provider-config one — keeping bare `exceeded` out of
+      // PROVIDER_CONFIG_PATTERN is what stops the misleading "check your API
+      // configuration" hint. It now gets its own actionable hint (#611) instead
+      // of falling through to null.
+      expect(getErrorHint("context window exceeded for this prompt", "admin")).toBe(
+        CONTEXT_OVERFLOW_HINT
+      );
+      expect(getErrorHint("context window exceeded for this prompt", "member")).toBe(
+        CONTEXT_OVERFLOW_HINT
+      );
+    });
+  });
+
+  describe("context-overflow → compact/new-chat hint, not OpenClaw's /reset advice (#611)", () => {
+    const overflowTexts = [
+      "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.",
+      "context window exceeded for this prompt",
+      "The prompt is too large for the model's context length.",
+      "Please use a larger-context model.",
+    ];
+
+    it.each(overflowTexts)("returns the compact hint (role-independent): %s", (text) => {
+      expect(getErrorHint(text, "admin")).toBe(CONTEXT_OVERFLOW_HINT);
+      expect(getErrorHint(text, "member")).toBe(CONTEXT_OVERFLOW_HINT);
+    });
+
+    it("presentProviderError replaces OpenClaw's /reset advice with a clean message", () => {
+      const raw =
+        "Context overflow: prompt too large for the model. Try /reset (or /new) to start a fresh session, or use a larger-context model.";
+      const shown = presentProviderError(raw);
+      expect(shown).toBe(CONTEXT_OVERFLOW_MESSAGE);
+      expect(shown).not.toMatch(/\/reset|\/new/);
+    });
+
+    it("presentProviderError leaves non-overflow errors unchanged", () => {
+      expect(presentProviderError("Invalid API key provided")).toBe("Invalid API key provided");
+      expect(presentProviderError("Rate limit exceeded")).toBe("Rate limit exceeded");
     });
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
@@ -5,7 +5,7 @@ import { appendAuditLog } from "@/lib/audit";
 import { recordAuditFailure } from "@/lib/audit-deferred";
 import { directSessionKey } from "@/lib/session-key";
 import { getActiveChatSessionError, dismissChatSessionError } from "@/server/chat-session-errors";
-import { getErrorHint } from "@/server/error-hints";
+import { getErrorHint, presentProviderError } from "@/server/error-hints";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -34,7 +34,10 @@ export const GET = withAuth<RouteContext>(async (request, { params }, session) =
           model: row.model,
           errorClass: row.errorClass,
           transientReason: row.transientReason,
-          providerError: row.providerError,
+          // Banner display only — rewrites OpenClaw's context-overflow /reset
+          // advice (#611), matching the live error frame. The stored row keeps
+          // the raw text, so the hint below still classifies off it.
+          providerError: presentProviderError(row.providerError),
           // The banner renders no hint of its own; derive the same role-gated
           // guidance the live error frame gets (client-router) so a durable
           // provider-rejection points an admin at their provider config (#584).

--- a/packages/web/src/components/sidebar.tsx
+++ b/packages/web/src/components/sidebar.tsx
@@ -3,7 +3,7 @@
 import Link from "next/link";
 import { usePathname } from "next/navigation";
 import { useMemo, useSyncExternalStore } from "react";
-import { getLastChat } from "@/lib/last-chat-store";
+import { getLastChat, subscribeLastChat } from "@/lib/last-chat-store";
 import { BarChart3, Bug, ClipboardList, Plus, Settings } from "lucide-react";
 import { LogoutButton } from "@/components/logout-button";
 import { useAgentsContext } from "@/components/agents-provider";
@@ -28,13 +28,19 @@ interface AppSidebarProps {
   isAdmin: boolean;
 }
 
-// localStorage has no same-tab change event; a cross-tab write fires "storage".
-// Same-tab updates are picked up because navigating re-renders the sidebar
-// (usePathname), which re-runs the snapshot read below.
+// Refresh the resolved agent links on BOTH change sources: a cross-tab write
+// fires the `storage` event, while a same-tab write (the common case — the open
+// chat recording itself) fires no `storage` event and is delivered via the
+// store's own in-module notifier. Relying on navigation re-renders alone left
+// the link one render behind the write, so it reopened an older chat (#508).
 function subscribeLastChats(callback: () => void) {
   if (typeof window === "undefined") return () => {};
   window.addEventListener("storage", callback);
-  return () => window.removeEventListener("storage", callback);
+  const unsubscribeSameTab = subscribeLastChat(callback);
+  return () => {
+    window.removeEventListener("storage", callback);
+    unsubscribeSameTab();
+  };
 }
 
 export function AppSidebar({ isAdmin }: AppSidebarProps) {

--- a/packages/web/src/lib/last-chat-store.ts
+++ b/packages/web/src/lib/last-chat-store.ts
@@ -16,6 +16,26 @@
  */
 const KEY_PREFIX = "pinchy:lastChat:";
 
+// localStorage emits no same-tab change event (`storage` only fires in OTHER
+// tabs), so a component reading this store via useSyncExternalStore — the sidebar
+// (#508) — would never see a write made in its own tab. Its resolved agent link
+// would then lag one render behind `recordLastChat` (which runs in a post-render
+// effect) and reopen an OLDER chat. Keep an in-module listener set and notify it
+// on every write so same-tab subscribers re-read immediately.
+const listeners = new Set<() => void>();
+
+/**
+ * Subscribe to same-tab changes of the last-chat store. Returns an unsubscribe
+ * function. Pair this with the cross-tab `storage` event in the consumer's
+ * `useSyncExternalStore` subscribe so both same-tab and cross-tab writes refresh.
+ */
+export function subscribeLastChat(listener: () => void): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
 export function recordLastChat(agentId: string, chatId: string | null | undefined): void {
   if (typeof localStorage === "undefined") return;
   const key = KEY_PREFIX + agentId;
@@ -24,6 +44,7 @@ export function recordLastChat(agentId: string, chatId: string | null | undefine
   } else {
     localStorage.removeItem(key);
   }
+  for (const listener of listeners) listener();
 }
 
 export function getLastChat(agentId: string): string | null {

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -27,7 +27,7 @@ import {
 } from "@/server/model-unavailable-throttle";
 import { SessionCache } from "@/server/session-cache";
 import { resolveUserPlaceholder } from "@/server/user-placeholder";
-import { getErrorHint } from "@/server/error-hints";
+import { getErrorHint, presentProviderError } from "@/server/error-hints";
 import { classifyModelError, classifyUpstreamFormatError } from "@/server/model-error-classifier";
 import {
   classifyAgentError,
@@ -1330,7 +1330,9 @@ export class ClientRouter {
             this.broadcastForRun(sessionKey, clientWs, {
               type: "error",
               agentName: agent.name,
-              providerError: chunk.text,
+              // Banner display only — rewrites OpenClaw's context-overflow /reset
+              // advice (#611). The audit + durable-persist keep the raw text.
+              providerError: presentProviderError(chunk.text),
               hint: getErrorHint(chunk.text, this.userRole),
               messageId,
               ...(modelUnavailable ? { modelUnavailable } : {}),

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -2,12 +2,32 @@ import {
   TRANSIENT_PATTERN,
   PROVIDER_CONFIG_PATTERN,
   PROVIDER_REJECTED_GENERIC_PATTERN,
+  CONTEXT_OVERFLOW_PATTERN,
 } from "@/server/error-patterns";
 
 export const PROVIDER_SETTINGS_HINT = "Go to Settings > Providers to check your API configuration.";
 
+// A context-window overflow can't be retried as-is. OpenClaw's own error text
+// advises its `/reset` / `/new` slash commands, but Pinchy's web composer sends
+// those as literal messages (they'd just trigger another error). Point the user
+// at the controls Pinchy actually has — the Compact action or a fresh chat (#611).
+export const CONTEXT_OVERFLOW_HINT =
+  "Compact this conversation from the chat header, or start a new chat.";
+
+// User-facing replacement for OpenClaw's raw context-overflow text, which embeds
+// the misleading `/reset` advice. Only the banner uses this; the audit trail
+// keeps the raw provider text.
+export const CONTEXT_OVERFLOW_MESSAGE =
+  "This conversation is too long for the model's context window.";
+
 export function getErrorHint(errorText: string, userRole: string): string | null {
-  // Check transient errors first — "Rate limit exceeded" contains "exceeded"
+  // Context-overflow first: it's specific, role-independent, and must not fall
+  // through to the generic/provider branches (or to null, the pre-#611 behavior).
+  if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
+    return CONTEXT_OVERFLOW_HINT;
+  }
+
+  // Check transient errors next — "Rate limit exceeded" contains "exceeded"
   // which would otherwise match the provider config pattern.
   if (TRANSIENT_PATTERN.test(errorText)) {
     return "Try again in a moment.";
@@ -28,4 +48,18 @@ export function getErrorHint(errorText: string, userRole: string): string | null
   }
 
   return null;
+}
+
+/**
+ * Map a raw provider-error string to the user-facing banner text. Currently this
+ * only rewrites context-overflow errors — OpenClaw's text embeds `/reset`/`/new`
+ * advice that doesn't work in Pinchy's composer (#611) — and passes everything
+ * else through untouched. Apply it where the error is shown to the user (the live
+ * error frame and the durable-banner route); the audit trail keeps the raw text.
+ */
+export function presentProviderError(errorText: string): string {
+  if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
+    return CONTEXT_OVERFLOW_MESSAGE;
+  }
+  return errorText;
 }

--- a/packages/web/src/server/error-patterns.ts
+++ b/packages/web/src/server/error-patterns.ts
@@ -63,3 +63,15 @@ export const HTTP_5XX_PATTERN = /HTTP\s+(5\d\d)\b/i;
  */
 export const PROVIDER_REJECTED_GENERIC_PATTERN =
   /provider rejected the request schema or tool payload/i;
+
+/**
+ * Matches a context-window overflow: the conversation/prompt no longer fits the
+ * model's context window. A model-capability/length issue, NOT a provider-config
+ * one (see PROVIDER_CONFIG_PATTERN's note on deliberately excluding bare
+ * `exceeded`). OpenClaw surfaces this with advice to use its `/reset` or `/new`
+ * slash commands — which Pinchy's web composer doesn't support — so
+ * `error-hints.ts` replaces that advice with a hint pointing at the Compact
+ * action instead (#611).
+ */
+export const CONTEXT_OVERFLOW_PATTERN =
+  /context (overflow|window|length)|prompt (is )?too large|larger[- ]context|maximum context|too many (input )?tokens/i;


### PR DESCRIPTION
## What & why

Two fixes found during the v0.8.0 `:next` staging click-through. Both are small, user-facing chat bugs; each is its own commit.

### 1. Sidebar reopened an older chat (`fix(chat): … same-tab writes (#508)`)

The sidebar resolves each agent link to the device's last-viewed chat via `useSyncExternalStore`, but its `subscribe` only listened to the cross-tab `storage` event — which **never fires for a same-tab write**. The common case (the open chat recording itself via `recordLastChat` in a post-render effect) left the resolved link one render behind, so clicking the agent reopened an **older** chat.

Fix: `last-chat-store` gains an in-module listener set; `recordLastChat` notifies same-tab subscribers, and the sidebar subscribes to it alongside `storage`. Covered at the store level and end-to-end in the sidebar (the new sidebar test was verified red without the wiring).

### 2. Context-overflow error advised `/reset`, which Pinchy doesn't support (`fix(chat): … context-overflow advice (#611)`)

On a context-window overflow, OpenClaw's error text advises its `/reset` / `/new` slash commands — but Pinchy's web composer sends those as literal messages, which just trigger another error. `getErrorHint` had no branch for this class, so Pinchy showed the raw, misleading text.

Fix: add `CONTEXT_OVERFLOW_PATTERN`; `getErrorHint` returns an actionable hint ("Compact this conversation from the chat header, or start a new chat"), and `presentProviderError` rewrites the banner text. Applied at the two user-facing points — the live error frame (`client-router`) and the durable-banner route (`active-error`) — while the **audit trail and the stored row keep the raw provider text**.

## Tests

- `last-chat-store.test.ts` — same-tab notifier (red→green).
- `sidebar.test.tsx` — link refreshes on a same-tab write without navigating (verified red without the fix).
- `error-hints.test.ts` — context-overflow → compact hint; `presentProviderError` rewrites overflow, passes everything else through; the prior "→ null" assertion updated to the new behavior.

Targeted suites green locally (error-hints, client-router, sidebar, last-chat-store, banner). Full local suite is blocked only by an unrelated `better-sqlite3` native-ABI mismatch in this worktree (pinchy-files PDF cache) — untouched here; CI runs it in a correct environment.

## Follow-ups (tracked, out of scope)

- #609 — durable "aborted/timed out" banner not cleared when the run later completes (pre-existing watchdog edge).
- #610 — cache the per-agent chat list so the switcher isn't empty on every open (cosmetic).
- #611 — in-composer slash commands (`/compact`, `/new`, …); the real fix behind this PR's interim hint.

Part of the v0.8.0 release prep.
