### PR TITLE
fix(diagnostics): export any of the user's own chats + graceful degrade (#639)

### DIFF
--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -26,6 +26,8 @@ If you have more than one conversation with an agent, the dialog lets you pick w
 
 When you open the dialog from a specific conversation, that chat is preselected; from Settings, the agent's default chat is preselected. If a chat's transcript is no longer on disk, we still produce a valid file from the audit-log entries alone and flag it (`scope.trajectoryMissing`), so support can tell an absent transcript apart from an empty one.
 
+For Telegram chats the export includes the conversation transcript, but the audit-log section is currently limited — audit entries are attributed to your web account, so a Telegram chat's file may ship without them. The transcript is still the primary signal for debugging.
+
 ## Two ways to start
 
 ### From an agent reply

--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -20,6 +20,12 @@ The diagnostics export is a single JSON file that captures:
 
 Secrets are filtered out before the file is generated. API keys, Bearer tokens, and any values under sensitive keys (`password`, `apikey`, `authorization`, and friends) are automatically redacted, and the OpenClaw `sessionKey` is hashed with SHA-256 so it can't be replayed. Your agent's instructions are never written into the file — only a hash of them, so we can spot when they've changed without reading your custom prompt.
 
+## Choosing which chat to export
+
+If you have more than one conversation with an agent, the dialog lets you pick which one to export. The selector lists all of your own chats with that agent — including named chats and read-only Telegram conversations linked to your account. You can only export your own chats.
+
+When you open the dialog from a specific conversation, that chat is preselected; from Settings, the agent's default chat is preselected. If a chat's transcript is no longer on disk, we still produce a valid file from the audit-log entries alone and flag it (`scope.trajectoryMissing`), so support can tell an absent transcript apart from an empty one.
+
 ## Two ways to start
 
 ### From an agent reply
@@ -39,6 +45,7 @@ If the issue isn't tied to one reply — say the agent feels generally slow, or 
 1. Open **Settings → Support**.
 2. Pick the agent the issue is about (if more than one is accessible).
 3. Click **Generate diagnostics export**.
+4. Choose the chat to export in the dialog (the default chat is preselected).
 
 The same dialog appears as the per-message flow.
 

--- a/packages/web/e2e/integration/diagnostics-export.spec.ts
+++ b/packages/web/e2e/integration/diagnostics-export.spec.ts
@@ -100,6 +100,13 @@ test.describe.serial("Self-service diagnostics export", () => {
     await expect(openDialogButton).toBeVisible({ timeout: 10000 });
     await openDialogButton.click();
 
+    // The chat picker (#639) renders once the user's chats load — at minimum the
+    // default chat the seed turn created. Waiting for it also makes the export
+    // deterministic (the default chat is preselected and its sessionId sent).
+    await expect(page.getByRole("combobox", { name: /chat to export/i })).toBeVisible({
+      timeout: 10000,
+    });
+
     const download = await clickDialogGenerateAndAwaitDownload(page);
     expect(download.suggestedFilename()).toMatch(/^pinchy-bugreport-.+\.json$/);
 

--- a/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
@@ -11,9 +11,9 @@
 // Everything else (Drizzle agent lookup, agent-access enforcement, audit
 // writes via appendAuditLog -> auditLog table) runs for real.
 
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { NextRequest } from "next/server";
-import { and, eq, desc } from "drizzle-orm";
+import { eq, desc } from "drizzle-orm";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -154,6 +154,14 @@ describe("POST /api/diagnostics/export (integration)", () => {
     vi.clearAllMocks();
     vi.mocked(resolveSessionId).mockResolvedValue("ses_FIXTURE_SESSION_0001");
     vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
+  });
+
+  // Drain every test's deferred audit writes (deferAuditLog -> after()) before
+  // the next test's beforeEach truncate, so an un-awaited write from one test
+  // can't race into another's table state. Without this, audit-row assertions
+  // would need per-test actorId scoping to stay deterministic.
+  afterEach(async () => {
+    await flushAfter();
   });
 
   it("returns 401 when there is no session", async () => {
@@ -475,14 +483,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
       expect(response.status).toBe(200);
       await flushAfter();
 
-      // Scope to THIS test's actor: prior successful exports in this block
-      // schedule their audit writes via after() without flushing, and those
-      // can land after this test's beforeEach truncate. Each test seeds a fresh
-      // user, so filtering by actorId isolates the row we asserted on.
       const rows = await db
         .select()
         .from(auditLog)
-        .where(and(eq(auditLog.eventType, "diagnostics.exported"), eq(auditLog.actorId, owner.id)))
+        .where(eq(auditLog.eventType, "diagnostics.exported"))
         .orderBy(desc(auditLog.timestamp));
       expect(rows).toHaveLength(1);
       const detail = rows[0].detail as Record<string, unknown>;

--- a/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
@@ -13,7 +13,7 @@
 
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
-import { eq, desc } from "drizzle-orm";
+import { and, eq, desc } from "drizzle-orm";
 import { readFileSync } from "node:fs";
 import { join } from "node:path";
 
@@ -79,12 +79,26 @@ vi.mock("@/lib/diagnostics/jsonl-reader", async () => {
   };
 });
 
+// The chat enumeration (#639 selector path) hits OpenClaw's sessions.list;
+// mock it so tests can hand the route a deterministic, already-authorized set
+// of the user's own chats. The default (no-selector) path never calls it.
+vi.mock("@/lib/chats/list-user-agent-chats", () => ({
+  listUserAgentChats: vi.fn(),
+}));
+
+import { createHash } from "node:crypto";
 import { db } from "@/db";
 import { agents, auditLog, users } from "@/db/schema";
 import { auth } from "@/lib/auth";
 import { getSession } from "@/lib/auth";
 import { resolveSessionId, readTrajectoryJsonl } from "@/lib/diagnostics/jsonl-reader";
+import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
+import { TrajectoryFileNotFoundError } from "@/lib/diagnostics/jsonl-reader";
 import { POST } from "@/app/api/diagnostics/export/route";
+
+function sessionKeyHash(key: string) {
+  return "sha256:" + createHash("sha256").update(key).digest("hex");
+}
 
 async function seedUser(email = "user@test.local", role = "member") {
   const result = await auth.api.signUpEmail({
@@ -291,5 +305,229 @@ describe("POST /api/diagnostics/export (integration)", () => {
     const bundle = await response.json();
     expect(bundle.spans).toEqual([]);
     expect(bundle.scope.includedTurnRange).toEqual([0, -1]);
+  });
+
+  // ── #639: per-chat + Telegram selector, graceful degrade ─────────────────
+
+  describe("sessionId selector (#639)", () => {
+    it("resolves the SELECTED named chat's trajectory, not the default", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+
+      const namedKey = `agent:${agent.id}:direct:${owner.id}:chat-new`;
+      vi.mocked(listUserAgentChats).mockResolvedValue({
+        chats: [
+          {
+            sessionId: "s-legacy",
+            key: `agent:${agent.id}:direct:${owner.id}`,
+            origin: "web",
+            writable: true,
+            chatId: null,
+            lastInteractionAt: 1000,
+          },
+          {
+            sessionId: "s-named",
+            key: namedKey,
+            origin: "web",
+            writable: true,
+            chatId: "chat-new",
+            lastInteractionAt: 5000,
+          },
+        ],
+        labelByKey: new Map(),
+      });
+      // Fail loudly if the route ever falls back to resolveSessionId here.
+      vi.mocked(resolveSessionId).mockResolvedValue("s-legacy");
+      vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
+
+      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      expect(response.status).toBe(200);
+      const bundle = await response.json();
+
+      // The trajectory was read for the NAMED session, and the bundle's
+      // hashed key is the named chat's key — not the default.
+      expect(vi.mocked(readTrajectoryJsonl)).toHaveBeenCalledWith(agent.id, "s-named");
+      expect(bundle.scope.sessionKeyHash).toBe(sessionKeyHash(namedKey));
+      expect(vi.mocked(resolveSessionId)).not.toHaveBeenCalled();
+    });
+
+    it("exports a linked Telegram chat selected by sessionId", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+
+      const tgKey = `agent:${agent.id}:direct:tg-peer-1`;
+      vi.mocked(listUserAgentChats).mockResolvedValue({
+        chats: [
+          {
+            sessionId: "s-tg",
+            key: tgKey,
+            origin: "telegram",
+            writable: false,
+            chatId: null,
+            lastInteractionAt: 3000,
+          },
+        ],
+        labelByKey: new Map(),
+      });
+      vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
+
+      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-tg" }));
+      expect(response.status).toBe(200);
+      const bundle = await response.json();
+      expect(vi.mocked(readTrajectoryJsonl)).toHaveBeenCalledWith(agent.id, "s-tg");
+      expect(bundle.scope.sessionKeyHash).toBe(sessionKeyHash(tgKey));
+    });
+
+    it("returns 404 when the selected sessionId is not one of the user's chats", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+      vi.mocked(listUserAgentChats).mockResolvedValue({ chats: [], labelByKey: new Map() });
+
+      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-someone-else" }));
+      expect(response.status).toBe(404);
+      expect(vi.mocked(readTrajectoryJsonl)).not.toHaveBeenCalled();
+    });
+
+    it("degrades to trajectoryMissing=true (not 404) when the selected chat's trajectory file is gone", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+
+      vi.mocked(listUserAgentChats).mockResolvedValue({
+        chats: [
+          {
+            sessionId: "s-named",
+            key: `agent:${agent.id}:direct:${owner.id}:chat-new`,
+            origin: "web",
+            writable: true,
+            chatId: "chat-new",
+            lastInteractionAt: 5000,
+          },
+        ],
+        labelByKey: new Map(),
+      });
+      vi.mocked(readTrajectoryJsonl).mockRejectedValue(
+        new TrajectoryFileNotFoundError("/gone.jsonl")
+      );
+
+      // An audit row for this user+agent must still make it into the bundle.
+      await db.insert(auditLog).values({
+        actorType: "user",
+        actorId: owner.id,
+        eventType: "tool.pinchy_ls",
+        resource: `agent:${agent.id}`,
+        detail: { agentId: agent.id },
+        outcome: "success",
+        rowHmac: "test-placeholder-hmac",
+        timestamp: new Date("2026-05-19T12:15:00Z"),
+      });
+
+      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      expect(response.status).toBe(200);
+      const bundle = await response.json();
+      expect(bundle.scope.trajectoryMissing).toBe(true);
+      expect(bundle.spans).toEqual([]);
+      const toolEntries = (bundle.auditEntries as Array<{ eventType: string }>).filter((e) =>
+        e.eventType.startsWith("tool.")
+      );
+      expect(toolEntries).toHaveLength(1);
+    });
+
+    it("degrades the DEFAULT chat too when its trajectory file is gone (was 404)", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+      vi.mocked(resolveSessionId).mockResolvedValue("ses_default");
+      vi.mocked(readTrajectoryJsonl).mockRejectedValue(
+        new TrajectoryFileNotFoundError("/gone.jsonl")
+      );
+
+      const response = await POST(makeRequest({ agentId: agent.id }));
+      expect(response.status).toBe(200);
+      const bundle = await response.json();
+      expect(bundle.scope.trajectoryMissing).toBe(true);
+    });
+
+    it("records the exported chatId and trajectoryMissing in the audit entry", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+
+      vi.mocked(listUserAgentChats).mockResolvedValue({
+        chats: [
+          {
+            sessionId: "s-named",
+            key: `agent:${agent.id}:direct:${owner.id}:chat-new`,
+            origin: "web",
+            writable: true,
+            chatId: "chat-new",
+            lastInteractionAt: 5000,
+          },
+        ],
+        labelByKey: new Map(),
+      });
+      vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
+
+      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      expect(response.status).toBe(200);
+      await flushAfter();
+
+      // Scope to THIS test's actor: prior successful exports in this block
+      // schedule their audit writes via after() without flushing, and those
+      // can land after this test's beforeEach truncate. Each test seeds a fresh
+      // user, so filtering by actorId isolates the row we asserted on.
+      const rows = await db
+        .select()
+        .from(auditLog)
+        .where(and(eq(auditLog.eventType, "diagnostics.exported"), eq(auditLog.actorId, owner.id)))
+        .orderBy(desc(auditLog.timestamp));
+      expect(rows).toHaveLength(1);
+      const detail = rows[0].detail as Record<string, unknown>;
+      expect(detail.chatId).toBe("chat-new");
+      expect(detail.trajectoryMissing).toBe(false);
+    });
+
+    it("exports BOTH a pre-#508 default-only session AND a new per-chat session (migration)", async () => {
+      const owner = await seedUser();
+      mockSession(owner);
+      const agent = await seedPersonalAgent(owner.id);
+
+      const legacyKey = `agent:${agent.id}:direct:${owner.id}`;
+      const namedKey = `agent:${agent.id}:direct:${owner.id}:chat-new`;
+      // Same index carries the OLD default-only chat and the NEW per-chat one.
+      vi.mocked(listUserAgentChats).mockResolvedValue({
+        chats: [
+          {
+            sessionId: "s-legacy",
+            key: legacyKey,
+            origin: "web",
+            writable: true,
+            chatId: null,
+            lastInteractionAt: 1000,
+          },
+          {
+            sessionId: "s-named",
+            key: namedKey,
+            origin: "web",
+            writable: true,
+            chatId: "chat-new",
+            lastInteractionAt: 5000,
+          },
+        ],
+        labelByKey: new Map(),
+      });
+      vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
+
+      const legacyRes = await POST(makeRequest({ agentId: agent.id, sessionId: "s-legacy" }));
+      expect(legacyRes.status).toBe(200);
+      expect((await legacyRes.json()).scope.sessionKeyHash).toBe(sessionKeyHash(legacyKey));
+
+      const namedRes = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      expect(namedRes.status).toBe(200);
+      expect((await namedRes.json()).scope.sessionKeyHash).toBe(sessionKeyHash(namedKey));
+    });
   });
 });

