### PR TITLE
perf(api): batch telegram-bot + allow-store settings N+1 + cache headers on list endpoints (#261)

### DIFF
--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -99,6 +99,9 @@ vi.mock("@/lib/path-validation", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue("anthropic"),
+  // recalculateTelegramAllowStores (triggered as a side effect) batches
+  // bot-token lookups via getSettingsByPrefix now — no bots in this test (#261).
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
 }));
 
 vi.mock("@/lib/provider-models", () => ({

--- a/packages/web/src/__tests__/api/agents-list-route.test.ts
+++ b/packages/web/src/__tests__/api/agents-list-route.test.ts
@@ -1,0 +1,46 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+
+const { mockGetSession } = vi.hoisted(() => ({ mockGetSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+  auth: { api: { getSession: mockGetSession } },
+}));
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/visible-agents", () => ({
+  getVisibleAgents: vi.fn().mockResolvedValue([
+    {
+      id: "a1",
+      name: "Smithers",
+      model: "anthropic/claude-sonnet-4-6",
+      isPersonal: false,
+      visibility: "all",
+      tagline: null,
+      starterPrompts: [],
+      avatarSeed: null,
+    },
+  ]),
+}));
+
+import { GET } from "@/app/api/agents/route";
+
+describe("GET /api/agents", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("sets a short private Cache-Control header to absorb navigation (#261)", async () => {
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: "user-1", role: "admin" },
+      expires: "",
+    } as never);
+
+    const request = new NextRequest("http://localhost:7777/api/agents");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=5, must-revalidate");
+  });
+});

