### PR TITLE
feat(diagnostics): enrich depth-truncated tool-call args from the audit log

### DIFF
--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -11,7 +11,7 @@ The diagnostics export is a single JSON file that captures:
 
 - Up to your last 10 conversation turns with the reported agent
 - The model and provider name plus token usage for each turn
-- Tool calls (name and arguments) along with their sanitized results
+- Tool calls (name and arguments) along with their sanitized results. When a tool's arguments were too deeply nested for the trajectory to capture in full, we recover the complete values from the audit log and tag each call with an `argsSource` of `"audit"` or `"trajectory"` so you can see which were enriched. Very large payloads that exceed the audit-log size limit may still be shortened.
 - Finish reasons for each turn (`stop`, `tool_use`, `aborted`, `timeout`, etc.)
 - Pinchy, OpenClaw, and openclaw-node version strings
 - A snapshot of the agent's configuration at export time: its configured model and provider (plus the default vision model, if one is set), the tools it's allowed to use, its template and personality preset, and a SHA-256 hash of each instruction file (`SOUL.md`, `AGENTS.md`). This tells us whether a problem came from the model you chose or from drifted instructions — without us ever seeing the instructions themselves.

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -149,11 +149,51 @@ describe("POST /api/internal/audit/tool-use", () => {
       detail: {
         toolName: "browser",
         success: true,
+        toolCallId: "tool-2",
         durationMs: 123,
       },
       outcome: "success",
       error: null,
     });
