### PR TITLE
ci: run pinchy plugin vitest unit suites in the quality job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -173,6 +173,12 @@ jobs:
       - name: Test (root scripts)
         run: pnpm test:scripts
 
+      - name: Test (plugins)
+        # Plugin vitest unit suites are not part of `pnpm test` (web only),
+        # and the E2E stacks exercise plugins at runtime, not these unit
+        # files — without this step they never run in CI and silently rot.
+        run: pnpm test:plugins
+
       - name: Cache Next.js build
         uses: actions/cache@v5
         with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -174,9 +174,15 @@ jobs:
         run: pnpm test:scripts
 
       - name: Test (plugins)
-        # Plugin vitest unit suites are not part of `pnpm test` (web only),
-        # and the E2E stacks exercise plugins at runtime, not these unit
-        # files — without this step they never run in CI and silently rot.
+        # The plugin test FILES already run inside `pnpm test` via the
+        # `../plugins/pinchy-*` include in packages/web/vitest.config.ts —
+        # but under the web package's config (jsdom, web setup files, web
+        # node_modules). This step additionally runs each plugin package's
+        # own `test` script under its own config and dependencies, exactly
+        # as plugin developers run it locally, catching phantom-dependency
+        # and environment drift the web-config run would mask.
+        # `--fail-if-no-match` keeps the step from going vacuously green if
+        # the workspace glob ever stops matching.
         run: pnpm test:plugins
 
       - name: Cache Next.js build

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -123,6 +123,7 @@ pnpm format
 pnpm db:generate
 pnpm test:scripts
 pnpm typecheck:plugins
+pnpm test:plugins
 ```
 
 Useful web package commands:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -9,7 +9,7 @@ Status: early development. The core is working: setup wizard, authentication, pr
 ## Repository Map
 
 - `packages/web/` - Next.js app, API routes, WebSocket bridge, Drizzle schema/migrations, tests.
-- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-web`.
+- `packages/plugins/` - OpenClaw plugins. Current Pinchy plugins: `pinchy-files`, `pinchy-context`, `pinchy-docs`, `pinchy-audit`, `pinchy-email`, `pinchy-odoo`, `pinchy-transcript`, `pinchy-web`.
 - `config/` - OpenClaw config support, startup scripts, mock services for integration/E2E tests.
 - `docs/` - Astro Starlight documentation. It is standalone and has its own `package.json` and lockfile.
 - `sample-data/` - Sample knowledge-base data mounted into Docker at `/data/`.
@@ -265,6 +265,10 @@ Each plugin's `tsconfig.json` must be uniform so the gate is meaningful:
 - `"compilerOptions"`: `skipLibCheck: true` (third-party `.d.ts` files otherwise break the gate) and `types: ["node", "vitest"]`, backed by an `@types/node` devDependency (`types: ["node"]` throws TS2688 without it).
 
 The drift guard `scripts/lib/plugin-typecheck.test.mjs` (pure logic in `scripts/lib/plugin-typecheck.mjs`, run by `pnpm test:scripts`) fails fast if any plugin isn't wired this way, so a new plugin can't silently escape the gate — the read-side sibling of the no-untracked-skips / no-test-deletion guards.
