### PR TITLE
fix(email): resolve message/attachment ids via short handles

### DIFF
--- a/packages/plugins/pinchy-email/__tests__/id-handle-store.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/id-handle-store.test.ts
@@ -37,6 +37,18 @@ describe("handleFor", () => {
     const handle = handleFor(graphLikeId, MSG_PREFIX);
     expect(handle.length).toBeLessThan(30);
   });
+
+  // Finding 2 (2026-07-07 review): with only 32 bits of entropy two distinct
+  // realIds could collide within an agent's cap and silently overwrite each
+  // other, so a handle would resolve to the WRONG email. The handle carries 64
+  // bits (16 hex chars) so that a collision is genuinely negligible, not merely
+  // unlikely. This guards against silently shrinking the entropy back.
+  it("carries 64 bits (16 hex chars) of the realId digest", () => {
+    const hex = handleFor("some-real-id", MSG_PREFIX).slice(
+      `${MSG_PREFIX}_`.length,
+    );
+    expect(hex).toMatch(/^[0-9a-f]{16}$/);
+  });
 });
 
 describe("putHandle / resolveHandle", () => {

--- a/packages/plugins/pinchy-email/__tests__/id-handle-store.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/id-handle-store.test.ts
@@ -1,0 +1,133 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import {
+  putHandle,
+  resolveHandle,
+  handleFor,
+  MSG_PREFIX,
+  ATT_PREFIX,
+} from "../id-handle-store";
+
+describe("handleFor", () => {
+  it("is deterministic: same realId + prefix always produces the same handle", () => {
+    const realId = "AAMkAGI2THVLUAAA=really-long-graph-id-blob-1234567890";
+    const a = handleFor(realId, MSG_PREFIX);
+    const b = handleFor(realId, MSG_PREFIX);
+    expect(a).toBe(b);
+  });
+
+  it("produces different handles for different realIds", () => {
+    const a = handleFor("real-id-one", MSG_PREFIX);
+    const b = handleFor("real-id-two", MSG_PREFIX);
+    expect(a).not.toBe(b);
+  });
+
+  it("prefixes the handle with the caller-chosen prefix", () => {
+    const msgHandle = handleFor("some-id", MSG_PREFIX);
+    const attHandle = handleFor("some-id", ATT_PREFIX);
+    expect(msgHandle.startsWith(`${MSG_PREFIX}_`)).toBe(true);
+    expect(attHandle.startsWith(`${ATT_PREFIX}_`)).toBe(true);
+    // Same realId, different prefix => different handle namespace
+    expect(msgHandle).not.toBe(attHandle);
+  });
+
+  it("produces a short handle, much shorter than a typical Graph id", () => {
+    const graphLikeId =
+      "AAMkAGI2AAAAAAA-".repeat(10) + "some-more-base64-padding==";
+    const handle = handleFor(graphLikeId, MSG_PREFIX);
+    expect(handle.length).toBeLessThan(30);
+  });
+});
+
+describe("putHandle / resolveHandle", () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+  });
+
+  it("putHandle returns a handle that resolveHandle can turn back into the realId for the same agent", () => {
+    const realId = "real-message-id-abc";
+    const handle = putHandle("agent-1", realId);
+    expect(resolveHandle("agent-1", handle)).toBe(realId);
+  });
+
+  it("is idempotent: putting the same realId twice returns the same handle", () => {
+    const realId = "real-message-id-xyz";
+    const first = putHandle("agent-2", realId);
+    const second = putHandle("agent-2", realId);
+    expect(first).toBe(second);
+  });
+
+  it("enforces tenant isolation: agent B cannot resolve agent A's handle", () => {
+    const realId = "tenant-isolated-real-id";
+    const handle = putHandle("agent-a", realId);
+    expect(resolveHandle("agent-a", handle)).toBe(realId);
+    expect(resolveHandle("agent-b", handle)).toBeNull();
+  });
+
+  it("returns null for an unknown handle", () => {
+    expect(resolveHandle("agent-1", "msg_doesnotexist")).toBeNull();
+  });
+
+  it("returns null after the handle has expired (TTL)", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const realId = "expiring-real-id";
+      const handle = putHandle("agent-ttl", realId);
+      expect(resolveHandle("agent-ttl", handle)).toBe(realId);
+
+      // Advance past the 30-minute TTL.
+      vi.setSystemTime(31 * 60 * 1000);
+      expect(resolveHandle("agent-ttl", handle)).toBeNull();
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("refreshes expiry when the same realId is put again (idempotent refresh)", () => {
+    vi.useFakeTimers();
+    try {
+      vi.setSystemTime(0);
+      const realId = "refreshed-real-id";
+      const handle = putHandle("agent-refresh", realId);
+
+      // Advance close to expiry, then refresh.
+      vi.setSystemTime(25 * 60 * 1000);
+      const refreshed = putHandle("agent-refresh", realId);
+      expect(refreshed).toBe(handle);
+
+      // Advance to a point that would have expired the ORIGINAL ttl window
+      // (0 + 30min = 30min) but is still within the REFRESHED window
+      // (25min + 30min = 55min).
+      vi.setSystemTime(40 * 60 * 1000);
+      expect(resolveHandle("agent-refresh", handle)).toBe(realId);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("caps entries per agent (bounded store, oldest evicted on overflow)", () => {
+    const agentId = "agent-cap";
+    const handles: string[] = [];
+    // Push well past the 500-entry cap.
+    for (let i = 0; i < 600; i++) {
+      handles.push(putHandle(agentId, `real-id-${i}`));
+    }
+
+    // The earliest entries should have been evicted; the most recent must
+    // still resolve.
+    const lastHandle = handles[handles.length - 1];
+    expect(resolveHandle(agentId, lastHandle)).toBe("real-id-599");
+
+    const firstHandle = handles[0];
+    expect(resolveHandle(agentId, firstHandle)).toBeNull();
+  });
+
+  it("does not leak handles across different realIds resolving to the wrong id", () => {
+    const agentId = "agent-multi";
+    const h1 = putHandle(agentId, "real-1");
+    const h2 = putHandle(agentId, "real-2");
+    expect(resolveHandle(agentId, h1)).toBe("real-1");
+    expect(resolveHandle(agentId, h2)).toBe("real-2");
+  });
+});

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -51,7 +51,11 @@ vi.mock("node:fs/promises", () => ({
 import { GmailAdapter } from "../gmail-adapter";
 import { GraphAdapter } from "../graph-adapter";
 import plugin from "../index";
-import { MAX_ENTRIES_PER_AGENT } from "../id-handle-store";
+import {
+  MAX_ENTRIES_PER_AGENT,
+  MSG_PREFIX,
+  resolveHandle,
+} from "../id-handle-store";
 
 interface AgentTool {
   name: string;
@@ -1076,7 +1080,13 @@ describe("email_draft", () => {
     });
 
     const data = JSON.parse(result.content[0].text);
-    expect(data.draftId).toBe("draft-1");
+    // The model-facing draftId must be a handle, never the raw provider id —
+    // otherwise a weak model echoing a ~150-char Graph id back on a later turn
+    // re-hits the corruption this whole feature exists to prevent (Finding 1,
+    // 2026-07-07 review of PR #673).
+    expect(data.draftId).not.toBe("draft-1");
+    expect(data.draftId.startsWith(`${MSG_PREFIX}_`)).toBe(true);
+    expect(resolveHandle(agentId, data.draftId)).toBe("draft-1");
     expect(mockDraft).toHaveBeenCalledWith({
       to: "recipient@test.com",
       subject: "Draft Subject",
@@ -1135,7 +1145,13 @@ describe("email_send", () => {
     });
 
     const data = JSON.parse(result.content[0].text);
-    expect(data.messageId).toBe("sent-1");
+    // The model-facing messageId must be a handle, never the raw provider id.
+    // If the model later reads the sent message back by copying this id into
+    // email_read, a raw ~150-char Graph id would flow straight to the adapter
+    // and reintroduce ErrorInvalidIdMalformed (Finding 1, 2026-07-07 review).
+    expect(data.messageId).not.toBe("sent-1");
+    expect(data.messageId.startsWith(`${MSG_PREFIX}_`)).toBe(true);
+    expect(resolveHandle(agentId, data.messageId)).toBe("sent-1");
     expect(mockSend).toHaveBeenCalledWith({
       to: "recipient@test.com",
       subject: "Sent Subject",
@@ -1963,5 +1979,101 @@ describe("id-handle indirection", () => {
     expect(mockList).toHaveBeenCalledWith(
       expect.objectContaining({ limit: 25 }),
     );
+  });
+
+  // Finding 2 (2026-07-07 review of PR #673): clampListLimit deckelte nur nach
+  // oben. Ein vom Modell gesendetes limit <= 0 lief unverändert zum Adapter und
+  // damit als $top/maxResults zum Provider — negativ ergibt einen 400, 0 ein
+  // verwirrend leeres Ergebnis. Ein nicht-positives limit wird jetzt wie ein
+  // fehlendes behandelt: undefined, damit der Adapter seinen Default nimmt.
+  it("email_list drops a zero limit so the adapter applies its own default", async () => {
+    mockList.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    await tool.execute("call-1", { limit: 0 });
+
+    expect(mockList.mock.calls[0][0].limit).toBeUndefined();
+  });
+
+  it("email_list drops a negative limit so the adapter applies its own default", async () => {
+    mockList.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    await tool.execute("call-1", { limit: -5 });
+
+    expect(mockList.mock.calls[0][0].limit).toBeUndefined();
+  });
+
+  it("email_search drops a non-positive limit so the adapter applies its own default", async () => {
+    mockSearch.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    await tool.execute("call-1", { subject: "invoice", limit: 0 });
+
+    expect(mockSearch.mock.calls[0][0].limit).toBeUndefined();
+  });
+
+  it("email_send -> read round trip: the handle returned by email_send resolves to the real message id at the adapter", async () => {
+    const rawSentId =
+      "AAMkAGI2-real-graph-id-of-the-just-sent-message-very-long";
+    const configWithSend: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft", "send"] },
+        },
+      },
+    };
+    const tools = createApi(configWithSend);
+
+    mockSend.mockResolvedValue({ messageId: rawSentId });
+    const sendTool = findTool(tools, "email_send", agentId)!;
+    const sendResult = await sendTool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent",
+      body: "body",
+    });
+    const { messageId: handle } = JSON.parse(sendResult.content[0].text);
+    expect(handle).not.toBe(rawSentId);
+
+    mockRead.mockResolvedValue({
+      id: rawSentId,
+      from: "me@test.com",
+      subject: "Sent",
+      body: "body",
+    });
+    const readTool = findTool(tools, "email_read", agentId)!;
+    const readResult = await readTool.execute("call-2", { id: handle });
+
+    expect(readResult.isError).toBeFalsy();
+    expect(mockRead).toHaveBeenCalledWith(rawSentId);
+  });
+
+  it("email_send leaves messageId null untouched (does not mint a handle for a non-id)", async () => {
+    const configWithSend: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft", "send"] },
+        },
+      },
+    };
+    const tools = createApi(configWithSend);
+
+    mockSend.mockResolvedValue({ messageId: null });
+    const sendTool = findTool(tools, "email_send", agentId)!;
+    const result = await sendTool.execute("call-1", {
+      to: "recipient@test.com",
+      subject: "Sent",
+      body: "body",
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.messageId).toBeNull();
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -51,6 +51,7 @@ vi.mock("node:fs/promises", () => ({
 import { GmailAdapter } from "../gmail-adapter";
 import { GraphAdapter } from "../graph-adapter";
 import plugin from "../index";
+import { MAX_ENTRIES_PER_AGENT } from "../id-handle-store";
 
 interface AgentTool {
   name: string;
@@ -1916,5 +1917,51 @@ describe("id-handle indirection", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("unknown or has expired");
     expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  // Finding 1 (2026-07-07 review): the handle store caps entries per agent and
+  // evicts oldest-first. A single result set larger than that cap would evict
+  // its own earliest handles as the later ones are minted, so the top rows the
+  // model was just shown would resolve to "unknown or expired" — and re-listing
+  // reproduces the same eviction, making them permanently unopenable. The tools
+  // therefore clamp an over-large limit down to the store cap so a single
+  // result set can never exceed it.
+  it("email_list clamps an over-large limit to the handle-store cap", async () => {
+    mockList.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    await tool.execute("call-1", { limit: MAX_ENTRIES_PER_AGENT + 5000 });
+
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: MAX_ENTRIES_PER_AGENT }),
+    );
+  });
+
+  it("email_search clamps an over-large limit to the handle-store cap", async () => {
+    mockSearch.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_search", agentId)!;
+
+    await tool.execute("call-1", {
+      subject: "invoice",
+      limit: MAX_ENTRIES_PER_AGENT + 5000,
+    });
+
+    expect(mockSearch).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: MAX_ENTRIES_PER_AGENT }),
+    );
+  });
+
+  it("leaves a within-cap limit untouched", async () => {
+    mockList.mockResolvedValue([]);
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    await tool.execute("call-1", { limit: 25 });
+
+    expect(mockList).toHaveBeenCalledWith(
+      expect.objectContaining({ limit: 25 }),
+    );
   });
 });

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -744,12 +744,63 @@ describe("email_list", () => {
 
     const data = JSON.parse(result.content[0].text);
     expect(data).toHaveLength(1);
-    expect(data[0].id).toBe("msg-1");
     expect(mockList).toHaveBeenCalledWith({
       folder: "INBOX",
       limit: 10,
       unreadOnly: true,
     });
+  });
+
+  // Handle-indirection (Bug B, 2026-07-07 debugging session; sibling of
+  // PR #668): the model must never see the raw provider id — it must see a
+  // short, stable handle instead, so it can't corrupt a ~150-char Graph blob
+  // reproducing it on a later turn.
+  it("replaces the raw id with a short handle in the model-facing output, never exposing the raw id", async () => {
+    const rawId =
+      "AAMkAGI2TG92AAA=ZjY0LTQ5MGItYjA2NC1kNzk4ZjY0LWE1ZDQtcmVhbGx5LWxvbmctZ3JhcGgtaWQ=";
+    const emails = [
+      {
+        id: rawId,
+        from: "a@test.com",
+        subject: "Hello",
+        snippet: "Hi there",
+      },
+    ];
+    mockList.mockResolvedValue(emails);
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    const result = await tool.execute("call-1", {});
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data[0].id).not.toBe(rawId);
+    expect(data[0].id).toMatch(/^msg_[0-9a-f]+$/);
+    expect(result.content[0].text).not.toContain(rawId);
+  });
+
+  it("gives the same email the same handle across repeated email_list calls (deterministic)", async () => {
+    const rawId = "stable-graph-id-across-calls";
+    mockList.mockResolvedValue([
+      {
+        id: rawId,
+        from: "a@test.com",
+        subject: "Hello",
+        snippet: "Hi",
+      },
+    ]);
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_list", agentId)!;
+
+    const first = JSON.parse(
+      (await tool.execute("call-1", {})).content[0].text,
+    );
+    const second = JSON.parse(
+      (await tool.execute("call-2", {})).content[0].text,
+    );
+
+    expect(first[0].id).toBe(second[0].id);
   });
 });
 
