### PR TITLE
fix(chat): adopt refocus history when a leading greeting hides the landed reply

### DIFF
--- a/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
+++ b/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
@@ -142,4 +142,21 @@ describe("shouldReplaceLocalWithServerHistory", () => {
       false
     );
   });
+
+  // Greeting-offset regression (staging 2026-07-05): a fresh session's local
+  // list carries the client-only agent greeting (assistant at index 0) that the
+  // server omits from history once real turns exist. After a tab-refocus during
+  // the first turn — local ends in the acked user message, server history is
+  // [user, assistant] — the greeting pads prev.length to EQUAL the server
+  // history length, so the #310 strictly-longer guard alone wrongly drops the
+  // completed reply and the agent looks silent though it answered.
+  it("adopts server history when a leading greeting makes it look equal-length but the reply landed", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [assistant("Good day. How may I help?"), user("what time is it?", "sent")],
+        [user("what time is it?"), assistant("It's 07:12 UTC.")],
+        true
+      )
+    ).toBe(true);
+  });
 });

--- a/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
+++ b/packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts
@@ -159,4 +159,32 @@ describe("shouldReplaceLocalWithServerHistory", () => {
       )
     ).toBe(true);
   });
+
+  // Data-loss guard (review of the greeting-offset fix): adopting on a
+  // greeting offset must NEVER fire for a SHORTER server history — that would
+  // erase a just-sent local user turn the server hasn't persisted yet. The
+  // trigger is a reload during a PENDING run: the user sends a follow-up in an
+  // EXISTING chat, OpenClaw hasn't streamed the first chunk, so client-router
+  // withholds the activeRun signal (its `firstChunkAt !== null` gate). The
+  // history frame carries the PREVIOUS turn's canonical [user, assistant] with
+  // NO activeRun, while local already holds
+  // [greeting, user, assistant, follow-up(sent)]. That history ends in an
+  // assistant, so a naive "server ends in assistant" rule wrongly returns true
+  // and — with no activeRun — routes through the UN-guarded staged reconcile,
+  // dropping the follow-up. The greeting-adjusted length comparison keeps local
+  // because the server holds FEWER real turns than we do.
+  it("keeps local when the server history is SHORTER than local minus the greeting (pending follow-up must not be dropped)", () => {
+    expect(
+      shouldReplaceLocalWithServerHistory(
+        [
+          assistant("Good day. How may I help?"),
+          user("first question", "sent"),
+          assistant("first answer"),
+          user("second question", "sent"),
+        ],
+        [user("first question"), assistant("first answer")],
+        true
+      )
+    ).toBe(false);
+  });
 });

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
@@ -306,4 +306,76 @@ describe("useWsRuntime — tab-refocus reconcile must not shrink the message lis
     const replies = after.filter((m) => textOf(m) === "It's 07:12 UTC.");
     expect(replies.length).toBeGreaterThan(0);
   });
