### PR TITLE
feat(pinchy-odoo): resolve nested m2o in one2many command tuples (#615)

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -381,6 +381,76 @@ const MODEL_FIELDS = {
       readonly: false,
       relation: "res.partner",
     },
+    line_ids: {
+      string: "Journal Items",
+      type: "one2many",
+      required: false,
+      readonly: false,
+      relation: "account.move.line",
+    },
+    invoice_line_ids: {
+      string: "Invoice Lines",
+      type: "one2many",
+      required: false,
+      readonly: false,
+      relation: "account.move.line",
+    },
+  },
+  // Chart of accounts — company-scoped (optional company_id; false = shared).
+  // Seeded with a multi-company name collision mirroring account.journal, so
+  // nested account_id name lookups can exercise the OR-with-false scope.
+  "account.account": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    code: { string: "Code", type: "char", required: false, readonly: false },
+    name: { string: "Name", type: "char", required: false, readonly: false },
+    display_name: {
+      string: "Display Name",
+      type: "char",
+      required: false,
+      readonly: false,
+    },
+    account_type: {
+      string: "Type",
+      type: "char",
+      required: false,
+      readonly: false,
+    },
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.company",
+    },
+  },
+  // Journal items (the lines of a move). account_id is the m2o whose nested
+  // resolution (#615) this model exists to test.
+  "account.move.line": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: { string: "Label", type: "char", required: false, readonly: false },
+    debit: { string: "Debit", type: "float", required: false, readonly: false },
+    credit: { string: "Credit", type: "float", required: false, readonly: false },
+    account_id: {
+      string: "Account",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "account.account",
+    },
+    move_id: {
+      string: "Move",
+      type: "many2one",
+      required: true,
+      readonly: false,
+      relation: "account.move",
+    },
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.company",
+    },
   },
 };
 
@@ -534,6 +604,8 @@ function getDefaultRecords() {
       { id: 9, model: "res.company", name: "Company" },
       { id: 10, model: "account.journal", name: "Journal" },
       { id: 11, model: "account.move", name: "Journal Entry" },
+      { id: 12, model: "account.account", name: "Account" },
+      { id: 13, model: "account.move.line", name: "Journal Item" },
     ],
     "res.users": [
       { id: 2, name: "Mitch Admin", login: "admin" },
@@ -594,6 +666,36 @@ function getDefaultRecords() {
       },
     ],
     "account.move": [],
+    // Multi-company account collision: "Bank" exists in both companies with
+    // the same code, plus a shared account (company_id = false). Lets nested
+    // account_id name lookups exercise the OR-with-false scope.
+    "account.account": [
+      {
+        id: 42,
+        code: "1000",
+        name: "Bank",
+        display_name: "1000 Bank",
+        account_type: "asset_cash",
+        company_id: [1, "Helmcraft GmbH"],
+      },
+      {
+        id: 77,
+        code: "1000",
+        name: "Bank",
+        display_name: "1000 Bank",
+        account_type: "asset_cash",
+        company_id: [2, "Clemens Helm"],
+      },
+      {
+        id: 88,
+        code: "9999",
+        name: "Opening Balance",
+        display_name: "9999 Opening Balance",
+        account_type: "equity",
+        company_id: false,
+      },
+    ],
+    "account.move.line": [],
   };
 }
 
@@ -757,6 +859,88 @@ function sortRecords(records, orderStr) {
     }
     return 0;
   });
+}
+
+// ---------------------------------------------------------------------------
+// one2many command-tuple processing + m2o type validation (issue #615)
+// ---------------------------------------------------------------------------
+
+// Validate that m2o field values are Odoo-legal: false/null, a positive
+// integer id, or [int, name]. A bare string (e.g. an undecoded
+// `pinchy_ref:v1:…` token the agent copied into `line_ids[].account_id`) is
+// rejected the way real Odoo rejects it — reproducing the #615 audit-mystery:
+// without the plugin's nested ref-decoding, the create fails at the Odoo
+// layer (the plugin's audit `success` flag reflects Odoo acceptance, so a
+// rejection surfaces as `failure`). Returns a __jsonrpc_error object on
+// violation, else null.
+function validateM2oFields(model, values) {
+  const fields = MODEL_FIELDS[model] || {};
+  for (const [name, def] of Object.entries(fields)) {
+    if (def.type !== "many2one") continue;
+    if (!(name in values)) continue;
+    const v = values[name];
+    if (v === false || v == null) continue;
+    if (typeof v === "number" && Number.isInteger(v) && v > 0) continue;
+    if (
+      Array.isArray(v) &&
+      v.length === 2 &&
+      typeof v[0] === "number" &&
+      typeof v[1] === "string"
+    ) {
+      continue;
+    }
+    return {
+      __jsonrpc_error: true,
+      message: `Invalid value for many2one field "${name}" on ${model}: expected a positive integer id, [id, name], or false (got ${JSON.stringify(v)}).`,
+    };
+  }
+  return null;
+}
+
+// Find the inverse many2one field on a line model that points back at the
+// parent model (e.g. account.move.line.move_id → account.move), so created
+// child records carry the back-link the way Odoo sets it.
+function findInverseField(lineModel, parentModel) {
+  const fields = MODEL_FIELDS[lineModel] || {};
+  for (const [name, def] of Object.entries(fields)) {
+    if (def.type === "many2one" && def.relation === parentModel) return name;
+  }
+  return null;
+}
+
+// Materialize one2many command tuples into child records, mirroring Odoo's
+// create-with-lines semantics. Returns the resolved list of child ids for the
+// parent's field, OR a __jsonrpc_error object if a nested m2o value is
+// invalid. Codes: 0 create, 1 update, 2 delete, 3 unlink, 4 link, 5 clear,
+// 6 replace. Only 0/1 carry a values dict.
+function processOne2ManyTuples(model, fieldName, relation, tuples, parentId) {
+  const ids = [];
+  for (const tuple of tuples) {
+    if (!Array.isArray(tuple) || typeof tuple[0] !== "number") continue;
+    const code = tuple[0];
+    if (code === 0) {
+      const lineValues = { ...(tuple[2] || {}) };
+      const inverse = findInverseField(relation, model);
+      if (inverse) lineValues[inverse] = [parentId, ""];
+      const err = validateM2oFields(relation, lineValues);
+      if (err) return err;
+      const lineId = nextIds.get(relation) || 1;
+      nextIds.set(relation, lineId + 1);
+      store.get(relation).push({ id: lineId, ...lineValues });
+      ids.push(lineId);
+    } else if (code === 1) {
+      const lineId = tuple[1];
+      const rec = (store.get(relation) || []).find((r) => r.id === lineId);
+      if (rec) Object.assign(rec, tuple[2] || {});
+      ids.push(lineId);
+    } else if (code === 4) {
+      ids.push(tuple[1]);
+    } else if (code === 6) {
+      ids.push(...(tuple[2] || []));
+    }
+    // 2 (delete), 3 (unlink), 5 (clear) — no ids added on a fresh create.
+  }
+  return ids;
 }
 
 // ---------------------------------------------------------------------------
@@ -939,6 +1123,31 @@ function handleJsonRpc(body) {
 
         const newId = nextIds.get(model) || 1;
         nextIds.set(model, newId + 1);
+
+        // Validate top-level m2o values (Odoo rejects bare-string m2o ids;
+        // the plugin resolves refs/names to ints before reaching here).
+        const topErr = validateM2oFields(model, values);
+        if (topErr) return topErr;
+
+        // Materialize one2many command tuples into child records (e.g.
+        // account.move `line_ids: [[0, 0, { account_id, debit, credit }]]`
+        // → account.move.line rows with a move_id back-link), and validate
+        // their nested m2o values.
+        const modelFieldDefs = MODEL_FIELDS[model] || {};
+        for (const [name, def] of Object.entries(modelFieldDefs)) {
+          if (def.type !== "one2many" || !def.relation) continue;
+          if (!Array.isArray(values[name])) continue;
+          const result = processOne2ManyTuples(
+            model,
+            name,
+            def.relation,
+            values[name],
+            newId,
+          );
+          if (result && result.__jsonrpc_error) return result;
+          values[name] = result;
+        }
+
         const newRecord = { id: newId, ...values };
         store.get(model).push(newRecord);
         return newId;

--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -930,8 +930,11 @@ function processOne2ManyTuples(model, fieldName, relation, tuples, parentId) {
       ids.push(lineId);
     } else if (code === 1) {
       const lineId = tuple[1];
+      const updateValues = tuple[2] || {};
+      const err = validateM2oFields(relation, updateValues);
+      if (err) return err;
       const rec = (store.get(relation) || []).find((r) => r.id === lineId);
-      if (rec) Object.assign(rec, tuple[2] || {});
+      if (rec) Object.assign(rec, updateValues);
       ids.push(lineId);
     } else if (code === 4) {
       ids.push(tuple[1]);

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -795,3 +795,214 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
     });
   });
 });
