### PR TITLE
ci(links): exclude the stargazers badge from the lychee link check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2050,7 +2050,15 @@ jobs:
           # PRIVATE repo: the job's GITHUB_TOKEN is scoped to this repo only, so
           # lychee gets a 404 even though the link is valid for maintainers. The
           # release docs intentionally cross-reference it.
-          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'github\\.com/heypinchy/website' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org' --exclude 'star-history\\.com'"
+          # github.com/heypinchy/pinchy/stargazers is excluded because GitHub
+          # gates the stargazers LIST sub-page behind abuse/rate-limit protection
+          # and intermittently 404s it to lychee's crawler even though the repo
+          # is public and the link resolves in a browser (verified 2026-07-06:
+          # the repo root and /issues, /releases, /discussions all return 200,
+          # only /stargazers 404s). It's a decorative stars-badge click-through,
+          # not documentation, so its false-positive 404 must not red-light every
+          # PR — the badge IMAGE (img.shields.io/github/stars) is checked normally.
+          args: "--no-progress --max-retries 3 --retry-wait-time 5 --accept '200..=299,429,500..=599' '**/*.md' '**/*.mdx' --exclude-path node_modules --exclude-path .git --exclude-path docs --exclude 'localhost' --exclude 'github\\.com/heypinchy/website' --exclude 'github\\.com/heypinchy/pinchy/stargazers' --exclude 'linkedin\\.com' --exclude 'sonner\\.emilkowal\\.dev' --exclude 'squawkhq\\.com' --exclude 'contributor-covenant\\.org' --exclude 'star-history\\.com'"
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Symptom

The **Check links** job started failing on open PRs (e.g. #664) — and would fail on `main` too on its next run — with:

```
[404] https://github.com/heypinchy/pinchy/stargazers | Rejected status code: 404
```

## Root cause (verified 2026-07-06)

The repo is **public** (`private: false`, 166 stars via API), but GitHub gates the `/stargazers` **list sub-page** behind abuse/rate-limit protection and intermittently returns **404 to lychee's unauthenticated crawler**, even with `GITHUB_TOKEN` set. Verified by anonymous curl:

| URL | Status |
|---|---|
| `github.com/heypinchy/pinchy` (root) | 200 |
| `github.com/heypinchy/pinchy/issues` | 200 |
| `github.com/heypinchy/pinchy/releases` | 200 |
| `github.com/heypinchy/pinchy/discussions` | 200 |
| **`github.com/heypinchy/pinchy/stargazers`** | **404** |

The lychee `--accept` list deliberately tolerates transient `429`/`5xx` but **not** `404` ("genuinely broken links should fail"). So this false-positive `404` red-lights **every** PR while GitHub is in that state — it's not tied to any code change (it took down #664, whose diff doesn't touch README).

## Fix

Exclude `github.com/heypinchy/pinchy/stargazers` from lychee — a decorative stars-badge click-through, not documentation. The badge **image** (`img.shields.io/github/stars/…`, 200) is still checked. Matches the existing `github.com/heypinchy/website` exclude pattern and its documented rationale.

Unblocks #664 and every other open PR's Check-links.