### PR TITLE
feat(telegram): per-agent disconnect + channel_links cleanup (#476 gaps 2+3)

### DIFF
--- a/packages/web/src/__tests__/api/agent-telegram-channel.integration.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.integration.test.ts
@@ -1,0 +1,220 @@
+// Real-DB integration test for DELETE /api/agents/[agentId]/channels/telegram.
+//
+// The unit test in agent-telegram-channel.test.ts mocks `@/db` entirely, so it
+// only proves "db.delete was called" — not that the right rows actually
+// disappear. This test hits a real PostgreSQL (provisioned by global-setup.ts,
+// truncated between tests by setup.ts) to verify the Gap 3 (#476) hardening
+// for real:
+//
+//   - When the last Telegram bot in the instance is disconnected, ALL
+//     channel_links rows with channel = "telegram" are deleted — across every
+//     user, not just the agent being disconnected — and the existing
+//     channel.deleted audit row records how many links were cleared via
+//     detail.channelLinksCleared.
+//   - When another agent's Telegram bot remains configured, channel_links are
+//     left untouched and channelLinksCleared is 0.
+//
+// What stays mocked, and why:
+//   - @/lib/auth (getSession) / next/headers — no real browser session exists
+//     in a test process; withAuth reads the session via headers().
+//   - @/lib/openclaw-config (updateTelegramChannelConfig) — writes OpenClaw's
+//     on-disk config and flips restart-state; irrelevant to the DB invariant
+//     under test and already covered by openclaw-config's own tests.
+//   - @/lib/telegram-allow-store (clearAllowStoreForAccount,
+//     recalculateTelegramAllowStores) — file-system allow-list side effects,
+//     not DB state.
+//
+// Everything else (settings, channel_links, audit_log) runs against the real
+// database.
+
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { NextRequest } from "next/server";
+import { eq } from "drizzle-orm";
+
+// ── Mocks ──────────────────────────────────────────────────────────────────
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
+}));
+
+const mockUpdateTelegramChannelConfig = vi.fn();
+vi.mock("@/lib/openclaw-config", () => ({
+  updateTelegramChannelConfig: (...args: unknown[]) => mockUpdateTelegramChannelConfig(...args),
+}));
+
+const mockClearAllowStoreForAccount = vi.fn();
+const mockRecalculateTelegramAllowStores = vi.fn().mockResolvedValue(undefined);
+vi.mock("@/lib/telegram-allow-store", () => ({
+  clearAllowStoreForAccount: (...args: unknown[]) => mockClearAllowStoreForAccount(...args),
+  recalculateTelegramAllowStores: (...args: unknown[]) =>
+    mockRecalculateTelegramAllowStores(...args),
+}));
+
+// ── Real DB imports (loaded AFTER mocks are declared) ──────────────────────
+
+import { db } from "@/db";
+import { users, agents, channelLinks, settings, auditLog } from "@/db/schema";
+import { setSetting } from "@/lib/settings";
+import { DELETE } from "@/app/api/agents/[agentId]/channels/telegram/route";
+
+// ── Fixtures / helpers ───────────────────────────────────────────────────
+
+async function seedUser(overrides?: Partial<typeof users.$inferInsert>) {
+  const [row] = await db
+    .insert(users)
+    .values({
+      name: "Test User",
+      email: `user-${crypto.randomUUID()}@example.com`,
+      emailVerified: true,
+      role: "member",
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+async function seedPersonalAgent(ownerId: string, overrides?: Partial<typeof agents.$inferInsert>) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Smithers",
+      model: "anthropic/claude-haiku-4-5-20251001",
+      greetingMessage: "Hello!",
+      isPersonal: true,
+      visibility: "restricted",
+      ownerId,
+      ...overrides,
+    })
+    .returning();
+  return row;
+}
+
+async function seedTelegramBot(agentId: string, botIdPrefix: string) {
+  await setSetting(`telegram_bot_token:${agentId}`, `${botIdPrefix}:secret-token`, true);
+  await setSetting(`telegram_bot_username:${agentId}`, `${botIdPrefix}_bot`, false);
+}
+
+async function seedChannelLink(userId: string, channelUserId: string) {
+  const [row] = await db
+    .insert(channelLinks)
+    .values({ userId, channel: "telegram", channelUserId })
+    .returning();
+  return row;
+}
+
+function makeRequest() {
+  return new NextRequest("http://localhost/api/agents/agent-1/channels/telegram", {
+    method: "DELETE",
+  });
+}
+
+function makeParams(agentId: string) {
+  return { params: Promise.resolve({ agentId }) };
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("DELETE /api/agents/[agentId]/channels/telegram (real DB)", () => {
+  it("Case A — last bot removed: wipes ALL telegram channel_links org-wide and records the count on the audit row", async () => {
+    const owner = await seedUser({ role: "member" });
+    const agent = await seedPersonalAgent(owner.id);
+    await seedTelegramBot(agent.id, "111111");
+
+    // channel_links from several different users — proving the wipe is
+    // org-wide, not scoped to the disconnecting agent/user.
+    const otherUser1 = await seedUser();
+    const otherUser2 = await seedUser();
+    await seedChannelLink(owner.id, "tg-owner");
+    await seedChannelLink(otherUser1.id, "tg-other-1");
+    await seedChannelLink(otherUser2.id, "tg-other-2");
+
+    mockGetSession.mockResolvedValue({
+      user: { id: owner.id, email: owner.email, role: "member" },
+    });
+
+    const resp = await DELETE(makeRequest(), makeParams(agent.id));
+    expect(resp.status).toBe(200);
+
+    // All telegram channel_links are gone — a later re-registered bot cannot
+    // auto-grant access to stale pairings without re-pairing.
+    const remainingLinks = await db
+      .select()
+      .from(channelLinks)
+      .where(eq(channelLinks.channel, "telegram"));
+    expect(remainingLinks).toHaveLength(0);
+
+    // The bot-token setting is gone too.
+    const remainingSettings = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, `telegram_bot_token:${agent.id}`));
+    expect(remainingSettings).toHaveLength(0);
+
+    // The channel.deleted audit row is attributable: it records exactly how
+    // many links the org-wide sweep cleared.
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "channel.deleted"));
+    expect(auditRows).toHaveLength(1);
+    expect(auditRows[0].actorId).toBe(owner.id);
+    const detail = auditRows[0].detail as Record<string, unknown>;
+    expect(detail.channelLinksCleared).toBe(3);
+    expect(detail.channel).toBe("telegram");
+  });
+
+  it("Case B — another bot remains: channel_links are untouched and channelLinksCleared is 0", async () => {
+    const owner1 = await seedUser({ role: "member" });
+    const owner2 = await seedUser({ role: "member" });
+    const agent1 = await seedPersonalAgent(owner1.id, { name: "Smithers 1" });
+    const agent2 = await seedPersonalAgent(owner2.id, { name: "Smithers 2" });
+    await seedTelegramBot(agent1.id, "111111");
+    await seedTelegramBot(agent2.id, "222222");
+
+    const linkedUser = await seedUser();
+    await seedChannelLink(linkedUser.id, "tg-linked-user");
+
+    mockGetSession.mockResolvedValue({
+      user: { id: owner1.id, email: owner1.email, role: "member" },
+    });
+
+    // Disconnect only agent1's bot — agent2's bot remains, so the sweep must
+    // not fire.
+    const resp = await DELETE(makeRequest(), makeParams(agent1.id));
+    expect(resp.status).toBe(200);
+
+    const remainingLinks = await db
+      .select()
+      .from(channelLinks)
+      .where(eq(channelLinks.channel, "telegram"));
+    expect(remainingLinks).toHaveLength(1);
+    expect(remainingLinks[0].userId).toBe(linkedUser.id);
+
+    // agent1's own token setting is gone; agent2's remains untouched.
+    const agent1Settings = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, `telegram_bot_token:${agent1.id}`));
+    expect(agent1Settings).toHaveLength(0);
+    const agent2Settings = await db
+      .select()
+      .from(settings)
+      .where(eq(settings.key, `telegram_bot_token:${agent2.id}`));
+    expect(agent2Settings).toHaveLength(1);
+
+    const auditRows = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "channel.deleted"));
+    expect(auditRows).toHaveLength(1);
+    const detail = auditRows[0].detail as Record<string, unknown>;
+    expect(detail.channelLinksCleared).toBe(0);
+  });
+});

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -5,8 +5,17 @@ vi.mock("next/headers", () => ({
 }));
 
 const mockRequireAdmin = vi.fn();
