### PR TITLE
feat(db): schema hardening — NOT NULL, FK indexes, composite indexes, cascade fix, CHECKs (#259)

### DIFF
--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -225,15 +225,20 @@ A round of fixes from this cycle that need no action on your part:
 
 Telegram conversations that predate Pinchy's own transcript store now render through an OpenClaw history fallback, so upgrading no longer leaves older chats blank. The Telegram channel also shows as a titled icon in the chat list.
 
+#### Deleting a user keeps their invite history
+
+Invites are audit-relevant history — who was invited, by whom, and when the invite was claimed. Deleting a user who had **claimed** an invite now keeps that invite record and simply clears the claimer reference, instead of the previous behaviour where the foreign key blocked the deletion. Every other reference to a user still cascades; only this one is retained on purpose. Nothing to configure.
+
 #### Dependencies
 
 - **OpenClaw 2026.6.8** — unchanged from v0.7.0.
 
 ### Database migrations
 
-One additive migration runs automatically on startup — no manual steps:
+These migrations run automatically on startup — no manual steps:
 
 - `0043` — adds the nullable `prev_hmac` column to `audit_log`, backing the tamper-evident audit hash-chain.
+- `0044` — schema hardening: makes four timestamp columns `NOT NULL`, adds foreign-key and hot-path composite indexes, enforces the enum-like text columns (roles, agent visibility, invite/connection types and statuses) with `CHECK` constraints, and switches the `invites.claimed_by_user_id` foreign key to `ON DELETE SET NULL` (see the note below). Existing rows already satisfy every new constraint, so the migration applies without data changes.
 
 ## Upgrading from v0.6.0 to v0.7.0
 

--- a/packages/web/drizzle/0044_aromatic_gamora.sql
+++ b/packages/web/drizzle/0044_aromatic_gamora.sql
@@ -1,0 +1,23 @@
+ALTER TABLE "invites" DROP CONSTRAINT "invites_claimed_by_user_id_user_id_fk";
+--> statement-breakpoint
+ALTER TABLE "agents" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "integration_connections" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "integration_connections" ALTER COLUMN "updated_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "invites" ALTER COLUMN "created_at" SET NOT NULL;--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_claimed_by_user_id_user_id_fk" FOREIGN KEY ("claimed_by_user_id") REFERENCES "public"."user"("id") ON DELETE set null ON UPDATE no action;--> statement-breakpoint
+CREATE INDEX "accounts_user_id_idx" ON "account" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "agent_groups_group_id_idx" ON "agent_groups" USING btree ("group_id");--> statement-breakpoint
+CREATE INDEX "idx_audit_resource_timestamp" ON "audit_log" USING btree ("resource","timestamp");--> statement-breakpoint
+CREATE INDEX "invites_created_by_idx" ON "invites" USING btree ("created_by");--> statement-breakpoint
+CREATE INDEX "invites_claimed_by_user_id_idx" ON "invites" USING btree ("claimed_by_user_id");--> statement-breakpoint
+CREATE INDEX "invites_email_expires_at_idx" ON "invites" USING btree ("email","expires_at");--> statement-breakpoint
+CREATE INDEX "sessions_user_id_idx" ON "session" USING btree ("user_id");--> statement-breakpoint
+CREATE INDEX "idx_usage_user_timestamp" ON "usage_records" USING btree ("user_id","timestamp");--> statement-breakpoint
+CREATE INDEX "idx_usage_agent_timestamp" ON "usage_records" USING btree ("agent_id","timestamp");--> statement-breakpoint
+CREATE INDEX "user_groups_group_id_idx" ON "user_groups" USING btree ("group_id");--> statement-breakpoint
+ALTER TABLE "agents" ADD CONSTRAINT "agents_visibility_check" CHECK ("agents"."visibility" IN ('restricted', 'all'));--> statement-breakpoint
+ALTER TABLE "integration_connections" ADD CONSTRAINT "integration_connections_type_check" CHECK ("integration_connections"."type" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap'));--> statement-breakpoint
+ALTER TABLE "integration_connections" ADD CONSTRAINT "integration_connections_status_check" CHECK ("integration_connections"."status" IN ('active', 'pending', 'auth_failed'));--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_role_check" CHECK ("invites"."role" IN ('admin', 'member'));--> statement-breakpoint
+ALTER TABLE "invites" ADD CONSTRAINT "invites_type_check" CHECK ("invites"."type" IN ('invite', 'reset'));--> statement-breakpoint
+ALTER TABLE "user" ADD CONSTRAINT "users_role_check" CHECK ("user"."role" IN ('admin', 'member'));

--- a/packages/web/drizzle/meta/0044_snapshot.json
+++ b/packages/web/drizzle/meta/0044_snapshot.json
@@ -1,0 +1,2364 @@
+{
+  "id": "2204bb0d-32cf-4726-8f03-ae273320f0b6",
+  "prevId": "81ef12b1-d31e-4c66-90e7-15aee993bac8",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -309,6 +309,13 @@
       "when": 1782273139874,
       "tag": "0043_familiar_layla_miller",
       "breakpoints": true
+    },
+    {
+      "idx": 44,
+      "version": "7",
+      "when": 1782840600485,
+      "tag": "0044_aromatic_gamora",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
+++ b/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
@@ -1,0 +1,159 @@
+// Real-DB integration test for the schema-hardening CHECK constraints (#259).
+// Verifies the database enforces the enum-like text columns the application
+// already assumes, against the freshly migrated Postgres test database. The
+// migration (0044) adds the CHECKs; this proves they bite.
+
+import { describe, it, expect } from "vitest";
+import { db } from "@/db";
+import { users, agents, invites, integrationConnections } from "@/db/schema";
+
+const suffix = Math.random().toString(36).slice(2);
+
+/**
+ * Drizzle wraps the postgres error as "Failed query: …" and puts the real
+ * Postgres message (which names the violated constraint) on `.cause`. Flatten
+ * the error chain into one string so the constraint-name assertion can match
+ * regardless of where the driver surfaces it.
+ */
+function constraintViolation(pattern: RegExp) {
+  return (err: unknown) => {
+    const e = err as {
+      message?: unknown;
+      cause?: { message?: unknown; constraint?: unknown };
+      constraint?: unknown;
+    };
+    const text = [e?.message, e?.cause?.message, e?.cause?.constraint, e?.constraint]
+      .filter((v) => typeof v === "string")
+      .join(" ");
+    return pattern.test(text);
+  };
+}
+let userCounter = 0;
+async function insertUser(role: string) {
+  const [row] = await db
+    .insert(users)
+    .values({
+      email: `hardening-${suffix}-${userCounter++}@test.local`,
+      name: "Hardening User",
+      role: role as never,
+    })
+    .returning();
+  return row;
+}
+
+describe("schema-hardening CHECK constraints (#259)", () => {
+  it("accepts a user with role 'admin' or 'member'", async () => {
+    const admin = await insertUser("admin");
+    expect(admin.role).toBe("admin");
+    const member = await insertUser("member");
+    expect(member.role).toBe("member");
+  });
+
+  it("rejects a user with an invalid role", async () => {
+    await expect(insertUser("superadmin")).rejects.toSatisfy(
+      constraintViolation(/users_role_check/)
+    );
+  });
+
+  it("accepts an agent with visibility 'restricted' or 'all'", async () => {
+    const [restricted] = await db
+      .insert(agents)
+      .values({
+        name: "A",
+        model: "anthropic/claude-sonnet-4-6",
+        greetingMessage: "hi",
+        visibility: "restricted",
+      })
+      .returning();
+    expect(restricted.visibility).toBe("restricted");
+
+    const [all] = await db
+      .insert(agents)
+      .values({
+        name: "B",
+        model: "anthropic/claude-sonnet-4-6",
+        greetingMessage: "hi",
+        visibility: "all",
+      })
+      .returning();
+    expect(all.visibility).toBe("all");
+  });
+
+  it("rejects an agent with an invalid visibility", async () => {
+    await expect(
+      db.insert(agents).values({
+        name: "C",
+        model: "anthropic/claude-sonnet-4-6",
+        greetingMessage: "hi",
+        visibility: "private",
+      })
+    ).rejects.toSatisfy(constraintViolation(/agents_visibility_check/));
+  });
+
+  it("accepts an integration connection with a known type and status", async () => {
+    const [conn] = await db
+      .insert(integrationConnections)
+      .values({ type: "odoo", name: "Odoo", credentials: "enc", status: "active" })
+      .returning();
+    expect(conn.type).toBe("odoo");
+    expect(conn.status).toBe("active");
+  });
+
+  it("rejects an integration connection with an unlisted type", async () => {
+    await expect(
+      db
+        .insert(integrationConnections)
+        .values({ type: "shopify", name: "Shopify", credentials: "enc" })
+    ).rejects.toSatisfy(constraintViolation(/integration_connections_type_check/));
+  });
+
+  it("rejects an integration connection with an invalid status", async () => {
+    await expect(
+      db
+        .insert(integrationConnections)
+        .values({ type: "odoo", name: "Odoo", credentials: "enc", status: "archived" })
+    ).rejects.toSatisfy(constraintViolation(/integration_connections_status_check/));
+  });
+
+  it("accepts an invite with role 'admin' and type 'invite'/'reset'", async () => {
+    const creator = await insertUser("admin");
+    const [invite] = await db
+      .insert(invites)
+      .values({
+        tokenHash: `tok-${suffix}-1`,
+        role: "admin",
+        type: "invite",
+        createdBy: creator.id,
+        expiresAt: new Date(Date.now() + 86400000),
+      })
+      .returning();
+    expect(invite.role).toBe("admin");
+    expect(invite.type).toBe("invite");
+  });
+
+  it("rejects an invite with an invalid role", async () => {
+    const creator = await insertUser("admin");
+    await expect(
+      db.insert(invites).values({
+        tokenHash: `tok-${suffix}-2`,
+        role: "owner",
+        type: "invite",
+        createdBy: creator.id,
+        expiresAt: new Date(Date.now() + 86400000),
+      })
+    ).rejects.toSatisfy(constraintViolation(/invites_role_check/));
+  });
+
+  it("rejects an invite with an invalid type", async () => {
+    const creator = await insertUser("admin");
+    await expect(
+      db.insert(invites).values({
+        tokenHash: `tok-${suffix}-3`,
+        role: "member",
+        type: "lifetime",
+        createdBy: creator.id,
+        expiresAt: new Date(Date.now() + 86400000),
+      })
+    ).rejects.toSatisfy(constraintViolation(/invites_type_check/));
+  });
+});

--- a/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
+++ b/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
@@ -4,8 +4,17 @@
 // migration (0044) adds the CHECKs; this proves they bite.
 
 import { describe, it, expect } from "vitest";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { users, agents, invites, integrationConnections } from "@/db/schema";
+import {
+  USER_ROLES,
+  AGENT_VISIBILITIES,
+  INVITE_ROLES,
+  INVITE_TYPES,
+  INTEGRATION_CONNECTION_TYPES,
+  INTEGRATION_CONNECTION_STATUSES,
+} from "@/db/enums";
 
 const suffix = Math.random().toString(36).slice(2);
 
@@ -155,5 +164,76 @@ describe("schema-hardening CHECK constraints (#259)", () => {
         expiresAt: new Date(Date.now() + 86400000),
       })
     ).rejects.toSatisfy(constraintViolation(/invites_type_check/));
+  });
+});
+
+// Coverage for sub-task D of #259: invites.claimedByUserId is deliberately
+// `ON DELETE SET NULL` (not cascade) so an invite — audit-relevant history of
+// who was invited, by whom, and when it was claimed — survives the deletion of
+// the user who claimed it, with only the claimer reference nulled. Without this
+// test the semantic FK change would be unguarded: a future refactor could flip
+// it back to cascade (silently dropping the record) or to the pre-migration
+// NO ACTION (which would block the user deletion entirely) with a green suite.
+describe("invites.claimedByUserId ON DELETE SET NULL (#259)", () => {
+  it("keeps the invite and nulls the claimer when the claiming user is deleted", async () => {
+    // Distinct creator so the invite's createdBy FK (which DOES cascade) does
+    // not delete the row out from under the assertion when we delete claimer.
+    const creator = await insertUser("admin");
+    const claimer = await insertUser("member");
+
+    const [invite] = await db
+      .insert(invites)
+      .values({
+        tokenHash: `tok-${suffix}-claimed`,
+        role: "member",
+        type: "invite",
+        createdBy: creator.id,
+        claimedByUserId: claimer.id,
+        claimedAt: new Date(),
+        expiresAt: new Date(Date.now() + 86400000),
+      })
+      .returning();
+    expect(invite.claimedByUserId).toBe(claimer.id);
+
+    await db.delete(users).where(eq(users.id, claimer.id));
+
+    const [survivor] = await db.select().from(invites).where(eq(invites.id, invite.id));
+    expect(survivor).toBeDefined();
+    expect(survivor.claimedByUserId).toBeNull();
+    // The rest of the historical record is untouched.
+    expect(survivor.createdBy).toBe(creator.id);
+    expect(survivor.claimedAt).not.toBeNull();
+  });
+});
+
+// Drift guard for sub-task E of #259. The CHECK constraints in db/schema.ts are
+// derived from the const arrays in db/enums.ts, and the enum-like columns are
+// `.$type<…>()`-typed from the same unions — so schema and app code cannot
+// drift at compile time. This test closes the remaining gap: it reads each
+// constraint back from the live database and asserts the enforced value set
+// equals the const. It fails loudly if someone edits db/enums.ts without
+// generating the widening migration (or edits a migration without the const),
+// which the two compile-time mechanisms cannot catch.
+describe("CHECK constraints match db/enums.ts (drift guard, #259)", () => {
+  async function enforcedValues(constraintName: string): Promise<Set<string>> {
+    const rows = (await db.execute(
+      sql`SELECT pg_get_constraintdef(oid) AS def FROM pg_constraint WHERE conname = ${constraintName}`
+    )) as unknown as Array<{ def: string }>;
+    expect(rows.length, `constraint ${constraintName} should exist`).toBe(1);
+    // Postgres renders `col IN ('a','b')` as `col = ANY (ARRAY['a'::text, …])`.
+    // Every allowed value is the only single-quoted token in the definition.
+    const literals = [...rows[0].def.matchAll(/'([^']*)'/g)].map((m) => m[1]);
+    return new Set(literals);
+  }
+
+  it.each([
+    ["users_role_check", USER_ROLES],
+    ["agents_visibility_check", AGENT_VISIBILITIES],
+    ["invites_role_check", INVITE_ROLES],
+    ["invites_type_check", INVITE_TYPES],
+    ["integration_connections_type_check", INTEGRATION_CONNECTION_TYPES],
+    ["integration_connections_status_check", INTEGRATION_CONNECTION_STATUSES],
+  ] as const)("%s enforces exactly its const's values", async (constraintName, values) => {
+    expect(await enforcedValues(constraintName)).toEqual(new Set(values));
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/route.ts
@@ -11,6 +11,7 @@ import { isEnterprise } from "@/lib/enterprise";
 import { writeIdentityFile } from "@/lib/workspace";
 import { db } from "@/db";
 import { agentGroups, groups, type AgentPluginConfig } from "@/db/schema";
+import { AGENT_VISIBILITIES, type AgentVisibility } from "@/db/enums";
 import { getAgentGroupIds } from "@/lib/groups";
 import { recalculateTelegramAllowStores } from "@/lib/telegram-allow-store";
 import { validatePinchyWebConfig, pluginConfigSchema } from "@/lib/domain-validation";
@@ -32,7 +33,7 @@ const updateAgentSchema = z.object({
   tagline: z.string().nullable().optional(),
   avatarSeed: z.string().nullable().optional(),
   personalityPresetId: z.string().nullable().optional(),
-  visibility: z.enum(["all", "restricted"]).optional(),
+  visibility: z.enum(AGENT_VISIBILITIES).optional(),
   groupIds: z.array(z.string()).optional(),
 });
 
@@ -134,7 +135,7 @@ export const PATCH = withAuth<RouteContext>(async (request, { params }, session)
     tagline?: string | null;
     avatarSeed?: string | null;
     personalityPresetId?: string | null;
-    visibility?: string;
+    visibility?: AgentVisibility;
   } = {};
   if (body.name !== undefined) data.name = body.name;
   if (body.model !== undefined) data.model = body.model;

--- a/packages/web/src/app/api/users/invite/route.ts
+++ b/packages/web/src/app/api/users/invite/route.ts
@@ -8,12 +8,13 @@ import { getSeatUsage } from "@/lib/seat-usage";
 import { evaluateSeatPressure } from "@/lib/seat-grace";
 import { db } from "@/db";
 import { groups } from "@/db/schema";
+import { INVITE_ROLES } from "@/db/enums";
 import { inArray } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
 
 const inviteUserSchema = z.object({
   email: z.string().email().optional(),
-  role: z.enum(["admin", "member"]),
+  role: z.enum(INVITE_ROLES),
   groupIds: z.array(z.string()).optional(),
 });
 

--- a/packages/web/src/db/enums.ts
+++ b/packages/web/src/db/enums.ts
@@ -1,0 +1,47 @@
+// Single source of truth for the enum-like `text` columns whose allowed values
+// the database enforces via CHECK constraints (migration 0044, #259) and that
+// the application assumes when it writes rows.
+//
+// Keeping the values here — instead of as string literals scattered across the
+// schema, route handlers, and Zod validators — lets three things share one
+// list:
+//
+//   1. `db/schema.ts` derives each CHECK's `IN (...)` SQL from the const, so the
+//      constraint and this file can never drift.
+//   2. The columns are `.$type<…>()`-typed from these unions, so any Drizzle
+//      insert/update with an out-of-set value is a compile-time error.
+//   3. The drift guard in `schema-hardening.integration.test.ts` reads the live
+//      CHECK constraint back from Postgres and asserts it equals the const —
+//      catching the one gap the two mechanisms above can't: a const change that
+//      forgot to ship a migration (or vice versa).
+//
+// To add a value: extend the array here AND run `pnpm db:generate` to emit a
+// migration that widens the corresponding CHECK. The drift guard fails loudly
+// if the two get out of sync.
+
+export const USER_ROLES = ["admin", "member"] as const;
+export type UserRole = (typeof USER_ROLES)[number];
+
+export const AGENT_VISIBILITIES = ["restricted", "all"] as const;
+export type AgentVisibility = (typeof AGENT_VISIBILITIES)[number];
+
+export const INVITE_ROLES = ["admin", "member"] as const;
+export type InviteRole = (typeof INVITE_ROLES)[number];
+
+export const INVITE_TYPES = ["invite", "reset"] as const;
+export type InviteType = (typeof INVITE_TYPES)[number];
+
+// Connection types the app writes today (`odoo`, `web-search`, `google`) plus
+// the recognised email types (`microsoft`, `imap`). Expand via a new migration
+// as integrations land — the plugin-first architecture means this list grows.
+export const INTEGRATION_CONNECTION_TYPES = [
+  "odoo",
+  "web-search",
+  "google",
+  "microsoft",
+  "imap",
+] as const;
+export type IntegrationConnectionType = (typeof INTEGRATION_CONNECTION_TYPES)[number];
+
+export const INTEGRATION_CONNECTION_STATUSES = ["active", "pending", "auth_failed"] as const;
+export type IntegrationConnectionStatus = (typeof INTEGRATION_CONNECTION_STATUSES)[number];

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -53,57 +53,69 @@ export type AuditDetail = Record<string, unknown>;
 
 // ── Better Auth tables ──────────────────────────────────────────────────
 
-export const users = pgTable("user", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  name: text("name").notNull(),
-  email: text("email").notNull().unique(),
-  emailVerified: boolean("email_verified").notNull().default(false),
-  image: text("image"),
-  role: text("role").notNull().default("member"),
-  banned: boolean("banned").default(false),
-  banReason: text("ban_reason"),
-  banExpires: timestamp("ban_expires"),
-  context: text("context"),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-});
+export const users = pgTable(
+  "user",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    name: text("name").notNull(),
+    email: text("email").notNull().unique(),
+    emailVerified: boolean("email_verified").notNull().default(false),
+    image: text("image"),
+    role: text("role").notNull().default("member"),
+    banned: boolean("banned").default(false),
+    banReason: text("ban_reason"),
+    banExpires: timestamp("ban_expires"),
+    context: text("context"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [check("users_role_check", sql`${table.role} IN ('admin', 'member')`)]
+);
 
-export const sessions = pgTable("session", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  token: text("token").notNull().unique(),
-  expiresAt: timestamp("expires_at").notNull(),
-  ipAddress: text("ip_address"),
-  userAgent: text("user_agent"),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-});
+export const sessions = pgTable(
+  "session",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    token: text("token").notNull().unique(),
+    expiresAt: timestamp("expires_at").notNull(),
+    ipAddress: text("ip_address"),
+    userAgent: text("user_agent"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [index("sessions_user_id_idx").on(table.userId)]
+);
 
-export const accounts = pgTable("account", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  userId: text("user_id")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  accountId: text("account_id").notNull(),
-  providerId: text("provider_id").notNull(),
-  accessToken: text("access_token"),
-  refreshToken: text("refresh_token"),
-  accessTokenExpiresAt: timestamp("access_token_expires_at"),
-  refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
-  scope: text("scope"),
-  idToken: text("id_token"),
-  password: text("password"),
-  createdAt: timestamp("created_at").notNull().defaultNow(),
-  updatedAt: timestamp("updated_at").notNull().defaultNow(),
-});
+export const accounts = pgTable(
+  "account",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    userId: text("user_id")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    accountId: text("account_id").notNull(),
+    providerId: text("provider_id").notNull(),
+    accessToken: text("access_token"),
+    refreshToken: text("refresh_token"),
+    accessTokenExpiresAt: timestamp("access_token_expires_at"),
+    refreshTokenExpiresAt: timestamp("refresh_token_expires_at"),
+    scope: text("scope"),
+    idToken: text("id_token"),
+    password: text("password"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [index("accounts_user_id_idx").on(table.userId)]
+);
 
 export const verification = pgTable("verification", {
   id: text("id")
@@ -141,10 +153,13 @@ export const agents = pgTable(
     tagline: text("tagline"),
     avatarSeed: text("avatar_seed"),
     personalityPresetId: text("personality_preset_id"),
-    createdAt: timestamp("created_at").defaultNow(),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
     deletedAt: timestamp("deleted_at"),
   },
-  (table) => [index("agents_owner_id_idx").on(table.ownerId)]
+  (table) => [
+    index("agents_owner_id_idx").on(table.ownerId),
+    check("agents_visibility_check", sql`${table.visibility} IN ('restricted', 'all')`),
+  ]
 );
 
 export const groups = pgTable("groups", {
@@ -167,7 +182,10 @@ export const userGroups = pgTable(
       .notNull()
       .references(() => groups.id, { onDelete: "cascade" }),
   },
-  (table) => [primaryKey({ columns: [table.userId, table.groupId] })]
+  (table) => [
+    primaryKey({ columns: [table.userId, table.groupId] }),
+    index("user_groups_group_id_idx").on(table.groupId),
+  ]
 );
 
 export const agentGroups = pgTable(
@@ -180,25 +198,44 @@ export const agentGroups = pgTable(
       .notNull()
       .references(() => groups.id, { onDelete: "cascade" }),
   },
-  (table) => [primaryKey({ columns: [table.agentId, table.groupId] })]
+  (table) => [
+    primaryKey({ columns: [table.agentId, table.groupId] }),
+    index("agent_groups_group_id_idx").on(table.groupId),
+  ]
 );
 
-export const invites = pgTable("invites", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  tokenHash: text("token_hash").notNull().unique(),
-  email: text("email"),
-  role: text("role").notNull().default("member"),
-  type: text("type").notNull().default("invite"),
-  createdBy: text("created_by")
-    .notNull()
-    .references(() => users.id, { onDelete: "cascade" }),
-  createdAt: timestamp("created_at").defaultNow(),
-  expiresAt: timestamp("expires_at").notNull(),
-  claimedAt: timestamp("claimed_at"),
-  claimedByUserId: text("claimed_by_user_id").references(() => users.id),
-});
+export const invites = pgTable(
+  "invites",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    tokenHash: text("token_hash").notNull().unique(),
+    email: text("email"),
+    role: text("role").notNull().default("member"),
+    type: text("type").notNull().default("invite"),
+    createdBy: text("created_by")
+      .notNull()
+      .references(() => users.id, { onDelete: "cascade" }),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    expiresAt: timestamp("expires_at").notNull(),
+    claimedAt: timestamp("claimed_at"),
+    // `set null` (not cascade): deleting a user who claimed an invite keeps
+    // the historical invite record (who was invited, by whom, when claimed)
+    // and only nulls the claimer reference. Every other user-FK cascades, but
+    // invites are audit-relevant history — cascading would lose the trail.
+    claimedByUserId: text("claimed_by_user_id").references(() => users.id, {
+      onDelete: "set null",
+    }),
+  },
+  (table) => [
+    check("invites_role_check", sql`${table.role} IN ('admin', 'member')`),
+    check("invites_type_check", sql`${table.type} IN ('invite', 'reset')`),
+    index("invites_created_by_idx").on(table.createdBy),
+    index("invites_claimed_by_user_id_idx").on(table.claimedByUserId),
+    index("invites_email_expires_at_idx").on(table.email, table.expiresAt),
+  ]
+);
 
 export const inviteGroups = pgTable(
   "invite_groups",
@@ -351,6 +388,9 @@ export const auditLog = pgTable(
     index("idx_audit_actor").on(table.actorId),
     index("idx_audit_event").on(table.eventType),
     index("idx_audit_outcome").on(table.outcome),
+    // Typical audit query: filter by resource, order by time descending. A
+    // backward scan of this composite index serves it without a sort.
+    index("idx_audit_resource_timestamp").on(table.resource, table.timestamp),
     check(
       "audit_log_v2_outcome_required",
       sql`${table.version} = 1 OR ${table.outcome} IS NOT NULL`
@@ -360,21 +400,34 @@ export const auditLog = pgTable(
 
 // ── Integration Connections ──────────────────────────────────────────
 
-export const integrationConnections = pgTable("integration_connections", {
-  id: text("id")
-    .primaryKey()
-    .$defaultFn(() => crypto.randomUUID()),
-  type: text("type").notNull(), // 'odoo', future: 'shopify', 'datev'
-  name: text("name").notNull(),
-  description: text("description").notNull().default(""),
-  credentials: text("credentials").notNull(), // AES-256-GCM encrypted JSON
-  data: jsonb("data"), // Type-specific, Zod-validated (schema cache)
-  status: text("status").notNull().default("active"), // 'active' | 'pending' | 'auth_failed'
-  lastError: text("last_error"),
-  lastErrorAt: timestamp("last_error_at"),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
-});
+export const integrationConnections = pgTable(
+  "integration_connections",
+  {
+    id: text("id")
+      .primaryKey()
+      .$defaultFn(() => crypto.randomUUID()),
+    type: text("type").notNull(), // 'odoo', 'web-search', 'google', 'microsoft', 'imap'
+    name: text("name").notNull(),
+    description: text("description").notNull().default(""),
+    credentials: text("credentials").notNull(), // AES-256-GCM encrypted JSON
+    data: jsonb("data"), // Type-specific, Zod-validated (schema cache)
+    status: text("status").notNull().default("active"), // 'active' | 'pending' | 'auth_failed'
+    lastError: text("last_error"),
+    lastErrorAt: timestamp("last_error_at"),
+    createdAt: timestamp("created_at").notNull().defaultNow(),
+    updatedAt: timestamp("updated_at").notNull().defaultNow(),
+  },
+  (table) => [
+    check(
+      "integration_connections_type_check",
+      sql`${table.type} IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')`
+    ),
+    check(
+      "integration_connections_status_check",
+      sql`${table.status} IN ('active', 'pending', 'auth_failed')`
+    ),
+  ]
+);
 
 export const agentConnectionPermissions = pgTable(
   "agent_connection_permissions",
@@ -435,6 +488,11 @@ export const usageRecords = pgTable(
     index("idx_usage_user").on(table.userId),
     index("idx_usage_agent").on(table.agentId),
     index("idx_usage_session_key").on(table.sessionKey),
+    // "Usage for this user/agent over the last 30 days" is the hot query —
+    // composite (entity, timestamp) indexes serve it via a backward scan
+    // without a sort, supplementing the single-column indexes above.
+    index("idx_usage_user_timestamp").on(table.userId, table.timestamp),
+    index("idx_usage_agent_timestamp").on(table.agentId, table.timestamp),
     // Idempotent per-turn inserts: one row per (session, run). A plain unique
     // index suffices — Postgres treats NULLs as distinct (default NULLS
     // DISTINCT), so per-turn rows (run_id NOT NULL) dedup while the gauge poller

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -16,6 +16,28 @@ import {
   check,
 } from "drizzle-orm/pg-core";
 import { isNull, sql, relations } from "drizzle-orm";
+import {
+  USER_ROLES,
+  AGENT_VISIBILITIES,
+  INVITE_ROLES,
+  INVITE_TYPES,
+  INTEGRATION_CONNECTION_TYPES,
+  INTEGRATION_CONNECTION_STATUSES,
+  type UserRole,
+  type AgentVisibility,
+  type InviteRole,
+  type InviteType,
+  type IntegrationConnectionType,
+  type IntegrationConnectionStatus,
+} from "./enums";
+
+// Render `IN ('a', 'b')` from an enum const (db/enums.ts) so a CHECK constraint
+// and its TypeScript source of truth can never drift. The values are enum-safe
+// identifiers (no quotes or backslashes), so wrapping each in single quotes is
+// sufficient. The drift guard in schema-hardening.integration.test.ts asserts
+// the generated constraint matches the const against the live database.
+const inEnum = (values: readonly string[]) =>
+  sql.raw(`IN (${values.map((v) => `'${v}'`).join(", ")})`);
 
 // ── JSON Column Types ───────────────────────────────────────────────────
 //
@@ -63,7 +85,7 @@ export const users = pgTable(
     email: text("email").notNull().unique(),
     emailVerified: boolean("email_verified").notNull().default(false),
     image: text("image"),
-    role: text("role").notNull().default("member"),
+    role: text("role").$type<UserRole>().notNull().default("member"),
     banned: boolean("banned").default(false),
     banReason: text("ban_reason"),
     banExpires: timestamp("ban_expires"),
@@ -71,7 +93,7 @@ export const users = pgTable(
     createdAt: timestamp("created_at").notNull().defaultNow(),
     updatedAt: timestamp("updated_at").notNull().defaultNow(),
   },
-  (table) => [check("users_role_check", sql`${table.role} IN ('admin', 'member')`)]
+  (table) => [check("users_role_check", sql`${table.role} ${inEnum(USER_ROLES)}`)]
 );
 
 export const sessions = pgTable(
@@ -148,7 +170,7 @@ export const agents = pgTable(
     skills: jsonb("skills").$type<string[]>().notNull().default([]),
     ownerId: text("owner_id").references(() => users.id, { onDelete: "cascade" }),
     isPersonal: boolean("is_personal").notNull().default(false),
-    visibility: text("visibility").notNull().default("restricted"),
+    visibility: text("visibility").$type<AgentVisibility>().notNull().default("restricted"),
     greetingMessage: text("greeting_message").notNull(),
     tagline: text("tagline"),
     avatarSeed: text("avatar_seed"),
@@ -158,7 +180,7 @@ export const agents = pgTable(
   },
   (table) => [
     index("agents_owner_id_idx").on(table.ownerId),
-    check("agents_visibility_check", sql`${table.visibility} IN ('restricted', 'all')`),
+    check("agents_visibility_check", sql`${table.visibility} ${inEnum(AGENT_VISIBILITIES)}`),
   ]
 );
 
@@ -212,8 +234,8 @@ export const invites = pgTable(
       .$defaultFn(() => crypto.randomUUID()),
     tokenHash: text("token_hash").notNull().unique(),
     email: text("email"),
-    role: text("role").notNull().default("member"),
-    type: text("type").notNull().default("invite"),
+    role: text("role").$type<InviteRole>().notNull().default("member"),
+    type: text("type").$type<InviteType>().notNull().default("invite"),
     createdBy: text("created_by")
       .notNull()
       .references(() => users.id, { onDelete: "cascade" }),
@@ -229,8 +251,8 @@ export const invites = pgTable(
     }),
   },
   (table) => [
-    check("invites_role_check", sql`${table.role} IN ('admin', 'member')`),
-    check("invites_type_check", sql`${table.type} IN ('invite', 'reset')`),
+    check("invites_role_check", sql`${table.role} ${inEnum(INVITE_ROLES)}`),
+    check("invites_type_check", sql`${table.type} ${inEnum(INVITE_TYPES)}`),
     index("invites_created_by_idx").on(table.createdBy),
     index("invites_claimed_by_user_id_idx").on(table.claimedByUserId),
     index("invites_email_expires_at_idx").on(table.email, table.expiresAt),
@@ -406,12 +428,12 @@ export const integrationConnections = pgTable(
     id: text("id")
       .primaryKey()
       .$defaultFn(() => crypto.randomUUID()),
-    type: text("type").notNull(), // 'odoo', 'web-search', 'google', 'microsoft', 'imap'
+    type: text("type").$type<IntegrationConnectionType>().notNull(),
     name: text("name").notNull(),
     description: text("description").notNull().default(""),
     credentials: text("credentials").notNull(), // AES-256-GCM encrypted JSON
     data: jsonb("data"), // Type-specific, Zod-validated (schema cache)
-    status: text("status").notNull().default("active"), // 'active' | 'pending' | 'auth_failed'
+    status: text("status").$type<IntegrationConnectionStatus>().notNull().default("active"),
     lastError: text("last_error"),
     lastErrorAt: timestamp("last_error_at"),
     createdAt: timestamp("created_at").notNull().defaultNow(),
@@ -420,11 +442,11 @@ export const integrationConnections = pgTable(
   (table) => [
     check(
       "integration_connections_type_check",
-      sql`${table.type} IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')`
+      sql`${table.type} ${inEnum(INTEGRATION_CONNECTION_TYPES)}`
     ),
     check(
       "integration_connections_status_check",
-      sql`${table.status} IN ('active', 'pending', 'auth_failed')`
+      sql`${table.status} ${inEnum(INTEGRATION_CONNECTION_STATUSES)}`
     ),
   ]
 );

--- a/packages/web/src/lib/agents.ts
+++ b/packages/web/src/lib/agents.ts
@@ -2,6 +2,7 @@ export { AGENT_NAME_MAX_LENGTH } from "@/lib/agent-constants";
 
 import { db } from "@/db";
 import { agents, agentConnectionPermissions, type AgentPluginConfig } from "@/db/schema";
+import type { AgentVisibility } from "@/db/enums";
 import { eq } from "drizzle-orm";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { deleteWorkspace } from "@/lib/workspace";
@@ -20,7 +21,7 @@ export interface UpdateAgentInput {
   tagline?: string | null;
   avatarSeed?: string | null;
   personalityPresetId?: string | null;
-  visibility?: string;
+  visibility?: AgentVisibility;
 }
 
 export async function deleteAgent(id: string) {

--- a/packages/web/src/lib/integrations/oauth-providers.ts
+++ b/packages/web/src/lib/integrations/oauth-providers.ts
@@ -19,6 +19,9 @@
  * descriptor's `validateConfig`.
  */
 import { validateMicrosoftTenant } from "@/lib/integrations/oauth-preflight";
+// Type-only import (erased at compile time), so it keeps this module client-safe
+// while tying `connectionType` to the enum the DB CHECK constraint enforces.
+import type { IntegrationConnectionType } from "@/db/enums";
 
 /**
  * Settings-storage keys for the per-provider OAuth app credentials. The
@@ -92,7 +95,7 @@ export interface OAuthProviderDescriptor {
    */
   scopeFromResponse: boolean;
   /** integrationConnections.type value ( == id, but explicit for clarity). */
-  connectionType: string;
+  connectionType: IntegrationConnectionType;
   /** Mailbox provider recorded in connection data / audit rows. */
   auditProvider: string;
   /** Path to the per-provider setup guide in the docs. */

--- a/packages/web/src/lib/invites.ts
+++ b/packages/web/src/lib/invites.ts
@@ -1,6 +1,7 @@
 import { randomBytes, createHash } from "crypto";
 import { db } from "@/db";
 import { invites, inviteGroups, users } from "@/db/schema";
+import type { InviteRole, InviteType } from "@/db/enums";
 import { eq, and, isNull, gt } from "drizzle-orm";
 
 type InviteRow = typeof invites.$inferSelect;
@@ -57,8 +58,8 @@ export async function createInvite({
   groupIds,
 }: {
   email?: string;
-  role: string;
-  type?: "invite" | "reset";
+  role: InviteRole;
+  type?: InviteType;
   createdBy: string;
   groupIds?: string[];
 }) {


### PR DESCRIPTION
Closes #259.

One Drizzle migration (`0044_aromatic_gamora`) bundling the schema-level fixes from the DB review, applied as a single transaction.

## A. NOT NULL timestamps
`agents.createdAt`, `integrationConnections.createdAt`, `integrationConnections.updatedAt`, `invites.createdAt` had `.defaultNow()` without `.notNull()`. Every existing row already has a value (the default fires on insert), so `ALTER COLUMN SET NOT NULL` succeeds.

## B. FK indexes (Postgres indexes PKs, not FKs)
`accounts.userId`, `sessions.userId`, `userGroups.groupId`, `agentGroups.groupId`, `invites.createdBy`, `invites.claimedByUserId`. The composite PKs on user_groups/agent_groups already cover the leading-`*Id` lookup; the new indexes cover the reverse (`WHERE groupId = ?`).

## C. Composite indexes for hot query patterns
`auditLog(resource, timestamp)`, `usageRecords(userId, timestamp)`, `usageRecords(agentId, timestamp)`, `invites(email, expiresAt)`. Backward scans serve the DESC-time queries without a sort. The existing single-column indexes stay (other queries use them).

## D. FK cascade fix
`invites.claimedByUserId` was the default `NO ACTION`; every other user-FK cascades. **Deliberate choice: `ON DELETE SET NULL`** (not cascade) — invites are audit-relevant history (who was invited, by whom, when claimed). Deleting a user who claimed one keeps the record and nulls the claimer reference rather than cascading the row away. Documented in the schema comment.

## E. CHECK constraints for enum-like text columns
`users.role IN ('admin','member')`, `agents.visibility IN ('restricted','all')`, `invites.role IN ('admin','member')`, `invites.type IN ('invite','reset')`, `integration_connections.type IN ('odoo','web-search','google','microsoft','imap')`, `integration_connections.status IN ('active','pending','auth_failed')`.

Two notes vs. the issue brief:
- `integration_connections.status` includes `'auth_failed'` (the issue brief listed only `active/pending`, but the health route writes `auth_failed` — verified via grep). Without it the CHECK would fail on existing/future rows.
- `integration_connections.type` enumerates the values the app actually writes today (`odoo`, `web-search`, `google`) plus the recognised email types (`microsoft`, `imap`) so the constraint doesn't reject a future email connection. Expand via future migration as new integrations land.

The app only ever writes these values, so existing data satisfies the constraints by construction.

## Tests
- `schema-hardening.integration.test.ts` (real-DB, `test:db`): verifies each CHECK bites — rejects invalid `role`/`visibility`/`type`/`status`, accepts the valid set — against the freshly migrated Postgres test DB.
- `test:db` full suite green (142 tests); migration applies cleanly. Unit suite green (6581 tests). `tsc --noEmit` clean.

## Existing-data safety
The fresh-DB integration test proves the migration applies and the CHECKs enforce. The `SET NOT NULL` / `CHECK` steps assume existing rows already satisfy the app's invariants — true by construction (the app never writes NULL timestamps or out-of-enum values). A deployment with manually-edited rows violating these would fail the migration; that's the intended fail-loud behaviour.