### PR TITLE
fix(email): emit details.error on failed tool results (#404)

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -64,6 +64,7 @@ interface AgentTool {
   ) => Promise<{
     content: Array<{ type: string; text: string }>;
     isError?: boolean;
+    details?: unknown;
   }>;
 }
 
@@ -1115,6 +1116,50 @@ describe("error handling", () => {
 
     expect(result.content[0].text).toContain("Unknown error");
     expect(result.isError).toBe(true);
+  });
+
+  // Audit-integrity contract (see packages/web/src/app/api/internal/audit/tool-use/route.ts
+  // lines ~116-122, issue #404): OpenClaw strips the MCP `isError` flag before
+  // forwarding tool results to /api/internal/audit/tool-use, so the audit
+  // endpoint falls back to `result.details.error` to record a failure.
+  // Without it, a failed email tool call is logged as outcome=success (verified
+  // on staging: tool.email_read and tool.email_get_attachment rows logged
+  // outcome=success despite an "Id is malformed" failure).
+  it("attaches details.error on a client-thrown error so the audit records a failure even when OpenClaw strips isError", async () => {
+    mockList.mockRejectedValue(new Error("Gmail API rate limit exceeded"));
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    const result = await tool.execute("call-1", {});
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "Gmail API rate limit exceeded",
+    );
+    // The details.error message must match content[0].text (same human-readable string).
+    expect((result.details as { error?: string } | undefined)?.error).toBe(
+      result.content[0].text,
+    );
+  });
+
+  it("attaches details.error on a permission-denied result", async () => {
+    const tools = createApi();
+    const tool = findTool(tools, "email_send", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      to: "test@example.com",
+      subject: "Hello",
+      body: "World",
+    });
+
+    expect(result.isError).toBe(true);
+    expect((result.details as { error?: string } | undefined)?.error).toContain(
+      "Permission denied",
+    );
+    expect((result.details as { error?: string } | undefined)?.error).toBe(
+      result.content[0].text,
+    );
   });
 });
 

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -171,6 +171,12 @@ describe("tool registration", () => {
       // Stub execute() must fail fast rather than call external services
       const result = await stub!.execute("call-probe", {});
       expect(result.isError).toBe(true);
+      // The stub is an error-returning path too, so it must carry a non-empty
+      // details.error — on staging OpenClaw strips isError and the audit route
+      // only counts non-empty details.error strings as a failure (issue #404).
+      const details = result.details as { error?: string } | undefined;
+      expect(details?.error).toBeTruthy();
+      expect(details?.error).toBe(result.content[0].text);
     }
   });
 

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -146,7 +146,11 @@ interface AgentTool {
     toolCallId: string,
     params: Record<string, unknown>,
     signal?: AbortSignal,
-  ) => Promise<{ content: ContentBlock[]; isError?: boolean }>;
+  ) => Promise<{
+    content: ContentBlock[];
+    isError?: boolean;
+    details?: { error: string };
+  }>;
 }
 
 interface PluginConfig {
@@ -210,29 +214,38 @@ async function reportAuthFailure(
   }
 }
 
+/**
+ * Audit-integrity contract (see packages/web/src/app/api/internal/audit/tool-use/route.ts
+ * lines ~116-122, issue #404): OpenClaw's tool-use hook strips the MCP
+ * `isError` flag before forwarding results to the audit route, so
+ * `details.error` is often the only remaining failure signal. Every
+ * error-returning path below must set it, mirroring pinchy-odoo's
+ * toolError() helper.
+ */
 function permissionDenied(operation: string): {
   content: ContentBlock[];
   isError: true;
+  details: { error: string };
 } {
+  const text = `Permission denied: email.${operation} is not allowed for this agent.`;
   return {
     isError: true,
-    content: [
-      {
-        type: "text",
-        text: `Permission denied: email.${operation} is not allowed for this agent.`,
-      },
-    ],
+    content: [{ type: "text", text }],
+    details: { error: text },
   };
 }
 
 function errorResult(error: unknown): {
   content: ContentBlock[];
   isError: true;
+  details: { error: string };
 } {
   const message = error instanceof Error ? error.message : "Unknown error";
+  const text = `Error: ${message}`;
   return {
     isError: true,
-    content: [{ type: "text", text: `Error: ${message}` }],
+    content: [{ type: "text", text }],
+    details: { error: text },
   };
 }
 
@@ -364,6 +377,7 @@ const plugin = {
         execute: async () => ({
           content: [{ type: "text", text: "" }],
           isError: true as const,
+          details: { error: "" },
         }),
       };
     }

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -374,11 +374,19 @@ const plugin = {
         label: name,
         description: "",
         parameters: { type: "object", properties: {} },
-        execute: async () => ({
-          content: [{ type: "text", text: "" }],
-          isError: true as const,
-          details: { error: "" },
-        }),
+        execute: async () => {
+          // A real session call (with agentId) supersedes this stub, so an
+          // executed stub means the tool ran without session context. Emit a
+          // non-empty message: the audit route only counts non-empty
+          // details.error as a failure once OpenClaw strips isError (#404),
+          // so an empty string here would be logged outcome=success on staging.
+          const text = `Error: ${name} is not available without an active session.`;
+          return {
+            content: [{ type: "text", text }],
+            isError: true as const,
+            details: { error: text },
+          };
+        },
       };
     }
 


### PR DESCRIPTION
## Summary
- pinchy-email's error-returning tool results (`errorResult()`, `permissionDenied()`, and the probe-stub's inline error) set `isError: true` but never `details.error`, so on staging — where OpenClaw's tool-use hook strips the `isError` flag before forwarding to `/api/internal/audit/tool-use` (issue #404) — failed email tool calls (e.g. `email_read`, `email_get_attachment`) were logged with `outcome: "success"`.
- Mirrors pinchy-odoo's existing `toolError()` pattern: every error path now also returns `details: { error: <message> }` where `<message>` is identical to `content[0].text`. Success paths are untouched.

## Test plan
- [x] `pnpm -C packages/plugins/pinchy-email test` — 185 passed (183 pre-existing + 2 new)
- [x] `pnpm typecheck:plugins` — all 8 plugin packages typecheck cleanly
- [x] `pnpm test:plugins` — all plugin packages pass (pinchy-email 185, pinchy-odoo 287, pinchy-files 174, etc.)
- [x] `pnpm -C packages/web test tool-use` — 36 passed (route untouched)
- [x] `pnpm test` (full web suite) — 7234 passed, 13 skipped (pre-existing, unaffected)
- [x] `pnpm test:scripts` — 202 passed
- [x] `pnpm build` — succeeds
- [x] `prettier --check` on changed files — clean