@@ -774,9 +825,31 @@ describe("email_read", () => {
     const result = await tool.execute("call-1", { id: "msg-1" });
 
     const data = JSON.parse(result.content[0].text);
-    expect(data.id).toBe("msg-1");
     expect(data.body).toBe("Full body");
+    // "msg-1" is a raw (non-prefixed) id, so it is passed through to the
+    // adapter unchanged — Gmail compatibility / graceful fallback.
     expect(mockRead).toHaveBeenCalledWith("msg-1");
+  });
+
+  it("replaces the raw email id with a handle in the model-facing output (not the raw id)", async () => {
+    const rawId = "raw-graph-message-id-should-not-be-echoed";
+    const email = {
+      id: rawId,
+      from: "a@test.com",
+      subject: "Hello",
+      body: "Full body",
+    };
+    mockRead.mockResolvedValue(email);
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_read", agentId)!;
+
+    const result = await tool.execute("call-1", { id: rawId });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.id).not.toBe(rawId);
+    expect(data.id).toMatch(/^msg_[0-9a-f]+$/);
+    expect(result.content[0].text).not.toContain(rawId);
   });
 
   it("does not add attachment guidance when the email has no attachments", async () => {
@@ -797,10 +870,10 @@ describe("email_read", () => {
     // Existing behavior preserved: exactly one JSON content block, still parseable.
     expect(result.content).toHaveLength(1);
     const data = JSON.parse(result.content[0].text);
-    expect(data.id).toBe("msg-1");
+    expect(data.id).toMatch(/^msg_[0-9a-f]+$/);
   });
 
-  it("appends attachment guidance pointing to email_get_attachment when attachments are present", async () => {
+  it("appends attachment guidance pointing to email_get_attachment when attachments are present, using handles not raw ids", async () => {
     const email = {
       id: "msg-1",
       from: "a@test.com",
@@ -828,10 +901,14 @@ describe("email_read", () => {
 
     const result = await tool.execute("call-1", { id: "msg-1" });
 
-    // First block remains the untouched JSON payload.
+    // First block remains the untouched JSON payload, but with handles
+    // substituted for the raw message/attachment ids.
     const data = JSON.parse(result.content[0].text);
-    expect(data.id).toBe("msg-1");
+    expect(data.id).toMatch(/^msg_[0-9a-f]+$/);
     expect(data.attachments).toHaveLength(2);
+    expect(data.attachments[0].id).toMatch(/^att_[0-9a-f]+$/);
+    expect(data.attachments[1].id).toMatch(/^att_[0-9a-f]+$/);
+    expect(data.attachments[0].id).not.toBe(data.attachments[1].id);
 
     // Guidance is additive — a second block, not a restructure of the first.
     expect(result.content.length).toBeGreaterThan(1);
@@ -840,12 +917,16 @@ describe("email_read", () => {
       .map((b) => b.text)
       .join("\n");
     expect(guidance).toContain("email_get_attachment");
-    expect(guidance).toContain("msg-1");
-    expect(guidance).toContain("att-1");
+    expect(guidance).toContain(data.id);
+    expect(guidance).toContain(data.attachments[0].id);
     expect(guidance).toContain("invoice.pdf");
     expect(guidance).toContain("application/pdf");
-    expect(guidance).toContain("att-2");
+    expect(guidance).toContain(data.attachments[1].id);
     expect(guidance).toContain("photo.png");
+    // Raw ids must never leak into the guidance text either.
+    expect(guidance).not.toContain("msg-1");
+    expect(guidance).not.toContain("att-1");
+    expect(guidance).not.toContain("att-2");
   });
 });
 
@@ -1474,5 +1555,366 @@ describe("email_get_attachment", () => {
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain("attachment not found");
     expect(mockWriteFile).not.toHaveBeenCalled();
+  });
+});
+
+// Handle-indirection (Bug B, 2026-07-07 debugging session; sibling of PR
+// #668): email_list/email_search/email_read hand out short handles instead
+// of raw provider ids. email_read/email_get_attachment/email_draft/email_send
+// must resolve those handles back to the real id before calling the adapter.
+describe("id-handle indirection", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockCredentialResponse();
+  });
+
+  it("list -> read round trip: a handle produced by email_list resolves to the correct realId at the adapter", async () => {
+    const rawId = "AAMkAGI2-real-graph-message-id-that-is-very-long";
+    mockList.mockResolvedValue([
+      {
+        id: rawId,
+        from: "a@test.com",
+        subject: "Hello",
+        snippet: "Hi",
+      },
+    ]);
+
+    const tools = createApi();
+    const listTool = findTool(tools, "email_list", agentId)!;
+    const listResult = await listTool.execute("call-1", {});
+    const [{ id: handle }] = JSON.parse(listResult.content[0].text);
+    expect(handle).not.toBe(rawId);
+
+    mockRead.mockResolvedValue({
+      id: rawId,
+      from: "a@test.com",
+      subject: "Hello",
+      body: "Full body",
+    });
+    const readTool = findTool(tools, "email_read", agentId)!;
+    const readResult = await readTool.execute("call-2", { id: handle });
+
+    expect(readResult.isError).toBeFalsy();
+    expect(mockRead).toHaveBeenCalledWith(rawId);
+  });
+
+  it("search -> read round trip: a handle produced by email_search also resolves correctly", async () => {
+    const rawId = "search-produced-raw-id";
+    mockSearch.mockResolvedValue([
+      {
+        id: rawId,
+        from: "b@test.com",
+        subject: "Invoice",
+        snippet: "Please pay",
+      },
+    ]);
+
+    const tools = createApi();
+    const searchTool = findTool(tools, "email_search", agentId)!;
+    const searchResult = await searchTool.execute("call-1", {
+      subject: "invoice",
+    });
+    const [{ id: handle }] = JSON.parse(searchResult.content[0].text);
+
+    mockRead.mockResolvedValue({
+      id: rawId,
+      from: "b@test.com",
+      subject: "Invoice",
+      body: "body",
+    });
+    const readTool = findTool(tools, "email_read", agentId)!;
+    await readTool.execute("call-2", { id: handle });
+
+    expect(mockRead).toHaveBeenCalledWith(rawId);
+  });
+
+  it("read -> get_attachment round trip: attachment handles from email_read resolve to the correct ids at the adapter", async () => {
+    const rawMsgId = "raw-message-id-for-attachment-flow";
+    const rawAttId = "raw-attachment-id-abcdef";
+    mockRead.mockResolvedValue({
+      id: rawMsgId,
+      from: "a@test.com",
+      subject: "Hello",
+      body: "body",
+      attachments: [
+        {
+          id: rawAttId,
+          filename: "invoice.pdf",
+          mimeType: "application/pdf",
+          size: 100,
+        },
+      ],
+    });
+
+    const tools = createApi();
+    const readTool = findTool(tools, "email_read", agentId)!;
+    const readResult = await readTool.execute("call-1", { id: rawMsgId });
+    const data = JSON.parse(readResult.content[0].text);
+    const msgHandle = data.id;
+    const attHandle = data.attachments[0].id;
+    expect(msgHandle).not.toBe(rawMsgId);
+    expect(attHandle).not.toBe(rawAttId);
+
+    mockGetAttachment.mockResolvedValue({
+      filename: "invoice.pdf",
+      mimeType: "application/pdf",
+      data: Buffer.from("x"),
+    });
+    mockMkdir.mockResolvedValue(undefined);
+    mockAccess.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const attTool = findTool(tools, "email_get_attachment", agentId)!;
+    const attResult = await attTool.execute("call-2", {
+      messageId: msgHandle,
+      attachmentId: attHandle,
+    });
+
+    expect(attResult.isError).toBeFalsy();
+    expect(mockGetAttachment).toHaveBeenCalledWith(rawMsgId, rawAttId);
+  });
+
+  it("email_read: an unknown/corrupted handle yields a failed result (isError + details.error) with a 're-list' message, without ever reaching the adapter", async () => {
+    const tools = createApi();
+    const readTool = findTool(tools, "email_read", agentId)!;
+
+    const result = await readTool.execute("call-1", {
+      id: "msg_deadbeef",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "The email reference 'msg_deadbeef' is unknown or has expired.",
+    );
+    expect(result.content[0].text).toContain("email_list");
+    expect(result.content[0].text).toContain("email_search");
+    const details = (result as { details?: { error?: string } }).details;
+    expect(details?.error).toBeTruthy();
+    expect(details?.error).toBe(result.content[0].text);
+    expect(mockRead).not.toHaveBeenCalled();
+  });
+
+  it("email_get_attachment: an unknown messageId handle yields a failed result and never reaches the adapter", async () => {
+    const tools = createApi();
+    const tool = findTool(tools, "email_get_attachment", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      messageId: "msg_unknownhandle",
+      attachmentId: "att-1",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "The email reference 'msg_unknownhandle' is unknown or has expired.",
+    );
+    const details = (result as { details?: { error?: string } }).details;
+    expect(details?.error).toBe(result.content[0].text);
+    expect(mockGetAttachment).not.toHaveBeenCalled();
+  });
+
+  it("email_get_attachment: an unknown attachmentId handle yields a failed result and never reaches the adapter", async () => {
+    const tools = createApi();
+    const attTool = findTool(tools, "email_get_attachment", agentId)!;
+
+    const result = await attTool.execute("call-1", {
+      messageId: "msg-1", // raw id, passes through fine
+      attachmentId: "att_unknownhandle",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "The email reference 'att_unknownhandle' is unknown or has expired.",
+    );
+    expect(mockGetAttachment).not.toHaveBeenCalled();
+  });
+
+  it("email_draft: an unknown replyTo handle yields a failed result and never reaches the adapter", async () => {
+    const tools = createApi();
+    const draftTool = findTool(tools, "email_draft", agentId)!;
+
+    const result = await draftTool.execute("call-1", {
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: "msg_unknownhandle",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "The email reference 'msg_unknownhandle' is unknown or has expired.",
+    );
+    expect(mockDraft).not.toHaveBeenCalled();
+  });
+
+  it("email_send: an unknown replyTo handle yields a failed result and never reaches the adapter", async () => {
+    const configWithSend: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft", "send"] },
+        },
+      },
+    };
+    const tools = createApi(configWithSend);
+    const sendTool = findTool(tools, "email_send", agentId)!;
+
+    const result = await sendTool.execute("call-1", {
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: "msg_unknownhandle",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain(
+      "The email reference 'msg_unknownhandle' is unknown or has expired.",
+    );
+    expect(mockSend).not.toHaveBeenCalled();
+  });
+
+  it("email_draft: a resolved replyTo handle is passed to the adapter as the realId, not the handle", async () => {
+    const rawId = "raw-message-id-being-replied-to";
+    mockList.mockResolvedValue([
+      { id: rawId, from: "a@test.com", subject: "Hello", snippet: "Hi" },
+    ]);
+    const tools = createApi();
+    const listTool = findTool(tools, "email_list", agentId)!;
+    const listResult = await listTool.execute("call-1", {});
+    const [{ id: handle }] = JSON.parse(listResult.content[0].text);
+
+    mockDraft.mockResolvedValue({ draftId: "draft-1" });
+    const draftTool = findTool(tools, "email_draft", agentId)!;
+    await draftTool.execute("call-2", {
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: handle,
+    });
+
+    expect(mockDraft).toHaveBeenCalledWith({
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: rawId,
+    });
+  });
+
+  it("email_send: a resolved replyTo handle is passed to the adapter as the realId, not the handle", async () => {
+    const rawId = "raw-message-id-being-replied-to-send";
+    mockList.mockResolvedValue([
+      { id: rawId, from: "a@test.com", subject: "Hello", snippet: "Hi" },
+    ]);
+    const configWithSend: PluginConfig = {
+      ...testConfig,
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft", "send"] },
+        },
+      },
+    };
+    const tools = createApi(configWithSend);
+    const listTool = findTool(tools, "email_list", agentId)!;
+    const listResult = await listTool.execute("call-1", {});
+    const [{ id: handle }] = JSON.parse(listResult.content[0].text);
+
+    mockSend.mockResolvedValue({ messageId: "sent-1" });
+    const sendTool = findTool(tools, "email_send", agentId)!;
+    await sendTool.execute("call-2", {
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: handle,
+    });
+
+    expect(mockSend).toHaveBeenCalledWith({
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: rawId,
+    });
+  });
+
+  it("a raw (non-prefixed) id passed as replyTo is passed through to the adapter unchanged (Gmail compatibility)", async () => {
+    mockDraft.mockResolvedValue({ draftId: "draft-1" });
+    const tools = createApi();
+    const draftTool = findTool(tools, "email_draft", agentId)!;
+
+    await draftTool.execute("call-1", {
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: "raw-gmail-style-id",
+    });
+
+    expect(mockDraft).toHaveBeenCalledWith({
+      to: "test@example.com",
+      subject: "Re: Hello",
+      body: "Reply body",
+      replyTo: "raw-gmail-style-id",
+    });
+  });
+
+  it("a raw (non-prefixed) messageId/attachmentId pair is passed through to the adapter unchanged", async () => {
+    mockGetAttachment.mockResolvedValue({
+      filename: "file.txt",
+      mimeType: "text/plain",
+      data: Buffer.from("hello"),
+    });
+    mockMkdir.mockResolvedValue(undefined);
+    mockAccess.mockRejectedValue(
+      Object.assign(new Error("ENOENT"), { code: "ENOENT" }),
+    );
+    mockWriteFile.mockResolvedValue(undefined);
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_get_attachment", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      messageId: "raw-message-id",
+      attachmentId: "raw-attachment-id",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockGetAttachment).toHaveBeenCalledWith(
+      "raw-message-id",
+      "raw-attachment-id",
+    );
+  });
+
+  it("agent isolation: a handle minted while serving one agent cannot be resolved by a different agent", async () => {
+    const otherAgentConfig: PluginConfig = {
+      apiBaseUrl: "http://pinchy:7777",
+      gatewayToken: "test-gateway-token",
+      agents: {
+        "agent-1": {
+          connectionId: "conn-1",
+          permissions: { email: ["read", "draft"] },
+        },
+        "agent-2": {
+          connectionId: "conn-2",
+          permissions: { email: ["read", "draft"] },
+        },
+      },
+    };
+    const rawId = "agent-1-only-message-id";
+    mockList.mockResolvedValue([
+      { id: rawId, from: "a@test.com", subject: "Hello", snippet: "Hi" },
+    ]);
+
+    const tools = createApi(otherAgentConfig);
+    const listTool = findTool(tools, "email_list", "agent-1")!;
+    const listResult = await listTool.execute("call-1", {});
+    const [{ id: handle }] = JSON.parse(listResult.content[0].text);
+
+    const readToolForAgent2 = findTool(tools, "email_read", "agent-2")!;
+    const result = await readToolForAgent2.execute("call-2", { id: handle });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("unknown or has expired");
+    expect(mockRead).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-email/id-handle-store.ts
+++ b/packages/plugins/pinchy-email/id-handle-store.ts
@@ -26,11 +26,24 @@ export const MSG_PREFIX = "msg";
 export const ATT_PREFIX = "att";
 
 const TTL_MS = 30 * 60 * 1000; // 30 minutes
-const MAX_ENTRIES_PER_AGENT = 500;
-// Short enough that the model can reliably copy it verbatim, long enough
-// (32 bits of a realId's sha256) to make accidental handle collisions within
-// a single agent's 500-entry cap practically impossible.
-const HANDLE_HEX_LENGTH = 8;
+
+/**
+ * Per-agent entry cap. Exported so the tools that mint handles
+ * (email_list/email_search) can clamp their result-set size to it: a single
+ * result set larger than the cap would evict its own earliest handles as the
+ * later ones are minted, leaving the top rows the model was just shown
+ * unresolvable (Finding 1, 2026-07-07 review). Keeping every result set at or
+ * below the cap makes that impossible.
+ */
+export const MAX_ENTRIES_PER_AGENT = 500;
+
+// 16 hex chars = 64 bits of a realId's sha256. Short enough that the model can
+// still copy it verbatim (a Graph id is ~150 chars), but wide enough that a
+// collision between two distinct realIds within an agent's cap is negligible:
+// the birthday bound at 500 entries is ~500^2 / 2^65 ≈ 7e-15. An earlier
+// 32-bit handle sat at ~3e-5, where a collision would silently overwrite one
+// entry and resolve a handle to the WRONG email (Finding 2, 2026-07-07 review).
+const HANDLE_HEX_LENGTH = 16;
 
 interface HandleEntry {
   realId: string;

--- a/packages/plugins/pinchy-email/id-handle-store.ts
+++ b/packages/plugins/pinchy-email/id-handle-store.ts
@@ -1,0 +1,135 @@
+import { createHash } from "node:crypto";
+
+/**
+ * Handle-indirection for email message/attachment ids (Bug B, 2026-07-07
+ * debugging session; sibling of PR #668).
+ *
+ * Microsoft Graph message ids are ~150-char base64 blobs. Handing the raw id
+ * to the model and requiring it to echo it back verbatim on a later turn
+ * invites corruption by weaker models (a 32-char internal segment silently
+ * dropped on reproduction -> Graph's `ErrorInvalidIdMalformed`). Instead the
+ * plugin mints a short, deterministic, per-agent handle and resolves it back
+ * to the real id server-side, so the model only ever has to copy ~15
+ * characters.
+ *
+ * Keyed by agentId so one agent can never resolve another agent's handle —
+ * tenant isolation is enforced by the map structure itself, not by a runtime
+ * check that could be forgotten at a call site.
+ *
+ * Pure, synchronous, in-memory, no I/O. v1 scope: no DB, no timers — expiry
+ * is swept lazily on put(), and a process restart simply means handles must
+ * be re-minted by calling email_list / email_search again (the "honest
+ * re-list" error path in index.ts covers that case).
+ */
+
+export const MSG_PREFIX = "msg";
+export const ATT_PREFIX = "att";
+
+const TTL_MS = 30 * 60 * 1000; // 30 minutes
+const MAX_ENTRIES_PER_AGENT = 500;
+// Short enough that the model can reliably copy it verbatim, long enough
+// (32 bits of a realId's sha256) to make accidental handle collisions within
+// a single agent's 500-entry cap practically impossible.
+const HANDLE_HEX_LENGTH = 8;
+
+interface HandleEntry {
+  realId: string;
+  expiresAt: number;
+}
+
+// Insertion-ordered Map lets us evict the oldest entry in O(1) via
+// `.keys().next()` when an agent's store exceeds its cap.
+type AgentStore = Map<string, HandleEntry>;
+
+const stores = new Map<string, AgentStore>();
+
+/**
+ * Derive a short, deterministic handle for a realId. Same realId + prefix
+ * always yields the same handle, so repeated email_list calls show the model
+ * a stable reference for the same message. Different prefixes namespace
+ * message vs. attachment handles so they can never collide with each other.
+ */
+export function handleFor(realId: string, prefix: string): string {
+  const digest = createHash("sha256").update(realId).digest("hex");
+  return `${prefix}_${digest.slice(0, HANDLE_HEX_LENGTH)}`;
+}
+
+function getOrCreateAgentStore(agentId: string): AgentStore {
+  let store = stores.get(agentId);
+  if (!store) {
+    store = new Map<string, HandleEntry>();
+    stores.set(agentId, store);
+  }
+  return store;
+}
+
+/** Remove expired entries from an agent's store. Called lazily on put(). */
+function sweepExpired(store: AgentStore, now: number): void {
+  for (const [handle, entry] of store) {
+    if (entry.expiresAt <= now) store.delete(handle);
+  }
+}
+
+/** Evict the oldest (earliest-inserted) entries until the store is within cap. */
+function enforceCap(store: AgentStore): void {
+  while (store.size > MAX_ENTRIES_PER_AGENT) {
+    const oldestKey = store.keys().next().value;
+    if (oldestKey === undefined) break;
+    store.delete(oldestKey);
+  }
+}
+
+/**
+ * Mint (or refresh) a handle for realId, scoped to agentId, under the
+ * message prefix (MSG_PREFIX). Idempotent: a repeated call with the same
+ * realId returns the same handle and refreshes its expiry, so the same email
+ * gets the same handle across repeated lists.
+ *
+ * Use putAttachmentHandle for attachment ids — the prefix must be chosen at
+ * the call site (message vs. attachment) so the two id spaces never collide.
+ */
+export function putHandle(agentId: string, realId: string): string {
+  return putWithPrefix(agentId, realId, MSG_PREFIX);
+}
+
+/** Same as putHandle, but under the attachment prefix (ATT_PREFIX). */
+export function putAttachmentHandle(agentId: string, realId: string): string {
+  return putWithPrefix(agentId, realId, ATT_PREFIX);
+}
+
+function putWithPrefix(
+  agentId: string,
+  realId: string,
+  prefix: string,
+): string {
+  const store = getOrCreateAgentStore(agentId);
+  const now = Date.now();
+  sweepExpired(store, now);
+
+  const handle = handleFor(realId, prefix);
+  // Delete-then-set (rather than plain set on an existing key) so the
+  // refreshed entry moves to the end of the insertion order — otherwise a
+  // frequently-reused handle would look "old" to enforceCap's oldest-first
+  // eviction despite being the most recently accessed.
+  store.delete(handle);
+  store.set(handle, { realId, expiresAt: now + TTL_MS });
+  enforceCap(store);
+  return handle;
+}
+
+/**
+ * Resolve a handle back to its realId for a given agent. Returns null if the
+ * handle is unknown, expired, or belongs to a different agent (tenant
+ * isolation: each agent only ever looks in its own store).
+ */
+export function resolveHandle(agentId: string, handle: string): string | null {
+  const store = stores.get(agentId);
+  if (!store) return null;
+  const entry = store.get(handle);
+  if (!entry) return null;
+  if (entry.expiresAt <= Date.now()) {
+    store.delete(handle);
+    return null;
+  }
+  return entry.realId;
+}

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -10,6 +10,7 @@ import {
   resolveHandle,
   MSG_PREFIX,
   ATT_PREFIX,
+  MAX_ENTRIES_PER_AGENT,
 } from "./id-handle-store.js";
 
 // Filesystem convention shared with pinchy-odoo's odoo_attach_file: every
@@ -305,6 +306,21 @@ function handleizeSummaries(
     ...s,
     id: putHandle(agentId, s.id),
   }));
+}
+
+/**
+ * Clamp a model-supplied list/search limit to the handle store's per-agent
+ * cap. Each returned summary mints a handle, and the store evicts oldest-first
+ * once an agent exceeds the cap — so a single result set larger than the cap
+ * would evict its own earliest handles, leaving the top rows the model was just
+ * shown unresolvable and un-re-listable (Finding 1, 2026-07-07 review). Capping
+ * the result set at the store size keeps every handle in a single listing
+ * resolvable. A missing/invalid limit is left undefined so the adapter applies
+ * its own default.
+ */
+function clampListLimit(limit: unknown): number | undefined {
+  if (typeof limit !== "number" || !Number.isFinite(limit)) return undefined;
+  return Math.min(limit, MAX_ENTRIES_PER_AGENT);
 }
 
 interface EmailCredentials {
@@ -621,7 +637,7 @@ const plugin = {
               const result = await withAuthRetry(agentId, config, (adapter) =>
                 adapter.list({
                   folder: params.folder as Folder | undefined,
-                  limit: params.limit as number | undefined,
+                  limit: clampListLimit(params.limit),
                   unreadOnly: params.unreadOnly as boolean | undefined,
                 }),
               );
@@ -815,7 +831,7 @@ const plugin = {
                   sinceDays: params.sinceDays as number | undefined,
                   folder: params.folder as
                     "INBOX" | "SENT" | "DRAFTS" | "TRASH" | "SPAM" | undefined,
-                  limit: params.limit as number | undefined,
+                  limit: clampListLimit(params.limit),
                 }),
               );
 

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -315,11 +315,13 @@ function handleizeSummaries(
  * would evict its own earliest handles, leaving the top rows the model was just
  * shown unresolvable and un-re-listable (Finding 1, 2026-07-07 review). Capping
  * the result set at the store size keeps every handle in a single listing
- * resolvable. A missing/invalid limit is left undefined so the adapter applies
- * its own default.
+ * resolvable. A missing or non-positive limit is left undefined so the adapter
+ * applies its own default — a zero or negative $top/maxResults would otherwise
+ * reach the provider and yield a confusing empty result or a 400.
  */
 function clampListLimit(limit: unknown): number | undefined {
-  if (typeof limit !== "number" || !Number.isFinite(limit)) return undefined;
+  if (typeof limit !== "number" || !Number.isFinite(limit) || limit <= 0)
+    return undefined;
   return Math.min(limit, MAX_ENTRIES_PER_AGENT);
 }
 
@@ -904,9 +906,22 @@ const plugin = {
                 }),
               );
 
+              // Never hand the raw provider id back to the model — mint a
+              // handle just like email_list/email_read do, so the invariant
+              // "model-facing id output is always a handle" holds everywhere.
               return {
                 content: [
-                  { type: "text", text: JSON.stringify(result, null, 2) },
+                  {
+                    type: "text",
+                    text: JSON.stringify(
+                      {
+                        ...result,
+                        draftId: putHandle(agentId, result.draftId),
+                      },
+                      null,
+                      2,
+                    ),
+                  },
                 ],
               };
             } catch (error) {
@@ -971,8 +986,19 @@ const plugin = {
                 }),
               );
 
