### PR TITLE
chore: bump OpenClaw core to 2026.6.11 + add update-openclaw skill

### DIFF
--- a/.claude/skills/update-openclaw/SKILL.md
+++ b/.claude/skills/update-openclaw/SKILL.md
@@ -52,7 +52,17 @@ version between current and target first.
    provider `baseUrl` handling — the areas that have bitten us before (see
    `reference_oc_*` / `reference_openclaw_*` memory entries). Look at
    sections titled "Sessions", "Gateway, Security, and Trust", "Plugins and
-   Packaging", and any breaking/migration language anywhere else.
+   Packaging", and any breaking/migration language anywhere else. **Watch
+   especially for new gateway-startup / config self-healing behavior** — these
+   don't show up in `pnpm test`/`tsc` at all and only fail in the docker E2Es.
+   Real example the 2026.6.11 bump tripped: OpenClaw 2026.6.x added startup
+   config auto-restore — on a size-drop / missing-meta vs last-known-good it
+   restores `openclaw.json.last-good` over `openclaw.json` at gateway start
+   (`recoverConfigFromLastKnownGood`). This broke the setup-wizard reset (it
+   deleted `openclaw.json` but not the backups, so OC restored the prior test's
+   config referencing wiped secrets → crash-loop). If notes mention config
+   backup / last-known-good / recovery / restore, expect the setup-wizard +
+   integration E2Es to need reset-choreography updates.
 
    **b. Resolved issues we have workarounds for.** Grep our own code for
    the upstream issue/PR numbers and version-guard comments before reading