-vi.mock("@/lib/api-auth", () => ({
-  requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+vi.mock("@/lib/api-auth", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/api-auth")>();
+  return {
+    ...actual,
+    requireAdmin: (...args: unknown[]) => mockRequireAdmin(...args),
+  };
+});
+
+const mockGetSession = vi.fn();
+vi.mock("@/lib/auth", () => ({
+  getSession: (...args: unknown[]) => mockGetSession(...args),
 }));
 
 const mockValidateTelegramBotToken = vi.fn();
@@ -50,6 +59,9 @@ vi.mock("@/db", () => ({
       from: vi.fn().mockReturnValue({
         where: vi.fn().mockResolvedValue([]),
       }),
+    }),
+    delete: vi.fn().mockReturnValue({
+      where: vi.fn().mockResolvedValue(undefined),
     }),
   },
 }));
@@ -365,6 +377,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   beforeEach(() => {
     vi.clearAllMocks();
     mockRequireAdmin.mockResolvedValue(adminSession);
+    mockGetSession.mockResolvedValue(adminSession);
     vi.mocked(db.query.agents.findFirst).mockResolvedValue(mockAgent as any);
   });
 
@@ -393,23 +406,91 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
     );
   });
 
-  it("returns 400 when trying to disconnect a personal agent's bot (and does not mutate channels.telegram)", async () => {
-    // updateTelegramChannelConfig must NOT be called — any write triggers an OC
-    // restart for nothing (see openclaw-config restart-state integration tests).
-    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
-      ...mockAgent,
-      isPersonal: true,
+  it("clears stale channel_links when the last Telegram bot is removed (#476 gap 3)", async () => {
+    // db.select().from().where() is mocked to resolve [] → no bot remains.
+    const response = await DELETE(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    expect(response.status).toBe(200);
+    expect(db.delete).toHaveBeenCalled();
+  });
+
+  it("does not clear channel_links when other Telegram bots remain (#476 gap 3)", async () => {
+    vi.mocked(db.select).mockReturnValueOnce({
+      from: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue([{ key: "telegram_bot_token:other" }]),
+      }),
     } as any);
 
     const response = await DELETE(new Request("http://localhost"), {
       params: mockParams,
     });
-    const data = await response.json();
+    expect(response.status).toBe(200);
+    expect(db.delete).not.toHaveBeenCalled();
+  });
 
-    expect(response.status).toBe(400);
-    expect(data.error).toContain("Remove Telegram for everyone");
+  it("allows an admin to disconnect a personal agent's bot (#476 gap 2)", async () => {
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      ...mockAgent,
+      isPersonal: true,
+      ownerId: "someone-else",
+    } as any);
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    expect(response.status).toBe(200);
+    expect(deleteSetting).toHaveBeenCalledWith("telegram_bot_token:agent-1");
+  });
+
+  it("allows a personal agent's owner (non-admin) to disconnect their own bot (#476 gap 2)", async () => {
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      ...mockAgent,
+      isPersonal: true,
+      ownerId: "user-2",
+    } as any);
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: "user-2", role: "member" },
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    expect(response.status).toBe(200);
+    expect(deleteSetting).toHaveBeenCalledWith("telegram_bot_token:agent-1");
+  });
+
+  it("forbids a non-admin who is not the personal agent's owner (#476 gap 2)", async () => {
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      ...mockAgent,
+      isPersonal: true,
+      ownerId: "user-2",
+    } as any);
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: "user-3", role: "member" },
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    expect(response.status).toBe(403);
     expect(deleteSetting).not.toHaveBeenCalled();
