### PR TITLE
feat(diagnostics): include an agent-config snapshot (model, tools, prompt hash) in the bundle

### DIFF
--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -14,10 +14,11 @@ The diagnostics export is a single JSON file that captures:
 - Tool calls (name and arguments) along with their sanitized results
 - Finish reasons for each turn (`stop`, `tool_use`, `aborted`, `timeout`, etc.)
 - Pinchy, OpenClaw, and openclaw-node version strings
+- A snapshot of the agent's configuration at export time: its configured model and provider (plus the default vision model, if one is set), the tools it's allowed to use, its template and personality preset, and a SHA-256 hash of each instruction file (`SOUL.md`, `AGENTS.md`). This tells us whether a problem came from the model you chose or from drifted instructions — without us ever seeing the instructions themselves.
 - Recent audit-log entries scoped to your interactions with the agent
 - A free-form description you write before exporting (up to 500 characters)
 
-Secrets are filtered out before the file is generated. API keys, Bearer tokens, and any values under sensitive keys (`password`, `apikey`, `authorization`, and friends) are automatically redacted, and the OpenClaw `sessionKey` is hashed with SHA-256 so it can't be replayed.
+Secrets are filtered out before the file is generated. API keys, Bearer tokens, and any values under sensitive keys (`password`, `apikey`, `authorization`, and friends) are automatically redacted, and the OpenClaw `sessionKey` is hashed with SHA-256 so it can't be replayed. Your agent's instructions are never written into the file — only a hash of them, so we can spot when they've changed without reading your custom prompt.
 
 ## Two ways to start
 

