### PR TITLE
fix(integrations): OAuth connect failures as a persistent banner, not a toast

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -193,7 +193,9 @@ This makes contract drift between client payload and server schema a compile-tim
 
 Use inline form errors when the error is tied to a field, the user can correct the input, and the form/dialog stays open.
 
-Use toast notifications for completed actions, background/system errors, and actions that navigate away or close the dialog.
+Use toast notifications for completed actions, background/system errors, and transient errors the user can simply retry.
+
+Use a persistent, dismissible inline banner (not an auto-expiring toast) for a permanent, actionable error that lands after a full-page redirect — e.g. an OAuth connect failure surfaced via a `?error=` query param. "The action navigated away" does NOT by itself justify a toast: after a redirect the user's attention is on the provider, so a few-second toast is gone before they read it, and the error needs a configuration fix that outlives a toast. Classify by whether the error is transient-and-retryable (toast) or permanent-and-actionable (persistent inline banner), not by whether the flow navigated.
 
 Do not mix inline errors and toast errors for the same action. Success confirmations should be toasts unless a multi-step flow intentionally shows a success screen.
 

--- a/packages/web/src/__tests__/components/settings-integrations.test.tsx
+++ b/packages/web/src/__tests__/components/settings-integrations.test.tsx
@@ -737,83 +737,102 @@ describe("SettingsIntegrations — derived 'app not configured' state", () => {
   });
 });
 