--- a/packages/web/src/__tests__/api/agents-visibility.test.ts
+++ b/packages/web/src/__tests__/api/agents-visibility.test.ts
@@ -96,6 +96,9 @@ vi.mock("@/lib/path-validation", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue("anthropic"),
+  // recalculateTelegramAllowStores (triggered as a side effect) batches
+  // bot-token lookups via getSettingsByPrefix now — no bots in this test (#261).
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
 }));
 
 vi.mock("@/lib/enterprise", () => ({

--- a/packages/web/src/__tests__/api/audit-route.test.ts
+++ b/packages/web/src/__tests__/api/audit-route.test.ts
@@ -176,6 +176,16 @@ describe("GET /api/audit", () => {
     expect(mockEntriesOffset).toHaveBeenCalledWith(0);
   });
 
+  it("sets a short private Cache-Control header to absorb navigation (#261)", async () => {
+    setupMocks();
+
+    const request = new NextRequest("http://localhost:7777/api/audit");
+    const response = await GET(request);
+
+    expect(response.status).toBe(200);
+    expect(response.headers.get("Cache-Control")).toBe("private, max-age=5, must-revalidate");
+  });
+
   it("supports custom page and limit parameters", async () => {
     setupMocks([], 100);
 

--- a/packages/web/src/__tests__/api/audit-route.test.ts
+++ b/packages/web/src/__tests__/api/audit-route.test.ts
@@ -176,14 +176,17 @@ describe("GET /api/audit", () => {
     expect(mockEntriesOffset).toHaveBeenCalledWith(0);
   });
 
-  it("sets a short private Cache-Control header to absorb navigation (#261)", async () => {
+  it("does not cache the audit trail — it is the security record of admin actions (#261)", async () => {
     setupMocks();
 
     const request = new NextRequest("http://localhost:7777/api/audit");
     const response = await GET(request);
 
     expect(response.status).toBe(200);
-    expect(response.headers.get("Cache-Control")).toBe("private, max-age=5, must-revalidate");
+    // The audit log is sensitive, compliance-relevant, and must always be
+    // fresh — an admin refreshing to confirm an action was logged must never
+    // see a stale (or disk-persisted) copy. no-store, not a short private TTL.
+    expect(response.headers.get("Cache-Control")).toBe("no-store");
   });
 
   it("supports custom page and limit parameters", async () => {

--- a/packages/web/src/__tests__/api/settings-telegram-bots.test.ts
+++ b/packages/web/src/__tests__/api/settings-telegram-bots.test.ts
@@ -9,9 +9,18 @@ vi.mock("@/lib/auth", () => ({
   getSession: (...args: unknown[]) => mockGetSession(...args),
 }));
 
-const mockGetSetting = vi.fn();
+// Map-based settings mock: tests populate `mockSettings` with the keys they
+// want present. `getSetting` reads it; `getSettingsByPrefix` filters it in one
+// call (the production code is batched now — #261).
+const mockSettings = new Map<string, string>();
+const { mockGetSettingsByPrefix } = vi.hoisted(() => ({
+  mockGetSettingsByPrefix: vi.fn((prefix: string, map: Map<string, string>) =>
+    Promise.resolve(new Map(Array.from(map.entries()).filter(([k]) => k.startsWith(prefix))))
+  ),
+}));
 vi.mock("@/lib/settings", () => ({
-  getSetting: (...args: unknown[]) => mockGetSetting(...args),
+  getSetting: (key: string) => Promise.resolve(mockSettings.get(key) ?? null),
+  getSettingsByPrefix: (prefix: string) => mockGetSettingsByPrefix(prefix, mockSettings),
 }));
 
 const mockGetVisibleAgents = vi.fn();
@@ -40,7 +49,13 @@ describe("GET /api/settings/telegram/bots", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
-    mockGetSetting.mockResolvedValue(null);
+    mockSettings.clear();
+    // Re-wire the prefix spy after clearAllMocks (its impl reads mockSettings).
+    mockGetSettingsByPrefix.mockImplementation((prefix: string) =>
+      Promise.resolve(
+        new Map(Array.from(mockSettings.entries()).filter(([k]) => k.startsWith(prefix)))
+      )
+    );
     mockGetVisibleAgents.mockResolvedValue([]);
     mockGetOrgPairingSmithers.mockResolvedValue([]);
   });
@@ -69,10 +84,7 @@ describe("GET /api/settings/telegram/bots", () => {
       { id: "a1", name: "Smithers", isPersonal: false, visibility: "all" },
       { id: "a2", name: "Support", isPersonal: false, visibility: "all" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:a1") return "acme_smithers_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:a1", "acme_smithers_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -88,11 +100,8 @@ describe("GET /api/settings/telegram/bots", () => {
       { id: "a1", name: "Silvia", isPersonal: false, visibility: "all" },
       { id: "a2", name: "Smithers", isPersonal: true, ownerId: "user-1" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:a1") return "silvia_bot";
-      if (key === "telegram_bot_username:a2") return "smithers_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:a1", "silvia_bot");
+    mockSettings.set("telegram_bot_username:a2", "smithers_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -114,11 +123,8 @@ describe("GET /api/settings/telegram/bots", () => {
     mockGetVisibleAgents.mockResolvedValueOnce([
       { id: "a1", name: "Smithers", isPersonal: false, visibility: "all" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:a1") return "acme_smithers_bot";
-      if (key === "telegram_bot_username:a2") return "hr_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:a1", "acme_smithers_bot");
+    mockSettings.set("telegram_bot_username:a2", "hr_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -132,11 +138,8 @@ describe("GET /api/settings/telegram/bots", () => {
     mockGetVisibleAgents.mockResolvedValueOnce([
       { id: "a-self", name: "Smithers", isPersonal: true, ownerId: "user-2" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:a-self") return "self_smithers_bot";
-      if (key === "telegram_bot_username:a-admin") return "admin_smithers_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:a-self", "self_smithers_bot");
+    mockSettings.set("telegram_bot_username:a-admin", "admin_smithers_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -159,12 +162,9 @@ describe("GET /api/settings/telegram/bots", () => {
       { id: "a2", name: "Support", isPersonal: false, visibility: "all" },
       { id: "a3", name: "HR", isPersonal: false, visibility: "restricted" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:a1") return "smithers_bot";
-      if (key === "telegram_bot_username:a2") return "support_bot";
-      if (key === "telegram_bot_username:a3") return "hr_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:a1", "smithers_bot");
+    mockSettings.set("telegram_bot_username:a2", "support_bot");
+    mockSettings.set("telegram_bot_username:a3", "hr_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -193,10 +193,7 @@ describe("GET /api/settings/telegram/bots", () => {
         isPersonal: true,
       },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_username:admin-smithers-real-uuid") return "acme_smithers_bot";
-      return null;
-    });
+    mockSettings.set("telegram_bot_username:admin-smithers-real-uuid", "acme_smithers_bot");
 
     const response = await GET();
     const data = await response.json();
@@ -222,25 +219,26 @@ describe("GET /api/settings/telegram/bots", () => {
     expect(mockGetOrgPairingSmithers).toHaveBeenCalledWith(new Set(["a1", "a2"]));
   });
 
-  it("fetches bot usernames in parallel (single Promise.all, not sequential)", async () => {
+  it("fetches bot usernames in a single batched prefix query, not per-candidate (#261)", async () => {
     mockGetVisibleAgents.mockResolvedValueOnce([
       { id: "a1", name: "A", isPersonal: false, visibility: "all" },
       { id: "a2", name: "B", isPersonal: false, visibility: "all" },
       { id: "a3", name: "C", isPersonal: false, visibility: "all" },
     ]);
+    mockSettings.set("telegram_bot_username:a1", "a_bot");
+    mockSettings.set("telegram_bot_username:a2", "b_bot");
+    mockSettings.set("telegram_bot_username:a3", "c_bot");
 
-    const callOrder: string[] = [];
-    mockGetSetting.mockImplementation(async (key: string) => {
-      callOrder.push(`start:${key}`);
-      await new Promise((r) => setTimeout(r, 5));
-      callOrder.push(`end:${key}`);
-      return null;
-    });
+    const response = await GET();
+    const data = await response.json();
 
-    await GET();
-
-    // All three should start before any ends — proves parallel execution
-    const firstThree = callOrder.slice(0, 3);
-    expect(firstThree.every((c) => c.startsWith("start:"))).toBe(true);
+    // One batched call — not one per candidate.
+    expect(mockGetSettingsByPrefix).toHaveBeenCalledTimes(1);
+    expect(mockGetSettingsByPrefix).toHaveBeenCalledWith("telegram_bot_username:", mockSettings);
+    expect(data.bots.map((b: { botUsername: string }) => b.botUsername).sort()).toEqual([
+      "a_bot",
+      "b_bot",
+      "c_bot",
+    ]);
   });
 });

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -23,6 +23,9 @@ vi.mock("@/lib/settings", () => ({
   getAllSettings: vi.fn().mockResolvedValue([]),
   getSetting: vi.fn().mockResolvedValue(null),
   setSetting: vi.fn().mockResolvedValue(undefined),
+  // recalculateTelegramAllowStores (triggered as a side effect) batches
+  // bot-token lookups via getSettingsByPrefix now — no bots in this test (#261).
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
 }));
 
 vi.mock("@/lib/provider-models", () => ({

--- a/packages/web/src/__tests__/api/users.test.ts
+++ b/packages/web/src/__tests__/api/users.test.ts
@@ -40,6 +40,13 @@ vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
 
+// The DELETE route recalculates Telegram allow-stores as a side effect; this
+// suite asserts user-deletion + audit, not allow-store recalculation, so stub
+// it out (it otherwise hits the DB via getSettingsByPrefix — #261).
+vi.mock("@/lib/telegram-allow-store", () => ({
+  recalculateTelegramAllowStores: vi.fn().mockResolvedValue(undefined),
+}));
+
 vi.mock("@/db", () => ({
   db: {
     query: {

--- a/packages/web/src/__tests__/integration/openclaw-config-validates-against-oc.test.ts
+++ b/packages/web/src/__tests__/integration/openclaw-config-validates-against-oc.test.ts
@@ -33,6 +33,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/integration/openclaw-secretref-builtins.test.ts
+++ b/packages/web/src/__tests__/integration/openclaw-secretref-builtins.test.ts
@@ -46,6 +46,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/integration/secret-ref-roundtrip.test.ts
+++ b/packages/web/src/__tests__/integration/secret-ref-roundtrip.test.ts
@@ -53,6 +53,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config-bootstrap-caps.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-bootstrap-caps.test.ts
@@ -51,6 +51,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config-email.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-email.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config-skills.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-skills.test.ts
@@ -50,6 +50,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-tools-md.test.ts
@@ -75,6 +75,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config-web-search.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-web-search.test.ts
@@ -47,6 +47,7 @@ vi.mock("@/db", () => ({
 
 vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -55,8 +55,38 @@ vi.mock("@/db", () => ({
   },
 }));
 
+// getSettingsByPrefix is mocked to resolve against the SAME `getSetting` mock
+// implementation each test already sets up (probing a fixed set of candidate
+// agent IDs used with `telegram_bot_token:` across this file). This keeps
+// every existing telegram-bot-token test working unchanged while letting the
+// production bot-token loop switch from per-agent getSetting calls to one
+// batched prefix query (#261).
+const { mockGetSetting, mockGetSettingsByPrefix } = vi.hoisted(() => {
+  const TELEGRAM_BOT_TOKEN_TEST_AGENT_IDS = [
+    "agent-1",
+    "agent-2",
+    "agent-42",
+    "admin-smithers",
+    "agent-id-with-bot",
+  ];
+  const getSetting = vi.fn().mockResolvedValue(null);
+  return {
+    mockGetSetting: getSetting,
+    mockGetSettingsByPrefix: vi.fn(async (prefix: string) => {
+      const map = new Map<string, string>();
+      for (const id of TELEGRAM_BOT_TOKEN_TEST_AGENT_IDS) {
+        const key = `${prefix}${id}`;
+        const value = await getSetting(key);
+        if (value) map.set(key, value);
+      }
+      return map;
+    }),
+  };
+});
+
 vi.mock("@/lib/settings", () => ({
-  getSetting: vi.fn().mockResolvedValue(null),
+  getSetting: mockGetSetting,
+  getSettingsByPrefix: mockGetSettingsByPrefix,
   setSetting: vi.fn().mockResolvedValue(undefined),
 }));
 
@@ -5430,6 +5460,53 @@ describe("restart-state integration", () => {
 
     expect(config.channels.telegram.accounts).toEqual({
       "agent-1": { botToken: "123456:ABC-token" },
+    });
+  });
+
+  it("resolves telegram bot tokens via a single batched prefix query, not one getSetting per liveAgent (#261)", async () => {
+    let callCount = 0;
+    mockedDb.select.mockReturnValue({
+      from: vi.fn().mockImplementation(() => {
+        callCount++;
+        if (callCount === 1) {
+          return Object.assign(
+            Promise.resolve([
+              { id: "agent-1", name: "Smithers", model: "m", allowedTools: [] },
+              { id: "agent-2", name: "Support", model: "m", allowedTools: [] },
+            ]),
+            { innerJoin: mockInnerJoin([]), where: vi.fn().mockResolvedValue([]) }
+          );
+        }
+        return Object.assign(Promise.resolve([]), {
+          innerJoin: mockInnerJoin([]),
+          where: vi.fn().mockResolvedValue([]),
+        });
+      }),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "token-1";
+      if (key === "telegram_bot_token:agent-2") return "token-2";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    // Batched: exactly one getSettingsByPrefix("telegram_bot_token:") call
+    // resolves both liveAgents' bot tokens, instead of production code calling
+    // getSetting once per agent. (getSettingsByPrefix's own mock implementation
+    // internally probes candidate keys via getSetting — that's test plumbing,
+    // not the production call path under test here.)
+    const telegramPrefixCalls = mockGetSettingsByPrefix.mock.calls.filter(
+      ([prefix]) => prefix === "telegram_bot_token:"
+    );
+    expect(telegramPrefixCalls).toHaveLength(1);
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    expect(config.channels.telegram.accounts).toEqual({
+      "agent-1": { botToken: "token-1" },
+      "agent-2": { botToken: "token-2" },
     });
   });
 

--- a/packages/web/src/__tests__/lib/settings.test.ts
+++ b/packages/web/src/__tests__/lib/settings.test.ts
@@ -32,7 +32,13 @@ vi.mock("@/lib/encryption", () => ({
 
 import { db } from "@/db";
 import { encrypt, decrypt } from "@/lib/encryption";
-import { getSetting, setSetting, deleteSetting, getAllSettings } from "@/lib/settings";
+import {
+  getSetting,
+  setSetting,
+  deleteSetting,
+  getAllSettings,
+  getSettingsByPrefix,
+} from "@/lib/settings";
 
 describe("getSetting", () => {
   beforeEach(() => vi.clearAllMocks());
@@ -128,5 +134,37 @@ describe("getAllSettings", () => {
     fromMock.mockResolvedValueOnce(rows);
     const result = await getAllSettings();
     expect(result).toEqual(rows);
+  });
+});
+
+describe("getSettingsByPrefix", () => {
+  beforeEach(() => vi.clearAllMocks());
+
+  it("returns only the settings whose key starts with the prefix, decrypted, in one query (#261)", async () => {
+    fromMock.mockResolvedValueOnce([
+      { key: "telegram_bot_token:agent-1", value: "tok-1", encrypted: false },
+      { key: "telegram_bot_token:agent-2", value: "encrypted:tok-2", encrypted: true },
+      { key: "telegram_bot_username:agent-1", value: "botone", encrypted: false },
+      { key: "default_provider", value: "anthropic", encrypted: false },
+    ]);
+    const map = await getSettingsByPrefix("telegram_bot_token:");
+    // Single select — no N+1 findFirst calls.
+    expect(db.select).toHaveBeenCalledTimes(1);
+    expect(map.size).toBe(2);
+    expect(map.get("telegram_bot_token:agent-1")).toBe("tok-1");
+    // Encrypted row is decrypted.
+    expect(map.get("telegram_bot_token:agent-2")).toBe("tok-2");
+    expect(decrypt).toHaveBeenCalledWith("encrypted:tok-2");
+    // Non-matching keys are excluded.
+    expect(map.has("telegram_bot_username:agent-1")).toBe(false);
+    expect(map.has("default_provider")).toBe(false);
+  });
+
+  it("returns an empty map when nothing matches", async () => {
+    fromMock.mockResolvedValueOnce([
+      { key: "default_provider", value: "anthropic", encrypted: false },
+    ]);
+    const map = await getSettingsByPrefix("telegram_bot_token:");
+    expect(map.size).toBe(0);
   });
 });

--- a/packages/web/src/__tests__/lib/telegram-allow-store.test.ts
+++ b/packages/web/src/__tests__/lib/telegram-allow-store.test.ts
@@ -74,9 +74,18 @@ vi.mock("drizzle-orm", async (importOriginal) => {
   };
 });
 
-const mockGetSetting = vi.fn();
+// Map-based settings mock: tests populate `mockSettings` with the keys they
+// want present. `getSetting` reads it; `getSettingsByPrefix` filters it in one
+// call (the production code batches bot-token lookups now — #261).
+const mockSettings = new Map<string, string>();
+const { mockGetSettingsByPrefix } = vi.hoisted(() => ({
+  mockGetSettingsByPrefix: vi.fn((prefix: string, map: Map<string, string>) =>
+    Promise.resolve(new Map(Array.from(map.entries()).filter(([k]) => k.startsWith(prefix))))
+  ),
+}));
 vi.mock("@/lib/settings", () => ({
-  getSetting: (...args: unknown[]) => mockGetSetting(...args),
+  getSetting: (key: string) => Promise.resolve(mockSettings.get(key) ?? null),
+  getSettingsByPrefix: (prefix: string) => mockGetSettingsByPrefix(prefix, mockSettings),
 }));
 
 import {
@@ -293,7 +302,14 @@ describe("telegram-allow-store", () => {
     }
 
     beforeEach(() => {
-      mockGetSetting.mockResolvedValue(null);
+      mockSettings.clear();
+      // Re-wire the prefix spy after the outer clearAllMocks (its impl reads
+      // mockSettings, which each test populates via mockSettings.set).
+      mockGetSettingsByPrefix.mockImplementation((prefix: string) =>
+        Promise.resolve(
+          new Map(Array.from(mockSettings.entries()).filter(([k]) => k.startsWith(prefix)))
+        )
+      );
       mockReaddirSync.mockReturnValue([]);
     });
 
@@ -319,9 +335,7 @@ describe("telegram-allow-store", () => {
           { id: "user-2", role: "member", banned: false },
         ],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -359,9 +373,7 @@ describe("telegram-allow-store", () => {
           { id: "user-2", role: "member", banned: false },
         ],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -392,9 +404,7 @@ describe("telegram-allow-store", () => {
         userGroups: [], // admin is NOT in group-1
         users: [{ id: "user-admin", role: "admin", banned: false }],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -430,11 +440,8 @@ describe("telegram-allow-store", () => {
         userGroups: [{ userId: "user-1", groupId: "group-1" }],
         users: [{ id: "user-1", role: "member", banned: false }],
       });
-      mockGetSetting.mockImplementation((key: string) => {
-        if (key === "telegram_bot_token:agent-1") return Promise.resolve("token-1");
-        if (key === "telegram_bot_token:agent-2") return Promise.resolve("token-2");
-        return Promise.resolve(null);
-      });
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
+      mockSettings.set("telegram_bot_token:agent-2", "token-2");
 
       await recalculateTelegramAllowStores();
 
@@ -479,9 +486,7 @@ describe("telegram-allow-store", () => {
         users: [{ id: "user-1", role: "member", banned: false }],
       });
       // Only agent-1 has a bot token
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -506,9 +511,7 @@ describe("telegram-allow-store", () => {
         userGroups: [],
         users: [],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
       // Orphaned store file for agent that no longer has a bot
       mockReaddirSync.mockReturnValue([
         "telegram-agent-1-allowFrom.json",
@@ -538,9 +541,7 @@ describe("telegram-allow-store", () => {
         userGroups: [],
         users: [],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
       mockReaddirSync.mockReturnValue([
         "telegram-allowFrom.json", // legacy
         "telegram-agent-1-allowFrom.json",
@@ -569,9 +570,7 @@ describe("telegram-allow-store", () => {
         userGroups: [],
         users: [],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -600,7 +599,7 @@ describe("telegram-allow-store", () => {
         userGroups: [],
         users: [],
       });
-      mockGetSetting.mockResolvedValue(null); // no bot tokens
+      // no bot tokens — mockSettings is empty
 
       await recalculateTelegramAllowStores();
 
@@ -625,9 +624,7 @@ describe("telegram-allow-store", () => {
         userGroups: [],
         users: [{ id: "user-1", role: "member", banned: false }],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:smithers-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:smithers-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -662,9 +659,7 @@ describe("telegram-allow-store", () => {
           { id: "user-banned", role: "member", banned: true },
         ],
       });
-      mockGetSetting.mockImplementation((key: string) =>
-        key === "telegram_bot_token:agent-1" ? Promise.resolve("token-1") : Promise.resolve(null)
-      );
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
 
       await recalculateTelegramAllowStores();
 
@@ -675,6 +670,53 @@ describe("telegram-allow-store", () => {
       const written = JSON.parse(accountWrite![1] as string);
       expect(written.allowFrom).toContain("111222333");
       expect(written.allowFrom).not.toContain("444555666");
+    });
+
+    it("fetches bot tokens in a single batched prefix query, not one getSetting per agent (#261)", async () => {
+      setupDbMocks({
+        agents: [
+          {
+            id: "agent-1",
+            visibility: "all",
+            isPersonal: false,
+            deletedAt: null,
+            avatarSeed: null,
+          },
+          {
+            id: "agent-2",
+            visibility: "all",
+            isPersonal: false,
+            deletedAt: null,
+            avatarSeed: null,
+          },
+          {
+            id: "agent-3",
+            visibility: "all",
+            isPersonal: false,
+            deletedAt: null,
+            avatarSeed: null,
+          },
+        ],
+        channelLinks: [{ userId: "user-1", channelUserId: "111222333" }],
+        agentGroups: [],
+        userGroups: [],
+        users: [{ id: "user-1", role: "member", banned: false }],
+      });
+      mockSettings.set("telegram_bot_token:agent-1", "token-1");
+      mockSettings.set("telegram_bot_token:agent-2", "token-2");
+      mockSettings.set("telegram_bot_token:agent-3", "token-3");
+
+      await recalculateTelegramAllowStores();
+
+      // One batched prefix query — not one getSetting round-trip per agent.
+      expect(mockGetSettingsByPrefix).toHaveBeenCalledTimes(1);
+      expect(mockGetSettingsByPrefix).toHaveBeenCalledWith("telegram_bot_token:", mockSettings);
+
+      // All three agents' stores were still written from the batched result.
+      const written = mockWriteFileSync.mock.calls.map((c: unknown[]) => c[0] as string);
+      expect(written.some((p) => p.includes("telegram-agent-1-allowFrom.json"))).toBe(true);
+      expect(written.some((p) => p.includes("telegram-agent-2-allowFrom.json"))).toBe(true);
+      expect(written.some((p) => p.includes("telegram-agent-3-allowFrom.json"))).toBe(true);
     });
   });
 });

--- a/packages/web/src/__tests__/lib/telegram.test.ts
+++ b/packages/web/src/__tests__/lib/telegram.test.ts
@@ -1,8 +1,18 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
 const mockGetSetting = vi.fn();
+// Map-based settings mock: tests populate `mockSettings` with the keys they
+// want present. `getSetting` reads it; `getSettingsByPrefix` filters it in one
+// call (the production code batches bot-token lookups now — #261).
+const mockSettings = new Map<string, string>();
+const { mockGetSettingsByPrefix } = vi.hoisted(() => ({
+  mockGetSettingsByPrefix: vi.fn((prefix: string, map: Map<string, string>) =>
+    Promise.resolve(new Map(Array.from(map.entries()).filter(([k]) => k.startsWith(prefix))))
+  ),
+}));
 vi.mock("@/lib/settings", () => ({
   getSetting: (...args: unknown[]) => mockGetSetting(...args),
+  getSettingsByPrefix: (prefix: string) => mockGetSettingsByPrefix(prefix, mockSettings),
 }));
 
 const mockFindMany = vi.fn();
@@ -229,49 +239,42 @@ describe("probeTelegramPollingConflict", () => {
 describe("hasMainTelegramBot", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSettings.clear();
   });
 
   it("returns false when there are no personal agents", async () => {
     mockFindMany.mockResolvedValueOnce([]);
     await expect(hasMainTelegramBot()).resolves.toBe(false);
-    expect(mockGetSetting).not.toHaveBeenCalled();
+    expect(mockGetSettingsByPrefix).not.toHaveBeenCalled();
   });
 
   it("returns false when no personal agent has a telegram bot token", async () => {
     mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }, { id: "smithers-2" }]);
-    mockGetSetting.mockResolvedValue(null);
     await expect(hasMainTelegramBot()).resolves.toBe(false);
-    expect(mockGetSetting).toHaveBeenCalledWith("telegram_bot_token:smithers-1");
-    expect(mockGetSetting).toHaveBeenCalledWith("telegram_bot_token:smithers-2");
   });
 
   it("returns true when a personal agent has a telegram bot token", async () => {
     mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }, { id: "smithers-2" }]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_token:smithers-2") return "123456:ABC-token";
-      return null;
-    });
+    mockSettings.set("telegram_bot_token:smithers-2", "123456:ABC-token");
     await expect(hasMainTelegramBot()).resolves.toBe(true);
   });
 
-  it("short-circuits as soon as it finds a token", async () => {
+  it("uses a single batched prefix query, not one getSetting per agent (#261)", async () => {
     mockFindMany.mockResolvedValueOnce([
       { id: "smithers-1" },
       { id: "smithers-2" },
       { id: "smithers-3" },
     ]);
-    mockGetSetting.mockImplementation(async (key: string) => {
-      if (key === "telegram_bot_token:smithers-1") return "123456:ABC-token";
-      return null;
-    });
+    mockSettings.set("telegram_bot_token:smithers-1", "123456:ABC-token");
     await expect(hasMainTelegramBot()).resolves.toBe(true);
-    // Should not query the 2nd and 3rd agents once it found the first one
-    expect(mockGetSetting).toHaveBeenCalledTimes(1);
+    expect(mockGetSettingsByPrefix).toHaveBeenCalledTimes(1);
+    expect(mockGetSettingsByPrefix).toHaveBeenCalledWith("telegram_bot_token:", mockSettings);
+    expect(mockGetSetting).not.toHaveBeenCalled();
   });
 
   it("treats an empty-string token as not configured", async () => {
     mockFindMany.mockResolvedValueOnce([{ id: "smithers-1" }]);
-    mockGetSetting.mockResolvedValueOnce("");
+    mockSettings.set("telegram_bot_token:smithers-1", "");
     await expect(hasMainTelegramBot()).resolves.toBe(false);
   });
 });

--- a/packages/web/src/app/api/agents/route.ts
+++ b/packages/web/src/app/api/agents/route.ts
@@ -47,7 +47,12 @@ const createAgentSchema = z.object({
 
 export const GET = withAuth(async (_req, _ctx, session) => {
   const visibleAgents = await getVisibleAgents(session.user.id!, session.user.role ?? "member");
-  return NextResponse.json(visibleAgents);
+  // Short private cache absorbs back-and-forth agent-switch navigation
+  // without re-querying on every mount; the list is per-user (private) and
+  // 5 s keeps it fresh for operational changes (#261).
+  return NextResponse.json(visibleAgents, {
+    headers: { "Cache-Control": "private, max-age=5, must-revalidate" },
+  });
 });
 
 export const POST = withAdmin(async (request, _ctx, session) => {

--- a/packages/web/src/app/api/audit/route.ts
+++ b/packages/web/src/app/api/audit/route.ts
@@ -105,10 +105,19 @@ export async function GET(request: NextRequest) {
     error: e.error,
   }));
 
-  return NextResponse.json({
-    entries: processedEntries,
-    total: totalResult[0]?.count ?? 0,
-    page,
-    limit,
-  });
+  return NextResponse.json(
+    {
+      entries: processedEntries,
+      total: totalResult[0]?.count ?? 0,
+      page,
+      limit,
+    },
+    {
+      // Short private cache absorbs audit-page navigation/refreshes without
+      // re-running the (potentially heavy) filtered count + scan on every
+      // request; the trail is admin-only (private) and 5 s keeps it fresh
+      // for newly-appended rows (#261).
+      headers: { "Cache-Control": "private, max-age=5, must-revalidate" },
+    }
+  );
 }

--- a/packages/web/src/app/api/audit/route.ts
+++ b/packages/web/src/app/api/audit/route.ts
@@ -113,11 +113,12 @@ export async function GET(request: NextRequest) {
       limit,
     },
     {
-      // Short private cache absorbs audit-page navigation/refreshes without
-      // re-running the (potentially heavy) filtered count + scan on every
-      // request; the trail is admin-only (private) and 5 s keeps it fresh
-      // for newly-appended rows (#261).
-      headers: { "Cache-Control": "private, max-age=5, must-revalidate" },
+      // The audit trail is the security/compliance record of admin actions,
+      // so it is never cached: an admin refreshing to confirm an action was
+      // logged must always see fresh data, and a sensitive log should not be
+      // persisted to the browser disk cache. (Unlike /api/agents, whose short
+      // private TTL absorbs navigation — the audit log's freshness wins.) #261
+      headers: { "Cache-Control": "no-store" },
     }
   );
 }

--- a/packages/web/src/app/api/settings/telegram/bots/route.ts
+++ b/packages/web/src/app/api/settings/telegram/bots/route.ts
@@ -1,6 +1,6 @@
 import { NextResponse } from "next/server";
 import { withAuth } from "@/lib/api-auth";
-import { getSetting } from "@/lib/settings";
+import { getSettingsByPrefix } from "@/lib/settings";
 import { getVisibleAgents } from "@/lib/visible-agents";
 import { getOrgPairingSmithers, type PairingCandidate } from "@/lib/pairing-candidates";
 
@@ -19,15 +19,13 @@ export const GET = withAuth(async (_req, _ctx, session) => {
     ...orgPairing,
   ];
 
-  const resolved = await Promise.all(
-    candidates.map(async (c) => ({
-      candidate: c,
-      botUsername: await getSetting(`telegram_bot_username:${c.realId}`),
-    }))
-  );
+  // Batched: one `telegram_bot_username:` prefix query instead of a
+  // `getSetting` round-trip per candidate (#261 N+1).
+  const botUsernameByKey = await getSettingsByPrefix("telegram_bot_username:");
 
-  const bots = resolved.flatMap(({ candidate, botUsername }) =>
-    botUsername
+  const bots = candidates.flatMap((candidate) => {
+    const botUsername = botUsernameByKey.get(`telegram_bot_username:${candidate.realId}`);
+    return botUsername
       ? [
           {
             agentId: candidate.publicId,
@@ -36,8 +34,8 @@ export const GET = withAuth(async (_req, _ctx, session) => {
             isPersonal: candidate.isPersonal,
           },
         ]
-      : []
-  );
+      : [];
+  });
 
   // Sort personal agents (Smithers) first — the pairing UI uses bots[0] as
   // the primary bot for the QR code. Users should always pair via Smithers

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -12,7 +12,7 @@ import {
   integrationConnections,
   channelLinks,
 } from "@/db/schema";
-import { getSetting } from "@/lib/settings";
+import { getSetting, getSettingsByPrefix } from "@/lib/settings";
 import {
   computeAllowedTools,
   getEmailToolsForOperations,
@@ -1215,8 +1215,10 @@ export async function regenerateOpenClawConfig() {
   const bindings: TelegramBinding[] = [];
   const personalBotsAccountIds: Array<{ accountId: string; ownerId: string | null }> = [];
 
+  // Single batched query instead of one getSetting per liveAgent (#261).
+  const botTokenByKey = await getSettingsByPrefix("telegram_bot_token:");
   for (const agent of liveAgents) {
-    const botToken = await getSetting(`telegram_bot_token:${agent.id}`);
+    const botToken = botTokenByKey.get(`telegram_bot_token:${agent.id}`);
     // #477 layer 2: an account auto-disabled after a sustained getUpdates-409
     // conflict must stay excluded across a full config regen (restart, agent
     // create, etc.) — not just at the moment of the targeted disable write.

--- a/packages/web/src/lib/settings.ts
+++ b/packages/web/src/lib/settings.ts
@@ -30,3 +30,20 @@ export async function deleteSetting(key: string): Promise<void> {
 export async function getAllSettings() {
   return db.select().from(settings);
 }
+
+/**
+ * Fetch every setting whose key starts with `prefix` in a single query and
+ * return them as a Map (key → decrypted value). Replaces the N+1 pattern of
+ * looping `getSetting(key)` per agent — the settings table is small enough
+ * that one round-trip beats N (#261). Mirrors `getSetting`'s decrypt rule.
+ */
+export async function getSettingsByPrefix(prefix: string): Promise<Map<string, string>> {
+  const rows = await getAllSettings();
+  const out = new Map<string, string>();
+  for (const r of rows) {
+    if (r.key.startsWith(prefix)) {
+      out.set(r.key, r.encrypted ? decrypt(r.value) : r.value);
+    }
+  }
+  return out;
+}

--- a/packages/web/src/lib/telegram-allow-store.ts
+++ b/packages/web/src/lib/telegram-allow-store.ts
@@ -26,7 +26,7 @@ import { dirname, join } from "path";
 import { db } from "@/db";
 import { agents, channelLinks, agentGroups, userGroups, users } from "@/db/schema";
 import { eq, and, isNull } from "drizzle-orm";
-import { getSetting } from "@/lib/settings";
+import { getSettingsByPrefix } from "@/lib/settings";
 
 const CONFIG_PATH = process.env.OPENCLAW_CONFIG_PATH || "/openclaw-config/openclaw.json";
 const CREDENTIALS_DIR = join(dirname(CONFIG_PATH), "credentials");
@@ -126,10 +126,12 @@ async function recalculateTelegramAllowStoresImpl(): Promise<void> {
   // which can have Telegram bots connected via Settings → Telegram)
   const allAgents = await db.select().from(agents).where(isNull(agents.deletedAt));
 
-  // 2. Find which agents have bot tokens
+  // 2. Find which agents have bot tokens. Batched: one `telegram_bot_token:`
+  // prefix query instead of a `getSetting` round-trip per agent (#261 N+1).
+  const botTokenByKey = await getSettingsByPrefix("telegram_bot_token:");
   const agentsWithBots: Array<{ id: string; visibility: string; isPersonal: boolean }> = [];
   for (const agent of allAgents) {
-    const botToken = await getSetting(`telegram_bot_token:${agent.id}`);
+    const botToken = botTokenByKey.get(`telegram_bot_token:${agent.id}`);
     if (botToken) {
       agentsWithBots.push({
         id: agent.id,

--- a/packages/web/src/lib/telegram.ts
+++ b/packages/web/src/lib/telegram.ts
@@ -1,7 +1,7 @@
 import { db } from "@/db";
 import { agents } from "@/db/schema";
 import { eq } from "drizzle-orm";
-import { getSetting } from "@/lib/settings";
+import { getSettingsByPrefix } from "@/lib/settings";
 
 interface TelegramValidationSuccess {
   valid: true;
@@ -104,9 +104,11 @@ export async function hasMainTelegramBot(): Promise<boolean> {
     where: eq(agents.isPersonal, true),
     columns: { id: true },
   });
-  for (const agent of personalAgents) {
-    const token = await getSetting(`telegram_bot_token:${agent.id}`);
-    if (token) return true;
-  }
-  return false;
+  if (personalAgents.length === 0) return false;
+
+  // Single batched query instead of one getSetting per personal agent (#261).
+  const botTokenByKey = await getSettingsByPrefix("telegram_bot_token:");
+  return personalAgents.some((agent) =>
+    Boolean(botTokenByKey.get(`telegram_bot_token:${agent.id}`))
+  );
 }


### PR DESCRIPTION
Part of #261 — sub-tasks **B, C, and E**. (A and D handled elsewhere; see below.)

## C — N+1 in GET /api/settings/telegram/bots
The route called `getSetting('telegram_bot_username:<id>')` once per candidate agent (Promise.all over N candidates = N DB round-trips). Added `getSettingsByPrefix(prefix)` to `lib/settings` — one `select` returning a decrypted `Map<key, value>` filtered by prefix — and the bots route now resolves every candidate's bot username from a single query.

## B — N+1 in `recalculateTelegramAllowStoresImpl`
`lib/telegram-allow-store.ts` looped a **sequential** `await getSetting('telegram_bot_token:' + agent.id)` per non-deleted agent — N serial round-trips (worse than C, which was parallel). Switched to the same `getSettingsByPrefix('telegram_bot_token:')` batch, so the helper introduced for C now has a second caller instead of being a single-use abstraction. Four side-effect callers that trigger the recalculation had their settings mocks extended (the batched path calls `getAllSettings()` unconditionally).

## E — Cache headers on read APIs used in navigation
Two endpoints, two deliberately different answers:
- **`GET /api/agents`** → `Cache-Control: private, max-age=5, must-revalidate`. A short private cache absorbs back-and-forth agent-switch navigation without re-querying; per-user (private), conservative TTL.
- **`GET /api/audit`** → `Cache-Control: no-store`. The audit trail is the security/compliance **record of admin actions**, so it is never cached — an admin refreshing to confirm an action was logged must always see fresh data, and a sensitive log should not be persisted to the browser disk cache. The issue's own guidance ("anything tied to admin actions stays uncached") applies to the audit log itself; a short private TTL there would contradict it. This matches the external best-practice consensus (`no-store` for sensitive/audit endpoints).

## Handled elsewhere
- **A** (sync `fs` → `fs/promises`) — deferred. The issue's line refs are stale (`openclaw-config.ts` split into `openclaw-config/*.ts`). See the recommendation on #261: the high-value slice (the synchronous EACCES busy-wait spin-loop in `readExistingConfig`) forces an async cascade into `write.ts` — the most race-condition-sensitive file in the codebase (documented incidents #314/#464/#193) — and no bounded low-risk slice exists. Disproportionate for the current scale; wants a deliberate, dedicated effort.
- **D** (usage-poller adaptive backoff) — done in #680.

## Tests
- `settings.test.ts`: `getSettingsByPrefix` — one query, decrypts, filters, empty-map.
- `settings-telegram-bots.test.ts` + `telegram-allow-store.test.ts`: Map-based settings mock; assert a single batched `getSettingsByPrefix` call.
- `agents-list-route.test.ts` (new): asserts the private cache header on `/api/agents`.
- `audit-route.test.ts`: asserts `/api/audit` returns `no-store`.

Full web unit suite green; `tsc` + prettier + eslint clean.