+  });
+
+  // #640: diagnostics export matches a depth-truncated trajectory argument back
+  // to its fuller audit `params` by tool call id, so the id must be persisted.
+  it("records toolCallId in detail when the payload carries one", async () => {
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "odoo_create",
+        agentId: "agent-9",
+        toolCallId: "call-xyz",
+        sessionKey: "agent:agent-9:direct:user-1",
+        params: { model: "res.partner", values: { name: "Acme" } },
+        result: { ok: true },
+      })
+    );
+
+    expect(res.status).toBe(200);
+    expect(appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "tool.odoo_create",
+        detail: expect.objectContaining({ toolCallId: "call-xyz" }),
+      })
+    );
+  });
+
+  it("omits toolCallId from detail when the payload has none", async () => {
+    const res = await POST(
+      makeRequest({
+        phase: "end",
+        toolName: "docs_list",
+        agentId: "agent-9",
+        result: "ok",
+      })
+    );
+
+    expect(res.status).toBe(200);
+    const call = vi.mocked(appendAuditLog).mock.calls.at(-1)?.[0];
+    expect(call?.detail).not.toHaveProperty("toolCallId");
   });
 
   it("falls back to agent actorType when sessionKey has no user portion", async () => {

--- a/packages/web/src/__tests__/lib/diagnostics/enrich-tool-args.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/enrich-tool-args.test.ts
@@ -1,0 +1,340 @@
+import { describe, it, expect } from "vitest";
+import { enrichToolCallArgs, containsDepthLimitMarker } from "@/lib/diagnostics/enrich-tool-args";
+import { sanitizeBundle } from "@/lib/diagnostics/sanitize-bundle";
+import type { OtelSpan } from "@/lib/diagnostics/otel-builder";
+import type { CollectedAuditEntry } from "@/lib/diagnostics/audit-collector";
+
+// The exact marker OpenClaw's trajectory capture writes when a value is deeper
+// than its depth-6 budget. Pinchy passes it through verbatim into spans.
+const MARKER = { truncated: true, reason: "trajectory-depth-limit", limitDepth: 6 };
+
+interface Call {
+  id: string;
+  name: string;
+  arguments: unknown;
+}
+
+function buildSpan(opts: { start?: number; end?: number; calls: Call[] }): OtelSpan {
+  return {
+    name: "agent.turn",
+    ...(opts.start !== undefined ? { startTime: new Date(opts.start).toISOString() } : {}),
+    ...(opts.end !== undefined ? { endTime: new Date(opts.end).toISOString() } : {}),
+    attributes: {
+      "gen_ai.tool.call.arguments": opts.calls.map((c) => ({
+        id: c.id,
+        name: c.name,
+        arguments: c.arguments,
+      })),
+    },
+  };
+}
+
+function auditRow(opts: {
+  name: string;
+  at: number;
+  detail: Record<string, unknown>;
+}): CollectedAuditEntry {
+  return {
+    timestamp: new Date(opts.at),
+    eventType: `tool.${opts.name}`,
+    actorType: "user",
+    actorId: "u1",
+    resource: "agent:a1",
+    detail: opts.detail,
+    outcome: "success",
+    error: null,
+  };
+}
+
+function toolArgs(span: OtelSpan): Array<Record<string, unknown>> {
+  return span.attributes["gen_ai.tool.call.arguments"] as Array<Record<string, unknown>>;
+}
+
+describe("containsDepthLimitMarker", () => {
+  it("detects the marker at the top level", () => {
+    expect(containsDepthLimitMarker(MARKER)).toBe(true);
+  });
+
+  it("detects the marker nested inside an object/array", () => {
+    expect(containsDepthLimitMarker({ model: "res.partner", values: MARKER })).toBe(true);
+    expect(containsDepthLimitMarker({ a: { b: [1, { c: MARKER }] } })).toBe(true);
+  });
+
+  it("returns false for fully-resolved arguments", () => {
+    expect(containsDepthLimitMarker({ model: "res.partner", values: { name: "x" } })).toBe(false);
+    expect(containsDepthLimitMarker(null)).toBe(false);
+    expect(containsDepthLimitMarker("plain")).toBe(false);
+  });
+});
+
+describe("enrichToolCallArgs", () => {
+  it("replaces a nested depth-limit marker with full audit params and marks argsSource=audit", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [
+        { id: "tc1", name: "odoo_create", arguments: { model: "res.partner", values: MARKER } },
+      ],
+    });
+    const fullParams = {
+      model: "res.partner",
+      values: { name: "Acme", child_ids: [[0, 0, { name: "Contact" }]] },
+    };
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1500,
+        detail: { toolName: "odoo_create", success: true, params: fullParams },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("audit");
+    expect(arg.arguments).toEqual(fullParams);
+  });
+
+  it("replaces arguments that are themselves the marker", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "odoo_read", arguments: MARKER }],
+    });
+    const fullParams = { model: "res.partner", filters: [["is_company", "=", true]] };
+    const audit = [auditRow({ name: "odoo_read", at: 1500, detail: { params: fullParams } })];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("audit");
+    expect(arg.arguments).toEqual(fullParams);
+  });
+
+  it("keeps the marker (argsSource=trajectory) when no matching audit row exists", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],
+    });
+    // Wrong tool name -> not a candidate.
+    const audit = [auditRow({ name: "odoo_read", at: 1500, detail: { params: { model: "x" } } })];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ values: MARKER });
+  });
+
+  it("keeps the marker when the audit row is outside the span time window", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],
+    });
+    const audit = [
+      auditRow({ name: "odoo_create", at: 9999, detail: { params: { values: { real: true } } } }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ values: MARKER });
+  });
+
+  it("keeps the marker when the audit row itself was byte-cap truncated (no params)", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],
+    });
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1500,
+        detail: { _truncated: true, _originalSize: 5000, summary: '{"toolName":"odoo_create",...' },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ values: MARKER });
+  });
+
+  it("leaves fully-resolved trajectory arguments untouched and marks them trajectory", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "docs_list", arguments: { q: "hello" } }],
+    });
+    const audit = [
+      auditRow({ name: "docs_list", at: 1500, detail: { params: { q: "SHOULD-NOT-WIN" } } }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ q: "hello" });
+  });
+
+  it("aligns multiple same-tool calls positionally when counts match (n === m)", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [
+        { id: "tc1", name: "odoo_create", arguments: { seq: 1, values: MARKER } },
+        { id: "tc2", name: "odoo_create", arguments: { seq: 2, values: MARKER } },
+      ],
+    });
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1200,
+        detail: { params: { seq: 1, values: { first: true } } },
+      }),
+      auditRow({
+        name: "odoo_create",
+        at: 1400,
+        detail: { params: { seq: 2, values: { second: true } } },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const args = toolArgs(out);
+    expect(args[0].argsSource).toBe("audit");
+    expect(args[0].arguments).toEqual({ seq: 1, values: { first: true } });
+    expect(args[1].argsSource).toBe("audit");
+    expect(args[1].arguments).toEqual({ seq: 2, values: { second: true } });
+  });
+
+  it("does not guess when same-tool call/candidate counts differ (n !== m)", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [
+        { id: "tc1", name: "odoo_create", arguments: { seq: 1, values: MARKER } },
+        { id: "tc2", name: "odoo_create", arguments: { seq: 2, values: MARKER } },
+      ],
+    });
+    // Only one audit candidate for two calls -> ambiguous -> keep both markers.
+    const audit = [
+      auditRow({ name: "odoo_create", at: 1200, detail: { params: { values: { only: true } } } }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const args = toolArgs(out);
+    expect(args[0].argsSource).toBe("trajectory");
+    expect(args[0].arguments).toEqual({ seq: 1, values: MARKER });
+    expect(args[1].argsSource).toBe("trajectory");
+    expect(args[1].arguments).toEqual({ seq: 2, values: MARKER });
+  });
+
+  it("uses exact toolCallId matching when the audit detail carries one (order-independent)", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [
+        { id: "tc1", name: "odoo_create", arguments: { seq: 1, values: MARKER } },
+        { id: "tc2", name: "odoo_create", arguments: { seq: 2, values: MARKER } },
+      ],
+    });
+    // Audit rows arrive in reverse order but carry toolCallId -> match by id, not position.
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1400,
+        detail: { toolCallId: "tc2", params: { seq: 2, ok: "two" } },
+      }),
+      auditRow({
+        name: "odoo_create",
+        at: 1600,
+        detail: { toolCallId: "tc1", params: { seq: 1, ok: "one" } },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const args = toolArgs(out);
+    expect(args[0].arguments).toEqual({ seq: 1, ok: "one" });
+    expect(args[1].arguments).toEqual({ seq: 2, ok: "two" });
+  });
+
+  it("keeps markers for spans without timestamps (cannot scope audit rows)", () => {
+    const span = buildSpan({
+      calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],
+    });
+    const audit = [
+      auditRow({ name: "odoo_create", at: 1500, detail: { params: { values: { real: true } } } }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ values: MARKER });
+  });
+
+  it("keeps secret redaction on enriched params through the sanitize step (pipeline order)", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "http_call", arguments: { config: MARKER } }],
+    });
+    const audit = [
+      auditRow({
+        name: "http_call",
+        at: 1500,
+        detail: { params: { config: { apiKey: "sk-ant-abcdefghijklmnopqrstuvwxyz012345" } } },
+      }),
+    ];
+
+    const enriched = enrichToolCallArgs([span], audit);
+    // Route order: enrich -> sanitizeBundle -> size cap. Secret must be gone.
+    const sanitized = sanitizeBundle({ spans: enriched });
+    const arg = (
+      sanitized.spans[0].attributes["gen_ai.tool.call.arguments"] as Array<Record<string, unknown>>
+    )[0];
+    expect(arg.argsSource).toBe("audit");
+    const config = (arg.arguments as { config: { apiKey: string } }).config;
+    expect(config.apiKey).toBe("[REDACTED]");
+  });
+
+  it("redacts a deeply-nested secret in enriched params at inject time (bundle-depth-independent)", () => {
+    // In the bundle the enriched arguments already sit ~6 levels deep, so the
+    // bundle-level sanitize's depth-10 guard barely reaches inside them. This
+    // secret sits deeper than that guard alone would scrub, so enrichment must
+    // re-scrub the params from their own root — the redaction here proves it
+    // does NOT depend on a later sanitizeBundle pass.
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "http_call", arguments: { a: MARKER } }],
+    });
+    const audit = [
+      auditRow({
+        name: "http_call",
+        at: 1500,
+        detail: {
+          params: { a: { b: { c: { d: { apiKey: "sk-ant-abcdefghijklmnopqrstuvwxyz012345" } } } } },
+        },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("audit");
+    const leaf = arg.arguments as { a: { b: { c: { d: { apiKey: string } } } } };
+    expect(leaf.a.b.c.d.apiKey).toBe("[REDACTED]");
+  });
+
+  it("does not mutate the source audit entry's params when injecting", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "http_call", arguments: { config: MARKER } }],
+    });
+    const params = { config: { apiKey: "sk-ant-abcdefghijklmnopqrstuvwxyz012345" } };
+    const audit = [auditRow({ name: "http_call", at: 1500, detail: { params } })];
+
+    enrichToolCallArgs([span], audit);
+    // Redaction happens on a copy; the audit row we read from stays intact.
+    expect(params.config.apiKey).toBe("sk-ant-abcdefghijklmnopqrstuvwxyz012345");
+  });
+});

