### PR TITLE
fix(pinchy-odoo): resolve bare _pinchy_ref in m2o fields + scope by company

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -102,6 +102,16 @@ const MODEL_FIELDS = {
       readonly: false,
       relation: "res.country",
     },
+    // Optional company_id: false means the partner is shared across companies
+    // (the Odoo multi-company convention). Present so the plugin's
+    // company-scoping (OR-with-false) can be exercised against res.partner.
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.company",
+    },
   },
   "res.country": {
     id: { string: "ID", type: "integer", required: false, readonly: true },
@@ -364,6 +374,13 @@ const MODEL_FIELDS = {
       readonly: false,
       relation: "res.company",
     },
+    partner_id: {
+      string: "Partner",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.partner",
+    },
   },
 };
 
@@ -454,6 +471,25 @@ function getDefaultRecords() {
         zip: "5020",
         state_id: [4, "Salzburg"],
         country_id: [14, "Austria"],
+      },
+      // A SHARED partner (company_id = false) — visible across companies per
+      // Odoo's multi-company convention. Used to exercise the OR-with-false
+      // scoping: a create with company_id set must still resolve this partner.
+      {
+        id: 5,
+        name: "Shared Vendor",
+        email: "shared@vendor.at",
+        is_company: true,
+        country_id: [14, "Austria"],
+        company_id: false,
+      },
+      {
+        id: 6,
+        name: "Helmcraft Vendor",
+        email: "vendor@helmcraft.at",
+        is_company: true,
+        country_id: [14, "Austria"],
+        company_id: [1, "Helmcraft GmbH"],
       },
     ],
     "res.country": [

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -298,6 +298,73 @@ const MODEL_FIELDS = {
       ],
     },
   },
+  // Multi-company accounting models — seeded so the plugin's m2o resolution
+  // and the cross-company guard can be exercised end-to-end. Two companies
+  // each carry a "Miscellaneous Operations" journal (code SONST), mirroring
+  // the production collision that blocked the Penny agent's opening-balance
+  // booking: journal codes/names are unique per-company in Odoo, not globally.
+  "res.company": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: {
+      string: "Name",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+  },
+  "account.journal": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: {
+      string: "Name",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    code: {
+      string: "Short Code",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "res.company",
+    },
+  },
+  "account.move": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: { string: "Name", type: "char", required: false, readonly: false },
+    ref: { string: "Reference", type: "char", required: false, readonly: false },
+    date: { string: "Date", type: "char", required: false, readonly: false },
+    move_type: {
+      string: "Move Type",
+      type: "selection",
+      required: false,
+      readonly: false,
+      selection: [
+        ["entry", "Journal Entry"],
+        ["out_invoice", "Customer Invoice"],
+        ["in_invoice", "Vendor Bill"],
+      ],
+    },
+    journal_id: {
+      string: "Journal",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "account.journal",
+    },
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "res.company",
+    },
+  },
 };
 
 // ---------------------------------------------------------------------------
@@ -428,6 +495,9 @@ function getDefaultRecords() {
       { id: 6, model: "mail.activity", name: "Activity" },
       { id: 7, model: "mail.activity.type", name: "Activity Type" },
       { id: 8, model: "res.users", name: "User" },
+      { id: 9, model: "res.company", name: "Company" },
+      { id: 10, model: "account.journal", name: "Journal" },
+      { id: 11, model: "account.move", name: "Journal Entry" },
     ],
     "res.users": [
       { id: 2, name: "Mitch Admin", login: "admin" },
@@ -466,6 +536,28 @@ function getDefaultRecords() {
       },
     ],
     "mail.activity": [],
+    "res.company": [
+      { id: 1, name: "Helmcraft GmbH" },
+      { id: 2, name: "Clemens Helm" },
+    ],
+    // Two journals share name "Miscellaneous Operations" / code "SONST" — one
+    // per company. A free-floating name/code lookup is ambiguous across
+    // these; the plugin must scope by company or resolve via the opaque ref.
+    "account.journal": [
+      {
+        id: 17,
+        name: "Miscellaneous Operations",
+        code: "SONST",
+        company_id: [1, "Helmcraft GmbH"],
+      },
+      {
+        id: 24,
+        name: "Miscellaneous Operations",
+        code: "SONST",
+        company_id: [2, "Clemens Helm"],
+      },
+    ],
+    "account.move": [],
   };
 }
 

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -610,3 +610,153 @@ describe("pinchy-odoo record-action tools against real mock-odoo", () => {
     expect(JSON.parse(result.content[0].text).completed).toBe(true);
   });
 });