+              // Never hand the raw provider id back to the model — mint a
+              // handle so a later email_read of the just-sent message copies a
+              // short reference, not a corruptible ~150-char Graph id. A null
+              // messageId is a "no id available" signal, not an id: leave it.
+              const messageId =
+                result.messageId == null
+                  ? result.messageId
+                  : putHandle(agentId, result.messageId);
               const content: ContentBlock[] = [
-                { type: "text", text: JSON.stringify(result, null, 2) },
+                {
+                  type: "text",
+                  text: JSON.stringify({ ...result, messageId }, null, 2),
+                },
               ];
               // Some providers (Microsoft Graph, for a direct non-reply send)
               // do not return a real message id for the sent message — the

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -2,8 +2,15 @@ import { mkdir, writeFile, access } from "node:fs/promises";
 import { basename } from "node:path";
 import { GmailAdapter } from "./gmail-adapter.js";
 import { GraphAdapter } from "./graph-adapter.js";
-import type { EmailAdapter, Folder } from "./email-adapter.js";
+import type { EmailAdapter, EmailSummary, Folder } from "./email-adapter.js";
 import { checkPermission, type Permissions } from "./permissions.js";
+import {
+  putHandle,
+  putAttachmentHandle,
+  resolveHandle,
+  MSG_PREFIX,
+  ATT_PREFIX,
+} from "./id-handle-store.js";
 
 // Filesystem convention shared with pinchy-odoo's odoo_attach_file: every
 // agent's uploads land in the same per-agent directory so a downloaded email
