### PR TITLE
fix(chat): rewrite generic provider-rejection envelope + dedicated audit class (#584)

### DIFF
--- a/packages/web/src/__tests__/server/agent-error-classifier.test.ts
+++ b/packages/web/src/__tests__/server/agent-error-classifier.test.ts
@@ -88,6 +88,34 @@ describe("classifyAgentError", () => {
     expect(classifyAgentError("")).toBe("unknown");
   });
 
+  it("classifies OpenClaw's generic provider-rejection envelope as provider_rejected_generic (#584)", () => {
+    // When a provider rejects a run for an account-side reason OpenClaw
+    // collapses (e.g. depleted credit), the error chunk carries exactly this
+    // wording and nothing cause-specific. The real cause is unknowable from
+    // this text, so it gets its own honest audit class — not `unknown` (which
+    // buckets it with truly unrecognised strings) and not `provider_config`
+    // (which would assert an unproven cause in the append-only audit trail).
+    const text = "LLM request failed: provider rejected the request schema or tool payload.";
+    expect(classifyAgentError(text)).toBe("provider_rejected_generic");
+  });
+
+  it("still classifies the thought_signature payload as schema_rejection, not provider_rejected_generic (#584)", () => {
+    // The Gemini-3 schema-rejection payload carries the generic envelope text
+    // AND a thought_signature — the specific schema signal must win so the
+    // audit class stays schema_rejection.
+    const text =
+      "LLM request failed: provider rejected the request schema or tool payload. " +
+      'rawError=400 "Function call is missing a thought_signature in functionCall parts."';
+    expect(classifyAgentError(text)).toBe("schema_rejection");
+  });
+
+  it("still classifies a credit/balance wording as provider_config, not provider_rejected_generic (#584)", () => {
+    // If the cause-specific wording DOES reach the chunk (credit/balance), it
+    // must classify as provider_config — the generic class is only for the
+    // cause-unknowable envelope.
+    expect(classifyAgentError("Your credit balance is too low")).toBe("provider_config");
+  });
+
   it("classifies transient before provider_config when text mentions 'exceeded'", () => {
     // Defensive: `rate limit exceeded` contains "exceeded" which would also
     // match the provider-config family. Mirrors the same precedence rule

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -3,6 +3,7 @@ import {
   getErrorHint,
   presentProviderError,
   PROVIDER_SETTINGS_HINT,
+  PROVIDER_REJECTED_GENERIC_MESSAGE,
   CONTEXT_OVERFLOW_HINT,
   CONTEXT_OVERFLOW_MESSAGE,
 } from "@/server/error-hints";
@@ -141,6 +142,29 @@ describe("getErrorHint", () => {
     it("presentProviderError leaves non-overflow errors unchanged", () => {
       expect(presentProviderError("Invalid API key provided")).toBe("Invalid API key provided");
       expect(presentProviderError("Rate limit exceeded")).toBe("Rate limit exceeded");
+    });
+
+    it("presentProviderError rewrites the generic provider-rejection envelope so the banner doesn't read like a malformed-request bug (#584)", () => {
+      const raw = "LLM request failed: provider rejected the request schema or tool payload.";
+      const shown = presentProviderError(raw);
+      expect(shown).toBe(PROVIDER_REJECTED_GENERIC_MESSAGE);
+      // The misleading "schema or tool payload" framing must not reach the user.
+      expect(shown).not.toMatch(/schema or tool payload/i);
+      // It should point at the provider-account cause family.
+      expect(shown).toMatch(/billing|quota|api key|provider/i);
+    });
+
+    it("presentProviderError does NOT rewrite the thought_signature payload's envelope (schema_rejection keeps its own wording) (#584)", () => {
+      // The Gemini-3 schema-rejection text carries the generic envelope plus a
+      // thought_signature. Its own branch (classifyUpstreamFormatError) handles
+      // the user-facing wording; presentProviderError must not collapse it into
+      // the generic-account message. The raw envelope text passes through here.
+      const raw =
+        "LLM request failed: provider rejected the request schema or tool payload. " +
+        'rawError=400 "Function call is missing a thought_signature in functionCall parts."';
+      // The thought_signature payload is not context-overflow and not the bare
+      // generic envelope (it has extra content), so it passes through unchanged.
+      expect(presentProviderError(raw)).toBe(raw);
     });
   });
 });

--- a/packages/web/src/server/agent-error-classifier.ts
+++ b/packages/web/src/server/agent-error-classifier.ts
@@ -28,6 +28,8 @@
 import {
   TRANSIENT_PATTERN,
   PROVIDER_CONFIG_PATTERN,
+  PROVIDER_REJECTED_GENERIC_PATTERN,
+  isThoughtSignatureRejection,
   HTTP_5XX_PATTERN,
 } from "@/server/error-patterns";
 import type { TransientReason } from "@/lib/schemas/chat-frames";
@@ -48,17 +50,11 @@ export type AgentErrorClass =
   | "model_unavailable"
   | "transient"
   | "provider_config"
+  | "provider_rejected_generic"
   | "silent_stream_timeout"
   | "unknown";
 
 const FAILOVER_INCOMPLETE_STREAM_PATTERN = /FailoverError[\s\S]*incomplete terminal response/i;
-
-// Mirrors the narrower regex anchoring in model-error-classifier.ts: both
-// real OpenClaw variants carry a separator (snake_case `_` or camelCase `S`),
-// so a future provider error mentioning a bare-word `thoughtsignature` in
-// unrelated text cannot hijack this branch.
-const THOUGHT_SIGNATURE_SNAKE = /thought_signature/i;
-const THOUGHT_SIGNATURE_CAMEL = /thoughtSignature/;
 
 /**
  * Reasons Pinchy itself synthesises an error frame (no upstream provider
@@ -110,7 +106,7 @@ export function classifyAgentError(errorText: string): AgentErrorClass {
   if (FAILOVER_INCOMPLETE_STREAM_PATTERN.test(errorText)) {
     return "failover_incomplete_stream";
   }
-  if (THOUGHT_SIGNATURE_SNAKE.test(errorText) || THOUGHT_SIGNATURE_CAMEL.test(errorText)) {
+  if (isThoughtSignatureRejection(errorText)) {
     return "schema_rejection";
   }
   // `transient` is checked before `model_unavailable` so HTTP 529 — Anthropic's
@@ -125,6 +121,20 @@ export function classifyAgentError(errorText: string): AgentErrorClass {
   }
   if (PROVIDER_CONFIG_PATTERN.test(errorText)) {
     return "provider_config";
+  }
+  // OpenClaw's generic provider-rejection catch-all (#584). When a provider
+  // rejects a run for an account-side reason it collapses (verified on staging:
+  // depleted credit surfaces as exactly this string), the real cause never
+  // reaches Pinchy in the chunk text. Honest own audit class — NOT
+  // `provider_config` (that would assert an unproven cause in the append-only
+  // audit trail) and NOT `unknown` (that buckets it with truly unrecognised
+  // strings). Cause-specific wording (credit/balance) is caught above as
+  // `provider_config`; a thought_signature schema rejection is caught above as
+  // `schema_rejection`. Checked AFTER provider_config so a chunk that carries
+  // both the generic envelope AND cause-specific wording still classifies by
+  // the cause.
+  if (PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText)) {
+    return "provider_rejected_generic";
   }
   return "unknown";
 }

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -2,10 +2,21 @@ import {
   TRANSIENT_PATTERN,
   PROVIDER_CONFIG_PATTERN,
   PROVIDER_REJECTED_GENERIC_PATTERN,
+  isThoughtSignatureRejection,
   CONTEXT_OVERFLOW_PATTERN,
 } from "@/server/error-patterns";
 
 export const PROVIDER_SETTINGS_HINT = "Go to Settings > Providers to check your API configuration.";
+
+// User-facing replacement for OpenClaw's generic provider-rejection envelope
+// (#584). The raw wording — "provider rejected the request schema or tool
+// payload" — reads like a malformed-request bug; the real cause (most often a
+// provider-account issue: billing, API key, quota) is collapsed by OpenClaw and
+// never reaches Pinchy in the chunk text. This honest message points an admin at
+// the provider-account cause family without asserting a specific cause. Only the
+// banner uses this; the audit trail keeps the raw text.
+export const PROVIDER_REJECTED_GENERIC_MESSAGE =
+  "The AI provider rejected the request. This is often a provider-account issue (billing, API key, or quota) — check Settings > Providers.";
 
 // A context-window overflow can't be retried as-is. OpenClaw's own error text
 // advises its `/reset` / `/new` slash commands, but Pinchy's web composer sends
@@ -39,10 +50,12 @@ export function getErrorHint(errorText: string, userRole: string): string | null
 
   // OpenClaw's generic provider-rejection catch-all (#584). The real cause —
   // most often a provider-account issue like depleted credit or an invalid
-  // key — never reaches Pinchy in the chunk text, so the audit class stays
-  // honest (`unknown`). The bare wording reads like a malformed-request bug;
-  // pointing an admin at their provider configuration is the most actionable
-  // honest guidance we can give without asserting a cause we can't prove.
+  // key — never reaches Pinchy in the chunk text, so the audit class is its
+  // own honest `provider_rejected_generic` (not `provider_config`, which
+  // would assert an unproven cause). The bare wording reads like a
+  // malformed-request bug; pointing an admin at their provider configuration
+  // is the most actionable honest guidance we can give without asserting a
+  // cause we can't prove.
   if (PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText)) {
     return userRole === "admin" ? PROVIDER_SETTINGS_HINT : "Please contact your administrator.";
   }
@@ -51,15 +64,27 @@ export function getErrorHint(errorText: string, userRole: string): string | null
 }
 
 /**
- * Map a raw provider-error string to the user-facing banner text. Currently this
- * only rewrites context-overflow errors — OpenClaw's text embeds `/reset`/`/new`
- * advice that doesn't work in Pinchy's composer (#611) — and passes everything
- * else through untouched. Apply it where the error is shown to the user (the live
- * error frame and the durable-banner route); the audit trail keeps the raw text.
+ * Map a raw provider-error string to the user-facing banner text. Rewrites
+ * context-overflow errors (OpenClaw's text embeds `/reset`/`/new` advice that
+ * doesn't work in Pinchy's composer, #611) and the generic provider-rejection
+ * envelope (whose "schema or tool payload" wording reads like a
+ * malformed-request bug — #584); passes everything else through untouched.
+ * Apply it where the error is shown to the user (the live error frame and the
+ * durable-banner route); the audit trail keeps the raw text.
  */
 export function presentProviderError(errorText: string): string {
   if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
     return CONTEXT_OVERFLOW_MESSAGE;
+  }
+  // The generic envelope is rewritten to an honest account-issue message — but
+  // ONLY when it isn't carrying a thought_signature, which is a schema
+  // rejection (#338) with its own user-facing handling. Without this guard the
+  // schema-rejection wording would be collapsed into the account-issue message.
+  if (
+    PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText) &&
+    !isThoughtSignatureRejection(errorText)
+  ) {
+    return PROVIDER_REJECTED_GENERIC_MESSAGE;
   }
   return errorText;
 }

