### PR TITLE
feat(settings): grouped sidebar navigation replacing the overflowing tab bar (#479)

### DIFF
--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -153,18 +153,10 @@ export function SettingsPageContent({
             >
               Personal
             </div>
-            <TabsTrigger value="context" className="w-full justify-start">
-              Context {contextDirty && <DirtyDot />}
-            </TabsTrigger>
-            <TabsTrigger value="profile" className="w-full justify-start">
-              Profile {profileDirty && <DirtyDot />}
-            </TabsTrigger>
-            <TabsTrigger value="telegram" className="w-full justify-start">
-              Telegram
-            </TabsTrigger>
-            <TabsTrigger value="support" className="w-full justify-start">
-              Support
-            </TabsTrigger>
+            <TabsTrigger value="context">Context {contextDirty && <DirtyDot />}</TabsTrigger>
+            <TabsTrigger value="profile">Profile {profileDirty && <DirtyDot />}</TabsTrigger>
+            <TabsTrigger value="telegram">Telegram</TabsTrigger>
+            <TabsTrigger value="support">Support</TabsTrigger>
             {isAdmin && (
               <>
                 <div
@@ -173,16 +165,12 @@ export function SettingsPageContent({
                 >
                   Administration
                 </div>
-                <TabsTrigger value="provider" className="w-full justify-start">
+                <TabsTrigger value="provider">
                   AI Provider {providerDirty && <DirtyDot />}
                 </TabsTrigger>
-                <TabsTrigger value="users" className="w-full justify-start">
-                  Users
-                </TabsTrigger>
-                <TabsTrigger value="groups" className="w-full justify-start">
-                  Groups
-                </TabsTrigger>
-                <TabsTrigger value="integrations" className="w-full justify-start">
+                <TabsTrigger value="users">Users</TabsTrigger>
+                <TabsTrigger value="groups">Groups</TabsTrigger>
+                <TabsTrigger value="integrations">
                   Integrations {needsAttentionCount > 0 && <ErrorDot />}
                 </TabsTrigger>
                 <div
@@ -191,12 +179,8 @@ export function SettingsPageContent({
                 >
                   Security &amp; Compliance
                 </div>
-                <TabsTrigger value="security" className="w-full justify-start">
-                  Security
-                </TabsTrigger>
-                <TabsTrigger value="license" className="w-full justify-start">
-                  License
-                </TabsTrigger>
+                <TabsTrigger value="security">Security</TabsTrigger>
+                <TabsTrigger value="license">License</TabsTrigger>
               </>
             )}
           </TabsList>

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -134,32 +134,72 @@ export function SettingsPageContent({
 
   return (
     <div className="overflow-y-auto">
-      <div className="p-4 md:p-8 max-w-3xl">
+      <div className="p-4 md:p-8 max-w-5xl">
         <h1 className="text-2xl font-bold mb-6">Settings</h1>
 
-        <Tabs value={activeTab} onValueChange={setActiveTab}>
-          <div className="overflow-x-auto">
-            <TabsList>
-              <TabsTrigger value="context">Context {contextDirty && <DirtyDot />}</TabsTrigger>
-              <TabsTrigger value="profile">Profile {profileDirty && <DirtyDot />}</TabsTrigger>
-              <TabsTrigger value="telegram">Telegram</TabsTrigger>
-              <TabsTrigger value="support">Support</TabsTrigger>
-              {isAdmin && (
-                <TabsTrigger value="provider">
+        <Tabs
+          value={activeTab}
+          onValueChange={setActiveTab}
+          orientation="vertical"
+          className="flex-col md:flex-row"
+        >
+          <TabsList
+            variant="line"
+            className="h-fit w-full shrink-0 flex-col items-stretch gap-0.5 md:w-56 md:border-r md:pr-2"
+          >
+            <div
+              role="presentation"
+              className="px-2 pt-1 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+            >
+              Personal
+            </div>
+            <TabsTrigger value="context" className="w-full justify-start">
+              Context {contextDirty && <DirtyDot />}
+            </TabsTrigger>
+            <TabsTrigger value="profile" className="w-full justify-start">
+              Profile {profileDirty && <DirtyDot />}
+            </TabsTrigger>
+            <TabsTrigger value="telegram" className="w-full justify-start">
+              Telegram
+            </TabsTrigger>
+            <TabsTrigger value="support" className="w-full justify-start">
+              Support
+            </TabsTrigger>
+            {isAdmin && (
+              <>
+                <div
+                  role="presentation"
+                  className="px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Administration
+                </div>
+                <TabsTrigger value="provider" className="w-full justify-start">
                   AI Provider {providerDirty && <DirtyDot />}
                 </TabsTrigger>
-              )}
-              {isAdmin && <TabsTrigger value="users">Users</TabsTrigger>}
-              {isAdmin && <TabsTrigger value="groups">Groups</TabsTrigger>}
-              {isAdmin && (
-                <TabsTrigger value="integrations">
+                <TabsTrigger value="users" className="w-full justify-start">
+                  Users
+                </TabsTrigger>
+                <TabsTrigger value="groups" className="w-full justify-start">
+                  Groups
+                </TabsTrigger>
+                <TabsTrigger value="integrations" className="w-full justify-start">
                   Integrations {needsAttentionCount > 0 && <ErrorDot />}
                 </TabsTrigger>
-              )}
-              {isAdmin && <TabsTrigger value="license">License</TabsTrigger>}
-              {isAdmin && <TabsTrigger value="security">Security</TabsTrigger>}
-            </TabsList>
-          </div>
+                <div
+                  role="presentation"
+                  className="px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                >
+                  Security &amp; Compliance
+                </div>
+                <TabsTrigger value="security" className="w-full justify-start">
+                  Security
+                </TabsTrigger>
+                <TabsTrigger value="license" className="w-full justify-start">
+                  License
+                </TabsTrigger>
+              </>
+            )}
+          </TabsList>
 
           {isAdmin && (
             <TabsContent value="security">


### PR DESCRIPTION
Closes #479.

## What
The Settings page had outgrown its horizontal tab bar (10 tabs no longer fit the viewport, hidden behind `overflow-x-auto` which hides sections from view). Replace it with a **grouped vertical sidebar**:

- **Personal** (all users): Context · Profile · Telegram · Support
- **Administration** (admin-only): Provider · Users · Groups · Integrations
- **Security & Compliance** (admin-only): Security · License

Content pane sits to the right on `md+`; on mobile the sidebar stacks above the content as a vertical list (no horizontal overflow). Members see a clean 4-item Personal list.

## How
A pure presentation swap for `TabsList`: the shadcn `Tabs` primitive already supports `orientation="vertical"` (`TabsList` becomes a vertical column, triggers get `w-full justify-start` + a right-side active bar). The `Tabs`/`TabsContent` contract, the `?tab=` deep links (`useTabParam`), `keepMounted` behavior, and the dirty-state dots all stay — so all existing deep links and E2E tests keep working. Group headers are non-interactive `role="presentation"` elements inside the `TabsList`; the triggers keep `role="tab"` so keyboard roving and the existing `getByRole("tab")` tests are unchanged. No per-tab component changes, no API changes.

Per the issue's note, I kept the lightweight `TabsList`-as-sidebar approach rather than pulling in the full `ui/sidebar` (SidebarProvider) primitive — the latter would restructure the whole page and risk the `keepMounted` state of the provider/integrations forms for no functional gain. A future sheet/drawer collapse on very small screens can build on this if needed.

## Tests
- `settings-page.test.tsx` (20 tests) green — the `getByRole("tab", { name })` assertions and tab-activation flows all pass unchanged.
- Unit suite green; `tsc --noEmit` clean.