### PR TITLE
refactor(models): default balanced-tier agent templates to kimi-k2.6

### DIFF
--- a/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts
@@ -36,6 +36,18 @@ describe("resolveOllamaCloud", () => {
   });
 });
 
+describe("resolveOllamaCloud — balanced tier (#669)", () => {
+  it("resolves balanced/general to kimi-k2.6", () => {
+    const result = resolveOllamaCloud({ tier: "balanced", taskType: "general" });
+    expect(result.model).toBe("ollama-cloud/kimi-k2.6");
+  });
+
+  it("resolves balanced tier with vision capability to kimi-k2.6", () => {
+    const result = resolveOllamaCloud({ tier: "balanced", capabilities: ["vision"] });
+    expect(result.model).toBe("ollama-cloud/kimi-k2.6");
+  });
+});
+
 describe("resolveOllamaCloud — allowlist invariant", () => {
   it("every resolver target is present in TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS", () => {
     const allowlist = new Set<string>(TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS);

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -28,13 +28,17 @@ const BY_TIER_FAMILY: Record<
     vision: "ollama-cloud/ministral-3:8b",
   },
   balanced: {
-    general: "ollama-cloud/glm-4.7",
+    // glm-4.7 (general) and gemma4:31b (vision) were replaced 2026-07-07
+    // after production/staging fallout: glm-4.7 is reasoning-by-default and
+    // loops when the `/v1` client drops `reasoning_content` between turns;
+    // gemma4:31b corrupted a ~150-char Microsoft Graph message ID across
+    // turns ("Id is malformed") in a staging email agent. Deep-research
+    // (2026-07-07) plus prior production experience endorse kimi-k2.6 as the
+    // strongest non-thinking-preferred tool-driver: vision:true, 256K
+    // context, already in the curated catalog (issue #669).
+    general: "ollama-cloud/kimi-k2.6",
     coder: "ollama-cloud/qwen3-coder:480b",
-    // qwen3-vl:235b(-instruct) was the pick but Ollama dropped both from the
-    // cloud catalog (2026-06-17 discovery sweep). gemma4:31b is the balanced
-    // vision replacement: vision+reasoning+tools, 262K context, already
-    // empirically verified in ollama-cloud-models.ts.
-    vision: "ollama-cloud/gemma4:31b",
+    vision: "ollama-cloud/kimi-k2.6",
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",


### PR DESCRIPTION
## Summary
- Changes the ollama-cloud resolver's `balanced` tier so both the `general` and `vision` slots default to `kimi-k2.6`, replacing `glm-4.7` (general) and `gemma4:31b` (vision).
- `glm-4.7` is reasoning-by-default and loops when the `/v1` client drops `reasoning_content` between turns. `gemma4:31b` corrupted a ~150-char Microsoft Graph message ID across turns ("Id is malformed") in a staging email agent.
- `kimi-k2.6` is a non-thinking-preferred strong tool-driver (`vision: true`, 256K context) already in the curated ollama-cloud catalog, endorsed by deep research (2026-07-07) and prior production experience.
- Scope is strictly `balanced.general` and `balanced.vision`. `balanced.coder`, `fast`, and `reasoning` are untouched. The model catalog, reasoning flags, image-offload preference, and agent templates are untouched.

Tracking: #669. Related: #668.

## Test plan
- [x] TDD: updated `packages/web/src/lib/model-resolver/__tests__/ollama-cloud.test.ts` first with two new assertions expecting `kimi-k2.6` for balanced/general and balanced/vision — confirmed red against the old map.
- [x] Implemented the map change in `packages/web/src/lib/model-resolver/providers/ollama-cloud.ts` — confirmed green (117 passed in `model-resolver`).
- [x] `pnpm -C packages/web test model-resolver` — 117 passed.
- [x] `pnpm -C packages/web test` (full suite) — 7235 passed, 13 skipped (pre-existing).
- [x] `pnpm build` — Next.js build + typecheck succeeded.
- [x] `pnpm -C packages/web lint` — 0 errors (612 pre-existing warnings unrelated to changed lines).
- [x] `pnpm -C packages/web format:check` — clean.
- [x] Drift guards verified intact and passing: allowlist invariant, vision-slot blocklist-compliance guards, and the vision:true drift guard.