-    expect(mockUpdateTelegramChannelConfig).not.toHaveBeenCalled();
+  });
+
+  it("forbids a non-admin from disconnecting a shared agent's bot (#476 gap 2)", async () => {
+    vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce({
+      ...mockAgent,
+      isPersonal: false,
+    } as any);
+    mockGetSession.mockResolvedValueOnce({
+      user: { id: "user-3", role: "member" },
+    });
+
+    const response = await DELETE(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    expect(response.status).toBe(403);
+    expect(deleteSetting).not.toHaveBeenCalled();
   });
 
   it("returns 404 for non-existent agent", async () => {
@@ -425,9 +506,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("returns 401 when not authenticated", async () => {
-    mockRequireAdmin.mockResolvedValueOnce(
-      NextResponse.json({ error: "Unauthorized" }, { status: 401 })
-    );
+    mockGetSession.mockResolvedValueOnce(null);
 
     const response = await DELETE(new Request("http://localhost"), {
       params: mockParams,

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -61,7 +61,9 @@ vi.mock("@/db", () => ({
       }),
     }),
     delete: vi.fn().mockReturnValue({
-      where: vi.fn().mockResolvedValue(undefined),
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([]),
+      }),
     }),
   },
 }));
@@ -408,11 +410,30 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
 
   it("clears stale channel_links when the last Telegram bot is removed (#476 gap 3)", async () => {
     // db.select().from().where() is mocked to resolve [] → no bot remains.
+    vi.mocked(db.delete).mockReturnValueOnce({
+      where: vi.fn().mockReturnValue({
+        returning: vi.fn().mockResolvedValue([{ id: "link-1" }, { id: "link-2" }]),
+      }),
+    } as any);
+
     const response = await DELETE(new Request("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(200);
     expect(db.delete).toHaveBeenCalled();
+
+    // The org-wide wipe count must be visible on the existing channel.deleted
+    // audit row (#476 gap 3 hardening) — a normal member disconnecting their
+    // own personal bot can trigger this wipe for everyone, so it must be
+    // attributable via the audit trail rather than silent.
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "channel.deleted",
+        detail: expect.objectContaining({
+          channelLinksCleared: 2,
+        }),
+      })
+    );
   });
 
   it("does not clear channel_links when other Telegram bots remain (#476 gap 3)", async () => {
@@ -427,6 +448,14 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
     });
     expect(response.status).toBe(200);
     expect(db.delete).not.toHaveBeenCalled();
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "channel.deleted",
+        detail: expect.objectContaining({
+          channelLinksCleared: 0,
+        }),
+      })
+    );
   });
 
   it("allows an admin to disconnect a personal agent's bot (#476 gap 2)", async () => {

--- a/packages/web/src/__tests__/components/agent-settings-page-content-telegram-tab.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-page-content-telegram-tab.test.tsx
@@ -1,0 +1,99 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import "@testing-library/jest-dom";
+import { render, screen, waitFor } from "@testing-library/react";
+
+// #476 gap 2: a personal agent's owner may disconnect its own Telegram bot
+// without an admin. The permission change on the route is only useful if the
+// owner can actually reach the Disconnect button — i.e. the Telegram tab must
+// be visible to a non-admin owner, not only to admins.
+
+const mockSession = vi.fn();
+vi.mock("@/lib/auth-client", () => ({
+  authClient: { useSession: () => mockSession() },
+}));
+
+vi.mock("next/navigation", () => ({
+  useParams: () => ({ agentId: "agent-1" }),
+  useRouter: () => ({ replace: vi.fn(), push: vi.fn() }),
+  useSearchParams: () => new URLSearchParams(),
+  usePathname: () => "/chat/agent-1/settings",
+}));
+
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ triggerRestart: vi.fn() }),
+}));
+
+// Stub the tab bodies — this test only exercises the page's tab wiring.
+vi.mock("@/components/agent-settings-general", () => ({ AgentSettingsGeneral: () => <div /> }));
+vi.mock("@/components/agent-settings-file", () => ({ AgentSettingsFile: () => <div /> }));
+vi.mock("@/components/agent-settings-personality", () => ({
+  AgentSettingsPersonality: () => <div />,
+}));
+vi.mock("@/components/agent-settings-permissions", () => ({
+  AgentSettingsPermissions: () => <div />,
+}));
+vi.mock("@/components/agent-settings-access", () => ({ AgentSettingsAccess: () => <div /> }));
+vi.mock("@/components/agent-settings-diagnostics", () => ({
+  AgentSettingsDiagnostics: () => <div />,
+}));
+vi.mock("@/components/agent-telegram-settings", () => ({
+  AgentTelegramSettings: () => <div data-testid="agent-telegram-settings" />,
+}));
+
+import { AgentSettingsPageContent } from "@/components/agent-settings-page-content";
+
+const baseAgent = {
+  id: "agent-1",
+  name: "Smithers",
+  model: "anthropic/claude-haiku-4-5-20251001",
+  allowedTools: [],
+  pluginConfig: null,
+  tagline: null,
+  avatarSeed: null,
+  personalityPresetId: null,
+  visibility: "restricted",
+  groupIds: [],
+};
+
+function mockFetchReturning(agent: object) {
+  global.fetch = vi.fn().mockImplementation((url: unknown) => {
+    if (url === "/api/agents/agent-1") {
+      return Promise.resolve({ ok: true, json: () => Promise.resolve(agent) });
+    }
+    return Promise.resolve({ ok: true, json: () => Promise.resolve({}) });
+  }) as unknown as typeof fetch;
+}
+
+describe("AgentSettingsPageContent — Telegram tab visibility (#476 gap 2)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+  });
+
+  it("shows the Telegram tab to a non-admin owner of a personal agent", async () => {
+    mockSession.mockReturnValue({
+      data: { user: { id: "u1", role: "member" } },
+      isPending: false,
+    });
+    mockFetchReturning({ ...baseAgent, isPersonal: true });
+
+    render(<AgentSettingsPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /telegram/i })).toBeInTheDocument();
+    });
+  });
+
+  it("shows the Telegram tab to an admin on a shared agent", async () => {
+    mockSession.mockReturnValue({
+      data: { user: { id: "admin-1", role: "admin" } },
+      isPending: false,
+    });
+    mockFetchReturning({ ...baseAgent, isPersonal: false });
+
+    render(<AgentSettingsPageContent />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("tab", { name: /telegram/i })).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -94,4 +94,29 @@ describe("AgentTelegramSettings", () => {
     });
     expect(screen.queryByText(/Telegram isn't set up yet/i)).not.toBeInTheDocument();
   });
+
+  // #476 gap 2: a non-admin owner can DISCONNECT their personal bot, but the
+  // connect path stays admin-only. So a non-admin must not be shown a bot-token
+  // form they cannot submit (POST would 403) — show an ask-your-admin note.
+  it("shows an ask-your-admin note instead of the connect form for non-admins", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: true });
+
+    render(<AgentTelegramSettings agentId="smithers-1" isSmithers isAdmin={false} />);
+
+    await waitFor(() => {
+      expect(screen.getByText(/administrator/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByLabelText(/Bot Token/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /^Connect$/i })).not.toBeInTheDocument();
+  });
+
+  it("still renders the connect form when isAdmin is not specified (default)", async () => {
+    global.fetch = mockFetch({ configured: false, mainBotConfigured: true });
+
+    render(<AgentTelegramSettings agentId="agent-1" />);
+
+    await waitFor(() => {
+      expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -1,6 +1,6 @@
 import { NextRequest, NextResponse } from "next/server";
 import { z } from "zod";
-import { requireAdmin } from "@/lib/api-auth";
+import { requireAdmin, withAuth } from "@/lib/api-auth";
 import { validateTelegramBotToken, hasMainTelegramBot } from "@/lib/telegram";
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
 import { appendAuditLog } from "@/lib/audit";
@@ -10,7 +10,7 @@ import {
   recalculateTelegramAllowStores,
 } from "@/lib/telegram-allow-store";
 import { db } from "@/db";
-import { agents, settings } from "@/db/schema";
+import { agents, channelLinks, settings } from "@/db/schema";
 import { eq, like } from "drizzle-orm";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -125,51 +125,61 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ age
   });
 }
 
-export async function DELETE(req: Request, { params }: { params: Promise<{ agentId: string }> }) {
-  const admin = await requireAdmin();
-  if (admin instanceof NextResponse) return admin;
-  const { agentId } = await params;
+export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
+  async (_req, { params }, session) => {
+    const { agentId } = await params;
 
-  const agent = await db.query.agents.findFirst({
-    where: eq(agents.id, agentId),
-  });
-  if (!agent) {
-    return NextResponse.json({ error: "Agent not found" }, { status: 404 });
-  }
+    const agent = await db.query.agents.findFirst({
+      where: eq(agents.id, agentId),
+    });
+    if (!agent) {
+      return NextResponse.json({ error: "Agent not found" }, { status: 404 });
+    }
 
-  // Personal agents (Smithers) can only be disconnected via "Remove Telegram for everyone"
-  // in Settings. Uses isPersonal flag (not avatarSeed which is user-editable).
-  if (agent.isPersonal) {
-    return NextResponse.json(
-      {
-        error:
-          "Smithers' bot cannot be disconnected individually. Use 'Remove Telegram for everyone' in Settings.",
+    // Gap 2 (#476): a personal agent's owner may disconnect its own bot without
+    // an admin — the org-wide "Remove Telegram for everyone" was the only prior
+    // path and is too blunt for a single user's Smithers. Admins can disconnect
+    // any agent (shared or personal). The connect path stays admin-only.
+    const isOwner = agent.isPersonal && agent.ownerId === session.user.id;
+    if (session.user.role !== "admin" && !isOwner) {
+      return NextResponse.json({ error: "Forbidden" }, { status: 403 });
+    }
+
+    await deleteSetting(`telegram_bot_token:${agentId}`);
+    await deleteSetting(`telegram_bot_username:${agentId}`);
+
+    // Clear only this account's allow-from store (other agents' bots are unaffected)
+    clearAllowStoreForAccount(agentId);
+    // Remove this account from config (other accounts preserved).
+    // updateTelegramChannelConfig() notifies restart-state on actual write.
+    updateTelegramChannelConfig(agentId, null);
+
+    // Gap 3 (#476): if this was the last Telegram bot, clear the user↔telegram-user
+    // channel_links so a later re-registered bot can't re-grant access to stale
+    // pairings without re-pairing. The org-wide "Remove Telegram for everyone"
+    // already clears channel_links; this closes the per-agent-removal path where
+    // every bot is gone individually but the links persisted.
+    const remainingBotTokens = await db
+      .select()
+      .from(settings)
+      .where(like(settings.key, "telegram_bot_token:%"));
+    if (remainingBotTokens.length === 0) {
+      await db.delete(channelLinks).where(eq(channelLinks.channel, "telegram"));
+    }
+
+    await appendAuditLog({
+      actorType: "user",
+      actorId: session.user.id,
+      eventType: "channel.deleted",
+      resource: `agent:${agentId}`,
+      detail: {
+        name: `telegram:${agent.name}`,
+        agent: { id: agentId, name: agent.name },
+        channel: "telegram",
       },
-      { status: 400 }
-    );
+      outcome: "success",
+    });
+
+    return NextResponse.json({ success: true });
   }
-
-  await deleteSetting(`telegram_bot_token:${agentId}`);
-  await deleteSetting(`telegram_bot_username:${agentId}`);
-
-  // Clear only this account's allow-from store (other agents' bots are unaffected)
-  clearAllowStoreForAccount(agentId);
-  // Remove this account from config (other accounts preserved).
-  // updateTelegramChannelConfig() notifies restart-state on actual write.
-  updateTelegramChannelConfig(agentId, null);
-
-  await appendAuditLog({
-    actorType: "user",
-    actorId: admin.user.id,
-    eventType: "channel.deleted",
-    resource: `agent:${agentId}`,
-    detail: {
-      name: `telegram:${agent.name}`,
-      agent: { id: agentId, name: agent.name },
-      channel: "telegram",
-    },
-    outcome: "success",
-  });
-
-  return NextResponse.json({ success: true });
-}
+);

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -163,8 +163,13 @@ export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
       .select()
       .from(settings)
       .where(like(settings.key, "telegram_bot_token:%"));
+    let channelLinksCleared = 0;
     if (remainingBotTokens.length === 0) {
-      await db.delete(channelLinks).where(eq(channelLinks.channel, "telegram"));
+      const clearedLinks = await db
+        .delete(channelLinks)
+        .where(eq(channelLinks.channel, "telegram"))
+        .returning({ id: channelLinks.id });
+      channelLinksCleared = clearedLinks.length;
     }
 
     await appendAuditLog({
@@ -176,6 +181,11 @@ export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
         name: `telegram:${agent.name}`,
         agent: { id: agentId, name: agent.name },
         channel: "telegram",
+        // Gap 3 (#476) hardening: a normal member disconnecting their own
+        // personal bot can trigger an org-wide channel_links wipe if it was
+        // the last Telegram bot. Surface the count here so the sweep is
+        // attributable, not silent — 0 when other bots remain.
+        channelLinksCleared,
       },
       outcome: "success",
     });

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -111,13 +111,19 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   const { data: session, isPending } = authClient.useSession();
   const { triggerRestart } = useRestart();
   const isAdmin = session?.user?.role === "admin";
+  const [agent, setAgent] = useState<Agent | null>(null);
+  // A personal agent's owner may manage its Telegram bot (disconnect) without
+  // being an admin. The page is only viewable by the owner or an admin (see
+  // `canEdit`), so `isPersonal` here implies the viewer owns it. (#476 gap 2)
+  const canManageTelegram = isAdmin || agent?.isPersonal === true;
   const visibleTabs: AgentSettingsTab[] =
     isPending || isAdmin
       ? [...AGENT_SETTINGS_TABS]
-      : AGENT_SETTINGS_TABS.filter((tab) => !ADMIN_ONLY_TABS.has(tab));
+      : AGENT_SETTINGS_TABS.filter(
+          (tab) => !ADMIN_ONLY_TABS.has(tab) || (tab === "telegram" && canManageTelegram)
+        );
   const [activeTab, setActiveTab] = useTabParam("general", visibleTabs, initialTab);
 
-  const [agent, setAgent] = useState<Agent | null>(null);
   const [providers, setProviders] = useState<Provider[]>([]);
   const [soulContent, setSoulContent] = useState("");
   const [agentsContent, setAgentsContent] = useState("");
@@ -429,7 +435,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
                 Access {dirtyTabs.has("access") && <DirtyDot />}
               </TabsTrigger>
             )}