+
+// Nested many2one resolution inside one2many command tuples (issue #615):
+// account.move created with `line_ids: [[0, 0, { account_id, debit, credit }]]`
+// must decode bare _pinchy_ref strings and company-scope nested name lookups,
+// enforce the cross-company guard on line-level refs, and require a
+// account.move.line grant. End-to-end through the real mock-odoo (which now
+// materializes [0,0,{…}] tuples into account.move.line rows and validates m2o
+// field types the way Odoo does).
+describe("pinchy-odoo nested line_ids resolution (#615)", () => {
+  const nestedAgentId = "agent-nested";
+  const nestedConnectionId = "conn-nested";
+  const nestedConfig = {
+    connectionId: nestedConnectionId,
+    permissions: {
+      "res.company": ["read"],
+      "account.journal": ["read"],
+      "account.account": ["read"],
+      "account.move": ["read", "create"],
+      "account.move.line": ["read", "create", "write", "delete"],
+    },
+  };
+
+  beforeAll(async () => {
+    credentialsByConnectionId.set(nestedConnectionId, {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  beforeEach(async () => {
+    // Reset per test so line-count assertions are isolated (the mock
+    // otherwise accumulates account.move.line rows across tests).
+    await fetch(`http://127.0.0.1:${mockOdoo.controlPort}/control/reset`, {
+      method: "POST",
+    });
+  });
+
+  function ref(
+    model: string,
+    id: number,
+    label: string,
+    companyId?: number,
+    companyLabel?: string,
+  ): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: nestedConnectionId,
+      model,
+      id,
+      label,
+      ...(companyId !== undefined && companyLabel !== undefined
+        ? { companyId, companyLabel }
+        : {}),
+    });
+  }
+
+  async function readBack(model: string): Promise<Array<Record<string, unknown>>> {
+    return (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=${model}`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+  }
+
+  it("decodes a bare _pinchy_ref nested in line_ids[].account_id and materializes the line", async () => {
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    const accountRef = ref("account.account", 42, "1000 Bank [Helmcraft GmbH]", 1, "Helmcraft GmbH");
+
+    const tools = createApi({ [nestedAgentId]: nestedConfig });
+    const tool = findTool(tools, "odoo_create", nestedAgentId);
+    const result = await tool.execute("nested-bare", {
+      model: "account.move",
+      values: {
+        ref: "Eröffnung per 01.01.2026",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        line_ids: [[0, 0, { account_id: accountRef, debit: 466.65, credit: 0, name: "Eröffnung" }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const { id } = JSON.parse(result.content[0].text) as { id: number };
+    const lines = await readBack("account.move.line");
+    const line = lines.find((l) => l.move_id && (l.move_id as [number, string])[0] === id);
+    expect(line).toBeDefined();
+    expect(line!.account_id).toBe(42); // decoded bare ref → numeric id
+  });
+
+  it("scopes a nested account_id name lookup by the move's company", async () => {
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+
+    const tools = createApi({ [nestedAgentId]: nestedConfig });
+    const tool = findTool(tools, "odoo_create", nestedAgentId);
+    const result = await tool.execute("nested-scoped", {
+      model: "account.move",
+      values: {
+        ref: "Bank booking",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        // "Bank" exists in both companies (account 42 in co 1, 77 in co 2);
+        // the scope must pick 42.
+        line_ids: [[0, 0, { account_id: "Bank", debit: 100, credit: 0 }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const lines = await readBack("account.move.line");
+    const created = lines.filter((l) => (l.account_id as number) === 42 || (l.account_id as number) === 77);
+    expect(created.every((l) => l.account_id === 42)).toBe(true);
+  });
+
+  it("rejects a cross-company bare ref nested in line_ids end-to-end", async () => {
+    const companyRefA = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    const accountRefB = ref("account.account", 77, "1000 Bank [Clemens Helm]", 2, "Clemens Helm");
+
+    const tools = createApi({ [nestedAgentId]: nestedConfig });
+    const tool = findTool(tools, "odoo_create", nestedAgentId);
+    const result = await tool.execute("nested-xc", {
+      model: "account.move",
+      values: {
+        ref: "should be rejected",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRefA },
+        journal_id: "Miscellaneous Operations",
+        line_ids: [[0, 0, { account_id: accountRefB, debit: 100, credit: 0 }]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/cross-company/i);
+    expect(result.content[0].text).toMatch(/line_ids|account_id/);
+    const lines = await readBack("account.move.line");
+    expect(lines.some((l) => l.account_id === 77)).toBe(false);
+  });
+
+  it("requires account.move.line:write for a [1,id,{…}] line update (inline [0] create needs no line grant)", async () => {
+    // Inline [0,0,{…}] create is part of the parent's atomic create and needs
+    // no account.move.line grant. But editing an existing line via [1,id,{…}]
+    // is a write on account.move.line and must require the grant.
+    const noLineWriteConfig = {
+      ...nestedConfig,
+      permissions: {
+        "res.company": ["read"],
+        "account.journal": ["read"],
+        "account.account": ["read"],
+        "account.move": ["read", "create"],
+        "account.move.line": ["read", "create"], // write deliberately omitted
+      },
+    };
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+
+    const tools = createApi({ [nestedAgentId]: noLineWriteConfig });
+    const tool = findTool(tools, "odoo_create", nestedAgentId);
+    const result = await tool.execute("nested-perm-write", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        line_ids: [[1, 42, { debit: 50 }]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/write/);
+  });
+
+  // Audit-mystery verification (#615): a bare-string m2o value reaching Odoo
+  // is rejected (Odoo-faithful). The plugin decodes bare refs before they
+  // reach Odoo, so this is only reachable by bypassing the plugin — it
+  // documents the contract that makes the nested fix necessary.
+  it("mock (Odoo-faithful) rejects a bare-string account_id inside line_ids", async () => {
+    const body = {
+      jsonrpc: "2.0",
+      method: "call",
+      id: 1,
+      params: {
+        service: "object",
+        method: "execute_kw",
+        args: [
+          "testdb",
+          2,
+          "test-api-key",
+          "account.move",
+          "create",
+          [
+            {
+              company_id: 1,
+              journal_id: 17,
+              line_ids: [[0, 0, { account_id: "pinchy_ref:v1:not-a-real-token", debit: 1, credit: 0 }]],
+            },
+          ],
+          {},
+        ],
+      },
+    };
+    const res = await fetch(`http://127.0.0.1:${mockOdoo.jsonRpcPort}/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { error?: { data?: { message?: string } } };
+    expect(json.error).toBeDefined();
+    expect(json.error?.data?.message ?? json.error?.data).toMatch(/account_id|many2one/i);
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -1005,4 +1005,49 @@ describe("pinchy-odoo nested line_ids resolution (#615)", () => {
     expect(json.error).toBeDefined();
     expect(json.error?.data?.message ?? json.error?.data).toMatch(/account_id|many2one/i);
   });
+
+  // Review finding #6 (#615/#616): the mock only validated nested m2o types
+  // on code-0 (create) line_ids tuples. A code-1 (update) tuple's values
+  // dict went straight to Object.assign with no type check, so a bare-string
+  // account_id inside `[1, <id>, {...}]` was silently accepted — not
+  // Odoo-faithful, and exactly the kind of gap that would hide a regression
+  // where the plugin fails to decode a nested ref inside an update tuple
+  // (the false-success audit trap #615 exists to prevent).
+  it("mock (Odoo-faithful) rejects a bare-string account_id inside a [1,id,{…}] line_ids update tuple", async () => {
+    const body = {
+      jsonrpc: "2.0",
+      method: "call",
+      id: 1,
+      params: {
+        service: "object",
+        method: "execute_kw",
+        args: [
+          "testdb",
+          2,
+          "test-api-key",
+          "account.move",
+          "create",
+          [
+            {
+              company_id: 1,
+              journal_id: 17,
+              line_ids: [
+                [0, 0, { account_id: 42, debit: 1, credit: 0 }],
+                [1, 1, { account_id: "pinchy_ref:v1:not-a-real-token" }],
+              ],
+            },
+          ],
+          {},
+        ],
+      },
+    };
+    const res = await fetch(`http://127.0.0.1:${mockOdoo.jsonRpcPort}/jsonrpc`, {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify(body),
+    });
+    const json = (await res.json()) as { error?: { data?: { message?: string } } };
+    expect(json.error).toBeDefined();
+    expect(json.error?.data?.message ?? json.error?.data).toMatch(/account_id|many2one/i);
+  });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -4369,6 +4369,400 @@ describe("relationHasCompanyId / findCompanyIdField helper", () => {
   });
 });
 
+// Nested many2one fields inside one2many command tuples (issue #615):
+// `account.move` created with `line_ids: [[0, 0, { account_id: "…", debit,
+// credit }]]` must get the same bare-ref decoding, company scoping (OR-with
+// false), cross-company guard, and nested-relation permission enforcement as
+// top-level m2o fields. Only Command codes 0 (create) and 1 (update) carry a
+// values dict; 2/3/4/5/6 are passed through untouched.
+describe("nested m2o resolution in one2many command tuples (#615)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  // Shared field defs for the account.move → account.move.line → account.account
+  // chain. account.account is company-scoped (optional company_id, like res.partner).
+  function mockAccountMoveChain() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "account_id",
+            type: "many2one",
+            relation: "account.account",
+            required: true,
+            readonly: false,
+          },
+          { name: "debit", type: "float", required: false, readonly: false },
+          { name: "credit", type: "float", required: false, readonly: false },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "account.account") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "code", type: "char", required: false, readonly: false },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "display_name",
+            type: "char",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  it("decodes a bare _pinchy_ref nested in line_ids[].account_id to a numeric id", async () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const accountRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 42,
+      label: "1000 Bank [Helmcraft GmbH]",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(555);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-bare-ref", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRef },
+        line_ids: [
+          [0, 0, { account_id: accountRef, debit: 466.65, credit: 0, name: "Eröffnung" }],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.company_id).toBe(1);
+    const line = (written.line_ids as Array<[number, number, Record<string, unknown>]>)[0];
+    expect(line[0]).toBe(0);
+    expect(line[2].account_id).toBe(42); // decoded bare ref → numeric id
+    // The bare ref short-circuits the name lookup — no searchRead on account.account.
+    expect(
+      mockSearchRead.mock.calls.some(([m]) => m === "account.account"),
+    ).toBe(false);
+  });
+
+  it("scopes a nested account_id name lookup by the move's company (OR-with-false)", async () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+
+    mockAccountMoveChain();
+    mockSearchRead.mockImplementation(async (model: string, domain: unknown) => {
+      if (model === "account.account") {
+        const scoped = Array.isArray(domain) && domain.includes("|");
+        return scoped
+          ? {
+              records: [
+                { id: 42, name: "Bank", display_name: "Bank", company_id: [1, "Helmcraft GmbH"] },
+              ],
+              total: 1,
+              limit: 20,
+              offset: 0,
+            }
+          : {
+              records: [
+                { id: 42, name: "Bank", display_name: "Bank", company_id: [1, "Helmcraft GmbH"] },
+                { id: 77, name: "Bank", display_name: "Bank", company_id: [2, "Clemens Helm"] },
+              ],
+              total: 2,
+              limit: 20,
+              offset: 0,
+            };
+      }
+      return { records: [], total: 0, limit: 20, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(556);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-scoped-name", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRef },
+        line_ids: [[0, 0, { account_id: "Bank", debit: 100, credit: 0 }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const acctLookup = mockSearchRead.mock.calls.find(([m]) => m === "account.account");
+    expect(acctLookup).toBeDefined();
+    expect(acctLookup![1]).toEqual(
+      expect.arrayContaining(["|", ["company_id", "=", false], ["company_id", "=", 1]]),
+    );
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    const line = (written.line_ids as Array<[number, number, Record<string, unknown>]>)[0];
+    expect(line[2].account_id).toBe(42); // company-1 account, not the ambiguous 77
+  });
+
+  it("rejects a cross-company bare ref nested in line_ids against the move's company_id", async () => {
+    const companyRefA = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const accountRefB = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 77,
+      label: "Bank [Clemens Helm]",
+      companyId: 2,
+      companyLabel: "Clemens Helm",
+    });
+
+    mockAccountMoveChain();
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-xc", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRefA },
+        line_ids: [[0, 0, { account_id: accountRefB, debit: 100, credit: 0 }]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/cross-company/i);
+    expect(result.content[0].text).toMatch(/line_ids|account_id/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("passes non-0/1 command codes (4 link, 5 clear, 6 replace) through untouched", async () => {
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(557);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-codes", {
+      model: "account.move",
+      values: {
+        line_ids: [[4, 55], [5], [6, false, [55, 56]]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.line_ids).toEqual([[4, 55], [5], [6, false, [55, 56]]]);
+    expect(
+      mockSearchRead.mock.calls.some(([m]) => m === "account.account"),
+    ).toBe(false);
+  });
+
+  it("inline [0,0,{…}] line-create needs NO line grant (covered by the parent account.move:create)", async () => {
+    const accountRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 42,
+      label: "1000 Bank",
+    });
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(558);
+
+    // No account.move.line grant at all — inline create must still work.
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-perm-inline-create", {
+      model: "account.move",
+      values: {
+        line_ids: [[0, 0, { account_id: accountRef, debit: 100, credit: 0 }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  it("enforces nested-relation permission: [1,id,{…}] needs account.move.line:write, [2,id] needs delete", async () => {
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(559);
+
+    // account.move:create + account.move.line:create, but NO line:write →
+    // [1, ...] update must be denied.
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.move.line": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const updateRes = await tool.execute("nested-perm-write", {
+      model: "account.move",
+      values: { line_ids: [[1, 9, { debit: 50 }]] },
+    });
+    expect(updateRes.isError).toBe(true);
+    expect(updateRes.content[0].text).toMatch(/account\.move\.line/);
+    expect(updateRes.content[0].text).toMatch(/write/);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    const deleteRes = await tool.execute("nested-perm-delete", {
+      model: "account.move",
+      values: { line_ids: [[2, 9]] },
+    });
+    expect(deleteRes.isError).toBe(true);
+    expect(deleteRes.content[0].text).toMatch(/account\.move\.line/);
+    expect(deleteRes.content[0].text).toMatch(/delete/);
+  });
+
+  it("scopes a nested lookup by the line's own company_id when the move has none", async () => {
+    // Move with no company_id; the line carries company_id. The line's
+    // account_id lookup must be scoped to the line's company.
+    const lineCompanyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 2,
+      label: "Clemens Helm",
+      companyId: 2,
+      companyLabel: "Clemens Helm",
+    });
+
+    mockAccountMoveChain();
+    mockSearchRead.mockImplementation(async (model: string, domain: unknown) => {
+      if (model === "account.account") {
+        const scoped =
+          Array.isArray(domain) &&
+          domain.some(
+            (c) => Array.isArray(c) && c[0] === "company_id" && c[2] === 2,
+          );
+        return scoped
+          ? {
+              records: [
+                { id: 77, name: "Bank", display_name: "Bank", company_id: [2, "Clemens Helm"] },
+              ],
+              total: 1,
+              limit: 20,
+              offset: 0,
+            }
+          : { records: [], total: 0, limit: 20, offset: 0 };
+      }
+      return { records: [], total: 0, limit: 20, offset: 0 };
+    });
+    mockCreate.mockResolvedValue(560);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-line-company", {
+      model: "account.move",
+      values: {
+        line_ids: [
+          [0, 0, { company_id: { ref: lineCompanyRef }, account_id: "Bank", debit: 10, credit: 0 }],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const acctLookup = mockSearchRead.mock.calls.find(([m]) => m === "account.account");
+    expect(acctLookup![1]).toEqual(
+      expect.arrayContaining(["|", ["company_id", "=", false], ["company_id", "=", 2]]),
+    );
+  });
+});
+
 describe("odoo_schedule_activity", () => {
   beforeEach(() => {
     vi.clearAllMocks();

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1326,6 +1326,240 @@ describe("odoo_read", () => {
   });
 });
 
+describe("odoo_read one2many line refs", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  // testPermissions has no account.move grant; these tests read account.move.
+  const moveReadAgentConfig = {
+    ...agentConfig,
+    permissions: { ...testPermissions, "account.move": ["read"] },
+  };
+
+  // account.move.line_ids (o2m) alongside partner_id (m2o) and tag_ids (m2m)
+  // so a single record exercises all three relation kinds at once.
+  function mockMoveWithLinesAndTags() {
+    mockFields.mockResolvedValue([
+      { name: "id", string: "ID", type: "integer" },
+      { name: "name", string: "Name", type: "char" },
+      {
+        name: "partner_id",
+        string: "Partner",
+        type: "many2one",
+        relation: "res.partner",
+      },
+      {
+        name: "line_ids",
+        string: "Journal Items",
+        type: "one2many",
+        relation: "account.move.line",
+      },
+      {
+        name: "tag_ids",
+        string: "Tags",
+        type: "many2many",
+        relation: "account.move.line.tag",
+      },
+    ]);
+  }
+
+  it("wraps each one2many child id into a { _pinchy_ref, id, model } object", async () => {
+    mockMoveWithLinesAndTags();
+    mockSearchRead.mockResolvedValue({
+      records: [
+        {
+          id: 5,
+          name: "INV/001",
+          partner_id: [3, "Acme Inc"],
+          line_ids: [10, 11],
+          tag_ids: [20, 21],
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: moveReadAgentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-o2m-refs", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "partner_id", "line_ids", "tag_ids"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    const record = data.records[0];
+
+    // one2many: each child id wrapped into a ref-carrying object that
+    // decodes back to the correct relation model/id (round-trip, not just
+    // string presence).
+    expect(record.line_ids).toHaveLength(2);
+    const [line0, line1] = record.line_ids as Array<{
+      _pinchy_ref: string;
+      id: number;
+      model: string;
+    }>;
+    expect(line0.id).toBe(10);
+    expect(line0.model).toBe("account.move.line");
+    expect(decodeRef(line0._pinchy_ref)).toMatchObject({
+      model: "account.move.line",
+      id: 10,
+    });
+    expect(line1.id).toBe(11);
+    expect(decodeRef(line1._pinchy_ref)).toMatchObject({
+      model: "account.move.line",
+      id: 11,
+    });
+
+    // many2one on the same record: still wrapped as before (regression
+    // guard — our o2m change must not disturb m2o wrapping).
+    expect(record.partner_id).toEqual({
+      ref: expect.stringMatching(/^pinchy_ref:v1:/),
+      label: "Acme Inc",
+      model: "res.partner",
+    });
+
+    // many2many is explicitly OUT of scope for this change — left as the
+    // raw id array Odoo returns.
+    expect(record.tag_ids).toEqual([20, 21]);
+  });
+
+  it("leaves an empty one2many array as []", async () => {
+    mockMoveWithLinesAndTags();
+    mockSearchRead.mockResolvedValue({
+      records: [
+        {
+          id: 6,
+          name: "INV/002",
+          partner_id: false,
+          line_ids: [],
+          tag_ids: [],
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: moveReadAgentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-o2m-empty", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "line_ids"],
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.records[0].line_ids).toEqual([]);
+  });
+
+  it("passes through a non-array-of-numbers one2many value unchanged (defensive)", async () => {
+    mockMoveWithLinesAndTags();
+    // Not realistic for a real Odoo read, but defends against a malformed
+    // or already-wrapped value reaching wrapReadResult twice.
+    mockSearchRead.mockResolvedValue({
+      records: [
+        {
+          id: 7,
+          name: "INV/003",
+          line_ids: [{ already: "wrapped" }],
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: moveReadAgentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-o2m-defensive", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "line_ids"],
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.records[0].line_ids).toEqual([{ already: "wrapped" }]);
+  });
+
+  it("round-trips a read-emitted one2many line ref into an edit command tuple's id position", async () => {
+    // The point of the feature: a ref emitted by wrapReadResult for a child
+    // line must decode back to the right numeric id when pasted into a
+    // [1, <ref>, {...}] update tuple through odoo_create's normalizer.
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer" },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer" },
+          { name: "debit", type: "float" },
+        ];
+      }
+      return [];
+    });
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 5, line_ids: [88] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(900);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["read", "create"],
+          "account.move.line": ["write"],
+        },
+      },
+    });
+    const readTool = findTool(tools, "odoo_read", agentId)!;
+    const createTool = findTool(tools, "odoo_create", agentId)!;
+
+    const readResult = await readTool.execute("call-o2m-roundtrip-read", {
+      model: "account.move",
+      filters: [],
+      fields: ["line_ids"],
+    });
+    const readData = JSON.parse(readResult.content[0].text);
+    const lineRef = readData.records[0].line_ids[0]._pinchy_ref as string;
+    expect(lineRef).toMatch(/^pinchy_ref:v1:/);
+
+    const createResult = await createTool.execute("call-o2m-roundtrip-write", {
+      model: "account.move",
+      values: { line_ids: [[1, lineRef, { debit: 5 }]] },
+    });
+
+    expect(createResult.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const line = (
+      written.line_ids as Array<[number, unknown, Record<string, unknown>]>
+    )[0];
+    expect(line[0]).toBe(1);
+    expect(line[1]).toBe(88); // decoded from the read-emitted ref to numeric id
+    expect(line[2]).toEqual({ debit: 5 });
+  });
+});
+
 describe("odoo_count", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -4616,7 +4850,7 @@ describe("nested m2o resolution in one2many command tuples (#615)", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  it("passes non-0/1 command codes (4 link, 5 clear, 6 replace) through untouched", async () => {
+  it("passes link (4) through untouched without requiring a delete grant", async () => {
     mockAccountMoveChain();
     mockCreate.mockResolvedValue(557);
 
@@ -4630,13 +4864,42 @@ describe("nested m2o resolution in one2many command tuples (#615)", () => {
     const result = await tool.execute("nested-codes", {
       model: "account.move",
       values: {
-        line_ids: [[4, 55], [5], [6, false, [55, 56]]],
+        line_ids: [[4, 55]],
       },
     });
 
     expect(result.isError).toBeFalsy();
     const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
-    expect(written.line_ids).toEqual([[4, 55], [5], [6, false, [55, 56]]]);
+    expect(written.line_ids).toEqual([[4, 55]]);
+    expect(
+      mockSearchRead.mock.calls.some(([m]) => m === "account.account"),
+    ).toBe(false);
+  });
+
+  it("passes destructive clear (5) and replace (6) through untouched when the agent HAS the delete grant", async () => {
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(557);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["delete"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-codes-destructive", {
+      model: "account.move",
+      values: {
+        line_ids: [[5], [6, false, [55, 56]]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.line_ids).toEqual([[5], [6, false, [55, 56]]]);
     expect(
       mockSearchRead.mock.calls.some(([m]) => m === "account.account"),
     ).toBe(false);
@@ -4700,6 +4963,77 @@ describe("nested m2o resolution in one2many command tuples (#615)", () => {
     expect(deleteRes.content[0].text).toMatch(/delete/);
   });
 
+  it("rejects clear [5] on line_ids without account.move.line:delete (Odoo #13082 — clear deletes orphaned children)", async () => {
+    mockAccountMoveChain();
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-clear-no-delete", {
+      model: "account.move",
+      values: { line_ids: [[5]] },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/delete/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("rejects replace [6,0,[...]] on line_ids without account.move.line:delete (Odoo #13082 — replace deletes orphaned children)", async () => {
+    mockAccountMoveChain();
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-replace-no-delete", {
+      model: "account.move",
+      values: { line_ids: [[6, 0, [123]]] },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/delete/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("allows replace [6,0,[...]] on line_ids when the agent HAS account.move.line:delete", async () => {
+    mockAccountMoveChain();
+    mockCreate.mockResolvedValue(561);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create", "write", "delete"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("nested-replace-with-delete", {
+      model: "account.move",
+      values: { line_ids: [[6, 0, [123]]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
   it("scopes a nested lookup by the line's own company_id when the move has none", async () => {
     // Move with no company_id; the line carries company_id. The line's
     // account_id lookup must be scoped to the line's company.
@@ -4760,6 +5094,483 @@ describe("nested m2o resolution in one2many command tuples (#615)", () => {
     expect(acctLookup![1]).toEqual(
       expect.arrayContaining(["|", ["company_id", "=", false], ["company_id", "=", 2]]),
     );
+  });
+
+  // Self-referential one2many so a single mockFields implementation can
+  // supply schema at every recursion depth: m.node.children -> m.node,
+  // and m.node.owner_id is a many2one carrying a bare ref to resolve.
+  function mockSelfReferentialNode() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "m.node") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "owner_id",
+            type: "many2one",
+            relation: "res.partner",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "children",
+            type: "one2many",
+            relation: "m.node",
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  // Build a [0,0,{children:[...]}] tuple nested `depth` levels deep, with a
+  // bare ref on `owner_id` at the innermost level.
+  function buildDeepNode(depth: number, innerRef: string): unknown {
+    if (depth === 0) {
+      return { owner_id: innerRef };
+    }
+    return { children: [[0, 0, buildDeepNode(depth - 1, innerRef)]] };
+  }
+
+  it("throws a depth-cap error instead of passing unresolved refs beyond MAX_NORMALIZE_DEPTH (#615 regression guard)", async () => {
+    mockSelfReferentialNode();
+    const ownerRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.partner",
+      id: 9,
+      label: "Deep Owner",
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "m.node": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    // MAX_NORMALIZE_DEPTH + 1 levels of nesting — exceeds the cap.
+    const result = await tool.execute("deep-nest", {
+      model: "m.node",
+      values: buildDeepNode(9, ownerRef) as Record<string, unknown>,
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/depth/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+// many2many command-tuple resolution (#615 follow-up): m2m fields (e.g.
+// `tax_ids` on account.move) were previously skipped entirely by
+// normalizeValuesRecord's field loop, so a bare _pinchy_ref inside
+// `[[6,0,[ref]]]` reached Odoo unresolved and was rejected. m2m is a join
+// table, not a required-inverse cascade: only codes 0/1/2 touch the target
+// model's rows (create/write/delete), while 3/4/5/6 only rewire the join
+// table and need no target-model grant. Every id position (codes 1-4, and
+// each element of the 6 id-list) must still be ref-decodable so a line ref
+// captured by odoo_read can be pasted back into an edit.
+describe("many2many command-tuple resolution (#615 follow-up)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  // account.move --(line_ids: o2m)--> account.move.line --(tax_ids: m2m)--> account.tax
+  // account.move also carries a top-level tax_ids m2m directly to account.tax,
+  // so both "top-level m2m" and "nested-inside-o2m m2m" can be exercised from
+  // one schema chain.
+  function mockMoveWithTaxes() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "tax_ids",
+            type: "many2many",
+            relation: "account.tax",
+          },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "debit", type: "float", required: false, readonly: false },
+          { name: "credit", type: "float", required: false, readonly: false },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "tax_ids",
+            type: "many2many",
+            relation: "account.tax",
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "account.tax") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "amount",
+            type: "float",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  function taxRef(id: number, opts: Partial<Parameters<typeof encodeRef>[0]> = {}) {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.tax",
+      id,
+      label: `Tax ${id}`,
+      ...opts,
+    });
+  }
+
+  it("decodes a bare ref inside a top-level [6,0,[ref]] replace tuple to a numeric id", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(601);
+    const ref = taxRef(9);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-top-level", {
+      model: "account.move",
+      values: { tax_ids: [[6, 0, [ref]]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.tax_ids).toEqual([[6, 0, [9]]]);
+  });
+
+  it("decodes a bare ref inside an m2m tuple nested inside an o2m create tuple", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(602);
+    const ref = taxRef(11);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.move.line": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-nested", {
+      model: "account.move",
+      values: {
+        line_ids: [[0, 0, { debit: 100, credit: 0, tax_ids: [[6, 0, [ref]]] }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    const line = (written.line_ids as Array<[number, number, Record<string, unknown>]>)[0];
+    expect(line[2].tax_ids).toEqual([[6, 0, [11]]]);
+  });
+
+  it("decodes a bare ref in a [4, ref] link tuple to a numeric id", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(603);
+    const ref = taxRef(13);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-link", {
+      model: "account.move",
+      values: { tax_ids: [[4, ref]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.tax_ids).toEqual([[4, 13]]);
+  });
+
+  it("requires account.tax:create for m2m [0,0,{values}] and normalizes the inner values when granted", async () => {
+    mockMoveWithTaxes();
+
+    const noGrantTools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const noGrantTool = findTool(noGrantTools, "odoo_create", agentId)!;
+    const denied = await noGrantTool.execute("m2m-create-denied", {
+      model: "account.move",
+      values: { tax_ids: [[0, 0, { name: "VAT 19%", amount: 19 }]] },
+    });
+    expect(denied.isError).toBe(true);
+    expect(denied.content[0].text).toMatch(/account\.tax/);
+    expect(denied.content[0].text).toMatch(/create/);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    mockCreate.mockResolvedValue(604);
+    const grantedTools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.tax": ["create"] },
+      },
+    });
+    const grantedTool = findTool(grantedTools, "odoo_create", agentId)!;
+    const allowed = await grantedTool.execute("m2m-create-allowed", {
+      model: "account.move",
+      values: { tax_ids: [[0, 0, { name: "VAT 19%", amount: 19 }]] },
+    });
+    expect(allowed.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    const tuple = (written.tax_ids as Array<[number, number, Record<string, unknown>]>)[0];
+    expect(tuple[0]).toBe(0);
+    expect(tuple[2].name).toBe("VAT 19%");
+  });
+
+  it("requires account.tax:write for m2m [1,id,{values}]", async () => {
+    mockMoveWithTaxes();
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const denied = await tool.execute("m2m-write-denied", {
+      model: "account.move",
+      values: { tax_ids: [[1, 9, { amount: 20 }]] },
+    });
+    expect(denied.isError).toBe(true);
+    expect(denied.content[0].text).toMatch(/account\.tax/);
+    expect(denied.content[0].text).toMatch(/write/);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    mockCreate.mockResolvedValue(605);
+    const grantedTools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.tax": ["write"] },
+      },
+    });
+    const grantedTool = findTool(grantedTools, "odoo_create", agentId)!;
+    const allowed = await grantedTool.execute("m2m-write-allowed", {
+      model: "account.move",
+      values: { tax_ids: [[1, 9, { amount: 20 }]] },
+    });
+    expect(allowed.isError).toBeFalsy();
+  });
+
+  it("requires account.tax:delete for m2m [2,id]", async () => {
+    mockMoveWithTaxes();
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const denied = await tool.execute("m2m-delete-denied", {
+      model: "account.move",
+      values: { tax_ids: [[2, 9]] },
+    });
+    expect(denied.isError).toBe(true);
+    expect(denied.content[0].text).toMatch(/account\.tax/);
+    expect(denied.content[0].text).toMatch(/delete/);
+    expect(mockCreate).not.toHaveBeenCalled();
+
+    mockCreate.mockResolvedValue(606);
+    const grantedTools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.tax": ["delete"] },
+      },
+    });
+    const grantedTool = findTool(grantedTools, "odoo_create", agentId)!;
+    const allowed = await grantedTool.execute("m2m-delete-allowed", {
+      model: "account.move",
+      values: { tax_ids: [[2, 9]] },
+    });
+    expect(allowed.isError).toBeFalsy();
+  });
+
+  it("needs no target-model grant for m2m unlink [3], link [4], clear [5], replace [6]", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(607);
+
+    // Only account.move:create granted — no account.tax grant of any kind.
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-join-only", {
+      model: "account.move",
+      values: { tax_ids: [[3, 9], [4, 10], [5], [6, 0, [11, 12]]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.tax_ids).toEqual([[3, 9], [4, 10], [5], [6, 0, [11, 12]]]);
+  });
+
+  it("passes raw numeric ids through unchanged for m2m tuples (backward-compat)", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(608);
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-raw-ids", {
+      model: "account.move",
+      values: { tax_ids: [[6, false, [55, 56]]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    expect(written.tax_ids).toEqual([[6, false, [55, 56]]]);
+  });
+
+  it("decodes the id position of an o2m [1, ref, {values}] update tuple to a numeric id (read→edit roundtrip)", async () => {
+    mockMoveWithTaxes();
+    mockCreate.mockResolvedValue(609);
+    const lineRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move.line",
+      id: 88,
+      label: "Line 88",
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"], "account.move.line": ["write"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("o2m-id-ref", {
+      model: "account.move",
+      values: { line_ids: [[1, lineRef, { debit: 5 }]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [string, Record<string, unknown>];
+    const line = (written.line_ids as Array<[number, unknown, Record<string, unknown>]>)[0];
+    expect(line[1]).toBe(88); // tuple[1] decoded from ref to numeric id
+  });
+
+  it("rejects a cross-company ref nested in tax_ids[6][2] against the move's company_id", async () => {
+    mockMoveWithTaxes();
+    const companyRefA = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const taxRefOtherCompany = taxRef(21, {
+      companyId: 2,
+      companyLabel: "Clemens Helm",
+    });
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("m2m-xc", {
+      model: "account.move",
+      values: {
+        company_id: { ref: companyRefA },
+        tax_ids: [[6, 0, [taxRefOtherCompany]]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/cross-company/i);
+    expect(result.content[0].text).toMatch(/tax_ids/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+});
+
+describe("assertNoCrossCompanyRefs recursion cap (defense-in-depth)", () => {
+  it("still detects a normal-depth cross-company ref", () => {
+    const companyRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.company",
+      id: 1,
+      label: "Helmcraft GmbH",
+      companyId: 1,
+      companyLabel: "Helmcraft GmbH",
+    });
+    const accountRefB = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 77,
+      label: "Bank [Clemens Helm]",
+      companyId: 2,
+      companyLabel: "Clemens Helm",
+    });
+
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: { ref: companyRef },
+        line_ids: [[0, 0, { account_id: { ref: accountRefB } }]],
+      }),
+    ).toThrow(/cross-company/i);
+  });
+
+  it("throws a depth-cap error rather than recursing unbounded on a pathologically deep nested structure", () => {
+    // Build line_ids nested far deeper than any legitimate schema — each
+    // level wraps a [0,0,{...}] tuple with a nested `line_ids` array again.
+    function buildDeepLineIds(depth: number): unknown {
+      if (depth === 0) return { debit: 1 };
+      return { line_ids: [[0, 0, buildDeepLineIds(depth - 1)]] };
+    }
+
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: {
+          ref: encodeRef({
+            integrationType: "odoo",
+            connectionId: "conn-test-1",
+            model: "res.company",
+            id: 1,
+            label: "Helmcraft GmbH",
+            companyId: 1,
+            companyLabel: "Helmcraft GmbH",
+          }),
+        },
+        line_ids: [[0, 0, buildDeepLineIds(50)]],
+      }),
+    ).toThrow(/depth/i);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -793,6 +793,89 @@ describe("assertNoCrossCompanyRefs", () => {
       }),
     ).not.toThrow();
   });
+
+  // Command codes 1 (update), 2 (delete), 3 (unlink) all carry a
+  // company-taggable id at tuple[1], exactly like code 4 (link) already
+  // checked. The normalizer resolves those ids too, so a company-tagged ref
+  // there must not bypass the guard.
+  it("throws when a code-2 (delete) tuple's id is cross-company tagged", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [[2, tagged("account.move.line", 9, 2, "GmbH B")]],
+      }),
+    ).toThrow(/cross-company/i);
+  });
+
+  it("throws when a code-3 (unlink) tuple's id is cross-company tagged", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [[3, tagged("account.move.line", 9, 2, "GmbH B")]],
+      }),
+    ).toThrow(/cross-company/i);
+  });
+
+  it("throws when a code-1 (update) tuple's id is cross-company tagged", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [[1, tagged("account.move.line", 9, 2, "GmbH B"), {}]],
+      }),
+    ).toThrow(/cross-company/i);
+  });
+
+  // normalizeValuesRecord re-derives scopeCompanyId from a line's OWN
+  // company_id (see the "scopes a nested lookup by the line's own
+  // company_id" normalizer test), so a line legitimately scoped to company B
+  // is accepted by the normalizer. The guard must use the SAME baseline or
+  // it false-rejects a self-consistent line.
+  it("does NOT throw when a line declares its own company_id and every other field in that line agrees with it (self-consistent to B, not the parent A)", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [
+          [
+            0,
+            0,
+            {
+              company_id: tagged("res.company", 2, 2, "GmbH B"),
+              account_id: tagged("account.account", 42, 2, "GmbH B"),
+            },
+          ],
+        ],
+      }),
+    ).not.toThrow();
+  });
+
+  it("throws when a line's own company_id disagrees with another field in that SAME line", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [
+          [
+            0,
+            0,
+            {
+              company_id: tagged("res.company", 2, 2, "GmbH B"),
+              account_id: tagged("account.account", 42, 3, "GmbH C"),
+            },
+          ],
+        ],
+      }),
+    ).toThrow(/cross-company/i);
+  });
+
+  it("still rejects against the PARENT company when the line declares no company_id of its own (preserves existing behavior)", () => {
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: tagged("res.company", 1, 1, "GmbH A"),
+        line_ids: [
+          [0, 0, { account_id: tagged("account.account", 42, 2, "GmbH B") }],
+        ],
+      }),
+    ).toThrow(/cross-company/i);
+  });
 });
 
 describe("formatMultiMatchError", () => {
@@ -1557,6 +1640,194 @@ describe("odoo_read one2many line refs", () => {
     expect(line[0]).toBe(1);
     expect(line[1]).toBe(88); // decoded from the read-emitted ref to numeric id
     expect(line[2]).toEqual({ debit: 5 });
+  });
+
+  it("round-trips a WHOLE read-emitted one2many line object (not just its _pinchy_ref string) into an edit command tuple's id position", async () => {
+    // wrapOne2ManyValue emits child objects keyed `_pinchy_ref` (not `ref`,
+    // which the m2o wrapper uses). refToId must decode BOTH keys so pasting
+    // the whole `{ _pinchy_ref, id, model }` object — not just the string —
+    // into a Command tuple id position resolves instead of throwing "Raw
+    // numeric IDs are not accepted".
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer" },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer" },
+          { name: "debit", type: "float" },
+        ];
+      }
+      return [];
+    });
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 5, line_ids: [88] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(901);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["read", "create"],
+          "account.move.line": ["write"],
+        },
+      },
+    });
+    const readTool = findTool(tools, "odoo_read", agentId)!;
+    const createTool = findTool(tools, "odoo_create", agentId)!;
+
+    const readResult = await readTool.execute("call-o2m-object-roundtrip-read", {
+      model: "account.move",
+      filters: [],
+      fields: ["line_ids"],
+    });
+    const readData = JSON.parse(readResult.content[0].text);
+    const lineObject = readData.records[0].line_ids[0] as {
+      _pinchy_ref: string;
+      id: number;
+      model: string;
+    };
+
+    const createResult = await createTool.execute(
+      "call-o2m-object-roundtrip-write",
+      {
+        model: "account.move",
+        values: { line_ids: [[1, lineObject, { debit: 5 }]] },
+      },
+    );
+
+    expect(createResult.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const line = (
+      written.line_ids as Array<[number, unknown, Record<string, unknown>]>
+    )[0];
+    expect(line[0]).toBe(1);
+    expect(line[1]).toBe(88); // decoded from the pasted whole object to numeric id
+    expect(line[2]).toEqual({ debit: 5 });
+  });
+
+  it("round-trips the read-emitted line_ids array VERBATIM into a [6,0,<ids>] replace tuple", async () => {
+    // Pasting the whole read-emitted array of `{ _pinchy_ref, id, model }`
+    // objects back into a replace tuple must resolve every element to its
+    // numeric id.
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer" },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [{ name: "id", type: "integer" }];
+      }
+      return [];
+    });
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 5, line_ids: [88, 89] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+    mockCreate.mockResolvedValue(902);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["read", "create"],
+          "account.move.line": ["create", "write", "delete"],
+        },
+      },
+    });
+    const readTool = findTool(tools, "odoo_read", agentId)!;
+    const createTool = findTool(tools, "odoo_create", agentId)!;
+
+    const readResult = await readTool.execute("call-o2m-array-roundtrip-read", {
+      model: "account.move",
+      filters: [],
+      fields: ["line_ids"],
+    });
+    const readData = JSON.parse(readResult.content[0].text);
+    const lineIdsArray = readData.records[0].line_ids;
+
+    const createResult = await createTool.execute(
+      "call-o2m-array-roundtrip-write",
+      {
+        model: "account.move",
+        values: { line_ids: [[6, 0, lineIdsArray]] },
+      },
+    );
+
+    expect(createResult.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const tuple = (written.line_ids as Array<[number, unknown, number[]]>)[0];
+    expect(tuple[0]).toBe(6);
+    expect(tuple[2]).toEqual([88, 89]); // every element decoded to its numeric id
+  });
+
+  it("regression: an m2o { ref } object still resolves unchanged", async () => {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer" },
+          {
+            name: "partner_id",
+            type: "many2one",
+            relation: "res.partner",
+          },
+        ];
+      }
+      return [];
+    });
+    mockCreate.mockResolvedValue(903);
+
+    const partnerRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.partner",
+      id: 42,
+      label: "Acme Inc",
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const createTool = findTool(tools, "odoo_create", agentId)!;
+    const result = await createTool.execute("call-m2o-ref-object-regression", {
+      model: "account.move",
+      values: { partner_id: { ref: partnerRef } },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(written.partner_id).toBe(42);
   });
 });
 