--- a/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
@@ -171,6 +171,15 @@ describe("POST /api/diagnostics/export (integration)", () => {
     expect(bundle.scope.sessionKeyHash).toMatch(/^sha256:/);
     expect(Array.isArray(bundle.spans)).toBe(true);
     expect(Array.isArray(bundle.auditEntries)).toBe(true);
+    // agentConfig snapshot (#642): configured model/provider, per-agent tool
+    // allow-list, and an instructions HASH — never the raw prompt. The enriched
+    // bundle still passes through sanitize + the 5 MB cap (it returned 200).
+    expect(bundle.agentConfig.agent).toEqual({ id: agent.id, name: agent.name });
+    expect(bundle.agentConfig.model).toBe("ollama/qwen3");
+    expect(bundle.agentConfig.provider).toBe("ollama");
+    expect(Array.isArray(bundle.agentConfig.allowedTools)).toBe(true);
+    expect(bundle.agentConfig.instructionsHash["SOUL.md"]).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(bundle.agentConfig.instructionsHash["AGENTS.md"]).toMatch(/^sha256:[a-f0-9]{64}$/);
   });
 
   it("denies access when the caller does not own the agent and is not admin", async () => {

--- a/packages/web/src/__tests__/lib/diagnostics/agent-config-collector.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/agent-config-collector.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// Mock the on-disk workspace reader so the collector test is hermetic (no fs).
+const readWorkspaceFile = vi.fn<(agentId: string, file: string) => string>();
+vi.mock("@/lib/workspace", () => ({
+  ALLOWED_FILES: ["SOUL.md", "AGENTS.md"] as const,
+  readWorkspaceFile: (agentId: string, file: string) => readWorkspaceFile(agentId, file),
+}));
+
+const getTemplate = vi.fn();
+vi.mock("@/lib/agent-templates/registry", () => ({
+  getTemplate: (id: string) => getTemplate(id),
+}));
+
+const getPersonalityPreset = vi.fn();
+vi.mock("@/lib/personality-presets", () => ({
+  getPersonalityPreset: (id: string) => getPersonalityPreset(id),
+}));
+
+const resolveDefaultImageModel = vi.fn<() => Promise<string | null>>();
+vi.mock("@/lib/openclaw-config/default-media-models", () => ({
+  resolveDefaultImageModel: () => resolveDefaultImageModel(),
+}));
+
+import { collectAgentConfig } from "@/lib/diagnostics/agent-config-collector";
+
+const baseAgent = {
+  id: "agt_1",
+  name: "Smithers",
+  model: "openai/gpt-5.4-mini",
+  allowedTools: ["pinchy_web_fetch", "memory"],
+  templateId: "smithers",
+  personalityPresetId: "the-butler",
+};
+
+describe("collectAgentConfig", () => {
+  beforeEach(() => {
+    readWorkspaceFile.mockReset();
+    getTemplate.mockReset();
+    getPersonalityPreset.mockReset();
+    resolveDefaultImageModel.mockReset();
+    readWorkspaceFile.mockReturnValue("");
+    getTemplate.mockReturnValue({ name: "Smithers" });
+    getPersonalityPreset.mockReturnValue({ name: "The Butler" });
+    resolveDefaultImageModel.mockResolvedValue(null);
+  });
+
+  it("snapshots the agent id and name as an { id, name } pair", async () => {
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.agent).toEqual({ id: "agt_1", name: "Smithers" });
+  });
+
+  it("captures the configured model and derives the provider from the prefix", async () => {
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.model).toBe("openai/gpt-5.4-mini");
+    expect(snap.provider).toBe("openai");
+  });
+
+  it("falls back to provider 'unknown' when the model has no provider prefix", async () => {
+    const snap = await collectAgentConfig({ ...baseAgent, model: "bare-model" });
+    expect(snap.provider).toBe("unknown");
+  });
+
+  it("captures the per-agent allowed-tools list verbatim", async () => {
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.allowedTools).toEqual(["pinchy_web_fetch", "memory"]);
+  });
+
+  it("resolves template and personality preset as { id, name } pairs", async () => {
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.template).toEqual({ id: "smithers", name: "Smithers" });
+    expect(snap.personalityPreset).toEqual({ id: "the-butler", name: "The Butler" });
+  });
+
+  it("returns null template/preset when unset or not found in the registry", async () => {
+    getTemplate.mockReturnValue(undefined);
+    const snap = await collectAgentConfig({
+      ...baseAgent,
+      templateId: null,
+      personalityPresetId: null,
+    });
+    expect(snap.template).toBeNull();
+    expect(snap.personalityPreset).toBeNull();
+  });
+
+  it("hashes each instruction file as a sha256 map, never the raw prompt", async () => {
+    const fakeSecret = "sk-ant-FAKE0123456789abcdefSECRET";
+    readWorkspaceFile.mockImplementation((_id, file) =>
+      file === "SOUL.md" ? `You are a butler. ${fakeSecret}` : "# Instructions"
+    );
+
+    const snap = await collectAgentConfig(baseAgent);
+
+    expect(snap.instructionsHash["SOUL.md"]).toMatch(/^sha256:[a-f0-9]{64}$/);
+    expect(snap.instructionsHash["AGENTS.md"]).toMatch(/^sha256:[a-f0-9]{64}$/);
+    // The raw instruction text (and its embedded secret) must not leak.
+    const serialized = JSON.stringify(snap);
+    expect(serialized).not.toContain(fakeSecret);
+    expect(serialized).not.toContain("You are a butler");
+  });
+
+  it("includes the resolved default image model when one is available", async () => {
+    resolveDefaultImageModel.mockResolvedValue("anthropic/claude-vision");
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.imageModel).toBe("anthropic/claude-vision");
+  });
+
+  it("omits imageModel when no default resolves", async () => {
+    resolveDefaultImageModel.mockResolvedValue(null);
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.imageModel).toBeUndefined();
+  });
+
+  it("omits imageModel when the resolver throws (best-effort)", async () => {
+    resolveDefaultImageModel.mockRejectedValue(new Error("db down"));
+    const snap = await collectAgentConfig(baseAgent);
+    expect(snap.imageModel).toBeUndefined();
+  });
+});

