### PR TITLE
feat(ops): production hardening — graceful shutdown, DB pool, Docker limits (#263)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -176,6 +176,8 @@ Adding the `squawk-ignore` comment is a deliberate act — Reviewers are expecte
 
 [Drizzle does not support down-migrations](https://github.com/drizzle-team/drizzle-orm/discussions/1339), and writing reliable down-SQL by hand for every migration costs more than it saves. Our explicit stance: **rollback = restore from `pg_dump` + re-pin previous image tag.** This is also documented in the upgrading guide so admins aren't surprised.
 
+Forward-only is a stance on migration _tooling_, not on operator safety net: the operational backup step that makes rollback possible in practice lives in the [Upgrading guide → Take a pre-migration backup](https://docs.heypinchy.com/guides/upgrading/#standard-upgrade) (step 1 of every standard upgrade), with the full rollback path in [Restoring from backup](https://docs.heypinchy.com/guides/upgrading/#restoring-from-backup). Point admins there, not at this section, when they ask "how do I undo a migration."
+
 ## UI Conventions
 
 ### Error Messages & Notifications

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -23,12 +23,15 @@ services:
       test:
         [
           "CMD-SHELL",
-          "node -e \"require('http').get('http://localhost:7777/api/internal/openclaw-config-ready', r => process.exit(r.statusCode === 200 ? 0 : 1))\"",
+          'node -e "require(''http'').get(''http://localhost:7777/api/internal/openclaw-config-ready'', r => process.exit(r.statusCode === 200 ? 0 : 1))"',
         ]
       interval: 2s
       timeout: 3s
       retries: 30
       start_period: 5s
+    # Resource limits (#263) — overridable via env for larger deployments.
+    mem_limit: ${PINCHY_MEM_LIMIT:-1g}
+    cpus: ${PINCHY_CPUS:-1.5}
 
   openclaw:
     image: ghcr.io/heypinchy/pinchy-openclaw:${PINCHY_VERSION:?set PINCHY_VERSION in .env (e.g. PINCHY_VERSION=v0.5.0)}
@@ -54,6 +57,22 @@ services:
     depends_on:
       pinchy:
         condition: service_healthy
+    # Liveness check: the gateway listens on 18789. A TCP connect succeeds once
+    # the WS server is up (the OpenClaw start script's own health loop respawns
+    # the gateway process if it dies; this surfaces that to Docker so a stuck
+    # container restarts instead of staying unhealthy-but-running). #263
+    healthcheck:
+      test:
+        [
+          "CMD-SHELL",
+          'node -e "const s=require(''net'').connect(18789,''localhost'');s.on(''connect'',()=>process.exit(0));s.on(''error'',()=>process.exit(1));setTimeout(()=>process.exit(1),2000)"',
+        ]
+      interval: 10s
+      timeout: 5s
+      retries: 5
+      start_period: 15s
+    mem_limit: ${OPENCLAW_MEM_LIMIT:-2g}
+    cpus: ${OPENCLAW_CPUS:-2}
 
   db:
     image: postgres:17
@@ -69,6 +88,8 @@ services:
       interval: 5s
       timeout: 5s
       retries: 5
+    mem_limit: ${DB_MEM_LIMIT:-1g}
+    cpus: ${DB_CPUS:-1}
 
 volumes:
   pgdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -59,8 +59,10 @@ services:
         condition: service_healthy
     # Liveness check: the gateway listens on 18789. A TCP connect succeeds once
     # the WS server is up (the OpenClaw start script's own health loop respawns
-    # the gateway process if it dies; this surfaces that to Docker so a stuck
-    # container restarts instead of staying unhealthy-but-running). #263
+    # the gateway process if it dies). This is diagnostic only — Compose does
+    # NOT restart an unhealthy-but-running container, so a stuck container
+    # surfaces as `unhealthy` in `docker compose ps` for an operator to act on,
+    # it does not self-heal. #263
     healthcheck:
       test:
         [

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -131,7 +131,7 @@ DB_CPUS=0.5
 
 ### Health checks
 
-`db` and `pinchy` each have a Docker health check: `db` polls `pg_isready`, and `pinchy` polls its own `/api/internal/openclaw-config-ready` endpoint. `openclaw` has a lightweight **TCP liveness check** — a raw connect to the gateway's WebSocket port (`18789`) that succeeds as soon as the gateway is accepting connections. It doesn't inspect the gateway's internal state, only that something is listening; OpenClaw's own start script already respawns the gateway process if it dies internally, so this check exists to surface a fully stuck container (process alive, port not listening) to Docker so it gets restarted instead of sitting "up" but unreachable.
+`db` and `pinchy` each have a Docker health check: `db` polls `pg_isready`, and `pinchy` polls its own `/api/internal/openclaw-config-ready` endpoint. `openclaw` has a lightweight **TCP liveness check** — a raw connect to the gateway's WebSocket port (`18789`) that succeeds as soon as the gateway is accepting connections. It doesn't inspect the gateway's internal state, only that something is listening; OpenClaw's own start script already respawns the gateway process if it dies internally, so this check exists to surface a fully stuck container (process alive, port not listening). Note that Compose does **not** restart a container just because it is `unhealthy` — `restart:` policies act on container _exit_, not health status. The check is diagnostic: a stuck container shows as `unhealthy` in `docker compose ps` so you can spot it and restart it yourself, rather than it silently sitting "up" but unreachable.
 
 You can watch health status with:
 

--- a/docs/src/content/docs/guides/customizing-deployment.mdx
+++ b/docs/src/content/docs/guides/customizing-deployment.mdx
@@ -88,3 +88,55 @@ This prints the effective configuration (base + override merged) without startin
 ## Overrides and upgrades
 
 Your `docker-compose.override.yml` survives upgrades unchanged. However, if a new Pinchy release changes a base-file field you're overriding (for example, renames a volume), the merge may produce an unexpected result. Re-check `docker compose config` after every major release.
+
+## Resource limits and health checks
+
+Pinchy's `docker-compose.yml` caps memory and CPU for all three containers, and gives `pinchy` and `db` HTTP/TCP health checks so Docker can tell a wedged container from a healthy one. All six limits are overridable via `.env` — you never need to touch `docker-compose.yml` itself.
+
+| Variable             | Default | Caps                                                              |
+| -------------------- | ------- | ----------------------------------------------------------------- |
+| `PINCHY_MEM_LIMIT`   | `1g`    | Memory for the `pinchy` container (web UI, API, WebSocket bridge) |
+| `PINCHY_CPUS`        | `1.5`   | CPU cores for `pinchy`                                            |
+| `OPENCLAW_MEM_LIMIT` | `2g`    | Memory for the `openclaw` container (agent runtime, model calls)  |
+| `OPENCLAW_CPUS`      | `2`     | CPU cores for `openclaw`                                          |
+| `DB_MEM_LIMIT`       | `1g`    | Memory for the `db` container (PostgreSQL 17)                     |
+| `DB_CPUS`            | `1`     | CPU cores for `db`                                                |
+
+### Why these exist
+
+Without a limit, a single runaway container — a leaking process, a model call that buffers an oversized response, a query that goes wide — can exhaust all memory on the host and take down every other container (and often the host itself) with it. `mem_limit`/`cpus` contain that failure to the one container that caused it. Combined with `restart: unless-stopped` (already set on all three services and not something you should change), an OOM-killed container comes back on its own instead of leaving the deployment wedged until someone notices and runs `docker compose up -d` by hand.
+
+### Sizing your host
+
+The defaults add up to roughly 4 GB of memory ceiling across the three containers (1 + 2 + 1). That's a ceiling, not a reservation — containers use less at idle — but your host needs headroom **above** that total for the OS, Docker itself, and any reverse proxy you run alongside Pinchy. We recommend a host with meaningfully more than 4 GB, e.g. **6–8 GB or more**, so the limits are a backstop rather than a wall you hit during normal operation.
+
+If you're intentionally running on a constrained 4 GB VPS — a real scenario, not just a hypothetical — lower the limits in `.env` so the three containers leave the OS enough room to breathe:
+
+```bash
+# .env — tuned for a 4 GB VPS
+PINCHY_MEM_LIMIT=768m
+PINCHY_CPUS=1
+OPENCLAW_MEM_LIMIT=1.5g
+OPENCLAW_CPUS=1.5
+DB_MEM_LIMIT=512m
+DB_CPUS=0.5
+```
+
+<Aside type="tip">
+  Lowering `OPENCLAW_MEM_LIMIT` too far can cause the gateway to be OOM-killed
+  under normal agent traffic, especially with larger local models. If you see
+  `openclaw` restarting repeatedly under load, that's the first place to look —
+  raise the limit before assuming something else is wrong.
+</Aside>
+
+### Health checks
+
+`db` and `pinchy` each have a Docker health check: `db` polls `pg_isready`, and `pinchy` polls its own `/api/internal/openclaw-config-ready` endpoint. `openclaw` has a lightweight **TCP liveness check** — a raw connect to the gateway's WebSocket port (`18789`) that succeeds as soon as the gateway is accepting connections. It doesn't inspect the gateway's internal state, only that something is listening; OpenClaw's own start script already respawns the gateway process if it dies internally, so this check exists to surface a fully stuck container (process alive, port not listening) to Docker so it gets restarted instead of sitting "up" but unreachable.
+
+You can watch health status with:
+
+```bash
+docker compose ps
+```
+
+A container stuck in `unhealthy` for longer than its configured `retries` × `interval` is a signal worth investigating in `docker compose logs <service>` before assuming a resource limit is to blame.

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -420,10 +420,11 @@ This is the sequence for restoring Pinchy onto a brand-new host — a full disas
 
 2. **Restore the database**
 
-   Start only the `db` service, then restore your most recent `pg_dump`:
+   Start only the `db` service, wait until PostgreSQL is actually accepting connections (`up -d` returns as soon as the container has _started_, not when the database is ready), then restore your most recent `pg_dump`:
 
    ```bash
    docker compose up db -d
+   until docker compose exec -T db pg_isready -U pinchy -q; do sleep 1; done
    gunzip < pinchy-backup-20260222.sql.gz | docker compose exec -T db psql -U pinchy pinchy
    ```
 

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -3,6 +3,8 @@ title: Hardening Guide
 description: Security best practices for deploying Pinchy in production environments.
 ---
 
+import { Aside, Steps } from "@astrojs/starlight/components";
+
 This guide covers security hardening measures for production Pinchy deployments. Pinchy is self-hosted — infrastructure security is your responsibility. These recommendations assume a Linux server with Docker, but most apply to any OS.
 
 ## Reverse proxy with TLS
@@ -377,6 +379,76 @@ OpenClaw 2026.5.12+ refuses to bind on a non-loopback interface without a `gatew
 **Failure mode to watch for.** If `boot-inits.ts` cannot reach the database at startup (DB outage, mis-configured `DATABASE_URL`), the seed step logs a FATAL line and Pinchy refuses to start — better to fail fast than to leave OpenClaw stuck. If you see `pinchy-openclaw` restart-looping with `Refusing to bind gateway to lan without auth` _and_ Pinchy itself is healthy, the seed wrote successfully but OpenClaw is reading from a different config path — verify the `openclaw-config` volume mount.
 
 ## Backup & recovery
+
+:::note
+The `openclaw-secrets` volume is a **tmpfs** — it lives in RAM, not on disk. It holds OpenClaw's device identity and per-session secret material, and is deliberately reseeded from scratch on every container restart. There is nothing to back up here: the volume is designed to be lost. If you go looking for it in a backup and don't find it, that's working as intended, not a gap.
+:::
+
+### What to back up beyond `pgdata`
+
+PostgreSQL's `pgdata` volume holds the bulk of Pinchy's state — users, agents, settings, encrypted API keys, and the audit log — and is the backup most guides (including this one) lead with. A full cold restore on a new host also needs three things that don't live in `pgdata`:
+
+| What                                                                                             | Why it matters if lost                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                              |
+| ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Your `.env` secrets (`DB_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, `AUDIT_HMAC_SECRET`) | If any of these were auto-generated rather than pinned, they're persisted as files in the `pinchy-secrets` volume, not in `.env` — back up that volume too (see below). Losing `ENCRYPTION_KEY` makes every stored LLM provider API key permanently unreadable. Losing `AUDIT_HMAC_SECRET` breaks integrity verification for every audit row signed under it. Losing `BETTER_AUTH_SECRET` invalidates every active session.                                                                                                                         |
+| The `pinchy-secrets` volume                                                                      | Where Pinchy persists any of the four secrets above that you didn't pin explicitly in `.env` (see [VPS Deployment → Pin your secrets](/guides/vps-deployment/#deploy-pinchy)). Same consequences as losing the `.env` values themselves.                                                                                                                                                                                                                                                                                                            |
+| The `openclaw-config` volume                                                                     | Holds `openclaw.json` — the gateway's bootstrap auth token and the regenerated agent/provider configuration. Pinchy rebuilds most of this from the database on every start, so a lost volume mostly self-heals; the exception is the `gateway.auth.token` bootstrap credential (see [Gateway-auth bootstrap](#gateway-auth-bootstrap)), which regenerates automatically but invalidates the old value — harmless on a full restore where both `pinchy` and `openclaw` come up together, worth knowing if you ever restore this volume in isolation. |
+
+<Aside type="tip">
+  If you always pin `DB_PASSWORD`, `BETTER_AUTH_SECRET`, `ENCRYPTION_KEY`, and
+  `AUDIT_HMAC_SECRET` explicitly in `.env` (recommended for production — see
+  [VPS Deployment](/guides/vps-deployment/#deploy-pinchy)), your `.env` backup
+  already covers them and the `pinchy-secrets` volume backup becomes a
+  belt-and-suspenders step rather than the only copy.
+</Aside>
+
+### Cold-restore walkthrough (fresh host)
+
+This is the sequence for restoring Pinchy onto a brand-new host — a full disaster-recovery scenario, not a routine upgrade rollback (for that, see [Restoring from backup](/guides/upgrading/#restoring-from-backup) in the upgrading guide).
+
+<Steps>
+
+1. **Restore `.env` and `docker-compose.yml`**
+
+   Copy your backed-up `.env` and `docker-compose.yml` onto the new host, into `/opt/pinchy` (or wherever you run Pinchy from):
+
+   ```bash
+   mkdir -p /opt/pinchy && cd /opt/pinchy
+   # copy .env and docker-compose.yml here from your backup
+   chmod 600 .env
+   ```
+
+2. **Restore the database**
+
+   Start only the `db` service, then restore your most recent `pg_dump`:
+
+   ```bash
+   docker compose up db -d
+   gunzip < pinchy-backup-20260222.sql.gz | docker compose exec -T db psql -U pinchy pinchy
+   ```
+
+3. **Restore the `openclaw-config` and `pinchy-secrets` volumes**
+
+   If you backed up these named volumes (rather than relying on `.env` alone), restore them before starting the rest of the stack. Docker volumes live under `/var/lib/docker/volumes/<project>_<volume-name>/_data` — restore your archive into that path, or use a throwaway container to copy the data in:
+
+   ```bash
+   docker run --rm -v pinchy_pinchy-secrets:/target -v "$(pwd)/backup/pinchy-secrets:/source:ro" \
+     alpine sh -c "cp -a /source/. /target/"
+   docker run --rm -v pinchy_openclaw-config:/target -v "$(pwd)/backup/openclaw-config:/source:ro" \
+     alpine sh -c "cp -a /source/. /target/"
+   ```
+
+   If you always pin all four secrets in `.env` (see above), you can skip restoring `pinchy-secrets` — Pinchy reads the values from the environment instead. `openclaw-config` is safe to skip too; Pinchy regenerates it from the restored database on boot, at the cost of a fresh gateway bootstrap token.
+
+4. **Start the rest of the stack**
+
+   ```bash
+   docker compose up -d
+   ```
+
+   Verify with `curl -s http://localhost:7777/api/version` and check `docker compose logs pinchy --tail 50` for warnings, same as after a normal upgrade.
+
+</Steps>
 
 ### PostgreSQL backups
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -19,9 +19,9 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
 
 <Steps>
 
-1. **Back up your database**
+1. **Take a pre-migration backup**
 
-   Before any upgrade, create a database backup. This lets you roll back if anything goes wrong.
+   Step 3 below (`docker compose up -d`) applies any pending database migrations automatically the moment it restarts — that's what makes upgrades a one-command affair, but it also means there's no separate "review the migration first" pause. This backup is your known-good restore point from **before** any schema change, so create it now, before pulling new images or restarting anything:
 
    ```bash
    mkdir -p backups
@@ -29,6 +29,13 @@ Pinchy handles most upgrade steps automatically — database migrations run on s
    ```
 
    Keeping backups under `backups/` instead of loose in `/opt/pinchy/` means they don't sit next to your `docker-compose.yml` / `.env`, and the directory is easy to target with your off-host backup rotation.
+
+   <Aside type="tip">
+     See [Backup & recovery](/guides/hardening/#backup--recovery) in the
+     Hardening Guide for the fuller picture: encrypted off-site backups, what to
+     back up beyond the database, and a cold-restore walkthrough for a brand-new
+     host.
+   </Aside>
 
 2. **Bump the version pin**
 
@@ -126,11 +133,12 @@ If you need to roll back after an upgrade:
    docker compose exec -T db psql -U pinchy pinchy < backups/pinchy-YYYYMMDD-HHMMSS.sql
    ```
 
-3. **Pull the previous version**
+3. **Re-pin the previous version**
 
-   Replace `vX.Y.Z` with the version you want to roll back to (check the [Releases page](https://github.com/heypinchy/pinchy/releases)):
+   Replace `vX.Y.Z` with the version you want to roll back to (check the [Releases page](https://github.com/heypinchy/pinchy/releases)). Update `PINCHY_VERSION` in `.env` to match — `docker compose` refuses to start without it set — and re-fetch `docker-compose.yml` for that tag if the release notes said it changed:
 
    ```bash
+   sed -i 's/PINCHY_VERSION=.*/PINCHY_VERSION=vX.Y.Z/' .env
    curl -fsSL https://raw.githubusercontent.com/heypinchy/pinchy/vX.Y.Z/docker-compose.yml -o docker-compose.yml
    docker compose pull
    ```

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -23,6 +23,7 @@ import { setChannelHealthMonitor } from "./src/server/channel-health-singleton";
 import { appendAuditLog } from "./src/lib/audit";
 import { recordAuditFailure } from "./src/lib/audit-deferred";
 import { db } from "./src/db";
+import { closeDb } from "./src/db";
 import { agents } from "./src/db/schema";
 import { eq } from "drizzle-orm";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
@@ -345,10 +346,28 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
     () => stopChatErrorGc(),
     () => stopUsagePoller(),
     () => (stopMemoryAuditWatcher ? stopMemoryAuditWatcher() : Promise.resolve()),
+    // Disconnect from the OpenClaw Gateway cleanly so the WS + its in-flight
+    // RPCs don't dangle past the HTTP server close (#263). `openclawClient` is
+    // assigned later in boot; the closure reads it at shutdown time.
+    () => openclawClient?.disconnect() ?? Promise.resolve(),
+    // Drain browser WebSockets: close each client (1001 = going away) then
+    // close the WS server. Without this `docker compose down` hits the 30s
+    // SIGKILL timeout because idle WS clients keep the event loop alive past
+    // `server.close()` (#263).
+    () =>
+      new Promise<void>((resolve) => {
+        for (const ws of wss.clients) {
+          if (ws.readyState === WebSocket.OPEN) ws.close(1001, "server shutting down");
+        }
+        wss.close(() => resolve());
+      }),
     () =>
       new Promise<void>((resolve) => {
         server.close(() => resolve());
       }),
+    // Close the DB pool last, after in-flight requests (drained by
+    // server.close) have settled. `timeout: 5` lets running queries finish.
+    () => closeDb(),
   ]);
 
   // Connect to OpenClaw AFTER bootInits so the gateway token and config are

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -22,8 +22,7 @@ import {
 import { setChannelHealthMonitor } from "./src/server/channel-health-singleton";
 import { appendAuditLog } from "./src/lib/audit";
 import { recordAuditFailure } from "./src/lib/audit-deferred";
-import { db } from "./src/db";
-import { closeDb } from "./src/db";
+import { db, closeDb } from "./src/db";
 import { agents } from "./src/db/schema";
 import { eq } from "drizzle-orm";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
@@ -40,6 +39,7 @@ import {
 import { logCapture } from "./src/lib/log-capture";
 import { startUsagePoller, stopUsagePoller } from "./src/lib/usage-poller";
 import { registerShutdownHandlers } from "./src/lib/shutdown";
+import { buildShutdownSteps } from "./src/server/shutdown-steps";
 import { seedSessionCache } from "./src/server/session-cache-seeder";
 import { readGatewayToken } from "./src/lib/gateway-token-reader";
 import { regenerateOpenClawConfig } from "./src/lib/openclaw-config";
@@ -331,9 +331,12 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   startChatErrorGc();
 
   // Graceful shutdown: stop the upload GC + usage poller intervals, close the
-  // memory-audit watcher, then close the HTTP server. Without this, a SIGTERM
-  // (e.g. from Docker Compose) leaves the setInterval handles dangling and
-  // the process hangs until the container's kill-grace period expires.
+  // memory-audit watcher, disconnect from OpenClaw, drain browser WebSockets,
+  // then close the HTTP server and DB pool. Without this, a SIGTERM (e.g.
+  // from Docker Compose) leaves the setInterval handles / WS connections
+  // dangling and the process hangs until the container's kill-grace period
+  // expires. Steps are defined in `buildShutdownSteps` (@/server/shutdown-steps)
+  // so they can be unit-tested independently of the real HTTP server (#263).
   //
   // Note: registration happens AFTER bootInits() + watcher boot so the
   // memory-audit stop fn can be included in the array. A SIGTERM arriving
@@ -341,34 +344,22 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   // gracefully; that window is short (a few seconds at most) and the
   // alternative (mutable wrapper / re-registration) adds noise for negligible
   // benefit.
-  registerShutdownHandlers([
-    () => stopUploadGc(),
-    () => stopChatErrorGc(),
-    () => stopUsagePoller(),
-    () => (stopMemoryAuditWatcher ? stopMemoryAuditWatcher() : Promise.resolve()),
-    // Disconnect from the OpenClaw Gateway cleanly so the WS + its in-flight
-    // RPCs don't dangle past the HTTP server close (#263). `openclawClient` is
-    // assigned later in boot; the closure reads it at shutdown time.
-    () => openclawClient?.disconnect() ?? Promise.resolve(),
-    // Drain browser WebSockets: close each client (1001 = going away) then
-    // close the WS server. Without this `docker compose down` hits the 30s
-    // SIGKILL timeout because idle WS clients keep the event loop alive past
-    // `server.close()` (#263).
-    () =>
-      new Promise<void>((resolve) => {
-        for (const ws of wss.clients) {
-          if (ws.readyState === WebSocket.OPEN) ws.close(1001, "server shutting down");
-        }
-        wss.close(() => resolve());
-      }),
-    () =>
-      new Promise<void>((resolve) => {
-        server.close(() => resolve());
-      }),
-    // Close the DB pool last, after in-flight requests (drained by
-    // server.close) have settled. `timeout: 5` lets running queries finish.
-    () => closeDb(),
-  ]);
+  registerShutdownHandlers(
+    buildShutdownSteps({
+      stopUploadGc: () => stopUploadGc(),
+      stopChatErrorGc: () => stopChatErrorGc(),
+      stopUsagePoller: () => stopUsagePoller(),
+      stopMemoryAuditWatcher: () =>
+        stopMemoryAuditWatcher ? stopMemoryAuditWatcher() : Promise.resolve(),
+      getOpenclawClient: () => openclawClient,
+      wss,
+      closeHttpServer: () =>
+        new Promise<void>((resolve) => {
+          server.close(() => resolve());
+        }),
+      closeDb: () => closeDb(),
+    })
+  );
 
   // Connect to OpenClaw AFTER bootInits so the gateway token and config are
   // ready. On a completed install, bootInits() has already run

--- a/packages/web/src/__tests__/db/index.test.ts
+++ b/packages/web/src/__tests__/db/index.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock postgres-js so importing db/index doesn't open a real connection.
+const { endMock, postgresMock, drizzleMock } = vi.hoisted(() => {
+  const endMock = vi.fn().mockResolvedValue(undefined);
+  const postgresMock = vi.fn(() => ({ end: endMock }));
+  const drizzleMock = vi.fn((client: unknown, opts: unknown) => ({ client, opts }));
+  return { endMock, postgresMock, drizzleMock };
+});
+vi.mock("postgres", () => ({ default: postgresMock }));
+vi.mock("drizzle-orm/postgres-js", () => ({ drizzle: drizzleMock }));
+
+import { closeDb } from "@/db";
+
+describe("db client pool + closeDb (#263)", () => {
+  beforeEach(() => {
+    // Don't clear postgresMock — its import-time call records the pool config.
+    endMock.mockClear();
+  });
+
+  it("configures an explicit pool (max/idle_timeout/connect_timeout)", () => {
+    expect(postgresMock).toHaveBeenCalledTimes(1);
+    const [, options] = postgresMock.mock.calls[0];
+    expect(options).toMatchObject({ max: 20, idle_timeout: 30, connect_timeout: 10 });
+  });
+
+  it("closeDb ends the pool with a 5s timeout", async () => {
+    await closeDb();
+    expect(endMock).toHaveBeenCalledWith({ timeout: 5 });
+  });
+});

--- a/packages/web/src/__tests__/server/shutdown-steps.test.ts
+++ b/packages/web/src/__tests__/server/shutdown-steps.test.ts
@@ -1,0 +1,176 @@
+import { describe, it, expect, vi } from "vitest";
+import { buildShutdownSteps, type ShutdownDeps } from "@/server/shutdown-steps";
+
+// ws readyState constants (avoid importing the real "ws" package for a pure
+// unit test): CONNECTING=0, OPEN=1, CLOSING=2, CLOSED=3.
+const WS_CONNECTING = 0;
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+function makeFakeClient(readyState: number) {
+  return { readyState, close: vi.fn() };
+}
+
+function makeDeps(overrides: Partial<ShutdownDeps> = {}, calls: string[] = []): ShutdownDeps {
+  const wssClose = vi.fn((cb: () => void) => cb());
+  return {
+    stopUploadGc: vi.fn(async () => {
+      calls.push("stopUploadGc");
+    }),
+    stopChatErrorGc: vi.fn(async () => {
+      calls.push("stopChatErrorGc");
+    }),
+    stopUsagePoller: vi.fn(async () => {
+      calls.push("stopUsagePoller");
+    }),
+    stopMemoryAuditWatcher: vi.fn(async () => {
+      calls.push("stopMemoryAuditWatcher");
+    }),
+    getOpenclawClient: vi.fn(() => null),
+    wss: {
+      clients: new Set(),
+      close: wssClose,
+    },
+    closeHttpServer: vi.fn(async () => {
+      calls.push("closeHttpServer");
+    }),
+    closeDb: vi.fn(async () => {
+      calls.push("closeDb");
+    }),
+    ...overrides,
+  };
+}
+
+describe("buildShutdownSteps (#263)", () => {
+  it("returns exactly 8 steps in the documented order", async () => {
+    const calls: string[] = [];
+    const deps = makeDeps({}, calls);
+    const steps = buildShutdownSteps(deps);
+
+    expect(steps).toHaveLength(8);
+
+    for (const step of steps) {
+      await step();
+    }
+
+    expect(calls).toEqual([
+      "stopUploadGc",
+      "stopChatErrorGc",
+      "stopUsagePoller",
+      "stopMemoryAuditWatcher",
+      // disconnect + WS drain + closeHttpServer produce no `calls` entry by
+      // default (getOpenclawClient -> null, no fake ws clients), so the next
+      // recorded entries are:
+      "closeHttpServer",
+      "closeDb",
+    ]);
+  });
+
+  it("invokes each step's own dependency call in array order", async () => {
+    const client = { disconnect: vi.fn(async () => {}) };
+    const calls: string[] = [];
+    const deps = makeDeps(
+      {
+        getOpenclawClient: vi.fn(() => client),
+      },
+      calls
+    );
+    const steps = buildShutdownSteps(deps);
+
+    for (const step of steps) {
+      await step();
+    }
+
+    expect(deps.stopUploadGc).toHaveBeenCalledTimes(1);
+    expect(deps.stopChatErrorGc).toHaveBeenCalledTimes(1);
+    expect(deps.stopUsagePoller).toHaveBeenCalledTimes(1);
+    expect(deps.stopMemoryAuditWatcher).toHaveBeenCalledTimes(1);
+    expect(client.disconnect).toHaveBeenCalledTimes(1);
+    expect(deps.wss.close).toHaveBeenCalledTimes(1);
+    expect(deps.closeHttpServer).toHaveBeenCalledTimes(1);
+    expect(deps.closeDb).toHaveBeenCalledTimes(1);
+
+    // closeDb must be the very last step, and stopUploadGc the very first.
+    expect(steps[0]).toBeTypeOf("function");
+    expect(calls[0]).toBe("stopUploadGc");
+    expect(calls[calls.length - 1]).toBe("closeDb");
+  });
+
+  describe("OpenClaw disconnect step", () => {
+    it("calls disconnect on the client returned by getOpenclawClient", async () => {
+      const client = { disconnect: vi.fn(async () => {}) };
+      const deps = makeDeps({ getOpenclawClient: vi.fn(() => client) });
+      const steps = buildShutdownSteps(deps);
+
+      // Step index 4 (0-based) is the OpenClaw disconnect step.
+      await steps[4]();
+
+      expect(client.disconnect).toHaveBeenCalledTimes(1);
+    });
+
+    it("is a no-op that still resolves when getOpenclawClient returns null", async () => {
+      const deps = makeDeps({ getOpenclawClient: vi.fn(() => null) });
+      const steps = buildShutdownSteps(deps);
+
+      await expect(steps[4]()).resolves.toBeUndefined();
+    });
+  });
+
+  describe("WS drain step", () => {
+    it("closes only OPEN clients with code 1001, leaves others untouched, then closes wss", async () => {
+      const openClient = makeFakeClient(WS_OPEN);
+      const closedClient = makeFakeClient(WS_CLOSED);
+      const connectingClient = makeFakeClient(WS_CONNECTING);
+
+      const wssClose = vi.fn((cb: () => void) => cb());
+      const deps = makeDeps({
+        wss: {
+          clients: new Set([openClient, closedClient, connectingClient]) as never,
+          close: wssClose,
+        },
+      });
+      const steps = buildShutdownSteps(deps);
+
+      // Step index 5 (0-based) is the WS-drain step.
+      await steps[5]();
+
+      expect(openClient.close).toHaveBeenCalledWith(1001, "server shutting down");
+      expect(closedClient.close).not.toHaveBeenCalled();
+      expect(connectingClient.close).not.toHaveBeenCalled();
+      expect(wssClose).toHaveBeenCalledTimes(1);
+    });
+
+    it("resolves once wss.close's callback fires (does not hang)", async () => {
+      const deps = makeDeps();
+      const steps = buildShutdownSteps(deps);
+
+      const timeout = new Promise((_, reject) =>
+        setTimeout(() => reject(new Error("WS drain step hung")), 500)
+      );
+
+      await expect(Promise.race([steps[5](), timeout])).resolves.toBeUndefined();
+    });
+  });
+
+  describe("closeHttpServer and closeDb steps", () => {
+    it("calls the injected closeHttpServer", async () => {
+      const deps = makeDeps();
+      const steps = buildShutdownSteps(deps);
+
+      // Step index 6 (0-based) closes the HTTP server.
+      await steps[6]();
+
+      expect(deps.closeHttpServer).toHaveBeenCalledTimes(1);
+    });
+
+    it("calls closeDb last", async () => {
+      const deps = makeDeps();
+      const steps = buildShutdownSteps(deps);
+
+      // Step index 7 (0-based) closes the DB pool.
+      await steps[7]();
+
+      expect(deps.closeDb).toHaveBeenCalledTimes(1);
+    });
+  });
+});

--- a/packages/web/src/db/index.ts
+++ b/packages/web/src/db/index.ts
@@ -4,5 +4,25 @@ import * as schema from "./schema";
 
 const connectionString = process.env.DATABASE_URL!;
 
-const client = postgres(connectionString);
+// Explicit pool sizing (#263): postgres-js defaults to max=10 with
+// idle_timeout=0 (idle connections never close). At ~50 concurrent requests
+// the default pool saturates and queues. max=20 with a 30 s idle timeout
+// keeps headroom for bursty chat/audit/usage traffic while letting idle
+// connections reclaim during quiet periods; connect_timeout=10 fails fast
+// against a misconfigured/unreachable DB instead of hanging boot.
+const client = postgres(connectionString, {
+  max: 20,
+  idle_timeout: 30,
+  connect_timeout: 10,
+});
 export const db = drizzle(client, { schema });
+
+/**
+ * Close the postgres-js connection pool. Called during graceful shutdown so
+ * `docker compose down` doesn't hang on lingering DB connections past the
+ * HTTP server close. `timeout: 5` gives in-flight queries up to 5 s to settle
+ * before the pool is force-closed (#263).
+ */
+export async function closeDb(): Promise<void> {
+  await client.end({ timeout: 5 });
+}

--- a/packages/web/src/server/shutdown-steps.ts
+++ b/packages/web/src/server/shutdown-steps.ts
@@ -1,0 +1,59 @@
+/**
+ * Ordered graceful-shutdown steps for the custom Next.js server (#263).
+ *
+ * Extracted from `server.ts` so the individual steps — including the
+ * OpenClaw disconnect, browser-WebSocket drain, and DB-pool close — can be
+ * unit-tested without booting the real HTTP server.
+ *
+ * Consumed by `registerShutdownHandlers` (see `@/lib/shutdown`), which runs
+ * every step in array order on SIGTERM/SIGINT and tolerates individual
+ * step failures.
+ */
+import { WebSocket, type WebSocketServer } from "ws";
+
+export type ShutdownStopFn = () => void | Promise<void>;
+
+export interface ShutdownDeps {
+  stopUploadGc: ShutdownStopFn;
+  stopChatErrorGc: ShutdownStopFn;
+  stopUsagePoller: ShutdownStopFn;
+  stopMemoryAuditWatcher: ShutdownStopFn;
+  getOpenclawClient: () => { disconnect: () => void | Promise<void> } | null;
+  wss: Pick<WebSocketServer, "clients" | "close">;
+  closeHttpServer: () => Promise<void>;
+  closeDb: () => Promise<void>;
+}
+
+/**
+ * Builds the ordered array of shutdown steps. Without this ordering, a
+ * SIGTERM (e.g. from Docker Compose) leaves setInterval handles, the
+ * OpenClaw WS connection, and/or idle browser WS clients dangling, and the
+ * process hangs until the container's kill-grace period expires.
+ */
+export function buildShutdownSteps(deps: ShutdownDeps): ShutdownStopFn[] {
+  return [
+    () => deps.stopUploadGc(),
+    () => deps.stopChatErrorGc(),
+    () => deps.stopUsagePoller(),
+    () => deps.stopMemoryAuditWatcher(),
+    // Disconnect from the OpenClaw Gateway cleanly so the WS + its in-flight
+    // RPCs don't dangle past the HTTP server close (#263). The client is
+    // assigned later in boot; the getter reads it at shutdown time.
+    () => deps.getOpenclawClient()?.disconnect() ?? Promise.resolve(),
+    // Drain browser WebSockets: close each client (1001 = going away) then
+    // close the WS server. Without this `docker compose down` hits the 30s
+    // SIGKILL timeout because idle WS clients keep the event loop alive past
+    // `server.close()` (#263).
+    () =>
+      new Promise<void>((resolve) => {
+        for (const ws of deps.wss.clients as Set<WebSocket>) {
+          if (ws.readyState === WebSocket.OPEN) ws.close(1001, "server shutting down");
+        }
+        deps.wss.close(() => resolve());
+      }),
+    () => deps.closeHttpServer(),
+    // Close the DB pool last, after in-flight requests (drained by
+    // server.close) have settled. `timeout: 5` lets running queries finish.
+    () => deps.closeDb(),
+  ];
+}


### PR DESCRIPTION
Closes #263.

## A — Graceful shutdown
The SIGTERM/SIGINT handler previously only stopped the UsagePoller and closed the HTTP server. Idle browser WebSockets and the postgres-js client kept the event loop alive past `server.close()`, so `docker compose down` hit the 30 s SIGKILL timeout. The handler now runs, in order:

1. stop upload/chat-error GC, usage poller, memory-audit watcher (unchanged)
2. **disconnect the OpenClaw Gateway** — read via a getter at shutdown time (assigned later in boot)
3. **drain browser WebSockets** — close each OPEN client with code 1001, then `wss.close()`
4. close the HTTP server (unchanged)
5. **close the DB pool** (`closeDb()`) — last, after in-flight requests drained by `server.close` have settled

The steps are now extracted into `buildShutdownSteps()` (`packages/web/src/server/shutdown-steps.ts`) so the previously-untested closures are unit-tested directly (see Tests). `shutdown.ts` plumbing already runs every stopFn in order, awaits async ones, and keeps going if an earlier one throws.

## B — Postgres pool
`db/index.ts` configures `postgres(connectionString, { max: 20, idle_timeout: 30, connect_timeout: 10 })` (defaults were `max: 10, idle_timeout: 0`). `closeDb()` ends the pool with `{ timeout: 5 }`.

## C — Docker healthchecks + limits
- **openclaw** gets a TCP liveness healthcheck (connect to `18789`). `pinchy` and `db` already had healthchecks.
- All three services get `mem_limit` + `cpus`, **env-overridable**: `PINCHY_MEM_LIMIT`/`PINCHY_CPUS` (1g / 1.5), `OPENCLAW_MEM_LIMIT`/`OPENCLAW_CPUS` (2g / 2), `DB_MEM_LIMIT`/`DB_CPUS` (1g / 1).
- **Restart policy:** kept `restart: unless-stopped` deliberately — combined with `mem_limit`, an OOM-killed container self-heals instead of the whole host being exhausted (or the container wedging after `on-failure` gives up). Documented rather than changed.
- Documented in the customizing-deployment guide: env-override table, host-sizing math (defaults cap ~4 GB, recommend headroom above), and a 4 GB VPS tuning example.

## D — Backup playbook (now included)
Hardening guide: tmpfs volatility callout for `openclaw-secrets`, a "what to back up beyond `pgdata`" table (`ENCRYPTION_KEY` / `BETTER_AUTH_SECRET` / `AUDIT_HMAC_SECRET`, `pinchy-secrets`, `openclaw-config`) with the consequence of losing each, and a cold-restore walkthrough for a fresh host.

## E — Pre-migration backup + rollback (now included)
Upgrade guide: step 1 reframed as an explicit **pre-migration** backup (migrations auto-apply on `up -d`), and the rollback path fixed to **re-pin `PINCHY_VERSION`** in `.env` — `docker compose` refuses to start without it, so the previously-documented rollback would have failed. `CONTRIBUTING.md` schema policy now cross-links the operational backup step.

## Tests
- `shutdown-steps.test.ts` (new): asserts the WS drain closes only OPEN clients with code 1001 then `wss.close`, the OpenClaw disconnect is null-safe, `closeDb` runs last, step order, and that the drain step resolves without hanging.
- `db/index.test.ts`: pool config + `closeDb({ timeout: 5 })`.
- `shutdown.test.ts`: handler plumbing for arbitrary stopFn arrays.

Gates: unit suite green, `tsc --noEmit` clean, `next build` clean, `docker compose config` validates, docs build (57 pages) clean.

## Out of scope (per the issue's own follow-up note)
pgbouncer in front of postgres for a future serverless tier — separate issue.