--- a/packages/web/src/__tests__/lib/diagnostics/enrich-tool-args.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/enrich-tool-args.test.ts
@@ -257,6 +257,58 @@ describe("enrichToolCallArgs", () => {
     expect(args[1].arguments).toEqual({ seq: 2, ok: "two" });
   });
 
+  it("does not fall back to positional when id-bearing candidates don't cover the call", () => {
+    // Cross-session safety: the exported call's own audit row is missing, but a
+    // concurrent same-agent chat left a same-tool, in-window row that carries an
+    // id. Counts coincide (1 === 1), so the legacy positional path would inject
+    // the wrong chat's params. Because the candidate carries an id, we take the
+    // id path only — and tc1 has no matching id, so the marker is kept.
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],
+    });
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1500,
+        detail: { toolCallId: "other-session-call", params: { values: { fromOtherChat: true } } },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const arg = toolArgs(out)[0];
+    expect(arg.argsSource).toBe("trajectory");
+    expect(arg.arguments).toEqual({ values: MARKER });
+  });
+
+  it("enriches id-matched calls and keeps markers for the rest under partial id coverage", () => {
+    const span = buildSpan({
+      start: 1000,
+      end: 2000,
+      calls: [
+        { id: "tc1", name: "odoo_create", arguments: { values: MARKER } },
+        { id: "tc2", name: "odoo_create", arguments: { values: MARKER } },
+      ],
+    });
+    // Only tc1's row is present (tc2's audit write was lost). tc1 matches by id;
+    // tc2 keeps its marker rather than being positionally mis-paired to tc1's row.
+    const audit = [
+      auditRow({
+        name: "odoo_create",
+        at: 1500,
+        detail: { toolCallId: "tc1", params: { values: { real: 1 } } },
+      }),
+    ];
+
+    const [out] = enrichToolCallArgs([span], audit);
+    const args = toolArgs(out);
+    expect(args[0].argsSource).toBe("audit");
+    expect(args[0].arguments).toEqual({ values: { real: 1 } });
+    expect(args[1].argsSource).toBe("trajectory");
+    expect(args[1].arguments).toEqual({ values: MARKER });
+  });
+
   it("keeps markers for spans without timestamps (cannot scope audit rows)", () => {
     const span = buildSpan({
       calls: [{ id: "tc1", name: "odoo_create", arguments: { values: MARKER } }],

--- a/packages/web/src/app/api/diagnostics/export/route.ts
+++ b/packages/web/src/app/api/diagnostics/export/route.ts
@@ -35,6 +35,7 @@ import {
 } from "@/lib/diagnostics/jsonl-reader";
 import { parseJsonlLines } from "@/lib/diagnostics/jsonl-parser";
 import { buildOtelSpans } from "@/lib/diagnostics/otel-builder";
+import { enrichToolCallArgs } from "@/lib/diagnostics/enrich-tool-args";
 import { sanitizeBundle } from "@/lib/diagnostics/sanitize-bundle";
 import { computeScope } from "@/lib/diagnostics/scope-resolver";
 import { enforceSizeCap } from "@/lib/diagnostics/size-guard";
@@ -116,8 +117,14 @@ export const POST = withAuth(async (request, _ctx, session) => {
   // from model choice. Never embeds the raw prompt — only its hash (#642).
   const agentConfig = await collectAgentConfig(agent);
 
+  // Recover tool-call arguments that OpenClaw's trajectory capped at depth 6
+  // from the audit log's fuller (depth-10) `params`. Runs BEFORE sanitize +
+  // size cap so injected params still get secret-redacted and counted toward
+  // the 5 MB cap. Each argument is stamped argsSource: "audit" | "trajectory".
+  const enrichedSpans = enrichToolCallArgs(spans, auditEntries);
+
   const bundle = buildBundle({
-    spans,
+    spans: enrichedSpans,
     versions: getDiagnosticsVersions(),
     agentConfig,
     scope: {

--- a/packages/web/src/app/api/internal/audit/tool-use/route.ts
+++ b/packages/web/src/app/api/internal/audit/tool-use/route.ts
@@ -166,12 +166,16 @@ export async function POST(request: NextRequest) {
   const detailError = rawDetailError !== undefined ? safeProviderError(rawDetailError) : undefined;
 
   // Audit entries should answer: who, what, when, on what, outcome.
-  // No full result payloads (contain business data), no OpenClaw-internal IDs.
+  // No full result payloads (contain business data). We do keep the tool call's
+  // `toolCallId` when present: it's an opaque per-call correlation id (not a
+  // secret), and the diagnostics export uses it to match a depth-truncated
+  // trajectory argument back to this row's fuller `params` (#640).
   const detail: Record<string, unknown> = {
     toolName: payload.toolName,
     success: outcome === "success",
   };
 
+  if (payload.toolCallId !== undefined) detail.toolCallId = payload.toolCallId;
   if (payload.params !== undefined) detail.params = payload.params;
   if (detailError !== undefined) detail.error = detailError;
   if (payload.durationMs !== undefined) detail.durationMs = payload.durationMs;
@@ -190,6 +194,7 @@ export async function POST(request: NextRequest) {
     // Plugins must not override these system fields. Re-apply after merge.
     detail.toolName = payload.toolName;
     detail.success = outcome === "success";
+    if (payload.toolCallId !== undefined) detail.toolCallId = payload.toolCallId;
     if (detailError !== undefined) detail.error = detailError;
     else delete detail.error;
   }

--- a/packages/web/src/lib/diagnostics/audit-collector.ts
+++ b/packages/web/src/lib/diagnostics/audit-collector.ts
@@ -62,7 +62,12 @@ export async function fetchAuditEntriesForSession(
     })
     .from(auditLog)
     .where(and(...conditions))
-    .orderBy(asc(auditLog.timestamp));
+    // Secondary sort by the serial row id: it's assigned at insert time under
+    // the audit hash-chain advisory lock, so it strictly reflects write order.
+    // This breaks equal-timestamp ties into execution order, which the
+    // diagnostics enrichment's positional matching relies on for legacy rows
+    // that predate the per-call `toolCallId`.
+    .orderBy(asc(auditLog.timestamp), asc(auditLog.id));
 
   return rows;
 }

--- a/packages/web/src/lib/diagnostics/enrich-tool-args.ts
+++ b/packages/web/src/lib/diagnostics/enrich-tool-args.ts
@@ -1,0 +1,223 @@
+// Enrich a diagnostics bundle's tool-call arguments from the audit log.
+//
+// OpenClaw's trajectory capture caps nested values at depth 6 and writes a
+// `{ truncated: true, reason: "trajectory-depth-limit", limitDepth: 6 }` marker
+// in their place. Pinchy passes those markers through verbatim into span
+// `gen_ai.tool.call.arguments`, which makes exactly the payloads a bundle
+// exists to explain (odoo_create `values`, odoo_read `filters`, …) unreadable.
+//
+// Pinchy already holds a fuller copy of the same arguments: `pinchy-audit`
+// records tool `params` sanitized at depth 10 (no depth-6 cap). This module
+// swaps a truncated trajectory argument for the matching audit `params` when we
+// can match it unambiguously, and stamps every tool-call argument with an
+// `argsSource: "audit" | "trajectory"` marker so a reader knows which calls were
+// enriched.
+//
+// Two independent truncation axes exist and only one is fixed here:
+//   - trajectory depth-6 cap (this module recovers it from audit params), and
+//   - the audit `detail` 2048-byte byte-cap (`truncateDetail` in lib/audit.ts),
+//     which replaces the whole detail with a `{ _truncated, summary }` marker.
+// When the audit row itself was byte-cap truncated it carries no `params`, so we
+// keep the trajectory marker rather than fabricate — the real fix for oversized
+// payloads is an upstream OpenClaw change to the trajectory depth cap.
+//
+// This runs BEFORE `sanitizeBundle` in the export route so the injected params
+// are counted toward the 5 MB size cap. Redaction of the injected params does
+// not rely on that later bundle-level pass (which reaches them only shallowly at
+// their depth in the tree); we re-scrub each params object from its own root as
+// we inject it — see `applyAuditParams`.
+
+import { sanitizeDetail } from "@/lib/audit-sanitize";
+import type { OtelSpan } from "./otel-builder";
+import type { CollectedAuditEntry } from "./audit-collector";
+
+const DEPTH_LIMIT_REASON = "trajectory-depth-limit";
+const TOOL_EVENT_PREFIX = "tool.";
+
+interface ToolCallArg {
+  id?: unknown;
+  name?: unknown;
+  arguments?: unknown;
+  argsSource?: "audit" | "trajectory";
+  [key: string]: unknown;
+}
+
+/**
+ * True when `value` is — or contains anywhere in its object/array tree — a
+ * trajectory depth-limit marker. A marker can replace the whole `arguments`
+ * object or just one nested value (e.g. `arguments.fields`), so we look for it
+ * recursively and, when present, replace the entire `arguments` with the
+ * complete audit copy.
+ */
+export function containsDepthLimitMarker(value: unknown): boolean {
+  if (value === null || typeof value !== "object") return false;
+  if (Array.isArray(value)) return value.some(containsDepthLimitMarker);
+  const obj = value as Record<string, unknown>;
+  if (obj.reason === DEPTH_LIMIT_REASON) return true;
+  return Object.values(obj).some(containsDepthLimitMarker);
+}
+
+// A usable audit candidate is a stored tool row whose detail survived the
+// byte-cap (not `_truncated`) and still carries structured `params`. Curated
+// details that strip params (pinchy_write et al.) and byte-cap summaries both
+// fail this check and are excluded, so an ambiguous count falls back to keeping
+// the marker.
+function usableParams(detail: unknown): Record<string, unknown> | null {
+  if (detail === null || typeof detail !== "object") return null;
+  const d = detail as Record<string, unknown>;
+  if (d._truncated === true) return null;
+  const params = d.params;
+  if (params === null || typeof params !== "object") return null;
+  return params as Record<string, unknown>;
+}
+
+function detailToolCallId(entry: CollectedAuditEntry): string | undefined {
+  const detail = entry.detail;
+  if (detail === null || typeof detail !== "object") return undefined;
+  const id = (detail as Record<string, unknown>).toolCallId;
+  return typeof id === "string" ? id : undefined;
+}
+
+/**
+ * Replace depth-truncated trajectory arguments with the fuller audit-log
+ * `params` for the same tool call, where a match can be made without guessing.
+ * Returns new spans; inputs are not mutated.
+ */
+export function enrichToolCallArgs(
+  spans: OtelSpan[],
+  auditEntries: CollectedAuditEntry[]
+): OtelSpan[] {
+  return spans.map((span) => enrichSpan(span, auditEntries));
+}
+
+function enrichSpan(span: OtelSpan, auditEntries: CollectedAuditEntry[]): OtelSpan {
+  const raw = span.attributes["gen_ai.tool.call.arguments"];
+  if (!Array.isArray(raw) || raw.length === 0) return span;
+
+  // Every tool-call argument gets a source marker; enrichment upgrades matched
+  // ones to "audit" below.
+  const calls: ToolCallArg[] = raw.map((c) => ({
+    ...(c as ToolCallArg),
+    argsSource: "trajectory",
+  }));
+
+  const windowStart = span.startTime ? Date.parse(span.startTime) : NaN;
+  const windowEnd = span.endTime ? Date.parse(span.endTime) : NaN;
+  const hasWindow = Number.isFinite(windowStart) && Number.isFinite(windowEnd);
+
+  if (hasWindow) {
+    const candidatesByName = collectCandidates(auditEntries, windowStart, windowEnd);
+    const callsByName = groupBy(calls, (c) => (typeof c.name === "string" ? c.name : undefined));
+
+    for (const [name, callsOfName] of callsByName) {
+      const candidates = candidatesByName.get(name) ?? [];
+      matchToolCalls(callsOfName, candidates);
+    }
+  }
+
+  return {
+    ...span,
+    attributes: { ...span.attributes, "gen_ai.tool.call.arguments": calls },
+  };
+}
+
+// Audit rows for one span's time window, grouped by tool name and ordered by
+// timestamp so positional alignment is deterministic.
+function collectCandidates(
+  auditEntries: CollectedAuditEntry[],
+  windowStart: number,
+  windowEnd: number
+): Map<string, CollectedAuditEntry[]> {
+  const byName = new Map<string, CollectedAuditEntry[]>();
+  for (const entry of auditEntries) {
+    if (typeof entry.eventType !== "string" || !entry.eventType.startsWith(TOOL_EVENT_PREFIX)) {
+      continue;
+    }
+    if (usableParams(entry.detail) === null) continue;
+    const t =
+      entry.timestamp instanceof Date
+        ? entry.timestamp.getTime()
+        : Date.parse(String(entry.timestamp));
+    if (!Number.isFinite(t) || t < windowStart || t > windowEnd) continue;
+    const name = entry.eventType.slice(TOOL_EVENT_PREFIX.length);
+    const list = byName.get(name);
+    if (list) list.push(entry);
+    else byName.set(name, [entry]);
+  }
+  for (const list of byName.values()) {
+    list.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
+  }
+  return byName;
+}
+
+// Copy an audit row's `params` onto a tool call, stamping it enriched. The
+// params are re-sanitized from their own root here: once embedded in the bundle
+// they'd sit ~6 levels deep, where `sanitizeBundle`'s depth-10 guard barely
+// reaches into them, so we scrub at depth-0 to match the write-time guarantee
+// rather than rely on the shallower bundle-level pass. `sanitizeDetail` returns
+// a fresh object, so the shared audit `detail.params` is never mutated.
+function applyAuditParams(call: ToolCallArg, detail: unknown): void {
+  call.arguments = sanitizeDetail(usableParams(detail));
+  call.argsSource = "audit";
+}
+
+// For a single tool name:
+//   - Preferred (audit rows written since #640 carry `toolCallId`): match each
+//     truncated call to its row by id. Order-independent and session-safe — ids
+//     are unique per call, so a concurrent chat's row can't be mismatched in.
+//   - Legacy fallback (rows predating the id, e.g. an already-captured bundle):
+//     positional alignment within the span's time window, guarded by a strict
+//     count check. This is a heuristic, not a guarantee: `fetchAuditEntriesForSession`
+//     scopes rows by agent + user + time only (no chat/session discriminator),
+//     so with two concurrent same-agent chats a coincidental count match could
+//     misalign. The window is one narrow turn, so the collision needs a double
+//     coincidence; we accept it for legacy rows rather than fabricate. New rows
+//     take the id path and avoid it entirely.
+function matchToolCalls(callsOfName: ToolCallArg[], candidates: CollectedAuditEntry[]): void {
+  const markerCalls = callsOfName.filter((c) => containsDepthLimitMarker(c.arguments));
+  if (markerCalls.length === 0) return;
+
+  const candidatesHaveIds =
+    candidates.length > 0 && candidates.every((c) => detailToolCallId(c) !== undefined);
+  if (candidatesHaveIds) {
+    const byId = new Map<string, CollectedAuditEntry>();
+    for (const c of candidates) byId.set(detailToolCallId(c)!, c);
+    const everyMarkerHasId = markerCalls.every(
+      (call) => typeof call.id === "string" && byId.has(call.id)
+    );
+    if (everyMarkerHasId) {
+      for (const call of markerCalls) {
+        applyAuditParams(call, byId.get(call.id as string)!.detail);
+      }
+      return;
+    }
+    // Ids present but not a full cover — fall through to positional.
+  }
+
+  // Positional: the audit log records every call, so the number of usable
+  // candidates must equal the total number of same-tool calls in the span for
+  // the alignment to be unambiguous. Otherwise we keep the markers. Candidates
+  // are timestamp-ordered and calls execute sequentially, so nth call ↔ nth
+  // row; consume them as a queue so each call maps to its positional peer
+  // without index arithmetic.
+  if (callsOfName.length !== candidates.length) return;
+  const queue = [...candidates];
+  for (const call of callsOfName) {
+    const candidate = queue.shift();
+    if (candidate === undefined) continue;
+    if (!containsDepthLimitMarker(call.arguments)) continue;
+    applyAuditParams(call, candidate.detail);
+  }
+}
+
+function groupBy<T>(items: T[], keyOf: (item: T) => string | undefined): Map<string, T[]> {
+  const map = new Map<string, T[]>();
+  for (const item of items) {
+    const key = keyOf(item);
+    if (key === undefined) continue;
+    const list = map.get(key);
+    if (list) list.push(item);
+    else map.set(key, [item]);
+  }
+  return map;
+}

--- a/packages/web/src/lib/diagnostics/enrich-tool-args.ts
+++ b/packages/web/src/lib/diagnostics/enrich-tool-args.ts
@@ -144,6 +144,10 @@ function collectCandidates(
     if (list) list.push(entry);
     else byName.set(name, [entry]);
   }
+  // Stable sort by timestamp. Entries arrive already ordered by (timestamp,
+  // row id) from the collector query, and Array.prototype.sort is stable, so
+  // equal-timestamp rows keep their insertion-order (= execution-order)
+  // sequence rather than being reshuffled.
   for (const list of byName.values()) {
     list.sort((a, b) => a.timestamp.getTime() - b.timestamp.getTime());
   }
@@ -163,16 +167,19 @@ function applyAuditParams(call: ToolCallArg, detail: unknown): void {
 
 // For a single tool name:
 //   - Preferred (audit rows written since #640 carry `toolCallId`): match each
-//     truncated call to its row by id. Order-independent and session-safe — ids
-//     are unique per call, so a concurrent chat's row can't be mismatched in.
+//     truncated call to its row strictly by id. This is the ONLY path taken once
+//     any usable candidate carries an id — a marker call whose id isn't present
+//     keeps its marker rather than falling back to positional guessing. That
+//     matters because `fetchAuditEntriesForSession` scopes rows by agent + user
+//     + time only (no chat discriminator), so a positional guess could pull in a
+//     concurrent same-agent chat's same-tool row. Ids are unique per call, so
+//     the id path can never mismatch across sessions.
 //   - Legacy fallback (rows predating the id, e.g. an already-captured bundle):
 //     positional alignment within the span's time window, guarded by a strict
-//     count check. This is a heuristic, not a guarantee: `fetchAuditEntriesForSession`
-//     scopes rows by agent + user + time only (no chat/session discriminator),
-//     so with two concurrent same-agent chats a coincidental count match could
-//     misalign. The window is one narrow turn, so the collision needs a double
-//     coincidence; we accept it for legacy rows rather than fabricate. New rows
-//     take the id path and avoid it entirely.
+//     count check. Candidates are ordered by (timestamp, audit-row id), so nth
+//     call ↔ nth row holds even for equal-timestamp calls. This remains a
+//     heuristic for the narrow concurrent-chat case, but only legacy id-less
+//     rows can reach it; anything captured since #640 takes the id path above.
 function matchToolCalls(callsOfName: ToolCallArg[], candidates: CollectedAuditEntry[]): void {
   const markerCalls = callsOfName.filter((c) => containsDepthLimitMarker(c.arguments));
   if (markerCalls.length === 0) return;
@@ -182,24 +189,22 @@ function matchToolCalls(callsOfName: ToolCallArg[], candidates: CollectedAuditEn
   if (candidatesHaveIds) {
     const byId = new Map<string, CollectedAuditEntry>();
     for (const c of candidates) byId.set(detailToolCallId(c)!, c);
-    const everyMarkerHasId = markerCalls.every(
-      (call) => typeof call.id === "string" && byId.has(call.id)
-    );
-    if (everyMarkerHasId) {
-      for (const call of markerCalls) {
-        applyAuditParams(call, byId.get(call.id as string)!.detail);
-      }
-      return;
+    for (const call of markerCalls) {
+      const id = typeof call.id === "string" ? call.id : undefined;
+      const match = id !== undefined ? byId.get(id) : undefined;
+      // No id match ⇒ this call's own row is absent. Keep the marker; do NOT
+      // guess positionally, which could inject a concurrent chat's params.
+      if (match) applyAuditParams(call, match.detail);
     }
-    // Ids present but not a full cover — fall through to positional.
+    return;
   }
 
   // Positional: the audit log records every call, so the number of usable
   // candidates must equal the total number of same-tool calls in the span for
   // the alignment to be unambiguous. Otherwise we keep the markers. Candidates
-  // are timestamp-ordered and calls execute sequentially, so nth call ↔ nth
-  // row; consume them as a queue so each call maps to its positional peer
-  // without index arithmetic.
+  // are (timestamp, row-id) ordered — insertion order under the audit chain lock
+  // is execution order — so nth call ↔ nth row; consume them as a queue so each
+  // call maps to its positional peer without index arithmetic.
   if (callsOfName.length !== candidates.length) return;
   const queue = [...candidates];
   for (const call of callsOfName) {


### PR DESCRIPTION
## What does this PR do?

In a diagnostics bundle, OpenClaw's trajectory capture caps nested tool-call arguments at depth 6 and replaces them with a `{ truncated: true, reason: "trajectory-depth-limit", limitDepth: 6 }` marker — so exactly the payloads a bundle exists to explain (`odoo_create` `values`, `odoo_read` `filters`, `odoo_delete` `ids`) come out unreadable.

Pinchy already holds a fuller copy of the same arguments: `pinchy-audit` records tool `params` sanitized at depth 10. This PR adds a **read-side enrichment step** that swaps a depth-limit marker for the matching audit `params` when it can match unambiguously, and stamps every tool-call argument with `argsSource: "audit" | "trajectory"` so a reader knows which calls were enriched.

**Matching**
- **Preferred — exact `toolCallId`.** The tool-use audit route now persists the call's `toolCallId` in `detail` (an opaque per-call correlation id, not a secret). Matching is then order- and session-independent for bundles captured from here on.
- **Legacy fallback** (rows predating the id, e.g. an already-captured 0.7.0 bundle): positional alignment within the span's time window, guarded by a strict `n === m` count check. Documented as a heuristic — when ambiguous or unmatched, the marker is **kept, never fabricated**.

**Redaction** — injected `params` are re-sanitized from their own root as they are injected, matching the write-time depth-10 guarantee rather than relying on the shallower bundle-level `sanitizeBundle` pass (enriched args sit ~6 levels deep in the bundle). Enrichment runs **before** sanitize + the 5 MB size cap.

**Verification (the issue asks to verify first):** two independent truncation axes — trajectory caps by nesting *depth* (6), audit caps by *byte size* (2048). Enrichment recovers the common case (deeply-nested-but-small payloads). When the audit row itself was byte-cap truncated it carries no structured `params`, so the marker is kept; the real fix for oversized payloads is an upstream OpenClaw change to the trajectory depth cap.

Closes #640

### Reviewer notes
- Depends conceptually on #639 (chat-scope). **No file overlap** (this touches `enrich-tool-args.ts` / `export/route.ts` / `tool-use/route.ts`; #639 touches `route.ts` / schemas / dialog). Rebase on #639 when it lands — not stacked.
- The `toolCallId` addition to the tool-use audit `detail` is additive (~a few dozen bytes, no PII). Existing exact-shape assertions were updated accordingly.

## Type of change

- [ ] 🐛 Bug fix
- [x] ✨ New feature
- [x] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

<sub>Gates run locally: diagnostics suite + tool-use route (125 tests), enrich-tool-args (16 tests), `tsc --noEmit`, ESLint, Prettier, docs build — all green. TDD throughout.</sub>