--- a/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
@@ -5,6 +5,9 @@ import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog"
 
 vi.mock("@/lib/api-client", () => ({
   apiPost: vi.fn(async () => ({ schemaVersion: "pinchy.bugreport.v1" })),
+  // The chat picker (#639) fetches the user's chats on open. Default to an
+  // empty list so the legacy tests below export the default chat (no sessionId).
+  apiGet: vi.fn(async () => ({ chats: [] })),
   ApiError: class ApiError extends Error {
     constructor(
       public readonly status: number,
@@ -31,11 +34,13 @@ vi.mock("sonner", () => ({
 
 describe("DiagnosticsExportDialog", () => {
   beforeEach(async () => {
-    const { apiPost } = await import("@/lib/api-client");
+    const { apiPost, apiGet } = await import("@/lib/api-client");
     const { downloadBundle, buildBundleFilename } = await import("@/lib/diagnostics/download");
     const { toast } = await import("sonner");
     vi.mocked(apiPost).mockClear();
     vi.mocked(apiPost).mockResolvedValue({ schemaVersion: "pinchy.bugreport.v1" });
+    vi.mocked(apiGet).mockReset();
+    vi.mocked(apiGet).mockResolvedValue({ chats: [] });
     vi.mocked(downloadBundle).mockClear();
     vi.mocked(buildBundleFilename).mockClear();
     vi.mocked(buildBundleFilename).mockReturnValue("pinchy-bugreport-smithers-19700101-0000.json");
@@ -148,5 +153,95 @@ describe("DiagnosticsExportDialog", () => {
       "pinchy-bugreport-smithers-19700101-0000.json"
     );
     await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
+  // ── #639: chat picker + context-aware default selection ──────────────────
+
+  const CHATS = [
+    {
+      chatId: null,
+      sessionId: "s-default",
+      origin: "web" as const,
+      writable: true,
+      title: "Default chat",
+      lastInteractionAt: 1000,
+    },
+    {
+      chatId: "chat-x",
+      sessionId: "s-x",
+      origin: "web" as const,
+      writable: true,
+      title: "Quarterly report",
+      lastInteractionAt: 5000,
+    },
+    {
+      chatId: null,
+      sessionId: "s-tg",
+      origin: "telegram" as const,
+      writable: false,
+      title: "Telegram chat",
+      lastInteractionAt: 3000,
+    },
+  ];
+
+  it("renders a chat selector populated from the chats API", async () => {
+    const { apiGet } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    expect(await screen.findByRole("combobox", { name: /chat/i })).toBeInTheDocument();
+    expect(apiGet).toHaveBeenCalledWith("/api/agents/agt_1/chats");
+  });
+
+  it("exports the default chat's sessionId when launched from Settings (no chat context)", async () => {
+    const { apiGet, apiPost } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    await screen.findByRole("combobox", { name: /chat/i });
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith("/api/diagnostics/export", {
+        agentId: "agt_1",
+        sessionId: "s-default",
+      })
+    );
+  });
+
+  it("preselects and exports the active chat's sessionId from chat context", async () => {
+    const { apiGet, apiPost } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });
+    render(
+      <DiagnosticsExportDialog
+        open
+        agentId="agt_1"
+        agentName="Smithers"
+        chatId="chat-x"
+        onClose={() => {}}
+      />
+    );
+    await screen.findByRole("combobox", { name: /chat/i });
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith("/api/diagnostics/export", {
+        agentId: "agt_1",
+        sessionId: "s-x",
+      })
+    );
+  });
+
+  it("falls back to a default export (no sessionId) when the chats list fails to load", async () => {
+    const { apiGet, apiPost } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockRejectedValue(new Error("chats unreachable"));
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    // No selector renders when the list is empty/unavailable; Generate still works.
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith("/api/diagnostics/export", { agentId: "agt_1" })
+    );
   });
 });

--- a/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
@@ -232,6 +232,43 @@ describe("DiagnosticsExportDialog", () => {
     );
   });
 
+  it("falls back to the most-recent chat when no chat matches the active/default (avoids a silent wrong-chat/404 export)", async () => {
+    const { apiGet, apiPost } = await import("@/lib/api-client");
+    // Settings launch (no chatId) but the user has NO default web chat — only a
+    // named chat and a Telegram chat. Server returns most-recent first.
+    vi.mocked(apiGet).mockResolvedValue({
+      chats: [
+        {
+          chatId: "chat-x",
+          sessionId: "s-x",
+          origin: "web" as const,
+          writable: true,
+          title: "Quarterly report",
+          lastInteractionAt: 5000,
+        },
+        {
+          chatId: null,
+          sessionId: "s-tg",
+          origin: "telegram" as const,
+          writable: false,
+          title: "Telegram chat",
+          lastInteractionAt: 3000,
+        },
+      ],
+    });
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    await screen.findByRole("combobox", { name: /chat/i });
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith("/api/diagnostics/export", {
+        agentId: "agt_1",
+        sessionId: "s-x",
+      })
+    );
+  });
+
   it("falls back to a default export (no sessionId) when the chats list fails to load", async () => {
     const { apiGet, apiPost } = await import("@/lib/api-client");
     vi.mocked(apiGet).mockRejectedValue(new Error("chats unreachable"));

--- a/packages/web/src/__tests__/components/thread-report-issue.test.tsx
+++ b/packages/web/src/__tests__/components/thread-report-issue.test.tsx
@@ -143,6 +143,7 @@ vi.mock("@/components/chat", async () => {
   return {
     AgentAvatarContext: React.createContext<string | null>(null),
     AgentIdContext: React.createContext<string | null>(null),
+    ChatIdContext: React.createContext<string | null>(null),
     AgentNameContext: React.createContext<string | null>(null),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),
     RetryContinueContext: React.createContext<() => void>(() => {}),

--- a/packages/web/src/__tests__/lib/chats/list-user-agent-chats.test.ts
+++ b/packages/web/src/__tests__/lib/chats/list-user-agent-chats.test.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mocks ────────────────────────────────────────────────────────────────
+
+const mockList = vi.fn();
+vi.mock("@/server/openclaw-client", () => ({
+  getOpenClawClient: () => ({ sessions: { list: mockList } }),
+}));
+
+const mockWhere = vi.fn();
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockReturnValue({
+      from: vi.fn().mockReturnValue({
+        where: (...args: unknown[]) => mockWhere(...args),
+      }),
+    }),
+  },
+}));
+
+import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
+
+// ── Fixtures ─────────────────────────────────────────────────────────────
+
+/**
+ * A mixed `sessions.list` payload spanning every classification branch. The
+ * user is `user-1`; their linked Telegram peer is `tg-peer-111`.
+ */
+function mixedSessions() {
+  return {
+    sessions: [
+      {
+        key: "agent:agent-1:direct:user-1:chat-abc",
+        sessionId: "s-web-new",
+        label: "Quarterly report",
+        lastInteractionAt: 5000,
+      },
+      { key: "agent:agent-1:direct:user-1", sessionId: "s-web-legacy", lastInteractionAt: 1000 },
+      {
+        key: "agent:agent-1:direct:tg-peer-111",
+        sessionId: "s-telegram",
+        label: "Telegram chat",
+        lastInteractionAt: 3000,
+      },
+      // excluded: another user, unlinked peer, cron, subagent, other agent
+      { key: "agent:agent-1:direct:user-2:chat-zzz", sessionId: "s-other-user" },
+      { key: "agent:agent-1:direct:tg-peer-999", sessionId: "s-unlinked-peer" },
+      { key: "agent:agent-1:cron:nightly", sessionId: "s-cron" },
+      { key: "agent:agent-2:direct:user-1:chat-other", sessionId: "s-other-agent" },
+    ],
+  };
+}
+
+// ── Tests ────────────────────────────────────────────────────────────────
+
+describe("listUserAgentChats", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockWhere.mockResolvedValue([
+      { channel: "telegram", userId: "user-1", channelUserId: "tg-peer-111" },
+    ]);
+    mockList.mockResolvedValue(mixedSessions());
+  });
+
+  it("returns only the user's own web + telegram chats for this agent", async () => {
+    const { chats } = await listUserAgentChats("agent-1", "user-1");
+    const ids = chats.map((c) => c.sessionId).sort();
+    expect(ids).toEqual(["s-telegram", "s-web-legacy", "s-web-new"]);
+  });
+
+  it("classifies web chats writable and telegram read-only, with chatId", async () => {
+    const { chats } = await listUserAgentChats("agent-1", "user-1");
+    const byId = new Map(chats.map((c) => [c.sessionId, c]));
+    expect(byId.get("s-web-new")).toMatchObject({
+      origin: "web",
+      writable: true,
+      chatId: "chat-abc",
+    });
+    expect(byId.get("s-web-legacy")).toMatchObject({ origin: "web", chatId: null });
+    expect(byId.get("s-telegram")).toMatchObject({ origin: "telegram", writable: false });
+  });
+
+  it("exposes labels keyed by session key for callers that derive titles", async () => {
+    const { labelByKey } = await listUserAgentChats("agent-1", "user-1");
+    expect(labelByKey.get("agent:agent-1:direct:user-1:chat-abc")).toBe("Quarterly report");
+    expect(labelByKey.get("agent:agent-1:direct:user-1")).toBeNull();
+  });
+
+  it("propagates OpenClaw failures so callers can map them to 502", async () => {
+    mockList.mockRejectedValueOnce(new Error("OpenClaw WS disconnected"));
+    await expect(listUserAgentChats("agent-1", "user-1")).rejects.toThrow();
+  });
+});

--- a/packages/web/src/__tests__/lib/diagnostics/audit-collector.integration.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/audit-collector.integration.test.ts
@@ -167,4 +167,32 @@ describe("fetchAuditEntriesForSession (integration)", () => {
     const rows = await fetchAuditEntriesForSession(agentId, userId);
     expect(rows).toHaveLength(2);
   });
+
+  it("caps to the NEWEST `limit` rows, still returned chronologically", async () => {
+    const agentId = "agt_limit";
+    const userId = "user_limit";
+    await insertAuditAt({
+      agentId,
+      userId,
+      eventType: "tool.oldest",
+      timestamp: new Date("2026-01-01T10:00:00Z"),
+    });
+    await insertAuditAt({
+      agentId,
+      userId,
+      eventType: "tool.middle",
+      timestamp: new Date("2026-01-01T11:00:00Z"),
+    });
+    await insertAuditAt({
+      agentId,
+      userId,
+      eventType: "tool.newest",
+      timestamp: new Date("2026-01-01T12:00:00Z"),
+    });
+
+    // limit=2 keeps the two most recent rows and drops the oldest, but the
+    // result stays oldest→newest so it reads like a transcript window.
+    const rows = await fetchAuditEntriesForSession(agentId, userId, undefined, 2);
+    expect(rows.map((r) => r.eventType)).toEqual(["tool.middle", "tool.newest"]);
+  });
 });

