### PR TITLE
feat(agent-templates): grant Subscription Manager optional read on sale.subscription.plan

### DIFF
--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -729,16 +729,17 @@ describe("Additional Odoo templates (10 new)", () => {
   });
 
   it("Subscription Manager only references models that are in requiredModels (or guards them)", () => {
-    // The legacy sale.subscription / sale.subscription.plan models are NOT in
+    // The legacy sale.subscription record model (Odoo ≤16) is NOT in
     // requiredModels — modern Odoo (17+) uses sale.order with is_subscription
     // instead. The AGENTS.md must not tell the agent to confidently query
     // sale.subscription, otherwise it will get permission errors on every
     // query in modern Odoo. Any mention must be guarded with conditional
     // language ("if available", "may not exist", "check via odoo_schema first").
+    // Note: sale.subscription.plan is NOT legacy — it exists in modern Odoo
+    // as the target of sale.order.plan_id and is granted (optional) below.
     const t = getTemplate("odoo-subscription-manager")!;
     const grantedModels = t.odooConfig!.requiredModels.map((m) => m.model);
     expect(grantedModels).not.toContain("sale.subscription");
-    expect(grantedModels).not.toContain("sale.subscription.plan");
 
     // If sale.subscription is mentioned at all, it must be guarded
     if (/sale\.subscription/.test(t.defaultAgentsMd)) {
@@ -746,6 +747,31 @@ describe("Additional Odoo templates (10 new)", () => {
         /may not exist|if available|if (the )?model exists|check.*odoo_schema|not granted|legacy.*may/i
       );
     }
+  });
+
+  it("Subscription Manager gets optional read access to sale.subscription.plan", () => {
+    // sale.order.plan_id points at sale.subscription.plan in modern Odoo
+    // (Enterprise Subscriptions module, 17+). Without a read grant the agent
+    // cannot resolve a subscription's plan or read auto_close_limit — the
+    // days-unpaid threshold after which Odoo auto-closes (churns) a
+    // subscription, which is core context for a churn-tracking agent.
+    // Optional because the model only exists when the Subscriptions module
+    // is installed (same convention as finance-controller / bookkeeper).
+    const t = getTemplate("odoo-subscription-manager")!;
+    const plan = t.odooConfig!.requiredModels.find((m) => m.model === "sale.subscription.plan");
+    expect(plan).toBeDefined();
+    expect(plan!.operations).toEqual(["read"]);
+    expect(plan!.optional).toBe(true);
+  });
+
+  it("Subscription Manager documents sale.subscription.plan with auto_close_limit and guards it", () => {
+    // Optional models must be mentioned with "may not exist" language so the
+    // agent probes with odoo_describe_model instead of failing hard on
+    // instances without the Subscriptions module.
+    const t = getTemplate("odoo-subscription-manager")!;
+    expect(t.defaultAgentsMd).toContain("sale.subscription.plan");
+    expect(t.defaultAgentsMd).toContain("auto_close_limit");
+    expect(t.defaultAgentsMd).toMatch(/may not exist/i);
   });
 
   it("POS Analyst mentions pos.order and pos.session", () => {

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -1169,8 +1169,9 @@ Your primary working model is \`sale.order\` with \`is_subscription = true\` (Od
 - **sale.order.line** — Subscription lines. Key fields: \`product_id\`, \`product_uom_qty\`, \`price_unit\`, \`price_subtotal\`
 - **account.move** — Subscription invoices. Key fields: \`partner_id\`, \`invoice_date\`, \`amount_total\`, \`payment_state\`, \`subscription_id\` (if linked)
 - **res.partner** — Customers. Key fields: \`name\`, \`email\`, \`customer_rank\`
+- **sale.subscription.plan** — The recurring plan behind \`plan_id\` (read-only). Key fields: \`name\`, \`billing_period_value\`, \`billing_period_unit\`, \`auto_close_limit\` (days a subscription may stay unpaid before Odoo auto-closes it — the built-in churn-on-unpaid threshold). This model may not exist on instances without the Subscriptions module — call \`odoo_describe_model\` first and fall back to the \`sale.order\` fields if it is unavailable
 
-**Legacy \`sale.subscription\` model (Odoo ≤16)**: Older Odoo versions used a separate \`sale.subscription\` model (and \`sale.subscription.plan\`) instead of \`is_subscription\` on sale orders. This legacy model may not exist in your Odoo instance and is not granted to this agent by default. Before using it, call \`odoo_describe_model\` on \`sale.subscription\` — if the describe call fails or the model is not available, tell the user the legacy model isn't accessible and recommend granting it to this agent (or migrating to the modern \`is_subscription\` approach).
+**Legacy \`sale.subscription\` model (Odoo ≤16)**: Older Odoo versions used a separate \`sale.subscription\` record model instead of \`is_subscription\` on sale orders. This legacy model may not exist in your Odoo instance and is not granted to this agent by default. Before using it, call \`odoo_describe_model\` on \`sale.subscription\` — if the describe call fails or the model is not available, tell the user the legacy model isn't accessible and recommend granting it to this agent (or migrating to the modern \`is_subscription\` approach).
 
 **Important**: Always call \`odoo_describe_model\` first — subscription fields changed significantly between Odoo versions. Confirm which fields exist before querying.
 
@@ -1185,7 +1186,7 @@ Use \`odoo_aggregate\` on \`sale.order\` with \`filters: [["is_subscription", "=
 Use \`odoo_read\` on \`sale.order\` with \`filters: [["is_subscription", "=", true], ["next_invoice_date", ">=", START_OF_MONTH], ["next_invoice_date", "<=", END_OF_MONTH]]\`.
 
 ### Churn (subscriptions that ended recently)
-Use \`odoo_read\` on \`sale.order\` filtered by \`end_date\` or \`state = "cancel"\` within your reporting window, scoped to \`is_subscription = true\`.
+Use \`odoo_read\` on \`sale.order\` filtered by \`end_date\` or \`state = "cancel"\` within your reporting window, scoped to \`is_subscription = true\`. To explain a churn, check unpaid invoices on \`account.move\` against the plan's \`auto_close_limit\` (see \`sale.subscription.plan\`, if available) — Odoo auto-closes subscriptions whose invoices stay unpaid past that many days.
 
 ### Top subscribers by revenue
 Use \`odoo_aggregate\` with \`groupby: ["partner_id"]\`, \`fields: ["recurring_total:sum"]\`, \`orderby: "recurring_total desc"\`, \`limit: 20\`.
@@ -1200,6 +1201,7 @@ ${ODOO_RULES}
       { model: "sale.order.line", operations: ["read"] },
       { model: "account.move", operations: ["read"] },
       { model: "res.partner", operations: ["read"] },
+      { model: "sale.subscription.plan", operations: ["read"], optional: true },
     ],
     modelHint: { tier: "balanced", capabilities: ["vision", "tools"] },
   }),

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -20,6 +20,7 @@ export const MODEL_CATEGORIES: ModelCategory[] = [
       { model: "sale.order", name: "Orders" },
       { model: "sale.order.line", name: "Order Lines" },
       { model: "sale.order.template", name: "Quotation Templates" },
+      { model: "sale.subscription.plan", name: "Subscription Plans" },
     ],
   },
   {


### PR DESCRIPTION
## Why

The **odoo-subscription-manager** template documents `plan_id` on `sale.order` but had no grant on `sale.subscription.plan`, so the agent could not resolve a subscription's plan or read `auto_close_limit` — the days-unpaid threshold after which Odoo auto-closes (churns) a subscription. For an agent whose core job is churn tracking, that plan context matters.

`sale.subscription.plan` is **not** legacy: it exists in modern Odoo (17+/19, Enterprise Subscriptions module) as the target of `sale.order.plan_id`. Only the `sale.subscription` **record** model (Odoo ≤16) is legacy. The old test comment lumped both together; that framing is now corrected while the legacy `sale.subscription` not-granted assertions stay untouched.

## What

- Add `{ model: "sale.subscription.plan", operations: ["read"], optional: true }` to the Subscription Manager's `requiredModels` — same convention #655 uses for finance-controller / bookkeeper.
- Document the model in `defaultAgentsMd` (Available Data bullet with `auto_close_limit`, guarded with "may not exist" language per the optional-model convention) and extend the churn analysis pattern with the auto-close context.
- Reword the legacy paragraph so it no longer claims `sale.subscription.plan` is legacy-only.
- Register the model in `odoo-sync` `MODEL_CATEGORIES` ("Subscription Plans" under Sales) — the drift guard requires every template model to be categorized. The entry is identical to the one in #655 so the eventual merge stays conflict-free.

## Tests (TDD)

- New: "Subscription Manager gets optional read access to sale.subscription.plan" — grant shape (read-only, optional).
- New: "Subscription Manager documents sale.subscription.plan with auto_close_limit and guards it" — guarded-mention convention.
- Updated: the "only references models that are in requiredModels" test keeps its legacy `sale.subscription` assertions; only the misleading comment is corrected.

Both new tests were watched failing before implementation.

## Gates

- `vitest run` (packages/web): 6702 passed
- `pnpm test:db`: 140 passed
- `pnpm lint`: 0 errors, no new warnings on touched files
- `pnpm format:check`: clean
- `tsc --noEmit`: clean

Related: #655 (grants the same model to finance-controller / bookkeeper; this PR is independent and based on `main`).