-describe("SettingsIntegrations — OAuth callback errors", () => {
+describe("SettingsIntegrations — OAuth callback errors (persistent banner)", () => {
   beforeEach(() => {
     vi.clearAllMocks();
   });
 
-  it("shows a toast with human-readable error when oauthError='profile_fetch_failed'", async () => {
-    mockFetchConnections([]);
-    const { toast } = await import("sonner");
-    render(<SettingsIntegrations oauthError="profile_fetch_failed" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "Could not fetch your account profile. Check that your OAuth app grants the required profile permission."
-      );
-    });
-  });
-
-  it("shows generic error toast for unknown error codes", async () => {
-    mockFetchConnections([]);
-    const { toast } = await import("sonner");
-    render(<SettingsIntegrations oauthError="unknown_code" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith("OAuth connection failed.");
-    });
-  });
-
-  it("shows a reassuring toast when the user declined consent (oauthError='consent_declined')", async () => {
-    mockFetchConnections([]);
-    const { toast } = await import("sonner");
-    render(<SettingsIntegrations oauthError="consent_declined" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "You didn't authorize the connection, so nothing changed. You can try again whenever you're ready."
-      );
-    });
-  });
-
-  it("shows a toast for an unrecognized provider error (oauthError='provider_error')", async () => {
-    mockFetchConnections([]);
-    const { toast } = await import("sonner");
-    render(<SettingsIntegrations oauthError="provider_error" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "The provider reported a problem during sign-in. Please try again."
-      );
-    });
-  });
-
-  it("shows the sharpened token_exchange_failed message pointing at the Client Secret", async () => {
+  // An OAuth connect failure is a PERMANENT, actionable config error that comes
+  // back after a full-page redirect — it must live in the DOM until the user
+  // dismisses it, not vanish with a ~4-second toast (AGENTS.md "Error And
+  // Notification UI"; the token_exchange_failed toast is exactly what a user
+  // missed on staging 2026-07-06).
+  it("renders a persistent banner (NOT a toast) for token_exchange_failed, pointing at the Client Secret", async () => {
     mockFetchConnections([]);
     const { toast } = await import("sonner");
     render(<SettingsIntegrations oauthError="token_exchange_failed" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
+    expect(
+      await screen.findByText(
         "Sign-in worked, but Pinchy couldn't finish connecting — double-check the Client Secret under Connected apps, then try again."
-      );
-    });
+      )
+    ).toBeInTheDocument();
+    // Do not ALSO fire a toast for the same action (AGENTS.md: don't mix inline
+    // and toast errors).
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("shows a specific message when the token response was unreadable (oauthError='invalid_token_response')", async () => {
+  it("renders the profile_fetch_failed message in the banner", async () => {
     mockFetchConnections([]);
-    const { toast } = await import("sonner");
+    render(<SettingsIntegrations oauthError="profile_fetch_failed" />);
+    expect(
+      await screen.findByText(
+        "Could not fetch your account profile. Check that your OAuth app grants the required profile permission."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the invalid_token_response message in the banner", async () => {
+    mockFetchConnections([]);
     render(<SettingsIntegrations oauthError="invalid_token_response" />);
-    await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
+    expect(
+      await screen.findByText(
         "Sign-in worked, but the provider sent back a response Pinchy couldn't read. Please try connecting again."
-      );
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the missing_refresh_token message in the banner", async () => {
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="missing_refresh_token" />);
+    expect(
+      await screen.findByText(
+        "Sign-in worked, but the provider didn't return the long-lived token Pinchy needs to keep the mailbox connected. Please try again and be sure to grant offline access."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the reassuring consent_declined message in the banner", async () => {
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="consent_declined" />);
+    expect(
+      await screen.findByText(
+        "You didn't authorize the connection, so nothing changed. You can try again whenever you're ready."
+      )
+    ).toBeInTheDocument();
+  });
+
+  it("renders the provider_error message in the banner", async () => {
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="provider_error" />);
+    expect(
+      await screen.findByText("The provider reported a problem during sign-in. Please try again.")
+    ).toBeInTheDocument();
+  });
+
+  it("renders a generic banner message for unknown error codes", async () => {
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="unknown_code" />);
+    expect(await screen.findByText("OAuth connection failed.")).toBeInTheDocument();
+  });
+
+  it("dismisses the banner when the dismiss button is clicked", async () => {
+    const user = userEvent.setup();
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="token_exchange_failed" />);
+    const message =
+      "Sign-in worked, but Pinchy couldn't finish connecting — double-check the Client Secret under Connected apps, then try again.";
+    expect(await screen.findByText(message)).toBeInTheDocument();
+    await user.click(screen.getByRole("button", { name: /dismiss/i }));
+    await waitFor(() => {
+      expect(screen.queryByText(message)).not.toBeInTheDocument();
     });
   });
 
-  it("shows a specific message when no refresh token was returned (oauthError='missing_refresh_token')", async () => {
+  it("renders no error banner when there is no oauthError", async () => {
     mockFetchConnections([]);
-    const { toast } = await import("sonner");
-    render(<SettingsIntegrations oauthError="missing_refresh_token" />);
+    render(<SettingsIntegrations />);
     await waitFor(() => {
-      expect(toast.error).toHaveBeenCalledWith(
-        "Sign-in worked, but the provider didn't return the long-lived token Pinchy needs to keep the mailbox connected. Please try again and be sure to grant offline access."
-      );
+      expect(screen.queryByText(/couldn't finish connecting/i)).not.toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/__tests__/components/settings-integrations.test.tsx
+++ b/packages/web/src/__tests__/components/settings-integrations.test.tsx
@@ -832,7 +832,44 @@ describe("SettingsIntegrations — OAuth callback errors (persistent banner)", (
     mockFetchConnections([]);
     render(<SettingsIntegrations />);
     await waitFor(() => {
+      // No alert region at all when there's no error — not just the specific
+      // message string. Guards against an empty/generic banner regressing in.
+      expect(screen.queryByRole("alert")).not.toBeInTheDocument();
       expect(screen.queryByText(/couldn't finish connecting/i)).not.toBeInTheDocument();
     });
+  });
+
+  // The banner replaced the toast for EVERY OAuth error code — assert no code
+  // re-introduces a toast (double-signal, AGENTS.md "don't mix inline + toast").
+  // Broadens the single token_exchange_failed guard above to the whole set.
+  it.each([
+    "token_exchange_failed",
+    "profile_fetch_failed",
+    "invalid_token_response",
+    "missing_refresh_token",
+    "consent_declined",
+    "provider_error",
+    "unknown_code",
+  ])("shows the banner but fires no toast for oauthError=%s", async (code) => {
+    mockFetchConnections([]);
+    const { toast } = await import("sonner");
+    render(<SettingsIntegrations oauthError={code} />);
+    expect(await screen.findByRole("alert")).toBeInTheDocument();
+    expect(toast.error).not.toHaveBeenCalled();
+  });
+
+  // A ~4s toast that fired after the redirect could at least be announced by a
+  // screen reader's toast live region. A statically-rendered role="alert" that
+  // is already in the DOM at first paint is NOT reliably announced (SRs announce
+  // an alert region on mutation, not on initial render). So for a permanent,
+  // actionable error that lands after a full-page redirect we move focus to the
+  // banner — the GOV.UK / WCAG error-summary pattern — which guarantees the SR
+  // reads it, independent of live-region timing. This is a justified departure
+  // from the ambient insecure/enterprise info banners (which never grab focus).
+  it("moves focus to the error banner on mount so screen readers announce it after the redirect", async () => {
+    mockFetchConnections([]);
+    render(<SettingsIntegrations oauthError="token_exchange_failed" />);
+    const banner = await screen.findByRole("alert");
+    await waitFor(() => expect(banner).toHaveFocus());
   });
 });

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -2,7 +2,6 @@
 
 import { useState, useEffect, useCallback, useRef } from "react";
 import { useRouter } from "next/navigation";
-import { toast } from "sonner";
 import { useIntegrationActions } from "@/hooks/use-integration-actions";
 import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -32,6 +31,7 @@ import {
   Loader2,
   Clock,
   AlertTriangle,
+  X,
 } from "lucide-react";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "@/components/ui/tooltip";
 import { AddIntegrationDialog } from "./add-integration-dialog";
@@ -114,9 +114,18 @@ export function SettingsIntegrations({ oauthError }: { oauthError?: string } = {
   // key is explicitly `false`.
   const [appConfigured, setAppConfigured] = useState<Partial<Record<OAuthProviderId, boolean>>>({});
 
+  // A failed OAuth connect comes back as a ?error= param after a full-page
+  // redirect. It's a PERMANENT, actionable config error (e.g. a wrong Client
+  // Secret) — so it must persist as an inline banner until dismissed, not a
+  // transient toast that vanishes before the user (whose attention is still on
+  // the provider's redirect) can read it. See AGENTS.md "Error And Notification
+  // UI". Seed local state from the prop ONCE so stripping the URL below doesn't
+  // also clear the banner; the dismiss button clears it.
+  const [oauthErrorState, setOauthErrorState] = useState<string | undefined>(oauthError);
+
   useEffect(() => {
     if (!oauthError) return;
-    toast.error(OAUTH_ERROR_MESSAGES.get(oauthError) ?? "OAuth connection failed.");
+    // Strip the ?error= param so a manual refresh doesn't resurrect the banner.
     router.replace("/settings?tab=integrations", { scroll: false });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally mount-only
 
@@ -224,6 +233,27 @@ export function SettingsIntegrations({ oauthError }: { oauthError?: string } = {
 
   return (
     <div className="space-y-6">
+      {oauthErrorState && (
+        <div role="alert" className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+          <div className="flex items-start justify-between gap-3">
+            <div className="flex items-start gap-3">
+              <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />
+              <p className="text-sm text-destructive/90">
+                {OAUTH_ERROR_MESSAGES.get(oauthErrorState) ?? "OAuth connection failed."}
+              </p>
+            </div>
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              aria-label="Dismiss"
+              className="shrink-0 text-destructive hover:bg-destructive/10"
+              onClick={() => setOauthErrorState(undefined)}
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        </div>
+      )}
       <Card>
         <CardHeader className="flex flex-row items-center justify-between">
           <CardTitle>Integrations</CardTitle>

--- a/packages/web/src/components/settings-integrations.tsx
+++ b/packages/web/src/components/settings-integrations.tsx
@@ -122,12 +122,30 @@ export function SettingsIntegrations({ oauthError }: { oauthError?: string } = {
   // UI". Seed local state from the prop ONCE so stripping the URL below doesn't
   // also clear the banner; the dismiss button clears it.
   const [oauthErrorState, setOauthErrorState] = useState<string | undefined>(oauthError);
+  const oauthErrorBannerRef = useRef<HTMLDivElement>(null);
+  const hasFocusedOauthBanner = useRef(false);
 
   useEffect(() => {
     if (!oauthError) return;
     // Strip the ?error= param so a manual refresh doesn't resurrect the banner.
     router.replace("/settings?tab=integrations", { scroll: false });
   }, []); // eslint-disable-line react-hooks/exhaustive-deps -- intentionally mount-only
+
+  // Move focus to the banner so a screen reader announces the error after the
+  // full-page OAuth redirect. A statically-rendered role="alert" is NOT reliably
+  // announced by SRs (they fire on mutation of a live region, not on presence),
+  // and the toast this replaced at least had its own announcing live region.
+  // Focusing the error — the GOV.UK / WCAG error-summary pattern — guarantees the
+  // SR reads it, independent of live-region timing. Justified departure from the
+  // ambient insecure/enterprise info banners, which never grab focus: this is a
+  // permanent, actionable error. Runs once the banner is actually in the DOM
+  // (past the `loading` gate below), and only once so it never steals focus on a
+  // later re-render.
+  useEffect(() => {
+    if (loading || !oauthErrorState || hasFocusedOauthBanner.current) return;
+    hasFocusedOauthBanner.current = true;
+    oauthErrorBannerRef.current?.focus();
+  }, [loading, oauthErrorState]);
 
   const fetchConnections = useCallback(async () => {
     try {
@@ -234,7 +252,12 @@ export function SettingsIntegrations({ oauthError }: { oauthError?: string } = {
   return (
     <div className="space-y-6">
       {oauthErrorState && (
-        <div role="alert" className="rounded-lg border border-destructive/30 bg-destructive/5 p-4">
+        <div
+          ref={oauthErrorBannerRef}
+          role="alert"
+          tabIndex={-1}
+          className="rounded-lg border border-destructive/30 bg-destructive/5 p-4 focus:outline-none"
+        >
           <div className="flex items-start justify-between gap-3">
             <div className="flex items-start gap-3">
               <AlertTriangle className="h-5 w-5 shrink-0 text-destructive" />


### PR DESCRIPTION
## Problem (found on staging 2026-07-06)

An admin re-set-up the Microsoft OAuth app, logged in successfully, but got **only the app config and no integration**. Debugging the callback via SSH + the audit log pinned it to a real `token_exchange_failed` (wrong Client Secret) — Pinchy behaved correctly (deleted the pending row, audited the failure, redirected with `?error=`). But the only user-facing signal was a **transient `toast.error`** that auto-expires in ~4s — gone before a user whose attention is still on the provider's redirect can read it. So the actionable error ("double-check the Client Secret") vanished and the failure looked like a silent bug.

## Rule (why toast was wrong here)

AGENTS.md said "toast for actions that navigate away." The OAuth connect navigates away, so it formally fell into "toast" — but the rule had no category for a **permanent, actionable** error that lands *after* a redirect. That's the gap.

Best practice (LogRocket, RingCentral UX) and our own existing patterns (`cannotDecrypt`, `auth_failed`, "App not configured" are all persistent, but all require a surviving connection row — which a connect failure deletes) agree: a permanent, actionable error → **persistent inline banner**, not a transient toast.

## Change

- **`settings-integrations.tsx`**: render the `?error=` message as a **persistent, dismissible inline banner** at the top of the Integrations section (styled like the existing `cannotDecrypt` destructive alert), seeded from the prop into local state so stripping the URL doesn't clear it. Removed the `toast.error`. No toast for the same action (AGENTS.md: don't mix inline + toast).
- **AGENTS.md** "Error And Notification UI": clarified — "navigated away" alone does **not** justify a toast; classify by transient-and-retryable (toast) vs permanent-and-actionable (persistent inline banner).

## Tests (TDD, RED → GREEN)

- 7 existing OAuth-callback-error tests **converted in place** from toast assertions to banner assertions; **+2 net** (dismiss + no-error cases). All RED before the change, GREEN after.
- Full web unit suite: **7224 passed / 13 skipped** (no new skips), tsc clean, ESLint 0 errors, Prettier clean.

Not a release blocker by itself (the original failure was an Azure config issue), but it's the reason the config error was invisible — solid fix for the v0.8.0 email/OAuth surface.