--- a/packages/web/src/__tests__/lib/diagnostics/bundle-builder.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/bundle-builder.test.ts
@@ -68,4 +68,16 @@ describe("buildBundle", () => {
     const b = buildBundle(baseInput);
     expect(b.agentConfig).toEqual(agentConfig);
   });
+
+  it("defaults trajectoryMissing to false", () => {
+    expect(buildBundle(baseInput).scope.trajectoryMissing).toBe(false);
+  });
+
+  it("carries trajectoryMissing=true through when the trajectory file was absent", () => {
+    const b = buildBundle({
+      ...baseInput,
+      scope: { ...baseInput.scope, trajectoryMissing: true },
+    });
+    expect(b.scope.trajectoryMissing).toBe(true);
+  });
 });

--- a/packages/web/src/__tests__/lib/schemas/diagnostics.test.ts
+++ b/packages/web/src/__tests__/lib/schemas/diagnostics.test.ts
@@ -28,4 +28,28 @@ describe("diagnosticsExportRequestSchema", () => {
     const r = diagnosticsExportRequestSchema.safeParse({});
     expect(r.success).toBe(false);
   });
+
+  it("accepts a sessionId selector for a specific chat", () => {
+    const r = diagnosticsExportRequestSchema.safeParse({
+      agentId: "agt_1",
+      sessionId: "ses_FIXTURE_SESSION_0001",
+    });
+    expect(r.success).toBe(true);
+  });
+
+  it("rejects a malformed sessionId (contains a colon)", () => {
+    const r = diagnosticsExportRequestSchema.safeParse({
+      agentId: "agt_1",
+      sessionId: "agent:agt_1:direct:usr_1",
+    });
+    expect(r.success).toBe(false);
+  });
+
+  it("rejects a sessionId with a path separator", () => {
+    const r = diagnosticsExportRequestSchema.safeParse({
+      agentId: "agt_1",
+      sessionId: "../../etc/passwd",
+    });
+    expect(r.success).toBe(false);
+  });
 });

