### PR TITLE
fix(api): fail loudly with 503 when Google OAuth settings are missing during a required token refresh

### DIFF
--- a/docker-compose.email-test.yml
+++ b/docker-compose.email-test.yml
@@ -20,6 +20,9 @@ services:
       # Emit a dummy API-key SecretRef for the local Ollama provider so OpenClaw
       # authenticates when routing to host.docker.internal (not treated as local).
       - PINCHY_E2E_OLLAMA_LOCAL_API_KEY=1
+      # The web app performs the OAuth token refresh (credentials route), so it
+      # is the container that must talk to the mock's /token endpoint.
+      - GMAIL_OAUTH_BASE_URL=http://gmail-mock:9004
     extra_hosts:
       # Allows Pinchy (Docker) to fetch the Ollama model list from fake-Ollama on
       # the host during regenerateOpenClawConfig(). OpenClaw already has this
@@ -28,5 +31,5 @@ services:
 
   openclaw:
     environment:
+      # The pinchy-email plugin (running inside OpenClaw) calls the Gmail API.
       - GMAIL_API_BASE_URL=http://gmail-mock:9004
-      - GMAIL_OAUTH_BASE_URL=http://gmail-mock:9004

--- a/packages/web/e2e/email/helpers.ts
+++ b/packages/web/e2e/email/helpers.ts
@@ -113,6 +113,20 @@ export async function createGoogleConnectionInDb(
     scope: "https://www.googleapis.com/auth/gmail.modify",
   };
 
+  // The Google OAuth app settings are a prerequisite for that refresh: with an
+  // expired token and no settings, the credentials route fails loudly with 503
+  // instead of leaking the expired token to the plugin (OAuthSettingsMissingError).
+  // gmail-mock's /token endpoint accepts any client credentials.
+  const oauthSettings = JSON.stringify({
+    clientId: "mock-google-client-id",
+    clientSecret: "mock-google-client-secret",
+  });
+  await sql`
+    INSERT INTO settings (key, value, encrypted)
+    VALUES ('google_oauth_credentials', ${oauthSettings}, false)
+    ON CONFLICT (key) DO UPDATE SET value = ${oauthSettings}, encrypted = false
+  `;
+
   const encryptedCredentials = encryptCredentials(JSON.stringify(credentials));
 
   const id = randomUUID();

--- a/packages/web/src/__tests__/api/internal-integration-credentials.test.ts
+++ b/packages/web/src/__tests__/api/internal-integration-credentials.test.ts
@@ -221,26 +221,35 @@ describe("GET /api/internal/integrations/:connectionId/credentials", () => {
       expect(refreshAccessToken).not.toHaveBeenCalled();
     });
 
