### PR TITLE
chore(deps): bump openclaw-node to 0.13.1

### DIFF
--- a/.claude/skills/update-openclaw/SKILL.md
+++ b/.claude/skills/update-openclaw/SKILL.md
@@ -149,9 +149,14 @@ version between current and target first.
 5. **Check `openclaw-node`** (`packages/web/package.json` →
    `dependencies["openclaw-node"]`, our own client library in
    `~/projects/openclaw-node/`) for a matching newer release too —
-   `npm view openclaw-node version`. If it needs a bump and we own it, bump
-   and release it via `pnpm release X.Y.Z` in that repo first, not a manual
-   `gh release create`.
+   `npm view openclaw-node version`. If it needs a release and we own it:
+   openclaw-node has NO `pnpm release` script (that's Pinchy's mechanism).
+   Its actual release flow (v0.13.0/v0.13.1 precedent): add a CHANGELOG
+   entry, bump `package.json`, commit `chore: release vX.Y.Z` on main, wait
+   for CI on that commit, then `gh release create vX.Y.Z` — the GitHub
+   release triggers `publish.yml`, which re-verifies CI and publishes to
+   npm. Verify with `npm view openclaw-node version` before bumping the
+   Pinchy pin.
 
 6. **Install and verify:**
    ```bash

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -55,7 +55,7 @@
     "next": "16.2.9",
     "next-themes": "^0.4.6",
     "odoo-node": "0.3.0",
-    "openclaw-node": "0.13.0",
+    "openclaw-node": "0.13.1",
     "pdfkit": "^0.19.1",
     "postgres": "^3.4.9",
     "prismjs": "^1.30.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -253,8 +253,8 @@ importers:
         specifier: 0.3.0
         version: 0.3.0
       openclaw-node:
-        specifier: 0.13.0
-        version: 0.13.0
+        specifier: 0.13.1
+        version: 0.13.1
       pdfkit:
         specifier: ^0.19.1
         version: 0.19.1
@@ -6102,8 +6102,8 @@ packages:
       zod:
         optional: true
 
-  openclaw-node@0.13.0:
-    resolution: {integrity: sha512-hEU3kO3G2do36IrfFqEENoXsmcMzWbm5cDtzRZTV4CFRe7qG4nvFJSy57IejGcHEL7xNoyUmyb+rGChOxbcnFg==}
+  openclaw-node@0.13.1:
+    resolution: {integrity: sha512-MxLiYMz4WCK/nFlLL+NR3xDrJNDgiSa1aNjMOzbCLPqLp2+eeKcvOFIqx7EPeIomZ9ywrEsX+KvGX3DrLYKX8A==}
     engines: {node: '>=20.0.0'}
 
   openclaw@2026.6.11:
@@ -13634,7 +13634,7 @@ snapshots:
       ws: 8.21.0
       zod: 4.4.3
 
-  openclaw-node@0.13.0:
+  openclaw-node@0.13.1:
     optionalDependencies:
       ws: 8.21.0
     transitivePeerDependencies:


### PR DESCRIPTION
## Summary

- Bumps the `openclaw-node` pin 0.13.0 → 0.13.1 ([release](https://github.com/heypinchy/openclaw-node/releases/tag/v0.13.1), fix: heypinchy/openclaw-node#38).
- 0.13.1 makes a **device-identity persist failure non-fatal**: instead of throwing out of the `OpenClawClient` constructor, the client continues with an ephemeral in-memory identity and emits a `DeviceIdentityPersistWarning`. Together with the startup guard from #652 this closes both halves of the 2026-07-02 staging zombie incident: the library no longer dies on fs errors, and if anything else ever throws at startup, the server exits visibly instead of running without its chat backend.
- Also corrects the `update-openclaw` skill: it claimed openclaw-node releases via `pnpm release` — that script doesn't exist there; the real mechanism (v0.13.0/v0.13.1 precedent) is a `chore: release` commit + GitHub release triggering the CI-gated npm publish.

## update-openclaw skill checklist (scoped to 0.13.0 → 0.13.1)

- **(a) Incompatibility risk:** none — single additive error-tolerance change in the client constructor; no wire-protocol, session-key, or config.apply changes.
- **(b) Removable workarounds:** none removed. `startup.catch(exitOnStartupFailure)` (#652) stays deliberately — it is defense-in-depth for every startup throw, not a workaround for this bug.
- **(c) Native replaces bespoke / (d) new features:** n/a for a patch release of our own client library.

## Test plan

- [x] `openclaw-version-pin-drift.test.ts` green (core pin untouched)
- [x] Full suite with the bumped dependency: **6698 passed / 13 skipped (pre-existing)**
- [x] `node_modules` resolution verified: installed `openclaw-node` reports 0.13.1