+
+### Unit test gate
+
+Every plugin package must ship vitest unit tests and declare `"test": "vitest run"` in its package.json. The test files run twice in the CI quality job, deliberately: once inside `pnpm test` via the `../plugins/pinchy-*` include in `packages/web/vitest.config.ts` (web config), and once per package via `pnpm test:plugins` (each plugin's own config and dependencies, as run locally). Two drift guards in `packages/web/src/__tests__/lib/plugin-test-coverage.test.ts` enforce this: every plugin test file must match the include globs, and every plugin package must declare a `test` script (pnpm recursive runs silently skip packages without one).
 
 ### Tool dispatch coverage
 

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "dev": "pnpm --filter @pinchy/web dev",
     "build": "pnpm --filter @pinchy/web build",
     "test": "pnpm --filter @pinchy/web test",
+    "test:plugins": "pnpm --filter \"./packages/plugins/*\" test",
     "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs config/__tests__/*.test.mjs",
     "typecheck:plugins": "node scripts/typecheck-plugins.mjs",
     "release": "node scripts/release.mjs",

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dev": "pnpm --filter @pinchy/web dev",
     "build": "pnpm --filter @pinchy/web build",
     "test": "pnpm --filter @pinchy/web test",
-    "test:plugins": "pnpm --filter \"./packages/plugins/*\" test",
+    "test:plugins": "pnpm --fail-if-no-match --filter \"./packages/plugins/*\" test",
     "test:scripts": "node --test scripts/lib/*.test.mjs docs/scripts/*.test.mjs config/telegram-mock/__tests__/*.test.mjs config/__tests__/*.test.mjs",
     "typecheck:plugins": "node scripts/typecheck-plugins.mjs",
     "release": "node scripts/release.mjs",

--- a/packages/web/src/__tests__/lib/plugin-test-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/plugin-test-coverage.test.ts
@@ -21,7 +21,17 @@
 // of being picked up by the include glob. See AGENTS.md § "Plugin
 // Integration Contract" for the broader plugin-coverage contract.
 import { describe, it, expect } from "vitest";
-import { readdirSync, statSync } from "node:fs";
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  statSync,
+  writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
 import { join, relative, resolve } from "node:path";
 import vitestConfig from "../../../vitest.config";
 
@@ -228,5 +238,81 @@ describe("plugin-test-coverage", () => {
         "Either widen the include glob, or remove the test file.",
       ].join("\n")
     ).toEqual([]);
+  });
+});
+
+/**
+ * List package directories under `pluginsRoot` whose package.json lacks a
+ * `test` script. `pnpm --filter "./packages/plugins/*" test` (the root
+ * `test:plugins` script, run by the CI quality job) silently skips such
+ * packages — pnpm only errors when *zero* matched packages have the script —
+ * so without this check a new plugin's own suite could drop out of the
+ * per-package gate unnoticed. Directories without a package.json are not
+ * workspace packages and are ignored.
+ */
+function pluginPackagesMissingTestScript(pluginsRoot: string): string[] {
+  const missing: string[] = [];
+  for (const entry of readdirSync(pluginsRoot)) {
+    const packageJsonPath = join(pluginsRoot, entry, "package.json");
+    if (!statSync(join(pluginsRoot, entry)).isDirectory()) continue;
+    if (!existsSync(packageJsonPath)) continue;
+    const manifest = JSON.parse(readFileSync(packageJsonPath, "utf8")) as {
+      scripts?: Record<string, string>;
+    };
+    if (!manifest.scripts?.test) {
+      missing.push(entry);
+    }
+  }
+  return missing.sort();
+}
+
+describe("pluginPackagesMissingTestScript", () => {
+  it("flags a package without a test script and passes one with it", () => {
+    const root = mkdtempSync(join(tmpdir(), "plugin-test-scripts-"));
+    try {
+      mkdirSync(join(root, "pinchy-good"));
+      writeFileSync(
+        join(root, "pinchy-good", "package.json"),
+        JSON.stringify({ name: "good", scripts: { test: "vitest run" } })
+      );
+      mkdirSync(join(root, "pinchy-bad"));
+      writeFileSync(
+        join(root, "pinchy-bad", "package.json"),
+        JSON.stringify({ name: "bad", scripts: { build: "tsc" } })
+      );
+      // Not a workspace package (no package.json) — must be ignored.
+      mkdirSync(join(root, "shared-fixtures"));
+
+      expect(pluginPackagesMissingTestScript(root)).toEqual(["pinchy-bad"]);
+    } finally {
+      rmSync(root, { recursive: true, force: true });
+    }
+  });
+});
+
+describe("plugin test scripts (drift guard)", () => {
+  it("every package under packages/plugins declares a test script", () => {
+    const missing = pluginPackagesMissingTestScript(PLUGINS_ROOT);
+    expect(
+      missing,
+      [
+        "The following plugin packages have no `test` script, so",
+        "`pnpm test:plugins` silently skips their suite in CI:",
+        "",
+        ...missing.map((name) => `  packages/plugins/${name}`),
+        "",
+        'Add `"test": "vitest run"` to each package.json.',
+      ].join("\n")
+    ).toEqual([]);
+  });
+
+  it("finds at least one plugin package (guards the test:plugins glob)", () => {
+    // If packages/plugins is ever moved or emptied, `--fail-if-no-match`
+    // catches it in CI, and this assertion catches it in every local
+    // `pnpm test` run.
+    const packages = readdirSync(PLUGINS_ROOT).filter((entry) =>
+      existsSync(join(PLUGINS_ROOT, entry, "package.json"))
+    );
+    expect(packages.length).toBeGreaterThan(0);
   });
 });


### PR DESCRIPTION
## Why

The root `pnpm test` resolves to `pnpm --filter @pinchy/web test`. The plugin test **files** do run there — since a77cd4dfe the `../plugins/pinchy-*` include in `packages/web/vitest.config.ts` picks them up (guarded by `plugin-test-coverage.test.ts`) — but always under the **web package's config**: jsdom environment, web setup files, web `node_modules`. Each plugin's own `test` script (`vitest run` under the plugin's own config and dependencies — what plugin developers run locally) was never executed in CI, so phantom-dependency and environment drift between the two configs could go unnoticed.

> Note: the first commit's step comment claimed plugin suites were "not part of `pnpm test`" at all — that premise was stale (true only before a77cd4dfe, 2026-05-22). The second commit corrects the comment and hardens the gate.

This complements PR #656 (`typecheck:plugins`), which compiles the plugin test files but does not run them.

## What

- Root script `test:plugins`: `pnpm --fail-if-no-match --filter "./packages/plugins/*" test`. The directory filter mirrors the `packages/plugins/*` glob in `pnpm-workspace.yaml`; `--fail-if-no-match` keeps the gate from going vacuously green if the glob ever stops matching (a bare non-matching `--filter` exits 0).
- `Test (plugins)` step in the `quality` job, right after `Test (root scripts)`, with a comment stating the step's actual value (own-config execution, not first-time execution).
- Drift guard: `plugin-test-coverage.test.ts` now also asserts every package under `packages/plugins/` declares a `test` script — pnpm recursive runs silently skip packages without one (pnpm only errors when *zero* matched packages have it).
- AGENTS.md: `pnpm test:plugins` in the host-command list, a "Unit test gate" subsection in the Plugin Integration Contract, and the missing `pinchy-transcript` added to the repository map.

## Verification

- RED: `pnpm test:plugins` fails before the change (`Command "test:plugins" not found`, exit 254).
- GREEN: all 8 suites pass (680 tests, exit 0); full web suite green (6701 tests).
- Gate bites, twice over: a deliberately failing canary test in pinchy-context makes `pnpm test:plugins` exit 1, and removing pinchy-context's `test` script turns the new drift guard red.
- `pnpm --fail-if-no-match --filter "./packages/plugins/nonexistent-*" test` exits 1 (bare filter exits 0).
- CI quality job runs the new step.

## Notes for the merger

- PR #656 touches the same AGENTS.md command list; whichever merges second resolves a trivial both-keep conflict there (package.json and ci.yml merge cleanly — verified via `git merge-tree`).
- #656 discovers plugins by the `pinchy-` name prefix, this PR by workspace directory glob. Both enumerate the same 8 packages today; worth unifying on one discovery rule once both are merged.