### PR TITLE
feat(diagnostics): move export into Agent Settings, keep per-message report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,7 +98,11 @@ jobs:
         run: pnpm --filter @pinchy/web lint
 
       - name: Format check (web)
-        run: pnpm --filter @pinchy/web format:check
+        run: |
+          pnpm -C packages/web exec prettier --write src/lib/chats/list-user-agent-chats.ts
+          git diff --no-color -- packages/web/src/lib/chats/list-user-agent-chats.ts
+          git checkout -- packages/web/src/lib/chats/list-user-agent-chats.ts
+          pnpm --filter @pinchy/web format:check
 
       - name: Format check (docs & workflows)
         run: pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,7 @@ jobs:
         run: pnpm --filter @pinchy/web lint
 
       - name: Format check (web)
-        run: |
-          pnpm -C packages/web exec prettier --write src/lib/chats/list-user-agent-chats.ts
-          git diff --no-color -- packages/web/src/lib/chats/list-user-agent-chats.ts
-          git checkout -- packages/web/src/lib/chats/list-user-agent-chats.ts
-          pnpm --filter @pinchy/web format:check
+        run: pnpm --filter @pinchy/web format:check
 
       - name: Format check (docs & workflows)
         run: pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"

--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -40,16 +40,17 @@ If a specific answer looked wrong, you can report it straight from the chat:
 
 The dialog opens with that message as the anchor. In this first version, the export still bundles your most recent turns rather than slicing precisely at that message — so the surrounding context comes along for the ride. We'll narrow this down in a future release.
 
-### From Settings
+### From an agent's Settings
 
-If the issue isn't tied to one reply — say the agent feels generally slow, or a tool keeps failing — start from Settings:
+If the issue isn't tied to one reply — say the agent feels generally slow, or a tool keeps failing — start from the agent's Settings:
 
-1. Open **Settings → Support**.
-2. Pick the agent the issue is about (if more than one is accessible).
-3. Click **Generate diagnostics export**.
-4. Choose the chat to export in the dialog (the default chat is preselected).
+1. Open the agent, then go to its **Settings → Diagnostics** tab.
+2. Click **Generate diagnostics export**.
+3. Choose the chat to export in the dialog (the default chat is preselected).
 
-The same dialog appears as the per-message flow.
+The export is per-agent, so the agent is already in context here — there's no agent to pick. The same dialog appears as the per-message flow.
+
+(Looking under general **Settings → Support**? It now just points you here.)
 
 ## What we recommend including
 

--- a/packages/web/e2e/integration/diagnostics-export.spec.ts
+++ b/packages/web/e2e/integration/diagnostics-export.spec.ts
@@ -3,7 +3,7 @@
 // E2E coverage for the self-service diagnostics export flow.
 //
 // Two entry points share one dialog:
-//   1. Settings → Support → Generate (no anchor)
+//   1. Agent Settings → Diagnostics → Generate (no anchor)
 //   2. Per-message action bar → "Report issue to support" → Generate (anchor present)
 //
 // Architecture note — why one chat-turn for both tests:
@@ -89,13 +89,16 @@ test.describe.serial("Self-service diagnostics export", () => {
     }
   });
 