@@ -5519,6 +5790,10 @@ describe("many2many command-tuple resolution (#615 follow-up)", () => {
 });
 
 describe("assertNoCrossCompanyRefs recursion cap (defense-in-depth)", () => {
+  beforeEach(() => {
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
   it("still detects a normal-depth cross-company ref", () => {
     const companyRef = encodeRef({
       integrationType: "odoo",
@@ -5571,6 +5846,385 @@ describe("assertNoCrossCompanyRefs recursion cap (defense-in-depth)", () => {
         line_ids: [[0, 0, buildDeepLineIds(50)]],
       }),
     ).toThrow(/depth/i);
+  });
+
+  // Pins the exact cutoff so the guard's operator (`>=`, unified with the
+  // normalizer's own cap via `assertNormalizeDepth`) is asserted precisely,
+  // not just "eventually throws somewhere past 50 levels".
+  it("uses the exact same depth cutoff as normalizeValuesRecord (>= MAX_NORMALIZE_DEPTH)", () => {
+    // Build line_ids nested exactly `depth` levels deep, with the
+    // cross-company-tagged ref at the innermost leaf.
+    function buildTaggedAtDepth(depth: number, leafRef: unknown): unknown {
+      if (depth === 0) return { account_id: leafRef };
+      return { line_ids: [[0, 0, buildTaggedAtDepth(depth - 1, leafRef)]] };
+    }
+
+    const companyRef = {
+      ref: encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "res.company",
+        id: 1,
+        label: "Helmcraft GmbH",
+        companyId: 1,
+        companyLabel: "Helmcraft GmbH",
+      }),
+    };
+    const accountRefB = {
+      ref: encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "account.account",
+        id: 77,
+        label: "Bank [Clemens Helm]",
+        companyId: 2,
+        companyLabel: "Clemens Helm",
+      }),
+    };
+
+    // MAX_NORMALIZE_DEPTH is 8. The top-level `line_ids` field call starts at
+    // depth 0; each additional nested `line_ids` level increments depth by 1
+    // when descending into the next tuple's dict. Six additional nested
+    // levels lands the cross-company-tagged leaf's check at depth 7 —
+    // within the cap — so the cross-company check itself must still fire
+    // (not swallowed by a depth-cap throw).
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: companyRef,
+        line_ids: [[0, 0, buildTaggedAtDepth(6, accountRefB)]],
+      }),
+    ).toThrow(/cross-company/i);
+
+    // One level deeper pushes the leaf's check to depth 8 — exactly
+    // MAX_NORMALIZE_DEPTH — which the unified `>=` cutoff now rejects as a
+    // depth-cap error. Under the OLD `depth > MAX_NORMALIZE_DEPTH` guard
+    // operator this exact depth would NOT have thrown a depth-cap error
+    // (8 > 8 is false), masking the cross-company check with an off-by-one
+    // gap versus normalizeValuesRecord's `>=` cap.
+    expect(() =>
+      assertNoCrossCompanyRefs({
+        company_id: companyRef,
+        line_ids: [[0, 0, buildTaggedAtDepth(7, accountRefB)]],
+      }),
+    ).toThrow(/depth/i);
+  });
+});
+
+// #615 regression guard: if `client.fields(field.relation)` returns an empty
+// schema (Odoo unreachable, model renamed, permission quirk, etc.), the
+// nested m2o resolution loop inside normalizeCommandTuples has nothing to
+// resolve against and silently no-ops — so a bare ref buried in a code-0/1
+// values dict would reach Odoo undecoded, exactly the bug #615 fixed. Pure
+// raw-id tuples (e.g. `[6,0,[1,2,3]]`) need no schema at all and must still
+// pass through unchanged even when the schema fetch comes back empty.
+describe("empty line schema + resolution-needed guard (#615 hardening)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  function mockMoveWithEmptyLineSchema() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer" },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      // account.move.line schema fetch comes back empty.
+      if (model === "account.move.line") return [];
+      return [];
+    });
+  }
+
+  it("throws a clear error naming the field and relation when the line schema is empty AND a bare ref needs resolving", async () => {
+    mockMoveWithEmptyLineSchema();
+    const accountRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 42,
+      label: "1000 Bank",
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("empty-schema-bare-ref", {
+      model: "account.move",
+      values: {
+        line_ids: [[0, 0, { account_id: accountRef }]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/line_ids/);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("passes pure raw-id tuples through unchanged when the line schema is empty (no resolution needed)", async () => {
+    mockMoveWithEmptyLineSchema();
+    mockCreate.mockResolvedValue(700);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create", "write", "delete"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("empty-schema-raw-ids", {
+      model: "account.move",
+      values: {
+        line_ids: [[6, 0, [1, 2]]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    expect(written.line_ids).toEqual([[6, 0, [1, 2]]]);
+  });
+});
+
+// Per-invocation memoization of schema fetches and name lookups on the
+// nested-resolution path (issue #616, review finding #8). Before this fix,
+// every relation field at every recursion level issued its own uncached
+// `client.fields(model)` RPC, and every command tuple issued its own
+// `search_read` even when many lines resolve the SAME name in the SAME
+// company. For an N-line journal entry all booking to "Bank", that's ~N
+// identical `client.fields(account.move.line)` calls plus N identical
+// account.account `search_read`s — all redundant. The cache is scoped to a
+// single `normalizeMany2OneValues` call (i.e. one tool invocation), not a
+// module-global, so it must not leak across tool calls or connections.
+describe("nested schema + lookup memoization (#616 perf)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  function mockAccountMoveChain() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "line_ids",
+            type: "one2many",
+            relation: "account.move.line",
+          },
+        ];
+      }
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "account_id",
+            type: "many2one",
+            relation: "account.account",
+            required: true,
+            readonly: false,
+          },
+          { name: "debit", type: "float", required: false, readonly: false },
+          { name: "credit", type: "float", required: false, readonly: false },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      if (model === "account.account") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          { name: "code", type: "char", required: false, readonly: false },
+          { name: "name", type: "char", required: false, readonly: false },
+          {
+            name: "display_name",
+            type: "char",
+            required: false,
+            readonly: false,
+          },
+          {
+            name: "company_id",
+            type: "many2one",
+            relation: "res.company",
+            required: false,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+  }
+
+  function mockBankAccountLookup() {
+    mockSearchRead.mockImplementation(async (model: string) => {
+      if (model === "account.account") {
+        return {
+          records: [
+            {
+              id: 42,
+              name: "Bank",
+              display_name: "1000 Bank",
+              company_id: [1, "Helmcraft GmbH"],
+            },
+          ],
+        };
+      }
+      return { records: [] };
+    });
+  }
+
+  it("fetches account.move.line and account.account schemas only once for a 3-line create", async () => {
+    mockAccountMoveChain();
+    mockBankAccountLookup();
+    mockCreate.mockResolvedValue(555);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("perf-schema-memo", {
+      model: "account.move",
+      values: {
+        line_ids: [
+          [0, 0, { account_id: "Bank", debit: 100, credit: 0 }],
+          [0, 0, { account_id: "Bank", debit: 0, credit: 50 }],
+          [0, 0, { account_id: "Bank", debit: 0, credit: 50 }],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(
+      mockFields.mock.calls.filter((c) => c[0] === "account.move.line")
+        .length,
+    ).toBe(1);
+    expect(
+      mockFields.mock.calls.filter((c) => c[0] === "account.account").length,
+    ).toBe(1);
+  });
+
+  it("dedupes the account.account name lookup across 3 lines all booking 'Bank' and resolves them all to the same id", async () => {
+    mockAccountMoveChain();
+    mockBankAccountLookup();
+    mockCreate.mockResolvedValue(555);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("perf-lookup-dedupe", {
+      model: "account.move",
+      values: {
+        line_ids: [
+          [0, 0, { account_id: "Bank", debit: 100, credit: 0 }],
+          [0, 0, { account_id: "Bank", debit: 0, credit: 50 }],
+          [0, 0, { account_id: "Bank", debit: 0, credit: 50 }],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(
+      mockSearchRead.mock.calls.filter((c) => c[0] === "account.account")
+        .length,
+    ).toBe(1);
+    const [, written] = mockCreate.mock.calls[0] as [
+      string,
+      Record<string, unknown>,
+    ];
+    const lines = written.line_ids as Array<
+      [number, number, Record<string, unknown>]
+    >;
+    expect(lines).toHaveLength(3);
+    for (const line of lines) {
+      expect(line[2].account_id).toBe(42);
+    }
+  });
+
+  it("does not leak the schema/lookup cache across two separate odoo_create calls", async () => {
+    mockAccountMoveChain();
+    mockBankAccountLookup();
+    mockCreate.mockResolvedValue(555);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.move.line": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+
+    const firstResult = await tool.execute("perf-isolation-1", {
+      model: "account.move",
+      values: {
+        line_ids: [[0, 0, { account_id: "Bank", debit: 100, credit: 0 }]],
+      },
+    });
+    expect(firstResult.isError).toBeFalsy();
+    const callsAfterFirst = mockFields.mock.calls.filter(
+      (c) => c[0] === "account.move.line",
+    ).length;
+    expect(callsAfterFirst).toBe(1);
+
+    const secondResult = await tool.execute("perf-isolation-2", {
+      model: "account.move",
+      values: {
+        line_ids: [[0, 0, { account_id: "Bank", debit: 100, credit: 0 }]],
+      },
+    });
+    expect(secondResult.isError).toBeFalsy();
+    const callsAfterSecond = mockFields.mock.calls.filter(
+      (c) => c[0] === "account.move.line",
+    ).length;
+    // A second, separate tool invocation must re-fetch — proves the cache
+    // is per-call, not a module-global that would silently serve stale
+    // schema across unrelated tool invocations / connections.
+    expect(callsAfterSecond).toBe(callsAfterFirst + 1);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -869,11 +869,12 @@ function refToId(
  * prefix in `detail`. Admins can grep / filter for that string — no separate
  * audit pipeline is needed here.
  *
- * Scope: only top-level fields of `values` are inspected. Nested 2many/o2m
- * command tuples (e.g. `invoice_line_ids: [[0, 0, { account_id: ... }]]`)
- * are not walked — that broader check would require following Odoo's
- * Command structure, which is out of scope for this guard. Odoo's
- * server-side `company_id` constraint remains the ultimate authority.
+ * Scope: top-level fields of `values` AND nested one2many command tuples
+ * (e.g. `line_ids: [[0, 0, { account_id: <ref> }]]`) are inspected. A line-
+ * level ref whose company tag disagrees with the parent's `company_id` is
+ * rejected with the same "Cross-company write rejected" prefix and a path
+ * like `line_ids[0].account_id`. Odoo's server-side `company_id` constraint
+ * remains the ultimate authority.
  */
 export function assertNoCrossCompanyRefs(
   values: Record<string, unknown>,
@@ -884,16 +885,49 @@ export function assertNoCrossCompanyRefs(
 
   for (const [field, value] of Object.entries(values)) {
     if (field === "company_id") continue;
-    const sibling = readRefCompanyTag(value);
-    if (sibling === null) continue;
+    assertNoCrossCompanyValue(value, intended, intendedLabel, field);
+  }
+}
+
+/**
+ * Recursive companion to {@link assertNoCrossCompanyRefs}. Checks a single
+ * value: if it carries a company-tagged ref, compare against `intended`;
+ * if it is a one2many command-tuple array, descend into the create (0) and
+ * update (1) tuples' values dicts and check each field. `path` is threaded
+ * for actionable error messages (e.g. `line_ids[0].account_id`).
+ */
+function assertNoCrossCompanyValue(
+  value: unknown,
+  intended: { id: number; label: string | null },
+  intendedLabel: string,
+  path: string,
+): void {
+  const sibling = readRefCompanyTag(value);
+  if (sibling !== null) {
     if (sibling.id !== intended.id) {
       const otherLabel = sibling.label ?? `id=${sibling.id}`;
       throw new Error(
         `Cross-company write rejected: values.company_id points to "${intendedLabel}" ` +
-          `but values.${field} points to a record in "${otherLabel}". ` +
-          `Re-resolve ${field} in the right company first.`,
+          `but values.${path} points to a record in "${otherLabel}". ` +
+          `Re-resolve ${path} in the right company first.`,
       );
     }
+    return;
+  }
+  if (Array.isArray(value)) {
+    value.forEach((tuple, i) => {
+      // Odoo Command tuple: [code, ...]. Only 0 (create) and 1 (update)
+      // carry a values dict at index 2 with refs to check.
+      if (
+        Array.isArray(tuple) &&
+        (tuple[0] === 0 || tuple[0] === 1) &&
+        isRecord(tuple[2])
+      ) {
+        for (const [k, v] of Object.entries(tuple[2] as Record<string, unknown>)) {
+          assertNoCrossCompanyValue(v, intended, intendedLabel, `${path}[${i}].${k}`);
+        }
+      }
+    });
   }
 }
 
@@ -1047,20 +1081,69 @@ async function normalizeMany2OneValues(
   connectionId: string,
   model: string,
   values: Record<string, unknown>,
+  permissions: Permissions,
 ): Promise<Record<string, unknown>> {
   const fields = normalizeFields(await client.fields(model));
   if (fields.length === 0) return values;
+  return normalizeValuesRecord(
+    client,
+    connectionId,
+    model,
+    fields,
+    values,
+    null,
+    permissions,
+    0,
+  );
+}
 
+// Cap recursion into nested one2many command tuples. Pathological schemas
+// could nest deeply; beyond this the walker leaves tuples verbatim (the
+// pre-#615 behaviour) rather than risking unbounded descent.
+const MAX_NORMALIZE_DEPTH = 8;
+
+// Odoo Command codes that modify EXISTING nested records and therefore
+// require a grant on the line model. Inline create (0) is part of the
+// parent's atomic create — already gated by the top-level `create` check —
+// so it needs no separate line-model grant (this preserves the bookkeeper's
+// "lines only inline via invoice_line_ids, never standalone" atomicity
+// design: account.move.line:create stays ungranted while inline line creation
+// still works). Link (4), clear (5), replace (6) only rewire the parent's
+// relation set, not the nested records, so no nested permission is required.
+const NESTED_OP_BY_CODE: Record<number, "write" | "delete"> = {
+  1: "write",
+  2: "delete",
+  3: "delete",
+};
+
+/**
+ * Resolve the m2o fields of a single values dict and walk its one2many
+ * command tuples recursively. `scopeCompanyId` is derived from this dict's
+ * own `company_id` (overriding the parent's for this record's siblings) and
+ * threaded into both the m2o lookups (OR-with-`false` company scope) and the
+ * nested tuple walk. Reuses `resolveRelationValue` unchanged for every m2o
+ * value — bare `_pinchy_ref`, `{ref}` object, name/code lookup, country code
+ * are all covered. Nested create/write/delete Command codes are permission
+ * checked against the line model before any ref work for that tuple.
+ */
+async function normalizeValuesRecord(
+  client: OdooClient,
+  connectionId: string,
+  model: string,
+  fields: OdooField[],
+  values: Record<string, unknown>,
+  scopeCompanyId: number | null,
+  permissions: Permissions,
+  depth: number,
+): Promise<Record<string, unknown>> {
   const normalized = { ...values };
 
-  // Resolve `company_id` first so that company-scoped m2o lookups later in the
-  // loop (e.g. `journal_id`, where two companies can share a journal name/code)
+  // Resolve `company_id` first so company-scoped m2o lookups for this record
   // can be constrained to the target company — Odoo's own fix pattern for
-  // multi-company collisions (PR #269835 / commit 3fcd8a9). `res.company`
-  // itself has no `company_id` field, so this never recurses. When company_id
-  // is absent, false, or doesn't resolve to a positive integer, no scoping is
-  // applied and subsequent lookups behave exactly as before.
-  let scopeCompanyId: number | null = null;
+  // multi-company collisions (PR #269835 / commit 3fcd8a9). At top level this
+  // is the parent move's company; inside a line tuple it's the line's own
+  // company (which the cross-company guard has already checked agrees with
+  // the parent's, or the parent had none).
   const companyField = findCompanyIdField(fields);
   if (companyField && "company_id" in normalized) {
     const resolved = await resolveRelationValue(
@@ -1068,6 +1151,7 @@ async function normalizeMany2OneValues(
       connectionId,
       companyField,
       normalized.company_id,
+      scopeCompanyId,
     );
     normalized.company_id = resolved;
     if (
@@ -1082,10 +1166,6 @@ async function normalizeMany2OneValues(
   for (const field of fields) {
     if (field.type !== "many2one" || !(field.name in normalized)) continue;
     if (field.name === "company_id") continue; // already resolved above
-    // Only top-level m2o fields are resolved here. Nested one2many command
-    // tuples (e.g. account.move `line_ids: [[0, 0, { account_id: "…" }]]`) are
-    // passed through to Odoo verbatim — their m2o values get no ref decoding
-    // and no company scoping. Tracked separately in #615.
     normalized[field.name] = await resolveRelationValue(
       client,
       connectionId,
@@ -1094,7 +1174,84 @@ async function normalizeMany2OneValues(
       scopeCompanyId,
     );
   }
+
+  // Walk one2many command tuples (depth-capped). Codes 0 (create) and 1
+  // (update) carry a values dict at index 2 whose m2o fields are resolved
+  // recursively; 2/3/4/5/6 carry no resolvable m2o values. (issue #615)
+  if (depth < MAX_NORMALIZE_DEPTH) {
+    for (const field of fields) {
+      if (field.type !== "one2many" || !field.relation) continue;
+      if (!(field.name in normalized)) continue;
+      const tuples = normalized[field.name];
+      if (!Array.isArray(tuples)) continue;
+      const lineFields = normalizeFields(await client.fields(field.relation));
+      normalized[field.name] = await normalizeCommandTuples(
+        client,
+        connectionId,
+        field.relation,
+        lineFields,
+        tuples,
+        scopeCompanyId,
+        permissions,
+        depth,
+        field.name,
+      );
+    }
+  }
+
   return normalized;
+}
+
+async function normalizeCommandTuples(
+  client: OdooClient,
+  connectionId: string,
+  lineModel: string,
+  lineFields: OdooField[],
+  tuples: unknown[],
+  scopeCompanyId: number | null,
+  permissions: Permissions,
+  depth: number,
+  parentField: string,
+): Promise<unknown[]> {
+  const out: unknown[] = [];
+  for (const tuple of tuples) {
+    if (!Array.isArray(tuple) || typeof tuple[0] !== "number") {
+      out.push(tuple); // not a Command tuple — pass through unchanged
+      continue;
+    }
+    const code = tuple[0];
+    const op = NESTED_OP_BY_CODE[code];
+    if (op !== undefined && !checkPermission(permissions, lineModel, op)) {
+      // Pinchy-allowlist rejection (not an Odoo server AccessError): phrase so
+      // it bypasses errorResult's Odoo-re-sync mapping, which would otherwise
+      // mask the real missing grant with a misleading "re-sync the connection"
+      // hint aimed at Odoo-user permissions.
+      throw new Error(
+        `Agent missing ${op} grant on ${lineModel} ` +
+          `(nested via ${parentField} command ${code}). ` +
+          `Add ${op} on ${lineModel} to this agent's permissions.`,
+      );
+    }
+    // Only create (0) and update (1) carry a values dict at index 2 that may
+    // hold m2o fields to resolve. delete (2/3), link (4), clear (5), replace
+    // (6) carry no resolvable m2o values — pass through verbatim.
+    if ((code === 0 || code === 1) && isRecord(tuple[2])) {
+      const resolvedValues = await normalizeValuesRecord(
+        client,
+        connectionId,
+        lineModel,
+        lineFields,
+        tuple[2],
+        scopeCompanyId,
+        permissions,
+        depth + 1,
+      );
+      out.push([code, tuple[1], resolvedValues]);
+    } else {
+      out.push(tuple);
+    }
+  }
+  return out;
 }
 
 // The canonical Odoo external id for the built-in "To-Do" activity type.
@@ -2083,6 +2240,7 @@ const plugin = {
                       config.connectionId,
                       model,
                       cleaned,
+                      config.permissions,
                     );
                     values = await ensureActivityResModelId(
                       client,
@@ -2865,6 +3023,7 @@ const plugin = {
                       config.connectionId,
                       model,
                       cleaned,
+                      config.permissions,
                     );
                     values = await ensureActivityResModelId(
                       client,

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -16,6 +16,17 @@ const WORKSPACE_ROOT = "/root/.openclaw/workspaces";
 // roughly triple the file's footprint in memory).
 const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 
+// Cap recursion into nested one2many command tuples. Pathological schemas
+// could nest deeply; beyond this both `normalizeValuesRecord` (the m2o/ref
+// resolution walk) and `assertNoCrossCompanyValue` (the cross-company guard,
+// which runs BEFORE normalization) refuse to descend further and throw a
+// clear "exceeded the maximum depth" error instead of either silently
+// passing unresolved refs through to Odoo or recursing unbounded. Declared
+// once at module scope, near the top of the file, so both call sites (one
+// above, one below in source order) can reference it without a temporal-
+// dead-zone hazard.
+const MAX_NORMALIZE_DEPTH = 8;
+
 const MIME_BY_EXT: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -885,7 +896,7 @@ export function assertNoCrossCompanyRefs(
 
   for (const [field, value] of Object.entries(values)) {
     if (field === "company_id") continue;
-    assertNoCrossCompanyValue(value, intended, intendedLabel, field);
+    assertNoCrossCompanyValue(value, intended, intendedLabel, field, 0);
   }
 }
 
@@ -895,13 +906,26 @@ export function assertNoCrossCompanyRefs(
  * if it is a one2many command-tuple array, descend into the create (0) and
  * update (1) tuples' values dicts and check each field. `path` is threaded
  * for actionable error messages (e.g. `line_ids[0].account_id`).
+ *
+ * `depth` is threaded and capped at {@link MAX_NORMALIZE_DEPTH} — this guard
+ * runs BEFORE `normalizeValuesRecord`'s own depth cap (Fix B), so a
+ * pathologically deep nested structure must be stopped here too rather than
+ * recursing unbounded and risking a stack overflow before normalization ever
+ * gets a chance to reject it.
  */
 function assertNoCrossCompanyValue(
   value: unknown,
   intended: { id: number; label: string | null },
   intendedLabel: string,
   path: string,
+  depth: number,
 ): void {
+  if (depth > MAX_NORMALIZE_DEPTH) {
+    throw new Error(
+      `Nested relation resolution exceeded the maximum depth of ${MAX_NORMALIZE_DEPTH}; ` +
+        `refusing to pass one2many command tuples to Odoo without reference decoding.`,
+    );
+  }
   const sibling = readRefCompanyTag(value);
   if (sibling !== null) {
     if (sibling.id !== intended.id) {
@@ -916,16 +940,42 @@ function assertNoCrossCompanyValue(
   }
   if (Array.isArray(value)) {
     value.forEach((tuple, i) => {
-      // Odoo Command tuple: [code, ...]. Only 0 (create) and 1 (update)
-      // carry a values dict at index 2 with refs to check.
-      if (
-        Array.isArray(tuple) &&
-        (tuple[0] === 0 || tuple[0] === 1) &&
-        isRecord(tuple[2])
-      ) {
+      if (!Array.isArray(tuple)) return;
+      // Odoo Command tuple: [code, ...]. 0 (create) and 1 (update) carry a
+      // values dict at index 2 with refs to check.
+      if ((tuple[0] === 0 || tuple[0] === 1) && isRecord(tuple[2])) {
         for (const [k, v] of Object.entries(tuple[2] as Record<string, unknown>)) {
-          assertNoCrossCompanyValue(v, intended, intendedLabel, `${path}[${i}].${k}`);
+          assertNoCrossCompanyValue(
+            v,
+            intended,
+            intendedLabel,
+            `${path}[${i}].${k}`,
+            depth + 1,
+          );
         }
+      }
+      // many2many link (4, <ref>) — the id position itself may carry a
+      // company-tagged ref (no values dict to descend into).
+      if (tuple[0] === 4) {
+        assertNoCrossCompanyValue(
+          tuple[1],
+          intended,
+          intendedLabel,
+          `${path}[${i}]`,
+          depth + 1,
+        );
+      }
+      // replace (6, 0, [ids]) — check every id in the replacement list.
+      if (tuple[0] === 6 && Array.isArray(tuple[2])) {
+        (tuple[2] as unknown[]).forEach((id, j) => {
+          assertNoCrossCompanyValue(
+            id,
+            intended,
+            intendedLabel,
+            `${path}[${i}][${j}]`,
+            depth + 1,
+          );
+        });
       }
     });
   }
@@ -1097,24 +1147,78 @@ async function normalizeMany2OneValues(
   );
 }
 
-// Cap recursion into nested one2many command tuples. Pathological schemas
-// could nest deeply; beyond this the walker leaves tuples verbatim (the
-// pre-#615 behaviour) rather than risking unbounded descent.
-const MAX_NORMALIZE_DEPTH = 8;
-
 // Odoo Command codes that modify EXISTING nested records and therefore
 // require a grant on the line model. Inline create (0) is part of the
 // parent's atomic create — already gated by the top-level `create` check —
 // so it needs no separate line-model grant (this preserves the bookkeeper's
 // "lines only inline via invoice_line_ids, never standalone" atomicity
 // design: account.move.line:create stays ungranted while inline line creation
-// still works). Link (4), clear (5), replace (6) only rewire the parent's
-// relation set, not the nested records, so no nested permission is required.
+// still works). Link (4) only rewires the parent's relation set and creates
+// or destroys nothing, so it needs no nested permission. Clear (5) and
+// replace (6), however, are bulk forms of unlink (3): for a one2many with a
+// REQUIRED inverse many2one (e.g. account.move.line.move_id), Odoo deletes
+// every orphaned child record when the relation set is cleared or replaced
+// (Odoo "[FIX] fields: setting a one2many field deletes all its lines" #13082).
+// They are therefore gated exactly like 2/3 — an agent needs the `delete`
+// grant on the line model to clear or replace a one2many, not just `write`
+// on the parent. Templates intentionally withhold `delete` on line models;
+// agents build and edit lines via codes 0/1, and wholesale replace/clear is
+// correctly blocked as the destructive, audit-trail-erasing operation it is.
 const NESTED_OP_BY_CODE: Record<number, "write" | "delete"> = {
   1: "write",
   2: "delete",
   3: "delete",
+  5: "delete",
+  6: "delete",
 };
+
+// many2many Command permission map (#615 follow-up). Unlike one2many, m2m is
+// a join table with no required inverse — clearing or replacing the set
+// never cascade-deletes target rows, it only rewires the join table. So only
+// the codes that actually create/write/delete a TARGET record need a grant:
+//   0 create  → needs `create` on the target (relation) model
+//   1 update  → needs `write` on the target model
+//   2 delete  → needs `delete` on the target model
+//   3 unlink, 4 link, 5 clear, 6 replace → join-table only, no grant
+// (contrast with NESTED_OP_BY_CODE, where o2m codes 2/3/5/6 all need
+// `delete` because Odoo cascade-deletes orphaned children — see the comment
+// above that map).
+const M2M_OP_BY_CODE: Record<number, "create" | "write" | "delete"> = {
+  0: "create",
+  1: "write",
+  2: "delete",
+};
+
+/**
+ * Resolve a Command tuple's id position (tuple[1], or an element of the
+ * code-6 id list). Raw numeric ids — the standard Odoo wire format used by
+ * every pre-existing caller — pass straight through unchanged; `false`/`null`
+ * (code 6's "clear" id slot) also pass through. Only a ref-shaped value
+ * (`_pinchy_ref` bare string, `{ref}` object, or a name/code lookup string)
+ * is resolved via `resolveRelationValue`, so a line ref captured by
+ * `odoo_read` can be pasted back into an edit tuple's id position.
+ *
+ * `resolveRelationValue` itself throws on a raw number (its anti-enumeration
+ * guard) — the `typeof idValue === "number"` short-circuit here is what
+ * keeps raw-id tuples backward-compatible.
+ */
+async function resolveCommandTargetId(
+  client: OdooClient,
+  connectionId: string,
+  relationField: OdooField,
+  idValue: unknown,
+  scopeCompanyId: number | null,
+): Promise<unknown> {
+  if (typeof idValue === "number") return idValue;
+  if (idValue === false || idValue == null) return idValue;
+  return resolveRelationValue(
+    client,
+    connectionId,
+    relationField,
+    idValue,
+    scopeCompanyId,
+  );
+}
 
 /**
  * Resolve the m2o fields of a single values dict and walk its one2many
@@ -1175,33 +1279,70 @@ async function normalizeValuesRecord(
     );
   }
 
-  // Walk one2many command tuples (depth-capped). Codes 0 (create) and 1
-  // (update) carry a values dict at index 2 whose m2o fields are resolved
-  // recursively; 2/3/4/5/6 carry no resolvable m2o values. (issue #615)
-  if (depth < MAX_NORMALIZE_DEPTH) {
-    for (const field of fields) {
-      if (field.type !== "one2many" || !field.relation) continue;
-      if (!(field.name in normalized)) continue;
-      const tuples = normalized[field.name];
-      if (!Array.isArray(tuples)) continue;
-      const lineFields = normalizeFields(await client.fields(field.relation));
-      normalized[field.name] = await normalizeCommandTuples(
-        client,
-        connectionId,
-        field.relation,
-        lineFields,
-        tuples,
-        scopeCompanyId,
-        permissions,
-        depth,
-        field.name,
+  // Walk one2many AND many2many command tuples (depth-capped). Codes 0
+  // (create) and 1 (update) carry a values dict at index 2 whose m2o fields
+  // are resolved recursively; every code's id position(s) are ref-decoded.
+  // (issue #615; many2many follow-up)
+  //
+  // Beyond MAX_NORMALIZE_DEPTH we do NOT silently pass tuples through
+  // verbatim — that would reintroduce the exact undecoded-ref bug this
+  // normalizer exists to fix (a bare `_pinchy_ref` reaching Odoo unresolved).
+  // Instead, fail loud: any o2m/m2m field still carrying a non-empty array
+  // of command tuples at this depth throws, surfacing as a clear tool error
+  // rather than a silent data-corruption risk.
+  for (const field of fields) {
+    const kind =
+      field.type === "one2many"
+        ? "one2many"
+        : field.type === "many2many"
+          ? "many2many"
+          : null;
+    if (kind === null || !field.relation) continue;
+    if (!(field.name in normalized)) continue;
+    const tuples = normalized[field.name];
+    if (!Array.isArray(tuples) || tuples.length === 0) continue;
+    if (depth >= MAX_NORMALIZE_DEPTH) {
+      throw new Error(
+        `Nested relation resolution exceeded the maximum depth of ${MAX_NORMALIZE_DEPTH}; ` +
+          `refusing to pass ${kind} command tuples to Odoo without reference decoding.`,
       );
     }
+    const lineFields = normalizeFields(await client.fields(field.relation));
+    normalized[field.name] = await normalizeCommandTuples(
+      client,
+      connectionId,
+      field.relation,
+      lineFields,
+      tuples,
+      scopeCompanyId,
+      permissions,
+      depth,
+      field.name,
+      kind,
+      field,
+    );
   }
 
   return normalized;
 }
 
+/**
+ * Unified walker for one2many AND many2many Command tuples. The two kinds
+ * share the id-decode + nested-values-recursion + depth-cap machinery but
+ * differ in which codes require a permission grant on the relation
+ * ("target") model:
+ *
+ * - one2many (`NESTED_OP_BY_CODE`): the relation has a REQUIRED inverse
+ *   many2one back to the parent, so clearing/replacing/unlinking deletes
+ *   the child row server-side — codes 1/2/3/5/6 all need `write`/`delete`.
+ * - many2many (`M2M_OP_BY_CODE`): the relation is a join table with no
+ *   required inverse, so only codes that actually create/write/delete a
+ *   TARGET row (0/1/2) need a grant; 3/4/5/6 only rewire the join table.
+ *
+ * Every code's id position is ref-decodable via `resolveCommandTargetId`
+ * (raw numeric ids and `false`/`null` pass straight through, unchanged from
+ * before) so a ref captured by `odoo_read` can be pasted back into an edit.
+ */
 async function normalizeCommandTuples(
   client: OdooClient,
   connectionId: string,
@@ -1212,7 +1353,10 @@ async function normalizeCommandTuples(
   permissions: Permissions,
   depth: number,
   parentField: string,
+  kind: "one2many" | "many2many",
+  relationField: OdooField,
 ): Promise<unknown[]> {
+  const opByCode = kind === "one2many" ? NESTED_OP_BY_CODE : M2M_OP_BY_CODE;
   const out: unknown[] = [];
   for (const tuple of tuples) {
     if (!Array.isArray(tuple) || typeof tuple[0] !== "number") {
@@ -1220,7 +1364,7 @@ async function normalizeCommandTuples(
       continue;
     }
     const code = tuple[0];
-    const op = NESTED_OP_BY_CODE[code];
+    const op = opByCode[code];
     if (op !== undefined && !checkPermission(permissions, lineModel, op)) {
       // Pinchy-allowlist rejection (not an Odoo server AccessError): phrase so
       // it bypasses errorResult's Odoo-re-sync mapping, which would otherwise
@@ -1234,7 +1378,8 @@ async function normalizeCommandTuples(
     }
     // Only create (0) and update (1) carry a values dict at index 2 that may
     // hold m2o fields to resolve. delete (2/3), link (4), clear (5), replace
-    // (6) carry no resolvable m2o values — pass through verbatim.
+    // (6) carry no values dict to resolve m2o fields against. Every code's
+    // id position(s), however, may carry a ref that needs decoding.
     if ((code === 0 || code === 1) && isRecord(tuple[2])) {
       const resolvedValues = await normalizeValuesRecord(
         client,
@@ -1246,7 +1391,42 @@ async function normalizeCommandTuples(
         permissions,
         depth + 1,
       );
-      out.push([code, tuple[1], resolvedValues]);
+      const resolvedId =
+        code === 1
+          ? await resolveCommandTargetId(
+              client,
+              connectionId,
+              relationField,
+              tuple[1],
+              scopeCompanyId,
+            )
+          : tuple[1];
+      out.push([code, resolvedId, resolvedValues]);
+    } else if (
+      (code === 2 || code === 3 || code === 4) &&
+      tuple.length >= 2
+    ) {
+      const resolvedId = await resolveCommandTargetId(
+        client,
+        connectionId,
+        relationField,
+        tuple[1],
+        scopeCompanyId,
+      );
+      out.push([code, resolvedId, ...tuple.slice(2)]);
+    } else if (code === 6 && Array.isArray(tuple[2])) {
+      const resolvedIds = await Promise.all(
+        (tuple[2] as unknown[]).map((id) =>
+          resolveCommandTargetId(
+            client,
+            connectionId,
+            relationField,
+            id,
+            scopeCompanyId,
+          ),
+        ),
+      );
+      out.push([code, tuple[1], resolvedIds]);
     } else {
       out.push(tuple);
     }
@@ -1529,6 +1709,51 @@ function wrapMany2OneValue(
   } satisfies OdooRefValue;
 }
 
+/**
+ * Wrap each child id of a one2many field into a thin ref-carrying object so
+ * the agent can target that specific line (e.g. to edit or remove it) by
+ * pasting the `_pinchy_ref` into a Command tuple's id position — decoded
+ * back to a numeric id by `resolveCommandTargetId`. Odoo's read/search_read
+ * only ever returns o2m fields as a bare array of child ids (no name or
+ * company tag comes back at read time), so the label is the best we can do
+ * without an extra round trip: `<relation>#<id>`.
+ *
+ * Scope is one2many ONLY — many2many fields are left as raw id arrays
+ * (out of scope for this change; see AGENTS.md-tracked follow-up).
+ *
+ * Only transforms a non-empty array whose elements are all numbers. Empty
+ * arrays stay `[]` (nothing to wrap). Anything else (shouldn't happen for
+ * o2m on read, but the field loop is generic) passes through unchanged —
+ * defensive, never throws.
+ */
+function wrapOne2ManyValue(
+  connectionId: string,
+  field: OdooField,
+  value: unknown,
+): unknown {
+  if (
+    field.type !== "one2many" ||
+    !field.relation ||
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    !value.every((item) => typeof item === "number")
+  ) {
+    return value;
+  }
+  const relation = field.relation;
+  return value.map((id) => ({
+    _pinchy_ref: encodeRef({
+      integrationType: "odoo",
+      connectionId,
+      model: relation,
+      id: id as number,
+      label: `${relation}#${id}`,
+    }),
+    id,
+    model: relation,
+  }));
+}
+
 function wrapReadResult(
   connectionId: string,
   model: string,
@@ -1578,6 +1803,7 @@ function wrapReadResult(
       const field = byName.get(name);
       if (field) {
         wrapped[name] = wrapMany2OneValue(connectionId, field, value);
+        wrapped[name] = wrapOne2ManyValue(connectionId, field, wrapped[name]);
       }
     }
     return wrapped;
@@ -1968,7 +2194,7 @@ const plugin = {
         return {
           name: "odoo_read",
           label: "Odoo Read",
-          description: `Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
+          description: `Query records from Odoo. Returns matching records with field selection and pagination. Always returns { records, total, limit, offset } so you know if there's more data. One2many fields (e.g. \`line_ids\`) come back as a list of line references, each \`{ _pinchy_ref, id, model }\` — pass a line's \`_pinchy_ref\` back into an edit command tuple's id position to target that exact line, e.g. \`line_ids: [[1, <_pinchy_ref>, { ... }]]\` to edit it or \`[[2, <_pinchy_ref>]]\` to remove it. ${PRODUCT_REF_DISAMBIGUATION_HINT}`,
           parameters: {
             type: "object",
             properties: {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -27,6 +27,25 @@ const MAX_ATTACHMENT_BYTES = 25 * 1024 * 1024;
 // dead-zone hazard.
 const MAX_NORMALIZE_DEPTH = 8;
 
+/**
+ * Single source of truth for the depth-cap check, shared by
+ * `assertNoCrossCompanyValue` (the cross-company guard, which runs BEFORE
+ * normalization) and `normalizeValuesRecord` (the m2o/ref resolution walk).
+ * Both invariants are the same cap; extracting one helper keeps the
+ * comparison operator (`>=`) from drifting between the two call sites, which
+ * previously let a pathologically deep structure slip past the guard's
+ * `depth > MAX_NORMALIZE_DEPTH` check one level later than the normalizer's
+ * own `depth >= MAX_NORMALIZE_DEPTH` cutoff.
+ */
+function assertNormalizeDepth(depth: number, kind: string): void {
+  if (depth >= MAX_NORMALIZE_DEPTH) {
+    throw new Error(
+      `Nested relation resolution exceeded the maximum depth of ${MAX_NORMALIZE_DEPTH}; ` +
+        `refusing to pass ${kind} command tuples to Odoo without reference decoding.`,
+    );
+  }
+}
+
 const MIME_BY_EXT: Record<string, string> = {
   ".jpg": "image/jpeg",
   ".jpeg": "image/jpeg",
@@ -857,8 +876,20 @@ function refToId(
   field: OdooField,
   value: Record<string, unknown>,
 ): number | null {
-  if (typeof value.ref !== "string") return null;
-  return decodeAndValidateRef(connectionId, field, value.ref);
+  // Accept BOTH wire shapes: the m2o wrapper's `{ ref }` (wrapMany2OneValue)
+  // and the one2many wrapper's `{ _pinchy_ref }` (wrapOne2ManyValue). Without
+  // this an agent pasting a whole read-emitted o2m line object — or the
+  // read `line_ids` array verbatim — into a Command tuple id position would
+  // hit the "Raw numeric IDs are not accepted" guard below, because only the
+  // bare string decoded, not the object carrying it.
+  const refString =
+    typeof value.ref === "string"
+      ? value.ref
+      : typeof value._pinchy_ref === "string"
+        ? value._pinchy_ref
+        : null;
+  if (refString === null) return null;
+  return decodeAndValidateRef(connectionId, field, refString);
 }
 
 /**
@@ -920,12 +951,7 @@ function assertNoCrossCompanyValue(
   path: string,
   depth: number,
 ): void {
-  if (depth > MAX_NORMALIZE_DEPTH) {
-    throw new Error(
-      `Nested relation resolution exceeded the maximum depth of ${MAX_NORMALIZE_DEPTH}; ` +
-        `refusing to pass one2many command tuples to Odoo without reference decoding.`,
-    );
-  }
+  assertNormalizeDepth(depth, "one2many");
   const sibling = readRefCompanyTag(value);
   if (sibling !== null) {
     if (sibling.id !== intended.id) {
@@ -944,19 +970,35 @@ function assertNoCrossCompanyValue(
       // Odoo Command tuple: [code, ...]. 0 (create) and 1 (update) carry a
       // values dict at index 2 with refs to check.
       if ((tuple[0] === 0 || tuple[0] === 1) && isRecord(tuple[2])) {
-        for (const [k, v] of Object.entries(tuple[2] as Record<string, unknown>)) {
+        const lineDict = tuple[2] as Record<string, unknown>;
+        // A line may declare its OWN company_id; normalizeValuesRecord re-scopes
+        // that line's m2o lookups to it, so the guard must use the SAME baseline
+        // or it false-rejects a self-consistent line. Fall back to the parent's
+        // company when the line declares none.
+        const lineTag = readRefCompanyTag(lineDict.company_id);
+        const lineIntended = lineTag ?? intended;
+        const lineIntendedLabel = lineTag
+          ? (lineTag.label ?? `id=${lineTag.id}`)
+          : intendedLabel;
+        for (const [k, v] of Object.entries(lineDict)) {
+          if (k === "company_id") continue; // the scoping anchor itself
           assertNoCrossCompanyValue(
             v,
-            intended,
-            intendedLabel,
+            lineIntended,
+            lineIntendedLabel,
             `${path}[${i}].${k}`,
             depth + 1,
           );
         }
       }
-      // many2many link (4, <ref>) — the id position itself may carry a
-      // company-tagged ref (no values dict to descend into).
-      if (tuple[0] === 4) {
+      // Codes 1 (update), 2 (delete), 3 (unlink), 4 (link) all carry a
+      // company-taggable id at tuple[1]. (0 has no id; 6 is handled below.)
+      if (
+        tuple[0] === 1 ||
+        tuple[0] === 2 ||
+        tuple[0] === 3 ||
+        tuple[0] === 4
+      ) {
         assertNoCrossCompanyValue(
           tuple[1],
           intended,
@@ -991,17 +1033,22 @@ function assertNoCrossCompanyValue(
 function readRefCompanyTag(
   value: unknown,
 ): { id: number; label: string | null } | null {
-  // Accept the ref in either wire form the agent may pass: the structured
-  // `{ ref: "…" }` object OR a bare `_pinchy_ref` string (the form odoo_read
-  // emits and the prose tells the agent to copy verbatim). Without the
-  // bare-string branch, Layer 1's bare-ref support would let a bare ref slip
-  // past the cross-company guard entirely.
-  const refString =
-    isRecord(value) && typeof value.ref === "string"
+  // Accept the ref in any wire form the agent may pass: the m2o wrapper's
+  // `{ ref: "…" }` object, the one2many wrapper's `{ _pinchy_ref: "…" }`
+  // object (so a pasted whole o2m line object is visible to this guard too),
+  // OR a bare `_pinchy_ref` string (the form odoo_read emits and the prose
+  // tells the agent to copy verbatim). Without the bare-string branch,
+  // Layer 1's bare-ref support would let a bare ref slip past the
+  // cross-company guard entirely.
+  const refString = isRecord(value)
+    ? typeof value.ref === "string"
       ? value.ref
-      : isIntegrationRef(value)
-        ? value
-        : null;
+      : typeof value._pinchy_ref === "string"
+        ? value._pinchy_ref
+        : null
+    : isIntegrationRef(value)
+      ? value
+      : null;
   if (refString === null) return null;
   try {
     const payload = decodeRef(refString);
@@ -1013,6 +1060,68 @@ function readRefCompanyTag(
 }
 
 /**
+ * Per-invocation memoization for the nested m2o resolution path (issue #616,
+ * review finding #8). Without this, a recursive normalize walk issues one
+ * uncached `client.fields(model)` RPC per relation field at every recursion
+ * level, and one `search_read` per command tuple even when many lines
+ * resolve the SAME name in the SAME company — e.g. an N-line journal entry
+ * all booking to "Bank" triggers ~N identical `client.fields(account.move.line)`
+ * calls plus N identical `account.account` `search_read`s.
+ *
+ * Deliberately created fresh by `normalizeMany2OneValues` for EACH call and
+ * threaded down as an optional parameter — never a module-global — so it
+ * cannot leak stale schema/lookups across tool calls or connections. Every
+ * function on the nested path defaults this parameter to `undefined` and
+ * falls back to an uncached call when absent, so any other/future caller is
+ * unaffected.
+ *
+ * `lookups` caches the RESOLVED value returned by `searchRelationByName`
+ * (typically the `search_read` payload used to resolve a name/code lookup),
+ * keyed by `${relation} ${name} ${scopeCompanyId}` — the company must be part
+ * of the key because the same name can resolve to a different record in a
+ * different company. `fields` caches the normalized `OdooField[]`, keyed by
+ * model name. Both maps store PROMISES (not resolved values) so concurrent
+ * awaits for the same key dedupe onto the same in-flight request instead of
+ * firing a second RPC before the first resolves.
+ */
+interface NormalizeCaches {
+  fields: Map<string, Promise<OdooField[]>>;
+  lookups: Map<string, Promise<unknown>>;
+}
+
+function lookupCacheKey(
+  relation: string,
+  lookup: RelationLookup,
+  scopeCompanyId: number | null,
+): string {
+  const name = lookup.code ?? lookup.name ?? "";
+  return `${relation} ${name} ${scopeCompanyId}`;
+}
+
+/**
+ * Memoized `client.fields(model)` + `normalizeFields` loader. When `caches`
+ * is provided, the in-flight (or already-resolved) promise for `model` is
+ * stored and reused so repeated calls for the same model within one
+ * `normalizeMany2OneValues` invocation issue a single RPC. Without `caches`
+ * (any caller outside the nested-resolution path) this is exactly the old
+ * uncached `normalizeFields(await client.fields(model))`.
+ */
+function loadFields(
+  client: OdooClient,
+  model: string,
+  caches?: NormalizeCaches,
+): Promise<OdooField[]> {
+  if (!caches) {
+    return client.fields(model).then(normalizeFields);
+  }
+  const cached = caches.fields.get(model);
+  if (cached) return cached;
+  const promise = client.fields(model).then(normalizeFields);
+  caches.fields.set(model, promise);
+  return promise;
+}
+
+/**
  * Run the `name ilike` lookup on `field.relation`, requesting `company_id`
  * only when the relation actually has it. Models like `res.currency`,
  * `res.country`, `res.lang`, or `res.company` itself lack `company_id` —
@@ -1020,7 +1129,8 @@ function readRefCompanyTag(
  *
  * The gating mirrors `augmentFieldsWithCompanyId`, which is also used by
  * `odoo_read` to keep multi-company UX consistent. One extra `client.fields`
- * call per non-country lookup is the cost.
+ * call per non-country lookup is the cost (memoized via `caches.fields` when
+ * a cache is supplied).
  *
  * When `scopeCompanyId` is set (because the parent record's `company_id` was
  * resolvable), constrain the search to that company. Odoo journal codes/names
@@ -1030,34 +1140,53 @@ function readRefCompanyTag(
  * fix pattern (PR #269835 / commit 3fcd8a9). Only applied when the relation
  * actually has a `company_id` field, so company-shared models (res.currency,
  * res.partner, res.country) are never scoped.
+ *
+ * `caches.lookups`, when supplied, memoizes the resolved `search_read` result
+ * by `${relation} ${name} ${scopeCompanyId}` — the same name/code booked
+ * repeatedly against the same relation in the same company scope (e.g. many
+ * journal lines all naming "Bank") issues a single RPC instead of one per
+ * tuple.
  */
 async function searchRelationByName(
   client: OdooClient,
   field: OdooField,
   lookup: RelationLookup,
   scopeCompanyId: number | null = null,
+  caches?: NormalizeCaches,
 ): Promise<unknown> {
   const relation = field.relation as string;
-  const relationFields = normalizeFields(await client.fields(relation));
-  const lookupFields = augmentFieldsWithCompanyId(
-    ["id", "name", "display_name"],
-    relationFields,
-  ) ?? ["id", "name", "display_name"];
-  const domain: OdooDomain = [["name", "ilike", lookup.name ?? ""]];
-  if (scopeCompanyId !== null && relationHasCompanyId(relationFields)) {
-    // Mirror Odoo's `_check_company_domain`: include SHARED records
-    // (company_id = false), not just the target company. A strict
-    // `("company_id", "=", scope)` filter would exclude shared partners and
-    // products (company_id false, visible across companies) and break name
-    // lookups that resolved before. For company-EXCLUSIVE relations
-    // (account.journal, where company_id is required) the false branch
-    // never matches, so this is equivalent to the strict filter there.
-    domain.push("|", ["company_id", "=", false], ["company_id", "=", scopeCompanyId]);
+  const key = caches ? lookupCacheKey(relation, lookup, scopeCompanyId) : null;
+  if (key && caches) {
+    const cached = caches.lookups.get(key);
+    if (cached) return cached;
   }
-  return client.searchRead(relation, domain, {
-    fields: lookupFields,
-    limit: 20,
-  });
+
+  const run = async (): Promise<unknown> => {
+    const relationFields = await loadFields(client, relation, caches);
+    const lookupFields = augmentFieldsWithCompanyId(
+      ["id", "name", "display_name"],
+      relationFields,
+    ) ?? ["id", "name", "display_name"];
+    const domain: OdooDomain = [["name", "ilike", lookup.name ?? ""]];
+    if (scopeCompanyId !== null && relationHasCompanyId(relationFields)) {
+      // Mirror Odoo's `_check_company_domain`: include SHARED records
+      // (company_id = false), not just the target company. A strict
+      // `("company_id", "=", scope)` filter would exclude shared partners and
+      // products (company_id false, visible across companies) and break name
+      // lookups that resolved before. For company-EXCLUSIVE relations
+      // (account.journal, where company_id is required) the false branch
+      // never matches, so this is equivalent to the strict filter there.
+      domain.push("|", ["company_id", "=", false], ["company_id", "=", scopeCompanyId]);
+    }
+    return client.searchRead(relation, domain, {
+      fields: lookupFields,
+      limit: 20,
+    });
+  };
+
+  const promise = run();
+  if (key && caches) caches.lookups.set(key, promise);
+  return promise;
 }
 
 async function resolveRelationValue(
@@ -1066,6 +1195,7 @@ async function resolveRelationValue(
   field: OdooField,
   value: unknown,
   scopeCompanyId: number | null = null,
+  caches?: NormalizeCaches,
 ): Promise<unknown> {
   if (value == null || value === false) return value;
   if (typeof value === "number") {
@@ -1117,7 +1247,13 @@ async function resolveRelationValue(
           fields: ["id", "name", "display_name", "code"],
           limit: 1000,
         })
-      : await searchRelationByName(client, field, lookup, scopeCompanyId);
+      : await searchRelationByName(
+          client,
+          field,
+          lookup,
+          scopeCompanyId,
+          caches,
+        );
 
   return resolveReferenceFromRecords(
     field,
@@ -1133,7 +1269,13 @@ async function normalizeMany2OneValues(
   values: Record<string, unknown>,
   permissions: Permissions,
 ): Promise<Record<string, unknown>> {
-  const fields = normalizeFields(await client.fields(model));
+  // One cache per invocation (i.e. per tool call), never a module-global —
+  // see the `NormalizeCaches` doc comment above `searchRelationByName` for
+  // why. Created fresh here and threaded down through every nested call so
+  // repeated schema fetches / name lookups within THIS create/write are
+  // deduped, but nothing survives past this function's return.
+  const caches: NormalizeCaches = { fields: new Map(), lookups: new Map() };
+  const fields = await loadFields(client, model, caches);
   if (fields.length === 0) return values;
   return normalizeValuesRecord(
     client,
@@ -1144,6 +1286,7 @@ async function normalizeMany2OneValues(
     null,
     permissions,
     0,
+    caches,
   );
 }
 
@@ -1208,6 +1351,7 @@ async function resolveCommandTargetId(
   relationField: OdooField,
   idValue: unknown,
   scopeCompanyId: number | null,
+  caches?: NormalizeCaches,
 ): Promise<unknown> {
   if (typeof idValue === "number") return idValue;
   if (idValue === false || idValue == null) return idValue;
@@ -1217,7 +1361,47 @@ async function resolveCommandTargetId(
     relationField,
     idValue,
     scopeCompanyId,
+    caches,
   );
+}
+
+/**
+ * A single value is "ref-shaped" when it needs decoding before it can reach
+ * Odoo: a bare `_pinchy_ref` string, or a `{ref}`/`{_pinchy_ref}` object.
+ * Used by {@link commandTuplesNeedResolution} to decide whether an empty
+ * line schema is actually a problem for a given set of tuples.
+ */
+function isRefShaped(value: unknown): boolean {
+  if (isIntegrationRef(value)) return true;
+  return (
+    isRecord(value) &&
+    (typeof value.ref === "string" || typeof value._pinchy_ref === "string")
+  );
+}
+
+/**
+ * True when at least one command tuple in `tuples` actually needs relation
+ * resolution: a code-0/1 values dict containing a ref-shaped value, or an id
+ * position (tuple[1], or an element of a code-6 id list) that is neither a
+ * raw number nor `false`/`null` (Odoo's own wire shapes, which never need
+ * resolution). Pure raw-id tuples such as `[6, 0, [1, 2, 3]]` return false
+ * here — they carry nothing for `client.fields(field.relation)` to resolve
+ * against, so an empty/unavailable line schema is harmless for them.
+ */
+function commandTuplesNeedResolution(tuples: unknown[]): boolean {
+  const idNeedsResolution = (id: unknown): boolean =>
+    typeof id !== "number" && id !== false && id != null;
+  return tuples.some((tuple) => {
+    if (!Array.isArray(tuple)) return false;
+    const code = tuple[0];
+    if ((code === 0 || code === 1) && isRecord(tuple[2])) {
+      if (Object.values(tuple[2]).some(isRefShaped)) return true;
+    }
+    if (code === 6 && Array.isArray(tuple[2])) {
+      return (tuple[2] as unknown[]).some(idNeedsResolution);
+    }
+    return idNeedsResolution(tuple[1]);
+  });
 }
 
 /**
@@ -1239,6 +1423,7 @@ async function normalizeValuesRecord(
   scopeCompanyId: number | null,
   permissions: Permissions,
   depth: number,
+  caches?: NormalizeCaches,
 ): Promise<Record<string, unknown>> {
   const normalized = { ...values };
 
@@ -1256,6 +1441,7 @@ async function normalizeValuesRecord(
       companyField,
       normalized.company_id,
       scopeCompanyId,
+      caches,
     );
     normalized.company_id = resolved;
     if (
@@ -1276,6 +1462,7 @@ async function normalizeValuesRecord(
       field,
       normalized[field.name],
       scopeCompanyId,
+      caches,
     );
   }
 
@@ -1301,13 +1488,24 @@ async function normalizeValuesRecord(
     if (!(field.name in normalized)) continue;
     const tuples = normalized[field.name];
     if (!Array.isArray(tuples) || tuples.length === 0) continue;
-    if (depth >= MAX_NORMALIZE_DEPTH) {
-      throw new Error(
-        `Nested relation resolution exceeded the maximum depth of ${MAX_NORMALIZE_DEPTH}; ` +
-          `refusing to pass ${kind} command tuples to Odoo without reference decoding.`,
-      );
+    assertNormalizeDepth(depth, kind);
+    const lineFields = await loadFields(client, field.relation, caches);
+    if (lineFields.length === 0) {
+      // An empty schema means the nested m2o loop below has nothing to
+      // resolve against. When the tuples carry only raw ids (no ref-shaped
+      // value anywhere), that's fine — pass them through unchanged, exactly
+      // as Odoo's own wire format expects. But if resolution IS needed
+      // (issue #615), silently no-op-ing here would let a bare ref reach
+      // Odoo undecoded — fail loud instead.
+      if (commandTuplesNeedResolution(tuples)) {
+        throw new Error(
+          `Cannot resolve references in "${field.name}" (relation "${field.relation}"): ` +
+            `the schema for ${field.relation} came back empty, so many2one refs in its ` +
+            `command tuples cannot be decoded. Re-check the connection to Odoo and try again.`,
+        );
+      }
+      continue;
     }
-    const lineFields = normalizeFields(await client.fields(field.relation));
     normalized[field.name] = await normalizeCommandTuples(
       client,
       connectionId,
@@ -1320,6 +1518,7 @@ async function normalizeValuesRecord(
       field.name,
       kind,
       field,
+      caches,
     );
   }
 
@@ -1355,6 +1554,7 @@ async function normalizeCommandTuples(
   parentField: string,
   kind: "one2many" | "many2many",
   relationField: OdooField,
+  caches?: NormalizeCaches,
 ): Promise<unknown[]> {
   const opByCode = kind === "one2many" ? NESTED_OP_BY_CODE : M2M_OP_BY_CODE;
   const out: unknown[] = [];
@@ -1390,6 +1590,7 @@ async function normalizeCommandTuples(
         scopeCompanyId,
         permissions,
         depth + 1,
+        caches,
       );
       const resolvedId =
         code === 1
@@ -1399,6 +1600,7 @@ async function normalizeCommandTuples(
               relationField,
               tuple[1],
               scopeCompanyId,
+              caches,
             )
           : tuple[1];
       out.push([code, resolvedId, resolvedValues]);
@@ -1412,6 +1614,7 @@ async function normalizeCommandTuples(
         relationField,
         tuple[1],
         scopeCompanyId,
+        caches,
       );
       out.push([code, resolvedId, ...tuple.slice(2)]);
     } else if (code === 6 && Array.isArray(tuple[2])) {
@@ -1423,6 +1626,7 @@ async function normalizeCommandTuples(
             relationField,
             id,
             scopeCompanyId,
+            caches,
           ),
         ),
       );


### PR DESCRIPTION
## Problem

PR #614 fixed **top-level** many2one resolution (bare `_pinchy_ref` + company-scoped name lookups with OR-with-`false`). Nested m2o fields inside one2many command tuples — `account.move` created with `line_ids: [[0, 0, { account_id: "<bare pinchy_ref>", debit, credit }]]` — still passed **verbatim** to Odoo. A bare ref the agent copied from `odoo_read` reached Odoo as a string where an integer id was expected → ValidationError. The nested path didn’t get the ref-decoding or company scoping the top-level fix introduced.

Tracked in #615 (with an open question about a production audit showing `success: true` for such creates — see **Audit-mystery** below).

## Fix

**Core — recursive nested resolution.** `normalizeMany2OneValues` becomes a thin wrapper delegating to `normalizeValuesRecord` + `normalizeCommandTuples`. Only Command codes `0` (create) and `1` (update) carry a values dict; `2/3/4/5/6` pass through untouched. The parent’s `scopeCompanyId` threads down (a line’s own `company_id` overrides for its siblings). Nested m2o values reuse `resolveRelationValue` unchanged — bare ref, `{ref}` object, name/code lookup, OR-with-`false` company scope all covered. Recursion capped at `MAX_NORMALIZE_DEPTH=8`.

**Cross-company guard.** `assertNoCrossCompanyRefs` now recurses into `[0,0,{values}]` / `[1,id,{values}]` tuples via `readRefCompanyTag` (already bare-string + `{ref}` capable), reusing the parent’s `company_id` as `intended` and threading a path like `line_ids[0].account_id` into the error.

**Nested-relation permissions (refined enforce).** Inline `[0,0,{…}]` line creation is part of the parent’s atomic create — already gated by the top-level `account.move:create` check — so it needs **no** separate `account.move.line:create` grant. This preserves the bookkeeper’s *“lines only inline via invoice_line_ids, never standalone”* atomicity design (`account.move.line:create` stays ungranted — test `agent-templates.test.ts:1031` keeps passing). `[1,id,{…}]` line edits require `account.move.line:write`; `[2]/[3]` line record deletion requires `account.move.line:delete` (no template grants delete — the *“never delete”* audit-trail principle; agents clear/replace lines via `[5]`/`[6]`, which rewire the relation without deleting records and need no grant). This is consistent with **every** existing Odoo template grant — **no template migration needed**. (Decision: refined enforce — see #615 discussion; literal enforce would have required granting `account.move.line:create`, opening the standalone path the AGENTS.md forbids.)

**Mock.** Adds `account.account` + `account.move.line` models, `line_ids` + `invoice_line_ids` one2many on `account.move`, `ir.model` rows, and a multi-company account collision (mirroring `account.journal`). The create handler materializes `[0,0,{values}]` tuples into `account.move.line` child records with a `move_id` back-link and **validates m2o field types** — rejecting bare-string m2o values the way Odoo does.

## Audit-mystery (#615 open question)

Production audit rows showed `tool.odoo_create` on `account.move` with `line_ids: [[0,0,{account_id: "pinchy_ref:v1:…"}]]` recorded as `success: true`. Code analysis: `client.create` throws `OdooError` on Odoo ValidationError → `errorResult` → `isError:true` + `details.error` → audit `outcome: failure`. So a create where Odoo rejects a bare-string `account_id` would be `failure`, not `success`. The mock now confirms the Odoo-faithful contract: a bare-string m2o value reaching Odoo **is** rejected (integration test `mock (Odoo-faithful) rejects a bare-string account_id`). The plugin decodes bare refs before they reach Odoo, so the success path works. The historical `success: true` rows remain unexplained by current code + Odoo behavior — likely predating the verbatim nested pass-through or a different Odoo config. I’ll update #615 with this finding; production data cleanup (moves possibly created with missing `account_id`) should be assessed against real Odoo separately.

## Tests (TDD)

- **Unit (+7)**: bare ref nested decode; nested name lookup scoped; cross-company nested rejected; non-0/1 codes untouched; inline `[0]` needs no line grant; `[1]` needs write; `[2]` needs delete; line `company_id` scope override.
- **Integration (+5)** against the real mock-odoo: bare-ref line materialized + read-back; scoped nested name; cross-company rejected end-to-end; `[1]` write-permission; mock rejects bare-string m2o (audit-mystery verification).

## Verification

- Plugin suite: **295 passed** (was 283)
- Web suite: **6593 passed** (no mock regressions)
- agent-templates: **188 passed** (no template regression — no migration needed)
- `test:scripts`: **182 passed**
- `tsc --noEmit`: clean

## Out of scope

- `odoo_read` one2many wrapping / line `_pinchy_ref` emission on create response (Odoo `create` returns only the top-level id; separate read-side enhancement).
- `many2many` command tuples (only one2many descended).
- Production data cleanup of moves created with missing `account_id` (assess after confirming the audit-mystery against real Odoo).

Closes #615.