--- a/.claude/skills/update-openclaw/SKILL.md
+++ b/.claude/skills/update-openclaw/SKILL.md
@@ -1,0 +1,165 @@
+---
+name: update-openclaw
+description: Use when bumping the pinned OpenClaw core version (openclaw npm package), when preparing a Pinchy release, or when the user asks to "update OpenClaw" / "upgrade OpenClaw" / check for a newer OpenClaw version.
+---
+
+# Update the pinned OpenClaw version
+
+## Overview
+
+Pinchy pins the OpenClaw core runtime version in two places that a drift
+guard keeps in lockstep:
+
+- `packages/web/package.json` → `dependencies.openclaw`
+- `Dockerfile.openclaw` → `RUN npm install -g openclaw@<version>`
+
+`packages/web/src/__tests__/lib/openclaw-version-pin-drift.test.ts` greps
+`Dockerfile.openclaw` for the literal `npm install -g openclaw@` line and
+fails if it doesn't match `package.json`. Both places also feed
+`/api/version`.
+
+**Core principle: OpenClaw upgrades have repeatedly broken Pinchy in ways
+`pnpm test`/`tsc` don't catch**, because the breakage is in runtime protocol
+behavior (session keys, `tools.allow` semantics, `config.apply` timing,
+plugin manifest resolution) — see the `reference_oc_*` / `reference_openclaw_*`
+memory entries about past compatibility cliffs. Never treat "npm view shows a
+newer version" as a green light by itself. Read the release notes for every
+version between current and target first.
+
+## Procedure
+
+1. **Check current vs. latest.**
+   ```bash
+   grep openclaw packages/web/package.json
+   npm view openclaw version
+   npm view openclaw versions --json | tail -20   # see every point release in between
+   ```
+
+2. **Read every release's notes between current (exclusive) and target
+   (inclusive)** — not just the target's diff summary, since intermediate
+   point releases can carry changes too:
+   ```bash
+   gh release list --repo openclaw/openclaw --limit 20
+   gh release view v<version> --repo openclaw/openclaw
+   ```
+   Read the full text, not just headline "Highlights" — the "Additional ...
+   fixes" subsections often contain the entry that actually matters to us.
+   Work through it against these four questions, in this order, and write
+   down what you find for each before moving to step 3:
+
+   **a. Incompatibility risk.** Anything touching session keys, `tools.allow`
+   semantics, `config.apply` timing, plugin config/manifest resolution, or
+   provider `baseUrl` handling — the areas that have bitten us before (see
+   `reference_oc_*` / `reference_openclaw_*` memory entries). Look at
+   sections titled "Sessions", "Gateway, Security, and Trust", "Plugins and
+   Packaging", and any breaking/migration language anywhere else.
+
+   **b. Resolved issues we have workarounds for.** Grep our own code for
+   the upstream issue/PR numbers and version-guard comments before reading
+   notes:
+   ```bash
+   git grep -rniE "openclaw/openclaw#[0-9]+|openclaw issue|version.?guard|workaround|TODO\(#" -- packages/ config/ | grep -vi node_modules
+   ```
+   For each hit, check the upstream issue state (`gh issue view <n> --repo
+   openclaw/openclaw --json state,closedAt`). But **"issue closed" is
+   necessary, not sufficient** — a closed issue is where naive audits go
+   wrong. Before removing any workaround, confirm ALL of:
+
+   1. **The fix shipped in a release ≤ our target pin.** Close date ≠ release
+      date, and release notes often don't name the issue. When in doubt,
+      inspect the actually-installed bundle in
+      `node_modules/.pnpm/openclaw@<target>/node_modules/openclaw/dist` for
+      the fixed code, not just the changelog.
+   2. **The fix targets OUR code path**, not a sibling. Real example: openclaw
+      #75534 (config.apply no-op restart, tracked on our side by #215) fixed
+      OpenClaw's *own* `writeConfigFile` short-circuit — but Pinchy writes the
+      config file itself and then calls `config.apply`, a different path whose
+      `env.*`→default-`restart` mechanism was still present verbatim in
+      2026.6.11. Issue closed, workaround NOT removable.
+   3. **The workaround is actually a bug-workaround**, not a defensive
+      error-UX classifier or an architectural decoupling that stays valuable
+      after the bug is fixed. Real examples that are NOT removable-on-close:
+      the `thought_signature` error classifier (`model-error-classifier.ts`,
+      #338 — renders graceful UX whenever the upstream error surfaces, and its
+      removal is gated on an *empirical* live-path condition, not the issue
+      state), and the Telegram store-based `allowFrom` (#47458 — a
+      restart-avoiding design choice, see
+      `reference_ollama_local_rewrite_decoupling.md` for the "decoupling, not a
+      version workaround" pattern).
+   4. **Prefer the tracking issue's own stated verification** (e.g. "remove X,
+      run E2E `agent-create-no-restart.spec.ts`, confirm it stays green") over
+      bundle archaeology. Bundle-reading can prove a workaround is STILL needed
+      (mechanism present) but is weak evidence that one is safe to REMOVE —
+      that needs the prescribed test. Memory: `reference_config_apply_rate_limit_drop.md`
+      warns version guards can *become* bugs after an upstream fix, so this
+      cuts both ways.
+
+   If all four hold, remove the workaround in the same change with a test
+   proving native behavior now covers it. Otherwise leave it and record why.
+
+   **c. Features we built ourselves that OpenClaw now does natively.** Scan
+   for "native", new config keys, or new built-in capabilities in areas where
+   Pinchy has a bespoke plugin or workaround (e.g. transcript capture,
+   session identity, memory, approvals — see `reference_pinchy_owned_transcript.md`,
+   `reference_openclaw_approval_primitives.md`, `reference_mcp_native_credential_proxy.md`
+   for precedent: MCP was migrated from a Pinchy-built plugin to native
+   `mcp.servers` + a thin credential proxy once OpenClaw grew native support).
+   **Same feature name ≠ same scope — check whether the native capability
+   covers the REASON we built the bespoke version, not just its surface.**
+   Real example: 2026.6.10 added a native "session-transcript SDK" (read,
+   append, publish, lock), which sounds like it could replace `pinchy-transcript`.
+   But its methods are all keyed by `{ agentId, sessionKey, sessionId }` —
+   **session-scoped**. Pinchy owns `channel_messages` precisely because it
+   needs a *channel-lifetime* record that survives `/new`/reset/compaction
+   (per PR #553 / `reference_pinchy_owned_transcript.md`); adopting the
+   session-scoped SDK would reintroduce the exact blank-on-`/new` bug it fixed.
+   So: not adoptable. If a native capability genuinely covers the reason,
+   flag it as a follow-up simplification; if it only matches the name, record
+   why it doesn't fit so the next bump doesn't re-litigate it.
+
+   **d. New OpenClaw features worth exposing in Pinchy.** Anything new that
+   fits Pinchy's enterprise-governance angle (permissions, audit, channels,
+   models) or that Pinchy's target audience (self-hosted enterprise teams,
+   see "Product Context" in `AGENTS.md`) would plausibly want surfaced in the
+   UI/API. Note these separately as feature ideas — they are out of scope
+   for the bump itself, not blockers.
+
+3. **Summarize findings against the four questions before touching code.**
+   If (a) is empty, treat the bump as safe to proceed. If (a) is non-empty,
+   flag it to the user before proceeding — don't silently absorb a breaking
+   change into a routine bump. (b), (c), and (d) don't block the bump, but
+   report them: (b) as follow-up cleanup candidates (ideally done alongside
+   the bump if small), (c)/(d) as things worth a tracked issue or a
+   `spawn_task`-style follow-up rather than silently doing nothing with them.
+
+4. **Bump both pinned locations** to the same target version:
+   - `packages/web/package.json` → `dependencies.openclaw`
+   - `Dockerfile.openclaw` → the `npm install -g openclaw@...` line
+
+5. **Check `openclaw-node`** (`packages/web/package.json` →
+   `dependencies["openclaw-node"]`, our own client library in
+   `~/projects/openclaw-node/`) for a matching newer release too —
+   `npm view openclaw-node version`. If it needs a bump and we own it, bump
+   and release it via `pnpm release X.Y.Z` in that repo first, not a manual
+   `gh release create`.
+
+6. **Install and verify:**
+   ```bash
+   pnpm install
+   pnpm -C packages/web vitest run src/__tests__/lib/openclaw-version-pin-drift.test.ts
+   pnpm test
+   pnpm build
+   ```
+
+7. **Don't commit automatically.** Report the diff (`git status --short`,
+   `git diff --stat`) and let the user decide to commit/PR — this touches a
+   runtime dependency, not just app code.
+
+## If a release note flags something sensitive
+
+Don't just bump anyway. Options, in order of preference:
+- Pin to the last version before the risky change and note why in a commit
+  message / to the user.
+- Do the bump on a branch, add/adjust a regression test for the specific
+  behavior the release note describes, then bump.
+- Ask the user whether to proceed if the tradeoff isn't yours to make alone.

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -52,7 +52,7 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # `npm install -g openclaw@<version>` line to keep the runtime version in
 # lockstep with packages/web/package.json (which feeds /api/version). Keep the
 # literal form unchanged.