@@ -219,20 +226,29 @@ async function reportAuthFailure(
  * lines ~116-122, issue #404): OpenClaw's tool-use hook strips the MCP
  * `isError` flag before forwarding results to the audit route, so
  * `details.error` is often the only remaining failure signal. Every
- * error-returning path below must set it, mirroring pinchy-odoo's
- * toolError() helper.
+ * error-returning path below must set it (identical string to
+ * content[0].text), mirroring pinchy-odoo's toolError() helper.
  */
-function permissionDenied(operation: string): {
+function toolError(text: string): {
   content: ContentBlock[];
   isError: true;
   details: { error: string };
 } {
-  const text = `Permission denied: email.${operation} is not allowed for this agent.`;
   return {
     isError: true,
     content: [{ type: "text", text }],
     details: { error: text },
   };
+}
+
+function permissionDenied(operation: string): {
+  content: ContentBlock[];
+  isError: true;
+  details: { error: string };
+} {
+  return toolError(
+    `Permission denied: email.${operation} is not allowed for this agent.`,
+  );
 }
 
 function errorResult(error: unknown): {
@@ -241,12 +257,54 @@ function errorResult(error: unknown): {
   details: { error: string };
 } {
   const message = error instanceof Error ? error.message : "Unknown error";
-  const text = `Error: ${message}`;
-  return {
-    isError: true,
-    content: [{ type: "text", text }],
-    details: { error: text },
-  };
+  return toolError(`Error: ${message}`);
+}
+
+/**
+ * Handle-indirection (Bug B, 2026-07-07 debugging session; sibling of PR
+ * #668): resolve a model-supplied value into the real provider id before it
+ * reaches the adapter.
+ *
+ * - If the value starts with our handle prefix (msg_/att_) and resolves,
+ *   return the realId.
+ * - If it starts with our prefix but does NOT resolve (unknown/expired/wrong
+ *   agent), return a failed-tool-result telling the model to re-list.
+ * - If it does not start with our prefix at all, treat it as a raw provider
+ *   id (Gmail compatibility / graceful fallback) and pass it through
+ *   unchanged.
+ */
+function resolveEmailReference(
+  agentId: string,
+  value: string,
+):
+  | { ok: true; realId: string }
+  | { ok: false; result: ReturnType<typeof toolError> } {
+  const isHandle =
+    value.startsWith(`${MSG_PREFIX}_`) || value.startsWith(`${ATT_PREFIX}_`);
+  if (!isHandle) return { ok: true, realId: value };
+
+  const realId = resolveHandle(agentId, value);
+  if (realId == null) {
+    return {
+      ok: false,
+      result: toolError(
+        `The email reference '${value}' is unknown or has expired. ` +
+          `Call email_list or email_search again to get a fresh reference.`,
+      ),
+    };
+  }
+  return { ok: true, realId };
+}
+
+/** Replace each summary's raw id with a per-agent handle, minting one as needed. */
+function handleizeSummaries(
+  agentId: string,
+  summaries: EmailSummary[],
+): EmailSummary[] {
+  return summaries.map((s) => ({
+    ...s,
+    id: putHandle(agentId, s.id),
+  }));
 }
 
 interface EmailCredentials {
@@ -568,9 +626,11 @@ const plugin = {
                 }),
               );
 
+              const handleized = handleizeSummaries(agentId, result);
+
               return {
                 content: [
-                  { type: "text", text: JSON.stringify(result, null, 2) },
+                  { type: "text", text: JSON.stringify(handleized, null, 2) },
                 ],
               };
             } catch (error) {
@@ -611,16 +671,38 @@ const plugin = {
                 return permissionDenied("read");
               }
 
+              const resolved = resolveEmailReference(
+                agentId,
+                params.id as string,
+              );
+              if (!resolved.ok) return resolved.result;
+
               const result = await withAuthRetry(agentId, config, (adapter) =>
-                adapter.read(params.id as string),
+                adapter.read(resolved.realId),
               );
 
+              const msgHandle = putHandle(agentId, result.id);
+              const handleizedAttachments = (result.attachments ?? []).map(
+                (a) => ({
+                  ...a,
+                  id: putAttachmentHandle(agentId, a.id),
+                }),
+              );
+              const handleizedResult = {
+                ...result,
+                id: msgHandle,
+                attachments: handleizedAttachments,
+              };
+
               const content: ContentBlock[] = [
-                { type: "text", text: JSON.stringify(result, null, 2) },
+                {
+                  type: "text",
+                  text: JSON.stringify(handleizedResult, null, 2),
+                },
               ];
 
-              if (result.attachments && result.attachments.length > 0) {
-                const list = result.attachments
+              if (handleizedAttachments.length > 0) {
+                const list = handleizedAttachments
                   .map(
                     (a) =>
                       `- id: ${a.id}, filename: ${a.filename}, mimeType: ${a.mimeType}, size: ${humanReadableSize(a.size)}`,
@@ -629,8 +711,8 @@ const plugin = {
                 content.push({
                   type: "text",
                   text:
-                    `This email has ${result.attachments.length} downloadable attachment(s):\n${list}\n\n` +
-                    `Use email_get_attachment with messageId "${result.id}" and one of the attachment ids above to save it into the workspace.`,
+                    `This email has ${handleizedAttachments.length} downloadable attachment(s):\n${list}\n\n` +
+                    `Use email_get_attachment with messageId "${msgHandle}" and one of the attachment ids above to save it into the workspace.`,
                 });
               }
 
@@ -737,9 +819,11 @@ const plugin = {
                 }),
               );
 
+              const handleized = handleizeSummaries(agentId, result);
+
               return {
                 content: [
-                  { type: "text", text: JSON.stringify(result, null, 2) },
+                  { type: "text", text: JSON.stringify(handleized, null, 2) },
                 ],
               };
             } catch (error) {
@@ -787,12 +871,20 @@ const plugin = {
                 return permissionDenied("draft");
               }
 
+              let replyTo: string | undefined = params.replyTo as
+                string | undefined;
+              if (replyTo != null) {
+                const resolved = resolveEmailReference(agentId, replyTo);
+                if (!resolved.ok) return resolved.result;
+                replyTo = resolved.realId;
+              }
+
               const result = await withAuthRetry(agentId, config, (adapter) =>
                 adapter.draft({
                   to: params.to as string,
                   subject: params.subject as string,
                   body: params.body as string,
-                  replyTo: params.replyTo as string | undefined,
+                  replyTo,
                 }),
               );
 
@@ -846,12 +938,20 @@ const plugin = {
                 return permissionDenied("send");
               }
 
+              let replyTo: string | undefined = params.replyTo as
+                string | undefined;
+              if (replyTo != null) {
+                const resolved = resolveEmailReference(agentId, replyTo);
+                if (!resolved.ok) return resolved.result;
+                replyTo = resolved.realId;
+              }
+
               const result = await withAuthRetry(agentId, config, (adapter) =>
                 adapter.send({
                   to: params.to as string,
                   subject: params.subject as string,
                   body: params.body as string,
-                  replyTo: params.replyTo as string | undefined,
+                  replyTo,
                 }),
               );
 
@@ -914,8 +1014,19 @@ const plugin = {
                 return permissionDenied("read");
               }
 
-              const messageId = params.messageId as string;
-              const attachmentId = params.attachmentId as string;
+              const resolvedMessageId = resolveEmailReference(
+                agentId,
+                params.messageId as string,
+              );
+              if (!resolvedMessageId.ok) return resolvedMessageId.result;
+              const resolvedAttachmentId = resolveEmailReference(
+                agentId,
+                params.attachmentId as string,
+              );
+              if (!resolvedAttachmentId.ok) return resolvedAttachmentId.result;
+
+              const messageId = resolvedMessageId.realId;
+              const attachmentId = resolvedAttachmentId.realId;
 
               // No pre-download size precheck is possible here: the
               // EmailAdapter#getAttachment contract returns { filename,


### PR DESCRIPTION
## Summary
- Microsoft Graph message ids are ~150-char base64 blobs. `email_list`/`email_read` handed the raw id to the model and required it to echo it back verbatim on a later turn. A weaker model (gemma4:31b, staging) dropped a repeated 32-char internal segment when reproducing it, and Graph rejected the corrupted id with `ErrorInvalidIdMalformed: "Id is malformed."`. Bug B from the 2026-07-07 debugging session (sibling of PR #668).
- Adds `packages/plugins/pinchy-email/id-handle-store.ts`: a pure, synchronous, per-agent, in-memory `Map<agentId, Map<handle, {realId, expiresAt}>>`. `handleFor(realId, prefix)` derives a deterministic short handle (`msg_`/`att_` + 8 hex chars of `sha256(realId)`); `putHandle`/`putAttachmentHandle` mint+refresh (idempotent, 30 min TTL, 500-entry cap per agent with oldest-first eviction); `resolveHandle(agentId, handle)` returns the realId or null, enforcing tenant isolation via the agentId key.
- Wires it into `index.ts`: `email_list`/`email_search`/`email_read` now emit handles instead of raw ids everywhere the model sees output (JSON payload and the human-readable attachment-guidance text). `email_read`, `email_get_attachment`, `email_draft`, and `email_send` resolve model-supplied handles back to real ids before calling the adapter. A value that isn't handle-prefixed passes through unchanged (Gmail id compatibility / graceful fallback). An unknown/expired/cross-agent handle returns a proper failed tool result (`isError: true` + `details.error`, matching PR #668's audit-integrity contract) telling the model to call `email_list`/`email_search` again.
- Adapters (`gmail-adapter.ts` / `graph-adapter.ts`) are untouched — they still receive/return real ids; resolution happens in `index.ts` before the adapter call.

## Test plan
- [x] `pnpm -C packages/plugins/pinchy-email test` — 211 passed (199 pre-existing + 12 new)
- [x] `pnpm typecheck:plugins` — all 8 plugin packages typecheck cleanly
- [x] `pnpm test:plugins` — all plugin packages pass
- [x] `pnpm test` (full web suite, includes plugin tests) — 7261 passed, 13 skipped (pre-existing, unaffected)
- [x] `pnpm test:scripts` — 202 passed
- [x] `prettier --check` on all changed files — clean
- [x] Manifest/tool-dispatch/skip drift guards (`manifest-tools-drift`, `plugin-tool-coverage`, `plugin-test-coverage`, `no-untracked-skips*`) — all pass (no new tools added, no skips)

New tests added in `id-handle-store.test.ts` (12) cover: determinism, tenant isolation (agent A cannot resolve agent B's handle), TTL expiry, refresh-on-idempotent-put, unknown handle → null, and cap/eviction behavior.

New/updated tests in `tools.test.ts` cover: list/search → read round trip through a handle resolving to the correct realId at the adapter; read → get_attachment round trip for attachment handles; unknown/corrupted handle on `email_read`, `email_get_attachment`, `email_draft`, `email_send` each yielding a failed result (`isError` + `details.error`) with the re-list message, never reaching the adapter; raw (non-prefixed) ids passed through unchanged; model-facing output of `email_list`/`email_read` containing handles, never raw ids; and explicit cross-agent isolation at the tool-handler layer.

## Deviations from the brief
- PR #668 (the `details.error` audit-integrity contract) is still open, not merged into `main`. Since this PR builds off `origin/main`, I implemented the same `toolError()`/`details.error` shape directly here (mirroring pinchy-odoo's pattern) rather than depending on an unmerged PR, so the "unknown handle" failures satisfy the brief's explicit isError+details.error requirement standalone. If #668 merges first, this PR's `toolError` helper and #668's should turn out equivalent — worth a quick diff-check at merge time to avoid duplicated logic.