### PR TITLE
fix(chat): preserve the user's message when OpenClaw omits it for size

### DIFF
--- a/packages/web/src/__tests__/hooks/preserve-richer-local-over-oversized-history.test.ts
+++ b/packages/web/src/__tests__/hooks/preserve-richer-local-over-oversized-history.test.ts
@@ -1,0 +1,107 @@
+/**
+ * Unit tests for `preserveRicherLocalOverOversizedHistory` — the merge step
+ * that runs on every history-reconcile. OpenClaw's `chat.history` RPC caps
+ * single-message size (128 KB — an inline image routinely trips this) and
+ * replaces an oversized message with a placeholder (server-side translated
+ * and flagged `oversized: true` in client-router.ts's fetchAndParseHistory).
+ * Without this merge, a tab refocus after sending an image to a text-only
+ * agent replaces the rich local user bubble (text + file chip) with the
+ * degraded placeholder — the vanishing-user-message bug found in v0.8.0
+ * staging. This function restores the richer local copy at that position
+ * while leaving genuine shrinks (real deletions/compaction) untouched, since
+ * those never carry the `oversized` flag.
+ */
+import { describe, it, expect } from "vitest";
+import { preserveRicherLocalOverOversizedHistory, type WsMessage } from "@/hooks/use-ws-runtime";
+
+function user(content: string, opts: Partial<WsMessage> = {}): WsMessage {
+  return { id: `u-${content}`, role: "user", content, ...opts };
+}
+
+function assistant(content: string, opts: Partial<WsMessage> = {}): WsMessage {
+  return { id: `a-${content}`, role: "assistant", content, ...opts };
+}
+
+describe("preserveRicherLocalOverOversizedHistory", () => {
+  it("returns historyMessages unchanged when nothing is flagged oversized", () => {
+    const history = [user("hi"), assistant("hello")];
+    const prev = [user("hi"), assistant("hello")];
+    expect(preserveRicherLocalOverOversizedHistory(history, prev)).toBe(history);
+  });
+
+  it("substitutes the richer local message at the oversized position", () => {
+    const history = [
+      user("This message was too large to reload from history.", { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const prev = [
+      user("Was hältst du von dem Bild?", {
+        files: [{ filename: "photo.jpg", mimeType: "image/jpeg" }],
+      }),
+      assistant("Nice picture!"),
+    ];
+
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+
+    expect(merged[0]).toEqual(prev[0]);
+    expect(merged[1]).toEqual(history[1]);
+  });
+
+  it("keeps the server placeholder when there is no local message at that position (fresh load, no cache)", () => {
+    const history = [
+      user("This message was too large to reload from history.", { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const merged = preserveRicherLocalOverOversizedHistory(history, []);
+    expect(merged[0]).toEqual(history[0]);
+  });
+
+  it("keeps the server placeholder when the local message at that position is itself empty", () => {
+    // No richer copy to fall back to — nothing is lost by keeping the
+    // friendly placeholder text instead of an empty local bubble.
+    const history = [
+      user("This message was too large to reload from history.", { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const prev = [user(""), assistant("Nice picture!")];
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+    expect(merged[0]).toEqual(history[0]);
+  });
+
+  it("does not substitute when the local message at that position has a different role", () => {
+    // Defends against a mismatched merge if positions ever drift between the
+    // two arrays — only ever substitute a like-for-like role.
+    const history = [
+      user("This message was too large to reload from history.", { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const prev = [assistant("unrelated"), assistant("Nice picture!")];
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+    expect(merged[0]).toEqual(history[0]);
+  });
+
+  it("ignores a trailing client-only placeholder when aligning positions", () => {
+    // stripTrailingPlaceholder parity with shouldReplaceLocalWithServerHistory
+    // — the send path can append an empty assistant placeholder that the
+    // server never knows about; it must not shift the alignment.
+    const history = [
+      user("This message was too large to reload from history.", { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const prev = [
+      user("Was hältst du von dem Bild?", {
+        files: [{ filename: "photo.jpg", mimeType: "image/jpeg" }],
+      }),
+      assistant("Nice picture!"),
+      assistant(""), // trailing in-flight placeholder
+    ];
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+    expect(merged[0]).toEqual(prev[0]);
+  });
+
+  it("leaves a genuine shrink (no oversized flag) untouched — not this function's concern", () => {
+    const history = [assistant("hello")];
+    const prev = [user("hi"), assistant("hello")];
+    expect(preserveRicherLocalOverOversizedHistory(history, prev)).toBe(history);
+  });
+});

--- a/packages/web/src/__tests__/hooks/preserve-richer-local-over-oversized-history.test.ts
+++ b/packages/web/src/__tests__/hooks/preserve-richer-local-over-oversized-history.test.ts
@@ -13,6 +13,7 @@
  */
 import { describe, it, expect } from "vitest";
 import { preserveRicherLocalOverOversizedHistory, type WsMessage } from "@/hooks/use-ws-runtime";
+import { OVERSIZED_HISTORY_MESSAGE_TEXT } from "@/lib/openclaw-history";
 
 function user(content: string, opts: Partial<WsMessage> = {}): WsMessage {
   return { id: `u-${content}`, role: "user", content, ...opts };
@@ -31,7 +32,7 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
 
   it("substitutes the richer local message at the oversized position", () => {
     const history = [
-      user("This message was too large to reload from history.", { oversized: true }),
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
       assistant("Nice picture!"),
     ];
     const prev = [
@@ -49,7 +50,7 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
 
   it("keeps the server placeholder when there is no local message at that position (fresh load, no cache)", () => {
     const history = [
-      user("This message was too large to reload from history.", { oversized: true }),
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
       assistant("Nice picture!"),
     ];
     const merged = preserveRicherLocalOverOversizedHistory(history, []);
@@ -60,7 +61,7 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
     // No richer copy to fall back to — nothing is lost by keeping the
     // friendly placeholder text instead of an empty local bubble.
     const history = [
-      user("This message was too large to reload from history.", { oversized: true }),
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
       assistant("Nice picture!"),
     ];
     const prev = [user(""), assistant("Nice picture!")];
@@ -72,7 +73,7 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
     // Defends against a mismatched merge if positions ever drift between the
     // two arrays — only ever substitute a like-for-like role.
     const history = [
-      user("This message was too large to reload from history.", { oversized: true }),
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
       assistant("Nice picture!"),
     ];
     const prev = [assistant("unrelated"), assistant("Nice picture!")];
@@ -85,7 +86,7 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
     // — the send path can append an empty assistant placeholder that the
     // server never knows about; it must not shift the alignment.
     const history = [
-      user("This message was too large to reload from history.", { oversized: true }),
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
       assistant("Nice picture!"),
     ];
     const prev = [
@@ -103,5 +104,45 @@ describe("preserveRicherLocalOverOversizedHistory", () => {
     const history = [assistant("hello")];
     const prev = [user("hi"), assistant("hello")];
     expect(preserveRicherLocalOverOversizedHistory(history, prev)).toBe(history);
+  });
+
+  it("substitutes across a leading client-only greeting that offsets the local list", () => {
+    // The common real case: an agent greeting is a client-only assistant
+    // message at index 0 that OpenClaw never persists, so the local list is
+    // one longer than server history. Head-index alignment would pair the
+    // oversized user turn with the greeting (role mismatch → miss) and lose
+    // the rich message. Tail alignment pairs the persisted suffix correctly.
+    const history = [
+      user(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
+      assistant("Nice picture!"),
+    ];
+    const prev = [
+      assistant("Hi, I am Texti!"), // greeting — client-only, not in server history
+      user("Was hältst du von dem Bild?", {
+        files: [{ filename: "photo.jpg", mimeType: "image/jpeg" }],
+      }),
+      assistant("Nice picture!"),
+    ];
+
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+
+    expect(merged[0]).toEqual(prev[1]); // the rich user turn, not the greeting
+    expect(merged[1]).toEqual(history[1]);
+  });
+
+  it("never substitutes a synthetic error bubble as the missing message", () => {
+    // A disconnect error bubble is a client-only assistant message with an
+    // `error` set; even if alignment lands on it, it must never masquerade as
+    // the user's lost content.
+    const history = [
+      assistant(OVERSIZED_HISTORY_MESSAGE_TEXT, { oversized: true }),
+      assistant("later reply"),
+    ];
+    const prev = [
+      assistant("some visible error text", { error: { message: "disconnected" } }),
+      assistant("later reply"),
+    ];
+    const merged = preserveRicherLocalOverOversizedHistory(history, prev);
+    expect(merged[0]).toEqual(history[0]); // kept the placeholder, not the error bubble
   });
 });

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-oversized-history.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-oversized-history.test.tsx
@@ -1,0 +1,166 @@
+/**
+ * Regression guard for the vanishing/degraded user-message bug found in
+ * v0.8.0 staging: a user sent an image to a text-only-model agent (the
+ * vision-offload described it correctly), then refocused the tab minutes
+ * later — the user's own message (text + image) had disappeared, leaving
+ * only the assistant's reply.
+ *
+ * Root cause: OpenClaw's `chat.history` RPC caps single-message size (128 KB
+ * — an inline image routinely trips this) and replaces an oversized message
+ * with a fixed placeholder, discarding the original text AND the
+ * `<pinchy:attachments>` block embedded in it. Before the fix,
+ * client-router.ts's fetchAndParseHistory reduced that placeholder to ""
+ * (the timestamp-strip regex matches the whole bracketed string) and the
+ * content-or-files filter dropped the row entirely. Even with that server
+ * fix (which now flags the row `oversized: true` and keeps a friendly
+ * placeholder), the client's history-reconcile would still REPLACE the rich
+ * local message — the exact text + file chip this tab already rendered at
+ * send time — with the degraded server placeholder on any refocus/reconnect.
+ * `preserveRicherLocalOverOversizedHistory` is what stops that.
+ *
+ * Same testing approach as use-ws-runtime-refocus-shrink.test.tsx: a WS
+ * close+reconnect drives the IDENTICAL history-reconcile path as a real tab
+ * refocus, deterministically and without needing a real browser. This is a
+ * completed turn (no activeRun) — unlike the shrink-crash scenario, this path
+ * already runs behind the isReconcilingMessages unmount gate
+ * (stageDestructiveHistoryReconcile), so there's no separate crash risk here;
+ * the observable bug is purely the reconciled CONTENT, which jsdom can
+ * assert on directly.
+ */
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { renderHook, act } from "@testing-library/react";
+import { useWsRuntime } from "@/hooks/use-ws-runtime";
+
+vi.mock("@/lib/image-compression", () => ({
+  compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
+}));
+vi.mock("@/lib/upload-attachment", () => ({ uploadAttachment: vi.fn() }));
+vi.mock("sonner", () => ({ toast: vi.fn() }));
+vi.mock("@/components/restart-provider", () => ({
+  useRestart: () => ({ isRestarting: false, triggerRestart: vi.fn() }),
+}));
+vi.mock("@assistant-ui/react", () => ({
+  useExternalStoreRuntime: (config: unknown) => config,
+  SimpleImageAttachmentAdapter: class {
+    accept = "image/*";
+  },
+  SimpleTextAttachmentAdapter: class {
+    accept = "text/plain";
+  },
+  CompositeAttachmentAdapter: class {
+    accept = "";
+    constructor() {}
+  },
+}));
+
+let wsInstances: MockWebSocket[] = [];
+class MockWebSocket {
+  static CONNECTING = 0;
+  static OPEN = 1;
+  static CLOSING = 2;
+  static CLOSED = 3;
+  onopen: ((e: Event) => void) | null = null;
+  onmessage: ((e: MessageEvent) => void) | null = null;
+  onclose: ((e: CloseEvent) => void) | null = null;
+  onerror: ((e: Event) => void) | null = null;
+  readyState = 1;
+  send = vi.fn();
+  close = vi.fn();
+  constructor() {
+    wsInstances.push(this);
+  }
+  simulateOpen() {
+    this.onopen?.(new Event("open"));
+  }
+  simulateMessage(data: unknown) {
+    this.onmessage?.(new MessageEvent("message", { data: JSON.stringify(data) }));
+  }
+  simulateClose(code = 1006) {
+    this.readyState = 3;
+    this.onclose?.(new CloseEvent("close", { code }));
+  }
+}
+vi.stubGlobal("WebSocket", MockWebSocket);
+
+type ConvertedMessage = {
+  id: string;
+  role: string;
+  content: Array<{ type: string; text?: string }>;
+};
+function textsOf(runtime: unknown): Array<{ role: string; text: string }> {
+  const messages = ((runtime as { messages?: ConvertedMessage[] }).messages ??
+    []) as ConvertedMessage[];
+  return messages.map((m) => ({
+    role: m.role,
+    text: m.content.find((p) => p.type === "text")?.text ?? "",
+  }));
+}
+function sendText(result: { current: { runtime: unknown } }, text: string) {
+  (
+    result.current.runtime as {
+      onNew: (m: { content: { type: string; text: string }[]; parentId: string }) => void;
+    }
+  ).onNew({ content: [{ type: "text", text }], parentId: "root" });
+}
+
+const OVERSIZED_PLACEHOLDER_TEXT = "This message was too large to reload from history.";
+
+describe("useWsRuntime — refocus reconcile must not clobber a richer local message with an oversized-history placeholder", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+  });
+  afterEach(() => vi.useRealTimers());
+
+  it("keeps the original user text after a completed turn's message becomes oversized in history", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    act(() => ws1.simulateMessage({ type: "history", messages: [] }));
+
+    const originalText = "Was hältst du von dem Bild?";
+    act(() => sendText(result, originalText));
+    act(() =>
+      ws1.simulateMessage({
+        type: "chunk",
+        messageId: "srv-1",
+        content: "Ein richtig schönes Bild! Es zeigt einen Jungen …",
+      })
+    );
+    act(() => ws1.simulateMessage({ type: "complete" }));
+
+    expect(result.current.isRunning).toBe(false);
+    const before = textsOf(result.current.runtime);
+    expect(before).toEqual([
+      { role: "user", text: originalText },
+      { role: "assistant", text: "Ein richtig schönes Bild! Es zeigt einen Jungen …" },
+    ]);
+
+    // Tab backgrounded → ws drops → reconnect → refocus history request.
+    // OpenClaw's history now reports the user turn as oversized (server-side
+    // already translated per client-router.ts fetchAndParseHistory) — the
+    // exact frame shape client-router.ts sends after the Layer-1 fix.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: OVERSIZED_PLACEHOLDER_TEXT, oversized: true },
+          { role: "assistant", content: "Ein richtig schönes Bild! Es zeigt einen Jungen …" },
+        ],
+      })
+    );
+
+    const after = textsOf(result.current.runtime);
+    // The rich local text must survive — NOT be replaced by the degraded
+    // server placeholder, and NOT vanish entirely.
+    expect(after).toEqual(before);
+  });
+});

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-oversized-history.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-oversized-history.test.tsx
@@ -30,6 +30,7 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
 import { useWsRuntime } from "@/hooks/use-ws-runtime";
+import { OVERSIZED_HISTORY_MESSAGE_TEXT } from "@/lib/openclaw-history";
 
 vi.mock("@/lib/image-compression", () => ({
   compressImageForChat: vi.fn(async (file: File) => ({ ok: true, file, skipped: true })),
@@ -103,7 +104,7 @@ function sendText(result: { current: { runtime: unknown } }, text: string) {
   ).onNew({ content: [{ type: "text", text }], parentId: "root" });
 }
 
-const OVERSIZED_PLACEHOLDER_TEXT = "This message was too large to reload from history.";
+const OVERSIZED_PLACEHOLDER_TEXT = OVERSIZED_HISTORY_MESSAGE_TEXT;
 
 describe("useWsRuntime — refocus reconcile must not clobber a richer local message with an oversized-history placeholder", () => {
   beforeEach(() => {
@@ -162,5 +163,54 @@ describe("useWsRuntime — refocus reconcile must not clobber a richer local mes
     // The rich local text must survive — NOT be replaced by the degraded
     // server placeholder, and NOT vanish entirely.
     expect(after).toEqual(before);
+  });
+
+  it("keeps the original user text even when a client-only greeting offsets the local list", () => {
+    // The common case: the agent has a greeting, so the local list starts with
+    // a client-only assistant message OpenClaw never persists — making it one
+    // longer than the server history. A head-indexed merge pairs the oversized
+    // user turn with the greeting (role mismatch → the rich message is lost and
+    // the destructive reconcile then shows the degraded placeholder). This pins
+    // that the tail-anchored alignment preserves the user's original text.
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    // Fresh session: the server delivers the greeting as a synthetic assistant
+    // frame — it lives ONLY in local state, never in OpenClaw's session store.
+    act(() =>
+      ws1.simulateMessage({
+        type: "history",
+        messages: [{ role: "assistant", content: "Hi, I am Texti!" }],
+      })
+    );
+
+    const originalText = "Was hältst du von dem Bild?";
+    act(() => sendText(result, originalText));
+    act(() => ws1.simulateMessage({ type: "chunk", messageId: "srv-1", content: "Schönes Bild!" }));
+    act(() => ws1.simulateMessage({ type: "complete" }));
+
+    // Tab backgrounded → reconnect → refocus history. Server history has NO
+    // greeting and reports the user turn as oversized.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: OVERSIZED_PLACEHOLDER_TEXT, oversized: true },
+          { role: "assistant", content: "Schönes Bild!" },
+        ],
+      })
+    );
+    // Let the deferred destructive reconcile (setTimeout-staged) apply.
+    act(() => vi.advanceTimersByTime(100));
+
+    const userText = textsOf(result.current.runtime).find((m) => m.role === "user")?.text;
+    expect(userText).toBe(originalText);
   });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -1571,6 +1571,51 @@ describe("ClientRouter", () => {
     expect(userMsg.files).toEqual([{ filename: "silent-pdf.pdf", mimeType: "application/pdf" }]);
   });
 
+  it("preserves an oversized-omitted user message instead of silently dropping it", async () => {
+    // Root cause of the vanishing-user-message bug (image sent to a
+    // text-only-model agent, discovered in v0.8.0 staging): OpenClaw's
+    // `chat.history` RPC replaces ANY message over its internal
+    // CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES cap (128 KB — an inline image
+    // trips this on nearly every image-bearing turn) with the literal
+    // placeholder below, discarding the original text AND the
+    // <pinchy:attachments> block embedded in it.
+    //
+    // Without this fix, the timestamp-strip regex (`/^\[.*?\]\s*/`) matches
+    // the WHOLE bracketed placeholder (there's no other `]` in it) and
+    // reduces content to "" — then the content-or-files filter drops the row
+    // entirely. The assistant's reply survives; the user's own message does
+    // not. Verified against real OpenClaw 2026.6.8 output on staging.
+    const clientWs = createMockClientWs();
+    mockSessionsHistory.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+          timestamp: 1708460000000,
+        },
+        {
+          role: "assistant",
+          content: "Ein richtig schönes Bild! Es zeigt einen Jungen …",
+          timestamp: 1708460001000,
+        },
+      ],
+    });
+
+    await router.handleMessage(clientWs as any, { type: "history", agentId: "agent-1" });
+
+    const sent = clientWs.sent.map((s) => JSON.parse(s));
+    expect(sent[0].messages).toHaveLength(2);
+    const userMsg = sent[0].messages[0];
+    expect(userMsg.role).toBe("user");
+    // Non-empty so it survives the content-or-files filter, and distinct from
+    // OpenClaw's raw placeholder so the user never sees the internal RPC name.
+    expect(userMsg.content.length).toBeGreaterThan(0);
+    expect(userMsg.content).not.toContain("chat.history");
+    // The client's reconcile logic (use-ws-runtime.ts) needs this flag to
+    // prefer a richer LOCAL copy of the same message over this placeholder.
+    expect(userMsg.oversized).toBe(true);
+  });
+
   it("should omit attachments when content has no images", async () => {
     async function* fakeStream() {
       yield { type: "text" as const, text: "Hello!" };

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -160,6 +160,7 @@ vi.mock("@/server/attachment-pipeline", async (importOriginal) => {
 
 import { ClientRouter } from "@/server/client-router";
 import { SessionCache } from "@/server/session-cache";
+import { CHAT_HISTORY_OVERSIZED_PLACEHOLDER } from "@/lib/openclaw-history";
 
 function createMockClientWs() {
   const sent: string[] = [];
@@ -1590,7 +1591,7 @@ describe("ClientRouter", () => {
       messages: [
         {
           role: "user",
-          content: [{ type: "text", text: "[chat.history omitted: message too large]" }],
+          content: [{ type: "text", text: CHAT_HISTORY_OVERSIZED_PLACEHOLDER }],
           timestamp: 1708460000000,
         },
         {
@@ -1613,6 +1614,35 @@ describe("ClientRouter", () => {
     expect(userMsg.content).not.toContain("chat.history");
     // The client's reconcile logic (use-ws-runtime.ts) needs this flag to
     // prefer a richer LOCAL copy of the same message over this placeholder.
+    expect(userMsg.oversized).toBe(true);
+  });
+
+  it("detects an oversized placeholder even when OpenClaw prepends a timestamp", async () => {
+    // OpenClaw stamps user messages with a leading `[timestamp]` prefix (see
+    // "should strip timestamp prefix from user messages in history"). If it
+    // ever also stamps an oversized user turn, an exact-equality check would
+    // miss it: the timestamp-strip would then leave the RAW internal string
+    // "[chat.history omitted: message too large]" visible to the user, and the
+    // row would not be flagged oversized (so the client can't prefer the local
+    // copy). Detection must survive the prefix.
+    const clientWs = createMockClientWs();
+    mockSessionsHistory.mockResolvedValue({
+      messages: [
+        {
+          role: "user",
+          content: `[Fri 2026-02-20 21:30 UTC] ${CHAT_HISTORY_OVERSIZED_PLACEHOLDER}`,
+          timestamp: 1708460000000,
+        },
+        { role: "assistant", content: "reply", timestamp: 1708460001000 },
+      ],
+    });
+
+    await router.handleMessage(clientWs as any, { type: "history", agentId: "agent-1" });
+
+    const sent = clientWs.sent.map((s) => JSON.parse(s));
+    const userMsg = sent[0].messages[0];
+    expect(userMsg.role).toBe("user");
+    expect(userMsg.content).not.toContain("chat.history");
     expect(userMsg.oversized).toBe(true);
   });
 

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -74,6 +74,14 @@ export interface WsMessage {
   retryable?: boolean;
   /** Which retry action to invoke — only set when retryable is true */
   retryReason?: "orphan" | "partial_stream_failure" | "send_failure";
+  /**
+   * Server-flagged: OpenClaw's `chat.history` RPC replaced this message with
+   * its oversized-message placeholder (its 128 KB single-message cap — an
+   * inline image routinely trips this) because the original content exceeded
+   * OpenClaw's internal size cap. See client-router.ts's fetchAndParseHistory
+   * and `preserveRicherLocalOverOversizedHistory` below.
+   */
+  oversized?: boolean;
 }
 
 const DELAY_HINT_MS = 15_000;
@@ -369,6 +377,44 @@ export function shouldReplaceLocalWithServerHistory(
 
   // lastNonError.role === "user"
   return lastNonError.status === "sent" && historyMessages.length > prev.length;
+}
+
+/**
+ * Positional merge applied to every history frame BEFORE it's used for the
+ * shrink-length comparisons and (potential) destructive replace below.
+ *
+ * OpenClaw's `chat.history` RPC caps single-message size (128 KB — an inline
+ * image routinely trips this) and replaces an oversized message with a
+ * placeholder; client-router.ts's fetchAndParseHistory translates that into a
+ * friendly, non-empty message flagged `oversized: true`. Without this merge, a
+ * tab refocus after such a turn would replace the rich local bubble (the
+ * user's own text + file chip, already rendered in THIS tab) with that
+ * degraded placeholder — the vanishing/degraded-message bug found in v0.8.0
+ * staging.
+ *
+ * Only ever substitutes at a position the SERVER explicitly flagged
+ * `oversized`, and only when the local message there is a like-for-like role
+ * with actual content — so a genuine shrink (real deletion/compaction, never
+ * flagged `oversized`) is untouched and still reconciles normally.
+ */
+export function preserveRicherLocalOverOversizedHistory(
+  historyMessages: WsMessage[],
+  prevMessages: WsMessage[]
+): WsMessage[] {
+  if (!historyMessages.some((m) => m.oversized)) return historyMessages;
+
+  // Same rationale as shouldReplaceLocalWithServerHistory: the trailing
+  // in-flight placeholder is a client-only artifact the server never knows
+  // about, and must not shift the positional alignment used below.
+  const prev = stripTrailingPlaceholder(prevMessages);
+
+  return historyMessages.map((serverMsg, i) => {
+    if (!serverMsg.oversized) return serverMsg;
+    const local = prev[i];
+    if (!local || local.role !== serverMsg.role) return serverMsg;
+    const localHasContent = local.content.length > 0 || (local.files?.length ?? 0) > 0;
+    return localHasContent ? local : serverMsg;
+  });
 }
 
 export function useWsRuntime(
@@ -890,6 +936,7 @@ export function useWsRuntime(
             content: string;
             timestamp?: string;
             files?: WsFileMeta[];
+            oversized?: boolean;
           }> = data.messages ?? [];
           const sessionKnown: boolean = data.sessionKnown === true;
           // Server tells us the session exists but its history is currently
@@ -906,7 +953,28 @@ export function useWsRuntime(
             // strips the in-message markup and surfaces the file metadata
             // here so the file chip renders on reload.
             ...(msg.files && msg.files.length > 0 ? { files: msg.files } : {}),
+            ...(msg.oversized ? { oversized: true } : {}),
           }));
+
+          // Prefer a richer LOCAL copy over an oversized-history placeholder
+          // (see preserveRicherLocalOverOversizedHistory's doc). Applied
+          // before the shrink-length comparisons below so a turn that would
+          // otherwise look like a shrink (the row is still present, just
+          // degraded) doesn't trigger the destructive-reconcile path at all.
+          //
+          // The common case (no oversized message) returns the SAME array
+          // reference for zero-allocation — guard the in-place mutation on
+          // reference inequality, or `.length = 0` would wipe `preserved` too
+          // (same object) before the push reads from it, silently emptying
+          // history on every normal reconnect.
+          const preserved = preserveRicherLocalOverOversizedHistory(
+            historyMessages,
+            messagesRef.current
+          );
+          if (preserved !== historyMessages) {
+            historyMessages.length = 0;
+            historyMessages.push(...preserved);
+          }
 
           // Tier 2b: if the server reports an in-flight run for this
           // session, anchor the last assistant message in the reconciled

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -392,10 +392,22 @@ export function shouldReplaceLocalWithServerHistory(
  * degraded placeholder — the vanishing/degraded-message bug found in v0.8.0
  * staging.
  *
+ * Alignment is TAIL-anchored (`offset = prev.length - history.length`), not
+ * head-anchored: the local list carries client-only messages the server never
+ * persists — most commonly the agent GREETING (an assistant message at index 0)
+ * — which make it longer than the server history and would shift a head-indexed
+ * pairing by one, pairing the oversized user turn with the greeting (role
+ * mismatch → the rich message silently lost). The persisted turns line up at
+ * the TAIL, so anchoring there pairs them correctly regardless of a leading
+ * greeting. When the server history is instead LONGER than the local list, the
+ * offset goes negative and the leading server messages simply keep their
+ * placeholder (nothing local to prefer).
+ *
  * Only ever substitutes at a position the SERVER explicitly flagged
- * `oversized`, and only when the local message there is a like-for-like role
- * with actual content — so a genuine shrink (real deletion/compaction, never
- * flagged `oversized`) is untouched and still reconciles normally.
+ * `oversized`, and only with a like-for-like local message that has real
+ * content and is NOT a synthetic error bubble — so a genuine shrink (real
+ * deletion/compaction, never flagged `oversized`) is untouched, and a
+ * disconnect-error bubble can never masquerade as the user's lost message.
  */
 export function preserveRicherLocalOverOversizedHistory(
   historyMessages: WsMessage[],
@@ -405,13 +417,14 @@ export function preserveRicherLocalOverOversizedHistory(
 
   // Same rationale as shouldReplaceLocalWithServerHistory: the trailing
   // in-flight placeholder is a client-only artifact the server never knows
-  // about, and must not shift the positional alignment used below.
+  // about, and must not shift the tail-anchored alignment used below.
   const prev = stripTrailingPlaceholder(prevMessages);
+  const offset = prev.length - historyMessages.length;
 
   return historyMessages.map((serverMsg, i) => {
     if (!serverMsg.oversized) return serverMsg;
-    const local = prev[i];
-    if (!local || local.role !== serverMsg.role) return serverMsg;
+    const local = prev[i + offset];
+    if (!local || local.role !== serverMsg.role || local.error) return serverMsg;
     const localHasContent = local.content.length > 0 || (local.files?.length ?? 0) > 0;
     return localHasContent ? local : serverMsg;
   });

--- a/packages/web/src/lib/chats/telegram-transcript.ts
+++ b/packages/web/src/lib/chats/telegram-transcript.ts
@@ -1,5 +1,7 @@
 import { parseAttachmentBlock } from "@/server/attachment-pipeline";
 import type { TelegramTranscriptMessage } from "@/lib/schemas/sessions";
+// Shared with client-router.ts and their tests — see @/lib/openclaw-history.
+import { QUEUED_RETRY_PREFIX } from "@/lib/openclaw-history";
 
 /**
  * One raw entry from OpenClaw's `sessions.history` wire output. `content` is
@@ -11,13 +13,6 @@ export type RawHistoryMessage = {
   content?: unknown;
   timestamp?: number;
 };
-
-// OpenClaw marks user messages that arrived while another turn was still active
-// with this prefix and aggregates them. They are duplicates of the original
-// user turn already in history, so the live chat filters them out — we mirror
-// that here. (Kept verbatim in sync with `client-router.ts`.)
-const QUEUED_RETRY_PREFIX =
-  "[Queued user message that arrived while the previous turn was still active]";
 
 /**
  * Extract the rendered text from one OpenClaw history entry: join the text

--- a/packages/web/src/lib/openclaw-history.ts
+++ b/packages/web/src/lib/openclaw-history.ts
@@ -1,0 +1,32 @@
+/**
+ * Constants for parsing OpenClaw's `chat.history` (a.k.a. `sessions.history`)
+ * wire output. Centralised here so the live-chat parser (`client-router.ts`),
+ * the read-only Telegram mirror (`chats/telegram-transcript.ts`), and their
+ * tests all read from ONE source — an OpenClaw-side string change then can't
+ * quietly diverge between production and its test fixtures.
+ */
+
+/**
+ * Prefix OpenClaw stamps on a user message that arrived while another turn was
+ * still active; such messages are duplicates of the original user turn already
+ * in history and are filtered out before reaching the UI.
+ */
+export const QUEUED_RETRY_PREFIX =
+  "[Queued user message that arrived while the previous turn was still active]";
+
+/**
+ * The literal OpenClaw substitutes for a message whose serialized size exceeds
+ * its internal `CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES` cap (128 KB — an inline
+ * image routinely trips this). The original content, and for a user turn the
+ * embedded `<pinchy:attachments>` block, are discarded server-side. Verified
+ * against real OpenClaw 2026.6.8 output.
+ */
+export const CHAT_HISTORY_OVERSIZED_PLACEHOLDER = "[chat.history omitted: message too large]";
+
+/**
+ * The friendly, user-facing text Pinchy shows in place of OpenClaw's raw
+ * oversized placeholder so the user never sees the internal RPC string. Kept
+ * non-empty so the message survives the content-or-files history filter
+ * instead of being silently dropped.
+ */
+export const OVERSIZED_HISTORY_MESSAGE_TEXT = "This message was too large to reload from history.";

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -745,6 +745,18 @@ export class ClientRouter {
       const QUEUED_RETRY_PREFIX =
         "[Queued user message that arrived while the previous turn was still active]";
 
+      // OpenClaw's `chat.history` RPC replaces ANY message over its internal
+      // CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES cap (128 KB — an inline image
+      // routinely trips this) with this exact placeholder, discarding the
+      // original content and, for a user turn, the <pinchy:attachments> block
+      // embedded in it. Detected BEFORE the timestamp-strip regex below, which
+      // would otherwise reduce it to "" (there's no other `]` in the string)
+      // and let the content-or-files filter silently drop the whole row —
+      // the vanishing-user-message bug found in v0.8.0 staging. Verified
+      // against real OpenClaw 2026.6.8 output.
+      const OVERSIZED_HISTORY_PLACEHOLDER = "[chat.history omitted: message too large]";
+      const OVERSIZED_HISTORY_MESSAGE_TEXT = "This message was too large to reload from history.";
+
       return (
         rawMessages
           .filter((msg) => msg.role === "user" || msg.role === "assistant")
@@ -770,6 +782,8 @@ export class ClientRouter {
             // Strip protocol tags from assistant responses
             content = content.replace(/<\/?final>/g, "");
 
+            const isOversizedPlaceholder = content === OVERSIZED_HISTORY_PLACEHOLDER;
+
             // For user messages: strip OpenClaw's timestamp prefix AND extract
             // the per-message <pinchy:attachments> block (see buildAttachmentBlock
             // in attachment-pipeline.ts). The block lives in the message text in
@@ -777,7 +791,15 @@ export class ClientRouter {
             // wire-level `files` field so the browser can render the chip
             // without ever seeing the markup.
             let files: Array<{ filename: string; mimeType: string }> | undefined;
-            if (msg.role === "user") {
+            if (isOversizedPlaceholder) {
+              // The original content (and any attachment block it carried) is
+              // gone for good — OpenClaw already discarded it server-side.
+              // Surface a friendly, non-empty placeholder instead of dropping
+              // the row, and flag it so the client's history-reconcile can
+              // prefer a richer LOCAL copy of this same message when one
+              // exists (use-ws-runtime.ts).
+              content = OVERSIZED_HISTORY_MESSAGE_TEXT;
+            } else if (msg.role === "user") {
               content = content.replace(/^\[.*?\]\s*/, "");
               const parsed = parseAttachmentBlock(content);
               content = parsed.cleanText;
@@ -793,6 +815,7 @@ export class ClientRouter {
               role: msg.role as "user" | "assistant",
               content,
               files,
+              oversized: isOversizedPlaceholder,
               rawContent:
                 typeof msg.content === "string"
                   ? msg.content
@@ -816,7 +839,13 @@ export class ClientRouter {
           // of meaning in that case, so it must be enough on its own.
           .filter((msg) => msg.content || (msg.files && msg.files.length > 0))
           .filter((msg) => !(msg.role === "user" && msg.rawContent.startsWith(QUEUED_RETRY_PREFIX)))
-          .map(({ role, content, files, timestamp }) => ({ role, content, files, timestamp }))
+          .map(({ role, content, files, timestamp, oversized }) => ({
+            role,
+            content,
+            files,
+            timestamp,
+            ...(oversized ? { oversized: true as const } : {}),
+          }))
       );
     };
 

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -21,6 +21,11 @@ import { iterateUntilAborted } from "@/server/abortable-stream";
 import { NEVER_DISCONNECTS, type DisconnectSignal } from "@/server/openclaw-disconnect-signal";
 import { recordSessionTurnsUsage } from "@/lib/usage-per-turn";
 import {
+  QUEUED_RETRY_PREFIX,
+  CHAT_HISTORY_OVERSIZED_PLACEHOLDER,
+  OVERSIZED_HISTORY_MESSAGE_TEXT,
+} from "@/lib/openclaw-history";
+import {
   shouldEmitModelUnavailableAudit,
   shouldEmitSilentStreamAudit,
   shouldEmitUpstreamFormatErrorAudit,
@@ -738,24 +743,15 @@ export class ClientRouter {
       };
       const rawMessages = result?.messages ?? [];
 
-      // OpenClaw marks user messages that arrived while another turn was still
-      // active with this prefix and aggregates them with timestamp annotations.
-      // For our retry flow these are duplicates of the original user turn that
-      // is already in history, so they're filtered out before reaching the UI.
-      const QUEUED_RETRY_PREFIX =
-        "[Queued user message that arrived while the previous turn was still active]";
-
-      // OpenClaw's `chat.history` RPC replaces ANY message over its internal
-      // CHAT_HISTORY_MAX_SINGLE_MESSAGE_BYTES cap (128 KB — an inline image
-      // routinely trips this) with this exact placeholder, discarding the
-      // original content and, for a user turn, the <pinchy:attachments> block
-      // embedded in it. Detected BEFORE the timestamp-strip regex below, which
-      // would otherwise reduce it to "" (there's no other `]` in the string)
-      // and let the content-or-files filter silently drop the whole row —
-      // the vanishing-user-message bug found in v0.8.0 staging. Verified
-      // against real OpenClaw 2026.6.8 output.
-      const OVERSIZED_HISTORY_PLACEHOLDER = "[chat.history omitted: message too large]";
-      const OVERSIZED_HISTORY_MESSAGE_TEXT = "This message was too large to reload from history.";
+      // QUEUED_RETRY_PREFIX, CHAT_HISTORY_OVERSIZED_PLACEHOLDER, and
+      // OVERSIZED_HISTORY_MESSAGE_TEXT are shared with the Telegram mirror and
+      // the tests via @/lib/openclaw-history so an OpenClaw-side string change
+      // can't diverge between production and fixtures. See that module's docs
+      // for what each one is. The oversized placeholder is detected BEFORE the
+      // timestamp-strip regex below, which would otherwise reduce it to ""
+      // (there's no other `]` in the string) and let the content-or-files
+      // filter silently drop the whole row — the vanishing-user-message bug
+      // found in v0.8.0 staging.
 
       return (
         rawMessages
@@ -782,7 +778,14 @@ export class ClientRouter {
             // Strip protocol tags from assistant responses
             content = content.replace(/<\/?final>/g, "");
 
-            const isOversizedPlaceholder = content === OVERSIZED_HISTORY_PLACEHOLDER;
+            // Match the placeholder both bare and behind OpenClaw's optional
+            // leading `[timestamp]` prefix (which it stamps on user messages —
+            // see the timestamp-strip below). Without the second form, a
+            // timestamped oversized turn would slip past this check and its
+            // raw internal string would leak to the user, unflagged.
+            const isOversizedPlaceholder =
+              content === CHAT_HISTORY_OVERSIZED_PLACEHOLDER ||
+              content.replace(/^\[.*?\]\s*/, "") === CHAT_HISTORY_OVERSIZED_PLACEHOLDER;
 
             // For user messages: strip OpenClaw's timestamp prefix AND extract
             // the per-message <pinchy:attachments> block (see buildAttachmentBlock


### PR DESCRIPTION
## Summary

- Root-caused the v0.8.0 staging bug where a user's message (text + image) vanished from the chat thread after sending an image to a text-only-model agent and refocusing the tab minutes later — verified against real OpenClaw 2026.6.8 output on staging via the gateway's local `chat.history` RPC. The on-disk session JSONL was intact; neither the `TrajectoryFileNotFoundError` log flood (a separate usage-counter read) nor the pinned OpenClaw version was the cause.
- **Actual root cause**: OpenClaw's `chat.history` RPC caps single-message size at 128 KB (an inline image routinely trips this) and replaces an oversized message with a fixed placeholder, discarding the original text and the `<pinchy:attachments>` block embedded in it. `fetchAndParseHistory`'s timestamp-strip regex then reduced that placeholder to `""`, and the content-or-files filter silently dropped the row — the assistant's reply survived, the user's own turn did not.
- **Server fix** (`client-router.ts`): recognize OpenClaw's placeholder *before* the strip regex mangles it; keep the row with a friendly, non-empty placeholder and flag it `oversized: true`.
- **Client fix** (`use-ws-runtime.ts`): `preserveRicherLocalOverOversizedHistory` runs on every history-reconcile and prefers a richer LOCAL copy of a flagged message (the user's own text + file chip, already rendered in this tab) over the degraded server placeholder — so a refocus right after sending doesn't clobber what the user just saw. Genuine shrinks (real deletions/compaction, never flagged `oversized`) are untouched.
- Filed #636 as a scoped follow-up: on a completely fresh load (no local cache — a new device/tab), there's no richer local copy to fall back to, so the user still sees the friendly placeholder instead of their original image-bearing message. That's a real persistence gap (a Pinchy-owned web-chat transcript, analogous to the Telegram `channel_messages` mirror), scoped separately to keep this fix minimal.

## Test plan

- [x] `client-router.test.ts`: new test proves the pre-fix drop (RED) and the fix preserving + flagging the oversized row (GREEN).
- [x] `preserve-richer-local-over-oversized-history.test.ts`: new unit tests for the pure merge function (substitution, no-op fast path, fresh-load fallback, role-mismatch guard, trailing-placeholder alignment, genuine-shrink no-op).
- [x] `use-ws-runtime-oversized-history.test.tsx`: new jsdom `renderHook` regression test driving the identical WS close→reconnect→history-reconcile path a real tab refocus takes (same technique as `use-ws-runtime-refocus-shrink.test.tsx`); verified RED with the wiring disabled, then GREEN. A real-browser Playwright spec was intentionally not added — this is a content-preservation bug, not the `tapClientLookup` crash, and this completed-turn/no-`activeRun` path already runs behind the `isReconcilingMessages` unmount gate.
- [x] Full suite: `pnpm test` — 6634 passed, 0 introduced skips.
- [x] `pnpm lint` — 0 errors, no new warnings in changed files.
- [x] `pnpm build` — production build succeeds (client/server boundary intact).
- [x] `pnpm format:check` — clean.