### PR TITLE
fix(chat): tapClientLookup crash recovery + name the model in generic errors

### DIFF
--- a/packages/web/src/__tests__/components/chat-crash-boundary.test.tsx
+++ b/packages/web/src/__tests__/components/chat-crash-boundary.test.tsx
@@ -1,0 +1,182 @@
+/**
+ * Regression guard for the recurring `tapClientLookup: Index N out of bounds`
+ * full-page crash. Root cause: assistant-ui's index-keyed message list throws
+ * when the message array shrinks while `<ThreadPrimitive.Messages>` is mounted
+ * (a trailing-index child re-renders with a now-stale index one commit before
+ * React unmounts it). Four prior fixes (v0.5.7 anchor, #470 own-placeholder,
+ * #199 disconnect-defer, #510 reconcile-shrink-guard in use-ws-runtime.ts) each
+ * closed ONE shrink path reactively — #510's own comment says the crash
+ * "survived" the earlier two. `ChatCrashBoundary` is the path-agnostic fix: it
+ * catches this error CLASS regardless of which shrink path caused it, recovers
+ * by remounting just the thread, and — critically — rethrows anything else so
+ * unrelated bugs still surface via the normal app/error.tsx path instead of
+ * being silently swallowed.
+ */
+import { describe, it, expect, vi, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import { Component, useEffect, useState, type ReactNode } from "react";
+import { ChatCrashBoundary, isTapClientLookupCrash } from "@/components/chat-crash-boundary";
+
+// Mirrors app/error.tsx's role in production: the ancestor boundary a
+// genuinely-unrelated error must still reach. Flips to "outer-crashed" on ANY
+// throw — this is deliberately dumb/catch-all, standing in for the route-level
+// boundary that already exists in the app and is out of scope for this test.
+class OuterCrashBoundary extends Component<{ children: ReactNode }, { errored: boolean }> {
+  state = { errored: false };
+  static getDerivedStateFromError() {
+    return { errored: true };
+  }
+  componentDidCatch() {}
+  render() {
+    if (this.state.errored) return <div data-testid="outer-crashed">Something went wrong</div>;
+    return this.props.children;
+  }
+}
+
+/**
+ * A pure function of its `shouldStop` prop: throws `error` while false, renders
+ * normally once true. No wall-clock reads in its own render body — reading
+ * `Date.now()` directly here would be an impure render (React's own purity
+ * lint correctly flags this), and worse, a component that ALWAYS throws can
+ * never successfully commit, so it can never run its OWN effect to flip a
+ * timer — React never commits (and therefore never runs effects for) a
+ * throwing render. The timing lives in `DelayedStopGate` instead, a sibling
+ * component ABOVE `ChatCrashBoundary` that survives the boundary's internal
+ * catch/remount cycle and feeds `shouldStop` down as a plain prop.
+ */
+function Bomb({ error, shouldStop }: { error: Error; shouldStop: boolean }) {
+  if (!shouldStop) throw error;
+  return <div data-testid="recovered-content">recovered</div>;
+}
+
+/**
+ * Flips `shouldStop` to true `afterMs` after mount, via a real effect (not a
+ * render-time side effect). Must be mounted OUTSIDE `ChatCrashBoundary` — when
+ * `Bomb` throws, React unmounts the ENTIRE subtree up to the nearest boundary,
+ * so anything living INSIDE the boundary alongside `Bomb` would be torn down
+ * too and never get a chance to run its timer.
+ */
+function DelayedStopGate({
+  afterMs,
+  children,
+}: {
+  afterMs?: number;
+  children: (shouldStop: boolean) => ReactNode;
+}) {
+  const [shouldStop, setShouldStop] = useState(false);
+  useEffect(() => {
+    if (afterMs === undefined) return;
+    const timer = setTimeout(() => setShouldStop(true), afterMs);
+    return () => clearTimeout(timer);
+  }, [afterMs]);
+  return <>{children(shouldStop)}</>;
+}
+
+function AlwaysGood() {
+  return <div data-testid="good-content">good</div>;
+}
+
+const TAP_CLIENT_LOOKUP_ERROR = new Error("tapClientLookup: Index 18 out of bounds (length: 18)");
+const GENERIC_OUT_OF_BOUNDS_ERROR = new Error("Index 3 out of bounds (length: 3)");
+const UNRELATED_ERROR = new Error("totally unrelated boom");
+
+describe("isTapClientLookupCrash", () => {
+  it("matches the named tapClientLookup error", () => {
+    expect(isTapClientLookupCrash(TAP_CLIENT_LOOKUP_ERROR)).toBe(true);
+  });
+
+  it("matches the generic 'Index N out of bounds' wording without the function name", () => {
+    expect(isTapClientLookupCrash(GENERIC_OUT_OF_BOUNDS_ERROR)).toBe(true);
+  });
+
+  it("matches case-insensitively", () => {
+    expect(isTapClientLookupCrash(new Error("TAPCLIENTLOOKUP: INDEX 1 OUT OF BOUNDS"))).toBe(true);
+  });
+
+  it("does not match unrelated errors", () => {
+    expect(isTapClientLookupCrash(UNRELATED_ERROR)).toBe(false);
+    expect(isTapClientLookupCrash(new Error("Network request failed"))).toBe(false);
+  });
+
+  it("does not match a non-Error thrown value", () => {
+    expect(isTapClientLookupCrash("just a string")).toBe(false);
+    expect(isTapClientLookupCrash(undefined)).toBe(false);
+  });
+});
+
+describe("ChatCrashBoundary", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("renders children normally when nothing throws", () => {
+    render(
+      <ChatCrashBoundary>
+        <AlwaysGood />
+      </ChatCrashBoundary>
+    );
+    expect(screen.getByTestId("good-content")).toBeInTheDocument();
+  });
+
+  it("catches a tapClientLookup crash, shows a transient recovery state, then recovers to working content", async () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <DelayedStopGate afterMs={20}>
+        {(shouldStop) => (
+          <ChatCrashBoundary>
+            <Bomb error={TAP_CLIENT_LOOKUP_ERROR} shouldStop={shouldStop} />
+          </ChatCrashBoundary>
+        )}
+      </DelayedStopGate>
+    );
+
+    // Transient recovery state first — never the generic full-page crash text.
+    expect(screen.queryByText(/something went wrong/i)).not.toBeInTheDocument();
+    expect(screen.getByText(/reconnecting your conversation/i)).toBeInTheDocument();
+
+    // Recovers on its own (remounts the child) without any user action.
+    await waitFor(() => expect(screen.getByTestId("recovered-content")).toBeInTheDocument());
+    expect(screen.queryByText(/reconnecting your conversation/i)).not.toBeInTheDocument();
+
+    // No silent failure — the incident is logged.
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("does NOT swallow an unrelated error — it propagates to the outer boundary", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OuterCrashBoundary>
+        <ChatCrashBoundary>
+          <Bomb error={UNRELATED_ERROR} shouldStop={false} />
+        </ChatCrashBoundary>
+      </OuterCrashBoundary>
+    );
+
+    // The INNER boundary must not show its own recovery fallback for this class
+    // of error — it re-threw, so the OUTER boundary caught it instead.
+    expect(screen.queryByText(/reconnecting your conversation/i)).not.toBeInTheDocument();
+    expect(screen.getByTestId("outer-crashed")).toBeInTheDocument();
+    expect(errorSpy).toHaveBeenCalled();
+  });
+
+  it("stops auto-recovering and escalates after repeated crashes (loop protection)", async () => {
+    vi.spyOn(console, "error").mockImplementation(() => {});
+
+    render(
+      <OuterCrashBoundary>
+        <ChatCrashBoundary>
+          {/* Never stops throwing — simulates a pathological, unrecoverable loop. */}
+          <Bomb error={TAP_CLIENT_LOOKUP_ERROR} shouldStop={false} />
+        </ChatCrashBoundary>
+      </OuterCrashBoundary>
+    );
+
+    // Eventually gives up recovering internally and escalates to the outer
+    // boundary rather than spinning on "Reconnecting..." forever.
+    await waitFor(() => expect(screen.getByTestId("outer-crashed")).toBeInTheDocument(), {
+      timeout: 3000,
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/model-retirement.test.ts
+++ b/packages/web/src/__tests__/lib/model-retirement.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
-import { isRetiredModelError } from "@/lib/model-retirement";
+import { isRetiredModelError, RETIREMENT_PATTERNS } from "@/lib/model-retirement";
+import { matchesRetirement } from "@/server/error-patterns";
 
 describe("isRetiredModelError", () => {
   it("matches the HTTP 410 retired error we saw in production", () => {
@@ -41,4 +42,29 @@ describe("isRetiredModelError", () => {
     expect(isRetiredModelError(null)).toBe(false);
     expect(isRetiredModelError("")).toBe(false);
   });
+});
+
+describe("RETIREMENT_PATTERNS drift guard (#611 follow-up)", () => {
+  // error-patterns.ts's user-facing matchesRetirement() reuses THIS array
+  // rather than a hand-rolled copy, so self-heal's classification and the
+  // display layer's classification can never independently drift. This test
+  // pins that: if a future change swaps error-patterns.ts to a local copy
+  // instead of importing RETIREMENT_PATTERNS, this test won't catch every
+  // possible drift, but it does assert the array is exported and that a
+  // pattern it contains is honored by matchesRetirement — a change that
+  // silently forked the two would need to also break this.
+  it("is exported for reuse", () => {
+    expect(RETIREMENT_PATTERNS.length).toBeGreaterThan(0);
+  });
+
+  it.each(RETIREMENT_PATTERNS.map((re) => re.source))(
+    "matchesRetirement agrees with isRetiredModelError for pattern: %s",
+    () => {
+      // Every sample that trips isRetiredModelError must also trip
+      // matchesRetirement, proving both consume the same source array.
+      const sample = "410 model was retired, unknown model, model_not_found, no longer available";
+      expect(isRetiredModelError(sample)).toBe(true);
+      expect(matchesRetirement(sample)).toBe(true);
+    }
+  );
 });

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -5,6 +5,9 @@ import {
   PROVIDER_SETTINGS_HINT,
   CONTEXT_OVERFLOW_HINT,
   CONTEXT_OVERFLOW_MESSAGE,
+  MODEL_RETIRED_MESSAGE,
+  MODEL_RETIRED_HINT_ADMIN,
+  MODEL_RETIRED_HINT_MEMBER,
 } from "@/server/error-hints";
 
 describe("getErrorHint", () => {
@@ -141,6 +144,88 @@ describe("getErrorHint", () => {
     it("presentProviderError leaves non-overflow errors unchanged", () => {
       expect(presentProviderError("Invalid API key provided")).toBe("Invalid API key provided");
       expect(presentProviderError("Rate limit exceeded")).toBe("Rate limit exceeded");
+    });
+  });
+
+  describe("retired model → names the model, admin/member hint, no unproven cause elsewhere", () => {
+    // Real staging incident (2026-07-01): an agent pinned to
+    // ollama-cloud/qwen3-vl:235b-instruct (retired by Ollama Cloud on 2026-06-16)
+    // failed every turn. OpenClaw's OWN container log split the detail cleanly
+    // (`error=LLM request failed. rawError=410 {"error":"...was retired..."}`),
+    // but only the generic `error` half crosses the gateway RPC to Pinchy — the
+    // `rawError` detail never reaches `chunk.text` (see error-patterns.ts's
+    // PROVIDER_REJECTED_GENERIC_PATTERN note for the same upstream-collapsing
+    // limitation, #584/openclaw#93741). A retirement text WITH a surviving
+    // token (410/retired/unknown model/etc.) still gets the specific message
+    // below when one happens to survive (e.g. a different error source, per
+    // model-retirement.test.ts's PDF-model-resolution example, which DOES get
+    // the full body via a direct HTTP call rather than the collapsed WS RPC).
+    const retirementTexts = [
+      '410 "qwen3-vl:235b-instruct was retired at 2026-06-16 00:00:00 -0700 PDT"',
+      "Unknown model: ollama-cloud/gemini-2-preview-0514",
+      "model_not_found",
+      "the model was retired",
+    ];
+
+    it.each(retirementTexts)("presentProviderError names the model: %s", (text) => {
+      const shown = presentProviderError(text, "ollama-cloud/qwen3-vl:235b-instruct");
+      expect(shown).toBe(MODEL_RETIRED_MESSAGE("ollama-cloud/qwen3-vl:235b-instruct"));
+      expect(shown).toContain("ollama-cloud/qwen3-vl:235b-instruct");
+      expect(shown).not.toBe(text);
+    });
+
+    it("presentProviderError falls back to a generic (no-name) message when no model name is known", () => {
+      expect(presentProviderError(retirementTexts[0]!)).toBe(MODEL_RETIRED_MESSAGE(undefined));
+      expect(presentProviderError(retirementTexts[0]!)).not.toContain("qwen3-vl");
+    });
+
+    it.each(retirementTexts)("getErrorHint returns the admin/member hint: %s", (text) => {
+      expect(getErrorHint(text, "admin")).toBe(MODEL_RETIRED_HINT_ADMIN);
+      expect(getErrorHint(text, "member")).toBe(MODEL_RETIRED_HINT_MEMBER);
+    });
+
+    it("does not misroute a bare '410' into transient/provider-config/overflow", () => {
+      // A bare 410 is deliberately broad (mirrors model-retirement.ts's own
+      // RETIREMENT_PATTERNS reasoning) but must not collide with the other
+      // specific patterns (529/rate-limit for transient, credit/key/quota for
+      // provider-config, context/tokens for overflow) — none of them mention 410.
+      expect(getErrorHint("410", "admin")).toBe(MODEL_RETIRED_HINT_ADMIN);
+    });
+  });
+
+  describe("generic unclassified error → names the model without asserting a cause (#611 follow-up)", () => {
+    // The ACTUAL staging incident's stored providerError was the bare OpenClaw
+    // fallback string with ZERO retirement signal — ground truth, verified via
+    // `select provider_error from chat_session_errors` on staging (2026-07-01):
+    // `"LLM request failed."`. matchesRetirement (and every other pattern) can't
+    // fire on this — there is nothing to pattern-match. This is the actual fix
+    // for the reported bug: Pinchy already knows WHICH model it dispatched to
+    // regardless of why the dispatch failed, so naming it turns a fully opaque
+    // message into something actionable without asserting an unproven cause
+    // (the honest constraint that already shapes PROVIDER_REJECTED_GENERIC_PATTERN).
+    const bareFallback = "LLM request failed.";
+
+    it("appends the model name to an otherwise-unclassified error", () => {
+      expect(presentProviderError(bareFallback, "ollama-cloud/qwen3-vl:235b-instruct")).toBe(
+        "LLM request failed. (model: ollama-cloud/qwen3-vl:235b-instruct)"
+      );
+    });
+
+    it("leaves the text unchanged when no model name is known", () => {
+      expect(presentProviderError(bareFallback)).toBe(bareFallback);
+    });
+
+    it("does not append a model name to a fully-replaced message (overflow/retirement)", () => {
+      const overflow = presentProviderError(
+        "context window exceeded for this prompt",
+        "some-model"
+      );
+      expect(overflow).toBe(CONTEXT_OVERFLOW_MESSAGE);
+      expect(overflow).not.toContain("some-model");
+    });
+
+    it("getErrorHint stays null for the unclassified bucket (unchanged pre-existing behavior)", () => {
+      expect(getErrorHint(bareFallback, "admin")).toBeNull();
     });
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/active-error/route.ts
@@ -35,9 +35,10 @@ export const GET = withAuth<RouteContext>(async (request, { params }, session) =
           errorClass: row.errorClass,
           transientReason: row.transientReason,
           // Banner display only — rewrites OpenClaw's context-overflow /reset
-          // advice (#611), matching the live error frame. The stored row keeps
-          // the raw text, so the hint below still classifies off it.
-          providerError: presentProviderError(row.providerError),
+          // advice (#611) and names the model (#611 follow-up), matching the
+          // live error frame. The stored row keeps the raw text, so the hint
+          // below still classifies off it.
+          providerError: presentProviderError(row.providerError, row.model ?? undefined),
           // The banner renders no hint of its own; derive the same role-gated
           // guidance the live error frame gets (client-router) so a durable
           // provider-rejection points an admin at their provider config (#584).

--- a/packages/web/src/components/chat-crash-boundary.tsx
+++ b/packages/web/src/components/chat-crash-boundary.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { Component, Fragment, useEffect, type ErrorInfo, type ReactNode } from "react";
+
+/**
+ * Defense-in-depth against the recurring `tapClientLookup: Index N out of
+ * bounds (length: N)` full-page crash.
+ *
+ * Root cause (assistant-ui): `<ThreadPrimitive.Messages>` renders one child per
+ * message-array index; each child independently reads its own store slice by
+ * index. When the array shrinks while mounted, a trailing-index child re-renders
+ * with a now-stale index one commit before React unmounts it, and throws.
+ *
+ * Pinchy has closed four distinct shrink paths reactively (v0.5.7 in-flight
+ * anchor, #470 own-placeholder, #199 disconnect-defer, #510 reconcile-shrink-
+ * guard in use-ws-runtime.ts) — #510's own comment notes the crash "survived"
+ * the first two. Each fix closes ONE path; the library defect remains reachable
+ * via any future path. This boundary is the path-agnostic answer: it recovers
+ * from this error CLASS regardless of which shrink caused it, by remounting
+ * just the message thread (not the whole page/route) — while rethrowing any
+ * OTHER error so unrelated bugs still surface normally via app/error.tsx
+ * instead of being silently swallowed.
+ */
+export function isTapClientLookupCrash(error: unknown): boolean {
+  const message = error instanceof Error ? error.message : typeof error === "string" ? error : "";
+  if (!message) return false;
+  return /tapClientLookup|index\s+\d+\s+out of bounds/i.test(message);
+}
+
+// After this many recovery attempts without the crash going away, stop
+// swallowing and let it escalate to the nearest ancestor boundary instead of
+// spinning on the transient recovery state forever (a persistent crash must
+// still surface — "no silent failures").
+const MAX_RECOVERY_ATTEMPTS = 3;
+
+// Give the corrupted commit a tick to fully unwind before remounting the
+// thread — an immediate synchronous remount into the same still-shrinking
+// state could re-crash right away.
+const RECOVERY_DELAY_MS = 50;
+
+interface ChatCrashBoundaryState {
+  caught: unknown;
+  recoveryNonce: number;
+  recoveryAttempts: number;
+}
+
+export class ChatCrashBoundary extends Component<{ children: ReactNode }, ChatCrashBoundaryState> {
+  state: ChatCrashBoundaryState = { caught: null, recoveryNonce: 0, recoveryAttempts: 0 };
+
+  static getDerivedStateFromError(error: unknown): Partial<ChatCrashBoundaryState> {
+    return { caught: error };
+  }
+
+  componentDidCatch(error: unknown, info: ErrorInfo) {
+    // Only log here for the class we actually recover from. A non-matching
+    // error is rethrown in render() and propagates to the ancestor boundary,
+    // which reports it through its own path — logging it here too would be a
+    // confusing double-report of the same incident.
+    if (isTapClientLookupCrash(error)) {
+      console.error(
+        "[ChatCrashBoundary] recovered from an assistant-ui message-list crash:",
+        error,
+        info.componentStack
+      );
+    }
+  }
+
+  private recover = () => {
+    this.setState((s) => ({
+      caught: null,
+      recoveryNonce: s.recoveryNonce + 1,
+      recoveryAttempts: s.recoveryAttempts + 1,
+    }));
+  };
+
+  render() {
+    const { caught, recoveryNonce, recoveryAttempts } = this.state;
+    if (caught) {
+      // React error boundaries can't catch an error thrown from their OWN
+      // render — a boundary only catches errors from its descendants. So
+      // throwing here for a non-matching error (or once we've given up after
+      // MAX_RECOVERY_ATTEMPTS) correctly propagates to the nearest ANCESTOR
+      // boundary instead of looping back into this one.
+      if (!isTapClientLookupCrash(caught) || recoveryAttempts >= MAX_RECOVERY_ATTEMPTS) {
+        throw caught;
+      }
+      return <ChatRecoveryFallback onRecovered={this.recover} />;
+    }
+    // Keyed so a bumped nonce forces a full remount of the subtree, discarding
+    // whatever corrupted assistant-ui store slice caused the crash. The message
+    // data itself lives in use-ws-runtime's React state above this boundary and
+    // survives the remount — the recovered thread re-syncs from it.
+    return <Fragment key={recoveryNonce}>{this.props.children}</Fragment>;
+  }
+}
+
+function ChatRecoveryFallback({ onRecovered }: { onRecovered: () => void }) {
+  useEffect(() => {
+    const timer = setTimeout(onRecovered, RECOVERY_DELAY_MS);
+    return () => clearTimeout(timer);
+  }, [onRecovered]);
+
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center gap-3">
+      <div
+        data-testid="loading-spinner"
+        className="size-8 animate-spin rounded-full border-2 border-muted-foreground/20 border-t-muted-foreground"
+      />
+      <p className="text-sm font-medium text-muted-foreground">Reconnecting your conversation…</p>
+    </div>
+  );
+}

--- a/packages/web/src/components/chat.tsx
+++ b/packages/web/src/components/chat.tsx
@@ -5,6 +5,7 @@ import { AssistantRuntimeProvider } from "@assistant-ui/react";
 import type { AssistantRuntime } from "@assistant-ui/react";
 import type { PendingUpload } from "@/hooks/use-ws-runtime";
 import { Thread } from "@/components/assistant-ui/thread";
+import { ChatCrashBoundary } from "@/components/chat-crash-boundary";
 import { ChatErrorBanner } from "@/components/chat-error-banner";
 import { useChatSession } from "@/components/chat-session-provider";
 import { useAgentsContext } from "@/components/agents-provider";
@@ -314,7 +315,9 @@ export function Chat({
                                   onRetry={() => onRetryContinue("partial_stream_failure")}
                                 />
                                 <div className="flex-1 min-h-0 animate-in fade-in duration-300">
-                                  <Thread isReconcilingMessages={isReconcilingMessages} />
+                                  <ChatCrashBoundary>
+                                    <Thread isReconcilingMessages={isReconcilingMessages} />
+                                  </ChatCrashBoundary>
                                 </div>
                                 {!displayIsPersonal && (
                                   <p className="text-xs text-muted-foreground px-3 py-1">

--- a/packages/web/src/lib/model-retirement.ts
+++ b/packages/web/src/lib/model-retirement.ts
@@ -18,13 +18,18 @@
  * model" — re-resolving doesn't fix a model that exists but lacks a capability;
  * that's the curated-list's job, not self-heal's.
  */
-// Patterns are intentionally broad. The only consumer is the self-heal path,
-// where a false positive is cheap (one debounced, idempotent config
+// Patterns are intentionally broad. The primary consumer is the self-heal
+// path, where a false positive is cheap (one debounced, idempotent config
 // regeneration) but a false negative is costly (a genuinely retired model
 // keeps 410ing with no heal). So we bias toward catching retirements — e.g.
 // bare `410` matches even when the body doesn't say "retired". `\b410\b`
 // won't fire on substrings like "410ms" (no word boundary before "ms").
-const RETIREMENT_PATTERNS: readonly RegExp[] = [
+//
+// Exported so error-patterns.ts (the user-facing message/hint layer, #611
+// follow-up) classifies off the SAME source of truth instead of a hand-rolled
+// duplicate — two independent copies of "what counts as a retirement" would
+// drift the moment one changes.
+export const RETIREMENT_PATTERNS: readonly RegExp[] = [
   /\b410\b/,
   /\bretired\b/i,
   /\bunknown model\b/i,

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -1331,8 +1331,10 @@ export class ClientRouter {
               type: "error",
               agentName: agent.name,
               // Banner display only — rewrites OpenClaw's context-overflow /reset
-              // advice (#611). The audit + durable-persist keep the raw text.
-              providerError: presentProviderError(chunk.text),
+              // advice (#611) and names the dispatched model for a retired/
+              // unclassified error (#611 follow-up). The audit + durable-persist
+              // keep the raw text.
+              providerError: presentProviderError(chunk.text, agent.model ?? undefined),
               hint: getErrorHint(chunk.text, this.userRole),
               messageId,
               ...(modelUnavailable ? { modelUnavailable } : {}),

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -3,9 +3,31 @@ import {
   PROVIDER_CONFIG_PATTERN,
   PROVIDER_REJECTED_GENERIC_PATTERN,
   CONTEXT_OVERFLOW_PATTERN,
+  matchesRetirement,
 } from "@/server/error-patterns";
 
 export const PROVIDER_SETTINGS_HINT = "Go to Settings > Providers to check your API configuration.";
+
+// A retired model can't be retried as-is — an admin needs to pick a different
+// one for this agent. Deliberately NOT an automatic swap: an admin pinned this
+// model for a reason (cost, compliance, data residency, capability), and a
+// silent background change would undermine that governance decision the same
+// way the removed old "recovery dialog" did (see resolveImageTurnModel's
+// comment in client-router.ts). If this becomes a one-click suggested-swap
+// affordance later, it must go through the existing audited
+// `PATCH /api/agents/[agentId]` path, never a new silent one.
+export const MODEL_RETIRED_HINT_ADMIN = "Choose a different model for this agent in its settings.";
+export const MODEL_RETIRED_HINT_MEMBER = "Please contact your administrator.";
+
+// Pinchy already knows which model it dispatched to (it's the one that made
+// the request), so it can name it even though the retirement DATE never
+// reaches us (see matchesRetirement's doc comment — that's an upstream
+// OpenClaw limitation, not something we can parse around).
+export function MODEL_RETIRED_MESSAGE(modelName?: string): string {
+  return modelName
+    ? `The model "${modelName}" is no longer available — the provider has retired it.`
+    : "The agent's model is no longer available — the provider has retired it.";
+}
 
 // A context-window overflow can't be retried as-is. OpenClaw's own error text
 // advises its `/reset` / `/new` slash commands, but Pinchy's web composer sends
@@ -21,7 +43,13 @@ export const CONTEXT_OVERFLOW_MESSAGE =
   "This conversation is too long for the model's context window.";
 
 export function getErrorHint(errorText: string, userRole: string): string | null {
-  // Context-overflow first: it's specific, role-independent, and must not fall
+  // Retirement first, same reasoning as context-overflow: specific, and must
+  // not fall through to the generic/provider branches.
+  if (matchesRetirement(errorText)) {
+    return userRole === "admin" ? MODEL_RETIRED_HINT_ADMIN : MODEL_RETIRED_HINT_MEMBER;
+  }
+
+  // Context-overflow next: it's specific, role-independent, and must not fall
   // through to the generic/provider branches (or to null, the pre-#611 behavior).
   if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
     return CONTEXT_OVERFLOW_HINT;
@@ -51,15 +79,29 @@ export function getErrorHint(errorText: string, userRole: string): string | null
 }
 
 /**
- * Map a raw provider-error string to the user-facing banner text. Currently this
- * only rewrites context-overflow errors — OpenClaw's text embeds `/reset`/`/new`
- * advice that doesn't work in Pinchy's composer (#611) — and passes everything
- * else through untouched. Apply it where the error is shown to the user (the live
- * error frame and the durable-banner route); the audit trail keeps the raw text.
+ * Map a raw provider-error string to the user-facing banner text. `modelName`
+ * is the model Pinchy dispatched to (`agent.model`/the durable row's stored
+ * model) — data Pinchy already has independent of the error text, since it's
+ * the one that made the request. Apply this where the error is shown to the
+ * user (the live error frame and the durable-banner route); the audit trail
+ * and the stored row always keep the raw, unmodified text.
  */
-export function presentProviderError(errorText: string): string {
+export function presentProviderError(errorText: string, modelName?: string): string {
+  if (matchesRetirement(errorText)) {
+    return MODEL_RETIRED_MESSAGE(modelName);
+  }
   if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
     return CONTEXT_OVERFLOW_MESSAGE;
   }
-  return errorText;
+  // Final fallback: everything else (rate-limit, provider-config, the #584
+  // generic provider-rejection envelope, and any truly unclassified text) is
+  // shown as-is EXCEPT we still append which model was involved, when known.
+  // This is what actually fixes the reported bug: the real staging incident's
+  // stored providerError was the bare `"LLM request failed."` fallback with NO
+  // retirement token to match above, so `matchesRetirement` never fires for
+  // it — but Pinchy still knows which model it dispatched to regardless of
+  // WHY the dispatch failed, and naming it turns a fully opaque message into
+  // something actionable without asserting an unproven cause (the same
+  // honesty constraint that already shapes PROVIDER_REJECTED_GENERIC_PATTERN).
+  return modelName ? `${errorText} (model: ${modelName})` : errorText;
 }

--- a/packages/web/src/server/error-patterns.ts
+++ b/packages/web/src/server/error-patterns.ts
@@ -1,3 +1,5 @@
+import { RETIREMENT_PATTERNS } from "@/lib/model-retirement";
+
 /**
  * Shared error-text classification patterns used by both the user-facing
  * hint generator (`error-hints.ts`) and the audit umbrella classifier
@@ -75,3 +77,26 @@ export const PROVIDER_REJECTED_GENERIC_PATTERN =
  */
 export const CONTEXT_OVERFLOW_PATTERN =
   /context (overflow|window|length)|prompt (is )?too large|larger[- ]context|maximum context|too many (input )?tokens/i;
+
+/**
+ * Whether `text` indicates the dispatched model is no longer available
+ * upstream (retired/unknown/not-found) — reuses `model-retirement.ts`'s
+ * `RETIREMENT_PATTERNS`, the self-heal path's own classifier, so "what counts
+ * as a retirement" has one source of truth instead of two independent copies
+ * that could drift. The bare `410` entry is deliberately broad (see that
+ * file's reasoning) but doesn't collide with the patterns above: transient is
+ * `529`/rate-limit/timeout wording, provider-config is credit/key/quota,
+ * overflow is context/tokens wording — none of them mention 410.
+ *
+ * Known limitation (#611 follow-up): OpenClaw's gateway RPC only forwards a
+ * collapsed generic string for a chat-dispatch failure (verified against a
+ * real staging incident, 2026-07-01 — the stored providerError was the bare
+ * `"LLM request failed."`, with no retirement token at all). This matches
+ * PROVIDER_REJECTED_GENERIC_PATTERN's note: the distinguishing detail lives in
+ * OpenClaw's own container log and never reaches Pinchy over the wire. This
+ * function can only fire when a token happens to survive in the text Pinchy
+ * actually receives.
+ */
+export function matchesRetirement(text: string): boolean {
+  return RETIREMENT_PATTERNS.some((re) => re.test(text));
+}


### PR DESCRIPTION
## What & why

Two fixes found during the v0.8.0 `:next` staging click-through (after [#612](https://github.com/heypinchy/pinchy/pull/612)). Both are chat-error robustness issues; each is its own commit.

### 1. `tapClientLookup` full-page crash → graceful recovery

`@assistant-ui`'s index-keyed message list throws `tapClientLookup: Index N out of bounds` when the message array shrinks while `<ThreadPrimitive.Messages>` is mounted. Four prior fixes (v0.5.7 anchor, #470 own-placeholder, #199 disconnect-defer, #510 reconcile-shrink-guard) each closed ONE shrink path reactively — #510's own comment notes the crash "survived" the earlier two. Reproduced again on the v0.8.0 staging RC.

Adds `ChatCrashBoundary` wrapping `<Thread>` in `chat.tsx`: catches this error **class**, regardless of which path caused it, and recovers by remounting just the thread (message state lives above the boundary and survives) with a brief "Reconnecting your conversation…" state — instead of crashing the whole page. Selectively rethrows anything else, so an unrelated crash still bubbles to `app/error.tsx` unchanged; gives up after repeated failures rather than looping forever.

A version bump was evaluated (upstream [assistant-ui#4051](https://github.com/assistant-ui/assistant-ui/issues/4051) is closed) but Pinchy already resolves a store version past the fix and still reproduces the crash, so a bump is unproven for this exact path — and it would break the pinned IME-composition IME patch (#449). Deferred as a gated follow-up: [#630](https://github.com/heypinchy/pinchy/issues/630).

### 2. "LLM request failed" → names the model

Staging hit an agent pinned to a since-retired Ollama Cloud model. Every turn showed the bare "LLM request failed." banner. **Ground-truthed against the actual staging DB row** (`chat_session_errors.provider_error`): the stored text carries zero retirement signal — OpenClaw's gateway RPC only forwards the collapsed generic string, never the richer detail its own container log shows separately.

Two layers, both display-only (audit trail + durable row always keep the raw text):
- `matchesRetirement()` reuses `model-retirement.ts`'s own `RETIREMENT_PATTERNS` (now exported, single source of truth with self-heal) — when a retirement token *does* survive in the text, the banner gets a specific, named "no longer available" message + a role-gated hint.
- **The actual fix for the reported case:** `presentProviderError`'s final fallback now appends `(model: X)` to any error that isn't already fully replaced, whenever the caller knows which model it dispatched to. Pinchy has that information independent of OpenClaw's collapsed text, so naming it turns a fully opaque message into something actionable without asserting an unproven cause.

Deliberately **not** an auto-swap — an admin pinned that model for a reason (cost, compliance, data residency, capability), and the codebase already removed a prior auto-swap "recovery dialog" for exactly this concern (see `resolveImageTurnModel`'s comment). An explicit, admin-confirmed one-click swap through the existing audited `PATCH /api/agents/[agentId]` path is a tracked follow-up: [#631](https://github.com/heypinchy/pinchy/issues/631).

## Tests

- `chat-crash-boundary.test.tsx` (new) — predicate matching, catch+recover with a transient fallback, **selective rethrow** (an unrelated error propagates past this boundary to an outer one, proving it can't mask real bugs), and loop-protection escalation. Stable across repeated runs.
- `error-hints.test.ts` — new describe blocks for the retirement-token path and the generic model-naming fallback, including the exact real staging string (`"LLM request failed."`) as a documented regression case.
- `model-retirement.test.ts` — drift guard asserting `error-patterns.ts`'s classification agrees with `model-self-heal.ts`'s.
- Full suite: 518/521 files, 6610/6623 tests green (3 files / 13 tests pre-existing conditional skips, unrelated). `tsc --noEmit` clean. Lint: 0 errors (pre-existing unrelated warnings only). `format:check` clean.

## Follow-ups (tracked, out of scope)

- [#630](https://github.com/heypinchy/pinchy/issues/630) — evaluate the `@assistant-ui` version bump + re-derive the IME patch.
- [#631](https://github.com/heypinchy/pinchy/issues/631) — one-click admin-confirmed model-swap affordance.

Part of v0.8.0 release prep — staging needs to be re-tested on this version before the release cut.
