### PR TITLE
feat(health): surface OpenClaw gateway connectivity in /api/health

### DIFF
--- a/docs/src/content/docs/reference/api.mdx
+++ b/docs/src/content/docs/reference/api.mdx
@@ -17,7 +17,22 @@ Agent chat is handled over WebSocket at `/api/ws`, not via REST. The browser sen
 
 Service health check. **Public — no authentication required.** Suitable for load-balancer probes and uptime monitoring.
 
-**Response:** `200 OK` when Pinchy is running. `503 Service Unavailable` when upstream dependencies (database, OpenClaw) are unreachable.
+**Response:** `200 OK` whenever the Pinchy web process is running.
+
+```json
+{
+  "status": "ok",
+  "secrets": {
+    "encryption_key": "envvar",
+    "auth_secret": "envvar",
+    "audit_hmac_secret": "envvar",
+    "db_password": "default"
+  },
+  "openclaw": { "connected": true }
+}
+```
+
+`openclaw.connected` reflects whether the web process currently has a live WebSocket connection to the OpenClaw gateway — the dependency chat relies on. Top-level `status` deliberately stays `"ok"` even when `openclaw.connected` is `false`: brief disconnects during OpenClaw restarts (for example while applying a config change) are expected and self-heal, and flipping `status` would make the Docker healthcheck restart-loop the container during normal operation. Monitor `openclaw.connected` directly (or poll `/api/health/openclaw`) if you need alerting on gateway reachability specifically.
 
 ### `GET /api/health/openclaw`
 

--- a/packages/web/src/__tests__/api/health.test.ts
+++ b/packages/web/src/__tests__/api/health.test.ts
@@ -1,9 +1,19 @@
-import { describe, it, expect, vi, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "@/app/api/health/route";
 import { NextRequest } from "next/server";
+import { openClawConnectionState } from "@/server/openclaw-connection-state";
 
 describe("GET /api/health", () => {
-  afterEach(() => vi.unstubAllEnvs());
+  const originalConnected = openClawConnectionState.connected;
+
+  beforeEach(() => {
+    openClawConnectionState.connected = false;
+  });
+
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    openClawConnectionState.connected = originalConnected;
+  });
 
   it("should return 200 with status ok", async () => {
     const request = new NextRequest("http://localhost/api/health", { method: "GET" });
@@ -44,5 +54,44 @@ describe("GET /api/health", () => {
     expect(body).not.toContain("a".repeat(64));
     expect(body).not.toContain("super-secret-auth-value");
     expect(body).not.toContain("pinchy_dev");
+  });
+
+  // Issue #651: the 2026-07-02 staging incident had the OpenClaw gateway
+  // client dead while `/api/health` reported `status: "ok"` the whole time —
+  // chat was completely unavailable and no monitor could see it.
+  describe("openclaw connectivity (#651)", () => {
+    it("reports openclaw.connected: true when the gateway client is connected", async () => {
+      openClawConnectionState.connected = true;
+
+      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.openclaw).toEqual({ connected: true });
+    });
+
+    it("reports openclaw.connected: false when the gateway client is disconnected", async () => {
+      openClawConnectionState.connected = false;
+
+      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(data.openclaw).toEqual({ connected: false });
+    });
+
+    it("keeps top-level status 'ok' and HTTP 200 even when the gateway is disconnected", async () => {
+      // Deliberate: brief disconnects during config.apply-triggered OpenClaw
+      // restarts are expected. Flipping status here would make the Docker
+      // healthcheck restart-loop the container during normal operation.
+      openClawConnectionState.connected = false;
+
+      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
+      const response = await GET(request);
+      const data = await response.json();
+
+      expect(response.status).toBe(200);
+      expect(data.status).toBe("ok");
+    });
   });
 });

--- a/packages/web/src/app/api/health/route.ts
+++ b/packages/web/src/app/api/health/route.ts
@@ -1,13 +1,28 @@
 import { NextResponse } from "next/server";
 import { getSecretsProvenance } from "@/lib/secret-source";
+import { openClawConnectionState } from "@/server/openclaw-connection-state";
 
 export async function GET() {
   return NextResponse.json({
+    // Issue #651: `status` deliberately does NOT reflect OpenClaw gateway
+    // connectivity. Brief disconnects during config.apply-triggered OpenClaw
+    // restarts are expected and self-heal; flipping `status` here would make
+    // the Docker healthcheck restart-loop the container during normal
+    // operation. Use `openclaw.connected` below (or `/api/health/openclaw`)
+    // to monitor gateway reachability separately.
     status: "ok",
     // Issue #156: provenance only ("envvar" | "file" | "unset" /
     // "custom" | "default") — never secret values. Lets operators see from
     // the shell whether the file fallback is active before rotating
     // anything (rotating an auto-generated encryption key loses data).
     secrets: getSecretsProvenance(),
+    // Issue #651: during the 2026-07-02 staging incident, the OpenClaw
+    // gateway client was dead while this endpoint still reported "ok" —
+    // chat was completely unavailable but no monitor could see it. Surface
+    // the gateway connection state so uptime checks catch this class of
+    // failure even though top-level `status` intentionally stays "ok".
+    openclaw: {
+      connected: openClawConnectionState.connected,
+    },
   });
 }


### PR DESCRIPTION
## Summary

- Adds `openclaw: { connected: boolean }` to `GET /api/health`, read from the existing `openClawConnectionState` globalThis singleton (`packages/web/src/server/openclaw-connection-state.ts`) — no new plumbing needed.
- Top-level `status` deliberately stays `"ok"` regardless of gateway state, with a code comment explaining why: brief disconnects during config.apply-triggered OpenClaw restarts are expected, and flipping `status` would make the Docker healthcheck restart-loop the container during normal operation.
- Response shape is additive/backward compatible — existing consumers (Docker healthcheck, uptime monitors) are unaffected.
- Updates `docs/src/content/docs/reference/api.mdx` to document the new field (and correct a stale claim that `/api/health` returns `503` on upstream failure, which it never did).

During the 2026-07-02 staging incident, the OpenClaw gateway client was dead while `/api/health` returned `status: "ok"` the entire time — chat was completely unavailable but no monitor could see it. This is the third layer of defense after the openclaw-node device-identity fix and the Pinchy startup-exit fix.

Closes #651

## Test plan

- [x] Extended `packages/web/src/__tests__/api/health.test.ts` FIRST with a new `describe("openclaw connectivity (#651)")` block (3 new tests), confirmed RED before implementing.
- [x] Implemented the route change, confirmed GREEN.
- [x] `pnpm exec vitest run src/__tests__/api/health.test.ts` — 6/6 passed.
- [x] Verified no cross-test leakage: ran `health.test.ts` + `health-openclaw.test.ts` (which shares the same singleton) together — 15/15 passed.
- [x] `pnpm exec prettier --check` on changed files — clean.
- [x] `pnpm exec eslint` on changed files — clean.
- [x] `pnpm exec tsc --noEmit` — clean.
- [x] Full `pnpm test` from `packages/web` — 6695 passed, 13 skipped (pre-existing, untouched by this change), 0 failed.
- [x] `pnpm build` (via Husky pre-push hook) — succeeded.