--- a/packages/web/src/app/api/agents/[agentId]/chats/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/chats/route.ts
@@ -1,14 +1,11 @@
 import { NextResponse } from "next/server";
-import { and, eq } from "drizzle-orm";
 import { withAuth } from "@/lib/api-auth";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { getOpenClawClient } from "@/server/openclaw-client";
-import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
 import { firstUserMessageTitle } from "@/lib/chats/first-user-message-title";
 import type { RawHistoryMessage } from "@/lib/chats/telegram-transcript";
 import type { ChatListItem } from "@/lib/schemas/sessions";
-import { db } from "@/db";
-import { channelLinks } from "@/db/schema";
 
 type RouteContext = { params: Promise<{ agentId: string }> };
 
@@ -66,34 +63,16 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
 
   const userId = session.user.id!;
 
-  // Telegram peers linked to THIS user, lowercased — the classifier compares
-  // verbatim against OpenClaw's lowercased principal segment, so a peer id that
-  // isn't lowercased here would silently never match.
-  const links = await db
-    .select()
-    .from(channelLinks)
-    .where(and(eq(channelLinks.channel, "telegram"), eq(channelLinks.userId, userId)));
-  const linkedTelegramPeerIds = new Set(links.map((l) => l.channelUserId.toLowerCase()));
-
-  // `sessions.list` is untyped wire output: `{ sessions?: RawSession[] }`.
-  let raw: { sessions?: RawSession[] } | undefined;
+  // Shared, authorized enumeration of the user's own chats (web + linked
+  // Telegram peers). Throws when OpenClaw is unreachable / mid-reconnect — 502
+  // (not 500) so the client can surface a retryable "couldn't load chats" toast.
+  let classified: Awaited<ReturnType<typeof listUserAgentChats>>["chats"];
+  let labelByKey: Map<string, string | null>;
   try {
-    raw = (await getOpenClawClient().sessions.list({})) as { sessions?: RawSession[] } | undefined;
+    ({ chats: classified, labelByKey } = await listUserAgentChats(agentId, userId));
   } catch {
-    // OpenClaw unreachable / mid-reconnect. 502 (not 500) so the client can
-    // surface a retryable "couldn't load chats" toast rather than a hard error.
     return NextResponse.json({ error: "Failed to load chats" }, { status: 502 });
   }
-  const sessionsArr = Array.isArray(raw?.sessions) ? raw.sessions : [];
-
-  // Scope to THIS agent before classifying — the classifier checks identity and
-  // key shape but not the agentId, so cross-agent isolation is enforced here.
-  // Keys are `agent:<agentId>:direct:<principal>[:<chatId>]`.
-  const scoped = sessionsArr.filter(
-    (s) => typeof s?.key === "string" && s.key.split(":")[1] === agentId
-  );
-
-  const classified = classifyUserSessions(scoped, userId, linkedTelegramPeerIds);
 
   // Carry the human-readable title and sort by recency so the most recent
   // conversation surfaces first. The internal session `key` stays server-side —
