### PR TITLE
fix(chat): image-attachment note reflects the vision-model offload, not "unsupported"

### DIFF
--- a/packages/web/src/__tests__/lib/attachment-capability.test.ts
+++ b/packages/web/src/__tests__/lib/attachment-capability.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from "vitest";
-import { requiredCapabilityForFile } from "@/lib/attachment-capability";
+import {
+  requiredCapabilityForFile,
+  imageInputNote,
+  IMAGE_INPUT_OFFLOAD_NOTE,
+} from "@/lib/attachment-capability";
 
 describe("requiredCapabilityForFile", () => {
   it("requires vision for image attachments — images ship base64 as direct model input", () => {
@@ -16,5 +20,35 @@ describe("requiredCapabilityForFile", () => {
     expect(requiredCapabilityForFile("text/plain")).toBeNull();
     expect(requiredCapabilityForFile("text/csv")).toBeNull();
     expect(requiredCapabilityForFile("application/json")).toBeNull();
+  });
+});
+
+describe("imageInputNote", () => {
+  // Staging finding: a text-only agent model (GLM 5.2) showed the flat warning
+  // "This model doesn't support image input." yet returned a correct image
+  // description — because Pinchy offloads the image to the configured vision
+  // model (resolveImageTurnModel). The note must reflect that offload, not
+  // contradict the outcome the user sees.
+
+  it("notes the vision-model offload when the agent's model can't read images itself", () => {
+    expect(imageInputNote("image/png", false)).toBe(IMAGE_INPUT_OFFLOAD_NOTE);
+    // Honest, not a flat "doesn't support" — the image usually still works.
+    expect(IMAGE_INPUT_OFFLOAD_NOTE).not.toMatch(/doesn't support/i);
+    expect(IMAGE_INPUT_OFFLOAD_NOTE).toMatch(/vision model/i);
+  });
+
+  it("shows no note when the agent's model IS vision-capable", () => {
+    expect(imageInputNote("image/png", true)).toBeNull();
+  });
+
+  it("shows no note before capabilities have loaded (unknown vision support)", () => {
+    // modelCapabilities is null/undefined until /api/models/capabilities resolves.
+    expect(imageInputNote("image/png", null)).toBeNull();
+    expect(imageInputNote("image/png", undefined)).toBeNull();
+  });
+
+  it("shows no note for non-image files (PDFs/text route via pinchy_read)", () => {
+    expect(imageInputNote("application/pdf", false)).toBeNull();
+    expect(imageInputNote("text/plain", false)).toBeNull();
   });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/attachment-preview.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/attachment-preview.test.tsx
@@ -194,7 +194,11 @@ describe("AttachmentPreview — amber capability warning", () => {
     );
   }
 
-  it("shows amber warning when image attached and model has no vision", async () => {
+  it("notes the vision-model offload when an image is attached to a text-only model", async () => {
+    // A text-only agent model can't read images directly, but Pinchy offloads
+    // to the configured vision model — so the note must reflect that (and NOT
+    // flatly claim "doesn't support image input", which contradicted the correct
+    // description a text-only model returned on staging).
     mockUseMessagePartFile.mockReturnValue({
       mimeType: "image/png",
       filename: "screenshot.png",
@@ -212,7 +216,8 @@ describe("AttachmentPreview — amber capability warning", () => {
       refetch: vi.fn(),
     });
     await renderWithModel(TEXT_ONLY_MODEL);
-    expect(await screen.findByText(/doesn't support image input/i)).toBeInTheDocument();
+    expect(await screen.findByText(/a vision model will describe it/i)).toBeInTheDocument();
+    expect(screen.queryByText(/doesn't support image input/i)).not.toBeInTheDocument();
   });
 
   it("shows no warning for PDFs regardless of model capabilities — PDFs route via the pdf tool, not the agent model", async () => {

--- a/packages/web/src/components/assistant-ui/attachment-preview.tsx
+++ b/packages/web/src/components/assistant-ui/attachment-preview.tsx
@@ -5,7 +5,7 @@ import { useMessagePartFile } from "@assistant-ui/react";
 import { FileText, Loader2 } from "lucide-react";
 import { AgentIdContext, AgentModelContext } from "@/components/chat";
 import { Dialog, DialogContent, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
-import { requiredCapabilityForFile } from "@/lib/attachment-capability";
+import { imageInputNote } from "@/lib/attachment-capability";
 
 import { useModelCapabilities } from "@/hooks/use-model-capabilities";
 
@@ -91,13 +91,7 @@ export const AttachmentPreview: FC = () => {
   const url = isPreviewable ? buildUploadUrl(agentId!, filename!) : null;
   const readiness = useUploadReadiness(url);
 
-  const requiredCapability = requiredCapabilityForFile(mimeType);
-  const capabilityWarning =
-    modelCapabilities && requiredCapability && !modelCapabilities[requiredCapability]
-      ? requiredCapability === "vision"
-        ? "This model doesn't support image input."
-        : "This model doesn't support document input."
-      : null;
+  const capabilityWarning = imageInputNote(mimeType, modelCapabilities?.vision);
 
   // Falls back to a chip when we don't have everything we need to build a URL.
   if (!agentId || !filename) {

--- a/packages/web/src/lib/attachment-capability.ts
+++ b/packages/web/src/lib/attachment-capability.ts
@@ -13,3 +13,32 @@ export function requiredCapabilityForFile(mimeType: string): "vision" | null {
   if (mimeType.startsWith("image/")) return "vision";
   return null;
 }
+
+/**
+ * Note shown on an image attachment when the AGENT's own model can't accept
+ * images directly. Deliberately NOT a flat "doesn't support image input" —
+ * Pinchy offloads the image to the configured vision model
+ * (`resolveImageTurnModel`/`getConfiguredImageModel`), which describes it and
+ * injects the description, so a text-only agent usually still answers correctly.
+ * The old wording contradicted that outcome (a text-only model returned a
+ * correct description yet the chip claimed it couldn't). If no vision model is
+ * configured anywhere, the send fails with the honest, admin-actionable
+ * `vision_unavailable` error at send time.
+ */
+export const IMAGE_INPUT_OFFLOAD_NOTE =
+  "This model can't read images directly — a vision model will describe it if one is configured.";
+
+/**
+ * The note (if any) to show on an attachment chip. Returns the offload note only
+ * for an image whose agent model is known to lack vision; null for non-images,
+ * for a vision-capable model, or while capabilities are still loading
+ * (`modelVisionCapable` is `null`/`undefined`) so nothing flashes before we know.
+ */
+export function imageInputNote(
+  mimeType: string,
+  modelVisionCapable: boolean | null | undefined
+): string | null {
+  if (requiredCapabilityForFile(mimeType) !== "vision") return null;
+  if (modelVisionCapable !== false) return null;
+  return IMAGE_INPUT_OFFLOAD_NOTE;
+}


### PR DESCRIPTION
## What & why

Staging finding: a text-only agent model (GLM 5.2) showed the flat chip warning **"This model doesn't support image input."** — yet the agent returned a **correct image description**. The warning contradicted the outcome.

Root cause: the note ([attachment-preview.tsx](packages/web/src/components/assistant-ui/attachment-preview.tsx)) checked only the **agent's own** model vision capability and ignored the v0.8.0 **vision-offload** — when a text-only model gets an image, Pinchy routes that turn to the configured vision model (`resolveImageTurnModel` / `getConfiguredImageModel`), which describes it and injects the description, so the turn usually succeeds.

## Change

- Extract the note into a pure, unit-tested `imageInputNote(mimeType, modelVisionCapable)` in `attachment-capability.ts`. New copy: *"This model can't read images directly — a vision model will describe it if one is configured."* Honest in both cases: if no vision model is configured anywhere, the send still fails with the existing, admin-actionable `vision_unavailable` error at send time.
- Drop the dead `"document input"` branch — `requiredCapabilityForFile` only ever returns `"vision" | null` (PDFs/text route via `pinchy_read`, no agent-model capability), so that message was unreachable.

## Tests

- `attachment-capability.test.ts` — `imageInputNote`: offload note for image + text-only model; null for vision-capable / not-yet-loaded / non-image.
- `attachment-preview.test.tsx` — updated the render assertion from the old copy to the offload note (conscious copy change, not a weakened test).
- Full suite: 518 files / 6614 tests green. tsc/lint/format clean.

## Follow-up (out of scope)

Suppress the note **entirely** when an image offload is actually available (needs the configured-image-model state exposed client-side — a small endpoint/hook). This PR makes the copy honest; that would remove it in the common case.

Part of v0.8.0 release prep.
