### PR TITLE
fix(pinchy-odoo): make `filters` optional on odoo_read/odoo_count/odoo_aggregate

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1115,6 +1115,45 @@ describe("odoo_read", () => {
     expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
   });
 
+  // `filters` must be OPTIONAL in the schema. OpenClaw validates tool-call
+  // arguments against this schema BEFORE the plugin's execute() runs, so a
+  // `required: ["model", "filters"]` rejects a perfectly reasonable "read all
+  // sale orders" call with "filters: must have required properties filters" —
+  // exactly the failure seen in the field with weaker tool-calling models
+  // (minimax-m3), which omit `filters` constantly. asDomain(undefined) already
+  // maps to [] (match all), so the required constraint only ever contradicts
+  // the tool's own documented behaviour.
+  it("does not require `filters` in the schema (only `model`)", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    const required = (tool.parameters as { required: string[] }).required;
+    expect(required).toContain("model");
+    expect(required).not.toContain("filters");
+  });
+
+  it("treats omitted `filters` as an empty domain (match all), not an error", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 1, name: "SO001" }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-no-filters", {
+      model: "sale.order",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      expect.any(Object),
+    );
+  });
+
   it("reads records with correct parameters", async () => {
     mockSearchRead.mockResolvedValue({
       records: [{ id: 1, name: "SO001" }],
@@ -1341,6 +1380,14 @@ describe("odoo_count", () => {
     expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
   });
 
+  it("does not require `filters` in the schema (only `model`)", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_count", agentId)!;
+    const required = (tool.parameters as { required: string[] }).required;
+    expect(required).toContain("model");
+    expect(required).not.toContain("filters");
+  });
+
   it("counts records for a permitted model", async () => {
     mockSearchCount.mockResolvedValue(42);
 
@@ -1403,6 +1450,16 @@ describe("odoo_aggregate", () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_aggregate", agentId)!;
     expect(tool.description).toContain(PRODUCT_REF_DISAMBIGUATION_HINT);
+  });
+
+  it("does not require `filters` in the schema (model/fields/groupby stay required)", () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+    const required = (tool.parameters as { required: string[] }).required;
+    expect(required).toContain("model");
+    expect(required).toContain("fields");
+    expect(required).toContain("groupby");
+    expect(required).not.toContain("filters");
   });
 
   it("aggregates data for a permitted model", async () => {

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1828,7 +1828,7 @@ const plugin = {
                     "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
                 },
                 description:
-                  "Odoo domain filter. Array of [field, operator, value] tuples. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Use [] for no filter.",
+                  "Odoo domain filter. Array of [field, operator, value] tuples. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Optional — omit or pass [] to match all records.",
               },
               fields: {
                 type: "array",
@@ -1848,7 +1848,7 @@ const plugin = {
                 description: "Sort order, e.g. 'date_order desc'",
               },
             },
-            required: ["model", "filters"],
+            required: ["model"],
           },
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
@@ -1925,10 +1925,11 @@ const plugin = {
                   items: {},
                   description: "A [field, operator, value] tuple",
                 },
-                description: "Odoo domain filter. Use [] for no filter.",
+                description:
+                  "Odoo domain filter. Optional — omit or pass [] to match all records.",
               },
             },
-            required: ["model", "filters"],
+            required: ["model"],
           },
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {
@@ -1979,7 +1980,8 @@ const plugin = {
                   items: {},
                   description: "A [field, operator, value] tuple",
                 },
-                description: "Odoo domain filter. Use [] for no filter.",
+                description:
+                  "Odoo domain filter. Optional — omit or pass [] to match all records.",
               },
               fields: {
                 type: "array",
@@ -2000,7 +2002,7 @@ const plugin = {
               },
               orderby: { type: "string", description: "Sort order for groups" },
             },
-            required: ["model", "filters", "fields", "groupby"],
+            required: ["model", "fields", "groupby"],
           },
           async execute(_toolCallId: string, params: Record<string, unknown>) {
             try {


### PR DESCRIPTION
## Problem

OpenClaw validates tool-call arguments against the JSON schema **before** the plugin's `execute()` runs. With `required: ["model", "filters"]`, every call that omitted `filters` was rejected:

```
Validation failed for tool "odoo_read":
  - filters: must have required properties filters
```

Weak tool-calling models (observed with `ollama-cloud/minimax-m3` in a test-customer diagnostics bundle, Pinchy 0.7.0) omit `filters` constantly — so even "read all sale orders" failed hard on every attempt, in every turn of the session.

## Why this is a plugin bug, not a model problem

The execute path already treats a missing domain as match-all: `asDomain(undefined)` → `[]`. The parameter description even said "Use [] for no filter", and an existing test pinned the omitted-filters behaviour for `odoo_count`. The `required` constraint only ever contradicted the tool's own documented behaviour.

## Change

- `odoo_read` / `odoo_count`: `required: ["model"]`
- `odoo_aggregate`: `required: ["model", "fields", "groupby"]`
- Filter descriptions now read "Optional — omit or pass [] to match all records."

## Tests (TDD)

Added failing-first schema assertions (`required` must not contain `filters`) for all three tools plus an omitted-filters behaviour test for `odoo_read`. Full plugin suite: 287 passed.