-    it("returns existing credentials when Google OAuth settings are missing (graceful degradation)", async () => {
+    it("returns 503 with a structured error when Google OAuth settings are missing for an expired token (no stale credentials leaked)", async () => {
       vi.mocked(isTokenExpired).mockReturnValue(true);
       vi.mocked(getOAuthSettings).mockResolvedValue(null);
 
       const expiredAt = new Date(Date.now() - 60_000).toISOString();
       vi.mocked(decrypt).mockReturnValue(
         JSON.stringify({
-          accessToken: "old-token",
-          refreshToken: "refresh-token",
+          accessToken: "google-stale-access-token",
+          refreshToken: "google-stale-refresh-token",
           expiresAt: expiredAt,
         })
       );
 
       const res = await GET(makeRequest("conn-google"), makeParams("conn-google"));
-      expect(res.status).toBe(200);
+      expect(res.status).toBe(503);
+
       const data = await res.json();
-      expect(data.type).toBe("google");
-      expect(data.credentials.accessToken).toBe("old-token");
-      expect(data.credentials.expiresAt).toBe(expiredAt);
+      expect(data.error).toBe(
+        "Google OAuth settings missing — reconnect the mailbox or restore the OAuth app"
+      );
+      // Must NOT leak the stale/expired credentials in the response body.
+      expect(data.credentials).toBeUndefined();
+      expect(JSON.stringify(data)).not.toContain("google-stale-access-token");
+      expect(JSON.stringify(data)).not.toContain("google-stale-refresh-token");
+
+      // Refresh must not have been attempted (no client credentials available)
+      // and the DB must not be touched.
       expect(refreshAccessToken).not.toHaveBeenCalled();
+      expect(db.update).not.toHaveBeenCalled();
     });
 
     it("returns existing credentials when token refresh fails (graceful degradation)", async () => {

--- a/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
+++ b/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
@@ -24,6 +24,22 @@ interface GoogleCredentials {
 // See issue #237.
 const inFlightGoogleRefreshes = new Map<string, Promise<GoogleCredentials>>();
 
+// Thrown when a token refresh is actually required (the access token is
+// expired) but the OAuth app settings needed to perform that refresh are
+// missing — reachable since OAuth app settings have a lifecycle independent
+// of connections (an admin can reset the OAuth app while connections still
+// exist). Unlike a failed refresh attempt (network/provider error, where the
+// stale credentials are a reasonable fallback), there is no credential to
+// fall back to here that will actually work — the plugin would cache a token
+// doomed to fail on first use. The route surfaces this as a loud 5xx rather
+// than silently returning expired credentials with a 200.
+class OAuthSettingsMissingError extends Error {
+  constructor(readonly provider: string) {
+    super(`${provider} OAuth settings not configured`);
+    this.name = "OAuthSettingsMissingError";
+  }
+}
+
 async function refreshGoogleCredentials(
   connectionId: string,
   current: GoogleCredentials
@@ -36,7 +52,7 @@ async function refreshGoogleCredentials(
       const oauthSettings = await getOAuthSettings("google");
       if (!oauthSettings) {
         console.error("Google OAuth token refresh failed: OAuth settings not configured");
-        return current;
+        throw new OAuthSettingsMissingError("Google");
       }
 
       const refreshed = await refreshAccessToken({
@@ -62,6 +78,11 @@ async function refreshGoogleCredentials(
       console.log("Refreshed Google OAuth token for connection", connectionId);
       return updated;
     } catch (err) {
+      if (err instanceof OAuthSettingsMissingError) {
+        // Re-throw: there is no safe stale fallback when settings are missing
+        // and a refresh is required (see class comment above).
+        throw err;
+      }
       console.error("Google OAuth token refresh failed:", err);
       return current;
     }
@@ -106,14 +127,31 @@ export async function GET(
     return NextResponse.json({ error: "Failed to decrypt credentials" }, { status: 500 });
   }
 
-  // Auto-refresh expired Google OAuth tokens (graceful degradation: return old credentials on failure).
-  // Concurrent callers for the same connectionId share a single refresh via inFlightGoogleRefreshes.
+  // Auto-refresh expired Google OAuth tokens. A failed refresh attempt degrades
+  // gracefully to the current credentials; missing OAuth settings fail loudly
+  // (see OAuthSettingsMissingError). Concurrent callers for the same
+  // connectionId share a single refresh via inFlightGoogleRefreshes.
   if (
     connection.type === "google" &&
     credentials.expiresAt &&
     isTokenExpired(credentials.expiresAt)
   ) {
-    credentials = await refreshGoogleCredentials(connectionId, credentials as GoogleCredentials);
+    try {
+      credentials = await refreshGoogleCredentials(connectionId, credentials as GoogleCredentials);
+    } catch (err) {
+      if (err instanceof OAuthSettingsMissingError) {
+        // The access token is expired and there is no way to refresh it —
+        // fail loudly instead of returning a 200 with stale/expired tokens
+        // that the plugin would cache for another 5 minutes and fail on.
+        return NextResponse.json(
+          {
+            error: `${err.provider} OAuth settings missing — reconnect the mailbox or restore the OAuth app`,
+          },
+          { status: 503 }
+        );
+      }
+      throw err;
+    }
   }
 
   return NextResponse.json({ type: connection.type, credentials });


### PR DESCRIPTION
## Why

`refreshGoogleCredentials` in the internal credentials route had the same latent bug that was fixed for Microsoft in 880cd4c3c: when `getOAuthSettings("google")` returns `null` while a token refresh is **required** (access token expired), it logged and returned the stale/expired credentials with HTTP 200. The pinchy-email plugin then cached those doomed credentials for its 5-minute TTL and failed later with confusing auth errors.

This path is reachable in production: since #328, OAuth app settings have a lifecycle independent of connections — an admin can reset the Google OAuth app while connections still exist.

## What

- New `OAuthSettingsMissingError`, thrown only when OAuth settings are missing during a **required** refresh. The `GET` handler catches it and returns **503** with a structured error body and no credentials.
- A failed refresh **attempt** (network/provider error) keeps degrading gracefully to the current credentials — only the no-settings case changes, exactly mirroring the Microsoft fix.
- TDD red-first: the previous test that pinned the buggy behavior ("returns existing credentials when Google OAuth settings are missing") is replaced by the 503 test, mirroring the Microsoft test from 880cd4c3c. Net test count unchanged.

## Email E2E: the fix exposed a hole in the suite (second commit)

The first CI run failed the Gmail E2E — correctly. The suite seeds a connection with an already-expired token "to verify the token refresh flow on first use", but never seeded the Google OAuth app settings, so the refresh never ran: the suite was green only because the route silently served expired tokens and gmail-mock doesn't validate them. The E2E stack was, in effect, permanently running in the exact production state this PR makes loud.

Two infra fixes make the refresh flow actually run:

- Seed `google_oauth_credentials` in `createGoogleConnectionInDb` (gmail-mock's `/token` accepts any client credentials).
- Move `GMAIL_OAUTH_BASE_URL` from the **openclaw** container to the **pinchy** container — its only consumer is the web app's credentials route; on openclaw it was dead config, and without it on pinchy the refresh would call the real `oauth2.googleapis.com` from CI.

Verified against a local stack: all 5 email E2E tests pass and the pinchy log shows `Refreshed Google OAuth token for connection …` (proof the mock's `/token` served the refresh).

## Note for the Microsoft branch

880cd4c3c lives on `claude/elegant-haslett-af3fa3` (not yet on `main`), so there was no `MicrosoftOAuthSettingsMissingError` here to reuse. The class in this PR is generalized (provider-parameterized) — when the Microsoft branch merges, its provider-specific class should be replaced by this one during conflict resolution.

## Gates

- Unit suite: 6698 passed
- `test:db`: 140 passed
- Email E2E (local stack): 5 passed, refresh flow verified in logs
- `lint` (0 errors), `format:check`, `tsc --noEmit`: clean