### PR TITLE
feat(agent-templates): give bookkeeper & finance-controller read access to Odoo subscriptions

### DIFF
--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -113,8 +113,8 @@ Each template auto-configures the agent's permissions, tools, and system instruc
 
 ### Finance
 
-- **Finance Controller** _(read-only)_ — Invoice tracking, payment status, aging analysis and margin reporting.
-- **Bookkeeper** _(read-write)_ — Books bills and invoices, reconciles payments and manages suppliers, drafting every entry first and posting only after explicit confirmation.
+- **Finance Controller** _(read-only)_ — Invoice tracking, payment status, aging analysis and margin reporting, plus read-only subscription diagnosis: why a subscription stopped invoicing or closed itself after unpaid invoices.
+- **Bookkeeper** _(read-write)_ — Books bills and invoices, reconciles payments and manages suppliers, drafting every entry first and posting only after explicit confirmation. Reads subscriptions to trace missing recurring invoices.
 - **Expense Auditor** _(read-only)_ — Reviews expense claims, flags policy violations, detects duplicates and unusual spending patterns.
 - **Approval Manager** _(read-write)_ — Reviews and approves expenses, leave and purchase orders against your policies, escalating anything above its authority.
 

--- a/packages/web/e2e/09-groups.spec.ts
+++ b/packages/web/e2e/09-groups.spec.ts
@@ -41,6 +41,13 @@ test.describe.serial("Groups CRUD", () => {
       data: { name: "__warmup__", description: null },
     });
     await page.request.delete(`/api/groups/${MISSING_GROUP_ID}`);
+    // /api/groups/[groupId]/members is a SEPARATE route module that compiles
+    // independently — creating a group with a member fires its first PUT (seen
+    // at next.js: 4.8s / application-code: 53ms), blowing the same 5s
+    // dialog-close assertion. Warm it too; the 404 creates no membership.
+    await page.request.put(`/api/groups/${MISSING_GROUP_ID}/members`, {
+      data: { userIds: [] },
+    });
 
     await page.close();
   });

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-bookkeeper.test.ts
@@ -36,4 +36,13 @@ describe("odoo-bookkeeper template", () => {
     // The record model `sale.subscription` does not exist in Odoo 17+ — never steer the agent there.
     expect(md).not.toMatch(/`sale\.subscription`/);
   });
+
+  it("guards the optional sale.subscription.plan mention with conditional language", () => {
+    // sale.subscription.plan is granted `optional: true` — it does not exist on
+    // instances without the Subscriptions module, so mentioning it without a
+    // caveat steers the agent into permission/model errors there (same
+    // convention as the Subscription Manager legacy-model guard).
+    expect(md).toMatch(/sale\.subscription\.plan/);
+    expect(md).toMatch(/may not exist/i);
+  });
 });

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-finance-controller.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-finance-controller.test.ts
@@ -1,33 +1,20 @@
 import { describe, it, expect } from "vitest";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
 