--- a/packages/web/src/__tests__/lib/diagnostics/bundle-builder.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/bundle-builder.test.ts
@@ -2,6 +2,16 @@ import { describe, it, expect } from "vitest";
 import { buildBundle } from "@/lib/diagnostics/bundle-builder";
 
 describe("buildBundle", () => {
+  const agentConfig = {
+    agent: { id: "agt_1", name: "Smithers" },
+    model: "openai/gpt-5.4-mini",
+    provider: "openai",
+    template: { id: "smithers", name: "Smithers" },
+    personalityPreset: { id: "the-butler", name: "The Butler" },
+    allowedTools: ["memory"],
+    instructionsHash: { "SOUL.md": "sha256:" + "a".repeat(64) },
+  };
+
   const baseInput = {
     spans: [{ name: "agent.turn", attributes: { "gen_ai.request.model": "x" } }],
     versions: { pinchy: "v0.5.4", openclaw: "2026.5.7", openclawNode: "0.9.0" },
@@ -13,6 +23,7 @@ describe("buildBundle", () => {
       includedTurnRange: [2, 5] as [number, number],
     },
     auditEntries: [],
+    agentConfig,
   };
 
   it("sets schemaVersion and generatedAt", () => {
@@ -51,5 +62,10 @@ describe("buildBundle", () => {
   it("includes userDescription only when provided", () => {
     expect(buildBundle(baseInput).userDescription).toBeUndefined();
     expect(buildBundle({ ...baseInput, userDescription: "x" }).userDescription).toBe("x");
+  });
+
+  it("passes the agentConfig snapshot through verbatim", () => {
+    const b = buildBundle(baseInput);
+    expect(b.agentConfig).toEqual(agentConfig);
   });
 });

--- a/packages/web/src/app/api/diagnostics/export/route.ts
+++ b/packages/web/src/app/api/diagnostics/export/route.ts
@@ -25,6 +25,7 @@ import { type AuditLogEntry } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
+import { collectAgentConfig } from "@/lib/diagnostics/agent-config-collector";
 import { buildBundle } from "@/lib/diagnostics/bundle-builder";
 import { fetchAuditEntriesForSession } from "@/lib/diagnostics/audit-collector";
 import {
@@ -110,9 +111,15 @@ export const POST = withAuth(async (request, _ctx, session) => {
   const auditRange = computeAuditRange(selectedTurns);
   const auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, auditRange);
 
+  // Snapshot the agent's configuration at export time (model/provider, allowed
+  // tools, instruction hashes) so a support reader can tell config drift apart
+  // from model choice. Never embeds the raw prompt — only its hash (#642).
+  const agentConfig = await collectAgentConfig(agent);
+
   const bundle = buildBundle({
     spans,
     versions: getDiagnosticsVersions(),
+    agentConfig,
     scope: {
       agentId,
       sessionKey,

--- a/packages/web/src/lib/diagnostics/agent-config-collector.ts
+++ b/packages/web/src/lib/diagnostics/agent-config-collector.ts
@@ -1,0 +1,98 @@
+// Diagnostics agent-config collector.
+//
+// Captures the agent's *configuration at export time* so a support reader can
+// tell whether a failure came from model choice or from drifted
+// instructions/permissions (issue #642). It reads from the SAME sources the
+// Agent Settings UI uses — the DB agent row (model, allowed tools, template,
+// personality preset) plus the on-disk workspace instruction files — so the
+// snapshot matches what the operator sees.
+//
+// Secret hygiene: the raw system prompt / instructions are NEVER embedded, only
+// a SHA-256 hash per file. That makes drift visible (AGENTS.md notes "agent
+// instructions can diverge" from the shipped template) without leaking custom
+// prompt content into support archives. Model ids, tool names, and template/
+// preset names carry no secrets; provider API keys and SecretRefs never enter
+// this snapshot.
+
+import { createHash } from "node:crypto";
+
+import { getTemplate } from "@/lib/agent-templates/registry";
+import { resolveDefaultImageModel } from "@/lib/openclaw-config/default-media-models";
+import { getPersonalityPreset } from "@/lib/personality-presets";
+import { ALLOWED_FILES, readWorkspaceFile } from "@/lib/workspace";
+
+/** The subset of the agent row this collector needs (structurally satisfied by
+ * the row returned from `getAgentWithAccess`). */
+export interface AgentConfigInput {
+  id: string;
+  name: string;
+  model: string;
+  allowedTools: string[];
+  templateId: string | null;
+  personalityPresetId: string | null;
+}
+
+export interface AgentConfigSnapshot {
+  agent: { id: string; name: string };
+  /** Full configured model id, e.g. "openai/gpt-5.4-mini". */
+  model: string;
+  /** Provider inferred from the model prefix, or "unknown" when unprefixed. */
+  provider: string;
+  /** Resolved default image/vision model in effect (vision offload), if any. */
+  imageModel?: string;
+  template: { id: string; name: string } | null;
+  personalityPreset: { id: string; name: string } | null;
+  /** Per-agent allow-list — the value the Permissions UI reads/writes. Not the
+   * union `computeAllowedTools()` emits to OpenClaw. */
+  allowedTools: string[];
+  /** SHA-256 hash per instruction file (e.g. SOUL.md, AGENTS.md), never the raw
+   * prompt. Same "sha256:"+hex shape as the bundle's sessionKeyHash. */
+  instructionsHash: Record<string, string>;
+}
+
+function sha256(content: string): string {
+  return "sha256:" + createHash("sha256").update(content).digest("hex");
+}
+
+/** Snapshot an id-referenced entity as an { id, name } pair (audit convention),
+ * or null when the id is unset or the registry has no match for it. */
+function resolveRef(
+  id: string | null,
+  lookup: (id: string) => { name: string } | undefined
+): { id: string; name: string } | null {
+  if (!id) return null;
+  const found = lookup(id);
+  return found ? { id, name: found.name } : null;
+}
+
+export async function collectAgentConfig(agent: AgentConfigInput): Promise<AgentConfigSnapshot> {
+  const provider = agent.model.includes("/") ? agent.model.split("/")[0] : "unknown";
+
+  const template = resolveRef(agent.templateId, getTemplate);
+  const personalityPreset = resolveRef(agent.personalityPresetId, getPersonalityPreset);
+
+  const instructionsHash: Record<string, string> = Object.fromEntries(
+    ALLOWED_FILES.map((file) => [file, sha256(readWorkspaceFile(agent.id, file))])
+  );
+
+  // Best-effort: no per-agent image model exists, so we snapshot the org-wide
+  // default vision model that actually handles image offload. A settings/DB
+  // hiccup must not fail the whole export.
+  let imageModel: string | undefined;
+  try {
+    imageModel = (await resolveDefaultImageModel()) ?? undefined;
+  } catch {
+    imageModel = undefined;
+  }
+
+  return {
+    agent: { id: agent.id, name: agent.name },
+    model: agent.model,
+    provider,
+    ...(imageModel ? { imageModel } : {}),
+    template,
+    personalityPreset,
+    allowedTools: agent.allowedTools,
+    instructionsHash,
+  };
+}

--- a/packages/web/src/lib/diagnostics/bundle-builder.ts
+++ b/packages/web/src/lib/diagnostics/bundle-builder.ts
@@ -1,9 +1,11 @@
 import { createHash } from "node:crypto";
+import type { AgentConfigSnapshot } from "./agent-config-collector";
 import type { OtelSpan } from "./otel-builder";
 
 export interface BundleInput {
   spans: OtelSpan[];
   versions: { pinchy: string; openclaw: string; openclawNode: string };
+  agentConfig: AgentConfigSnapshot;
   scope: {
     agentId: string;
     sessionKey: string;
@@ -38,6 +40,7 @@ export interface Bundle {
     skippedTurnsAfterAnchor: number;
   };
   userDescription?: string;
+  agentConfig: AgentConfigSnapshot;
   spans: OtelSpan[];
   auditEntries: unknown[];
 }
@@ -61,6 +64,7 @@ export function buildBundle(input: BundleInput): Bundle {
       skippedTurnsAfterAnchor: skipped,
     },
     ...(input.userDescription ? { userDescription: input.userDescription } : {}),
+    agentConfig: input.agentConfig,
     spans: input.spans,
     auditEntries: input.auditEntries,
   };


### PR DESCRIPTION
## What does this PR do?

Adds an `agentConfig` section to the diagnostics export bundle so a support reader can tell whether a failure came from the **model choice** or from **drifted instructions/permissions** — today the bundle records the per-turn request model but has no single, authoritative snapshot of the agent's configured model, allowed tools, or which instructions were in effect.

The snapshot captures, additively under `pinchy.bugreport.v1`:
- configured **model + provider** (provider derived from the model prefix) and a best-effort resolved **default vision model** (image offload),
- the per-agent **tool allow-list** (the value the Permissions UI reads/writes),
- **template** and **personality preset** as `{ id, name }` pairs (audit convention),
- a **SHA-256 hash of each instruction file** (`SOUL.md`, `AGENTS.md`) — never the raw prompt, so instruction drift from the shipped template is visible without leaking custom prompt content into support archives.

The collector reads from the same sources the Agent Settings UI uses (DB agent row + workspace files), so the snapshot matches what the operator sees. It rides through `sanitizeBundle` and counts toward the 5 MB cap like everything else — no changes to the sanitize/size-cap stages were needed.

Closes #642

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

## Notes for reviewers

- **No secrets:** only hashes, model ids, tool names, and template/preset names enter the snapshot; raw instructions are never embedded. A unit test asserts a fake secret placed in `SOUL.md` does **not** appear verbatim in the snapshot (only its hash).
- **Sequencing:** per issue #642, this touches `route.ts` (overlaps #639) and `bundle-builder.ts` (overlaps #640). The change is additive and rebase-friendly — no stacked PR. If #639 lands first, a quick rebase is expected.
- **TDD:** collector unit test, bundle-builder pass-through test, and a route-level integration assertion (200 response proves the enriched bundle still passes sanitize + the 5 MB cap).
- Gates run locally: tsc, eslint, prettier all clean; diagnostics unit suite 84/84; DB integration 8/8.