--- a/packages/web/src/server/error-patterns.ts
+++ b/packages/web/src/server/error-patterns.ts
@@ -65,6 +65,35 @@ export const PROVIDER_REJECTED_GENERIC_PATTERN =
   /provider rejected the request schema or tool payload/i;
 
 /**
+ * Matches OpenClaw's upstream schema/format rejection (verified on staging:
+ * Gemini 3 missing `thought_signature` on tool-call replay). Both the snake_case
+ * (`thought_signature`) and camelCase (`thoughtSignature`) variants reach Pinchy
+ * — the OpenAI-compat replay path used by ollama-cloud emits camelCase, the
+ * native Google path emits snake_case. Shared here so the audit classifier
+ * (`agent-error-classifier.ts`) and the user-facing rewriter (`error-hints.ts`)
+ * agree on what counts as a schema rejection: the generic provider-rejection
+ * envelope is rewritten to a clearer account-issue message ONLY when it is NOT
+ * carrying a thought_signature (otherwise the schema-rejection wording would be
+ * collapsed into the generic-account message — issue #584).
+ *
+ * Two patterns, mirroring the original narrower anchoring in
+ * `model-error-classifier.ts`: the snake_case form carries a `_` separator and
+ * is matched case-insensitively; the camelCase form requires the capital `S`
+ * (NO `i` flag) so a bare-word `thoughtsignature` in unrelated text cannot
+ * hijack the schema_rejection branch.
+ */
+export const THOUGHT_SIGNATURE_SNAKE_PATTERN = /thought_signature/i;
+export const THOUGHT_SIGNATURE_CAMEL_PATTERN = /thoughtSignature/;
+
+/** True if the text carries either thought_signature variant (a schema rejection). */
+export function isThoughtSignatureRejection(errorText: string): boolean {
+  return (
+    THOUGHT_SIGNATURE_SNAKE_PATTERN.test(errorText) ||
+    THOUGHT_SIGNATURE_CAMEL_PATTERN.test(errorText)
+  );
+}
+
+/**
  * Matches a context-window overflow: the conversation/prompt no longer fits the
  * model's context window. A model-capability/length issue, NOT a provider-config
  * one (see PROVIDER_CONFIG_PATTERN's note on deliberately excluding bare


### PR DESCRIPTION
Closes #584.

## What

When an LLM provider rejects a run for an **account-side reason** (depleted credit, invalid key, exhausted quota), OpenClaw collapses the cause and the error chunk Pinchy receives carries only the generic `"LLM request failed: provider rejected the request schema or tool payload."` wording — the real cause never reaches Pinchy in `chunk.text`. Two problems resulted:

1. The durable paused-error **banner** showed that raw wording, which reads like a malformed-request bug.
2. The audit row bucketed it as `error_class: "unknown"`, indistinguishable from truly unrecognised strings.

## Fix

- **Banner text:** `presentProviderError` now rewrites the bare generic envelope to an honest, actionable message: _"The AI provider rejected the request. This is often a provider-account issue (billing, API key, or quota) — check Settings > Providers."_ Applied at both the live error frame and the durable-banner route (`active-error/route.ts`), which already call `presentProviderError`. The audit trail keeps the raw text.
- **Audit class:** `classifyAgentError` gains a dedicated `provider_rejected_generic` class. It is honest — not `provider_config` (which would assert an unproven cause in the append-only, HMAC-signed audit trail) and not `unknown` (which buckets it with unrecognised strings). Operators get a distinguishable bucket for the generic collapse.
- **Precedence preserved:** cause-specific wording (credit/balance) still classifies as `provider_config`; a `thought_signature` schema rejection still classifies as `schema_rejection`. The generic check runs after `provider_config` so a chunk carrying both the envelope AND cause-specific wording still classifies by the cause.
- **Guard:** `presentProviderError` only rewrites the generic envelope when it is NOT carrying a `thought_signature` (the Gemini-3 schema rejection carries the same envelope text plus `thought_signature`, and has its own user-facing handling via `upstreamFormatError`). Without this guard the schema-rejection wording would be collapsed into the account-issue message.
- Shared `thought_signature` patterns moved to `error-patterns.ts` (`isThoughtSignatureRejection`) so the classifier and the rewriter agree, preserving the original narrow anchoring (snake_case with `i`, camelCase requiring the capital `S` so a bare `thoughtsignature` can't hijack the branch).

## Out of scope (upstream-gated)

Showing the **specific** billing cause (e.g. "credit balance too low") in the banner requires openclaw-node to expose the FailoverError `errorMessage`/`errorCode` on the `ChatChunk` error — today the chunk only carries `text`, which is the collapsed generic wording. That's an openclaw-node change; this PR does the honest Pinchy-side improvement without asserting a cause it can't see.

## Tests

- `agent-error-classifier.test.ts`: generic envelope → `provider_rejected_generic`; thought_signature payload still → `schema_rejection`; credit/balance still → `provider_config`.
- `error-hints.test.ts`: `presentProviderError` rewrites the bare generic envelope (no "schema or tool payload" reaches the user; message names the account-cause family); the thought_signature payload passes through unchanged.
- Full unit suite green; `tsc --noEmit` clean.