### PR TITLE
fix(test): broaden node_modules exclude in vitest.config to cover nested plugin deps

### DIFF
--- a/packages/web/vitest.config.ts
+++ b/packages/web/vitest.config.ts
@@ -22,7 +22,16 @@ export default defineConfig({
     // vitest.integration.config.ts (`pnpm test:db`). Excluded here so
     // `pnpm test` stays fast and Docker-free. Convention: any file named
     // *.integration.test.ts opts into the DB-backed runner.
-    exclude: ["node_modules", "e2e", "**/*.integration.test.{ts,tsx,js,jsx}"],
+    exclude: [
+      // Broad glob (not a bare "node_modules") so that *nested* node_modules
+      // under sibling plugin packages are excluded too. The plugin include
+      // glob below (`../plugins/pinchy-*/**/...`) otherwise traverses into
+      // e.g. packages/plugins/pinchy-files/node_modules/*/test/*.test.js and
+      // reports third-party suites as "No test suite found".
+      "**/node_modules/**",
+      "e2e",
+      "**/*.integration.test.{ts,tsx,js,jsx}",
+    ],
   },
   resolve: {
     alias: {


### PR DESCRIPTION
## What and why

The plugin include glob in `vitest.config.ts`:

```
"../plugins/pinchy-*/**/*.{test,spec}.?(c|m)[jt]s?(x)"
```

traverses into sibling plugin `node_modules` when those packages have
physically-nested dependencies (e.g. `pinchy-files/node_modules/duck/test/*.test.js`).
The previous `exclude` entry was a bare `"node_modules"` string, which Vitest
only matches against a top-level directory — it does **not** exclude nested
paths like `packages/plugins/pinchy-files/node_modules/...`.

This causes ~12 "No test suite found" failures locally whenever plugin `node_modules`
happen to contain third-party test files. CI stays green because it hoists
dependencies differently (no nested `node_modules` in the CI `.pnpm` store).

## Change

Replace `"node_modules"` with the standard Vitest/glob pattern `"**/node_modules/**"`.

## Verification

- `vitest list --filesOnly` returns **identical** 520 files under old and new
  config (diff is empty) — no first-party tests are lost.
- `pnpm -C packages/web test` → **517 test files passed | 3 skipped (520),
  6581 tests passed | 13 skipped (6594)**, exit 0.
- `prettier --check` passes on the changed file.