@@ -103,7 +82,6 @@ export const GET = withAuth<RouteContext>(async (_request, { params }, session) 
   // OWN web chats, derive it from the first user message. Telegram chats keep
   // their label/null (their transcript has a dedicated endpoint), and labelled
   // chats never trigger a history read.
-  const labelByKey = new Map(scoped.map((s) => [s.key, s.label ?? null]));
   const chats: ChatListItem[] = (
     await Promise.all(
       classified.map(async (c) => {

--- a/packages/web/src/app/api/diagnostics/export/route.ts
+++ b/packages/web/src/app/api/diagnostics/export/route.ts
@@ -46,6 +46,10 @@ import { diagnosticsExportRequestSchema } from "@/lib/schemas/diagnostics";
 
 const DEFAULT_TURN_WINDOW = 10;
 const AUDIT_RANGE_PADDING_MS = 5_000;
+// Backstop on audit rows in a bundle. Normal exports are already time-scoped to
+// the selected turns; this bounds the degrade/empty-session paths where the
+// range is unbounded, since the size guard only trims spans (not audit rows).
+const MAX_AUDIT_ROWS = 1_000;
 
 /**
  * Build the [from, to] window for audit-row scoping from the turns the bundle
@@ -131,35 +135,35 @@ export const POST = withAuth(async (request, _ctx, session) => {
     }
   }
 
-  let spans: ReturnType<typeof buildOtelSpans>;
-  let anchorTurnIndex: number | null;
-  let sessionTurnCount: number;
-  let includedTurnRange: [number, number];
-  let auditEntries: Awaited<ReturnType<typeof fetchAuditEntriesForSession>>;
-  if (trajectoryMissing) {
-    // No trajectory: empty spans, and pull the whole audit window for this
-    // user+agent (no turns to scope by). The size-cap still trims.
-    spans = [];
-    anchorTurnIndex = null;
-    sessionTurnCount = 0;
-    includedTurnRange = [0, -1];
-    auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, undefined);
-  } else {
-    const events = parseJsonlLines(raw ?? "");
-    const turns = extractTurns(events);
-    const scope = computeScope(turns, anchorMessageId, DEFAULT_TURN_WINDOW);
-    const selectedTurns = turns.slice(scope.includedTurnRange[0], scope.includedTurnRange[1] + 1);
-    spans = buildOtelSpans(selectedTurns);
-    // Scope audit rows to the same time window as the selected turns so a busy
-    // agent doesn't drown the bundle in unrelated history. Pad by 5s on each
-    // side to catch tool audit rows written just before/after the model.completed
-    // event (chat.* and tool.* are written from independent code paths).
-    const auditRange = computeAuditRange(selectedTurns);
-    auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, auditRange);
-    anchorTurnIndex = scope.anchorTurnIndex;
-    sessionTurnCount = turns.length;
-    includedTurnRange = scope.includedTurnRange;
-  }
+  // One pipeline for both cases: on a missing trajectory `raw` is null, which
+  // parses to zero events → zero turns, and every downstream step
+  // (computeScope, buildOtelSpans, computeAuditRange) already handles the empty
+  // case — computeScope returns the canonical empty slice `[0, -1]`, spans is
+  // `[]`, and the audit range is unbounded. No separate degrade branch needed.
+  const events = parseJsonlLines(raw ?? "");
+  const turns = extractTurns(events);
+  const scope = computeScope(turns, anchorMessageId, DEFAULT_TURN_WINDOW);
+  const selectedTurns = turns.slice(scope.includedTurnRange[0], scope.includedTurnRange[1] + 1);
+  const spans = buildOtelSpans(selectedTurns);
+  // Scope audit rows to the same time window as the selected turns so a busy
+  // agent doesn't drown the bundle in unrelated history. Pad by 5s on each
+  // side to catch tool audit rows written just before/after the model.completed
+  // event (chat.* and tool.* are written from independent code paths). With no
+  // turns (empty/missing trajectory) the range is undefined, so MAX_AUDIT_ROWS
+  // caps the otherwise-unbounded fetch.
+  //
+  // Known limitation: audit rows are scoped to `actorId = this web user`. For a
+  // selected Telegram chat the trajectory still exports, but its audit rows are
+  // stamped with the Telegram principal, so the bundle's audit section is empty
+  // for Telegram exports. Documented in reporting-issues.mdx; a cross-principal
+  // fetch is deferred to the admin/cross-user export work.
+  const auditRange = computeAuditRange(selectedTurns);
+  const auditEntries = await fetchAuditEntriesForSession(
+    agentId,
+    session.user.id,
+    auditRange,
+    MAX_AUDIT_ROWS
+  );
 
   // Snapshot the agent's configuration at export time (model/provider, allowed
   // tools, instruction hashes) so a support reader can tell config drift apart
@@ -173,9 +177,9 @@ export const POST = withAuth(async (request, _ctx, session) => {
     scope: {
       agentId,
       sessionKey,
-      anchorTurnIndex,
-      sessionTurnCount,
-      includedTurnRange,
+      anchorTurnIndex: scope.anchorTurnIndex,
+      sessionTurnCount: turns.length,
+      includedTurnRange: scope.includedTurnRange,
       trajectoryMissing,
     },
     auditEntries,
@@ -207,7 +211,9 @@ export const POST = withAuth(async (request, _ctx, session) => {
       byteSize: Buffer.byteLength(JSON.stringify(capped), "utf8"),
       droppedTurns: dropped,
       truncated,
-      trajectoryMissing: capped.scope.trajectoryMissing,
+      // Source from the local truth, not the round-tripped bundle, so a future
+      // change to how the bundle represents this can't silently skew the audit.
+      trajectoryMissing,
     },
     outcome: "success",
   };

--- a/packages/web/src/app/api/diagnostics/export/route.ts
+++ b/packages/web/src/app/api/diagnostics/export/route.ts
@@ -25,6 +25,7 @@ import { type AuditLogEntry } from "@/lib/audit";
 import { deferAuditLog } from "@/lib/audit-deferred";
 import { getAgentWithAccess } from "@/lib/agent-access";
 import { parseRequestBody } from "@/lib/api-validation";
+import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
 import { collectAgentConfig } from "@/lib/diagnostics/agent-config-collector";
 import { buildBundle } from "@/lib/diagnostics/bundle-builder";
 import { fetchAuditEntriesForSession } from "@/lib/diagnostics/audit-collector";
@@ -40,6 +41,7 @@ import { computeScope } from "@/lib/diagnostics/scope-resolver";
 import { enforceSizeCap } from "@/lib/diagnostics/size-guard";
 import { extractTurns } from "@/lib/diagnostics/turn-extractor";
 import { getDiagnosticsVersions } from "@/lib/diagnostics/versions";
+import { directSessionKey } from "@/lib/session-key";
 import { diagnosticsExportRequestSchema } from "@/lib/schemas/diagnostics";
 
 const DEFAULT_TURN_WINDOW = 10;
@@ -71,45 +73,93 @@ function computeAuditRange(
 export const POST = withAuth(async (request, _ctx, session) => {
   const parsed = await parseRequestBody(diagnosticsExportRequestSchema, request);
   if ("error" in parsed) return parsed.error;
-  const { agentId, anchorMessageId, userDescription } = parsed.data;
+  const { agentId, anchorMessageId, userDescription, sessionId: selectedSessionId } = parsed.data;
 
   const agentOrResp = await getAgentWithAccess(agentId, session.user.id, session.user.role);
   if (agentOrResp instanceof NextResponse) return agentOrResp;
   const agent = agentOrResp;
 
-  const sessionKey = `agent:${agentId}:direct:${session.user.id}`;
-  const sessionId = await resolveSessionId(agentId, sessionKey);
-  if (!sessionId) {
-    return NextResponse.json(
-      { error: "No chat session recorded for this user and agent yet" },
-      { status: 404 }
-    );
+  // Resolve which chat to export. Two paths:
+  //   - selector (#639): the client picked a specific chat by its opaque
+  //     sessionId. Re-authorize it by enumerating the user's OWN chats and
+  //     matching — this reaches named per-chat sessions (#508) and read-only
+  //     Telegram peers, which `directSessionKey` structurally can't. An
+  //     unmatched id is an unknown/inaccessible chat → 404.
+  //   - default (no selector): today's behaviour — the user's default chat.
+  let sessionKey: string;
+  let sessionId: string;
+  let exportedChatId: string | null;
+  if (selectedSessionId) {
+    let chats: Awaited<ReturnType<typeof listUserAgentChats>>["chats"];
+    try {
+      ({ chats } = await listUserAgentChats(agentId, session.user.id));
+    } catch {
+      return NextResponse.json({ error: "Failed to load chats" }, { status: 502 });
+    }
+    const match = chats.find((c) => c.sessionId === selectedSessionId);
+    if (!match) {
+      return NextResponse.json({ error: "No such chat for this user and agent" }, { status: 404 });
+    }
+    sessionKey = match.key;
+    sessionId = match.sessionId;
+    exportedChatId = match.chatId;
+  } else {
+    sessionKey = directSessionKey(agentId, session.user.id);
+    const resolved = await resolveSessionId(agentId, sessionKey);
+    if (!resolved) {
+      return NextResponse.json(
+        { error: "No chat session recorded for this user and agent yet" },
+        { status: 404 }
+      );
+    }
+    sessionId = resolved;
+    exportedChatId = null;
   }
 
-  let raw: string;
+  // Read the trajectory. When the chat is authorized but its trajectory file is
+  // gone (#639), don't 404 — degrade to an audit-only bundle so support still
+  // gets the audit trail, flagged with `trajectoryMissing`.
+  let raw: string | null = null;
+  let trajectoryMissing = false;
   try {
     raw = await readTrajectoryJsonl(agentId, sessionId);
   } catch (err) {
     if (err instanceof TrajectoryFileNotFoundError) {
-      return NextResponse.json(
-        { error: "Trajectory file missing for the recorded session" },
-        { status: 404 }
-      );
+      trajectoryMissing = true;
+    } else {
+      throw err;
     }
-    throw err;
   }
 
-  const events = parseJsonlLines(raw);
-  const turns = extractTurns(events);
-  const scope = computeScope(turns, anchorMessageId, DEFAULT_TURN_WINDOW);
-  const selectedTurns = turns.slice(scope.includedTurnRange[0], scope.includedTurnRange[1] + 1);
-  const spans = buildOtelSpans(selectedTurns);
-  // Scope audit rows to the same time window as the selected turns so a busy
-  // agent doesn't drown the bundle in unrelated history. Pad by 5s on each
-  // side to catch tool audit rows written just before/after the model.completed
-  // event (chat.* and tool.* are written from independent code paths).
-  const auditRange = computeAuditRange(selectedTurns);
-  const auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, auditRange);
+  let spans: ReturnType<typeof buildOtelSpans>;
+  let anchorTurnIndex: number | null;
+  let sessionTurnCount: number;
+  let includedTurnRange: [number, number];
+  let auditEntries: Awaited<ReturnType<typeof fetchAuditEntriesForSession>>;
+  if (trajectoryMissing) {
+    // No trajectory: empty spans, and pull the whole audit window for this
+    // user+agent (no turns to scope by). The size-cap still trims.
+    spans = [];
+    anchorTurnIndex = null;
+    sessionTurnCount = 0;
+    includedTurnRange = [0, -1];
+    auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, undefined);
+  } else {
+    const events = parseJsonlLines(raw ?? "");
+    const turns = extractTurns(events);
+    const scope = computeScope(turns, anchorMessageId, DEFAULT_TURN_WINDOW);
+    const selectedTurns = turns.slice(scope.includedTurnRange[0], scope.includedTurnRange[1] + 1);
+    spans = buildOtelSpans(selectedTurns);
+    // Scope audit rows to the same time window as the selected turns so a busy
+    // agent doesn't drown the bundle in unrelated history. Pad by 5s on each
+    // side to catch tool audit rows written just before/after the model.completed
+    // event (chat.* and tool.* are written from independent code paths).
+    const auditRange = computeAuditRange(selectedTurns);
+    auditEntries = await fetchAuditEntriesForSession(agentId, session.user.id, auditRange);
+    anchorTurnIndex = scope.anchorTurnIndex;
+    sessionTurnCount = turns.length;
+    includedTurnRange = scope.includedTurnRange;
+  }
 
   // Snapshot the agent's configuration at export time (model/provider, allowed
   // tools, instruction hashes) so a support reader can tell config drift apart
@@ -123,9 +173,10 @@ export const POST = withAuth(async (request, _ctx, session) => {
     scope: {
       agentId,
       sessionKey,
-      anchorTurnIndex: scope.anchorTurnIndex,
-      sessionTurnCount: turns.length,
-      includedTurnRange: scope.includedTurnRange,
+      anchorTurnIndex,
+      sessionTurnCount,
+      includedTurnRange,
+      trajectoryMissing,
     },
     auditEntries,
     userDescription,
@@ -146,6 +197,9 @@ export const POST = withAuth(async (request, _ctx, session) => {
     resource: `diagnostics:${agentId}`,
     detail: {
       agent: { id: agent.id, name: agent.name },
+      // Which chat was exported (#639): null = the default/legacy chat or a
+      // Telegram peer (both carry chatId: null).
+      chatId: exportedChatId,
       scope: {
         anchorTurnIndex: capped.scope.anchorTurnIndex,
         includedTurnRange: capped.scope.includedTurnRange,
@@ -153,6 +207,7 @@ export const POST = withAuth(async (request, _ctx, session) => {
       byteSize: Buffer.byteLength(JSON.stringify(capped), "utf8"),
       droppedTurns: dropped,
       truncated,
+      trajectoryMissing: capped.scope.trajectoryMissing,
     },
     outcome: "success",
   };

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -564,6 +564,9 @@ const AssistantActionBar: FC = () => {
   const messageId = useMessage((s) => s.id);
   const agentId = useContext(AgentIdContext) ?? "";
   const agentName = useContext(AgentNameContext) ?? "Unknown";
+  // The active chat (null = default/legacy) so the export dialog preselects the
+  // chat the user is actually looking at, not the default one (#639).
+  const chatId = useContext(ChatIdContext);
   const [reportIssueOpen, setReportIssueOpen] = useState(false);
 
   return (
@@ -619,6 +622,7 @@ const AssistantActionBar: FC = () => {
         agentId={agentId}
         agentName={agentName}
         anchorMessageId={messageId}
+        chatId={chatId}
         onClose={() => setReportIssueOpen(false)}
       />
     </ActionBarPrimitive.Root>

--- a/packages/web/src/components/chat-switcher.tsx
+++ b/packages/web/src/components/chat-switcher.tsx
@@ -14,6 +14,7 @@ import {
 import { Button } from "@/components/ui/button";
 import { apiGet } from "@/lib/api-client";
 import type { ChatListItem } from "@/lib/schemas/sessions";
+import { chatTitle } from "@/lib/chats/chat-title";
 import { generateChatId } from "@/lib/chats/generate-chat-id";
 import { useChatSessionIsRunning } from "@/components/chat-session-provider";
 import { useRunCompletionEffect } from "@/hooks/use-run-completion-effect";
@@ -43,12 +44,6 @@ interface ChatSwitcherProps {
 function isActive(item: ChatListItem, chatId: string | null, activeTelegram: boolean): boolean {
   if (item.origin === "telegram") return activeTelegram;
   return item.chatId === chatId && !activeTelegram;
-}
-
-/** Title to show for a chat — the saved label, or a date-stamped fallback. */
-function chatTitle(item: ChatListItem): string {
-  if (item.title && item.title.trim().length > 0) return item.title;
-  return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
 }
 
 /** sessionId we tag the optimistic current-chat row with (it has no real OpenClaw session yet). */

--- a/packages/web/src/components/diagnostics-export-dialog.tsx
+++ b/packages/web/src/components/diagnostics-export-dialog.tsx
@@ -1,7 +1,7 @@
 "use client";
 
-import { useState } from "react";
-import { Loader2 } from "lucide-react";
+import { useEffect, useState } from "react";
+import { Loader2, Lock, Send } from "lucide-react";
 import { toast } from "sonner";
 
 import {
@@ -14,15 +14,41 @@ import {
 } from "@/components/ui/dialog";
 import { Button } from "@/components/ui/button";
 import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
 import { Textarea } from "@/components/ui/textarea";
 
-import { apiPost, ApiError } from "@/lib/api-client";
+import { apiGet, apiPost, ApiError } from "@/lib/api-client";
 import { buildBundleFilename, downloadBundle } from "@/lib/diagnostics/download";
 import type { DiagnosticsExportRequest } from "@/lib/schemas/diagnostics";
+import type { ChatListItem } from "@/lib/schemas/sessions";
 
 import { DiagnosticsWhatsIncluded } from "./diagnostics-whats-included";
 
 const USER_DESCRIPTION_MAX = 500;
+
+/** Title to show for a chat — the saved label, or a date-stamped fallback. */
+function chatTitle(item: ChatListItem): string {
+  if (item.title && item.title.trim().length > 0) return item.title;
+  return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
+}
+
+/**
+ * Which listed chat should be selected by default. From chat context we match
+ * the active chat by `chatId` (`null` = the default/legacy chat); from Settings
+ * (`chatId` undefined) we fall back to the default chat too. Returns the chat's
+ * sessionId, or `null` when no web chat matches (→ the export route's default
+ * path). Telegram chats are never a default target — they're opt-in via the picker.
+ */
+function initialSessionId(chats: ChatListItem[], chatId: string | null): string | null {
+  const match = chats.find((c) => c.origin === "web" && c.chatId === chatId);
+  return match?.sessionId ?? null;
+}
 
 export interface DiagnosticsExportDialogProps {
   open: boolean;
@@ -30,6 +56,12 @@ export interface DiagnosticsExportDialogProps {
   agentName: string;
   /** Present for per-message exports; omitted for Settings-triggered ones. */
   anchorMessageId?: string;
+  /**
+   * The active chat when launched from chat context (`null` = default chat).
+   * Omitted (`undefined`) when launched from Settings, where the default chat
+   * is preselected. Drives the picker's initial selection (#639).
+   */
+  chatId?: string | null;
   onClose: () => void;
 }
 
@@ -38,12 +70,39 @@ export function DiagnosticsExportDialog({
   agentId,
   agentName,
   anchorMessageId,
+  chatId,
   onClose,
 }: DiagnosticsExportDialogProps) {
   const [userDescription, setUserDescription] = useState("");
   const [validationError, setValidationError] = useState<string | null>(null);
   const [submitting, setSubmitting] = useState(false);
   const [whatsIncludedOpen, setWhatsIncludedOpen] = useState(false);
+  const [chats, setChats] = useState<ChatListItem[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  // Fetch the user's chats when the dialog opens so they can pick which chat to
+  // export (#639), preselecting the active/default one. A failed fetch degrades
+  // to no picker → the export route's default-chat path — reporting a bug is a
+  // convenience path, never blocked on the chat list.
+  useEffect(() => {
+    if (!open) return;
+    let cancelled = false;
+    apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
+      .then((res) => {
+        if (cancelled) return;
+        const list = res.chats ?? [];
+        setChats(list);
+        setSelectedSessionId(initialSessionId(list, chatId ?? null));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setChats([]);
+        setSelectedSessionId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [open, agentId, chatId]);
 
   function handleOpenChange(next: boolean) {
     if (!next && !submitting) {
@@ -51,6 +110,8 @@ export function DiagnosticsExportDialog({
       setUserDescription("");
       setValidationError(null);
       setWhatsIncludedOpen(false);
+      setChats([]);
+      setSelectedSessionId(null);
       onClose();
     }
   }
@@ -75,6 +136,11 @@ export function DiagnosticsExportDialog({
     }
     if (trimmed.length > 0) {
       body.userDescription = trimmed;
+    }
+    // Omit sessionId when none is selected so the route takes its default-chat
+    // path (unchanged behaviour for users with no listable chats).
+    if (selectedSessionId) {
+      body.sessionId = selectedSessionId;
     }
 
     try {
@@ -116,6 +182,34 @@ export function DiagnosticsExportDialog({
             >
               Per-message reporting is in beta — this export includes your last 10 turns rather than
               a slice anchored on the specific message you clicked.
+            </div>
+          )}
+          {chats.length > 0 && (
+            <div className="space-y-2">
+              <Label htmlFor="diagnostics-chat-select">Chat to export</Label>
+              <Select
+                value={selectedSessionId ?? undefined}
+                onValueChange={(v) => setSelectedSessionId(v)}
+              >
+                <SelectTrigger id="diagnostics-chat-select" aria-label="Chat to export">
+                  <SelectValue placeholder="Select a chat" />
+                </SelectTrigger>
+                <SelectContent>
+                  {chats.map((c) => (
+                    <SelectItem key={c.sessionId} value={c.sessionId}>
+                      <span className="flex items-center gap-1.5">
+                        <span className="truncate">{chatTitle(c)}</span>
+                        {c.origin === "telegram" && (
+                          <Send className="size-3 shrink-0 opacity-70" aria-label="Telegram" />
+                        )}
+                        {!c.writable && (
+                          <Lock className="size-3 shrink-0 opacity-70" aria-label="Read-only" />
+                        )}
+                      </span>
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
             </div>
           )}
           <div className="space-y-2">

--- a/packages/web/src/components/diagnostics-export-dialog.tsx
+++ b/packages/web/src/components/diagnostics-export-dialog.tsx
@@ -24,6 +24,7 @@ import {
 import { Textarea } from "@/components/ui/textarea";
 
 import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { chatTitle } from "@/lib/chats/chat-title";
 import { buildBundleFilename, downloadBundle } from "@/lib/diagnostics/download";
 import type { DiagnosticsExportRequest } from "@/lib/schemas/diagnostics";
 import type { ChatListItem } from "@/lib/schemas/sessions";
@@ -32,22 +33,20 @@ import { DiagnosticsWhatsIncluded } from "./diagnostics-whats-included";
 
 const USER_DESCRIPTION_MAX = 500;
 
-/** Title to show for a chat — the saved label, or a date-stamped fallback. */
-function chatTitle(item: ChatListItem): string {
-  if (item.title && item.title.trim().length > 0) return item.title;
-  return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
-}
-
 /**
  * Which listed chat should be selected by default. From chat context we match
  * the active chat by `chatId` (`null` = the default/legacy chat); from Settings
- * (`chatId` undefined) we fall back to the default chat too. Returns the chat's
- * sessionId, or `null` when no web chat matches (→ the export route's default
- * path). Telegram chats are never a default target — they're opt-in via the picker.
+ * (`chatId` undefined) we prefer the default chat. When neither is present —
+ * e.g. a user with only named chats, or an active chat not yet in the list — we
+ * fall back to the most-recent listed chat (the server returns them newest
+ * first) rather than leaving the picker unselected, which would silently export
+ * the default chat (or 404) despite a populated dropdown. Returns `null` only
+ * for an empty list. Telegram chats are never the auto-match but can be the
+ * newest-first fallback and are always opt-in via the picker.
  */
 function initialSessionId(chats: ChatListItem[], chatId: string | null): string | null {
   const match = chats.find((c) => c.origin === "web" && c.chatId === chatId);
-  return match?.sessionId ?? null;
+  return match?.sessionId ?? chats[0]?.sessionId ?? null;
 }
 
 export interface DiagnosticsExportDialogProps {

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -413,6 +413,9 @@ export type AuditLogEntry =
       eventType: "diagnostics.exported";
       detail: {
         agent: { id: string; name: string };
+        // Which chat was exported (#639): null for the default/legacy chat or a
+        // Telegram peer (both carry chatId: null).
+        chatId: string | null;
         scope: {
           anchorTurnIndex: number | null;
           includedTurnRange: [number, number];
@@ -420,6 +423,9 @@ export type AuditLogEntry =
         byteSize: number;
         droppedTurns: number;
         truncated: boolean;
+        // True when the chat was authorized but its trajectory file was absent
+        // and the bundle fell back to audit rows only (#639).
+        trajectoryMissing: boolean;
       };
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/chats/chat-title.ts
+++ b/packages/web/src/lib/chats/chat-title.ts
@@ -1,0 +1,12 @@
+import type { ChatListItem } from "@/lib/schemas/sessions";
+
+/**
+ * Human-readable title for a chat row — the saved label when present, otherwise
+ * a date-stamped fallback derived from the chat's last interaction. Shared by
+ * the ChatSwitcher and the diagnostics-export picker so the fallback format
+ * can't drift between the two lists.
+ */
+export function chatTitle(item: ChatListItem): string {
+  if (item.title && item.title.trim().length > 0) return item.title;
+  return `Chat from ${new Date(item.lastInteractionAt).toLocaleDateString()}`;
+}

--- a/packages/web/src/lib/chats/list-user-agent-chats.ts
+++ b/packages/web/src/lib/chats/list-user-agent-chats.ts
@@ -1,0 +1,54 @@
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { channelLinks } from "@/db/schema";
+import { getOpenClawClient } from "@/server/openclaw-client";
+import { classifyUserSessions, type ClassifiedChat, type RawSession } from "./classify-sessions";
+
+/**
+ * Enumerate the requesting user's OWN chats with one agent — web (default +
+ * named #508) and read-only Telegram peers linked to them. This is the shared,
+ * authorized enumeration used by BOTH `GET /api/agents/[agentId]/chats` (which
+ * adds titles + sorting on top) and the diagnostics export route (#639, which
+ * uses it to authorize a `sessionId` selector before reading a trajectory).
+ *
+ * The authorization boundary lives entirely in `classifyUserSessions`, which
+ * fails closed on anything it can't positively attribute to this user. Keeping
+ * this in one place means the export route can't drift from the chats list and
+ * accidentally widen what a user may reach.
+ *
+ * Throws if OpenClaw is unreachable (untyped `sessions.list` rejection) — the
+ * caller maps that to a 502 so the client can retry.
+ *
+ * @returns the classified chats plus a `key → label` map so title-deriving
+ *   callers don't need the raw sessions again.
+ */
+export async function listUserAgentChats(
+  agentId: string,
+  userId: string
+): Promise<{ chats: ClassifiedChat[]; labelByKey: Map<string, string | null> }> {
+  // Telegram peers linked to THIS user, lowercased — the classifier compares
+  // verbatim against OpenClaw's lowercased principal segment.
+  const links = await db
+    .select()
+    .from(channelLinks)
+    .where(and(eq(channelLinks.channel, "telegram"), eq(channelLinks.userId, userId)));
+  const linkedTelegramPeerIds = new Set(links.map((l) => l.channelUserId.toLowerCase()));
+
+  // `sessions.list` is untyped wire output: `{ sessions?: RawSession[] }`.
+  const raw = (await getOpenClawClient().sessions.list({})) as
+    | { sessions?: RawSession[] }
+    | undefined;
+  const sessionsArr = Array.isArray(raw?.sessions) ? raw.sessions : [];
+
+  // Scope to THIS agent before classifying — the classifier checks identity and
+  // key shape but not the agentId, so cross-agent isolation is enforced here.
+  // Keys are `agent:<agentId>:direct:<principal>[:<chatId>]`.
+  const scoped = sessionsArr.filter(
+    (s) => typeof s?.key === "string" && s.key.split(":")[1] === agentId
+  );
+
+  const chats = classifyUserSessions(scoped, userId, linkedTelegramPeerIds);
+  const labelByKey = new Map(scoped.map((s) => [s.key, s.label ?? null]));
+  return { chats, labelByKey };
+}

--- a/packages/web/src/lib/diagnostics/audit-collector.ts
+++ b/packages/web/src/lib/diagnostics/audit-collector.ts
@@ -16,7 +16,7 @@
 // into a downloadable bundle — they're useless outside the audit DB context
 // and we want fewer secret-shaped bytes flying around in support archives.
 
-import { and, asc, eq, gte, lte, type SQL } from "drizzle-orm";
+import { and, asc, desc, eq, gte, lte, type SQL } from "drizzle-orm";
 import { db } from "@/db";
 import { auditLog } from "@/db/schema";
 
@@ -39,7 +39,13 @@ export interface AuditQueryRange {
 export async function fetchAuditEntriesForSession(
   agentId: string,
   userId: string,
-  range?: AuditQueryRange
+  range?: AuditQueryRange,
+  // Hard cap on rows. When set, the NEWEST `limit` rows are kept (a busy agent
+  // with an unbounded range — e.g. the trajectory-missing degrade path — must
+  // not stream its entire audit history into a size-capped bundle, since the
+  // size guard only trims spans, not audit rows). The result stays oldest→
+  // newest so it reads chronologically alongside the turns.
+  limit?: number
 ): Promise<CollectedAuditEntry[]> {
   const conditions: SQL[] = [
     eq(auditLog.resource, `agent:${agentId}`),
@@ -49,17 +55,31 @@ export async function fetchAuditEntriesForSession(
     conditions.push(gte(auditLog.timestamp, range.from));
     conditions.push(lte(auditLog.timestamp, range.to));
   }
+  const columns = {
+    timestamp: auditLog.timestamp,
+    eventType: auditLog.eventType,
+    actorType: auditLog.actorType,
+    actorId: auditLog.actorId,
+    resource: auditLog.resource,
+    detail: auditLog.detail,
+    outcome: auditLog.outcome,
+    error: auditLog.error,
+  };
+
+  if (limit !== undefined) {
+    // Take the newest `limit` rows (desc + limit), then restore chronological
+    // order for the bundle.
+    const newest = await db
+      .select(columns)
+      .from(auditLog)
+      .where(and(...conditions))
+      .orderBy(desc(auditLog.timestamp))
+      .limit(limit);
+    return newest.reverse();
+  }
+
   const rows = await db
-    .select({
-      timestamp: auditLog.timestamp,
-      eventType: auditLog.eventType,
-      actorType: auditLog.actorType,
-      actorId: auditLog.actorId,
-      resource: auditLog.resource,
-      detail: auditLog.detail,
-      outcome: auditLog.outcome,
-      error: auditLog.error,
-    })
+    .select(columns)
     .from(auditLog)
     .where(and(...conditions))
     .orderBy(asc(auditLog.timestamp));

--- a/packages/web/src/lib/diagnostics/bundle-builder.ts
+++ b/packages/web/src/lib/diagnostics/bundle-builder.ts
@@ -20,6 +20,13 @@ export interface BundleInput {
     anchorTurnIndex: number | null;
     sessionTurnCount: number;
     includedTurnRange: [number, number];
+    /**
+     * `true` when the chat was resolved and authorized but its trajectory file
+     * was absent on disk (#639). The bundle then carries only audit rows and
+     * empty spans — support can tell "trajectory was gone" from "chat was empty".
+     * Omitted → `false`.
+     */
+    trajectoryMissing?: boolean;
   };
   auditEntries: unknown[];
   userDescription?: string;
@@ -38,6 +45,7 @@ export interface Bundle {
     sessionTurnCount: number;
     includedTurnRange: [number, number];
     skippedTurnsAfterAnchor: number;
+    trajectoryMissing: boolean;
   };
   userDescription?: string;
   agentConfig: AgentConfigSnapshot;
@@ -62,6 +70,7 @@ export function buildBundle(input: BundleInput): Bundle {
       sessionTurnCount: input.scope.sessionTurnCount,
       includedTurnRange: input.scope.includedTurnRange,
       skippedTurnsAfterAnchor: skipped,
+      trajectoryMissing: input.scope.trajectoryMissing ?? false,
     },
     ...(input.userDescription ? { userDescription: input.userDescription } : {}),
     agentConfig: input.agentConfig,

--- a/packages/web/src/lib/schemas/diagnostics.ts
+++ b/packages/web/src/lib/schemas/diagnostics.ts
@@ -4,6 +4,21 @@ export const diagnosticsExportRequestSchema = z.object({
   agentId: z.string().min(1),
   anchorMessageId: z.string().min(1).optional(),
   userDescription: z.string().max(500).optional(),
+  /**
+   * Opaque OpenClaw session id of the chat to export (from `ChatListItem`).
+   * Unlike `chatId`, it uniquely identifies a chat even for Telegram peers and
+   * the default chat (both carry `chatId: null`). The route re-authorizes it
+   * against the user's own chats before reading anything. Omitted → today's
+   * behaviour (the user's default chat). The charset guard is defense-in-depth
+   * on top of the reader's `assertSafeSegment`: no `:` (session-key delimiter),
+   * no path separators.
+   */
+  sessionId: z
+    .string()
+    .min(1)
+    .max(128)
+    .regex(/^[A-Za-z0-9_-]+$/)
+    .optional(),
 });
 
 export type DiagnosticsExportRequest = z.infer<typeof diagnosticsExportRequestSchema>;


### PR DESCRIPTION
## What does this PR do?

The diagnostics/bug-report export only ever captured a user's **default** chat with an agent. It hardcoded the legacy session key (`agent:<id>:direct:<user>`), so every named per-chat session (#508) and every Telegram chat was invisible to the export, and a missing trajectory file returned a hard **404** instead of a still-useful audit-only bundle.

Now the export resolves the target chat from a client-supplied, opaque `sessionId` that is **re-authorized server-side** against the user's own chats (shared `classifyUserSessions` enumeration, fail-closed). Missing trajectories **degrade gracefully** to a valid bundle flagged with `scope.trajectoryMissing`, and the picker lets the user choose which chat to export.

Closes #639

### Key design note: `sessionId`, not `chatId`, is the selector

The issue's acceptance criteria centered on `chatId` + `directSessionKey`. But this PR also covers **Telegram** chats (confirmed in scope with the maintainer), and Telegram peers keep the peer id as the session-key principal with `chatId: null` — so `directSessionKey(agentId, userId, chatId)` structurally can't reach them, and `chatId` can't tell a Telegram chat apart from the default chat (both `null`). The unambiguous, already-exposed key is `ChatListItem.sessionId`. The route re-authorizes it by enumerating the user's own chats and matching — an id that isn't the user's simply isn't found → 404. `chatId` is still derived server-side and recorded in the audit log.

### What changed

- **Schema** (`schemas/diagnostics.ts`): optional, strictly-validated `sessionId` (malformed → structured 400). Omitting it keeps today's default-chat behaviour.
- **New shared helper** `lib/chats/list-user-agent-chats.ts`: the authorized web+Telegram chat enumeration, extracted from the GET `/chats` route and reused by both it and the export route (no drift).
- **Export route**: selector path (named + Telegram) with 404 only for unknown/inaccessible chats; graceful degrade to a `trajectoryMissing: true` audit-only bundle when the trajectory file is gone; `directSessionKey` (not a hardcoded string) for the default path; audit entry records `chatId` + `trajectoryMissing`.
- **`bundle-builder` + `audit.ts`**: `trajectoryMissing` flag threaded through and typed.
- **Export dialog**: chat picker populated from GET `/chats`, preselecting the active chat from chat context and the default chat from Settings; `thread.tsx` passes `ChatIdContext` through.
- **Docs**: `reporting-issues.mdx` documents chat selection + the trajectory-missing fallback.

Privacy boundary unchanged: a user may export **only their own** chats. No cross-user/admin export here.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [x] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality
- [x] I've updated the documentation
- [x] All existing tests pass

## Testing

TDD throughout. All local gates green:

- Unit suite: **6642 passed**
- Integration (`test:db`): **139 passed** — incl. the AGENTS.md migration rule: a **pre-#508 default-only session AND a new per-chat session in the same index are both exportable**; selector resolves the right chat; Telegram export; unknown-chat 404; degrade (selector + default paths); audit payload (`chatId` + `trajectoryMissing`)
- Schema test: malformed `sessionId` → 400
- Dialog tests: picker renders, context/Settings default selection, list-load failure falls back to the default export
- Lint: 0 errors · `format:check`: clean · **production build** passes (caught an `AuditLogEntry` detail-type mismatch that unit tests alone missed)

No existing diagnostics tests were weakened; no tests removed or skipped.