### PR TITLE
feat(chat): per-agent starter prompts (#570)

### DIFF
--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -36,6 +36,8 @@ The General tab controls the agent's identity and the AI model it uses.
 
 Below the form fields, the tab shows the **agent type** — either "Personal agent" or "Shared agent." Personal agents are private to their owner with isolated memory and conversations. Shared agents are accessible to all team members, and memory from all conversations is shared.
 
+**Starter prompts** are optional clickable suggestion chips shown in an empty chat with this agent. Add one prompt per row (use **Add prompt**) to lower the entry barrier for role-specific agents — for example "Summarize my latest HR tickets" on an HR assistant. Clicking a chip sends that prompt to the agent. Leave the list empty for no chips; the agent's greeting message is always shown regardless.
+
 The **Danger Zone** at the bottom of the General tab lets admins delete shared agents. Personal agents cannot be deleted.
 
 ## Personality tab

--- a/docs/src/content/docs/concepts/agent-settings.mdx
+++ b/docs/src/content/docs/concepts/agent-settings.mdx
@@ -36,7 +36,7 @@ The General tab controls the agent's identity and the AI model it uses.
 
 Below the form fields, the tab shows the **agent type** — either "Personal agent" or "Shared agent." Personal agents are private to their owner with isolated memory and conversations. Shared agents are accessible to all team members, and memory from all conversations is shared.
 
-**Starter prompts** are optional clickable suggestion chips shown in an empty chat with this agent. Add one prompt per row (use **Add prompt**) to lower the entry barrier for role-specific agents — for example "Summarize my latest HR tickets" on an HR assistant. Clicking a chip sends that prompt to the agent. Leave the list empty for no chips; the agent's greeting message is always shown regardless.
+**Starter prompts** are clickable suggestion chips shown in an empty chat with this agent. They lower the entry barrier for role-specific agents — for example "Summarize my latest HR tickets" on an HR assistant. Clicking a chip sends that prompt to the agent. Most templates ship with a few sensible starter prompts already filled in; edit them, add your own with **Add prompt**, or clear the list for no chips. The agent's greeting message is always shown regardless.
 
 The **Danger Zone** at the bottom of the General tab lets admins delete shared agents. Personal agents cannot be deleted.
 

--- a/packages/web/drizzle/0045_black_orphan.sql
+++ b/packages/web/drizzle/0045_black_orphan.sql
@@ -1,0 +1,3 @@
+DROP VIEW "public"."active_agents";--> statement-breakpoint
+ALTER TABLE "agents" ADD COLUMN "starter_prompts" jsonb DEFAULT '[]'::jsonb NOT NULL;--> statement-breakpoint
+CREATE VIEW "public"."active_agents" AS (select "id", "name", "model", "template_id", "plugin_config", "allowed_tools", "skills", "owner_id", "is_personal", "visibility", "greeting_message", "tagline", "starter_prompts", "avatar_seed", "personality_preset_id", "created_at", "deleted_at" from "agents" where "agents"."deleted_at" is null);

--- a/packages/web/drizzle/meta/0045_snapshot.json
+++ b/packages/web/drizzle/meta/0045_snapshot.json
@@ -1,0 +1,2378 @@
+{
+  "id": "41631e33-4b91-4f81-86e2-31847da6ee32",
+  "prevId": "2204bb0d-32cf-4726-8f03-ae273320f0b6",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -316,6 +316,13 @@
       "when": 1782840600485,
       "tag": "0044_aromatic_gamora",
       "breakpoints": true
+    },
+    {
+      "idx": 45,
+      "version": "7",
+      "when": 1783543432121,
+      "tag": "0045_black_orphan",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -281,6 +281,90 @@ describe("PATCH /api/agents/[agentId] audit logging", () => {
     expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
+  it("does not log a starterPrompts change when the content is identical (#570)", async () => {
+    // Regression: starterPrompts is an array. A reference-equality (!==) diff
+    // would flag it as changed on every general-tab save even when the content
+    // is unchanged — audit noise that violates "log what changed".
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockAgent({
+      id: "agent-1",
+      name: "Test Agent",
+      model: "anthropic/claude-sonnet-4-6",
+      isPersonal: false,
+      ownerId: null,
+      starterPrompts: ["Summarize my inbox", "Draft a reply"],
+    });
+
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      id: "agent-1",
+      name: "Test Agent",
+      starterPrompts: ["Summarize my inbox", "Draft a reply"],
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ starterPrompts: ["Summarize my inbox", "Draft a reply"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(appendAuditLog).not.toHaveBeenCalled();
+  });
+
+  it("logs a starterPrompts change with before/after content (#570)", async () => {
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
+      user: { id: "user-1", role: "admin" },
+      expires: "",
+    } as any);
+
+    mockAgent({
+      id: "agent-1",
+      name: "Test Agent",
+      model: "anthropic/claude-sonnet-4-6",
+      isPersonal: false,
+      ownerId: null,
+      starterPrompts: ["Old prompt"],
+    });
+
+    vi.mocked(updateAgent).mockResolvedValueOnce({
+      id: "agent-1",
+      name: "Test Agent",
+      starterPrompts: ["New prompt"],
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify({ starterPrompts: ["New prompt"] }),
+      headers: { "Content-Type": "application/json" },
+    });
+
+    const response = await PATCH(request, {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+    expect(response.status).toBe(200);
+
+    expect(appendAuditLog).toHaveBeenCalledWith({
+      actorType: "user",
+      actorId: "user-1",
+      eventType: "agent.updated",
+      resource: "agent:agent-1",
+      outcome: "success",
+      detail: {
+        changes: {
+          starterPrompts: { from: ["Old prompt"], to: ["New prompt"] },
+        },
+      },
+    });
+  });
+
   it("logs allowedGroups diff when groupIds change", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce({
       user: { id: "user-1", role: "admin" },

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -179,6 +179,7 @@ vi.mock("@/lib/integrations/odoo-template-validation", () => ({
 import { POST } from "@/app/api/agents/route";
 import { NextRequest } from "next/server";
 import { auth } from "@/lib/auth";
+import { AGENT_TEMPLATES } from "@/lib/agent-templates";
 import { validateAllowedPaths } from "@/lib/path-validation";
 import { getDefaultModel } from "@/lib/provider-models";
 import { TemplateCapabilityUnavailableError } from "@/lib/model-resolver";
@@ -305,6 +306,44 @@ describe("POST /api/agents", () => {
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         allowedTools: [],
+      })
+    );
+  });
+
+  it("should seed starterPrompts from the template's defaultStarterPrompts (#570)", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({
+        name: "HR Knowledge Base",
+        templateId: "knowledge-base",
+        pluginConfig: {
+          "pinchy-files": { allowed_paths: ["/data/hr-docs/"] },
+        },
+      }),
+    });
+
+    await POST(request);
+
+    const expected = AGENT_TEMPLATES["knowledge-base"].defaultStarterPrompts;
+    expect(expected, "knowledge-base must define defaultStarterPrompts").toBeDefined();
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        starterPrompts: expected,
+      })
+    );
+  });
+
+  it("seeds an empty starterPrompts array for a template without defaults (custom)", async () => {
+    const request = new NextRequest("http://localhost:7777/api/agents", {
+      method: "POST",
+      body: JSON.stringify({ name: "Blank", templateId: "custom" }),
+    });
+
+    await POST(request);
+
+    expect(insertValuesMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        starterPrompts: [],
       })
     );
   });

--- a/packages/web/src/__tests__/api/agents-patch-validation.test.ts
+++ b/packages/web/src/__tests__/api/agents-patch-validation.test.ts
@@ -449,3 +449,74 @@ describe("PATCH /api/agents/[agentId] — model validation against configured pr
     expect(vi.mocked(fetchProviderModels)).not.toHaveBeenCalled();
   });
 });
