### PR TITLE
feat(permissions): per-agent read-only toggle (#571)

### DIFF
--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -74,6 +74,14 @@ The Permissions tab shows all available tools grouped by category. Check or unch
 The Permissions tab is only visible to admins and only for shared agents. Personal agents (the auto-created Smithers each user gets) don't have this tab — they run with default tools only.
 :::
 
+### Read-only mode
+
+At the top of the Permissions tab there is a **Read-only mode** switch. Turning it on restricts the agent to read-only tools in one step — a crisp "this agent can look, but not touch" guarantee that is easy to reason about and to audit.
+
+When read-only mode is on, every powerful tool is dropped from the agent's OpenClaw allow-list at config-build time, regardless of what the per-integration sections below grant: file writes (`pinchy_write`), web search and fetch, Odoo create/write/delete and the governed action tools, and email draft/send. The read-only tools (file listing/reading, Odoo read/count/aggregate/list/describe, email list/read/search) and the read-only built-ins (memory, PDF/image reading, session status) stay available.
+
+This is a layer on top of the per-tool checkboxes, not a replacement for them. It overrides them: even if an admin has granted `pinchy_write` or Odoo write access in the sections below, a read-only agent cannot use those tools. Turn the switch off to configure write access again. The per-integration sections are disabled while read-only mode is on so the UI reflects what the agent can actually do.
+
 For the full list of tabs in Agent Settings and who sees which, see [Agent Settings](/concepts/agent-settings/).
 
 ### Configuring directory access

--- a/packages/web/drizzle/0044_tan_warstar.sql
+++ b/packages/web/drizzle/0044_tan_warstar.sql
@@ -1,0 +1,3 @@
+DROP VIEW "public"."active_agents";--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "read_only" boolean DEFAULT false NOT NULL;--> statement-breakpoint
+CREATE VIEW "public"."active_agents" AS (select "id", "name", "model", "template_id", "plugin_config", "allowed_tools", "skills", "owner_id", "is_personal", "read_only", "visibility", "greeting_message", "tagline", "avatar_seed", "personality_preset_id", "created_at", "deleted_at" from "agents" where "agents"."deleted_at" is null);

--- a/packages/web/drizzle/meta/0044_snapshot.json
+++ b/packages/web/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,2171 @@
+{
+  "id": "c3838292-587c-46ea-883f-12dc4fb46b5a",
+  "prevId": "81ef12b1-d31e-4c66-90e7-15aee993bac8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "read_only": {
+          "name": "read_only",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"read_only\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1782273139874,
       "tag": "0043_familiar_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1782814139905,
+      "tag": "0044_tan_warstar",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/api/agents-readonly.test.ts
+++ b/packages/web/src/__tests__/api/agents-readonly.test.ts
@@ -1,0 +1,190 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+vi.mock("next/cache", () => ({
+  revalidatePath: vi.fn(),
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/groups", () => ({
+  getUserGroupIds: vi.fn().mockResolvedValue([]),
+  getAgentGroupIds: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("@/lib/auth", () => {
+  const mockGetSession = vi.fn();
+  return {
+    getSession: mockGetSession,
+    auth: {
+      api: {
+        getSession: mockGetSession,
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/agents", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/agents")>();
+  return {
+    ...actual,
+    deleteAgent: vi.fn().mockResolvedValue({ id: "agent-1", name: "Test Agent" }),
+    updateAgent: vi.fn(),
+  };
+});
+
+vi.mock("@/lib/openclaw-config", () => ({
+  regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/db", () => {
+  const mockInsertValues = vi.fn().mockReturnValue({
+    returning: vi.fn().mockResolvedValue([]),
+  });
+  const mockInsert = vi.fn().mockReturnValue({ values: mockInsertValues });
+  const mockDeleteWhere = vi.fn().mockResolvedValue(undefined);
+  const mockDelete = vi.fn().mockReturnValue({ where: mockDeleteWhere });
+
+  const defaultSelect = () => ({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue([]),
+    }),
+  });
+
+  return {
+    db: {
+      insert: mockInsert,
+      select: vi.fn().mockImplementation(defaultSelect),
+      delete: mockDelete,
+    },
+  };
+});
+
+vi.mock("@/db/schema", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/db/schema")>();
+  return {
+    ...actual,
+    activeAgents: actual.activeAgents,
+  };
+});
+
+vi.mock("@/lib/workspace", () => ({
+  ensureWorkspace: vi.fn(),
+  writeWorkspaceFile: vi.fn(),
+  writeWorkspaceFileInternal: vi.fn(),
+  writeIdentityFile: vi.fn(),
+}));
+
+vi.mock("@/lib/context-sync", () => ({
+  getContextForAgent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/lib/path-validation", () => ({
+  validateAllowedPaths: vi.fn((paths: string[]) =>
+    paths.map((p) => (p.endsWith("/") ? p : p + "/"))
+  ),
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue("anthropic"),
+}));
+
+vi.mock("@/lib/enterprise", () => ({
+  isEnterprise: vi.fn().mockResolvedValue(true),
+  getLicenseState: vi.fn().mockResolvedValue("paid"),
+}));
+
+import { auth } from "@/lib/auth";
+import { updateAgent } from "@/lib/agents";
+import { db } from "@/db";
+
+function mockAgent(agent: Record<string, unknown> | undefined) {
+  vi.mocked(db.select).mockReturnValueOnce({
+    from: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(agent ? [agent] : []),
+    }),
+  } as never);
+}
+
+// ── PATCH /api/agents/[agentId] — readOnly ────────────────────────────────
+
+describe("PATCH /api/agents/[agentId] readOnly", () => {
+  let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/agents/[agentId]/route");
+    PATCH = mod.PATCH;
+  });
+
+  it("admin can enable read-only mode on a shared agent", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockAgent({ id: "agent-1", name: "My Agent", isPersonal: false, ownerId: "admin-1" });
+
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      id: "agent-1",
+      name: "My Agent",
+      readOnly: true,
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ readOnly: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    expect(response.status).toBe(200);
+    expect(updateAgent).toHaveBeenCalledWith("agent-1", { readOnly: true });
+  });
+
+  it("non-admin cannot change read-only mode (403)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "member" },
+      expires: "",
+    } as any);
+    mockAgent({ id: "agent-1", name: "My Agent", isPersonal: false, ownerId: "admin-1" });
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ readOnly: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    expect(response.status).toBe(403);
+    expect(updateAgent).not.toHaveBeenCalled();
+  });
+
+  it("cannot change read-only mode on personal agents (400)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+    mockAgent({ id: "agent-1", name: "My Agent", isPersonal: true, ownerId: "admin-1" });
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ readOnly: true }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, { params: Promise.resolve({ agentId: "agent-1" }) });
+
+    expect(response.status).toBe(400);
+    expect(updateAgent).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -69,6 +69,7 @@ const agentData = {
   model: "anthropic/claude-sonnet-4-6",
   isPersonal: false,
   allowedTools: [],
+  readOnly: false,
   pluginConfig: null,
   tagline: "A test agent",
   avatarSeed: "seed-1",
@@ -308,7 +309,7 @@ describe("AgentSettingsPage", () => {
     // Simulate permissions tab dirty with empty integrations (no connections configured)
     act(() => {
       _capturedOnChangePermissions?.(
-        { allowedTools: [], allowedPaths: [], integrations: [] },
+        { allowedTools: [], allowedPaths: [], readOnly: false, integrations: [] },
         true
       );
     });
@@ -347,6 +348,7 @@ describe("AgentSettingsPage", () => {
         {
           allowedTools: [],
           allowedPaths: [],
+          readOnly: false,
           integrations: [
             {
               connectionId: "conn-1",
@@ -395,6 +397,7 @@ describe("AgentSettingsPage", () => {
         {
           allowedTools: ["email_draft"],
           allowedPaths: [],
+          readOnly: false,
           integrations: [
             {
               connectionId: "conn-1",

--- a/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-permissions.test.tsx
@@ -113,6 +113,7 @@ describe("AgentSettingsPermissions", () => {
     model: "anthropic/claude-sonnet-4-6",
     isPersonal: false,
     allowedTools: [] as string[],
+    readOnly: false,
     pluginConfig: null as import("@/db/schema").AgentPluginConfig | null,
   };
 
@@ -539,7 +540,13 @@ describe("AgentSettingsPermissions", () => {
       );
 
       expect(onChange).toHaveBeenCalledWith(
-        { allowedTools: [], allowedPaths: [], integrations: [], webSearchConfig: {} },
+        {
+          allowedTools: [],
+          allowedPaths: [],
+          readOnly: false,
+          integrations: [],
+          webSearchConfig: {},
+        },
         false
       );
     });
@@ -599,6 +606,56 @@ describe("AgentSettingsPermissions", () => {
       />
     );
     expect(screen.getByLabelText("Write files")).toBeInTheDocument();
+  });
+
+  describe("read-only mode", () => {
+    it("disables powerful tool checkboxes when readOnly is on", () => {
+      render(
+        <AgentSettingsPermissions
+          agent={{ ...defaultAgent, readOnly: true }}
+          directories={[]}
+          connections={[]}
+          isAdmin={true}
+          onChange={vi.fn()}
+        />
+      );
+      // pinchy_write is a powerful KB tool — must be disabled in read-only mode.
+      const writeCheckbox = screen.getByLabelText("Write files");
+      expect(writeCheckbox).toBeDisabled();
+    });
+
+    it("drops powerful tools from the emitted allowedTools when readOnly is on", () => {
+      const onChange = vi.fn();
+      render(
+        <AgentSettingsPermissions
+          // Agent has pinchy_write granted, but read-only mode is on.
+          agent={{ ...defaultAgent, readOnly: true, allowedTools: ["pinchy_write"] }}
+          directories={[]}
+          connections={[]}
+          isAdmin={true}
+          onChange={onChange}
+        />
+      );
+
+      const lastCall = onChange.mock.calls.at(-1);
+      expect(lastCall).toBeDefined();
+      const [values] = lastCall!;
+      expect(values.allowedTools).not.toContain("pinchy_write");
+      expect(values.readOnly).toBe(true);
+    });
+
+    it("renders the read-only mode toggle for admins", () => {
+      render(
+        <AgentSettingsPermissions
+          agent={defaultAgent}
+          directories={[]}
+          connections={[]}
+          isAdmin={true}
+          onChange={vi.fn()}
+        />
+      );
+      expect(screen.getByLabelText("Read-only mode")).toBeInTheDocument();
+    });
   });
 
   it("does not render pinchy_ls or pinchy_read toggles", () => {

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -4,6 +4,7 @@ import {
   getToolById,
   getToolsByCategory,
   computeAllowedTools,
+  filterReadOnlyToolIds,
   getOdooTools,
   getOdooToolsForAccessLevel,
   detectOdooAccessLevel,
@@ -194,6 +195,69 @@ describe("computeAllowedTools", () => {
     for (const tool of mustNeverAllow) {
       expect(allowed.has(tool), `built-in "${tool}" must NOT be in the allowlist`).toBe(false);
     }
+  });
+});
+
+describe("filterReadOnlyToolIds", () => {
+  it("drops every tool categorized as powerful (write/web/odoo-write/email-write)", () => {
+    const input = [
+      "pinchy_read",
+      "pinchy_write",
+      "pinchy_web_search",
+      "pinchy_web_fetch",
+      "odoo_read",
+      "odoo_create",
+      "odoo_write",
+      "odoo_delete",
+      "email_read",
+      "email_send",
+    ];
+    const filtered = filterReadOnlyToolIds(input);
+    expect(filtered).not.toContain("pinchy_write");
+    expect(filtered).not.toContain("pinchy_web_search");
+    expect(filtered).not.toContain("pinchy_web_fetch");
+    expect(filtered).not.toContain("odoo_create");
+    expect(filtered).not.toContain("odoo_write");
+    expect(filtered).not.toContain("odoo_delete");
+    expect(filtered).not.toContain("email_send");
+  });
+
+  it("keeps every safe-category tool (read-only operations)", () => {
+    const input = ["odoo_read", "odoo_count", "odoo_list_models", "email_read", "email_search"];
+    const filtered = filterReadOnlyToolIds(input);
+    expect(filtered).toEqual(input);
+  });
+
+  it("keeps tools with no registry entry (built-ins + unclassified plugin tools are read-only by construction)", () => {
+    const input = [
+      "memory_search",
+      "memory_get",
+      "pdf",
+      "image",
+      "session_status",
+      "pinchy_save_context",
+    ];
+    const filtered = filterReadOnlyToolIds(input);
+    expect(filtered).toEqual(input);
+  });
+
+  it("applied to the full allowlist, leaves only safe + unclassified tools (the read-only guarantee)", () => {
+    const filtered = filterReadOnlyToolIds(computeAllowedTools());
+    // Every powerful registry tool is gone...
+    for (const tool of getToolsByCategory("powerful")) {
+      expect(
+        filtered,
+        `powerful tool "${tool.id}" must be dropped in read-only mode`
+      ).not.toContain(tool.id);
+    }
+    // ...and every safe registry tool survives.
+    for (const tool of getToolsByCategory("safe")) {
+      expect(filtered, `safe tool "${tool.id}" must survive in read-only mode`).toContain(tool.id);
+    }
+    // Built-in read-only tools survive too.
+    expect(filtered).toContain("memory_search");
+    expect(filtered).toContain("pdf");
+    expect(filtered).toContain("session_status");
   });
 });
 

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -33,6 +33,7 @@ const updateAgentSchema = z.object({
   avatarSeed: z.string().nullable().optional(),
   personalityPresetId: z.string().nullable().optional(),
   visibility: z.enum(["all", "restricted"]).optional(),
+  readOnly: z.boolean().optional(),
   groupIds: z.array(z.string()).optional(),
 });
 
@@ -76,6 +77,21 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
 
   // Only admins can change permissions on shared agents
   if (body.allowedTools !== undefined) {
+    if (session.user.role !== "admin") {
+      return NextResponse.json({ error: "Only admins can change permissions" }, { status: 403 });
+    }
+    if (existingAgent.isPersonal) {
+      return NextResponse.json(
+        { error: "Cannot change permissions for personal agents" },
+        { status: 400 }
+      );
+    }
+  }
+
+  // Read-only mode is a permissions-level restriction (it rewrites the agent's
+  // tool allowlist at config-build time — see filterReadOnlyToolIds). Gate it
+  // the same way as allowedTools: admin-only, not for personal agents.
+  if (body.readOnly !== undefined) {
     if (session.user.role !== "admin") {
       return NextResponse.json({ error: "Only admins can change permissions" }, { status: 403 });
     }
@@ -135,6 +151,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     avatarSeed?: string | null;
     personalityPresetId?: string | null;
     visibility?: string;
+    readOnly?: boolean;
   } = {};
   if (body.name !== undefined) data.name = body.name;
   if (body.model !== undefined) data.model = body.model;
@@ -145,6 +162,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   if (body.avatarSeed !== undefined) data.avatarSeed = body.avatarSeed;
   if (body.personalityPresetId !== undefined) data.personalityPresetId = body.personalityPresetId;
   if (body.visibility !== undefined) data.visibility = body.visibility;
+  if (body.readOnly !== undefined) data.readOnly = body.readOnly;
 
   const agent = Object.keys(data).length > 0 ? await updateAgent(agentId, data) : existingAgent;
 
@@ -154,6 +172,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     "name",
     "model",
     "visibility",
+    "readOnly",
     "greetingMessage",
     "tagline",
     "avatarSeed",
@@ -250,7 +269,11 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
 
   // Rebuild OpenClaw config when tool permissions or plugin config change — these
   // fields affect the generated openclaw.json (e.g. write_paths for pinchy_write).
-  if (data.allowedTools !== undefined || data.pluginConfig !== undefined) {
+  if (
+    data.allowedTools !== undefined ||
+    data.pluginConfig !== undefined ||
+    data.readOnly !== undefined
+  ) {
     await regenerateOpenClawConfig();
   }
 

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -33,6 +33,7 @@ interface Agent {
   model: string;
   isPersonal: boolean;
   allowedTools: string[];
+  readOnly: boolean;
   pluginConfig: AgentPluginConfig | null;
   tagline: string | null;
   avatarSeed: string | null;
@@ -75,6 +76,7 @@ interface PersonalityValues {
 interface PermissionsValues {
   allowedTools: string[];
   allowedPaths: string[];
+  readOnly: boolean;
   integrations: Array<{
     connectionId: string;
     permissions: Array<{ model: string; operation: string }>;
@@ -266,6 +268,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
       }
       if (dirtyTabs.has("permissions") && permissionsDraft.current) {
         agentPatch.allowedTools = permissionsDraft.current.allowedTools;
+        agentPatch.readOnly = permissionsDraft.current.readOnly;
         agentPatch.pluginConfig = {
           ...agent?.pluginConfig,
           "pinchy-files": { allowed_paths: permissionsDraft.current.allowedPaths },

--- a/packages/web/src/components/agent-settings-permissions.tsx
+++ b/packages/web/src/components/agent-settings-permissions.tsx
@@ -6,6 +6,7 @@ import { Label } from "@/components/ui/label";
 import { DirectoryPicker } from "@/components/directory-picker";
 import {
   getToolsByCategory,
+  filterReadOnlyToolIds,
   getOdooToolsForAccessLevel,
   getEmailToolsForOperations,
 } from "@/lib/tool-registry";
@@ -18,6 +19,7 @@ import type { AgentPluginConfig } from "@/db/schema";
 export interface PermissionsValues {
   allowedTools: string[];
   allowedPaths: string[];
+  readOnly: boolean;
   integrations: Array<{
     connectionId: string;
     permissions: Array<{ model: string; operation: string }>;
@@ -39,6 +41,7 @@ interface AgentSettingsPermissionsProps {
   agent: {
     id: string;
     allowedTools: string[];
+    readOnly: boolean;
     pluginConfig: AgentPluginConfig | null;
   };
   directories: Array<{ path: string; name: string }>;
@@ -85,10 +88,12 @@ export function AgentSettingsPermissions({
   const [webSearchConfig, setWebSearchConfig] = useState<AgentPluginConfig["pinchy-web"]>(
     agent.pluginConfig?.["pinchy-web"] ?? {}
   );
+  const [readOnly, setReadOnly] = useState<boolean>(!!agent.readOnly);
 
   const initialKbToolsRef = useRef(initialKbTools);
   const initialAllowedPaths = useRef(agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? []);
   const initialWebSearchConfig = useRef(agent.pluginConfig?.["pinchy-web"] ?? {});
+  const initialReadOnly = useRef(!!agent.readOnly);
 
   // Re-sync the "initial" snapshot when the agent prop changes (the parent
   // refetches the agent after a successful save, so the prop now reflects the
@@ -103,7 +108,8 @@ export function AgentSettingsPermissions({
     );
     initialAllowedPaths.current = agent.pluginConfig?.["pinchy-files"]?.allowed_paths ?? [];
     initialWebSearchConfig.current = agent.pluginConfig?.["pinchy-web"] ?? {};
-  }, [agent.allowedTools, agent.pluginConfig]);
+    initialReadOnly.current = !!agent.readOnly;
+  }, [agent.allowedTools, agent.pluginConfig, agent.readOnly]);
 
   const hasWebToolChecked = webTools.some((tool) => allowedKbTools.includes(tool.id));
 
@@ -168,9 +174,14 @@ export function AgentSettingsPermissions({
         emailToolIds = getEmailToolsForOperations(email.permissions.map((p) => p.operation));
       }
 
-      return [...currentKbTools, ...odooToolIds, ...emailToolIds];
+      const combined = [...currentKbTools, ...odooToolIds, ...emailToolIds];
+      // Read-only mode drops every powerful tool from the saved allowlist, so
+      // the persisted value already reflects what the build will emit. The
+      // build layer (filterReadOnlyToolIds) is the real guarantee; this keeps
+      // the stored value honest and the dirty-state comparison stable.
+      return readOnly ? filterReadOnlyToolIds(combined) : combined;
     },
-    []
+    [readOnly]
   );
 
   // Notify parent after every state change (and on mount)
@@ -183,7 +194,8 @@ export function AgentSettingsPermissions({
         JSON.stringify([...initialAllowedPaths.current].sort());
     const webConfigDirty =
       JSON.stringify(webSearchConfig) !== JSON.stringify(initialWebSearchConfig.current);
-    const isDirty = kbDirty || odooIsDirty || emailIsDirty || webConfigDirty;
+    const readOnlyDirty = readOnly !== initialReadOnly.current;
+    const isDirty = kbDirty || odooIsDirty || emailIsDirty || webConfigDirty || readOnlyDirty;
     // Collect all active integrations
     const integrations: Array<{
       connectionId: string;
@@ -195,6 +207,7 @@ export function AgentSettingsPermissions({
       {
         allowedTools: allAllowedTools,
         allowedPaths,
+        readOnly,
         integrations,
         webSearchConfig,
       },
@@ -203,6 +216,7 @@ export function AgentSettingsPermissions({
   }, [
     allowedKbTools,
     allowedPaths,
+    readOnly,
     odooIntegration,
     odooIsDirty,
     emailIntegration,
@@ -250,6 +264,36 @@ export function AgentSettingsPermissions({
 
   return (
     <div className="space-y-8">
+      {/* Read-only mode — single switch that restricts this agent to read-only
+          tools. Enforced at config-build time (filterReadOnlyToolIds drops
+          every powerful tool from the allowlist regardless of per-integration
+          grants). See issue #571. */}
+      {isAdmin && (
+        <section className="space-y-3 rounded-md border p-4">
+          <div className="flex items-start space-x-3">
+            <Checkbox
+              id="agent-read-only"
+              checked={readOnly}
+              onCheckedChange={(checked) => setReadOnly(checked === true)}
+              aria-label="Read-only mode"
+            />
+            <Label htmlFor="agent-read-only" className="cursor-pointer">
+              <span className="font-medium">Read-only mode</span>
+              <span className="block text-sm text-muted-foreground">
+                Restrict this agent to read-only tools. All write, web, and integration write tools
+                are disabled — even if granted below.
+              </span>
+            </Label>
+          </div>
+          {readOnly && (
+            <p className="text-sm text-muted-foreground">
+              Read-only mode is on. Write tools below are disabled; turn it off to configure write
+              access.
+            </p>
+          )}
+        </section>
+      )}
+
       {/* Knowledge Base section */}
       <section className="space-y-4">
         <h3 className="text-lg font-semibold">Knowledge Base</h3>
@@ -293,9 +337,13 @@ export function AgentSettingsPermissions({
               id={`tool-${tool.id}`}
               checked={allowedKbTools.includes(tool.id)}
               onCheckedChange={() => handleToolToggle(tool.id)}
+              disabled={readOnly}
               aria-label={tool.label}
             />
-            <Label htmlFor={`tool-${tool.id}`} className="cursor-pointer">
+            <Label
+              htmlFor={`tool-${tool.id}`}
+              className={readOnly ? "cursor-not-allowed opacity-60" : "cursor-pointer"}
+            >
               <span className="font-medium">{tool.label}</span>
               <span className="text-sm text-muted-foreground ml-2">{tool.description}</span>
             </Label>
@@ -314,9 +362,13 @@ export function AgentSettingsPermissions({
                   id={`tool-${tool.id}`}
                   checked={allowedKbTools.includes(tool.id)}
                   onCheckedChange={() => handleToolToggle(tool.id)}
+                  disabled={readOnly}
                   aria-label={tool.label}
                 />
-                <Label htmlFor={`tool-${tool.id}`} className="cursor-pointer">
+                <Label
+                  htmlFor={`tool-${tool.id}`}
+                  className={readOnly ? "cursor-not-allowed opacity-60" : "cursor-pointer"}
+                >
                   <span className="font-medium">{tool.label}</span>
                   <span className="text-sm text-muted-foreground ml-2">{tool.description}</span>
                 </Label>
@@ -324,7 +376,7 @@ export function AgentSettingsPermissions({
             ))}
           </div>
 
-          {hasWebToolChecked && (
+          {hasWebToolChecked && !readOnly && (
             <WebSearchPermissionSection
               config={webSearchConfig ?? {}}
               onChange={handleWebSearchConfigChange}
@@ -338,11 +390,13 @@ export function AgentSettingsPermissions({
       {showOdoo && (
         <section className="space-y-4">
           <h3 className="text-lg font-semibold">Odoo</h3>
-          <OdooPermissionSection
-            agentId={agent.id}
-            connections={odooConnections}
-            onChange={handleOdooChange}
-          />
+          <fieldset disabled={readOnly}>
+            <OdooPermissionSection
+              agentId={agent.id}
+              connections={odooConnections}
+              onChange={handleOdooChange}
+            />
+          </fieldset>
         </section>
       )}
 
@@ -350,11 +404,13 @@ export function AgentSettingsPermissions({
       {showEmail && (
         <section className="space-y-4">
           <h3 className="text-lg font-semibold">Email</h3>
-          <EmailPermissionSection
-            agentId={agent.id}
-            connections={emailConnections}
-            onChange={handleEmailChange}
-          />
+          <fieldset disabled={readOnly}>
+            <EmailPermissionSection
+              agentId={agent.id}
+              connections={emailConnections}
+              onChange={handleEmailChange}
+            />
+          </fieldset>
         </section>
       )}
 

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -136,6 +136,11 @@ export const agents = pgTable(
     skills: jsonb("skills").$type<string[]>().notNull().default([]),
     ownerId: text("owner_id").references(() => users.id, { onDelete: "cascade" }),
     isPersonal: boolean("is_personal").notNull().default(false),
+    // Read-only mode (issue #571): when true, the config build drops every
+    // powerful tool from this agent's allowlist — a one-switch "look, don't
+    // touch" guarantee that overrides per-integration write grants. Enforced
+    // in regenerateOpenClawConfig via filterReadOnlyToolIds.
+    readOnly: boolean("read_only").notNull().default(false),
     visibility: text("visibility").notNull().default("restricted"),
     greetingMessage: text("greeting_message").notNull(),
     tagline: text("tagline"),

--- a/packages/web/src/lib/agents.ts
+++ b/packages/web/src/lib/agents.ts
@@ -21,6 +21,7 @@ export interface UpdateAgentInput {
   avatarSeed?: string | null;
   personalityPresetId?: string | null;
   visibility?: string;
+  readOnly?: boolean;
 }
 
 export async function deleteAgent(id: string) {
@@ -52,6 +53,7 @@ const OPENCLAW_CONFIG_FIELDS: (keyof UpdateAgentInput)[] = [
   "model",
   "allowedTools",
   "pluginConfig",
+  "readOnly",
 ];
 
 export async function updateAgent(id: string, data: UpdateAgentInput) {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -13,7 +13,7 @@ import {
   channelLinks,
 } from "@/db/schema";
 import { getSetting } from "@/lib/settings";
-import { computeAllowedTools } from "@/lib/tool-registry";
+import { computeAllowedTools, filterReadOnlyToolIds } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
 import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
@@ -316,9 +316,21 @@ export async function regenerateOpenClawConfig() {
     // `tools.fs.workspaceOnly` confines the built-in `pdf`/`image` tools to the
     // agent's own workspace; without it they would have unrestricted
     // host-filesystem access (CISO-review note, PR #316).
-    const allowedTools = (agent.allowedTools as string[]) || [];
+    //
+    // Read-only mode (issue #571): when `agent.readOnly` is set, drop every
+    // powerful tool from both the per-agent allowlist and the downstream
+    // conditional logic. The allowlist is the outer boundary (full ∩ allow),
+    // so filtering it here denies write/web/odoo-write/email-send tools
+    // regardless of what the per-integration plugin config grants — a crisp
+    // "this agent can look but not touch" guarantee. Safe tools and the
+    // read-only built-ins (memory/pdf/image/session_status) survive.
+    const isReadOnly = !!agent.readOnly;
+    const allowedTools = isReadOnly
+      ? filterReadOnlyToolIds((agent.allowedTools as string[]) || [])
+      : (agent.allowedTools as string[]) || [];
+    const allow = isReadOnly ? filterReadOnlyToolIds(computeAllowedTools()) : computeAllowedTools();
     agentEntry.tools = {
-      allow: computeAllowedTools(),
+      allow,
       fs: { workspaceOnly: true },
     };
 
@@ -759,7 +771,12 @@ export async function regenerateOpenClawConfig() {
     const webAgentConfigs: Record<string, Record<string, unknown>> = {};
 
     for (const agent of liveAgents) {
-      const allowedTools = (agent.allowedTools as string[]) || [];
+      // Read-only agents never get web tools (pinchy_web_search/fetch are
+      // powerful — see issue #571). Filter before detecting so a read-only
+      // flag flip doesn't leave a stale web plugin config wired up.
+      const allowedTools = agent.readOnly
+        ? filterReadOnlyToolIds((agent.allowedTools as string[]) || [])
+        : (agent.allowedTools as string[]) || [];
       const hasWebSearch = allowedTools.includes("pinchy_web_search");
       const hasWebFetch = allowedTools.includes("pinchy_web_fetch");
 

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -257,6 +257,19 @@ export function getToolsByCategory(category: "safe" | "powerful"): ToolDefinitio
 }
 
 /**
+ * Return only the tool ids a read-only agent may use: drop everything
+ * categorized as `powerful` (write operations, web search/fetch, odoo
+ * create/write/delete, email draft/send, workspace writes). Tools with no
+ * registry entry — OpenClaw built-ins (`memory_search`, `pdf`, `image`,
+ * `session_status`) and unclassified plugin tools — are kept; they are
+ * read-only by construction. This is the per-agent read-only guarantee
+ * layered on top of the fail-closed `tools.allow` boundary. See issue #571.
+ */
+export function filterReadOnlyToolIds(toolIds: string[]): string[] {
+  return toolIds.filter((id) => getToolById(id)?.category !== "powerful");
+}
+
+/**
  * Compute the fail-closed tool allowlist emitted per agent as `tools.allow`.
  *
  * With no `tools.profile` set, OpenClaw treats `allow` as an absolute allowlist


### PR DESCRIPTION
Closes #571.

## What

A single **Read-only mode** switch on the Permissions tab that restricts an agent to read-only tools. When enabled, the OpenClaw config build drops every powerful tool from the agent's allow-list — a crisp "look, don't touch" guarantee that overrides per-integration write grants at the outer allow-list boundary.

## Why

Today an agent becomes "read-only" only implicitly, by granting no write/powerful tools across each integration section separately. There is no single switch. A per-agent read-only toggle is easier for customers to reason about than a per-operation permission matrix, and it's a crisp governance affordance directly on Pinchy's core differentiator (agent permissions & control). An auditable read-only guarantee is an easy sell for the sovereign/regulated positioning.

## How (enforcement)

The build layer is the real guarantee, not the UI: when `agent.readOnly` is set, the new `filterReadOnlyToolIds` helper filters the per-agent `tools.allow` list to safe-category tools only. Because OpenClaw treats `allow` (with no profile) as an absolute allow-list (`full ∩ allow`), every powerful tool is denied regardless of what the per-integration plugin config grants — Odoo create/write/delete, email draft/send, file writes, and web search/fetch all drop out. Read-only tools (file list/read, Odoo read/count/aggregate/list/describe, email list/read/search) and the read-only built-ins (memory, PDF/image reading, session status) survive.

The same filter is applied to the downstream build conditionals (write_paths for `pinchy_write`, context tools, web plugin config) so a read-only flag flip can't leave stale write wiring in place.

## Changes

- `agents.read_only` boolean column + Drizzle migration `0044_tan_warstar` (defaults `false`; recreates the `active_agents` view to include the column).
- `filterReadOnlyToolIds` in `tool-registry.ts` — drops tools categorized as `powerful`, keeps safe tools and unclassified tools (built-ins are read-only by construction).
- `build.ts` applies the filter to the per-agent allow-list and to the web-plugin-config detection.
- `PATCH /api/agents/[agentId]` accepts `readOnly`, gated admin-only and blocked for personal agents (same rule as `allowedTools`), with an audit diff entry and OpenClaw config regen.
- Permissions UI: a Read-only mode switch at the top of the Permissions tab; powerful KB/web checkboxes and the Odoo/Email sections are disabled while it's on, so the UI reflects what the agent can actually do. The emitted `allowedTools` is filtered to safe-only so the stored value matches what the build emits.
- Docs: documents read-only mode in `concepts/agent-permissions.mdx`.

## Tests

- `filterReadOnlyToolIds` unit tests (drops powerful, keeps safe + unclassified, full-allowlist read-only guarantee).
- Permissions component: powerful checkbox disabled + powerful tools dropped from emitted `allowedTools` when readOnly is on; toggle renders for admins.
- API route: admin can enable, non-admin gets 403, personal agent gets 400.
- Existing permissions/page/API tests updated for the new `readOnly` field in `PermissionsValues` / the agent shape.

## Notes / out of scope

- `pinchy_save_*` context tools are not in `TOOL_REGISTRY` (no category), so they survive the read-only filter. They save user context/memory rather than touching external systems, so this matches the issue's literal "safe-category only" proposal; classifying them is a separate decision.
- The build-time filter is the guarantee; the UI disabling is for clarity. The per-integration plugin configs still carry their granted operations, but the allow-list denies the powerful tools at the runtime boundary.