-RUN npm install -g openclaw@2026.6.8
+RUN npm install -g openclaw@2026.6.11
 
 # Install pinchy-files plugin dependencies (native modules must be built here).
 # Each bundle's node_modules is copied into /opt/<plugin>-deps so the runtime

--- a/packages/web/e2e/setup-wizard/helpers.ts
+++ b/packages/web/e2e/setup-wizard/helpers.ts
@@ -80,11 +80,21 @@ export async function resetStack(): Promise<void> {
   // secrets.json bootstrap pkill) keeps the freshly-created Smithers agent out
   // of OC's runtime `agents.list` for >90 s → the wizard's first chat times out
   // with `unknown agent id` (the google.spec.ts flake; CI run 26840320245).
+  //
+  // We also delete OpenClaw's config-recovery backups (`openclaw.json.last-good`
+  // and the rotating `openclaw.json.bak*` ring). OpenClaw 2026.6.x added
+  // startup self-healing: when the on-disk config is a size-drop / missing-meta
+  // vs the last-known-good, `recoverConfigFromLastKnownGood` restores
+  // `openclaw.json.last-good` over openclaw.json BEFORE Pinchy's regenerate can
+  // land. In a reset that stale last-good is the PREVIOUS test's ~20 KB config,
+  // which still references provider secrets we just wiped — so OpenClaw would
+  // crash-loop on "secrets.providers.pinchy.path is not readable" forever
+  // (2026.6.11 upgrade; recovery reads `${configPath}.last-good` and no-ops if
+  // the file is absent, so deleting it makes this a true fresh install).
+  // `sh -c` gives us glob expansion for the `.bak*` ring.
   execSync(
-    `docker compose ${COMPOSE_ARGS} exec -T openclaw rm -f ` +
-      `/root/.openclaw/openclaw.json ` +
-      `/openclaw-secrets/secrets.json ` +
-      `/openclaw-secrets/.bootstrap-applied`,
+    `docker compose ${COMPOSE_ARGS} exec -T openclaw sh -c ` +
+      `'rm -f /root/.openclaw/openclaw.json /root/.openclaw/openclaw.json.last-good /root/.openclaw/openclaw.json.bak* /openclaw-secrets/secrets.json /openclaw-secrets/.bootstrap-applied'`,
     { stdio: "pipe", cwd: REPO_ROOT }
   );
 

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -94,7 +94,7 @@
     "eslint-config-next": "16.2.6",
     "eslint-plugin-security": "^4.0.0",
     "jsdom": "^29.1.1",
-    "openclaw": "2026.6.8",
+    "openclaw": "2026.6.11",
     "prettier": "^3.8.3",
     "tailwindcss": "^4.3.0",
     "tw-animate-css": "^1.4.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -365,8 +365,8 @@ importers:
         specifier: ^29.1.1
         version: 29.1.1(@noble/hashes@2.0.1)
       openclaw:
-        specifier: 2026.6.8
-        version: 2026.6.8
+        specifier: 2026.6.11
+        version: 2026.6.11
       prettier:
         specifier: ^3.8.3
         version: 3.8.3
@@ -5329,8 +5329,8 @@ packages:
     resolution: {integrity: sha512-hEU3kO3G2do36IrfFqEENoXsmcMzWbm5cDtzRZTV4CFRe7qG4nvFJSy57IejGcHEL7xNoyUmyb+rGChOxbcnFg==}
     engines: {node: '>=20.0.0'}
 
-  openclaw@2026.6.8:
-    resolution: {integrity: sha512-iziR8fi69+ojrtX7FYYvTpkGcVnmyLpIhvchgt5LFkkdHVWw973XAAekKVZ3/xQJ5FG4NwgHkXL0LLTrgsNOSQ==}
+  openclaw@2026.6.11:
+    resolution: {integrity: sha512-T+P/g19IheeT1ckXMoPN61dYuE8vBF4MderI+kWkvpuFYxPkJxn8AXLpu9IXCnN9g36Acpm9+mMD/V+lsvOkyA==}
     engines: {node: '>=22.19.0'}
     hasBin: true
 
@@ -11949,7 +11949,7 @@ snapshots:
       - bufferutil
       - utf-8-validate
 
-  openclaw@2026.6.8:
+  openclaw@2026.6.11:
     dependencies:
       '@agentclientprotocol/sdk': 0.22.1(zod@4.4.3)
       '@anthropic-ai/sdk': 0.100.1(zod@4.4.3)
@@ -11971,7 +11971,6 @@ snapshots:
       clawpdf: 0.3.0
       commander: 14.0.3
       croner: 10.0.1
-      cross-spawn: 7.0.6
       diff: 9.0.0
       dotenv: 17.4.2
       express: 5.2.1


### PR DESCRIPTION
## What

Bumps the pinned OpenClaw runtime from **2026.6.8 → 2026.6.11** in both lockstep locations (`Dockerfile.openclaw` + `packages/web/package.json`, kept in sync by `openclaw-version-pin-drift.test.ts`), and adds a new **`update-openclaw` skill** that codifies the audit procedure this bump followed.

## Release-notes audit (2026.6.9–2026.6.11)

Worked the notes through four questions:

**a. Incompatibility risk — none.** `config.apply` now requires a `baseHash` (optimistic-lock / CAS) when the config file exists. Pinchy already sends it: `client.config.apply(supplemented, current.hash, …)` in `openclaw-config/write.ts`. Full `pnpm test` (6581 passing) and `pnpm build` verified against the installed 2026.6.11.

**b. Resolved issues with workarounds — none removable.** Audited all 5 upstream refs in our code:
- **#215** (config.apply no-op restart): the `env.*` → no-reload-rule → default `restart` mechanism is still present verbatim in 2026.6.11's reload-plan. Upstream #75534 fixed OpenClaw's *own* `writeConfigFile` short-circuit, **not** Pinchy's write-file-then-`config.apply` path → keep; #215 stays open.
- **#338** (`thought_signature` classifier): defensive error-UX, removal gated on an empirical Ollama-Cloud OpenAI-compat condition, not #34008's closure → keep.
- **#47458** (Telegram store-`allowFrom`): architectural decoupling, not a version workaround → keep.
- **#42172** (chat.abort): already resolved — feature re-shipped in 2026.6.5 with an E2E gate.

**c. Features now native — not adoptable.** The new native session-transcript SDK (PR #95030) is session-scoped (`{agentId, sessionKey, sessionId}`); `pinchy-transcript`/`channel_messages` needs a channel-lifetime record that survives `/new`, so adopting it would reintroduce the blank-on-`/new` bug PR #553 fixed.

**d. New features to expose — none** fitting Pinchy's governance angle in this window (mostly bugfix releases).

## Skill

`.claude/skills/update-openclaw/SKILL.md` captures the two lockstep pin locations, the four-question audit, and the concrete lessons ("issue closed ≠ removable"; "same feature name ≠ same scope").

## Test plan
- [x] `openclaw-version-pin-drift.test.ts` passes
- [x] `pnpm test` (full suite) green against 2026.6.11
- [x] `pnpm build` succeeds