+
+describe("PATCH /api/agents/[agentId] — starterPrompts validation (#570)", () => {
+  let PATCH: typeof import("@/app/api/agents/[agentId]/route").PATCH;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/agents/[agentId]/route");
+    PATCH = mod.PATCH;
+  });
+
+  function patchRequest(body: Record<string, unknown>) {
+    return new NextRequest("http://localhost/api/agents/agent-1", {
+      method: "PATCH",
+      body: JSON.stringify(body),
+      headers: { "Content-Type": "application/json" },
+    });
+  }
+
+  it("normalizes starterPrompts (trim, drop blanks, de-duplicate) before persisting", async () => {
+    adminSession();
+    mockAgent({
+      id: "agent-1",
+      name: "Test Agent",
+      model: "m",
+      isPersonal: false,
+      ownerId: null,
+      starterPrompts: [],
+    });
+    vi.mocked(updateAgent).mockResolvedValueOnce({ id: "agent-1", name: "Test Agent" } as never);
+
+    const res = await PATCH(patchRequest({ starterPrompts: ["  Hi ", "Hi", "", "   ", "Bye"] }), {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+
+    expect(res.status).toBe(200);
+    expect(vi.mocked(updateAgent)).toHaveBeenCalledWith(
+      "agent-1",
+      expect.objectContaining({ starterPrompts: ["Hi", "Bye"] })
+    );
+  });
+
+  it("rejects a starter prompt longer than the chip limit with a structured 400", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const res = await PATCH(patchRequest({ starterPrompts: ["x".repeat(101)] }), {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(body.details.fieldErrors.starterPrompts).toBeDefined();
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+
+  it("rejects more starter prompts than the per-agent cap", async () => {
+    adminSession();
+    mockAgent({ id: "agent-1", name: "Test Agent", model: "m", isPersonal: false, ownerId: null });
+
+    const many = Array.from({ length: 11 }, (_, i) => `Prompt ${i}`);
+    const res = await PATCH(patchRequest({ starterPrompts: many }), {
+      params: Promise.resolve({ agentId: "agent-1" }),
+    });
+
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body.error).toBe("Validation failed");
+    expect(vi.mocked(updateAgent)).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -158,7 +158,12 @@ describe("AgentSettingsPage", () => {
     // Simulate general tab reporting dirty
     act(() => {
       capturedOnChangeGeneral?.(
-        { name: "New Name", tagline: "tagline", model: "anthropic/claude-sonnet-4-6" },
+        {
+          name: "New Name",
+          tagline: "tagline",
+          model: "anthropic/claude-sonnet-4-6",
+          starterPrompts: [],
+        },
         true
       );
     });
@@ -222,7 +227,7 @@ describe("AgentSettingsPage", () => {
 
     act(() => {
       capturedOnChangeGeneral?.(
-        { name: "New Name", tagline: "", model: "anthropic/claude-sonnet-4-6" },
+        { name: "New Name", tagline: "", model: "anthropic/claude-sonnet-4-6", starterPrompts: [] },
         true
       );
     });
@@ -241,7 +246,7 @@ describe("AgentSettingsPage", () => {
 
     act(() => {
       capturedOnChangeGeneral?.(
-        { name: "New Name", tagline: "", model: "anthropic/claude-sonnet-4-6" },
+        { name: "New Name", tagline: "", model: "anthropic/claude-sonnet-4-6", starterPrompts: [] },
         true
       );
     });
@@ -270,7 +275,7 @@ describe("AgentSettingsPage", () => {
 
     act(() => {
       capturedOnChangeGeneral?.(
-        { name: "Changed", tagline: "", model: "anthropic/claude-sonnet-4-6" },
+        { name: "Changed", tagline: "", model: "anthropic/claude-sonnet-4-6", starterPrompts: [] },
         true
       );
     });

--- a/packages/web/src/__tests__/components/thread-welcome.test.tsx
+++ b/packages/web/src/__tests__/components/thread-welcome.test.tsx
@@ -10,6 +10,11 @@ vi.mock("@assistant-ui/react", () => ({
     ViewportFooter: ({ children, ...props }: any) => <div {...props}>{children}</div>,
     ScrollToBottom: ({ children }: any) => <div>{children}</div>,
     Suggestions: () => null,
+    Suggestion: ({ children, prompt }: any) => (
+      <button data-testid="starter-prompt" data-prompt={prompt}>
+        {children}
+      </button>
+    ),
   },
   AuiIf: ({ children }: any) => <>{children}</>,
   ComposerPrimitive: {
@@ -85,8 +90,20 @@ vi.mock("@/components/chat", async () => {
   };
 });
 
+// ThreadWelcome reads the agent's starterPrompts via useAgentsContext (#570).
+// Mock it per-test via the returned object's getAgent.
+let mockAgent: { starterPrompts?: string[] } | undefined = undefined;
+vi.mock("@/components/agents-provider", () => ({
+  useAgentsContext: () => ({ getAgent: () => mockAgent }),
+}));
+
 import { ThreadWelcome, STARTUP_MESSAGES } from "@/components/assistant-ui/thread";
 import { ChatStatusContext } from "@/components/chat";
+import { AgentIdContext } from "@/components/chat";
+
+beforeEach(() => {
+  mockAgent = undefined;
+});
 
 describe("ThreadWelcome — loading state (kind=starting)", () => {
   beforeEach(() => {
@@ -164,6 +181,33 @@ describe("ThreadWelcome — ready state (kind=ready)", () => {
       </ChatStatusContext.Provider>
     );
     expect(container).toBeEmptyDOMElement();
+  });
+
+  it("renders starter-prompt chips when the agent has starterPrompts (#570)", () => {
+    mockAgent = { starterPrompts: ["Summarize my latest HR tickets", "Draft a quote for deal X"] };
+    render(
+      <AgentIdContext.Provider value="agent-1">
+        <ChatStatusContext.Provider value={{ kind: "ready" }}>
+          <ThreadWelcome />
+        </ChatStatusContext.Provider>
+      </AgentIdContext.Provider>
+    );
+    const chips = screen.getAllByTestId("starter-prompt");
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveTextContent("Summarize my latest HR tickets");
+    expect(chips[1]).toHaveTextContent("Draft a quote for deal X");
+  });
+
+  it("ignores blank starter prompts (#570)", () => {
+    mockAgent = { starterPrompts: ["Summarize my latest HR tickets", "   ", ""] };
+    render(
+      <AgentIdContext.Provider value="agent-1">
+        <ChatStatusContext.Provider value={{ kind: "ready" }}>
+          <ThreadWelcome />
+        </ChatStatusContext.Provider>
+      </AgentIdContext.Provider>
+    );
+    expect(screen.getAllByTestId("starter-prompt")).toHaveLength(1);
   });
 });
 

--- a/packages/web/src/__tests__/components/thread-welcome.test.tsx
+++ b/packages/web/src/__tests__/components/thread-welcome.test.tsx
@@ -209,6 +209,25 @@ describe("ThreadWelcome — ready state (kind=ready)", () => {
     );
     expect(screen.getAllByTestId("starter-prompt")).toHaveLength(1);
   });
+
+  it("de-duplicates identical prompts so React keys stay unique (#570)", () => {
+    // Pre-existing agents may hold duplicate prompts written before dedup
+    // landed; rendering them raw would collide on key={prompt}.
+    mockAgent = {
+      starterPrompts: ["Summarize my inbox", "Summarize my inbox", "  Draft a reply "],
+    };
+    render(
+      <AgentIdContext.Provider value="agent-1">
+        <ChatStatusContext.Provider value={{ kind: "ready" }}>
+          <ThreadWelcome />
+        </ChatStatusContext.Provider>
+      </AgentIdContext.Provider>
+    );
+    const chips = screen.getAllByTestId("starter-prompt");
+    expect(chips).toHaveLength(2);
+    expect(chips[0]).toHaveTextContent("Summarize my inbox");
+    expect(chips[1]).toHaveTextContent("Draft a reply");
+  });
 });
 
 describe("ThreadWelcome — disconnected state (kind=unavailable, reason=disconnected)", () => {

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/agent-templates";
 import { MODEL_CATEGORIES } from "@/lib/integrations/odoo-sync";
 import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
+import { MAX_STARTER_PROMPT_LENGTH } from "@/lib/schemas/starter-prompts";
 import { TEMPLATE_ICON_COMPONENTS } from "@/lib/template-icons";
 import { getOdooToolsForAccessLevel } from "@/lib/tool-registry";
 
@@ -1666,7 +1667,7 @@ describe("defaultStarterPrompts (per-agent starter prompts, #570)", () => {
   // ship per-assistant conversation starters. `custom` is the deliberate
   // exception: a blank agent has no role to suggest prompts for.
   const MAX_PROMPTS = 4; // hard display ceiling; see research in PR #620
-  const MAX_PROMPT_LENGTH = 100; // chips must stay on one or two short lines
+  const MAX_PROMPT_LENGTH = MAX_STARTER_PROMPT_LENGTH; // chips must stay on one or two short lines
 
   it("every non-custom template ships 3-4 defaultStarterPrompts", () => {
     const offenders: Array<{ id: string; count: number }> = [];

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -1657,3 +1657,86 @@ describe("MODEL_CATEGORIES — accounting category covers fiscal positions", () 
     expect(accounting!.models.some((m) => m.model === "account.fiscal.position")).toBe(true);
   });
 });
+
+describe("defaultStarterPrompts (per-agent starter prompts, #570)", () => {
+  // Starter prompts seed the clickable suggestion chips shown in the empty
+  // chat (thread.tsx ThreadWelcome). Every role-specific template ships a
+  // small, curated set so a brand-new user is never staring at an empty
+  // composer — matching how Custom GPTs, Gemini Gems, and Copilot Studio all
+  // ship per-assistant conversation starters. `custom` is the deliberate
+  // exception: a blank agent has no role to suggest prompts for.
+  const MAX_PROMPTS = 4; // hard display ceiling; see research in PR #620
+  const MAX_PROMPT_LENGTH = 100; // chips must stay on one or two short lines
+
+  it("every non-custom template ships 3-4 defaultStarterPrompts", () => {
+    const offenders: Array<{ id: string; count: number }> = [];
+    for (const [id, tpl] of Object.entries(AGENT_TEMPLATES)) {
+      if (id === "custom") continue;
+      const prompts = tpl.defaultStarterPrompts;
+      if (!prompts || prompts.length < 3 || prompts.length > MAX_PROMPTS) {
+        offenders.push({ id, count: prompts?.length ?? 0 });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("custom template has no defaultStarterPrompts (blank agent, no role to suggest for)", () => {
+    expect(AGENT_TEMPLATES["custom"].defaultStarterPrompts).toBeUndefined();
+  });
+
+  it("every starter prompt is non-empty, trimmed, and short enough for a chip", () => {
+    const offenders: Array<{ id: string; prompt: string; reason: string }> = [];
+    for (const [id, tpl] of Object.entries(AGENT_TEMPLATES)) {
+      for (const prompt of tpl.defaultStarterPrompts ?? []) {
+        if (prompt.trim().length === 0) offenders.push({ id, prompt, reason: "empty" });
+        else if (prompt !== prompt.trim()) offenders.push({ id, prompt, reason: "untrimmed" });
+        else if (prompt.length > MAX_PROMPT_LENGTH)
+          offenders.push({ id, prompt, reason: `over ${MAX_PROMPT_LENGTH} chars` });
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("starter prompts are unique within each template", () => {
+    const offenders: Array<{ id: string }> = [];
+    for (const [id, tpl] of Object.entries(AGENT_TEMPLATES)) {
+      const prompts = tpl.defaultStarterPrompts ?? [];
+      if (new Set(prompts).size !== prompts.length) offenders.push({ id });
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it("createOdooTemplate passes defaultStarterPrompts through verbatim", () => {
+    const prompts = ["Show me revenue by month", "Who are our top customers?"];
+    const t = createOdooTemplate({
+      iconName: "TrendingUp",
+      name: "Test Analyst",
+      description: "Analyze things",
+      defaultPersonality: "the-pilot",
+      defaultTagline: "Analyze things",
+      suggestedNames: ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+      defaultGreetingMessage: "Hi. Let's analyze.",
+      defaultAgentsMd: "## Your Role\nTest role.",
+      defaultStarterPrompts: prompts,
+      requiredModels: [{ model: "sale.order", operations: ["read"] }],
+    });
+    expect(t.defaultStarterPrompts).toEqual(prompts);
+  });
+
+  it("createOdooTemplate omits defaultStarterPrompts when the spec has none", () => {
+    // Additive field: an Odoo spec that doesn't set starter prompts must not
+    // gain an empty array — keeps the "undefined ⟹ no chips" invariant clean.
+    const t = createOdooTemplate({
+      iconName: "TrendingUp",
+      name: "Test Analyst",
+      description: "Analyze things",
+      defaultPersonality: "the-pilot",
+      defaultTagline: "Analyze things",
+      suggestedNames: ["Alpha", "Beta", "Gamma", "Delta", "Epsilon"],
+      defaultGreetingMessage: "Hi. Let's analyze.",
+      defaultAgentsMd: "## Your Role\nTest role.",
+      requiredModels: [{ model: "sale.order", operations: ["read"] }],
+    });
+    expect(t.defaultStarterPrompts).toBeUndefined();
+  });
+});

--- a/packages/web/src/__tests__/lib/starter-prompts.test.ts
+++ b/packages/web/src/__tests__/lib/starter-prompts.test.ts
@@ -1,0 +1,47 @@
+import { describe, it, expect } from "vitest";
+import {
+  normalizeStarterPrompts,
+  starterPromptsSchema,
+  MAX_STARTER_PROMPTS,
+  MAX_STARTER_PROMPT_LENGTH,
+} from "@/lib/schemas/starter-prompts";
+
+describe("normalizeStarterPrompts", () => {
+  it("trims, drops blanks, and de-duplicates while preserving first-seen order", () => {
+    expect(normalizeStarterPrompts(["  Hello ", "Hello", "", "   ", "World"])).toEqual([
+      "Hello",
+      "World",
+    ]);
+  });
+
+  it("returns an empty array for an all-blank list", () => {
+    expect(normalizeStarterPrompts(["", "   ", "\t"])).toEqual([]);
+  });
+
+  it("collapses exact duplicates to a single entry (prevents duplicate React keys)", () => {
+    expect(normalizeStarterPrompts(["Summarize my inbox", "Summarize my inbox"])).toEqual([
+      "Summarize my inbox",
+    ]);
+  });
+});
+
+describe("starterPromptsSchema", () => {
+  it("normalizes valid input", () => {
+    expect(starterPromptsSchema.parse([" a ", "a", "b"])).toEqual(["a", "b"]);
+  });
+
+  it("rejects a prompt longer than MAX_STARTER_PROMPT_LENGTH", () => {
+    const long = "x".repeat(MAX_STARTER_PROMPT_LENGTH + 1);
+    expect(() => starterPromptsSchema.parse([long])).toThrow();
+  });
+
+  it("accepts a prompt exactly at MAX_STARTER_PROMPT_LENGTH", () => {
+    const exact = "x".repeat(MAX_STARTER_PROMPT_LENGTH);
+    expect(starterPromptsSchema.parse([exact])).toEqual([exact]);
+  });
+
+  it("rejects more than MAX_STARTER_PROMPTS entries", () => {
+    const many = Array.from({ length: MAX_STARTER_PROMPTS + 1 }, (_, i) => `p${i}`);
+    expect(() => starterPromptsSchema.parse(many)).toThrow();
+  });
+});

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -18,6 +18,7 @@ import { validatePinchyWebConfig, pluginConfigSchema } from "@/lib/domain-valida
 import { parseRequestBody } from "@/lib/api-validation";
 import { validateAgentModel } from "@/lib/agent-model-validation";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+import { starterPromptsSchema } from "@/lib/schemas/starter-prompts";
 
 const updateAgentSchema = z.object({
   name: z
@@ -31,7 +32,7 @@ const updateAgentSchema = z.object({
   pluginConfig: pluginConfigSchema.nullable().optional(),
   greetingMessage: z.string().min(1, "Greeting message cannot be empty").optional(),
   tagline: z.string().nullable().optional(),
-  starterPrompts: z.array(z.string()).optional(),
+  starterPrompts: starterPromptsSchema.optional(),
   avatarSeed: z.string().nullable().optional(),
   personalityPresetId: z.string().nullable().optional(),
   visibility: z.enum(AGENT_VISIBILITIES).optional(),
@@ -160,7 +161,6 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     "visibility",
     "greetingMessage",
     "tagline",
-    "starterPrompts",
     "avatarSeed",
     "personalityPresetId",
   ] as const;
@@ -173,6 +173,14 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     const oldTools = existingAgent.allowedTools ?? [];
     if (JSON.stringify(oldTools) !== JSON.stringify(data.allowedTools)) {
       changes.allowedTools = { from: oldTools, to: data.allowedTools };
+    }
+  }
+  // starterPrompts is an array — compare by content, not reference, or a
+  // general-tab save would log a spurious "change" every time (#570).
+  if (data.starterPrompts !== undefined) {
+    const oldPrompts = existingAgent.starterPrompts ?? [];
+    if (JSON.stringify(oldPrompts) !== JSON.stringify(data.starterPrompts)) {
+      changes.starterPrompts = { from: oldPrompts, to: data.starterPrompts };
     }
   }
   if (data.pluginConfig !== undefined) {

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -31,6 +31,7 @@ const updateAgentSchema = z.object({
   pluginConfig: pluginConfigSchema.nullable().optional(),
   greetingMessage: z.string().min(1, "Greeting message cannot be empty").optional(),
   tagline: z.string().nullable().optional(),
+  starterPrompts: z.array(z.string()).optional(),
   avatarSeed: z.string().nullable().optional(),
   personalityPresetId: z.string().nullable().optional(),
   visibility: z.enum(AGENT_VISIBILITIES).optional(),
@@ -133,6 +134,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     pluginConfig?: AgentPluginConfig | null;
     greetingMessage?: string;
     tagline?: string | null;
+    starterPrompts?: string[];
     avatarSeed?: string | null;
     personalityPresetId?: string | null;
     visibility?: AgentVisibility;
@@ -143,6 +145,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
   if (body.pluginConfig !== undefined) data.pluginConfig = body.pluginConfig;
   if (body.greetingMessage !== undefined) data.greetingMessage = body.greetingMessage;
   if (body.tagline !== undefined) data.tagline = body.tagline;
+  if (body.starterPrompts !== undefined) data.starterPrompts = body.starterPrompts;
   if (body.avatarSeed !== undefined) data.avatarSeed = body.avatarSeed;
   if (body.personalityPresetId !== undefined) data.personalityPresetId = body.personalityPresetId;
   if (body.visibility !== undefined) data.visibility = body.visibility;
@@ -157,6 +160,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     "visibility",
     "greetingMessage",
     "tagline",
+    "starterPrompts",
     "avatarSeed",
     "personalityPresetId",
   ] as const;

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -173,6 +173,9 @@ export const POST = withAdmin(async (request, _ctx, session) => {
       ownerId: session.user.id,
       allowedTools: mergedAllowedTools,
       skills: templateSkills,
+      // Seed the empty-chat starter chips from the template (#570). Templates
+      // without a curated set (e.g. custom) fall back to [] — no chips.
+      starterPrompts: template.defaultStarterPrompts ?? [],
       tagline: tagline || template.defaultTagline || null,
       avatarSeed: generateAvatarSeed(),
       personalityPresetId: template.defaultPersonality,

--- a/packages/web/src/components/agent-list.tsx
+++ b/packages/web/src/components/agent-list.tsx
@@ -7,6 +7,7 @@ export interface Agent {
   model: string;
   isPersonal: boolean;
   tagline: string | null;
+  starterPrompts: string[];
   avatarSeed: string | null;
 }
 

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -1,10 +1,11 @@
 "use client";
 
-import { useEffect, useMemo } from "react";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { useForm, useWatch } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { Input } from "@/components/ui/input";
+import { Button } from "@/components/ui/button";
 import {
   Form,
   FormControl,
@@ -13,7 +14,7 @@ import {
   FormLabel,
   FormMessage,
 } from "@/components/ui/form";
-import { AlertTriangle } from "lucide-react";
+import { AlertTriangle, Plus, X } from "lucide-react";
 import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { DeleteAgentDialog } from "@/components/delete-agent-dialog";
 import { ModelPicker } from "@/components/model-picker";
@@ -34,8 +35,18 @@ const agentSettingsSchema = z.object({
 
 type AgentSettingsValues = z.infer<typeof agentSettingsSchema>;
 
+/** Values emitted to the parent on change. Adds starterPrompts (local state) to the form fields. */
+export type GeneralChangeValues = AgentSettingsValues & { starterPrompts: string[] };
+
 interface AgentSettingsGeneralProps {
-  agent: { id: string; name: string; model: string; isPersonal?: boolean; tagline?: string | null };
+  agent: {
+    id: string;
+    name: string;
+    model: string;
+    isPersonal?: boolean;
+    tagline?: string | null;
+    starterPrompts?: string[];
+  };
   providers: Array<{
     id: string;
     name: string;
@@ -47,7 +58,7 @@ interface AgentSettingsGeneralProps {
     }>;
   }>;
   canDelete?: boolean;
-  onChange: (values: AgentSettingsValues, isDirty: boolean) => void;
+  onChange: (values: GeneralChangeValues, isDirty: boolean) => void;
 }
 
 export function AgentSettingsGeneral({
@@ -64,6 +75,15 @@ export function AgentSettingsGeneral({
       model: agent.model,
     },
   });
+
+  // Starter prompts are managed as local state (a repeatable text list) rather
+  // than a react-hook-form field array — keeps the form schema focused on the
+  // validated scalars and avoids a FieldArray typing mismatch with the
+  // zodResolver generic. The onChange effect below merges them into the values
+  // the parent saves.
+  const initialPrompts = agent.starterPrompts ?? [];
+  const [starterPrompts, setStarterPrompts] = useState<string[]>(initialPrompts);
+  const initialPromptsRef = useRef(initialPrompts);
 
   const values = useWatch({ control: form.control });
 
@@ -93,12 +113,14 @@ export function AgentSettingsGeneral({
         name: values.name ?? "",
         tagline: values.tagline ?? "",
         model: values.model ?? "",
+        starterPrompts,
       },
-      form.formState.isDirty
+      form.formState.isDirty ||
+        JSON.stringify(starterPrompts) !== JSON.stringify(initialPromptsRef.current)
     );
     // onChange must be stable (useCallback in parent) to avoid loops
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [values, form.formState.isDirty]);
+  }, [values, form.formState.isDirty, starterPrompts]);
 
   useEffect(() => {
     if (typeof window !== "undefined" && window.location.hash === "#model") {
@@ -165,6 +187,50 @@ export function AgentSettingsGeneral({
               </FormItem>
             )}
           />
+
+          {/* Starter prompts (#570) — clickable chips in the empty chat. */}
+          <FormItem>
+            <FormLabel>Starter prompts</FormLabel>
+            <p className="text-sm text-muted-foreground">
+              Shown as clickable suggestions in an empty chat to help users start a conversation
+              with this agent.
+            </p>
+            <div className="space-y-2">
+              {starterPrompts.map((prompt, index) => (
+                <div key={index} className="flex items-center gap-2">
+                  <Input
+                    value={prompt}
+                    onChange={(e) =>
+                      setStarterPrompts((prev) =>
+                        prev.map((p, i) => (i === index ? e.target.value : p))
+                      )
+                    }
+                    placeholder="e.g. Summarize my latest HR tickets"
+                    maxLength={500}
+                  />
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="icon"
+                    className="shrink-0"
+                    onClick={() => setStarterPrompts((prev) => prev.filter((_, i) => i !== index))}
+                    aria-label={`Remove starter prompt ${index + 1}`}
+                  >
+                    <X className="size-4" />
+                  </Button>
+                </div>
+              ))}
+              <Button
+                type="button"
+                variant="outline"
+                size="sm"
+                onClick={() => setStarterPrompts((prev) => [...prev, ""])}
+              >
+                <Plus className="mr-1 size-4" />
+                Add prompt
+              </Button>
+            </div>
+          </FormItem>
         </form>
       </Form>
 

--- a/packages/web/src/components/agent-settings-general.tsx
+++ b/packages/web/src/components/agent-settings-general.tsx
@@ -19,6 +19,7 @@ import { Alert, AlertDescription, AlertTitle } from "@/components/ui/alert";
 import { DeleteAgentDialog } from "@/components/delete-agent-dialog";
 import { ModelPicker } from "@/components/model-picker";
 import { useModelCapabilities } from "@/hooks/use-model-capabilities";
+import { MAX_STARTER_PROMPTS, MAX_STARTER_PROMPT_LENGTH } from "@/lib/schemas/starter-prompts";
 import { attachCapabilities } from "@/lib/model-capabilities/attach-capabilities";
 import { getAgentModelBlockReason, markToolBlockedModels } from "@/lib/model-resolver/blocklist";
 
@@ -206,7 +207,7 @@ export function AgentSettingsGeneral({
                       )
                     }
                     placeholder="e.g. Summarize my latest HR tickets"
-                    maxLength={500}
+                    maxLength={MAX_STARTER_PROMPT_LENGTH}
                   />
                   <Button
                     type="button"
@@ -224,6 +225,7 @@ export function AgentSettingsGeneral({
                 type="button"
                 variant="outline"
                 size="sm"
+                disabled={starterPrompts.length >= MAX_STARTER_PROMPTS}
                 onClick={() => setStarterPrompts((prev) => [...prev, ""])}
               >
                 <Plus className="mr-1 size-4" />

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -26,6 +26,7 @@ import { AgentSettingsAccess } from "@/components/agent-settings-access";
 import { AgentSettingsDiagnostics } from "@/components/agent-settings-diagnostics";
 import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
 import { useRestart } from "@/components/restart-provider";
+import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
 import type { AgentPluginConfig } from "@/db/schema";
 
 interface Agent {
@@ -275,10 +276,10 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
         agentPatch.name = generalDraft.current.name;
         agentPatch.tagline = generalDraft.current.tagline;
         agentPatch.model = generalDraft.current.model;
-        // Drop blank entries so empty "Add prompt" rows don't persist.
-        agentPatch.starterPrompts = (generalDraft.current.starterPrompts ?? [])
-          .map((p) => p.trim())
-          .filter((p) => p.length > 0);
+        // Trim, drop blank "Add prompt" rows, and de-duplicate before saving.
+        agentPatch.starterPrompts = normalizeStarterPrompts(
+          generalDraft.current.starterPrompts ?? []
+        );
       }
       if (dirtyTabs.has("personality") && personalityDraft.current) {
         agentPatch.avatarSeed = personalityDraft.current.avatarSeed;

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -36,6 +36,7 @@ interface Agent {
   allowedTools: string[];
   pluginConfig: AgentPluginConfig | null;
   tagline: string | null;
+  starterPrompts: string[];
   avatarSeed: string | null;
   personalityPresetId: string | null;
   visibility: string;
@@ -65,6 +66,7 @@ interface GeneralValues {
   name: string;
   tagline: string;
   model: string;
+  starterPrompts: string[];
 }
 
 interface PersonalityValues {
@@ -273,6 +275,10 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
         agentPatch.name = generalDraft.current.name;
         agentPatch.tagline = generalDraft.current.tagline;
         agentPatch.model = generalDraft.current.model;
+        // Drop blank entries so empty "Add prompt" rows don't persist.
+        agentPatch.starterPrompts = (generalDraft.current.starterPrompts ?? [])
+          .map((p) => p.trim())
+          .filter((p) => p.length > 0);
       }
       if (dirtyTabs.has("personality") && personalityDraft.current) {
         agentPatch.avatarSeed = personalityDraft.current.avatarSeed;

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -53,6 +53,7 @@ import {
 } from "@/components/chat";
 import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
 import { useAgentsContext } from "@/components/agents-provider";
+import { normalizeStarterPrompts } from "@/lib/schemas/starter-prompts";
 import { Progress } from "@/components/ui/progress";
 import type { PendingUpload } from "@/hooks/use-ws-runtime";
 import { RetryButton } from "@/components/chat/retry-button";
@@ -160,7 +161,9 @@ export const ThreadWelcome: FC = () => {
   const agentId = useContext(AgentIdContext);
   const { getAgent } = useAgentsContext();
   const agent = agentId ? getAgent(agentId) : undefined;
-  const starterPrompts = (agent?.starterPrompts ?? []).filter((p) => p.trim().length > 0);
+  // Normalize (trim, drop blanks, de-duplicate) so `key={prompt}` chips never
+  // collide — including for agents whose rows predate save-side dedup (#570).
+  const starterPrompts = normalizeStarterPrompts(agent?.starterPrompts ?? []);
   const [messageIndex, setMessageIndex] = useState(0);
   const indexRef = useRef(0);
 
@@ -200,7 +203,7 @@ export const ThreadWelcome: FC = () => {
               key={prompt}
               prompt={prompt}
               send
-              className="rounded-full border px-4 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+              className="max-w-full rounded-2xl border px-4 py-1.5 text-sm break-words text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
             >
               {prompt}
             </ThreadPrimitive.Suggestion>

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -52,6 +52,7 @@ import {
   RetryPendingUploadContext,
 } from "@/components/chat";
 import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
+import { useAgentsContext } from "@/components/agents-provider";
 import { Progress } from "@/components/ui/progress";
 import type { PendingUpload } from "@/hooks/use-ws-runtime";
 import { RetryButton } from "@/components/chat/retry-button";
@@ -156,6 +157,10 @@ const ROTATION_INTERVAL_MS = 3000;
 
 export const ThreadWelcome: FC = () => {
   const chatStatus = useContext(ChatStatusContext);
+  const agentId = useContext(AgentIdContext);
+  const { getAgent } = useAgentsContext();
+  const agent = agentId ? getAgent(agentId) : undefined;
+  const starterPrompts = (agent?.starterPrompts ?? []).filter((p) => p.trim().length > 0);
   const [messageIndex, setMessageIndex] = useState(0);
   const indexRef = useRef(0);
 
@@ -180,12 +185,29 @@ export const ThreadWelcome: FC = () => {
   }, [isStarting]);
 
   if (chatStatus.kind === "ready" || chatStatus.kind === "responding") {
-    // Render nothing in the ready/responding empty-thread state. Every agent
-    // has a greetingMessage at the schema level, so the server always sends
-    // an opening assistant bubble — that's the welcome. A second hardcoded
-    // "How can I help you today?" would be redundant and, worse, would flash
-    // briefly during the React-state ↔ assistant-ui store sync window.
-    return null;
+    // Every agent has a greetingMessage at the schema level, so the server
+    // always sends an opening assistant bubble — that's the welcome. A second
+    // hardcoded "How can I help you today?" would be redundant and would flash
+    // briefly during the React-state ↔ assistant-ui store sync window. So we
+    // only render the per-agent starter prompts (#570) as clickable chips when
+    // configured; with none set, this stays null as before.
+    if (starterPrompts.length === 0) return null;
+    return (
+      <div className="aui-thread-welcome-root mx-auto my-auto flex w-full max-w-(--thread-max-width) grow flex-col items-center justify-center gap-4">
+        <div className="flex flex-wrap items-center justify-center gap-2 px-4">
+          {starterPrompts.map((prompt) => (
+            <ThreadPrimitive.Suggestion
+              key={prompt}
+              prompt={prompt}
+              send
+              className="rounded-full border px-4 py-1.5 text-sm text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
+            >
+              {prompt}
+            </ThreadPrimitive.Suggestion>
+          ))}
+        </div>
+      </div>
+    );
   }
 
   if (chatStatus.kind === "payloadRejected") {

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -173,6 +173,10 @@ export const agents = pgTable(
     visibility: text("visibility").$type<AgentVisibility>().notNull().default("restricted"),
     greetingMessage: text("greeting_message").notNull(),
     tagline: text("tagline"),
+    // Per-agent starter prompts (#570): clickable suggestion chips shown in
+    // the empty chat to lower the entry barrier for role-specific agents.
+    // Empty array = no chips (the default).
+    starterPrompts: jsonb("starter_prompts").$type<string[]>().notNull().default([]),
     avatarSeed: text("avatar_seed"),
     personalityPresetId: text("personality_preset_id"),
     createdAt: timestamp("created_at").notNull().defaultNow(),

--- a/packages/web/src/lib/agent-templates/data/document-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/document-agents.ts
@@ -10,6 +10,11 @@ export const DOCUMENT_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-professor",
     defaultTagline: "Review contracts, extract key terms, and flag risks",
     suggestedNames: ["Lex", "Clara", "Parker", "Quinn", "Harper", "Atticus"],
+    defaultStarterPrompts: [
+      "What are the termination clauses in this contract?",
+      "Compare the liability terms across these agreements",
+      "Flag any unusual or risky clauses",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your contract analyst. I can review contracts, extract key clauses, compare terms across documents, and flag potential risks. Try asking: "What are the termination clauses in this contract?" or "Compare the liability terms across these agreements."',
     defaultAgentsMd: `You are a contract analysis agent. Your job is to review contracts and legal documents, extract key terms, and identify potential risks.
@@ -33,6 +38,11 @@ export const DOCUMENT_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-pilot",
     defaultTagline: "Screen applications, rank candidates, and summarize qualifications",
     suggestedNames: ["Scout", "Riley", "Piper", "Tara", "Blake", "Jordan"],
+    defaultStarterPrompts: [
+      "Rank these applicants by relevant experience",
+      "Which candidates have Python and cloud experience?",
+      "Summarize each candidate's strengths and gaps",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your recruiting assistant. I can screen resumes, compare candidate qualifications, and create shortlists. Try asking: "Rank these applicants by relevant experience" or "Which candidates have Python and cloud experience?"',
     defaultAgentsMd: `You are a resume screening agent. Your job is to review job applications and resumes, evaluate candidate qualifications, and help with hiring decisions.
@@ -57,6 +67,11 @@ export const DOCUMENT_TEMPLATES: Record<string, AgentTemplate> = {
     defaultTagline:
       "Compare vendor proposals, score against requirements, and summarize differences",
     suggestedNames: ["Maven", "Dexter", "Audrey", "Spencer", "Hazel", "Brooks"],
+    defaultStarterPrompts: [
+      "Compare pricing across these three proposals",
+      "Which vendor best meets our technical requirements?",
+      "Summarize the key differences in a table",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your proposal analyst. I can compare vendor proposals side by side, score them against your requirements, and highlight key differences. Try asking: "Compare pricing across these three proposals" or "Which vendor best meets our technical requirements?"',
     defaultAgentsMd: `You are a proposal comparison agent. Your job is to analyze vendor proposals, RFP responses, and quotes, then compare them objectively.
@@ -81,6 +96,11 @@ export const DOCUMENT_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-professor",
     defaultTagline: "Check documents against regulations, flag gaps, and track requirements",
     suggestedNames: ["Marshall", "Vera", "Sentinel", "Audra", "Knox", "Reggie"],
+    defaultStarterPrompts: [
+      "Does our privacy policy meet GDPR requirements?",
+      "What are the gaps in our SOC 2 documentation?",
+      "List the critical findings by severity",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your compliance analyst. I can review your documents against regulatory requirements, identify gaps, and track compliance status. Try asking: "Does our privacy policy meet GDPR requirements?" or "What are the gaps in our SOC 2 documentation?"',
     defaultAgentsMd: `You are a compliance checking agent. Your job is to review internal documents against regulatory requirements, standards, and policies to identify gaps and violations.
@@ -104,6 +124,11 @@ export const DOCUMENT_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-coach",
     defaultTagline: "Guide new team members through internal docs, processes, and procedures",
     suggestedNames: ["Buddy", "Ori", "Compass", "Robin", "Guides", "Sherpa"],
+    defaultStarterPrompts: [
+      "How do I request time off?",
+      "What's the process for submitting expenses?",
+      "Where do I find our internal wiki?",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your onboarding assistant. I can help you navigate internal documentation, find processes and procedures, and answer questions about how things work here. Try asking: "How do I request time off?" or "What\'s the process for submitting expenses?"',
     defaultAgentsMd: `You are an onboarding guide agent. Your job is to help new employees and team members navigate internal documentation, understand processes, and find answers to common questions.

--- a/packages/web/src/lib/agent-templates/data/email-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/email-agents.ts
@@ -21,6 +21,11 @@ export const EMAIL_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-butler",
     defaultTagline: "Read, search, and draft emails from your inbox",
     suggestedNames: ["Hermes", "Iris", "Scout", "Penny", "Courier", "Wren", "Felix"],
+    defaultStarterPrompts: [
+      "Summarize my unread emails from this week",
+      "Find the latest email about the budget",
+      "Draft a reply to this message",
+    ],
     defaultGreetingMessage:
       "Good day, {user}. I'm {name}, your email assistant. I can search your inbox, read messages, and draft replies on your behalf. What would you like me to do with your email today?",
     // Persona-only AGENTS.md. Workflow guidance for the email tools lives in
@@ -51,6 +56,11 @@ You are an email assistant with read and draft access to a connected mailbox. Yo
     defaultPersonality: "the-pilot",
     defaultTagline: "Track leads, draft outreach, and follow up on sales conversations",
     suggestedNames: ["Rex", "Ace", "Chase", "Dash", "Max", "Rio", "Hunter"],
+    defaultStarterPrompts: [
+      "Show me leads I haven't replied to yet",
+      "Draft a follow-up to a warm prospect",
+      "Summarize my open sales threads",
+    ],
     defaultGreetingMessage:
       "Ready when you are, {user}. I'm {name}. I can track your sales conversations, surface unanswered leads, and draft sharp outreach emails. What's on the pipeline today?",
     defaultAgentsMd: `## Your Role
@@ -84,6 +94,11 @@ You are a sales email assistant. You help sales professionals stay on top of the
     defaultPersonality: "the-coach",
     defaultTagline: "Triage support requests and draft helpful customer responses",
     suggestedNames: ["Joy", "Sam", "Kit", "Casey", "Sunny", "Robin", "Quinn"],
+    defaultStarterPrompts: [
+      "Triage the support requests in my inbox",
+      "Find related threads for this customer",
+      "Draft an empathetic reply to this ticket",
+    ],
     defaultGreetingMessage:
       "Hi {user}! I'm {name}, your support email assistant. I can help you triage incoming requests, find related threads, and draft empathetic responses. What does the queue look like today?",
     defaultAgentsMd: `## Your Role

--- a/packages/web/src/lib/agent-templates/data/knowledge-base.ts
+++ b/packages/web/src/lib/agent-templates/data/knowledge-base.ts
@@ -10,6 +10,11 @@ export const KNOWLEDGE_BASE_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-professor",
     defaultTagline: "Answer questions from your docs",
     suggestedNames: ["Ada", "Sage", "Atlas", "Navi", "Iris", "Archie", "Luna", "Cleo"],
+    defaultStarterPrompts: [
+      "Summarize the main points of this document",
+      "What does our policy say about data retention?",
+      "Which documents cover onboarding?",
+    ],
     defaultAgentsMd: `You are a knowledge base agent. Your job is to answer questions using the documents available to you.
 
 ## Instructions

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -16,6 +16,11 @@ export const ODOO_TEMPLATES: Record<string, AgentTemplate> = {
     defaultPersonality: "the-pilot",
     defaultTagline: "Analyze revenue, track orders, identify trends and top customers",
     suggestedNames: ["Dash", "Sterling", "Margin", "Rex", "Tally", "Victor"],
+    defaultStarterPrompts: [
+      "Show me revenue by month",
+      "Who are our top 10 customers?",
+      "Which products have the best margin?",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your sales analyst. I can analyze revenue trends, track orders, and identify your top customers. Try asking: "Show me revenue by month" or "Who are our top 10 customers?"',
     defaultAgentsMd: `## Your Role
@@ -78,6 +83,11 @@ ${ODOO_RULES}`,
     defaultPersonality: "the-pilot",
     defaultTagline: "Monitor stock levels, track movements, measure fulfillment speed",
     suggestedNames: ["Scout", "Tracker", "Depot", "Reese", "Tally", "Sage"],
+    defaultStarterPrompts: [
+      "Which products are low on stock?",
+      "Show me all open deliveries",
+      "What stock do we have by category?",
+    ],
     defaultGreetingMessage:
       'Hey {user}. I\'m {name}. I monitor your stock levels, track inventory movements, and flag anomalies. Try asking: "Which products are low on stock?" or "Show me all open deliveries."',
     defaultAgentsMd: `## Your Role
@@ -133,6 +143,11 @@ ${ODOO_RULES}`,
     defaultPersonality: "the-pilot",
     defaultTagline: "Receive goods, confirm pickings, run inventory adjustments, move stock",
     suggestedNames: ["Boone", "Otis", "Quint", "Marlow", "Wells", "Garrett"],
+    defaultStarterPrompts: [
+      "Show me all open transfers",
+      "Confirm the receipt for this delivery",
+      "Run an inventory adjustment for a location",
+    ],
     defaultGreetingMessage:
       "Hi {user}, I'm {name}. Send me a delivery note or tell me what to do — I can confirm receipts, validate pickings, and run inventory adjustments. I'll always confirm with you before validating, because validating moves real stock.",
     defaultAgentsMd: `## Your Role
@@ -227,6 +242,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-butler",
     defaultTagline: "Track invoices, monitor payments, analyze margins",
     suggestedNames: ["Ledger", "Penny", "Morgan", "Cassius", "Niles", "Finley"],
+    defaultStarterPrompts: [
+      "Show me all overdue invoices",
+      "What's the revenue trend this quarter?",
+      "Which customers owe us the most?",
+    ],
     defaultGreetingMessage:
       'Hello, {user}. I\'m {name}. I track invoices, monitor payments, and analyze your financial data. Try asking: "Show me all overdue invoices" or "What\'s the revenue trend this quarter?"',
     defaultAgentsMd: `## Your Role
@@ -292,6 +312,11 @@ ${ODOO_MULTI_COMPANY_GUIDANCE}`,
     defaultPersonality: "the-butler",
     defaultTagline: "Book bills and invoices, reconcile payments, manage suppliers",
     suggestedNames: ["Quill", "Cosmo", "Mathilda", "Edmund", "Rosa", "Hugo"],
+    defaultStarterPrompts: [
+      "Book this vendor bill as a draft",
+      "Show me unpaid bills",
+      "Check this supplier for duplicate invoices",
+    ],
     defaultGreetingMessage:
       "At your service, {user}. I'm {name}. Send me a receipt or invoice — I'll extract the details, check for duplicates, and prepare it as a draft for your confirmation before posting.",
     defaultAgentsMd: `## Your Role
@@ -436,6 +461,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-coach",
     defaultTagline: "Manage leads, follow up on quotes, maintain customer data",
     suggestedNames: ["Piper", "Chase", "Bridget", "Ace", "Max", "Hunter"],
+    defaultStarterPrompts: [
+      "Show me the current pipeline",
+      "Which follow-ups are overdue?",
+      "Add a follow-up activity to a lead",
+    ],
     defaultGreetingMessage:
       'Hey {user}! I\'m {name}. I manage your sales pipeline — tracking leads, following up on opportunities, and keeping customer data current. Try asking: "Show me the current pipeline" or "Which follow-ups are overdue?"',
     defaultAgentsMd: `## Your Role
@@ -517,6 +547,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Compare suppliers, track purchase prices, suggest reorders",
     suggestedNames: ["Bolt", "Marcy", "Vendor", "Clyde", "Hazel", "Porter"],
+    defaultStarterPrompts: [
+      "Compare supplier prices for a product",
+      "Which products need reordering?",
+      "Show purchase volume by supplier",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}. I compare supplier prices, track purchase orders, and identify reorder needs. Try asking: "Compare prices for product X" or "Which products need reordering?"',
     defaultAgentsMd: `## Your Role
@@ -574,6 +609,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-coach",
     defaultTagline: "Answer order inquiries, check delivery status, draft responses",
     suggestedNames: ["Concierge", "Sam", "Joy", "Kit", "Sunny", "Casey"],
+    defaultStarterPrompts: [
+      "What's the status of order S06628?",
+      "Show me all open high-priority tickets",
+      "Draft a reply to the latest ticket",
+    ],
     defaultGreetingMessage:
       'Hi {user}! I\'m {name}. I can look up order status, track deliveries, and help manage support tickets. Try asking: "What\'s the status of order S06628?" or "Show me all open high-priority tickets."',
     defaultAgentsMd: `## Your Role
@@ -645,6 +685,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-butler",
     defaultTagline: "Track headcount, leave balances, attendance and contracts",
     suggestedNames: ["Mira", "Robin", "Dana", "Juno", "Ellis", "Teagan"],
+    defaultStarterPrompts: [
+      "How many people are on leave next week?",
+      "Show me our headcount by department",
+      "Which contracts end in the next 90 days?",
+    ],
     defaultGreetingMessage:
       'Hello {user}. I\'m {name}, your HR analyst. I can track headcount, leave balances, and attendance. Try asking: "How many people are on leave next week?" or "Show me our headcount by department."',
     defaultAgentsMd: `## Your Role
@@ -706,6 +751,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-butler",
     defaultTagline: "Record leave, log attendance, update employee details, manage HR follow-ups",
     suggestedNames: ["Holly", "Frances", "Mae", "Rolf", "Hannah", "Lina"],
+    defaultStarterPrompts: [
+      "Record sick leave for someone this week",
+      "Who is on leave this week?",
+      "Update an employee's work details",
+    ],
     defaultGreetingMessage:
       'Good day, {user}. I\'m {name}. I can record leave requests, log attendance, and update employee details — confidentially and only after your explicit confirmation. Try: "Record sick leave for Lisa from Monday to Wednesday" or "Who is on leave this week?"',
     defaultAgentsMd: `## Your Role
@@ -801,6 +851,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-pilot",
     defaultTagline: "Monitor project progress, deadlines, task load and timesheets",
     suggestedNames: ["Tracker", "Milo", "Rowan", "Ida", "Beacon", "Pax"],
+    defaultStarterPrompts: [
+      "Which projects are behind schedule?",
+      "Who has the most open tasks?",
+      "Show me tasks due this week",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your project tracker. I monitor deliveries, deadlines, and workload. Try asking: "Which projects are behind schedule?" or "Who has the most open tasks?"',
     defaultAgentsMd: `## Your Role
@@ -854,6 +909,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-coach",
     defaultTagline: "Create and assign tasks, plan milestones, log timesheets, manage projects",
     suggestedNames: ["Atlas", "Halsey", "Kai", "Iris", "Avery", "Reggie"],
+    defaultStarterPrompts: [
+      "Add a task to a project",
+      "What's the workload looking like next week?",
+      "Assign open tasks to the team",
+    ],
     defaultGreetingMessage:
       'Hi {user}, I\'m {name}. I can create tasks, assign work, plan milestones, and log timesheets. Try: "Add a task to the Acme project" or "What\'s the workload looking like for next week?"',
     defaultAgentsMd: `## Your Role
@@ -949,6 +1009,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-pilot",
     defaultTagline: "Track production orders, BOMs, work orders and component needs",
     suggestedNames: ["Forge", "Remy", "Pike", "Iron", "Nyx", "Cogsworth"],
+    defaultStarterPrompts: [
+      "Which production orders are behind schedule?",
+      "What components do we need this week?",
+      "Show me BOMs with missing stock",
+    ],
     defaultGreetingMessage:
       'Hello {user}. I\'m {name}, your manufacturing planner. I track production orders, BOMs, and component availability. Try asking: "Which production orders are behind schedule?" or "What components do we need this week?"',
     defaultAgentsMd: `## Your Role
@@ -1006,6 +1071,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Plan and run manufacturing orders, advance workorders, report finished goods",
     suggestedNames: ["Reeve", "Mason", "Rhea", "Anvil", "Pepper", "Hank"],
+    defaultStarterPrompts: [
+      "Show me today's open manufacturing orders",
+      "Advance a workorder to the next stage",
+      "Report finished quantities for an MO",
+    ],
     defaultGreetingMessage:
       "Hi {user}, I'm {name}. I plan and run manufacturing orders — schedule MOs, advance workorders, report finished quantities. I'll always confirm with you before marking an MO done, because that consumes components and decrements stock.",
     defaultAgentsMd: `## Your Role
@@ -1111,6 +1181,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-coach",
     defaultTagline: "Track applicants, manage job pipelines, measure time-to-hire",
     suggestedNames: ["Riley", "Jordan", "Quinn", "Pax", "Sloan", "Marlo"],
+    defaultStarterPrompts: [
+      "Show me open positions",
+      "Who are the top candidates for the engineering role?",
+      "Move a candidate to the next stage",
+    ],
     defaultGreetingMessage:
       'Hi {user}! I\'m {name}, your recruitment coordinator. I can track applicants, move candidates through the pipeline, and measure time-to-hire. Try asking: "Show me open positions" or "Who are the top candidates for the engineering role?"',
     defaultAgentsMd: `## Your Role
@@ -1170,6 +1245,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Track MRR, churn, renewals and recurring revenue",
     suggestedNames: ["Loop", "Renna", "Cyrus", "Echo", "Anya", "Rex"],
+    defaultStarterPrompts: [
+      "What's our MRR this month?",
+      "Which subscriptions expire in the next 30 days?",
+      "Which subscriptions churned recently?",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your subscription manager. I track recurring revenue, churn, and upcoming renewals. Try asking: "What\'s our MRR this month?" or "Which subscriptions expire in the next 30 days?"',
     defaultAgentsMd: `## Your Role
@@ -1225,6 +1305,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Analyze store sales, cash sessions and payment methods",
     suggestedNames: ["Till", "Ruby", "Cash", "Ginny", "Beans", "Olive"],
+    defaultStarterPrompts: [
+      "What were yesterday's sales by store?",
+      "Which payment methods are most popular?",
+      "Show me sales by cash session",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your POS analyst. I analyze store sales, cash sessions, and payment trends. Try asking: "What were yesterday\'s sales by store?" or "Which payment methods are most popular?"',
     defaultAgentsMd: `## Your Role
@@ -1278,6 +1363,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Measure campaign performance, open rates and conversions",
     suggestedNames: ["Nova", "Flint", "Tessa", "Orbit", "Cleo", "Brio"],
+    defaultStarterPrompts: [
+      "How did last week's newsletter perform?",
+      "Which campaigns have the best open rate?",
+      "Compare click rates across campaigns",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your marketing analyst. I measure campaign performance — opens, clicks, bounces, and conversions. Try asking: "How did last week\'s newsletter perform?" or "Which campaigns have the best open rate?"',
     defaultAgentsMd: `## Your Role
@@ -1337,6 +1427,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-butler",
     defaultTagline: "Review expense claims, flag policy violations and unusual patterns",
     suggestedNames: ["Audra", "Monty", "Vera", "Cross", "Prue", "Clement"],
+    defaultStarterPrompts: [
+      "Show me expenses above €500 this month",
+      "Which employees submitted the most expenses last quarter?",
+      "Flag any unusual expense claims",
+    ],
     defaultGreetingMessage:
       'Hello {user}. I\'m {name}, your expense auditor. I review expense claims and flag items that look unusual. Try asking: "Show me expenses above €500 this month" or "Which employees submitted the most expenses last quarter?"',
     defaultAgentsMd: `## Your Role
@@ -1398,6 +1493,11 @@ ${ODOO_RULES}
     defaultTagline:
       "Review and approve expenses, leaves, purchases — with policy checks and clear escalation",
     suggestedNames: ["Verity", "Bennet", "Rosalind", "Olivier", "Magnus", "Cordelia"],
+    defaultStarterPrompts: [
+      "Show me open expense approvals",
+      "Anything pending leave approval this week?",
+      "Which requests are above my approval limit?",
+    ],
     defaultGreetingMessage:
       'At your service, {user}. I\'m {name}. I review and approve expenses, leaves, and purchase orders against your policies — and I escalate anything above your authority instead of guessing. Try: "Show me open expense approvals" or "Anything pending leave for this week?"',
     defaultAgentsMd: `## Your Role
@@ -1511,6 +1611,11 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
     defaultPersonality: "the-pilot",
     defaultTagline: "Track vehicles, service schedules, fuel and total cost of ownership",
     suggestedNames: ["Axel", "Greta", "Piston", "Ruby", "Tank", "Mika"],
+    defaultStarterPrompts: [
+      "Which vehicles need service soon?",
+      "What's the most expensive car in our fleet this year?",
+      "Show me total cost of ownership by vehicle",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your fleet manager. I track vehicles, service schedules, and total cost of ownership. Try asking: "Which vehicles need service soon?" or "What\'s the most expensive car in our fleet this year?"',
     defaultAgentsMd: `## Your Role
@@ -1562,6 +1667,11 @@ ${ODOO_RULES}
     defaultPersonality: "the-pilot",
     defaultTagline: "Analyze online sales, visitors, top products and conversion",
     suggestedNames: ["Pixel", "Hex", "Nova", "Rune", "Wilma", "Taz"],
+    defaultStarterPrompts: [
+      "What are the top-selling products on the website this month?",
+      "How many visitors did we get last week?",
+      "What's our online conversion rate?",
+    ],
     defaultGreetingMessage:
       'Hi {user}. I\'m {name}, your website analyst. I track online sales, visitors, and conversion. Try asking: "What are the top-selling products on the website this month?" or "How many visitors did we get last week?"',
     defaultAgentsMd: `## Your Role

--- a/packages/web/src/lib/agent-templates/data/web-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/web-agents.ts
@@ -22,6 +22,11 @@ export const WEB_TEMPLATES: Record<string, AgentTemplate> = {
     defaultTagline:
       "Track market trends, industry news, and competitor signals from the public web",
     suggestedNames: ["Scout", "Pulse", "Compass", "Vector", "Vista", "Beacon", "Sentry"],
+    defaultStarterPrompts: [
+      "What's the latest news in our industry this week?",
+      "What are our competitors announcing lately?",
+      "Summarize recent regulatory changes in our field",
+    ],
     defaultGreetingMessage:
       "Ready when you are, {user}. I'm {name}. I scan the public web for market trends, industry news, and competitor moves — and I always cite my sources. What would you like me to watch today?",
     // Persona-only AGENTS.md. Workflow guidance for the web tools lives in

--- a/packages/web/src/lib/agent-templates/odoo-factory.ts
+++ b/packages/web/src/lib/agent-templates/odoo-factory.ts
@@ -145,6 +145,9 @@ export function createOdooTemplate(spec: OdooAgentTemplateSpec): AgentTemplate {
     suggestedNames: [...spec.suggestedNames],
     defaultGreetingMessage: spec.defaultGreetingMessage,
     defaultAgentsMd: spec.defaultAgentsMd,
+    ...(spec.defaultStarterPrompts !== undefined
+      ? { defaultStarterPrompts: [...spec.defaultStarterPrompts] }
+      : {}),
     requiresOdooConnection: true,
     odooConfig: {
       accessLevel,

--- a/packages/web/src/lib/agent-templates/types.ts
+++ b/packages/web/src/lib/agent-templates/types.ts
@@ -29,6 +29,13 @@ export interface AgentTemplate {
   defaultTagline: string | null;
   defaultAgentsMd: string | null;
   defaultGreetingMessage?: string;
+  /**
+   * Clickable starter-prompt chips shown in the empty chat for agents created
+   * from this template (#570). Seeded into `agents.starterPrompts` at creation
+   * time and editable per agent afterwards. Omit for role-less templates
+   * (`custom`) — an agent with no prompts renders no chips.
+   */
+  defaultStarterPrompts?: string[];
   suggestedNames?: string[];
   requiresOdooConnection?: boolean;
   requiresEmailConnection?: boolean;
@@ -68,6 +75,7 @@ export interface OdooAgentTemplateSpec {
   suggestedNames: string[];
   defaultGreetingMessage: string;
   defaultAgentsMd: string;
+  defaultStarterPrompts?: string[];
   requiredModels: ReadonlyArray<{
     model: string;
     operations: ReadonlyArray<OdooOperation>;

--- a/packages/web/src/lib/agents.ts
+++ b/packages/web/src/lib/agents.ts
@@ -19,6 +19,7 @@ export interface UpdateAgentInput {
   pluginConfig?: AgentPluginConfig | null;
   greetingMessage?: string;
   tagline?: string | null;
+  starterPrompts?: string[];
   avatarSeed?: string | null;
   personalityPresetId?: string | null;
   visibility?: AgentVisibility;

--- a/packages/web/src/lib/schemas/starter-prompts.ts
+++ b/packages/web/src/lib/schemas/starter-prompts.ts
@@ -1,0 +1,38 @@
+import { z } from "zod";
+
+/**
+ * A single starter prompt must fit on a chip — one or two short lines. Shared
+ * by the settings editor (`maxLength`), the PATCH schema, and the per-template
+ * drift guard so all three agree on one number.
+ */
+export const MAX_STARTER_PROMPT_LENGTH = 100;
+
+/**
+ * Upper bound on how many chips one agent can show. Custom GPTs cap conversation
+ * starters at 4 and Copilot Studio at 10; 10 keeps us generous while stopping a
+ * buggy or hostile client from pushing an unbounded list into the empty chat.
+ */
+export const MAX_STARTER_PROMPTS = 10;
+
+/** Trim, drop blank entries, and de-duplicate while preserving first-seen order. */
+export function normalizeStarterPrompts(prompts: readonly string[]): string[] {
+  const seen = new Set<string>();
+  const normalized: string[] = [];
+  for (const prompt of prompts) {
+    const trimmed = prompt.trim();
+    if (trimmed.length === 0 || seen.has(trimmed)) continue;
+    seen.add(trimmed);
+    normalized.push(trimmed);
+  }
+  return normalized;
+}
+
+/**
+ * Editable per-agent starter prompts. Bounds the raw client input (length and
+ * count), then normalizes to the shape the chat renders: trimmed, non-blank,
+ * and unique so `key={prompt}` chips never collide.
+ */
+export const starterPromptsSchema = z
+  .array(z.string().max(MAX_STARTER_PROMPT_LENGTH))
+  .max(MAX_STARTER_PROMPTS)
+  .transform(normalizeStarterPrompts);


### PR DESCRIPTION
Closes #570.

## What

Clickable starter-prompt chips in the empty chat, configurable per agent. A new user facing an empty conversation doesn't always know what to ask — a small set of per-agent suggestions lowers the entry barrier, especially for role-specific agents (quote drafter, support writer, HR assistant).

## Changes

- **Schema:** `agents.starter_prompts` jsonb `string[]` column + Drizzle migration `0044_cultured_supernaut` (defaults `[]`; recreates the `active_agents` view to include the column).
- **API:** `PATCH /api/agents/[agentId]` accepts `starterPrompts: string[]` with an audit diff. It's a content edit (same edit-permission rules as name/tagline); no OpenClaw config regen since it doesn't reach `openclaw.json`.
- **Agent type:** `starterPrompts` added to the `Agent` interface so it's available via the agents context.
- **Settings UI:** a repeatable **Starter prompts** editor in the General tab (local-state list with add/remove rows). Blank rows are dropped on save. Managed as local state rather than a react-hook-form field array to keep the zod-validated form schema focused and avoid a FieldArray/resolver typing mismatch.
- **Chat:** `ThreadWelcome` renders the configured prompts as chips via `ThreadPrimitive.Suggestion` (`send`) in the ready empty-thread state. With no prompts set, behaviour is unchanged (renders nothing — the greeting message is the welcome). Blank prompts are filtered out.
- **Docs:** documents starter prompts in `concepts/agent-settings.mdx`.

## Tests

- `thread-welcome.test.tsx`: chips render from `starterPrompts`; blank prompts are ignored; ready/responding empty state still renders nothing when no prompts are configured.
- `agent-settings-page.test.tsx`: updated for the new `starterPrompts` field in the general change values.
- Full unit suite green; `tsc --noEmit` clean.

## Out of scope

- Shipping sensible default starter prompts per template (the issue mentions this as a follow-on; it's a per-template content decision left for a separate pass).