+
+// Production regression: the Penny agent (Helmcraft bookkeeping) could not
+// create an opening-balance account.move because `journal_id` would not
+// resolve — two companies share a "Miscellaneous Operations" / SONST journal,
+// the name/code lookup collided, and the bare `_pinchy_ref` the agent copied
+// from odoo_read fell through to a name lookup that never matches. These
+// tests exercise the full chain plugin → Pinchy credentials → odoo-node →
+// mock-odoo against the seeded multi-company journals.
+describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup)", () => {
+  const accountingAgentId = "agent-accounting";
+  const accountingConnectionId = "conn-accounting";
+  const accountingConfig = {
+    connectionId: accountingConnectionId,
+    permissions: {
+      "res.company": ["read"],
+      "account.journal": ["read"],
+      "account.move": ["read", "create"],
+    },
+  };
+
+  beforeAll(async () => {
+    await fetch(`http://127.0.0.1:${mockOdoo.controlPort}/control/reset`, {
+      method: "POST",
+    });
+    credentialsByConnectionId.set(accountingConnectionId, {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  function ref(model: string, id: number, label: string, companyId?: number, companyLabel?: string): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: accountingConnectionId,
+      model,
+      id,
+      label,
+      ...(companyId !== undefined && companyLabel !== undefined
+        ? { companyId, companyLabel }
+        : {}),
+    });
+  }
+
+  it("creates an account.move with a bare _pinchy_ref journal_id (the form odoo_read emits)", async () => {
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const readTool = findTool(tools, "odoo_read", accountingAgentId);
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    // 1. Read the Helmcraft SONST journal to obtain its `_pinchy_ref` — the
+    //    bare-string form the agent copies verbatim into the next call.
+    const readResult = await readTool.execute("read-journal", {
+      model: "account.journal",
+      filters: [["id", "=", 17]],
+      fields: ["name", "company_id"],
+    });
+    expect(readResult.isError).toBeFalsy();
+    const readData = JSON.parse(readResult.content[0].text);
+    const journal = readData.records[0];
+    expect(journal._pinchy_ref).toMatch(/^pinchy_ref:v1:/);
+
+    // 2. Create the move with the bare ref as journal_id (Layer 1) and a
+    //    res.company ref as company_id.
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    const createResult = await createTool.execute("create-move-bare-ref", {
+      model: "account.move",
+      values: {
+        ref: "Eröffnung 3530 per 01.01.2026",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: journal._pinchy_ref, // bare string — the production form
+      },
+    });
+
+    expect(createResult.isError).toBeFalsy();
+    const { id } = JSON.parse(createResult.content[0].text) as { id: number };
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.find((m) => m.id === id)).toMatchObject({
+      journal_id: 17,
+      company_id: 1,
+      ref: "Eröffnung 3530 per 01.01.2026",
+    });
+  });
+
+  it("scopes a journal name lookup by company_id, resolving the multi-company collision (Layer 2)", async () => {
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    // journal_id passed as a display NAME (not a ref) — ambiguous across the
+    // two companies without the company_id scope. With Layer 2 the lookup is
+    // constrained to company 1 and resolves to journal 17.
+    const createResult = await createTool.execute("create-move-scoped-name", {
+      model: "account.move",
+      values: {
+        ref: "Sonstbuchung per 01.01.2026",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+      },
+    });
+
+    expect(createResult.isError).toBeFalsy();
+    const { id } = JSON.parse(createResult.content[0].text) as { id: number };
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.find((m) => m.id === id)).toMatchObject({
+      journal_id: 17,
+      company_id: 1,
+    });
+  });
+
+  it("still rejects a bare ref pointing at the wrong company's journal (cross-company guard)", async () => {
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const companyRefA = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    // Bare ref for company 2's journal while company_id points at company 1.
+    const journalRefB = ref(
+      "account.journal",
+      24,
+      "Miscellaneous Operations [Clemens Helm]",
+      2,
+      "Clemens Helm",
+    );
+    const createResult = await createTool.execute("create-move-xc", {
+      model: "account.move",
+      values: {
+        ref: "should be rejected",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRefA },
+        journal_id: journalRefB,
+      },
+    });
+
+    expect(createResult.isError).toBe(true);
+    expect(createResult.content[0].text).toMatch(/cross-company/i);
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.some((m) => m.ref === "should be rejected")).toBe(false);
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -759,4 +759,39 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
     ).then((res) => res.json())) as Array<Record<string, unknown>>;
     expect(moves.some((m) => m.ref === "should be rejected")).toBe(false);
   });
+
+  it("resolves a SHARED partner (company_id=false) even when company_id is set on the create", async () => {
+    // Regression guard for the OR-with-false scoping: res.partner has an
+    // OPTIONAL company_id (false = shared across companies). A strict
+    // `["company_id","=",1]` filter would exclude the shared partner; the
+    // OR-with-false domain must keep it reachable.
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    const createResult = await createTool.execute("create-move-shared-partner", {
+      model: "account.move",
+      values: {
+        ref: "Bill for shared vendor",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        partner_id: "Shared Vendor",
+      },
+    });
+
+    expect(createResult.isError).toBeFalsy();
+    const { id } = JSON.parse(createResult.content[0].text) as { id: number };
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    // The shared partner (id 5, company_id false) resolves despite the
+    // company-1 scope; journal_id resolves to the company-1 journal (17).
+    expect(moves.find((m) => m.id === id)).toMatchObject({
+      partner_id: 5,
+      journal_id: 17,
+      company_id: 1,
+    });
+  });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -45,6 +45,7 @@ import plugin, {
   extractCompanyId,
   formatMultiMatchError,
   assertNoCrossCompanyRefs,
+  relationHasCompanyId,
   PRODUCT_REF_DISAMBIGUATION_HINT,
 } from "../index";
 
