### PR TITLE
fix(server): exit on startup failure instead of running as a zombie

### DIFF
--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -44,6 +44,7 @@ import { readGatewayToken } from "./src/lib/gateway-token-reader";
 import { regenerateOpenClawConfig } from "./src/lib/openclaw-config";
 import { SERVER_WS_MAX_PAYLOAD_BYTES } from "./src/lib/limits";
 import { evaluateDbPasswordPolicy } from "./src/lib/secret-source";
+import { exitOnStartupFailure } from "./src/server/startup-failure";
 
 logCapture.install();
 
@@ -87,7 +88,7 @@ if (dbPasswordPolicy.action === "warn") {
   console.warn(dbPasswordPolicy.message);
 }
 
-app.prepare().then(async () => {
+const startup = app.prepare().then(async () => {
   // Import request-handling modules before the server starts — these don't
   // depend on bootInits having run (domain cache starts empty and fills lazily).
   const { isHostAllowed } = await import("./src/server/host-check");
@@ -575,3 +576,10 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
     console.log("OPENCLAW_WS_URL not set — skipping OpenClaw connection");
   }
 });
+
+// Terminal catch for the whole startup chain. Next.js registers an
+// unhandledRejection handler that only logs, so without this a startup throw
+// (e.g. the OpenClawClient constructor failing on an unreadable
+// device-identity file) leaves a zombie server: HTTP up, health "ok", but no
+// OpenClaw wiring — every chat stuck on "Reconnecting to the agent…".
+startup.catch(exitOnStartupFailure);

--- a/packages/web/src/__tests__/server/startup-failure.test.ts
+++ b/packages/web/src/__tests__/server/startup-failure.test.ts
@@ -1,0 +1,56 @@
+import { describe, it, expect, vi, afterEach } from "vitest";
+import * as fs from "fs";
+import * as path from "path";
+import { exitOnStartupFailure } from "@/server/startup-failure";
+
+describe("exitOnStartupFailure", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("logs an actionable error and exits with code 1", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const exitSpy = vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    const cause = new Error("EACCES: permission denied, open '/app/secrets/device-identity.json'");
+    expect(() => exitOnStartupFailure(cause)).toThrow("process.exit(1)");
+
+    expect(exitSpy).toHaveBeenCalledWith(1);
+    expect(errorSpy).toHaveBeenCalledTimes(1);
+    const [message, loggedErr] = errorSpy.mock.calls[0];
+    // The message must tell the operator what happened and why exiting is
+    // deliberate — this line is all they see before the container restarts.
+    expect(String(message)).toContain("startup failed");
+    expect(String(message)).toContain("exiting");
+    expect(loggedErr).toBe(cause);
+  });
+
+  it("passes non-Error rejection values through to the log", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    vi.spyOn(process, "exit").mockImplementation(((code?: number) => {
+      throw new Error(`process.exit(${code})`);
+    }) as never);
+
+    expect(() => exitOnStartupFailure("string rejection")).toThrow("process.exit(1)");
+    expect(errorSpy.mock.calls[0][1]).toBe("string rejection");
+  });
+});
+
+describe("server.ts startup chain wiring", () => {
+  // The 2026-07-02 staging incident: the OpenClawClient constructor threw
+  // inside `app.prepare().then(async () => {...})`, which had no .catch. The
+  // rejection surfaced only as an unhandledRejection that Next.js logs and
+  // swallows, leaving a zombie server — HTTP up, /api/health "ok", but the
+  // OpenClaw wiring (connect, status broadcaster, watchdog) never ran, so
+  // every chat showed "Reconnecting to the agent…" forever. This guard fails
+  // if the terminal .catch is ever dropped from the startup chain.
+  it("attaches exitOnStartupFailure as the terminal .catch of app.prepare()", () => {
+    const serverSource = fs.readFileSync(path.resolve(__dirname, "../../../server.ts"), "utf8");
+    expect(serverSource).toContain(".catch(exitOnStartupFailure)");
+    expect(serverSource).toMatch(
+      /import \{ exitOnStartupFailure \} from ".\/src\/server\/startup-failure"/
+    );
+  });
+});

--- a/packages/web/src/server/startup-failure.ts
+++ b/packages/web/src/server/startup-failure.ts
@@ -1,0 +1,21 @@
+/**
+ * Terminal rejection handler for the server's async startup chain
+ * (`app.prepare().then(async () => {...})` in server.ts).
+ *
+ * Without it, a throw anywhere during startup — e.g. the OpenClawClient
+ * constructor failing on an unreadable device-identity file — surfaces only
+ * as an unhandledRejection that Next.js logs and swallows, leaving a zombie
+ * server: HTTP up, /api/health "ok", but the OpenClaw wiring (connect, status
+ * broadcaster, run watchdog) never ran, so every chat shows "Reconnecting to
+ * the agent…" forever with nothing actionable in the logs (staging incident,
+ * 2026-07-02). Exiting non-zero makes Docker restart the container visibly:
+ * a crash loop is diagnosable, a zombie is not.
+ */
+export function exitOnStartupFailure(err: unknown): never {
+  console.error(
+    "[pinchy] Server startup failed — exiting so the container restarts " +
+      "instead of running without its chat backend:",
+    err
+  );
+  process.exit(1);
+}


### PR DESCRIPTION
## Summary

- **Incident (staging, 2026-07-02):** the OpenClawClient constructor threw at boot (device-identity file unreadable — root-owned after a root `docker exec` debug probe). The async startup chain `app.prepare().then(...)` in `server.ts` has **no terminal `.catch`**, so the throw surfaced only as an `unhandledRejection` that Next.js logs and swallows. Result: a **zombie server** — HTTP up, `/api/health` "ok", Docker healthcheck green, but no OpenClaw wiring at all (no connect, no status broadcaster, no watchdog). The cold-start broadcaster sent every new browser socket `openclaw_status: false`, so **every chat session showed "Reconnecting to the agent…" forever** with a permanently red indicator.
- **Fix:** `startup.catch(exitOnStartupFailure)` — one loud, actionable `console.error` naming what happened, then `process.exit(1)`. Docker restarts the container visibly; a crash loop is diagnosable, a zombie is not. Same pattern as the existing missing-gateway-token exit in the same file.
- Deliberately a terminal catch on the whole chain rather than a try/catch around just the OpenClawClient constructor: any startup throw produces the same zombie, and the incident showed the failure mode generalizes (Vereinfachung vor Spezialfällen).
- Companion fix upstream: heypinchy/openclaw-node#38 makes the device-identity persist failure itself non-fatal (ephemeral identity + warning). Third layer tracked in #651 (surface gateway connectivity in /api/health).

## User impact

Real-user triggers for startup throws exist: disk full (ENOSPC) on first boot, backup-restore as root (ownership drift), read-only filesystems. Today those produce the silent zombie; with this fix they produce a visible restart loop with the actual error in the logs.

## Test plan

- [x] TDD: new `startup-failure.test.ts` written first (RED — module missing), then implementation (GREEN)
- [x] Unit: logs an actionable message (must contain "startup failed" + "exiting") with the original error object, exits 1; non-Error rejection values pass through
- [x] Wiring guard: source-level test pins `.catch(exitOnStartupFailure)` + import in `server.ts` (composition root has no unit harness)
- [x] Full suite: 6695 passed / 13 skipped (pre-existing) — 528 files
- [x] prettier, eslint, tsc clean; server.ts diff kept minimal (9+/1−, no reflow)