### PR TITLE
fix(chat): durable-banner scope + Dismiss + sidebar indicator for any session

### DIFF
--- a/packages/web/src/__tests__/components/chat-error-message.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-message.test.tsx
@@ -106,6 +106,43 @@ describe("ChatErrorMessage — transient (rate limit / overloaded) branch", () =
   });
 });
 
+describe("ChatErrorMessage — dismiss on the generic provider-error variant", () => {
+  // The durable banner now shows for non-transient retryable classes too
+  // (model_unavailable, silent_stream_timeout, schema_rejection,
+  // failover_incomplete_stream), which render via the GENERIC provider-error
+  // branch — not the transient one. That branch previously ignored onDismiss,
+  // so the banner had only a Retry button and no way to clear it. It must now
+  // honor onDismiss like the transient variant does.
+  it("renders a dismiss control and calls onDismiss when clicked", () => {
+    const onDismiss = vi.fn();
+    render(
+      <ChatErrorMessage
+        error={{
+          agentName: "Sterling Ollama",
+          providerError: "LLM request failed. (model: ollama-cloud/some-model)",
+        }}
+        agentId="agent-1"
+        onDismiss={onDismiss}
+      />
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: /dismiss/i }));
+    expect(onDismiss).toHaveBeenCalledTimes(1);
+  });
+
+  it("renders NO dismiss control when onDismiss is absent (inline thread usage)", () => {
+    // Inline errors in the thread pass no onDismiss — you don't 'dismiss' a
+    // conversation turn. The X must only appear when a caller (the banner) asks.
+    render(
+      <ChatErrorMessage
+        error={{ agentName: "Sterling Ollama", providerError: "LLM request failed." }}
+        agentId="agent-1"
+      />
+    );
+    expect(screen.queryByRole("button", { name: /dismiss/i })).not.toBeInTheDocument();
+  });
+});
+
 describe("ChatErrorMessage", () => {
   it("should render provider error with agent name and hint", () => {
     render(

--- a/packages/web/src/__tests__/components/chat-session-provider.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-provider.test.tsx
@@ -3,6 +3,7 @@ import { renderHook, act } from "@testing-library/react";
 import {
   ChatSessionProvider,
   MAX_LIVE_BUNDLES,
+  useAgentActivity,
   useChatSession,
   useChatSessionHasInlineError,
   useVisitedAgentIds,
@@ -145,6 +146,76 @@ describe("ChatSessionProvider", () => {
     it("does not throw outside a ChatSessionProvider (non-throwing fallback)", () => {
       const { result } = renderHook(() => useChatSessionHasInlineError("agent-1"));
       expect(result.current).toBe(false);
+    });
+  });
+
+  describe("useAgentActivity (sidebar indicator — ANY session, not just the first)", () => {
+    it("returns not-running / no-error when the agent has no sessions", () => {
+      const { result } = renderHook(() => useAgentActivity("agent-1"), { wrapper });
+      expect(result.current).toEqual({ isRunning: false, lastError: null });
+    });
+
+    it("reports running when a NON-default (chat-scoped) session is running", () => {
+      // The reported bug: the sidebar indicator read only the default session's
+      // bundle, so writing in another chat of the same agent lit nothing. It
+      // must reflect a run in ANY of the agent's sessions.
+      const { result } = renderHook(
+        () => ({
+          activity: useAgentActivity("agent-A"),
+          legacy: useChatSession("agent-A"),
+          chatX: useChatSession("agent-A", "chat-x"),
+        }),
+        { wrapper }
+      );
+
+      // Default session idle, a different chat's session running.
+      act(() =>
+        result.current.legacy.publish(fakeBundle({ agentId: "agent-A", isRunning: false }))
+      );
+      act(() =>
+        result.current.chatX.publish(
+          fakeBundle({ agentId: "agent-A", chatId: "chat-x", isRunning: true })
+        )
+      );
+
+      expect(result.current.activity.isRunning).toBe(true);
+    });
+
+    it("does not leak activity across agents (matches by agentId, not key prefix)", () => {
+      // Guard against a naive key-prefix match: "agent-A" is a prefix of
+      // "agent-A2", so matching on the store key would false-positive.
+      const { result } = renderHook(
+        () => ({
+          activityA: useAgentActivity("agent-A"),
+          publishA2: useChatSession("agent-A2").publish,
+        }),
+        { wrapper }
+      );
+
+      act(() => result.current.publishA2(fakeBundle({ agentId: "agent-A2", isRunning: true })));
+      expect(result.current.activityA.isRunning).toBe(false);
+    });
+
+    it("surfaces lastError from any of the agent's sessions", () => {
+      const { result } = renderHook(
+        () => ({
+          activity: useAgentActivity("agent-A"),
+          chatX: useChatSession("agent-A", "chat-x"),
+        }),
+        { wrapper }
+      );
+
+      act(() =>
+        result.current.chatX.publish(
+          fakeBundle({ agentId: "agent-A", chatId: "chat-x", lastError: "Reconnect exhausted" })
+        )
+      );
+      expect(result.current.activity.lastError).toBe("Reconnect exhausted");
+    });
+
+    it("does not throw outside a ChatSessionProvider (non-throwing fallback)", () => {
+      const { result } = renderHook(() => useAgentActivity("agent-1"));
+      expect(result.current).toEqual({ isRunning: false, lastError: null });
     });
   });
 

--- a/packages/web/src/__tests__/server/agent-error-classifier.test.ts
+++ b/packages/web/src/__tests__/server/agent-error-classifier.test.ts
@@ -3,6 +3,8 @@ import {
   classifyAgentError,
   classifySynthesisedError,
   classifyTransientReason,
+  shouldPersistDurableError,
+  type AgentErrorClass,
 } from "@/server/agent-error-classifier";
 
 describe("classifyTransientReason", () => {
@@ -124,6 +126,43 @@ describe("classifyAgentError", () => {
     expect(classifyAgentError("You exceeded your current quota for the month")).toBe(
       "provider_config"
     );
+  });
+});
+
+describe("shouldPersistDurableError", () => {
+  // The durable "paused" banner (chat_session_errors) exists to re-surface an
+  // error a user might have MISSED — a one-off/intermittent failure whose live
+  // bubble died on a reload/reconnect. For a PERSISTENT problem (a retired
+  // model, an over-large prompt, a bad provider config) the next attempt fails
+  // the same way, so the error can't be missed and a sticky, reappearing banner
+  // is pure annoyance. So we only persist the retryable/intermittent classes.
+
+  const durableClasses: AgentErrorClass[] = [
+    "transient",
+    "silent_stream_timeout",
+    "model_unavailable",
+    "schema_rejection",
+    "failover_incomplete_stream",
+  ];
+  const nonDurableClasses: AgentErrorClass[] = ["provider_config", "unknown"];
+
+  it.each(durableClasses)("persists a durable banner for retryable class: %s", (cls) => {
+    expect(shouldPersistDurableError(cls)).toBe(true);
+  });
+
+  it.each(nonDurableClasses)(
+    "does NOT persist a durable banner for persistent class: %s (shows inline only)",
+    (cls) => {
+      expect(shouldPersistDurableError(cls)).toBe(false);
+    }
+  );
+
+  it("keeps a retired model (unknown class) OUT of the durable banner", () => {
+    // The reported staging bug: an agent pinned to a retired model 410s every
+    // turn; its providerError collapses to the bare "LLM request failed." which
+    // classifies as `unknown`. Retry can't help until an admin changes the
+    // model, so it must not create a sticky durable banner.
+    expect(shouldPersistDurableError(classifyAgentError("LLM request failed."))).toBe(false);
   });
 });
 

--- a/packages/web/src/components/agent-sidebar-indicator.tsx
+++ b/packages/web/src/components/agent-sidebar-indicator.tsx
@@ -1,26 +1,27 @@
 "use client";
 
-import { useChatSession } from "@/components/chat-session-provider";
+import { useAgentActivity } from "@/components/chat-session-provider";
 
 export function AgentSidebarIndicator({ agentId }: { agentId: string }) {
-  const { bundle } = useChatSession(agentId);
-  if (!bundle) return null;
+  // Reflect activity across ANY of the agent's sessions, not just the default
+  // one — a run started in a non-default chat must still light the sidebar.
+  const { isRunning, lastError } = useAgentActivity(agentId);
 
   // Error wins over running: a stale error shouldn't be hidden by a
   // freshly-started retry. The only sidebar error is reconnect exhaustion;
   // it clears once the connection is re-established.
-  if (bundle.lastError) {
+  if (lastError) {
     return (
       <span
         data-testid="agent-error-indicator"
         aria-label="Agent error"
-        title={bundle.lastError}
+        title={lastError}
         className="size-1.5 rounded-full bg-destructive shrink-0"
       />
     );
   }
 
-  if (bundle.isRunning) {
+  if (isRunning) {
     return (
       <span
         data-testid="agent-running-indicator"

--- a/packages/web/src/components/assistant-ui/chat-error-message.tsx
+++ b/packages/web/src/components/assistant-ui/chat-error-message.tsx
@@ -260,6 +260,16 @@ export const ChatErrorMessage: FC<{
           <div className="flex items-center gap-2 font-medium text-destructive dark:text-red-200">
             <AlertTriangle className="size-4 shrink-0" data-testid="error-warning-icon" />
             <span className="flex-1">{`${agentLabel} couldn't respond`}</span>
+            {onDismiss && (
+              <button
+                type="button"
+                onClick={onDismiss}
+                aria-label="Dismiss"
+                className="shrink-0 rounded-xs opacity-70 transition-opacity hover:opacity-100"
+              >
+                <X className="size-4" />
+              </button>
+            )}
             {actionSlot}
           </div>
           <p className="mt-1.5 text-destructive/90 dark:text-red-300/90">{error.providerError}</p>

--- a/packages/web/src/components/chat-session-provider.tsx
+++ b/packages/web/src/components/chat-session-provider.tsx
@@ -168,6 +168,37 @@ export function useChatSessionHasInlineError(agentId: string, chatId?: string): 
   return useStore(store, (s) => s.bundles[key]?.hasInlineError ?? false);
 }
 
+/**
+ * Aggregate run/error activity across ALL of an agent's live sessions (#508),
+ * for the sidebar indicator. `useChatSession(agentId)` reads only the DEFAULT
+ * session's bundle — so a run started in a non-default chat lit nothing. This
+ * scans every bundle whose `agentId` matches (matched by the bundle's own
+ * `agentId` field, NOT a store-key prefix — "agent-A" is a prefix of
+ * "agent-A2") and reports running if any is running, plus the first non-null
+ * `lastError`. Non-throwing (fallback store) like the sibling hooks. Each
+ * selector returns a primitive so the useSyncExternalStore snapshot stays
+ * referentially stable between renders.
+ */
+export function useAgentActivity(agentId: string): {
+  isRunning: boolean;
+  lastError: string | null;
+} {
+  const store = useContext(ChatSessionStoreContext) ?? fallbackStore;
+  const isRunning = useStore(store, (s) => {
+    for (const b of Object.values(s.bundles)) {
+      if (b?.agentId === agentId && b.isRunning) return true;
+    }
+    return false;
+  });
+  const lastError = useStore(store, (s) => {
+    for (const b of Object.values(s.bundles)) {
+      if (b?.agentId === agentId && b.lastError) return b.lastError;
+    }
+    return null;
+  });
+  return useMemo(() => ({ isRunning, lastError }), [isRunning, lastError]);
+}
+
 export function useVisitedAgentIds(): string[] {
   const store = useStoreOrThrow();
   // Serialize to a stable string so useSyncExternalStore snapshot is referentially

--- a/packages/web/src/server/agent-error-classifier.ts
+++ b/packages/web/src/server/agent-error-classifier.ts
@@ -88,6 +88,41 @@ export function classifySynthesisedError(reason: SynthesisedErrorReason): AgentE
   }
 }
 
+/**
+ * Whether an agent error of this class should persist a durable "paused" banner
+ * (chat_session_errors), versus showing inline only.
+ *
+ * The banner exists to re-surface an error a user might have MISSED — a one-off
+ * or intermittent failure whose ephemeral live bubble died on a reload/reconnect
+ * (see chat-error-banner.tsx / chat-states.mdx). For a PERSISTENT problem the
+ * next attempt fails identically, so the error can't be missed and a sticky,
+ * reappearing banner is pure annoyance — the exact staging complaint for a
+ * retired model (bare "LLM request failed." → `unknown`) and for a bad provider
+ * config. Those show inline only; everything retryable keeps the banner.
+ *
+ * Exhaustive over `AgentErrorClass` (no `default`) so adding a future class is a
+ * compile error until its durability is explicitly decided — same discipline as
+ * `classifySynthesisedError` below.
+ */
+export function shouldPersistDurableError(errorClass: AgentErrorClass): boolean {
+  switch (errorClass) {
+    // Retryable / intermittent — a reload could have lost the live bubble and a
+    // fresh attempt may well succeed, so re-surface it on return.
+    case "transient":
+    case "silent_stream_timeout":
+    case "model_unavailable":
+    case "schema_rejection":
+    case "failover_incomplete_stream":
+      return true;
+    // Persistent — recurs every attempt until an admin changes something
+    // (model, provider config). The inline turn-failure is enough; a durable
+    // banner would just stick around and reappear on every navigation.
+    case "provider_config":
+    case "unknown":
+      return false;
+  }
+}
+
 // Sub-partition of TRANSIENT_PATTERN so the chat bubble can be honest about the
 // specific cause. `transient` (the audit class) spans rate-limit, overloaded,
 // timeout and HTTP 529 — calling all of them "rate limit" in the UI would be a

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -33,6 +33,7 @@ import {
   classifyAgentError,
   classifySynthesisedError,
   classifyTransientReason,
+  shouldPersistDurableError,
   type AgentErrorClass,
 } from "@/server/agent-error-classifier";
 import {
@@ -1746,22 +1747,31 @@ export class ClientRouter {
     try {
       // Derive sideEffects from the audit trail: OpenClaw doesn't signal tool
       // execution as a chat chunk, so a `tool.*` audit row since this run began
-      // is the reliable "the agent already acted" signal.
+      // is the reliable "the agent already acted" signal. Computed for EVERY
+      // class — the live inline retry's duplicate-write gate needs it even when
+      // we skip the durable row below.
       const sideEffects = await agentRanToolSince(args.agent.id, args.runStartedAt);
-      await recordChatSessionError({
-        userId: this.userId,
-        agentId: args.agent.id,
-        sessionKey: args.sessionKey,
-        clientMessageId: args.clientMessageId ?? null,
-        runId: args.runId ?? null,
-        agentName: args.agent.name,
-        model: args.agent.model ?? null,
-        errorClass: args.errorClass,
-        transientReason:
-          args.errorClass === "transient" ? classifyTransientReason(args.providerError) : null,
-        providerError: safeProviderError(args.providerError),
-        sideEffects,
-      });
+      // Only persist a durable "paused" banner for retryable/intermittent
+      // classes. A persistent problem (retired model, over-large prompt, bad
+      // provider config → `unknown`/`provider_config`) recurs every attempt, so
+      // a sticky banner that reappears on every navigation is annoyance, not
+      // help — the inline turn-failure is enough. See shouldPersistDurableError.
+      if (shouldPersistDurableError(args.errorClass)) {
+        await recordChatSessionError({
+          userId: this.userId,
+          agentId: args.agent.id,
+          sessionKey: args.sessionKey,
+          clientMessageId: args.clientMessageId ?? null,
+          runId: args.runId ?? null,
+          agentName: args.agent.name,
+          model: args.agent.model ?? null,
+          errorClass: args.errorClass,
+          transientReason:
+            args.errorClass === "transient" ? classifyTransientReason(args.providerError) : null,
+          providerError: safeProviderError(args.providerError),
+          sideEffects,
+        });
+      }
       return sideEffects;
     } catch (err) {
       console.error("Failed to persist durable chat error:", err);


### PR DESCRIPTION
## What & why

Three chat-UX issues found during the v0.8.0 `:next` staging session, plus a tracked follow-up. Two logical commits.

### 1. The durable error banner stopped being sticky + got a Dismiss button

The durable "paused" banner exists to re-surface an error a user might have **missed** — a one-off/intermittent failure whose live bubble died on a reload/reconnect. But it fired for **every** agent error, including persistent ones: a retired model (bare `"LLM request failed."` → `unknown`), context overflow (`unknown`), or a bad provider config. Those recur every attempt, so the error can't be missed — the banner just sticks around and reappears on every navigation (the reported staging complaint), and Retry can't help them anyway.

- **`shouldPersistDurableError(errorClass)`** — an exhaustive switch over `AgentErrorClass` (compile error until a new class's durability is decided): persist a durable row only for the retryable/intermittent classes (`transient`, `silent_stream_timeout`, `model_unavailable`, `schema_rejection`, `failover_incomplete_stream`); **not** `unknown`/`provider_config`, which now show inline only. Gated **inside** `persistDurableChatError`, so `sideEffects` is still computed for every class and the inline retry's duplicate-write gate is unaffected.
- **Dismiss control** added to the generic provider-error variant of `ChatErrorMessage`. The transient variant already had it, but the durable banner's non-transient retryable classes render the *generic* variant, which ignored `onDismiss` — leaving only Retry and no way to clear it. (Inline thread usage passes no `onDismiss`, so no X appears there.)

### 2. Sidebar agent indicator: any session, not just the first

`AgentSidebarIndicator` read `useChatSession(agentId)` — the **default** session's bundle only. A run started in a non-default chat (#508) of the same agent lit nothing. New `useAgentActivity(agentId)` scans every live bundle whose own `agentId` matches (by field, not a store-key prefix — `agent-A` is a prefix of `agent-A2`) and reports running if **any** session is running, plus the first non-null `lastError`.

## Tests

- `agent-error-classifier.test.ts` — `shouldPersistDurableError` per class (retryable → true, `unknown`/`provider_config` → false), incl. the retired-model bare-string case.
- `chat-error-message.test.tsx` — dismiss renders + fires on the generic variant; absent when no `onDismiss` (inline).
- `chat-session-provider.test.tsx` — `useAgentActivity` reports a non-default session's run, doesn't leak across agents by key prefix, surfaces `lastError`, non-throwing fallback.
- Full suite: 518 files / 6625 tests green. `tsc --noEmit` clean. Lint: 0 errors. `format:check` clean.

## Follow-up (tracked, out of scope)

- **#633** — replace the whole durable-error-banner subsystem with transcript-persisted inline errors, now that Pinchy owns the transcript. These two commits are the release-prep patches that buy time for that cleanup.

Part of v0.8.0 release prep — staging needs a re-test on this version before the cut.