-describe("odoo-bookkeeper template", () => {
-  const template = AGENT_TEMPLATES["odoo-bookkeeper"];
+describe("odoo-finance-controller template", () => {
+  const template = AGENT_TEMPLATES["odoo-finance-controller"];
   const md = template.defaultAgentsMd;
   const required = template.odooConfig?.requiredModels ?? [];
   const modelOps = (m: string) => required.find((r) => r.model === m)?.operations ?? [];
 
-  it("documents that price_unit is tax-exclusive (net)", () => {
-    expect(md).toMatch(/price_unit`[^.]{0,80}tax-exclusive/i);
-  });
-
-  it("mandates post-create verification against amount_total within tolerance", () => {
-    expect(md).toMatch(/verify the draft|amount_total.*receipt/i);
-    expect(md).toMatch(/0\.02 EUR/);
+  it("stays read-only", () => {
+    expect(template.odooConfig?.accessLevel).toBe("read-only");
   });
 
   it("grants read access to the subscription view (sale.order + line + plan)", () => {
     expect(modelOps("sale.order")).toContain("read");
     expect(modelOps("sale.order.line")).toContain("read");
     expect(modelOps("sale.subscription.plan")).toContain("read");
-  });
-
-  it("keeps the subscription models read-only (reference context, not managed here)", () => {
-    for (const m of ["sale.order", "sale.order.line", "sale.subscription.plan"]) {
-      expect(modelOps(m)).not.toContain("create");
-      expect(modelOps(m)).not.toContain("write");
-      expect(modelOps(m)).not.toContain("delete");
-    }
   });
 
   it("documents the modern is_subscription model, not the nonexistent legacy sale.subscription", () => {

--- a/packages/web/src/__tests__/lib/agent-templates/odoo-finance-controller.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates/odoo-finance-controller.test.ts
@@ -23,4 +23,13 @@ describe("odoo-finance-controller template", () => {
     // The record model `sale.subscription` does not exist in Odoo 17+ — never steer the agent there.
     expect(md).not.toMatch(/`sale\.subscription`/);
   });
+
+  it("guards the optional sale.subscription.plan mention with conditional language", () => {
+    // sale.subscription.plan is granted `optional: true` — it does not exist on
+    // instances without the Subscriptions module, so mentioning it without a
+    // caveat steers the agent into permission/model errors there (same
+    // convention as the Subscription Manager legacy-model guard).
+    expect(md).toMatch(/sale\.subscription\.plan/);
+    expect(md).toMatch(/may not exist/i);
+  });
 });

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -240,7 +240,7 @@ You track invoices, monitor payments, and analyze financial performance. You ens
 - **account.analytic.account** — Analytic accounts. Key fields: \`name\`, \`code\`, \`balance\`
 - **sale.order** — Subscriptions live here (Odoo 17+). A subscription is a \`sale.order\` with \`is_subscription = true\` — there is no separate subscription record model. Key fields: \`name\`, \`partner_id\`, \`is_subscription\`, \`subscription_state\` ("3_progress", "4_paused", "5_renewed", "6_churn"), \`plan_id\`, \`next_invoice_date\`, \`end_date\`, \`recurring_total\`, \`close_reason_id\`
 - **sale.order.line** — Subscription / order lines. Key fields: \`product_id\`, \`product_uom_qty\`, \`price_unit\`, \`price_subtotal\`
-- **sale.subscription.plan** — The recurring plan (read-only). Key field: \`auto_close_limit\` (days a subscription may stay unpaid before Odoo auto-closes it)
+- **sale.subscription.plan** — The recurring plan (read-only). Key field: \`auto_close_limit\` (days a subscription may stay unpaid before Odoo auto-closes it). This model may not exist on instances without the Subscriptions module — call \`odoo_describe_model\` first and fall back to the \`sale.order\` fields if it is unavailable
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
@@ -261,7 +261,7 @@ Use \`odoo_aggregate\` on \`account.move\` with \`filters: [["move_type", "=", "
 Group open invoices by \`invoice_date_due:month\` to see when payments are due.
 
 ### Why did a subscription stop invoicing / cancel itself?
-Subscriptions are \`sale.order\` with \`is_subscription = true\`. Read the order and inspect \`subscription_state\` and \`close_reason_id\`: a state of \`6_churn\` with close reason "Unpaid subscription" means Odoo auto-closed it because its invoices stayed unpaid past the plan's \`auto_close_limit\` (see \`sale.subscription.plan\`). Cross-check the open invoices on \`account.move\` (\`payment_state != "paid"\`). This is read-only diagnosis — reopening the subscription or reconciling payments happens in Odoo, not here.
+Subscriptions are \`sale.order\` with \`is_subscription = true\`. Read the order and inspect \`subscription_state\` and \`close_reason_id\`: a state of \`6_churn\` with close reason "Unpaid subscription" means Odoo auto-closed it because its invoices stayed unpaid past the plan's \`auto_close_limit\` (see \`sale.subscription.plan\`, if available). Cross-check the open invoices on \`account.move\` (\`payment_state != "paid"\`). This is read-only diagnosis — reopening the subscription or reconciling payments happens in Odoo, not here.
 
 ${ODOO_OUTPUT_FORMATTING}
 
@@ -307,7 +307,7 @@ You book incoming bills and customer invoices into Odoo, reconcile them against 
 - **account.journal** — Accounting journals (read-only). Key fields: \`name\`, \`code\`, \`type\` ("sale", "purchase", "cash", "bank", "general")
 - **res.currency** — Currencies (read-only). Key fields: \`name\` (ISO code), \`symbol\`, \`active\`
 - **account.analytic.line / account.analytic.account** — Cost-centre data (read-only context)
-- **sale.order / sale.order.line** — Subscriptions (read-only context). A subscription is a \`sale.order\` with \`is_subscription = true\` (Odoo 17+); there is no separate subscription record model. Useful when a recurring bill or invoice is missing: check \`subscription_state\` ("6_churn" = closed by Odoo), \`close_reason_id\`, and \`next_invoice_date\`. \`sale.subscription.plan.auto_close_limit\` is the days-unpaid threshold after which Odoo auto-closes a subscription. Diagnose here; reopening or reconciling happens in Odoo.
+- **sale.order / sale.order.line** — Subscriptions (read-only context). A subscription is a \`sale.order\` with \`is_subscription = true\` (Odoo 17+); there is no separate subscription record model. Useful when a recurring bill or invoice is missing: check \`subscription_state\` ("6_churn" = closed by Odoo), \`close_reason_id\`, and \`next_invoice_date\`. \`sale.subscription.plan.auto_close_limit\` is the days-unpaid threshold after which Odoo auto-closes a subscription (the plan model may not exist on instances without the Subscriptions module — verify with \`odoo_describe_model\` first). Diagnose here; reopening or reconciling happens in Odoo.
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -238,6 +238,9 @@ You track invoices, monitor payments, and analyze financial performance. You ens
 - **account.payment** — Payments. Key fields: \`partner_id\`, \`amount\`, \`payment_type\` ("inbound"=receipt, "outbound"=payment), \`date\`, \`state\`
 - **account.analytic.line** — Analytic entries. Key fields: \`account_id\`, \`amount\`, \`date\`, \`partner_id\`, \`product_id\`
 - **account.analytic.account** — Analytic accounts. Key fields: \`name\`, \`code\`, \`balance\`
+- **sale.order** — Subscriptions live here (Odoo 17+). A subscription is a \`sale.order\` with \`is_subscription = true\` — there is no separate subscription record model. Key fields: \`name\`, \`partner_id\`, \`is_subscription\`, \`subscription_state\` ("3_progress", "4_paused", "5_renewed", "6_churn"), \`plan_id\`, \`next_invoice_date\`, \`end_date\`, \`recurring_total\`, \`close_reason_id\`
+- **sale.order.line** — Subscription / order lines. Key fields: \`product_id\`, \`product_uom_qty\`, \`price_unit\`, \`price_subtotal\`
+- **sale.subscription.plan** — The recurring plan (read-only). Key field: \`auto_close_limit\` (days a subscription may stay unpaid before Odoo auto-closes it)
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
@@ -257,6 +260,9 @@ Use \`odoo_aggregate\` on \`account.move\` with \`filters: [["move_type", "=", "
 ### Receivables aging
 Group open invoices by \`invoice_date_due:month\` to see when payments are due.
 
+### Why did a subscription stop invoicing / cancel itself?
+Subscriptions are \`sale.order\` with \`is_subscription = true\`. Read the order and inspect \`subscription_state\` and \`close_reason_id\`: a state of \`6_churn\` with close reason "Unpaid subscription" means Odoo auto-closed it because its invoices stayed unpaid past the plan's \`auto_close_limit\` (see \`sale.subscription.plan\`). Cross-check the open invoices on \`account.move\` (\`payment_state != "paid"\`). This is read-only diagnosis — reopening the subscription or reconciling payments happens in Odoo, not here.
+
 ${ODOO_OUTPUT_FORMATTING}
 
 ${ODOO_RULES}
@@ -269,6 +275,9 @@ ${ODOO_MULTI_COMPANY_GUIDANCE}`,
       { model: "account.payment", operations: ["read"] },
       { model: "account.analytic.line", operations: ["read"] },
       { model: "account.analytic.account", operations: ["read"] },
+      { model: "sale.order", operations: ["read"] },
+      { model: "sale.order.line", operations: ["read"] },
+      { model: "sale.subscription.plan", operations: ["read"], optional: true },
     ],
     modelHint: {
       tier: "reasoning",
@@ -298,6 +307,7 @@ You book incoming bills and customer invoices into Odoo, reconcile them against 
 - **account.journal** — Accounting journals (read-only). Key fields: \`name\`, \`code\`, \`type\` ("sale", "purchase", "cash", "bank", "general")
 - **res.currency** — Currencies (read-only). Key fields: \`name\` (ISO code), \`symbol\`, \`active\`
 - **account.analytic.line / account.analytic.account** — Cost-centre data (read-only context)
+- **sale.order / sale.order.line** — Subscriptions (read-only context). A subscription is a \`sale.order\` with \`is_subscription = true\` (Odoo 17+); there is no separate subscription record model. Useful when a recurring bill or invoice is missing: check \`subscription_state\` ("6_churn" = closed by Odoo), \`close_reason_id\`, and \`next_invoice_date\`. \`sale.subscription.plan.auto_close_limit\` is the days-unpaid threshold after which Odoo auto-closes a subscription. Diagnose here; reopening or reconciling happens in Odoo.
 
 **Important**: Always call \`odoo_describe_model\` with the model name to discover the full list of fields before querying. The field names above are starting points — verify them.
 
@@ -409,6 +419,9 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
       { model: "res.currency", operations: ["read"] },
       { model: "account.analytic.line", operations: ["read"] },
       { model: "account.analytic.account", operations: ["read"] },
+      { model: "sale.order", operations: ["read"] },
+      { model: "sale.order.line", operations: ["read"] },
+      { model: "sale.subscription.plan", operations: ["read"], optional: true },
       { model: "ir.attachment", operations: ["read", "create"] },
     ],
     modelHint: {

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -20,6 +20,7 @@ export const MODEL_CATEGORIES: ModelCategory[] = [
       { model: "sale.order", name: "Orders" },
       { model: "sale.order.line", name: "Order Lines" },
       { model: "sale.order.template", name: "Quotation Templates" },
+      { model: "sale.subscription.plan", name: "Subscription Plans" },
     ],
   },
   {


### PR DESCRIPTION
## Why

The **Bookkeeper** and **Finance Controller** Odoo agent templates had no access to `sale.order`, so they could not answer *"why did this subscription stop invoicing this month?"* — a routine bookkeeping question.

Investigated against a live Odoo 19 instance: when asked, the agent reached for the legacy `sale.subscription` record model, which **does not exist in Odoo 17+**. Subscriptions are `sale.order` with `is_subscription = true`. The concrete trigger was a rent subscription Odoo **auto-churned** after being 15 days unpaid (`sale.subscription.plan.auto_close_limit = 15`, close reason "Unpaid subscription") — which the agent couldn't diagnose without `sale.order` visibility.

## What

Grant **read-only** access to the subscription view on both templates:

- `sale.order` + `sale.order.line` (read)
- `sale.subscription.plan` (read, optional) — exposes `auto_close_limit`

Plus `## Available Data` docs and a diagnosis pattern that steer the agent to the modern `is_subscription` model (never the nonexistent `sale.subscription`) and explain the churn-on-unpaid behavior. Read-only keeps the agents focused — managing subscriptions stays with the `odoo-subscription-manager` agent.

Also registers `sale.subscription.plan` in the model-category picker (`odoo-sync.ts`).

Access levels unchanged: finance-controller stays `read-only`, bookkeeper stays `read-write`. `sales-analyst`/`crm-assistant` already had `sale.order` read — untouched.

## Tests (TDD)

- `odoo-bookkeeper.test.ts`: +3 — read grant, read-only guard, modern-`is_subscription` doc guard
- `odoo-finance-controller.test.ts`: new, mirrored + `read-only` access-level guard
- FK-deps guard stays green (read-only ⇒ not triggered)

## Follow-up (not in this PR)

Existing agents (e.g. prod "Penny") are template snapshots — they won't pick up the new models retroactively. Recreating from template or manually adding the models is deferred until after the release.

Verification: full web suite green (6587 passed), `format:check`, `lint` (0 errors), `build`, `test:db` (132 passed).