@@ -4169,6 +4170,202 @@ describe("company-scoped m2o name lookup (Layer 2)", () => {
     // res.currency has no company_id — adding a company_id domain would make
     // Odoo throw "Invalid field 'company_id' on model".
     expect(domain).toEqual([["name", "ilike", "USD"]]);
+  });
+});
+
+// Odoo's _check_company_domain includes SHARED records (company_id = false),
+// so a company scope must be `(company_id = false OR company_id = <scope>)`,
+// not a strict equality — otherwise shared partners/products (company_id
+// false, visible across companies) get excluded and a name lookup that
+// resolved before now fails with "Could not resolve". res.partner and
+// product.product both carry an OPTIONAL company_id where false means shared.
+describe("company scope includes shared records (company_id = false)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  it("scopes a company-optional relation with (company_id = false OR company_id = <scope>)", async () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "partner_id",
+            type: "many2one",
+            relation: "res.partner",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "res.partner") {
+        // res.partner has an OPTIONAL company_id (false = shared). The
+        // scoping gate must not treat "has a company_id field" as
+        // "company-exclusive" the way account.journal is.
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "display_name",
+            type: "char",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    // A shared partner (company_id = false) plus a company-1 partner plus a
+    // company-2 partner, all distinct names so the resolution is unambiguous.
+    mockSearchRead.mockImplementation(async (model: string, domain: unknown) => {
+      if (model === "res.partner") {
+        const hasSharedBranch =
+          Array.isArray(domain) &&
+          domain.some(
+            (c) => Array.isArray(c) && c[0] === "company_id" && c[2] === false,
+          );
+        return hasSharedBranch
+          ? {
+              records: [
+                {
+                  id: 5,
+                  name: "Shared Vendor",
+                  display_name: "Shared Vendor",
+                  company_id: false,
+                },
+              ],
+              total: 1,
+              limit: 20,
+              offset: 0,
+            }
+          : {
+              records: [
+                {
+                  id: 6,
+                  name: "Shared Vendor",
+                  display_name: "Shared Vendor",
+                  company_id: [1, "Helmcraft GmbH"],
+                },
+              ],
+              total: 1,
+              limit: 20,
+              offset: 0,
+            };
+      }
+      return { records: [], total: 0, limit: 20, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(999);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("shared-partner", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRef },
+        partner_id: "Shared Vendor",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const partnerLookup = mockSearchRead.mock.calls.find(
+      ([model]) => model === "res.partner",
+    );
+    expect(partnerLookup).toBeDefined();
+    const domain = partnerLookup![1];
+    // The scope must be the OR-with-false pattern, not a strict equality.
+    expect(domain).toEqual(
+      expect.arrayContaining([
+        "|",
+        ["company_id", "=", false],
+        ["company_id", "=", 1],
+      ]),
+    );
+    // … and NOT the strict-only form that would exclude shared records.
+    expect(domain).not.toEqual([
+      ["name", "ilike", "Shared Vendor"],
+      ["company_id", "=", 1],
+    ]);
+    // The shared partner (id 5, company_id false) resolves, not the
+    // company-1-only partner that a strict filter would have returned.
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move",
+      expect.objectContaining({ partner_id: 5, company_id: 1 }),
+    );
+  });
+});
+
+describe("formatMultiMatchError multi-company hint", () => {
+  it("points at adding company_id to the create values, not a broken odoo_read domain with a _pinchy_ref", () => {
+    const field = {
+      name: "journal_id",
+      string: "Journal",
+      type: "many2one",
+      relation: "account.journal",
+    } as unknown as Parameters<typeof formatMultiMatchError>[0];
+    const matches = [
+      { id: 17, company_id: [1, "Helmcraft GmbH"] },
+      { id: 24, company_id: [2, "Clemens Helm"] },
+    ] as unknown as Parameters<typeof formatMultiMatchError>[2];
+    const msg = formatMultiMatchError(field, { name: "Miscellaneous Operations" }, matches);
+    // The old hint told the agent to put a _pinchy_ref token as a domain
+    // value in odoo_read (`[["company_id", "=", <company _pinchy_ref>]]`) —
+    // Odoo does not decode pinchy_ref tokens in domains, so that recipe
+    // returns zero results and misroutes the agent.
+    expect(msg).not.toContain("<company _pinchy_ref>");
+    expect(msg).not.toMatch(/"company_id"\s*,\s*"="\s*,\s*[^[\]]*_pinchy_ref/);
+    // The actionable, cheap path: add company_id to the create/write values
+    // (the plugin scopes the lookup automatically).
+    expect(msg).toMatch(/company_id/);
+    expect(msg).toMatch(/create|write/);
+    expect(msg.length).toBeLessThan(600);
+  });
+});
+
+describe("relationHasCompanyId / findCompanyIdField helper", () => {
+  it("detects a many2one company_id field", () => {
+    const fields = normalizeFields([
+      { name: "id", type: "integer" },
+      { name: "company_id", type: "many2one", relation: "res.company" },
+    ]);
+    expect(relationHasCompanyId(fields)).toBe(true);
+  });
+  it("returns false when company_id is absent or not many2one", () => {
+    expect(
+      relationHasCompanyId(normalizeFields([{ name: "id", type: "integer" }])),
+    ).toBe(false);
+    expect(
+      relationHasCompanyId(
+        normalizeFields([{ name: "company_id", type: "char" }]),
+      ),
+    ).toBe(false);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -3740,6 +3740,438 @@ describe("cross-company write guard", () => {
   });
 });
 
+// The agent-facing output (odoo_read / odoo_create) emits `_pinchy_ref` as a
+// BARE string, and the prose tells the model to "pass the `_pinchy_ref`
+// verbatim". For dedicated ref params (odoo_attach_file.targetRef,
+// resolveAssigneeUserId) the bare string is already decoded. The general
+// many2one resolver must do the same — otherwise the agent copies the bare
+// ref into `journal_id` and it falls through to a name lookup that never
+// matches. This is the root cause of the production "Journal-Auflösung"
+// blocker, where a multi-company collision made the name/code path
+// ambiguous AND the bare-ref escape hatch was silently broken.
+describe("bare _pinchy_ref string for many2one fields (Layer 1)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  it("resolves a bare _pinchy_ref string to the decoded record id (no name lookup)", async () => {
+    const journalRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.journal",
+      id: 17,
+      label: "Miscellaneous Operations [Helmcraft GmbH]",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+    mockCreate.mockResolvedValue(555);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("bare-ref", {
+      model: "account.move",
+      // journal_id is a BARE string — the form odoo_read emits.
+      values: { company_id: { ref: companyRef }, journal_id: journalRef },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move",
+      expect.objectContaining({ journal_id: 17, company_id: 1 }),
+    );
+    // The bare ref must short-circuit the name lookup — no searchRead on
+    // account.journal should happen.
+    const journalLookup = mockSearchRead.mock.calls.find(
+      ([model]) => model === "account.journal",
+    );
+    expect(journalLookup).toBeUndefined();
+  });
+
+  it("rejects a bare _pinchy_ref whose model does not match the field relation", async () => {
+    const partnerRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.partner",
+      id: 99,
+      label: "Some Partner",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("wrong-model", {
+      model: "account.move",
+      values: { journal_id: partnerRef },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/expected account\.journal, got res\.partner/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects a bare _pinchy_ref from a different connection", async () => {
+    const otherConnRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "other-conn",
+      model: "account.journal",
+      id: 17,
+      label: "J",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("wrong-conn", {
+      model: "account.move",
+      values: { journal_id: otherConnRef },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/connection does not match/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("cross-company guard also catches bare-string refs whose company tags disagree", async () => {
+    // Without extending readRefCompanyTag to bare strings, Layer 1 would let a
+    // bare company-2 journal ref slip past the cross-company guard while
+    // company_id points at company 1.
+    const companyRefA = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const journalRefB = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.journal",
+      id: 24,
+      label: "Miscellaneous Operations [Clemens Helm]",
+      companyId: 2,
+      companyLabel: "Clemens Helm",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("xc-bare", {
+      model: "account.move",
+      values: { company_id: { ref: companyRefA }, journal_id: journalRefB },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/cross-company/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// Odoo journal codes/names are unique per-company, not globally. When two
+// companies share a journal name/code, a free-floating name lookup is
+// ambiguous by construction. Odoo's own fix (PR #269835 / commit 3fcd8a9) is
+// to scope the search to the record's company. When `values.company_id` is
+// resolvable, the m2o name lookup for a company-scoped relation must add a
+// `("company_id", "=", <resolved>)` domain so the collision resolves.
+describe("company-scoped m2o name lookup (Layer 2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  it("scopes a journal name lookup by values.company_id, resolving a multi-company collision", async () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "account.journal") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "display_name",
+            type: "char",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    mockSearchRead.mockImplementation(async (model: string, domain: unknown) => {
+      if (model === "account.journal") {
+        const hasCompanyScope =
+          Array.isArray(domain) &&
+          domain.some(
+            (c) => Array.isArray(c) && c[0] === "company_id" && c[2] === 1,
+          );
+        return hasCompanyScope
+          ? {
+              records: [
+                {
+                  id: 17,
+                  name: "Miscellaneous Operations",
+                  display_name: "Miscellaneous Operations",
+                  company_id: [1, "Helmcraft GmbH"],
+                },
+              ],
+              total: 1,
+              limit: 20,
+              offset: 0,
+            }
+          : {
+              records: [
+                {
+                  id: 17,
+                  name: "Miscellaneous Operations",
+                  display_name: "Miscellaneous Operations",
+                  company_id: [1, "Helmcraft GmbH"],
+                },
+                {
+                  id: 24,
+                  name: "Miscellaneous Operations",
+                  display_name: "Miscellaneous Operations",
+                  company_id: [2, "Clemens Helm"],
+                },
+              ],
+              total: 2,
+              limit: 20,
+              offset: 0,
+            };
+      }
+      return { records: [], total: 0, limit: 20, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(777);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("scope", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const journalLookup = mockSearchRead.mock.calls.find(
+      ([model]) => model === "account.journal",
+    );
+    expect(journalLookup).toBeDefined();
+    const domain = journalLookup![1];
+    expect(domain).toEqual(
+      expect.arrayContaining([["company_id", "=", 1]]),
+    );
+    expect(mockCreate).toHaveBeenCalledWith(
+      "account.move",
+      expect.objectContaining({ journal_id: 17 }),
+    );
+  });
+
+  it("does NOT scope the lookup when the relation has no company_id field (e.g. res.currency)", async () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "currency_id",
+            type: "many2one",
+            relation: "res.currency",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "res.currency") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "display_name",
+            type: "char",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 3, name: "USD", display_name: "USD" }],
+      total: 1,
+      limit: 20,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(888);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("no-scope", {
+      model: "account.move",
+      values: { company_id: { ref: companyRef }, currency_id: "USD" },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const currencyLookup = mockSearchRead.mock.calls.find(
+      ([model]) => model === "res.currency",
+    );
+    expect(currencyLookup).toBeDefined();
+    const domain = currencyLookup![1];
+    // res.currency has no company_id — adding a company_id domain would make
+    // Odoo throw "Invalid field 'company_id' on model".
+    expect(domain).toEqual([["name", "ilike", "USD"]]);
+  });
+});
+
 describe("odoo_schedule_activity", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2,7 +2,12 @@ import { readFile, stat } from "./io";
 import { basename, extname } from "path";
 import { OdooClient, type OdooDomain } from "odoo-node";
 import { checkPermission, type Permissions } from "./permissions";
-import { decodeRef, encodeRef, isIntegrationRef } from "./integration-ref";
+import {
+  decodeRef,
+  encodeRef,
+  isIntegrationRef,
+  type IntegrationRefPayload,
+} from "./integration-ref";
 
 const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 
@@ -495,15 +500,36 @@ export function compactSchema(
  * appended `company_id` to `[]` we'd silently flip the request into "only
  * company_id, please", changing behaviour vs. pre-Task-1.
  */
+/**
+ * Find the `company_id` many2one field on a model's field list, or undefined.
+ * Single source of truth for "does this relation carry a company_id?" — used
+ * by the read-side augmentation (`augmentFieldsWithCompanyId`) and the
+ * write-side scoping (`searchRelationByName`, `normalizeMany2OneValues`).
+ * Keeping the predicate in one place stops the write-side scoping gate from
+ * drifting from the read-side notion of "has a company_id".
+ */
+export function findCompanyIdField(fields: OdooField[]): OdooField | undefined {
+  return fields.find((f) => f.name === "company_id" && f.type === "many2one");
+}
+
+/**
+ * Boolean form of {@link findCompanyIdField}: true when the model has a
+ * `company_id` many2one field. Note this says nothing about whether the
+ * field is REQUIRED — `res.partner` and `product.product` have an OPTIONAL
+ * company_id (false = shared across companies), so "has a company_id field"
+ * is NOT "company-exclusive". Scoping code must use the OR-with-false domain
+ * pattern, not a strict equality, to keep shared records reachable.
+ */
+export function relationHasCompanyId(fields: OdooField[]): boolean {
+  return findCompanyIdField(fields) !== undefined;
+}
+
 export function augmentFieldsWithCompanyId(
   requested: string[] | undefined,
   modelFields: OdooField[],
 ): string[] | undefined {
   if (!requested || requested.length === 0) return requested;
-  const hasCompany = modelFields.some(
-    (f) => f.name === "company_id" && f.type === "many2one",
-  );
-  if (!hasCompany) return requested;
+  if (!relationHasCompanyId(modelFields)) return requested;
   if (requested.includes("company_id")) return requested;
   return [...requested, "company_id"];
 }
@@ -645,10 +671,11 @@ export function formatMultiMatchError(
     const list = shown.map((c) => `"${c}"`).join(", ") + overflow;
     return (
       `Could not resolve ${field.name}: multiple ${label} records match "${input}" ` +
-      `across companies (${list}). This is a multi-company collision — add a ` +
-      `\`company_id\` filter to your odoo_read first (e.g. ` +
-      `[["company_id", "=", <company _pinchy_ref>]]), then pass the exact ` +
-      `\`_pinchy_ref\` of the right record.`
+      `across companies (${list}). This is a multi-company collision. The ` +
+      `simplest fix is to add \`company_id\` to the values of this create/write ` +
+      `— the lookup is then scoped to that company automatically. Otherwise ` +
+      `re-read the relation filtered by company and pass the exact \`_pinchy_ref\` ` +
+      `of the right record (a bare \`_pinchy_ref\` string works for many2one fields).`
     );
   }
   return `Could not resolve ${field.name}: multiple ${label} records match "${input}".`;
@@ -738,14 +765,63 @@ function resolveReferenceFromRecords(
 }
 
 /**
- * Decode an opaque integration ref string and validate it against the field
- * being written: the integration must be `odoo`, the connection must match the
- * current tenant (prevents cross-connection ref injection), and the encoded
- * model must equal the field's relation (prevents a `res.partner` ref from
- * being written into a `journal_id` / `account.journal` field). Returns the
- * decoded record id on success, throws a descriptive error otherwise.
+ * Decode an opaque integration ref and enforce per-connection isolation: the
+ * integration must be `odoo` and the encoded `connectionId` must match the
+ * current tenant. A ref minted for a different connection decodes validly
+ * under a deployment's single ref key, so this gate is what stops a
+ * cross-connection ref from being acted on. Returns the decoded payload
+ * (model + id + optional company tag) so the caller can apply its own
+ * model-specific checks.
  *
- * Shared by the two ref entry points: the `{ ref: "…" }` object form
+ * Single source of truth for the connection gate — shared by every
+ * ref-consuming site: the many2one field resolver (`decodeAndValidateRef`),
+ * the assignee resolver, and every `target`/`targetRef` consumer
+ * (`decodeTargetRef`). A future tightening (key rotation, v2 prefix,
+ * deployment scoping) lands here and reaches all of them at once.
+ */
+function decodeOdooRefForConnection(
+  connectionId: string,
+  refString: string,
+): IntegrationRefPayload {
+  const ref = decodeRef(refString);
+  if (ref.integrationType !== "odoo") {
+    throw new Error("Invalid ref: expected odoo integration.");
+  }
+  if (ref.connectionId !== connectionId) {
+    throw new Error("Invalid ref: connection does not match.");
+  }
+  return ref;
+}
+
+/**
+ * Decode a `target`/`targetRef` for a tool that acts on an arbitrary target
+ * model (schedule/complete/reschedule activity, record-action tools,
+ * attach_file). Returns the payload on success, or null when the ref is
+ * malformed or belongs to a different connection — the caller surfaces a
+ * consistent "does not belong to this Odoo connection" error. No model
+ * check: these tools accept any target model and gate it through the
+ * permissions map instead.
+ */
+function decodeTargetRef(
+  connectionId: string,
+  refString: string,
+): IntegrationRefPayload | null {
+  try {
+    return decodeOdooRefForConnection(connectionId, refString);
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Decode an opaque integration ref string and validate it against the field
+ * being written: the connection gate runs via {@link decodeOdooRefForConnection},
+ * and the encoded model must equal the field's relation (prevents a
+ * `res.partner` ref from being written into a `journal_id` / `account.journal`
+ * field). Returns the decoded record id on success, throws a descriptive
+ * error otherwise.
+ *
+ * Shared by the two many2one ref entry points: the `{ ref: "…" }` object form
  * (`refToId`) and the bare `_pinchy_ref` string form accepted by
  * `resolveRelationValue`. Both forms carry the same encoded payload, so
  * both get the same validation — accepting the bare string loses no safety
@@ -756,15 +832,7 @@ function decodeAndValidateRef(
   field: OdooField,
   refString: string,
 ): number {
-  const ref = decodeRef(refString);
-  if (ref.integrationType !== "odoo") {
-    throw new Error(`Invalid ref for ${field.name}: expected odoo.`);
-  }
-  if (ref.connectionId !== connectionId) {
-    throw new Error(
-      `Invalid ref for ${field.name}: connection does not match.`,
-    );
-  }
+  const ref = decodeOdooRefForConnection(connectionId, refString);
   if (ref.model !== field.relation) {
     throw new Error(
       `Invalid ref for ${field.name}: expected ${field.relation}, got ${ref.model}.`,
@@ -887,18 +955,20 @@ async function searchRelationByName(
 ): Promise<unknown> {
   const relation = field.relation as string;
   const relationFields = normalizeFields(await client.fields(relation));
-  const hasCompanyField = relationFields.some(
-    (f) => f.name === "company_id" && f.type === "many2one",
-  );
   const lookupFields = augmentFieldsWithCompanyId(
     ["id", "name", "display_name"],
     relationFields,
   ) ?? ["id", "name", "display_name"];
-  const domain: Array<[string, string, unknown]> = [
-    ["name", "ilike", lookup.name ?? ""],
-  ];
-  if (scopeCompanyId !== null && hasCompanyField) {
-    domain.push(["company_id", "=", scopeCompanyId]);
+  const domain: OdooDomain = [["name", "ilike", lookup.name ?? ""]];
+  if (scopeCompanyId !== null && relationHasCompanyId(relationFields)) {
+    // Mirror Odoo's `_check_company_domain`: include SHARED records
+    // (company_id = false), not just the target company. A strict
+    // `("company_id", "=", scope)` filter would exclude shared partners and
+    // products (company_id false, visible across companies) and break name
+    // lookups that resolved before. For company-EXCLUSIVE relations
+    // (account.journal, where company_id is required) the false branch
+    // never matches, so this is equivalent to the strict filter there.
+    domain.push("|", ["company_id", "=", false], ["company_id", "=", scopeCompanyId]);
   }
   return client.searchRead(relation, domain, {
     fields: lookupFields,
@@ -991,9 +1061,7 @@ async function normalizeMany2OneValues(
   // is absent, false, or doesn't resolve to a positive integer, no scoping is
   // applied and subsequent lookups behave exactly as before.
   let scopeCompanyId: number | null = null;
-  const companyField = fields.find(
-    (f) => f.name === "company_id" && f.type === "many2one",
-  );
+  const companyField = findCompanyIdField(fields);
   if (companyField && "company_id" in normalized) {
     const resolved = await resolveRelationValue(
       client,
@@ -1014,6 +1082,10 @@ async function normalizeMany2OneValues(
   for (const field of fields) {
     if (field.type !== "many2one" || !(field.name in normalized)) continue;
     if (field.name === "company_id") continue; // already resolved above
+    // Only top-level m2o fields are resolved here. Nested one2many command
+    // tuples (e.g. account.move `line_ids: [[0, 0, { account_id: "…" }]]`) are
+    // passed through to Odoo verbatim — their m2o values get no ref decoding
+    // and no company scoping. Tracked separately in #615.
     normalized[field.name] = await resolveRelationValue(
       client,
       connectionId,
@@ -1113,13 +1185,9 @@ async function resolveAssigneeUserId(
   connectionId: string,
   assignee: string,
 ): Promise<number> {
-  if (assignee.startsWith("pinchy_ref:")) {
-    const ref = decodeRef(assignee);
-    if (
-      ref.integrationType !== "odoo" ||
-      ref.connectionId !== connectionId ||
-      ref.model !== "res.users"
-    ) {
+  if (isIntegrationRef(assignee)) {
+    const ref = decodeOdooRefForConnection(connectionId, assignee);
+    if (ref.model !== "res.users") {
       throw new Error("`assignee` ref must point to a res.users record.");
     }
     return ref.id;
@@ -2141,11 +2209,8 @@ const plugin = {
                 );
               }
 
-              const decoded = decodeRef(target);
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              const decoded = decodeTargetRef(config.connectionId, target);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`target` ref does not belong to this Odoo connection.",
@@ -2293,11 +2358,8 @@ const plugin = {
                   ),
                 );
               }
-              const decoded = decodeRef(target);
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              const decoded = decodeTargetRef(config.connectionId, target);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`target` ref does not belong to this Odoo connection.",
@@ -2420,11 +2482,8 @@ const plugin = {
                 );
               }
 
-              const decoded = decodeRef(target);
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              const decoded = decodeTargetRef(config.connectionId, target);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`target` ref does not belong to this Odoo connection.",
@@ -2523,11 +2582,8 @@ const plugin = {
                   ),
                 );
               }
-              const decoded = decodeRef(target);
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              const decoded = decodeTargetRef(config.connectionId, target);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`target` ref does not belong to this Odoo connection.",
@@ -2686,11 +2742,8 @@ const plugin = {
                   new Error('`decision` must be "approve" or "refuse".'),
                 );
               }
-              const decoded = decodeRef(target);
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              const decoded = decodeTargetRef(config.connectionId, target);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`target` ref does not belong to this Odoo connection.",
@@ -2935,16 +2988,12 @@ const plugin = {
               }
 
               const targetRef = params.targetRef as string;
-              const decoded = decodeRef(targetRef);
-
-              // Enforce per-connection isolation: a ref minted for a DIFFERENT
+              // Per-connection isolation: a ref minted for a DIFFERENT
               // connection decodes validly under this deployment's single ref
-              // key, so reject it before acting — same guard every other
-              // ref-consuming Odoo tool applies.
-              if (
-                decoded.integrationType !== "odoo" ||
-                decoded.connectionId !== config.connectionId
-              ) {
+              // key, so reject it before acting — same gate every other
+              // ref-consuming Odoo tool applies (decodeTargetRef).
+              const decoded = decodeTargetRef(config.connectionId, targetRef);
+              if (decoded === null) {
                 return errorResult(
                   new Error(
                     "`targetRef` ref does not belong to this Odoo connection.",

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2,7 +2,7 @@ import { readFile, stat } from "./io";
 import { basename, extname } from "path";
 import { OdooClient, type OdooDomain } from "odoo-node";
 import { checkPermission, type Permissions } from "./permissions";
-import { decodeRef, encodeRef } from "./integration-ref";
+import { decodeRef, encodeRef, isIntegrationRef } from "./integration-ref";
 
 const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 
@@ -737,13 +737,26 @@ function resolveReferenceFromRecords(
   );
 }
 
-function refToId(
+/**
+ * Decode an opaque integration ref string and validate it against the field
+ * being written: the integration must be `odoo`, the connection must match the
+ * current tenant (prevents cross-connection ref injection), and the encoded
+ * model must equal the field's relation (prevents a `res.partner` ref from
+ * being written into a `journal_id` / `account.journal` field). Returns the
+ * decoded record id on success, throws a descriptive error otherwise.
+ *
+ * Shared by the two ref entry points: the `{ ref: "…" }` object form
+ * (`refToId`) and the bare `_pinchy_ref` string form accepted by
+ * `resolveRelationValue`. Both forms carry the same encoded payload, so
+ * both get the same validation — accepting the bare string loses no safety
+ * versus the object form.
+ */
+function decodeAndValidateRef(
   connectionId: string,
   field: OdooField,
-  value: Record<string, unknown>,
-): number | null {
-  if (typeof value.ref !== "string") return null;
-  const ref = decodeRef(value.ref);
+  refString: string,
+): number {
+  const ref = decodeRef(refString);
   if (ref.integrationType !== "odoo") {
     throw new Error(`Invalid ref for ${field.name}: expected odoo.`);
   }
@@ -758,6 +771,15 @@ function refToId(
     );
   }
   return ref.id;
+}
+
+function refToId(
+  connectionId: string,
+  field: OdooField,
+  value: Record<string, unknown>,
+): number | null {
+  if (typeof value.ref !== "string") return null;
+  return decodeAndValidateRef(connectionId, field, value.ref);
 }
 
 /**
@@ -817,9 +839,20 @@ export function assertNoCrossCompanyRefs(
 function readRefCompanyTag(
   value: unknown,
 ): { id: number; label: string | null } | null {
-  if (!isRecord(value) || typeof value.ref !== "string") return null;
+  // Accept the ref in either wire form the agent may pass: the structured
+  // `{ ref: "…" }` object OR a bare `_pinchy_ref` string (the form odoo_read
+  // emits and the prose tells the agent to copy verbatim). Without the
+  // bare-string branch, Layer 1's bare-ref support would let a bare ref slip
+  // past the cross-company guard entirely.
+  const refString =
+    isRecord(value) && typeof value.ref === "string"
+      ? value.ref
+      : isIntegrationRef(value)
+        ? value
+        : null;
+  if (refString === null) return null;
   try {
-    const payload = decodeRef(value.ref);
+    const payload = decodeRef(refString);
     if (payload.companyId === undefined) return null;
     return { id: payload.companyId, label: payload.companyLabel ?? null };
   } catch {
@@ -836,19 +869,38 @@ function readRefCompanyTag(
  * The gating mirrors `augmentFieldsWithCompanyId`, which is also used by
  * `odoo_read` to keep multi-company UX consistent. One extra `client.fields`
  * call per non-country lookup is the cost.
+ *
+ * When `scopeCompanyId` is set (because the parent record's `company_id` was
+ * resolvable), constrain the search to that company. Odoo journal codes/names
+ * are unique per-company, not globally — without this scope, a name/code that
+ * exists in two companies returns multiple matches and the create fails with
+ * a multi-company collision. Scoping to the record's company is Odoo's own
+ * fix pattern (PR #269835 / commit 3fcd8a9). Only applied when the relation
+ * actually has a `company_id` field, so company-shared models (res.currency,
+ * res.partner, res.country) are never scoped.
  */
 async function searchRelationByName(
   client: OdooClient,
   field: OdooField,
   lookup: RelationLookup,
+  scopeCompanyId: number | null = null,
 ): Promise<unknown> {
   const relation = field.relation as string;
   const relationFields = normalizeFields(await client.fields(relation));
+  const hasCompanyField = relationFields.some(
+    (f) => f.name === "company_id" && f.type === "many2one",
+  );
   const lookupFields = augmentFieldsWithCompanyId(
     ["id", "name", "display_name"],
     relationFields,
   ) ?? ["id", "name", "display_name"];
-  return client.searchRead(relation, [["name", "ilike", lookup.name ?? ""]], {
+  const domain: Array<[string, string, unknown]> = [
+    ["name", "ilike", lookup.name ?? ""],
+  ];
+  if (scopeCompanyId !== null && hasCompanyField) {
+    domain.push(["company_id", "=", scopeCompanyId]);
+  }
+  return client.searchRead(relation, domain, {
     fields: lookupFields,
     limit: 20,
   });
@@ -859,6 +911,7 @@ async function resolveRelationValue(
   connectionId: string,
   field: OdooField,
   value: unknown,
+  scopeCompanyId: number | null = null,
 ): Promise<unknown> {
   if (value == null || value === false) return value;
   if (typeof value === "number") {
@@ -881,6 +934,19 @@ async function resolveRelationValue(
     }
   }
 
+  // Bare `_pinchy_ref` string — the exact form `odoo_read` / `odoo_create`
+  // emit and the tool prose tells the agent to "pass verbatim". Without this
+  // branch the string would fall through to `parseLookup` and be treated as a
+  // display-name search, which never matches a `pinchy_ref:v1:…` token and
+  // reports a misleading "Could not resolve". Decoding here gives the agent
+  // the unambiguous escape hatch the design promises — and, because the ref
+  // encodes the exact record (incl. company tag), it sidesteps multi-company
+  // name/code collisions entirely. Validation is shared with the `{ref}`
+  // object form via `decodeAndValidateRef`, so no safety is lost.
+  if (isIntegrationRef(value)) {
+    return decodeAndValidateRef(connectionId, field, value);
+  }
+
   const lookup = parseLookup(field, value);
   if (!lookup) return value;
   if (lookup.name === "") return false;
@@ -897,7 +963,7 @@ async function resolveRelationValue(
           fields: ["id", "name", "display_name", "code"],
           limit: 1000,
         })
-      : await searchRelationByName(client, field, lookup);
+      : await searchRelationByName(client, field, lookup, scopeCompanyId);
 
   return resolveReferenceFromRecords(
     field,
@@ -916,13 +982,44 @@ async function normalizeMany2OneValues(
   if (fields.length === 0) return values;
 
   const normalized = { ...values };
+
+  // Resolve `company_id` first so that company-scoped m2o lookups later in the
+  // loop (e.g. `journal_id`, where two companies can share a journal name/code)
+  // can be constrained to the target company — Odoo's own fix pattern for
+  // multi-company collisions (PR #269835 / commit 3fcd8a9). `res.company`
+  // itself has no `company_id` field, so this never recurses. When company_id
+  // is absent, false, or doesn't resolve to a positive integer, no scoping is
+  // applied and subsequent lookups behave exactly as before.
+  let scopeCompanyId: number | null = null;
+  const companyField = fields.find(
+    (f) => f.name === "company_id" && f.type === "many2one",
+  );
+  if (companyField && "company_id" in normalized) {
+    const resolved = await resolveRelationValue(
+      client,
+      connectionId,
+      companyField,
+      normalized.company_id,
+    );
+    normalized.company_id = resolved;
+    if (
+      typeof resolved === "number" &&
+      Number.isInteger(resolved) &&
+      resolved > 0
+    ) {
+      scopeCompanyId = resolved;
+    }
+  }
+
   for (const field of fields) {
     if (field.type !== "many2one" || !(field.name in normalized)) continue;
+    if (field.name === "company_id") continue; // already resolved above
     normalized[field.name] = await resolveRelationValue(
       client,
       connectionId,
       field,
       normalized[field.name],
+      scopeCompanyId,
     );
   }
   return normalized;


### PR DESCRIPTION
## Problem

Production regression reported on the **Penny** bookkeeping agent (`pinchy.heypinchy.com`): creating an opening-balance `account.move` (466,65 € Guthaben on account 3530 per 01.01.2026) was blocked at **`journal_id` resolution**. The agent tried ~30 combinations over ~2h — numeric id, `_pinchy_ref`, name, code, invented `“SONST [Helmcraft GmbH]”` — all rejected:

- numeric `17` / `24` → “Raw numeric IDs are not accepted” (plugin anti-enumeration guard)
- `_pinchy_ref` (bare string) → “Could not resolve journal_id”
- name “Miscellaneous Operations” → “multiple records match”
- code “SONST” → “Could not resolve”

Root cause is two intertwined bugs:

- **Multi-company collision**: Odoo journal codes/names are unique *per company*, not globally. The instance has two companies (Helmcraft GmbH, Clemens Helm), each with a “Miscellaneous Operations” / `SONST` journal. A free-floating name/code lookup is ambiguous by construction.
- **The bare-ref escape hatch was broken**: the tool prose says *“pass the `_pinchy_ref` verbatim”* and `odoo_read` / `odoo_create` emit it as a **bare string**, but the general many2one resolver only recognised the `{ ref: "…" }` object form. A bare string fell through to a `name ilike "pinchy_ref:v1:…"` search that never matches and reports a misleading “Could not resolve”. The agent never had a working unambiguous path.

## Fix — two coordinated layers

**Layer 1 — recognise a bare `pinchy_ref:v1:` string in `resolveRelationValue`** and decode+validate it via the same path as the `{ref}` object form (refactored into a shared `decodeAndValidateRef`). The ref encodes the exact record incl. company tag, so this sidesteps the multi-company collision entirely and makes the “verbatim” prose true. `readRefCompanyTag` now also reads bare-string refs so the cross-company write guard still applies (no guard gap from Layer 1).

**Layer 2 — company-scoped name/code lookup** following Odoo’s own fix pattern (PR #269835 / commit 3fcd8a9): when `values.company_id` is resolvable, scope the m2o lookup for company-scoped relations to that company (`("company_id", "=", <id>)`). `normalizeMany2OneValues` resolves `company_id` first, then threads the id into the remaining lookups. Company-shared models (`res.currency`, `res.partner`, `res.country`) are never scoped. Single-company tenants (no `company_id` in values) keep the previous behaviour unchanged.

## Why this design

Researched prior art before implementing: no Odoo MCP server does anti-enumeration + opaque refs (all expose raw numeric IDs and are silent on multi-company). The prefixed-handle precedent (Stripe `pi_…`, HubSpot `hubspot:{type}:{id}`, Slack) leans into **self-describing bare strings** — the whole point of a `pinchy_ref:v1:` prefix is that the string is recognisable as a ref without a wrapper object. The current bare-string rejection ran against that rationale. Odoo’s own collision fix is to scope by the record’s company, not the session company.

## Tests

- **Unit (`tools.test.ts`, +7)**: bare ref resolves to decoded id (no name lookup); wrong-model / wrong-connection bare refs rejected; cross-company guard catches disagreeing bare-string refs; company-scoped lookup resolves the collision; no-scope for company-less relations. Exercise the real plugin logic (only the Odoo RPC transport is mocked).
- **Integration (`integration.test.ts`, +3)** against the real in-process mock-odoo seeded with two companies’ SONST journals: bare-ref `account.move` create; company-scoped name-lookup create; cross-company rejection. End-to-end plugin → Pinchy credentials → odoo-node → Odoo JSON-RPC.
- Mock additions (`config/odoo-mock/server.js`) are additive: new `res.company` / `account.journal` / `account.move` models + records; existing models untouched.

## Verification

- `pnpm -C packages/plugins/pinchy-odoo test`: 278 passed (6 files)
- `pnpm -C packages/web test`: 6568 passed (no regressions from mock changes)
- `tsc --noEmit`: clean
- No mock-pinning / E2E assumptions broken (additive only)

## Out of scope

- Tightening the open `values` (`type: "object"`) schema to describe the `{ref}`/string/lookup wire shape per-field: model-dependent and dynamic, and risks OpenAI function-calling schema strictness. Left open; Layer 1 makes the existing prose correct.
- Nested `line_ids` command-tuple normalisation (out of scope per existing guard comment); Odoo’s server-side validation remains authoritative there.