-            {isAdmin && <TabsTrigger value="telegram">Telegram</TabsTrigger>}
+            {canManageTelegram && <TabsTrigger value="telegram">Telegram</TabsTrigger>}
             <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
           </TabsList>
 
@@ -487,9 +493,13 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
             </TabsContent>
           )}
 
-          {isAdmin && (
+          {canManageTelegram && (
             <TabsContent value="telegram">
-              <AgentTelegramSettings agentId={agentId} isSmithers={agent.isPersonal} />
+              <AgentTelegramSettings
+                agentId={agentId}
+                isSmithers={agent.isPersonal}
+                isAdmin={isAdmin}
+              />
             </TabsContent>
           )}
 

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -244,39 +244,33 @@ export function AgentTelegramSettings({
               Token ending in ····{config.hint}
             </p>
           )}
-          {isSmithers ? (
-            <p className="text-xs text-muted-foreground">
-              To disconnect this bot, use &quot;Remove Telegram for everyone&quot; in Settings.
-            </p>
-          ) : (
-            <AlertDialog>
-              <AlertDialogTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  className="text-destructive hover:text-destructive"
-                  disabled={removing}
-                >
-                  {removing ? "Disconnecting..." : "Disconnect"}
-                </Button>
-              </AlertDialogTrigger>
-              <AlertDialogContent>
-                <AlertDialogHeader>
-                  <AlertDialogTitle>Disconnect Telegram bot?</AlertDialogTitle>
-                  <AlertDialogDescription>
-                    This will remove the Telegram bot connection for this agent. Users will no
-                    longer be able to chat with the agent via Telegram.
-                  </AlertDialogDescription>
-                </AlertDialogHeader>
-                <AlertDialogFooter>
-                  <AlertDialogCancel>Cancel</AlertDialogCancel>
-                  <AlertDialogAction variant="destructive" onClick={handleDisconnect}>
-                    Disconnect
-                  </AlertDialogAction>
-                </AlertDialogFooter>
-              </AlertDialogContent>
-            </AlertDialog>
-          )}
+          <AlertDialog>
+            <AlertDialogTrigger asChild>
+              <Button
+                type="button"
+                variant="ghost"
+                className="text-destructive hover:text-destructive"
+                disabled={removing}
+              >
+                {removing ? "Disconnecting..." : "Disconnect"}
+              </Button>
+            </AlertDialogTrigger>
+            <AlertDialogContent>
+              <AlertDialogHeader>
+                <AlertDialogTitle>Disconnect Telegram bot?</AlertDialogTitle>
+                <AlertDialogDescription>
+                  This will remove the Telegram bot connection for this agent. Users will no longer
+                  be able to chat with the agent via Telegram.
+                </AlertDialogDescription>
+              </AlertDialogHeader>
+              <AlertDialogFooter>
+                <AlertDialogCancel>Cancel</AlertDialogCancel>
+                <AlertDialogAction variant="destructive" onClick={handleDisconnect}>
+                  Disconnect
+                </AlertDialogAction>
+              </AlertDialogFooter>
+            </AlertDialogContent>
+          </AlertDialog>
         </>
       ) : (
         <>

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -35,8 +35,18 @@ interface AgentTelegramSettingsProps {
   onConnected?: () => void;
   /** Render without Card wrapper (for embedding in an existing Card) */
   bare?: boolean;
-  /** Smithers' bot cannot be individually disconnected */
+  /**
+   * The agent is a personal agent (Smithers). Only used to keep the empty state
+   * from pointing at itself during first-time setup — Smithers IS the main bot.
+   */
   isSmithers?: boolean;
+  /**
+   * Whether the current user may connect a bot. The connect path is admin-only;
+   * a non-admin owner may disconnect their personal bot but cannot connect one,
+   * so when `false` we show an ask-your-admin note instead of the token form
+   * (which would 403 on submit). Defaults to allowing the form. (#476 gap 2)
+   */
+  isAdmin?: boolean;
 }
 
 export function AgentTelegramSettings({
@@ -44,6 +54,7 @@ export function AgentTelegramSettings({
   onConnected,
   bare,
   isSmithers,
+  isAdmin,
 }: AgentTelegramSettingsProps) {
   const { triggerRestart } = useRestart();
   const [config, setConfig] = useState<TelegramConfig | null>(null);
@@ -272,6 +283,10 @@ export function AgentTelegramSettings({
             </AlertDialogContent>
           </AlertDialog>
         </>
+      ) : isAdmin === false ? (
+        <p className="text-sm text-muted-foreground">
+          This agent&apos;s Telegram bot isn&apos;t connected. Ask an administrator to set it up.
+        </p>
       ) : (
         <>
           <p className="text-sm text-muted-foreground">


### PR DESCRIPTION
Part of #476 — gaps 2 and 3. (Gap 1 deferred; see below.)

## Gap 2 — per-personal-agent disconnect
A personal agent's owner can now disconnect its own Telegram bot without an admin. Previously the only path was the org-wide **"Remove Telegram for everyone"** (admin-only, removes every user's bot) — too blunt for a single user's Smithers.

`DELETE /api/agents/[id]/channels/telegram` now accepts **admins (any agent) OR the personal agent's owner**; the connect path stays admin-only. Switched from `requireAdmin` to `withAuth` so the owner-or-admin check can run (satisfies the `no-direct-session` lint rule via the wrapper). The agent-settings Telegram tab now shows the **Disconnect** button for personal agents too (was info-only text pointing at the org-wide action).

## Gap 3 — channel_links cleanup on last-bot removal
When the last Telegram bot is removed via the per-agent path, clear the user↔telegram-user `channel_links` so a later re-registered bot can't re-grant access to stale pairings without re-pairing. The org-wide removal already cleared `channel_links`; this closes the per-agent-removal path where every bot is gone individually but the links persisted. (If other bots remain, `channel_links` are left intact — they're per-user and shared across bots.)

## Deferred
**Gap 1** (a config change must promptly stop the OpenClaw poller, rather than waiting for OC's eventual inotify/restart) needs a `config.apply`/reload mechanism and is also a prerequisite for #477's auto-disable. Tracked separately to keep this PR focused.

## Tests
`agent-telegram-channel.test.ts` DELETE suite rewritten for the new auth:
- admin can disconnect a personal agent; a personal agent's owner (non-admin) can disconnect their own; a non-owner non-admin gets 403; a non-admin on a shared agent gets 403.
- gap 3: `channel_links` cleared when the last bot is removed; left intact when other bots remain.
- 404 / 401 unchanged.
Unit suite green; `tsc --noEmit` clean.