+
+  // Data-loss counterpart to the greeting-surface test above (review of the
+  // greeting-offset fix): the same leading greeting must NOT cause a SHORTER
+  // recovery history to be adopted, which would erase a just-sent follow-up.
+  //
+  // Established session that already has one completed turn on top of the
+  // client-only greeting, then a SECOND question sent and acked but still
+  // PENDING (no first chunk yet). On refocus, OpenClaw hasn't persisted the
+  // pending turn and — because the run hasn't streamed its first chunk —
+  // client-router withholds the activeRun signal (its `firstChunkAt !== null`
+  // gate). So the recovery frame is the PREVIOUS turn's [user, assistant] with
+  // NO activeRun, SHORTER than the rich local list. A "server ends in an
+  // assistant" rule would adopt it through the un-guarded staged reconcile and
+  // drop the follow-up; the greeting-adjusted length comparison keeps local.
+  it("no-activeRun shorter recovery history must not drop a just-sent pending follow-up (greeting offset)", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    // Fresh session: only the client-only greeting (assistant at index 0).
+    act(() =>
+      ws1.simulateMessage({
+        type: "history",
+        messages: [{ role: "assistant", content: "Hello there. How can I help today?" }],
+      })
+    );
+
+    // First turn runs to completion: user + its persisted reply.
+    act(() => sendText(result, "first question"));
+    act(() => ws1.simulateMessage({ type: "chunk", messageId: "srv-1", content: "first answer" }));
+    act(() => ws1.simulateMessage({ type: "complete" }));
+    expect(result.current.isRunning).toBe(false);
+
+    // Second question: sent and acked, but NO chunk yet — the pending-run window.
+    act(() => sendText(result, "second question"));
+    const sentPayload = JSON.parse(ws1.send.mock.calls.at(-1)![0] as string) as {
+      clientMessageId: string;
+    };
+    act(() => ws1.simulateMessage({ type: "ack", clientMessageId: sentPayload.clientMessageId }));
+
+    // Tab backgrounded → ws drops → reconnect → recovery history request.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+
+    // Recovery frame: the previous turn only (pending follow-up not persisted),
+    // ending in an assistant, and crucially WITHOUT an activeRun signal.
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "first question" },
+          { role: "assistant", content: "first answer" },
+        ],
+      })
+    );
+    // Drain any staged-reconcile timers so a wrongful destructive replace would
+    // have fully applied before we assert.
+    act(() => {
+      vi.advanceTimersByTime(0);
+      vi.advanceTimersByTime(16);
+    });
+
+    const after = messagesOf(result.current.runtime);
+    // The just-sent follow-up must survive the refocus.
+    expect(after.some((m) => textOf(m) === "second question")).toBe(true);
+    // And the earlier turn is still there — nothing was lost either way.
+    expect(after.some((m) => textOf(m) === "first answer")).toBe(true);
+  });
 });

--- a/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx
@@ -87,9 +87,19 @@ class MockWebSocket {
 }
 vi.stubGlobal("WebSocket", MockWebSocket);
 
