### PR TITLE
fix(integrations): actionable message when an agent's connection is gone

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -328,6 +328,9 @@ describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () =
 
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("404");
+    // The route's actionable body.error must be passed through, not swallowed —
+    // otherwise the agent reports a bare "HTTP 404" with no idea what to do.
+    expect(result.content[0].text).toContain("Connection not found");
   });
 });
 

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -87,7 +87,14 @@ beforeAll(async () => {
     const credentials = credentialsByConnectionId.get(connectionId);
     if (credentials === undefined) {
       res.writeHead(404, { "Content-Type": "application/json" });
-      res.end(JSON.stringify({ error: "Connection not found" }));
+      // Mirror the real credentials route's actionable body so this test
+      // exercises the production message, not a stale fixture string.
+      res.end(
+        JSON.stringify({
+          error:
+            "This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations.",
+        }),
+      );
       return;
     }
     res.writeHead(200, { "Content-Type": "application/json" });
@@ -330,7 +337,9 @@ describe("pinchy-odoo against real mock-odoo + mock-pinchy (#209 layer 2)", () =
     expect(result.content[0].text).toContain("404");
     // The route's actionable body.error must be passed through, not swallowed —
     // otherwise the agent reports a bare "HTTP 404" with no idea what to do.
-    expect(result.content[0].text).toContain("Connection not found");
+    // Assert the real production message, so a future wording change in the
+    // route is caught here too (same string the endpoint + pinchy-web tests use).
+    expect(result.content[0].text).toMatch(/no longer connected/i);
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -205,9 +205,22 @@ async function fetchCredentials(
     { headers: { Authorization: `Bearer ${gatewayToken}` } },
   );
   if (!response.ok) {
+    // The credentials route puts an actionable message in the JSON body (e.g. a
+    // 404 "This integration is no longer connected …") — surface it so the agent
+    // reports something a user can act on, not a bare HTTP status. Read the body
+    // tolerantly: a non-JSON body must not mask the original status.
+    const body = await (async () => {
+      try {
+        return (await response.json()) as { error?: unknown };
+      } catch {
+        return null;
+      }
+    })();
+    const detail =
+      body && typeof body.error === "string" ? `: ${body.error}` : "";
     throw new Error(
       `Failed to fetch Odoo credentials for connection ${connectionId}: ` +
-        `HTTP ${response.status} ${response.statusText}`,
+        `HTTP ${response.status} ${response.statusText}${detail}`,
     );
   }
   const data = (await response.json()) as { credentials?: unknown };

--- a/packages/plugins/pinchy-web/index.test.ts
+++ b/packages/plugins/pinchy-web/index.test.ts
@@ -283,6 +283,34 @@ describe("pinchy-web plugin", () => {
       expect(result.content[0].text).toContain("API rate limit");
     });
 
+    it("surfaces the actionable credentials-endpoint message when the connection was deleted (404)", async () => {
+      // The credentials fetch itself 404s (connection removed/replaced — e.g.
+      // deleted + re-added). The route body carries an actionable message; the
+      // plugin must pass it through, not report a bare "HTTP 404".
+      const fetchMock = vi.fn(async () => ({
+        ok: false,
+        status: 404,
+        statusText: "Not Found",
+        json: async () => ({
+          error:
+            "This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations.",
+        }),
+      }));
+      vi.stubGlobal("fetch", fetchMock);
+
+      const factories = collectFactories(
+        credentialsPluginConfig({
+          "agent-1": { tools: ["pinchy_web_search"] },
+        }),
+      );
+
+      const tool = factories.pinchy_web_search({ agentId: "agent-1" })!;
+      const result = await tool.execute("call-1", { query: "test" });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toMatch(/no longer connected/i);
+    });
+
     it("POSTs report-auth-failure when retry-once also returns a 401 from Brave", async () => {
       braveSearchMock
         .mockRejectedValueOnce(new Error("401 Unauthorized"))

--- a/packages/plugins/pinchy-web/index.ts
+++ b/packages/plugins/pinchy-web/index.ts
@@ -78,8 +78,20 @@ async function fetchBraveCredentials(
     { headers: { Authorization: `Bearer ${gatewayToken}` } },
   );
   if (!response.ok) {
+    // The credentials route puts an actionable message in the JSON body (e.g. a
+    // 404 "This integration is no longer connected …") — surface it so the agent
+    // reports something a user can act on, not a bare HTTP status. Read the body
+    // tolerantly: a non-JSON body must not mask the original status.
+    const body = await (async () => {
+      try {
+        return (await response.json()) as { error?: unknown };
+      } catch {
+        return null;
+      }
+    })();
+    const detail = body && typeof body.error === "string" ? `: ${body.error}` : "";
     throw new Error(
-      `Failed to fetch Brave credentials: HTTP ${response.status} ${response.statusText}`,
+      `Failed to fetch Brave credentials: HTTP ${response.status} ${response.statusText}${detail}`,
     );
   }
   const data = (await response.json()) as { credentials?: unknown };

--- a/packages/web/src/__tests__/api/internal-integration-credentials.test.ts
+++ b/packages/web/src/__tests__/api/internal-integration-credentials.test.ts
@@ -124,13 +124,18 @@ describe("GET /api/internal/integrations/:connectionId/credentials", () => {
     expect(data.error).toBe("Unauthorized");
   });
 
-  it("returns 404 for non-existent connection", async () => {
+  it("returns an actionable 404 message when the connection no longer exists", async () => {
     mockDbSelectResult([]);
 
     const res = await GET(makeRequest("non-existent"), makeParams("non-existent"));
     expect(res.status).toBe(404);
     const data = await res.json();
-    expect(data.error).toBe("Connection not found");
+    // This body.error is surfaced (via the plugins) into the agent's tool error,
+    // so a bare "Connection not found" turns into an opaque "technical problem
+    // (error 404)" for the user. Make it actionable and generic across providers:
+    // say what happened and where an admin fixes it.
+    expect(data.error).toMatch(/no longer connected/i);
+    expect(data.error).toMatch(/integrations/i);
   });
 
   it("returns 403 for pending connection", async () => {

--- a/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
+++ b/packages/web/src/app/api/internal/integrations/[connectionId]/credentials/route.ts
@@ -116,7 +116,18 @@ export async function GET(
     .limit(1);
 
   if (rows.length === 0) {
-    return NextResponse.json({ error: "Connection not found" }, { status: 404 });
+    // The plugins surface this body.error into the agent's tool error, so a bare
+    // "Connection not found" reaches the user as an opaque "technical problem
+    // (error 404)". Make it actionable and provider-generic: the connection was
+    // removed or replaced (e.g. deleted + re-added, which mints a new id and
+    // orphans this reference), and an admin fixes it under Settings → Integrations.
+    return NextResponse.json(
+      {
+        error:
+          "This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations.",
+      },
+      { status: 404 }
+    );
   }
 
   const connection = rows[0];


### PR DESCRIPTION
## Problem (found on staging 2026-07-07)

Deleting an integration connection — or deleting + re-adding it, which mints a **new** UUID and orphans the agent's reference — makes the internal credentials endpoint 404. The agent then surfaces an opaque *"technical problem connecting to your mailbox (error 404)"*, with no hint of what happened or how to fix it.

This is [#666](https://github.com/heypinchy/pinchy/issues/666) item #4 (the ~10-minute quick win), split out to land before the v0.8.0 cut. It's not a release blocker on its own (self-inflicted delete+add edge case) but it's the reason that failure looks like a silent bug.

## Change (generic across all integrations)

- **Endpoint:** the credentials route's 404 body goes from a bare `"Connection not found"` to an actionable, provider-generic message: *"This integration is no longer connected — it may have been removed or replaced. An admin can reconnect it under Settings → Integrations."* (`api/internal/integrations/[connectionId]/credentials/route.ts`)
- **Plugins:** `pinchy-odoo` and `pinchy-web` now pass the route's `body.error` through into the tool error, instead of reporting a bare `HTTP 404`. `pinchy-email` already did this — so all four integration types (Microsoft, Google, Odoo, Brave) now report the same actionable text.

Consistency by construction: the fix lives in the already-generic credentials layer, not in per-provider forks.

## Tests (TDD, RED → GREEN)

- Endpoint: 404 test asserts the message is actionable (`/no longer connected/i` + `/integrations/i`), full file 18 passed.
- `pinchy-web`: new test proves the deleted-connection 404 body is surfaced; full suite **82 passed**.
- `pinchy-odoo`: existing 404 test hardened to assert pass-through; full suite **287 passed**.
- Full web unit suite: **7233 passed / 13 skipped** (no new skips), Prettier + ESLint clean, pre-push build clean.

Behavior change → yours to merge.