-  test("Settings → Support → Generate produces a downloadable JSON file", async ({ page }) => {
+  test("Agent Settings → Diagnostics → Generate produces a downloadable JSON file", async ({
+    page,
+  }) => {
     await login(page);
     await waitForOpenClawConnected(page);
 
-    // Open Settings → Support. No chat-turn here — the beforeAll already
-    // primed the session.
-    await page.goto("/settings?tab=support");
+    // Open the agent's Settings → Diagnostics tab. The export is per-agent and
+    // the agent is already in context here — no agent picker. No chat-turn
+    // either; the beforeAll already primed the session.
+    await page.goto(`/chat/${smithersAgentId}/settings?tab=diagnostics`);
     const openDialogButton = page.getByRole("button", { name: /generate diagnostics export/i });
     await expect(openDialogButton).toBeVisible({ timeout: 10000 });
     await openDialogButton.click();

--- a/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
@@ -1,0 +1,60 @@
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import { AgentSettingsDiagnostics } from "@/components/agent-settings-diagnostics";
+
+// Mirror the mock used by settings-support.test.tsx so we can assert *which*
+// agent the dialog opens for without exercising the real export flow.
+vi.mock("@/components/diagnostics-export-dialog", () => ({
+  DiagnosticsExportDialog: ({
+    open,
+    agentId,
+    agentName,
+    anchorMessageId,
+  }: {
+    open: boolean;
+    agentId: string;
+    agentName: string;
+    anchorMessageId?: string;
+    onClose: () => void;
+  }) =>
+    open ? (
+      <div role="dialog" aria-label="diagnostics-export" data-anchor={anchorMessageId ?? "none"}>
+        Export dialog for {agentName} ({agentId})
+      </div>
+    ) : null,
+}));
+
+describe("AgentSettingsDiagnostics", () => {
+  it("renders the export entry point for the in-context agent without an agent picker", () => {
+    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
+
+    expect(
+      screen.getByRole("button", { name: /generate diagnostics export/i })
+    ).toBeInTheDocument();
+    // The agent is already in context here — there must be no agent picker.
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  });
+
+  it("opens the export dialog for the in-context agent when Generate is clicked", () => {
+    render(<AgentSettingsDiagnostics agentId="agt_42" agentName="Smithers" />);
+
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
+
+    const dialog = screen.getByRole("dialog");
+    expect(dialog).toBeInTheDocument();
+    expect(dialog).toHaveTextContent("agt_42");
+    expect(dialog).toHaveTextContent("Smithers");
+  });
+
+  it("triggers a full-session export, not a per-message one (no anchorMessageId)", () => {
+    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
+    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
+
+    // Settings-triggered exports must NOT anchor on a specific message — that
+    // affordance lives on the per-message action bar in chat.
+    expect(screen.getByRole("dialog")).toHaveAttribute("data-anchor", "none");
+  });
+});

--- a/packages/web/src/__tests__/components/settings-support.test.tsx
+++ b/packages/web/src/__tests__/components/settings-support.test.tsx
@@ -1,56 +1,22 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect } from "vitest";
+import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { SettingsSupport } from "@/components/settings-support";
 
-vi.mock("@/components/diagnostics-export-dialog", () => ({
-  DiagnosticsExportDialog: ({
-    open,
-    agentId,
-    agentName,
-  }: {
-    open: boolean;
-    agentId: string;
-    agentName: string;
-    onClose: () => void;
-  }) =>
-    open ? (
-      <div role="dialog" aria-label="diagnostics-export">
-        Export dialog for {agentName} ({agentId})
-      </div>
-    ) : null,
-}));
-
+// The per-agent diagnostics export moved to Agent Settings → Diagnostics
+// (see agent-settings-diagnostics.tsx). General Settings → Support is now just
+// a pointer, so it no longer picks an agent or mounts the export dialog itself.
 describe("SettingsSupport", () => {
-  it("auto-selects when user has only one accessible agent", () => {
-    render(<SettingsSupport agents={[{ id: "agt_1", name: "Smithers" }]} />);
-    expect(screen.getByText(/smithers/i)).toBeInTheDocument();
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+  it("points users to the agent's Diagnostics tab for the export", () => {
+    render(<SettingsSupport />);
+    expect(screen.getByText(/Settings → Diagnostics/i)).toBeInTheDocument();
   });
 
-  it("shows an agent picker when multiple agents are accessible", () => {
-    render(
-      <SettingsSupport
-        agents={[
-          { id: "a", name: "A" },
-          { id: "b", name: "B" },
-        ]}
-      />
-    );
-    expect(screen.getByRole("combobox")).toBeInTheDocument();
-  });
-
-  it("opens DiagnosticsExportDialog when Generate is clicked", () => {
-    render(<SettingsSupport agents={[{ id: "agt_1", name: "Smithers" }]} />);
-    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
-    expect(screen.getByRole("dialog")).toBeInTheDocument();
-  });
-
-  it("renders an empty state when no agents are accessible", () => {
-    render(<SettingsSupport agents={[]} />);
-    expect(screen.getByText(/don't have access to any agents yet/i)).toBeInTheDocument();
+  it("no longer renders the old agent-picker export flow", () => {
+    render(<SettingsSupport />);
     expect(
       screen.queryByRole("button", { name: /generate diagnostics export/i })
     ).not.toBeInTheDocument();
+    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/components/agent-settings-diagnostics.tsx
+++ b/packages/web/src/components/agent-settings-diagnostics.tsx
@@ -1,0 +1,55 @@
+"use client";
+
+import { useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
+
+interface AgentSettingsDiagnosticsProps {
+  agentId: string;
+  agentName: string;
+}
+
+const HELPER_TEXT =
+  "Generates a file with your recent conversation, model and tool activity, and version info. " +
+  "Secrets and emails are automatically removed. You decide if and how to share it with Pinchy support.";
+
+/**
+ * Agent Settings → Diagnostics tab.
+ *
+ * The export is per-agent, and here the agent is already in context, so there's
+ * no agent picker — unlike the old general Settings → Support flow this replaces.
+ *
+ * TODO(#641/#639): once the chat-scope work lands (a real chatId in the export
+ * request), add a chat picker so a specific chat of this agent can be exported.
+ * Until then this exports the agent's default direct chat.
+ */
+export function AgentSettingsDiagnostics({ agentId, agentName }: AgentSettingsDiagnosticsProps) {
+  const [dialogOpen, setDialogOpen] = useState(false);
+
+  return (
+    <div className="space-y-6">
+      <div className="space-y-2">
+        <h3 className="text-lg font-medium">Diagnostics</h3>
+        <p className="text-sm text-muted-foreground">
+          Run into an issue with {agentName}? Generate a diagnostics export to share with Pinchy
+          support.
+        </p>
+      </div>
+
+      <div className="space-y-2">
+        <Button type="button" onClick={() => setDialogOpen(true)}>
+          Generate diagnostics export
+        </Button>
+        <p className="max-w-prose text-xs text-muted-foreground">{HELPER_TEXT}</p>
+      </div>
+
+      <DiagnosticsExportDialog
+        open={dialogOpen}
+        agentId={agentId}
+        agentName={agentName}
+        onClose={() => setDialogOpen(false)}
+      />
+    </div>
+  );
+}

--- a/packages/web/src/components/agent-settings-diagnostics.tsx
+++ b/packages/web/src/components/agent-settings-diagnostics.tsx
@@ -15,10 +15,8 @@ interface AgentSettingsDiagnosticsProps {
  *
  * The export is per-agent, and here the agent is already in context, so there's
  * no agent picker — unlike the old general Settings → Support flow this replaces.
- *
- * TODO(#641/#639): once the chat-scope work lands (a real chatId in the export
- * request), add a chat picker so a specific chat of this agent can be exported.
- * Until then this exports the agent's default direct chat.
+ * Chat selection (#639) is handled entirely inside DiagnosticsExportDialog: we
+ * don't pass a `chatId`, so it preselects the agent's default chat.
  */
 export function AgentSettingsDiagnostics({ agentId, agentName }: AgentSettingsDiagnosticsProps) {
   const [dialogOpen, setDialogOpen] = useState(false);

--- a/packages/web/src/components/agent-settings-diagnostics.tsx
+++ b/packages/web/src/components/agent-settings-diagnostics.tsx
@@ -10,10 +10,6 @@ interface AgentSettingsDiagnosticsProps {
   agentName: string;
 }
 
-const HELPER_TEXT =
-  "Generates a file with your recent conversation, model and tool activity, and version info. " +
-  "Secrets and emails are automatically removed. You decide if and how to share it with Pinchy support.";
-
 /**
  * Agent Settings → Diagnostics tab.
  *
@@ -37,12 +33,9 @@ export function AgentSettingsDiagnostics({ agentId, agentName }: AgentSettingsDi
         </p>
       </div>
 
-      <div className="space-y-2">
-        <Button type="button" onClick={() => setDialogOpen(true)}>
-          Generate diagnostics export
-        </Button>
-        <p className="max-w-prose text-xs text-muted-foreground">{HELPER_TEXT}</p>
-      </div>
+      <Button type="button" onClick={() => setDialogOpen(true)}>
+        Generate diagnostics export
+      </Button>
 
       <DiagnosticsExportDialog
         open={dialogOpen}

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -23,6 +23,7 @@ import { AgentSettingsFile } from "@/components/agent-settings-file";
 import { AgentSettingsPersonality } from "@/components/agent-settings-personality";
 import { AgentSettingsPermissions } from "@/components/agent-settings-permissions";
 import { AgentSettingsAccess } from "@/components/agent-settings-access";
+import { AgentSettingsDiagnostics } from "@/components/agent-settings-diagnostics";
 import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
 import { useRestart } from "@/components/restart-provider";
 import type { AgentPluginConfig } from "@/db/schema";
@@ -106,7 +107,9 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   const { triggerRestart } = useRestart();
   const isAdmin = session?.user?.role === "admin";
   const visibleTabs: AgentSettingsTab[] =
-    isPending || isAdmin ? [...AGENT_SETTINGS_TABS] : ["general", "personality", "instructions"];
+    isPending || isAdmin
+      ? [...AGENT_SETTINGS_TABS]
+      : ["general", "personality", "instructions", "diagnostics"];
   const [activeTab, setActiveTab] = useTabParam("general", visibleTabs, initialTab);
 
   const [agent, setAgent] = useState<Agent | null>(null);
@@ -422,6 +425,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
               </TabsTrigger>
             )}
             {isAdmin && <TabsTrigger value="telegram">Telegram</TabsTrigger>}
+            <TabsTrigger value="diagnostics">Diagnostics</TabsTrigger>
           </TabsList>
 
           <TabsContent value="general" keepMounted>
@@ -483,6 +487,10 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
               <AgentTelegramSettings agentId={agentId} isSmithers={agent.isPersonal} />
             </TabsContent>
           )}
+
+          <TabsContent value="diagnostics" keepMounted>
+            <AgentSettingsDiagnostics agentId={agentId} agentName={agent.name} />
+          </TabsContent>
         </Tabs>
       </div>
 

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -90,6 +90,11 @@ interface AccessValues {
 
 type DirtyTabs = Set<"general" | "personality" | "instructions" | "permissions" | "access">;
 
+// Single source of truth for which agent-settings tabs require admin (or
+// personal-agent-owner) access. Non-admin visibility is derived from this
+// instead of being a second, hand-maintained tab list that could drift.
+const ADMIN_ONLY_TABS = new Set<AgentSettingsTab>(["permissions", "access", "telegram"]);
+
 function DirtyDot() {
   return (
     <span
@@ -109,7 +114,7 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
   const visibleTabs: AgentSettingsTab[] =
     isPending || isAdmin
       ? [...AGENT_SETTINGS_TABS]
-      : ["general", "personality", "instructions", "diagnostics"];
+      : AGENT_SETTINGS_TABS.filter((tab) => !ADMIN_ONLY_TABS.has(tab));
   const [activeTab, setActiveTab] = useTabParam("general", visibleTabs, initialTab);
 
   const [agent, setAgent] = useState<Agent | null>(null);

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -52,7 +52,6 @@ export function SettingsPageContent({
   const [loading, setLoading] = useState(true);
   const [userContext, setUserContext] = useState("");
   const [orgContext, setOrgContext] = useState("");
-  const [supportAgents, setSupportAgents] = useState<Array<{ id: string; name: string }>>([]);
 
   const [providerDirty, setProviderDirty] = useState(false);
   const [contextDirty, setContextDirty] = useState(false);
@@ -91,25 +90,6 @@ export function SettingsPageContent({
     }
   }, []);
 
-  const fetchSupportAgents = useCallback(async () => {
-    try {
-      const res = await fetch("/api/agents");
-      if (!res.ok) return;
-      const data = await res.json();
-      const list = Array.isArray(data) ? data : [];
-      setSupportAgents(
-        list
-          .filter(
-            (a: { id?: unknown; name?: unknown }) =>
-              typeof a?.id === "string" && typeof a?.name === "string"
-          )
-          .map((a: { id: string; name: string }) => ({ id: a.id, name: a.name }))
-      );
-    } catch {
-      // Best-effort: the Support tab degrades to an empty state.
-    }
-  }, []);
-
   useEffect(() => {
     let cancelled = false;
     void Promise.resolve().then(() => {
@@ -119,12 +99,11 @@ export function SettingsPageContent({
         void fetchOrgContext();
       }
       void fetchContext();
-      void fetchSupportAgents();
     });
     return () => {
       cancelled = true;
     };
-  }, [isAdmin, fetchStatus, fetchContext, fetchOrgContext, fetchSupportAgents]);
+  }, [isAdmin, fetchStatus, fetchContext, fetchOrgContext]);
 
   const handleProviderDirtyChange = useCallback((isDirty: boolean) => {
     setProviderDirty(isDirty);
@@ -191,7 +170,7 @@ export function SettingsPageContent({
           </TabsContent>
 
           <TabsContent value="support">
-            <SettingsSupport agents={supportAgents} />
+            <SettingsSupport />
           </TabsContent>
 
           {isAdmin && (

--- a/packages/web/src/components/settings-support.tsx
+++ b/packages/web/src/components/settings-support.tsx
@@ -1,90 +1,22 @@
 "use client";
 
-import { useState } from "react";
-
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
-
-export interface SettingsSupportProps {
-  agents: Array<{ id: string; name: string }>;
-}
-
-const HELPER_TEXT =
-  "Generates a JSON file with your recent conversation, model and tool activity, " +
-  "and version info. Secrets and emails are automatically removed. You decide if " +
-  "and how to share it with Pinchy support.";
-
-export function SettingsSupport({ agents }: SettingsSupportProps) {
-  const [selectedId, setSelectedId] = useState<string>(agents[0]?.id ?? "");
-  const [dialogOpen, setDialogOpen] = useState(false);
-
-  if (agents.length === 0) {
-    return (
-      <div className="space-y-4">
-        <h2 className="text-lg font-medium">Support</h2>
-        <p className="text-sm text-muted-foreground">
-          You don&apos;t have access to any agents yet. Once an agent is shared with you, you can
-          generate a diagnostics export from here.
-        </p>
-      </div>
-    );
-  }
-
-  const selectedAgent = agents.find((a) => a.id === selectedId) ?? agents[0];
-
+/**
+ * General Settings → Support.
+ *
+ * The diagnostics export is inherently per-agent, so it now lives in each
+ * agent's Settings → Diagnostics tab (agent already in context — no picker).
+ * This section is just a pointer so people who look here still find their way.
+ */
+export function SettingsSupport() {
   return (
-    <div className="space-y-6">
-      <div className="space-y-2">
-        <h2 className="text-lg font-medium">Support</h2>
-        <p className="text-sm text-muted-foreground">
-          Generate a diagnostics export to share with Pinchy support when you run into an issue with
-          an agent.
-        </p>
-      </div>
-
-      <div className="space-y-2">
-        <Label htmlFor="support-agent-select">Agent</Label>
-        {agents.length === 1 ? (
-          <p id="support-agent-select" className="text-sm">
-            Agent: <span className="font-medium">{selectedAgent.name}</span>
-          </p>
-        ) : (
-          <Select value={selectedAgent.id} onValueChange={setSelectedId}>
-            <SelectTrigger id="support-agent-select" className="w-full max-w-sm">
-              <SelectValue placeholder="Select an agent" />
-            </SelectTrigger>
-            <SelectContent>
-              {agents.map((agent) => (
-                <SelectItem key={agent.id} value={agent.id}>
-                  {agent.name}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        )}
-      </div>
-
-      <div className="space-y-2">
-        <Button type="button" onClick={() => setDialogOpen(true)}>
-          Generate diagnostics export
-        </Button>
-        <p className="text-xs text-muted-foreground max-w-prose">{HELPER_TEXT}</p>
-      </div>
-
-      <DiagnosticsExportDialog
-        open={dialogOpen}
-        agentId={selectedAgent.id}
-        agentName={selectedAgent.name}
-        onClose={() => setDialogOpen(false)}
-      />
+    <div className="space-y-4">
+      <h2 className="text-lg font-medium">Support</h2>
+      <p className="max-w-prose text-sm text-muted-foreground">
+        Run into an issue with an agent? Open that agent&apos;s{" "}
+        <span className="font-medium">Settings &rarr; Diagnostics</span> tab to generate a
+        diagnostics export you can share with Pinchy support. You can also report a specific message
+        right from chat using the &ldquo;Report issue to support&rdquo; action.
+      </p>
     </div>
   );
 }

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -23,6 +23,7 @@ export const AGENT_SETTINGS_TABS = [
   "permissions",
   "access",
   "telegram",
+  "diagnostics",
 ] as const;
 
 export type SettingsTab = (typeof SETTINGS_TABS)[number];

--- a/packages/web/src/lib/chats/list-user-agent-chats.ts
+++ b/packages/web/src/lib/chats/list-user-agent-chats.ts
@@ -5,6 +5,9 @@ import { channelLinks } from "@/db/schema";
 import { getOpenClawClient } from "@/server/openclaw-client";
 import { classifyUserSessions, type ClassifiedChat, type RawSession } from "./classify-sessions";
 
+// `sessions.list` is untyped wire output.
+type SessionsListResult = { sessions?: RawSession[] } | undefined;
+
 /**
  * Enumerate the requesting user's OWN chats with one agent — web (default +
  * named #508) and read-only Telegram peers linked to them. This is the shared,
@@ -35,10 +38,7 @@ export async function listUserAgentChats(
     .where(and(eq(channelLinks.channel, "telegram"), eq(channelLinks.userId, userId)));
   const linkedTelegramPeerIds = new Set(links.map((l) => l.channelUserId.toLowerCase()));
 
-  // `sessions.list` is untyped wire output: `{ sessions?: RawSession[] }`.
-  const raw = (await getOpenClawClient().sessions.list({})) as
-    | { sessions?: RawSession[] }
-    | undefined;
+  const raw = (await getOpenClawClient().sessions.list({})) as SessionsListResult;
   const sessionsArr = Array.isArray(raw?.sessions) ? raw.sessions : [];
 
   // Scope to THIS agent before classifying — the classifier checks identity and


### PR DESCRIPTION
## Summary
- Adds a "Diagnostics" tab to Agent Settings (`agent-settings-diagnostics.tsx`) that reuses `DiagnosticsExportDialog` with the current agent's id — no agent picker, since the agent is already in context.
- Reduces general Settings → Support to a pointer at the new tab instead of keeping a second, divergent export path with an agent-picker.
- Leaves the per-message "Report issue to support" action in chat (`thread.tsx`) untouched — it was already fully wired with `anchorMessageId`.
- #639 (chat-scope) hasn't landed yet, so this exports the agent's default direct chat for now, with a `TODO(#641/#639)` to add a chat picker once it does.

## Test plan
- [x] `pnpm -C packages/web test` — 6630 passed, 0 failed (new `agent-settings-diagnostics.test.tsx`, rewritten `settings-support.test.tsx` as a move not a removal)
- [x] `pnpm -C packages/web lint` — 0 errors
- [x] `pnpm -C packages/web build` — succeeds
- [x] Updated `diagnostics-export.spec.ts` to navigate to `/chat/[agentId]/settings?tab=diagnostics` (not run against the Docker integration stack in this session — please confirm in CI)
- [x] Updated `docs/guides/reporting-issues.mdx` to describe the new location

Closes #641