### PR TITLE
feat(chat): cache the per-agent chat list so the switcher isn't empty (#610)

### DIFF
--- a/packages/web/src/__tests__/lib/chat-list-cache.test.ts
+++ b/packages/web/src/__tests__/lib/chat-list-cache.test.ts
@@ -1,0 +1,61 @@
+import { describe, it, expect, beforeEach } from "vitest";
+import {
+  getChatList,
+  setChatList,
+  hasChatList,
+  __resetChatListCacheForTests,
+} from "@/lib/chat-list-cache";
+import type { ChatListItem } from "@/lib/schemas/sessions";
+
+const item = (chatId: string | null, title: string): ChatListItem => ({
+  chatId,
+  sessionId: `session-${chatId ?? "default"}`,
+  title,
+  origin: "web",
+  lastInteractionAt: 1_700_000_000_000,
+});
+
+beforeEach(() => {
+  __resetChatListCacheForTests();
+});
+
+describe("chat-list-cache", () => {
+  it("returns undefined and reports no cache before any set", () => {
+    expect(hasChatList("agent-1")).toBe(false);
+    expect(getChatList("agent-1")).toBeUndefined();
+  });
+
+  it("stores and returns a list per agent", () => {
+    setChatList("agent-1", [item("c1", "First"), item("c2", "Second")]);
+    expect(hasChatList("agent-1")).toBe(true);
+    expect(getChatList("agent-1")).toEqual([item("c1", "First"), item("c2", "Second")]);
+  });
+
+  it("caches agents independently", () => {
+    setChatList("agent-1", [item("c1", "A1")]);
+    setChatList("agent-2", [item("c2", "A2")]);
+    expect(getChatList("agent-1")).toEqual([item("c1", "A1")]);
+    expect(getChatList("agent-2")).toEqual([item("c2", "A2")]);
+  });
+
+  it("returns a copy so callers cannot mutate the cached list", () => {
+    setChatList("agent-1", [item("c1", "First")]);
+    const list = getChatList("agent-1")!;
+    list.push(item("c2", "Mutated"));
+    // The cached list is unaffected by the caller's mutation.
+    expect(getChatList("agent-1")).toEqual([item("c1", "First")]);
+  });
+
+  it("setChatList stores a copy so the caller's array can't mutate the cache", () => {
+    const original = [item("c1", "First")];
+    setChatList("agent-1", original);
+    original.push(item("c2", "Mutated"));
+    expect(getChatList("agent-1")).toEqual([item("c1", "First")]);
+  });
+
+  it("overwrites the previous list on a subsequent set", () => {
+    setChatList("agent-1", [item("c1", "First")]);
+    setChatList("agent-1", [item("c2", "Second")]);
+    expect(getChatList("agent-1")).toEqual([item("c2", "Second")]);
+  });
+});

--- a/packages/web/src/__tests__/lib/chat-list-cache.test.ts
+++ b/packages/web/src/__tests__/lib/chat-list-cache.test.ts
@@ -1,11 +1,20 @@
-import { describe, it, expect, beforeEach } from "vitest";
+import { describe, it, expect, beforeEach, vi } from "vitest";
 import {
   getChatList,
   setChatList,
   hasChatList,
+  prefetchChatList,
+  invalidateChatList,
   __resetChatListCacheForTests,
 } from "@/lib/chat-list-cache";
 import type { ChatListItem } from "@/lib/schemas/sessions";
