### PR TITLE
refactor(models): default ollama-cloud provider default to kimi-k2.6 (#669)

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -7050,14 +7050,17 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
   });
 
   it("picks the canonical-vision ollama-cloud model when only ollama-cloud is configured", async () => {
-    // The provider's general balanced default is `glm-4.7` (text-only) and
-    // several other ollama-cloud models are weaker on images: mistral-large-3
-    // and kimi-k2.5/k2.6 accept image input but occasionally misread digits,
-    // and qwen3.5:397b only claims vision (it hallucinates image contents and
-    // is flagged text-only). The image-default picker explicitly prefers the
-    // best empirically vision-verified models — gemini-3-flash > minimax-m3 >
-    // gemma4 (qwen3-vl led this list until Ollama dropped it upstream) — over
-    // those weaker models.
+    // The image-default picker (`resolveDefaultImageModel` /
+    // `pickOllamaCloudImageModel`) never consults the provider's general
+    // balanced default (`kimi-k2.6` as of #669) for ollama-cloud — it always
+    // routes through the curated `OLLAMA_CLOUD_IMAGE_PREFERENCE` list.
+    // Several ollama-cloud models are weaker on images regardless: mistral-
+    // large-3 and kimi-k2.5/k2.6 accept image input but occasionally misread
+    // digits, and qwen3.5:397b only claims vision (it hallucinates image
+    // contents and is flagged text-only). The image-default picker explicitly
+    // prefers the best empirically vision-verified models — gemini-3-flash >
+    // minimax-m3 > gemma4 (qwen3-vl led this list until Ollama dropped it
+    // upstream) — over those weaker models.
     mockedGetSetting.mockImplementation(async (key: string) =>
       key === "ollama_cloud_api_key" ? "test-key" : null
     );

--- a/packages/web/src/__tests__/lib/provider-models-drift.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models-drift.test.ts
@@ -72,7 +72,7 @@ describe("balanced default — drift resistance", () => {
       ["anthropic", "anthropic/claude-sonnet-4-6"],
       ["openai", "openai/gpt-5.5"],
       ["google", "google/gemini-2.5-pro"],
-      ["ollama-cloud", "ollama-cloud/glm-4.7"],
+      ["ollama-cloud", "ollama-cloud/kimi-k2.6"],
     ] as const)("%s: empty candidate list → anchor %s", (provider, anchor) => {
       const noMatch = [{ id: `${provider}/something-totally-unexpected`, name: "x" }];
       expect(selectDefaultModel(provider, noMatch)).toBe(anchor);

--- a/packages/web/src/__tests__/lib/provider-models.test.ts
+++ b/packages/web/src/__tests__/lib/provider-models.test.ts
@@ -32,7 +32,7 @@ vi.mock("@/lib/providers", () => ({
       name: "Ollama Cloud",
       settingsKey: "ollama_cloud_api_key",
       envVar: "OLLAMA_CLOUD_API_KEY",
-      defaultModel: "ollama-cloud/glm-4.7",
+      defaultModel: "ollama-cloud/kimi-k2.6",
       placeholder: "sk-...",
     },
     "ollama-local": {
@@ -776,7 +776,7 @@ describe("selectDefaultModel", () => {
       { id: "ollama-cloud/gemini-3-flash-preview", name: "Gemini 3 Flash Preview" },
       { id: "ollama-cloud/qwen3.5:397b", name: "Qwen 3.5 397B" },
     ];
-    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/glm-4.7");
+    expect(selectDefaultModel("ollama-cloud", models)).toBe("ollama-cloud/kimi-k2.6");
   });
 
   it("prefers stable versions over preview versions", async () => {

--- a/packages/web/src/__tests__/lib/providers.test.ts
+++ b/packages/web/src/__tests__/lib/providers.test.ts
@@ -132,7 +132,7 @@ describe("PROVIDERS", () => {
     expect(PROVIDERS.anthropic.defaultModel).toBe("anthropic/claude-sonnet-4-6");
     expect(PROVIDERS.openai.defaultModel).toBe("openai/gpt-5.5");
     expect(PROVIDERS.google.defaultModel).toBe("google/gemini-2.5-pro");
-    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/glm-4.7");
+    expect(PROVIDERS["ollama-cloud"].defaultModel).toBe("ollama-cloud/kimi-k2.6");
   });
 
   it("should have settings keys for all providers", () => {

--- a/packages/web/src/lib/provider-model-constants.ts
+++ b/packages/web/src/lib/provider-model-constants.ts
@@ -17,6 +17,6 @@ export const BALANCED_ANCHORS: Record<ProviderName, string> = {
   anthropic: "anthropic/claude-sonnet-4-6",
   openai: "openai/gpt-5.5",
   google: "google/gemini-2.5-pro",
-  "ollama-cloud": "ollama-cloud/glm-4.7",
+  "ollama-cloud": "ollama-cloud/kimi-k2.6",
   "ollama-local": "",
 };

--- a/packages/web/src/lib/provider-models.ts
+++ b/packages/web/src/lib/provider-models.ts
@@ -170,7 +170,7 @@ export const BALANCED_PATTERNS: Record<ProviderName, RegExp> = {
   anthropic: /^anthropic\/claude-sonnet-\d+-\d+(?:-\d{8})?$/,
   openai: /^openai\/gpt-([5-9]|\d{2,})(\.\d+)?(?:-\d{4}-\d{2}-\d{2})?$/,
   google: /^google\/gemini-[2-9](?:\.\d+)?-pro(?:-\d{3})?$/,
-  "ollama-cloud": /^ollama-cloud\/glm-4\.7$/,
+  "ollama-cloud": /^ollama-cloud\/kimi-k2\.6$/,
   "ollama-local": /.*/,
 };
 

--- a/packages/web/src/lib/providers.ts
+++ b/packages/web/src/lib/providers.ts
@@ -41,11 +41,14 @@ export const PROVIDERS: Record<ProviderName, ProviderConfig> = {
     authType: "api-key",
     settingsKey: "ollama_cloud_api_key",
     envVar: "OLLAMA_CLOUD_API_KEY",
-    // glm-4.7 is the balanced-tier general pick in the resolver and emits
-    // working tool calls on Ollama Cloud. qwen3-next:80b (the previous
-    // default) was dropped from the catalog — it cannot tool-call on the
-    // OpenAI-completions endpoint (see ollama-cloud-models.ts).
-    defaultModel: "ollama-cloud/glm-4.7",
+    // kimi-k2.6 is the balanced-tier general pick in the resolver (#669):
+    // gemma4:31b corrupted a Graph message ID, and glm-4.7 is
+    // reasoning-by-default and loops on the /v1 reasoning_content round-trip.
+    // kimi-k2.6 is a strong non-thinking-preferred tool driver, and this
+    // provider default mirrors that resolver pick. qwen3-next:80b (an
+    // earlier default) was dropped from the catalog — it cannot tool-call
+    // on the OpenAI-completions endpoint (see ollama-cloud-models.ts).
+    defaultModel: "ollama-cloud/kimi-k2.6",
     placeholder: "sk-...",
   },
   "ollama-local": {


### PR DESCRIPTION
## Summary
- Moves Pinchy's ollama-cloud provider-level "balanced default" from `glm-4.7` to `kimi-k2.6`, so no-template-hint agents (the `custom` template, cold-start fallback) and the runtime `selectDefaultModel()` follow the same best-practice driver sibling PR #671 already picked for the resolver's `balanced.general`/`balanced.vision` slots.
- `glm-4.7` is reasoning-by-default and loops on the `/v1` reasoning_content round-trip; `kimi-k2.6` is a strong non-thinking-preferred tool driver.
- Three coupled spots updated: `PROVIDERS["ollama-cloud"].defaultModel` (providers.ts), `BALANCED_ANCHORS["ollama-cloud"]` (provider-model-constants.ts), `BALANCED_PATTERNS["ollama-cloud"]` (provider-models.ts).
- `glm-4.7` stays in the catalog (`ollama-cloud-models.ts`) — only the default changes. The model-resolver (`model-resolver/providers/ollama-cloud.ts`, owned by #671) is untouched.

Tracking: #669

## Test plan
- [x] `pnpm -C packages/web test provider` — 336 passed, 5 skipped
- [x] `pnpm -C packages/web test openclaw-config` — 357 passed
- [x] `pnpm -C packages/web test` (full suite) — 7233 passed, 13 skipped
- [x] `pnpm build` — succeeds
- [x] `pnpm -C packages/web format:check` / `pnpm -C packages/web lint` — clean (0 errors; pre-existing warnings only, none touching changed lines)