-type Converted = { id: string; role: string };
+type Converted = {
+  id: string;
+  role: string;
+  content?: Array<{ type: string; text?: string }>;
+};
 function messagesOf(runtime: unknown): Converted[] {
   return ((runtime as { messages?: Converted[] }).messages ?? []) as Converted[];
+}
+function textOf(message: Converted): string {
+  return (message.content ?? [])
+    .filter((part) => part.type === "text")
+    .map((part) => part.text ?? "")
+    .join("");
 }
 function sendText(result: { current: { runtime: unknown } }, text: string) {
   (
@@ -210,5 +220,90 @@ describe("useWsRuntime — tab-refocus reconcile must not shrink the message lis
 
     const after = messagesOf(result.current.runtime).length;
     expect(after).toBeGreaterThanOrEqual(before);
+  });
+
+  // Greeting-offset regression (staging 2026-07-05): a fresh session's local
+  // list carries the client-only agent GREETING (assistant at index 0), which
+  // the server never persists. On a refocus during the FIRST real turn, that
+  // greeting pads the local length to equal the server history's length even
+  // though the run completed while backgrounded — the completed reply must
+  // still surface, not be silently dropped. See
+  // shouldReplaceLocalWithServerHistory in use-ws-runtime.ts.
+  //
+  // This test deliberately gives each phase its OWN act() so the
+  // `messagesRef.current = messages` effect (line ~645) commits between
+  // phases — exactly like a real tab-refocus, where seconds pass and effects
+  // have long since flushed by the time the recovery history frame arrives.
+  // It simulates the server's `ack` frame after sendText (WITHOUT a chunk) so
+  // the user message is genuinely acked ("sent", not "sending") and the
+  // in-flight placeholder stays EMPTY — the exact #310 bug precondition (WS
+  // drops between ack and first chunk) that
+  // shouldReplaceLocalWithServerHistory's `status === "sent"` guard checks
+  // for. It then advances the staged-reconcile timers
+  // (`stageDestructiveHistoryReconcile`'s setTimeout(0) + setTimeout(16))
+  // after the recovery history frame, since that path defers the actual
+  // setMessages call.
+  it("surfaces the completed reply after refocus when local history starts with the greeting", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws1 = wsInstances[0]!;
+    act(() => ws1.simulateOpen());
+
+    // Fresh session: only the client-only greeting, no real turns yet.
+    act(() =>
+      ws1.simulateMessage({
+        type: "history",
+        messages: [{ role: "assistant", content: "Hello there. How can I help today?" }],
+      })
+    );
+    // Appends user + in-flight placeholder. This act() must end on its own so
+    // the messagesRef effect commits: messagesRef becomes
+    // [greeting, user, placeholder] (3) before the reconnect phase below reads
+    // it via the outer-scope `prevMessages = messagesRef.current` in the
+    // history handler.
+    act(() => sendText(result, "what time is it?"));
+
+    // Server acks the send (WS drops before the first chunk arrives). The
+    // user message transitions "sending" → "sent" — required for the #310
+    // guard in shouldReplaceLocalWithServerHistory to even consider adopting.
+    const sentPayload = JSON.parse(ws1.send.mock.calls.at(-1)![0] as string) as {
+      clientMessageId: string;
+    };
+    act(() => ws1.simulateMessage({ type: "ack", clientMessageId: sentPayload.clientMessageId }));
+
+    // No chunk simulated: the placeholder stays empty, local ends in the
+    // acked user turn.
+
+    // Tab backgrounded → ws drops → reconnect → recovery history request.
+    act(() => {
+      ws1.simulateClose();
+      vi.advanceTimersByTime(1000);
+    });
+    const ws2 = wsInstances[1]!;
+    act(() => ws2.simulateOpen());
+
+    // The run completed while the tab was hidden: no activeRun, and server
+    // history now holds the real turn (greeting is never persisted server-side).
+    act(() =>
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "what time is it?" },
+          { role: "assistant", content: "It's 07:12 UTC." },
+        ],
+      })
+    );
+
+    // Drain the staged-reconcile timers (setTimeout(0) then setTimeout(16)) —
+    // shouldStageReplace routes through stageDestructiveHistoryReconcile
+    // instead of the synchronous setMessages path when messagesRef is
+    // current and the history is shorter than the rich local list.
+    act(() => {
+      vi.advanceTimersByTime(0);
+      vi.advanceTimersByTime(16);
+    });
+
+    const after = messagesOf(result.current.runtime);
+    const replies = after.filter((m) => textOf(m) === "It's 07:12 UTC.");
+    expect(replies.length).toBeGreaterThan(0);
   });
 });

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -376,7 +376,21 @@ export function shouldReplaceLocalWithServerHistory(
   if (lastNonError.role === "assistant") return true;
 
   // lastNonError.role === "user"
-  return lastNonError.status === "sent" && historyMessages.length > prev.length;
+  // Adopt the server history when our acked user turn's reply has landed there.
+  // The strictly-longer check (#310) alone is defeated by the client-only
+  // leading GREETING (an assistant message at index 0 that the server omits
+  // once the session has real turns): it pads prev.length to EQUAL the server
+  // history even though the server holds one more REAL turn — the completed
+  // reply. So ALSO adopt when the server history ends in an assistant turn.
+  // This mirrors the greeting-offset handling in
+  // preserveRicherLocalOverOversizedHistory. The status === "sent" guard still
+  // protects a queued ("sending") message from being wiped. Purely additive: no
+  // input that returned true before returns false now.
+  const serverEndsInAssistant = historyMessages[historyMessages.length - 1]?.role === "assistant";
+  return (
+    lastNonError.status === "sent" &&
+    (historyMessages.length > prev.length || serverEndsInAssistant)
+  );
 }
 
 /**

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -376,20 +376,32 @@ export function shouldReplaceLocalWithServerHistory(
   if (lastNonError.role === "assistant") return true;
 
   // lastNonError.role === "user"
-  // Adopt the server history when our acked user turn's reply has landed there.
-  // The strictly-longer check (#310) alone is defeated by the client-only
-  // leading GREETING (an assistant message at index 0 that the server omits
-  // once the session has real turns): it pads prev.length to EQUAL the server
-  // history even though the server holds one more REAL turn — the completed
-  // reply. So ALSO adopt when the server history ends in an assistant turn.
-  // This mirrors the greeting-offset handling in
+  // Adopt the server history only when it holds MORE real turns than we do —
+  // i.e. our acked user turn's reply has landed there. The bare strictly-longer
+  // check (#310) is defeated by the client-only leading GREETING (an assistant
+  // message at index 0 that the server omits once the session has real turns):
+  // it pads prev.length by one, so an equal-length server history [user,
+  // assistant] fails `> prev.length` even though the completed reply landed and
+  // the agent looks silent.
+  //
+  // Discount that greeting instead of widening the gate to "server ends in an
+  // assistant". A persisted OpenClaw history ALWAYS begins with a user turn
+  // (system turns are filtered out server-side in client-router's
+  // fetchAndParseHistory, and users open every conversation), so a leading
+  // assistant in the LOCAL list can only be the client-only greeting — subtract
+  // it from the comparison. This surfaces the landed reply for the greeting case
+  // WITHOUT adopting a SHORTER server history: a "server ends in assistant" rule
+  // would also fire on the pending-follow-up reload window, where the server
+  // returns the PREVIOUS turn's [user, assistant] (ending in an assistant) with
+  // NO activeRun signal — client-router withholds it until the first chunk
+  // (`firstChunkAt !== null`) — and that shorter frame would route through the
+  // UN-guarded staged reconcile and silently drop the just-sent follow-up.
+  // Mirrors the tail-anchored greeting handling in
   // preserveRicherLocalOverOversizedHistory. The status === "sent" guard still
-  // protects a queued ("sending") message from being wiped. Purely additive: no
-  // input that returned true before returns false now.
-  const serverEndsInAssistant = historyMessages[historyMessages.length - 1]?.role === "assistant";
+  // protects a queued ("sending") message from being wiped.
+  const leadingGreetingOffset = prev[0]?.role === "assistant" ? 1 : 0;
   return (
-    lastNonError.status === "sent" &&
-    (historyMessages.length > prev.length || serverEndsInAssistant)
+    lastNonError.status === "sent" && historyMessages.length > prev.length - leadingGreetingOffset
   );
 }
 


### PR DESCRIPTION
## Root cause

`shouldReplaceLocalWithServerHistory` in `packages/web/src/hooks/use-ws-runtime.ts` gates whole-list history reconcile on tab-refocus. Its #310 guard only adopted server history when it was strictly longer than the local list. A fresh session's local list carries the client-only agent GREETING (an assistant message at index 0) that the server omits from history once real turns exist. After a tab-refocus during the first turn — local ends in the acked user message (padded by the greeting to the same length as the server's `[user, assistant]` history) — `historyMessages.length > prev.length` was `2 > 2 = false`, so the completed assistant reply was silently dropped and the agent looked unresponsive.

## Fix

Purely additive: also adopt the server history when it ends in an assistant turn (mirroring the greeting-offset handling already used by the sibling function `preserveRicherLocalOverOversizedHistory`), while keeping the existing `status === "sent"` guard that protects a queued ("sending") message from being wiped.

```diff
   // lastNonError.role === "user"
-  return lastNonError.status === "sent" && historyMessages.length > prev.length;
+  const serverEndsInAssistant = historyMessages[historyMessages.length - 1]?.role === "assistant";
+  return (
+    lastNonError.status === "sent" &&
+    (historyMessages.length > prev.length || serverEndsInAssistant)
+  );
```

## Tests

- `packages/web/src/__tests__/hooks/should-replace-local-with-server-history.test.ts` — new unit test: "adopts server history when a leading greeting makes it look equal-length but the reply landed". RED before the fix (`expected false to be true`), GREEN after (13/13 passing).
- `packages/web/src/__tests__/hooks/use-ws-runtime-refocus-shrink.test.tsx` — new hook-level end-to-end test mirroring the existing renderHook + mock-WebSocket harness: fresh session with only the greeting, user sends, server acks (WS drops before the first chunk — the #310 precondition), tab backgrounds/reconnects, recovery history (no `activeRun`) holds `[user, assistant-reply]`. Asserts the reply text renders after refocus. Confirmed RED before the fix, GREEN after, with `shouldReplaceWithHistory: true` and `shouldStageReplace: true` routing through the crash-safe `stageDestructiveHistoryReconcile` path.

Found on staging 2026-07-05; blocks v0.8.0.