+
+vi.mock("@/lib/api-client", () => ({
+  apiGet: vi.fn(),
+}));
+import { apiGet } from "@/lib/api-client";
+
+const mockApiGet = apiGet as ReturnType<typeof vi.fn>;
 
 const item = (chatId: string | null, title: string): ChatListItem => ({
   chatId,
@@ -17,6 +26,7 @@ const item = (chatId: string | null, title: string): ChatListItem => ({
 
 beforeEach(() => {
   __resetChatListCacheForTests();
+  mockApiGet.mockReset();
 });
 
 describe("chat-list-cache", () => {
@@ -57,5 +67,49 @@ describe("chat-list-cache", () => {
     setChatList("agent-1", [item("c1", "First")]);
     setChatList("agent-1", [item("c2", "Second")]);
     expect(getChatList("agent-1")).toEqual([item("c2", "Second")]);
+  });
+});
+
+describe("prefetchChatList", () => {
+  it("fills the cache from the API when cold", async () => {
+    mockApiGet.mockResolvedValue({ chats: [item("c1", "First")] });
+    await prefetchChatList("agent-1");
+    expect(mockApiGet).toHaveBeenCalledWith("/api/agents/agent-1/chats");
+    expect(getChatList("agent-1")).toEqual([item("c1", "First")]);
+  });
+
+  it("is a no-op when the cache is already warm", async () => {
+    setChatList("agent-1", [item("c1", "First")]);
+    await prefetchChatList("agent-1");
+    expect(mockApiGet).not.toHaveBeenCalled();
+  });
+
+  it("deduplicates concurrent in-flight prefetches", async () => {
+    mockApiGet.mockReturnValue(new Promise(() => {})); // never resolves
+    void prefetchChatList("agent-1");
+    void prefetchChatList("agent-1");
+    expect(mockApiGet).toHaveBeenCalledTimes(1);
+  });
+
+  it("leaves the cache untouched and does not throw on failure", async () => {
+    mockApiGet.mockRejectedValue(new Error("boom"));
+    await prefetchChatList("agent-1");
+    expect(hasChatList("agent-1")).toBe(false);
+  });
+
+  it("can prefetch again after a failed attempt settles", async () => {
+    mockApiGet.mockRejectedValueOnce(new Error("boom"));
+    await prefetchChatList("agent-1");
+    mockApiGet.mockResolvedValueOnce({ chats: [item("c1", "First")] });
+    await prefetchChatList("agent-1");
+    expect(getChatList("agent-1")).toEqual([item("c1", "First")]);
+  });
+});
+
+describe("invalidateChatList", () => {
+  it("clears the cached entry for the agent", () => {
+    setChatList("agent-1", [item("c1", "First")]);
+    invalidateChatList("agent-1");
+    expect(hasChatList("agent-1")).toBe(false);
   });
 });

--- a/packages/web/src/components/__tests__/agent-list.test.tsx
+++ b/packages/web/src/components/__tests__/agent-list.test.tsx
@@ -1,0 +1,40 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { AgentList, type Agent } from "@/components/agent-list";
+
+vi.mock("@/lib/chat-list-cache", () => ({
+  prefetchChatList: vi.fn(),
+}));
+import { prefetchChatList } from "@/lib/chat-list-cache";
+
+const agents: Agent[] = [
+  { id: "a1", name: "Smithers", model: "m", isPersonal: false, tagline: null, avatarSeed: null },
+  {
+    id: "a2",
+    name: "Odoo Operator",
+    model: "m",
+    isPersonal: false,
+    tagline: null,
+    avatarSeed: null,
+  },
+];
+
+beforeEach(() => vi.clearAllMocks());
+
+describe("AgentList prefetch (#610)", () => {
+  it("prefetches an agent's chat list on hover", async () => {
+    const user = userEvent.setup();
+    render(<AgentList agents={agents} currentPath="/chat/a1" />);
+    await user.hover(screen.getByText("Odoo Operator"));
+    expect(prefetchChatList).toHaveBeenCalledWith("a2");
+  });
+
+  it("prefetches on focus for keyboard/a11y navigation", () => {
+    render(<AgentList agents={agents} currentPath="/chat/a1" />);
+    const link = screen.getByText("Odoo Operator").closest("a")!;
+    link.focus();
+    expect(prefetchChatList).toHaveBeenCalledWith("a2");
+  });
+});

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -5,6 +5,7 @@ import "@testing-library/jest-dom";
 import { ChatSwitcher } from "@/components/chat-switcher";
 import { chatIdSchema } from "@/lib/schemas/sessions";
 import type { ChatListItem } from "@/lib/schemas/sessions";
+import { setChatList, __resetChatListCacheForTests } from "@/lib/chat-list-cache";
 
 // --- mocks ----------------------------------------------------------------
 
@@ -99,6 +100,7 @@ function mockChats(chats: ChatListItem[]) {
 
 beforeEach(() => {
   vi.clearAllMocks();
+  __resetChatListCacheForTests();
 });
 
 // --- tests ----------------------------------------------------------------
@@ -422,5 +424,70 @@ describe("ChatSwitcher", () => {
     // Re-opening fetches again.
     await user.click(screen.getByTestId("open-dropdown"));
     await waitFor(() => expect(apiGet).toHaveBeenCalledTimes(3));
+  });
+
+  describe("per-agent chat-list cache (#610)", () => {
+    it("seeds the list from the cache so the dropdown isn't empty on reopen", async () => {
+      const user = userEvent.setup();
+      // Pre-seed the cache as if a previous mount had fetched this list.
+      setChatList("agent-1", [webChat]);
+      // A slow/never-resolving fetch so the cached seed is the only data source
+      // for the initial render — proves the cache, not the fetch, drives it.
+      (apiGet as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+      render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+      // The cached chat is rendered immediately, before the fetch settles.
+      const menu = await screen.findByRole("menu");
+      expect(within(menu).getByText("Quarterly report")).toBeInTheDocument();
+      // No loading state when the cache has data.
+      expect(screen.queryByText(/Loading your chats/i)).not.toBeInTheDocument();
+    });
+
+    it("still revalidates in the background after seeding from the cache", async () => {
+      setChatList("agent-1", [webChat]);
+      const refreshed: ChatListItem[] = [
+        { ...webChat, title: "Quarterly report (refreshed)" },
+        {
+          chatId: "chat-2",
+          sessionId: "s-2",
+          origin: "web",
+          writable: true,
+          title: "Another chat",
+          lastInteractionAt: 6_000,
+        },
+      ];
+      mockChats(refreshed);
+
+      render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+      // The background revalidation replaces the seeded list with the fresh
+      // list — the new chat from the refresh appears, proving the fetch ran
+      // and overwrote the cache seed.
+      await waitFor(() => {
+        expect(within(screen.getByRole("menu")).getByText("Another chat")).toBeInTheDocument();
+      });
+      expect(apiGet).toHaveBeenCalledWith("/api/agents/agent-1/chats");
+    });
+
+    it("caches per agent — a second agent's cache doesn't bleed into the first", async () => {
+      setChatList("agent-2", [
+        {
+          chatId: "other",
+          sessionId: "s-other",
+          origin: "web",
+          writable: true,
+          title: "Other agent chat",
+          lastInteractionAt: 7_000,
+        },
+      ]);
+      (apiGet as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+      render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+      const menu = await screen.findByRole("menu");
+      // agent-1's cache is empty, so the only row is the optimistic current chat.
+      expect(within(menu).queryByText("Other agent chat")).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -428,7 +428,6 @@ describe("ChatSwitcher", () => {
 
   describe("per-agent chat-list cache (#610)", () => {
     it("seeds the list from the cache so the dropdown isn't empty on reopen", async () => {
-      const user = userEvent.setup();
       // Pre-seed the cache as if a previous mount had fetched this list.
       setChatList("agent-1", [webChat]);
       // A slow/never-resolving fetch so the cached seed is the only data source

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -489,5 +489,20 @@ describe("ChatSwitcher", () => {
       // agent-1's cache is empty, so the only row is the optimistic current chat.
       expect(within(menu).queryByText("Other agent chat")).not.toBeInTheDocument();
     });
+
+    it("shows the cached chat's title in the header trigger, not the agent name", async () => {
+      // webChat.title = "Quarterly report", chatId "chat-abc" — the active chat.
+      setChatList("agent-1", [webChat]);
+      // A never-resolving fetch so the seed is the only data source: proves the
+      // trigger label comes from the cache, synchronously, not from a fetch.
+      (apiGet as ReturnType<typeof vi.fn>).mockReturnValue(new Promise(() => {}));
+
+      render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+      // The header trigger button shows the seeded chat title, never the agent
+      // name — proving the cache seed feeds triggerLabel on first render.
+      expect(await screen.findByRole("button", { name: /Quarterly report/i })).toBeInTheDocument();
+      expect(screen.queryByRole("button", { name: /Smithers/i })).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/components/__tests__/chat-switcher.test.tsx
+++ b/packages/web/src/components/__tests__/chat-switcher.test.tsx
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { render, screen, waitFor, within } from "@testing-library/react";
+import { render, screen, waitFor, within, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { ChatSwitcher } from "@/components/chat-switcher";
@@ -502,6 +502,27 @@ describe("ChatSwitcher", () => {
       // name — proving the cache seed feeds triggerLabel on first render.
       expect(await screen.findByRole("button", { name: /Quarterly report/i })).toBeInTheDocument();
       expect(screen.queryByRole("button", { name: /Smithers/i })).not.toBeInTheDocument();
+    });
+
+    it("keeps the seeded list when a background revalidation fails, instead of flashing empty", async () => {
+      // Warm cache as if a previous mount had loaded this agent's list.
+      setChatList("agent-1", [webChat]);
+      // The mount revalidation fails (transient network / server error).
+      (apiGet as ReturnType<typeof vi.fn>).mockRejectedValue(new Error("boom"));
+
+      render(<ChatSwitcher agentId="agent-1" chatId="chat-abc" agentName="Smithers" />);
+
+      // Let the failed revalidation settle and flush the resulting render.
+      await waitFor(() => expect(apiGet).toHaveBeenCalled());
+      await act(async () => {
+        await new Promise((resolve) => setTimeout(resolve, 0));
+      });
+
+      // The seeded chat survives the failed revalidation — clearing to [] would
+      // reintroduce the empty-flash this cache exists to prevent, replacing the
+      // real title with an optimistic "New chat" row and the agent name.
+      expect(within(screen.getByRole("menu")).getByText("Quarterly report")).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /Quarterly report/i })).toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/components/agent-list.tsx
+++ b/packages/web/src/components/agent-list.tsx
@@ -1,5 +1,8 @@
+"use client";
+
 import Link from "next/link";
 import { getAgentAvatarSvg } from "@/lib/avatar";
+import { prefetchChatList } from "@/lib/chat-list-cache";
 
 export interface Agent {
   id: string;
@@ -36,6 +39,8 @@ export function AgentList({ agents, currentPath, onAgentClick }: AgentListProps)
             <Link
               href={`/chat/${agent.id}`}
               onClick={onAgentClick}
+              onMouseEnter={() => prefetchChatList(agent.id)}
+              onFocus={() => prefetchChatList(agent.id)}
               data-active={isActive ? "true" : undefined}
               className={`flex items-center gap-3 rounded-lg px-3 py-2 transition-colors ${
                 isActive

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -136,9 +136,12 @@ export function ChatSwitcher({
 
   // Re-fetch the chat list on each load. Returns a cleanup-aware fetch so both
   // the mount effect and the open handler can ignore a settled result after the
-  // component unmounts. A failed fetch degrades quietly to the empty state
-  // rather than blocking the header. A successful fetch updates the cache so
-  // the next mount seeds from it.
+  // component unmounts. A successful fetch updates the cache so the next mount
+  // seeds from it. A failed fetch keeps whatever is already shown (the cache
+  // seed or the last good list) rather than clearing to the empty state —
+  // clearing would reintroduce the empty-flash this cache (#610) exists to
+  // prevent whenever a transient revalidation fails. On a cold cache the seed
+  // is already `[]`, so this quietly degrades to the empty state as before.
   const loadChats = useCallback(() => {
     let cancelled = false;
     apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
@@ -148,7 +151,7 @@ export function ChatSwitcher({
         if (!cancelled) setChats(list);
       })
       .catch(() => {
-        if (!cancelled) setChats([]);
+        // Keep the current list; a failed revalidation must not blank it.
       })
       .finally(() => {
         if (!cancelled) setIsLoading(false);

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -15,6 +15,7 @@ import { Button } from "@/components/ui/button";
 import { apiGet } from "@/lib/api-client";
 import type { ChatListItem } from "@/lib/schemas/sessions";
 import { chatTitle } from "@/lib/chats/chat-title";
+import { getChatList, hasChatList, setChatList } from "@/lib/chat-list-cache";
 import { generateChatId } from "@/lib/chats/generate-chat-id";
 import { useChatSessionIsRunning } from "@/components/chat-session-provider";
 import { useRunCompletionEffect } from "@/hooks/use-run-completion-effect";
@@ -127,18 +128,24 @@ export function ChatSwitcher({
   activeTelegram = false,
 }: ChatSwitcherProps) {
   const router = useRouter();
-  const [chats, setChats] = useState<ChatListItem[]>([]);
-  const [isLoading, setIsLoading] = useState(true);
+  // Seed from the per-agent cache (#610) so reopening the switcher for an
+  // agent whose list was just loaded isn't briefly empty. Revalidation happens
+  // in the background via the same fetch below; the cache is the seed only.
+  const [chats, setChats] = useState<ChatListItem[]>(() => getChatList(agentId) ?? []);
+  const [isLoading, setIsLoading] = useState(() => !hasChatList(agentId));
 
   // Re-fetch the chat list on each load. Returns a cleanup-aware fetch so both
   // the mount effect and the open handler can ignore a settled result after the
   // component unmounts. A failed fetch degrades quietly to the empty state
-  // rather than blocking the header.
+  // rather than blocking the header. A successful fetch updates the cache so
+  // the next mount seeds from it.
   const loadChats = useCallback(() => {
     let cancelled = false;
     apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
       .then((res) => {
-        if (!cancelled) setChats(res.chats ?? []);
+        const list = res.chats ?? [];
+        setChatList(agentId, list);
+        if (!cancelled) setChats(list);
       })
       .catch(() => {
         if (!cancelled) setChats([]);

--- a/packages/web/src/lib/chat-list-cache.ts
+++ b/packages/web/src/lib/chat-list-cache.ts
@@ -1,0 +1,41 @@
+import type { ChatListItem } from "@/lib/schemas/sessions";
+
+/**
+ * Module-level per-agent chat-list cache (#610).
+ *
+ * `ChatSwitcher` refetches `/api/agents/[agentId]/chats` on every mount, so
+ * switching agents shows an empty/"Loading your chats…" dropdown briefly each
+ * time — even for an agent whose list was just loaded a moment ago. This cache
+ * lets the switcher seed its initial state from the last successful list and
+ * revalidate in the background (SWR-style): the dropdown is never empty on
+ * re-open, and the existing re-fetch on dropdown-open / run-completion stays
+ * the source of truth.
+ *
+ * The cache holds a shallow copy of the list so callers can't mutate the
+ * cached entries in place. It is per-agent (keyed by `agentId`) and lives for
+ * the lifetime of the page (a navigation that reloads the bundle clears it,
+ * which is fine — the first open then behaves as before).
+ */
+
+const cache = new Map<string, ChatListItem[]>();
+
+/** Whether a cached list for this agent is available (so the UI can skip the loading state). */
+export function hasChatList(agentId: string): boolean {
+  return cache.has(agentId);
+}
+
+/** Returns a shallow copy of the cached list, or `undefined` if none is stored. */
+export function getChatList(agentId: string): ChatListItem[] | undefined {
+  const cached = cache.get(agentId);
+  return cached ? [...cached] : undefined;
+}
+
+/** Stores a shallow copy of the list for this agent. */
+export function setChatList(agentId: string, chats: ChatListItem[]): void {
+  cache.set(agentId, [...chats]);
+}
+
+/** Test-only: clear the cache between unit tests so they don't leak across each other. */
+export function __resetChatListCacheForTests(): void {
+  cache.clear();
+}

--- a/packages/web/src/lib/chat-list-cache.ts
+++ b/packages/web/src/lib/chat-list-cache.ts
@@ -1,4 +1,5 @@
 import type { ChatListItem } from "@/lib/schemas/sessions";
+import { apiGet } from "@/lib/api-client";
 
 /**
  * Module-level per-agent chat-list cache (#610).
@@ -18,6 +19,7 @@ import type { ChatListItem } from "@/lib/schemas/sessions";
  */
 
 const cache = new Map<string, ChatListItem[]>();
+const inFlight = new Set<string>();
 
 /** Whether a cached list for this agent is available (so the UI can skip the loading state). */
 export function hasChatList(agentId: string): boolean {
@@ -35,7 +37,38 @@ export function setChatList(agentId: string, chats: ChatListItem[]): void {
   cache.set(agentId, [...chats]);
 }
 
+/**
+ * Warms the cache for an agent (SWR-style prefetch). Deduplicated: a no-op when
+ * the cache is already warm or a request for this agent is already in flight.
+ * Fire-and-forget for callers; returns a promise so tests can await it. Fetch
+ * failures degrade silently, leaving the cache untouched — the switcher's own
+ * fetch on mount stays the source of truth.
+ */
+export function prefetchChatList(agentId: string): Promise<void> {
+  if (cache.has(agentId) || inFlight.has(agentId)) return Promise.resolve();
+  inFlight.add(agentId);
+  return apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
+    .then((res) => {
+      setChatList(agentId, res.chats ?? []);
+    })
+    .catch(() => {
+      // Silent — a cold cache just means the next open behaves as before.
+    })
+    .finally(() => {
+      inFlight.delete(agentId);
+    });
+}
+
+/**
+ * Drops the cached list for an agent so the next read refetches. Dock point for
+ * a future chat delete/rename that must not show a stale list.
+ */
+export function invalidateChatList(agentId: string): void {
+  cache.delete(agentId);
+}
+
 /** Test-only: clear the cache between unit tests so they don't leak across each other. */
 export function __resetChatListCacheForTests(): void {
   cache.clear();
+  inFlight.clear();
 }

--- a/packages/web/src/lib/chat-list-cache.ts
+++ b/packages/web/src/lib/chat-list-cache.ts
@@ -61,7 +61,8 @@ export function prefetchChatList(agentId: string): Promise<void> {
 
 /**
  * Drops the cached list for an agent so the next read refetches. Dock point for
- * a future chat delete/rename that must not show a stale list.
+ * a future chat delete/rename that must not show a stale list — intentionally
+ * unused until that UI lands, tracked in #689.
  */
 export function invalidateChatList(agentId: string): void {
   cache.delete(agentId);


### PR DESCRIPTION
Closes #610.

## What

`ChatSwitcher` refetches `/api/agents/[agentId]/chats` on every mount, starting from an empty list with `isLoading = true`. So switching agents — or re-opening the switcher — flashes an empty / "Loading your chats…" dropdown briefly each time, even for an agent whose list was just loaded a moment ago. The route also derives a title per labelless chat via an OpenClaw history read, so the list is not instant.

This makes the switcher **flicker-free on every switch** via two layers:

1. A module-level per-agent cache so the switcher seeds its initial state from the last successful list and revalidates in the background (SWR-style). The dropdown is never empty on re-open.
2. A **sidebar prefetch** (hover/focus) that warms the cache *before* the click — so even the **first** switch to an agent is flicker-free, not just re-opens.

## How

- `packages/web/src/lib/chat-list-cache.ts` — a tiny per-agent `Map<agentId, ChatListItem[]>` with `getChatList` / `setChatList` / `hasChatList`. Stores/returns shallow copies so callers can't mutate the cached list.
  - `prefetchChatList(agentId)` — SWR-style warm-up. **Deduplicated**: no-op when the cache is already warm or a request for that agent is in-flight. Fire-and-forget; fetch failures degrade silently (cache untouched — the switcher's own mount fetch stays the source of truth).
  - `invalidateChatList(agentId)` — dock point for a future chat delete/rename that must not show a stale list (intentionally unused today).
- `chat-switcher.tsx` — initial `chats` state seeds from `getChatList(agentId)`; `isLoading` starts true only when there is no cached list. A successful fetch writes to the cache. The existing re-fetch on mount / dropdown-open / run-completion stays the source of truth — the cache is the seed only.
- `agent-list.tsx` — sidebar agent links fire `prefetchChatList(agent.id)` on `onMouseEnter` **and** `onFocus` (the latter for keyboard/a11y navigation). Lives in the persistent layout, outside the `key`-based `<Chat>` remount. On mobile (no hover/focus) it falls back cleanly to plain cache behaviour.

## Design decision: no SWR/TanStack Query

The project uses raw `apiGet` + `useState` + hand-rolled stores (`draft-store`, `last-chat-store`, `chat-session-provider`). Introducing a data-layer dependency + provider for one fetch is disproportionate, and `keepPreviousData` (the one relevant SWR feature) is actually *wrong* here — it would briefly show the previous agent's chats on switch. A per-agent seed cache is more correct. **No TTL / LRU / cross-tab**: the cache is a pure anti-flicker seed; the three existing fetch triggers stay the source of truth, so the displayed list is never older than one round-trip.

## Scope

This is the **cosmetic** switcher-list fix, separate from the "reopens an older chat" correctness bug (fixed in the v0.8.0 chat-staging-fixes PR). The switcher list does not drive navigation.

## Tests

- `chat-list-cache.test.ts` — get/set/has, per-agent isolation, copy-on-read/write; `prefetchChatList` fills cold cache, dedups warm cache, dedups in-flight, degrades on failure, recovers after a failed attempt; `invalidateChatList` clears the entry.
- `agent-list.test.tsx` — hover and focus each trigger a prefetch for the right agent.
- `chat-switcher.test.tsx` — seeds from cache (no loading state, cached chat renders before the fetch settles), still revalidates in the background, per-agent isolation, and the header trigger label comes from the seed (no agent-name flash).
