### PR TITLE
fix(telegram): stop the poller promptly on disconnect via config.apply (#476 gap 1)

### DIFF
--- a/config/telegram-mock/__tests__/reset-offset.test.mjs
+++ b/config/telegram-mock/__tests__/reset-offset.test.mjs
@@ -6,7 +6,13 @@ import { createRequire } from "node:module";
 // boot the HTTPS/control servers (guarded by `require.main === module`), so
 // no ports are bound — this runs hermetically under `node --test`.
 const require = createRequire(import.meta.url);
-const { resetState, injectMessage, handleGetUpdates } = require("../server.js");
+const {
+  resetState,
+  injectMessage,
+  handleGetUpdates,
+  getHealthSnapshot,
+  ACTIVE_GRACE_MS,
+} = require("../server.js");
 
 const TOKEN = "123456:ABC-test-token-for-e2e";
 const CHAT_ID = "999888777";
@@ -65,4 +71,103 @@ test("update_id stays monotonic across reset so a stale poller offset still rece
     `stale poller (offset ${stalePollerOffset}) should receive update ` +
       `${idAfterReset}, got ${JSON.stringify(deliveredIds)}`
   );
+});
+
+// ── activePollingTokens (Issue #476 Gap 1 oracle) ───────────────────────
+//
+// `pollingTokens` only ever grows (cleared by /control/reset) — it answers
+// "has this bot EVER polled", not "is this bot polling RIGHT NOW". That makes
+// it useless as an oracle for "the poller stopped after disconnect": once a
+// token is in the set it stays there forever, even if OpenClaw's channel
+// worker for that bot has been torn down. `activePollingTokens` answers the
+// live question instead: a token is active while it has a getUpdates request
+// in flight, or settled one within a SHORT grace window (ACTIVE_GRACE_MS).
+// Tracking the in-flight connection — rather than only a freshness timestamp —
+// is what lets a disconnect test observe the stop within seconds: an open
+// long-poll keeps the token active no matter how long it runs, and once the
+// poll is aborted (client disconnect) the token drops out within the grace.
+test("activePollingTokens includes a token that just settled a poll", async () => {
+  resetState();
+
+  await handleGetUpdates(TOKEN, { offset: "0", timeout: "0" });
+
+  const health = getHealthSnapshot();
+  assert.ok(
+    health.activePollingTokens.includes(TOKEN),
+    `expected ${TOKEN} in activePollingTokens, got ${JSON.stringify(health.activePollingTokens)}`
+  );
+  // Back-compat: pollingTokens (ever-polled) must still include it too.
+  assert.ok(health.pollingTokens.includes(TOKEN));
+});
+
+test("activePollingTokens drops a settled token once the grace window elapses", async () => {
+  resetState();
+
+  await handleGetUpdates(TOKEN, { offset: "0", timeout: "0" });
+  assert.ok(getHealthSnapshot().activePollingTokens.includes(TOKEN));
+
+  // No poll in flight and the grace window has elapsed without a new poll.
+  const health = getHealthSnapshot(Date.now() + ACTIVE_GRACE_MS + 1);
+  assert.ok(
+    !health.activePollingTokens.includes(TOKEN),
+    `expected ${TOKEN} to have dropped out of activePollingTokens after the grace window, ` +
+      `got ${JSON.stringify(health.activePollingTokens)}`
+  );
+  // pollingTokens (ever-polled, back-compat) is NOT time-based and must still
+  // include it — other specs rely on this field never shrinking except on reset.
+  assert.ok(health.pollingTokens.includes(TOKEN));
+});
+
+// The core of the #476 Gap 1 fix: an OPEN long-poll must keep the token active
+// no matter how much wall-clock passes (so a healthy 30s long-poller is never
+// mistaken for stopped), yet once the poll is aborted the token must drop out
+// within the SHORT grace — NOT only after a full long-poll timeout. A pure
+// freshness window can't express both at once: a window long enough to survive
+// a 30s long-poll is necessarily longer than the ~1s stop the disconnect test
+// needs to see.
+test("an in-flight long-poll keeps a token active indefinitely; aborting it drops the token within the grace window", async () => {
+  resetState();
+
+  // Model OpenClaw's live poller: an open getUpdates connection we don't await.
+  const ac = new AbortController();
+  const inflight = handleGetUpdates(
+    TOKEN,
+    { offset: "0", timeout: "30" },
+    { signal: ac.signal }
+  );
+
+  // Even far beyond the grace window, an open poll reads as active.
+  const whilePolling = getHealthSnapshot(Date.now() + 100 * ACTIVE_GRACE_MS);
+  assert.ok(
+    whilePolling.activePollingTokens.includes(TOKEN),
+    `an in-flight long-poll must keep ${TOKEN} active regardless of elapsed time, ` +
+      `got ${JSON.stringify(whilePolling.activePollingTokens)}`
+  );
+
+  // Client disconnects (OpenClaw tears the worker down) → the poll settles.
+  ac.abort();
+  await inflight;
+
+  // Immediately after: still within grace, so still active.
+  assert.ok(getHealthSnapshot().activePollingTokens.includes(TOKEN));
+  // Past the grace window: dropped — the stop is observable within
+  // ACTIVE_GRACE_MS, well under the disconnect spec's 15s window.
+  const afterGrace = getHealthSnapshot(Date.now() + ACTIVE_GRACE_MS + 1);
+  assert.ok(
+    !afterGrace.activePollingTokens.includes(TOKEN),
+    `after abort + grace, ${TOKEN} must drop out of activePollingTokens, ` +
+      `got ${JSON.stringify(afterGrace.activePollingTokens)}`
+  );
+});
+
+test("/control/reset clears in-flight/last-poll state so activePollingTokens is empty", async () => {
+  resetState();
+  await handleGetUpdates(TOKEN, { offset: "0", timeout: "0" });
+  assert.ok(getHealthSnapshot().activePollingTokens.includes(TOKEN));
+
+  resetState();
+
+  const health = getHealthSnapshot();
+  assert.deepEqual(health.activePollingTokens, []);
+  assert.deepEqual(health.pollingTokens, []);
 });

--- a/config/telegram-mock/server.js
+++ b/config/telegram-mock/server.js
@@ -43,7 +43,77 @@ const pendingUpdates = new Map(); // token -> update[]
 // have started polling yet, especially during OpenClaw channel restarts
 // when adding a second bot account. Tests use this to wait for a SPECIFIC
 // bot to be live, instead of "any bot is registered".
+//
+// IMPORTANT: this set only ever GROWS (cleared only by /control/reset) — it
+// answers "has this bot EVER polled", not "is it polling RIGHT NOW". It
+// cannot detect a poller that stopped (e.g. after a Telegram channel
+// disconnect); use `activePollingTokens` in the health snapshot for that.
 const pollingTokens = new Set();
+
+// Per-token count of getUpdates requests CURRENTLY in flight (an open long-poll
+// connection). A live OpenClaw poller always keeps exactly one getUpdates
+// request outstanding — it re-issues immediately on return — so `inflightPolls
+// > 0` is a direct, latency-free signal that the bot is polling RIGHT NOW,
+// independent of how long each individual long-poll lasts. When OpenClaw tears
+// down a channel worker on disconnect it aborts the in-flight request; the HTTP
+// layer catches the socket close and settles the poll, dropping the count to 0.
+// Cleared by /control/reset.
+const inflightPolls = new Map();
+
+// Per-token timestamp (ms since epoch) of the most recent getUpdates begin or
+// settle. Only used to bridge the sub-millisecond hand-off between one long-poll
+// returning and OpenClaw re-issuing the next one, so a healthy poller never
+// flickers out of the active set during that gap. Cleared by /control/reset.
+const lastPollAt = new Map();
+
+// After a poll settles and no request is left in flight, a token stays "active"
+// for this grace period — just long enough to cover the re-issue hand-off plus
+// CI scheduling jitter. It is deliberately SHORT and unrelated to the 30s
+// long-poll timeout: that decoupling is the entire point. The previous
+// freshness-only oracle stamped `lastPollAt` on COMPLETION and called a token
+// active for FRESHNESS_MS afterwards, so the window had to exceed the 30s
+// long-poll (else a healthy poller looked "stopped" mid-poll) — which in turn
+// made a genuine stop undetectable for ~40s, far longer than the disconnect
+// test's window. Tracking the in-flight connection instead means a healthy
+// poller reads active via `inflightPolls` (not this grace), so the grace can be
+// short and a real stop surfaces within it once the aborted poll settles.
+const ACTIVE_GRACE_MS = 5000;
+
+/**
+ * Snapshot of poller state for GET /control/health. A token is "actively
+ * polling" if it has a getUpdates request in flight right now, or settled one
+ * within ACTIVE_GRACE_MS. `now` is injectable so unit tests can advance past
+ * the grace window without a real sleep.
+ */
+function getHealthSnapshot(now = Date.now()) {
+  const active = new Set();
+  for (const [token, count] of inflightPolls) {
+    if (count > 0) active.add(token);
+  }
+  for (const [token, ts] of lastPollAt) {
+    if (now - ts < ACTIVE_GRACE_MS) active.add(token);
+  }
+  return {
+    pollingTokens: [...pollingTokens],
+    activePollingTokens: [...active],
+  };
+}
+
+// Mark a getUpdates request as started/settled. `beginPoll` also records the
+// bot in the ever-grew `pollingTokens` set (has this bot EVER polled), while
+// `inflightPolls`/`lastPollAt` answer "is it polling right now".
+function beginPoll(token) {
+  pollingTokens.add(token);
+  inflightPolls.set(token, (inflightPolls.get(token) || 0) + 1);
+  lastPollAt.set(token, Date.now());
+}
+
+function endPoll(token) {
+  const remaining = (inflightPolls.get(token) || 0) - 1;
+  if (remaining > 0) inflightPolls.set(token, remaining);
+  else inflightPolls.delete(token);
+  lastPollAt.set(token, Date.now());
+}
 
 // When true, getUpdates returns HTTP-style 409 "Conflict: terminated by
 // other getUpdates request" — the exact response Telegram sends when a
@@ -71,6 +141,8 @@ function resetState() {
   pendingUpdates.clear();
   bots.clear();
   pollingTokens.clear();
+  inflightPolls.clear();
+  lastPollAt.clear();
   conflict409Tokens.clear();
   conflict409All = false;
   // message_id may safely reset, unlike update_id: nothing filters on it
@@ -160,68 +232,112 @@ function injectMessage({ token, chatId, text, userId, username, firstName, lastN
   return updateId;
 }
 
-// getUpdates is async (long-poll) — handled separately
-async function handleGetUpdates(token, body) {
-  // Mark this bot as actively polling. Tests rely on this to verify a
-  // specific bot's channel has come up, which is more reliable than the
-  // generic getMe-based registration count.
-  pollingTokens.add(token);
-
-  // Simulated duplicate-poller conflict: Telegram returns 409 when a second
-  // instance polls the same token. Return it immediately (no long-poll) so
-  // OpenClaw's channel worker exits and the health-monitor restart loop kicks
-  // in — the exact production failure mode for cross-environment bot sharing.
-  if (conflict409All || conflict409Tokens.has(token)) {
-    return {
-      ok: false,
-      error_code: 409,
-      description:
-        "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
-    };
-  }
-
-  const timeout = Math.min(parseInt(body?.timeout || "30", 10), 30);
-  const offset = parseInt(body?.offset || "0", 10);
-
-  // Check for existing updates
-  const updates = pendingUpdates.get(token) || [];
-  if (offset > 0) {
-    // Clear consumed updates
-    pendingUpdates.set(token, updates.filter((u) => u.update_id >= offset));
-  }
-
-  const filtered = (pendingUpdates.get(token) || []).filter(
-    (u) => u.update_id >= offset
-  );
-
-  if (filtered.length > 0) {
-    return { ok: true, result: filtered };
-  }
-
-  // Long-poll: wait for new updates or timeout
-  return new Promise((resolve) => {
-    const timer = setTimeout(() => {
-      // Remove this listener
-      const listeners = updateListeners.get(token) || [];
-      updateListeners.set(
-        token,
-        listeners.filter((cb) => cb !== onUpdate)
-      );
-      resolve({ ok: true, result: [] });
-    }, timeout * 1000);
-
-    const onUpdate = () => {
-      clearTimeout(timer);
-      const current = (pendingUpdates.get(token) || []).filter(
-        (u) => u.update_id >= offset
-      );
-      resolve({ ok: true, result: current });
-    };
-
-    if (!updateListeners.has(token)) {
-      updateListeners.set(token, []);
+// getUpdates is async (long-poll) — handled separately.
+//
+// `options.signal` (optional AbortSignal) lets the HTTP layer cancel an
+// in-flight long-poll when the client closes the connection — e.g. OpenClaw
+// aborting the request as it tears down a disconnected bot's channel worker.
+// Cancelling settles the poll so `inflightPolls` drops to 0 promptly, which is
+// what makes "the poller stopped" observable within ACTIVE_GRACE_MS rather than
+// only after a full 30s long-poll timeout (Issue #476 Gap 1).
+async function handleGetUpdates(token, body, options = {}) {
+  const { signal } = options;
+  // Mark this bot as actively polling (both the ever-grew `pollingTokens` set
+  // and the in-flight counter). `endPoll` in the finally clears the in-flight
+  // count on every exit path — 409, immediate return, timeout, update, abort.
+  beginPoll(token);
+  try {
+    // Simulated duplicate-poller conflict: Telegram returns 409 when a second
+    // instance polls the same token. Return it immediately (no long-poll) so
+    // OpenClaw's channel worker exits and the health-monitor restart loop kicks
+    // in — the exact production failure mode for cross-environment bot sharing.
+    if (conflict409All || conflict409Tokens.has(token)) {
+      return {
+        ok: false,
+        error_code: 409,
+        description:
+          "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running",
+      };
     }
-    updateListeners.get(token).push(onUpdate);
+
+    const timeout = Math.min(parseInt(body?.timeout || "30", 10), 30);
+    const offset = parseInt(body?.offset || "0", 10);
+
+    // Check for existing updates
+    const updates = pendingUpdates.get(token) || [];
+    if (offset > 0) {
+      // Clear consumed updates
+      pendingUpdates.set(token, updates.filter((u) => u.update_id >= offset));
+    }
+
+    const filtered = (pendingUpdates.get(token) || []).filter(
+      (u) => u.update_id >= offset
+    );
+
+    if (filtered.length > 0) {
+      return { ok: true, result: filtered };
+    }
+
+    // Long-poll: wait for new updates, timeout, or client abort.
+    return await new Promise((resolve) => {
+      const cleanup = () => {
+        clearTimeout(timer);
+        const listeners = updateListeners.get(token) || [];
+        updateListeners.set(
+          token,
+          listeners.filter((cb) => cb !== onUpdate)
+        );
+        if (signal) signal.removeEventListener("abort", onAbort);
+      };
+      const timer = setTimeout(() => {
+        cleanup();
+        resolve({ ok: true, result: [] });
+      }, timeout * 1000);
+      const onUpdate = () => {
+        cleanup();
+        const current = (pendingUpdates.get(token) || []).filter(
+          (u) => u.update_id >= offset
+        );
+        resolve({ ok: true, result: current });
+      };
+      // Client (OpenClaw) closed the request — e.g. its channel worker is being
+      // torn down on disconnect. Settle now so the in-flight count drops instead
+      // of lingering until the full long-poll timeout fires (and stamps a
+      // "zombie" completion 30s in the future).
+      const onAbort = () => {
+        cleanup();
+        resolve({ ok: true, result: [] });
+      };
+      if (signal) {
+        if (signal.aborted) {
+          cleanup();
+          resolve({ ok: true, result: [] });
+          return;
+        }
+        signal.addEventListener("abort", onAbort);
+      }
+      if (!updateListeners.has(token)) {
+        updateListeners.set(token, []);
+      }
+      updateListeners.get(token).push(onUpdate);
+    });
+  } finally {
+    endPoll(token);
+  }
+}
+
+// Wire an HTTP request/response to a getUpdates long-poll, cancelling the poll
+// if the client closes the connection before we answer — so a torn-down
+// poller's in-flight count drops promptly (Issue #476 Gap 1) instead of waiting
+// out the 30s long-poll. `res` "close" fires on abort AND on normal completion;
+// aborting an already-settled poll is a harmless no-op.
+function dispatchGetUpdates(req, res, token, body) {
+  const ac = new AbortController();
+  res.on("close", () => ac.abort());
+  handleGetUpdates(token, body, { signal: ac.signal }).then((result) => {
+    if (res.writableEnded) return;
+    res.writeHead(200, { "Content-Type": "application/json" });
+    res.end(JSON.stringify(result));
   });
 }
 
@@ -307,10 +423,7 @@ function startHttpsServer(cert) {
 
       // getUpdates is async (long-poll)
       if (method === "getUpdates") {
-        handleGetUpdates(token, bodyData).then((result) => {
-          res.writeHead(200, { "Content-Type": "application/json" });
-          res.end(JSON.stringify(result));
-        });
+        dispatchGetUpdates(req, res, token, bodyData);
         return;
       }
 
@@ -418,12 +531,14 @@ function startControlServer() {
 
       // GET /control/health
       if (req.method === "GET" && url.pathname === "/control/health") {
+        const { pollingTokens: pollingTokensSnapshot, activePollingTokens } = getHealthSnapshot();
         res.writeHead(200);
         res.end(
           JSON.stringify({
             ok: true,
             bots: [...bots.keys()].length,
-            pollingTokens: [...pollingTokens],
+            pollingTokens: pollingTokensSnapshot,
+            activePollingTokens,
             pendingUpdates: [...pendingUpdates.values()].flat().length,
             responses: botResponses.length,
             conflict409All,
@@ -439,10 +554,7 @@ function startControlServer() {
         const [, token, method] = botMatch;
         const botBody = parsedBody(body);
         if (method === "getUpdates") {
-          handleGetUpdates(token, botBody).then((result) => {
-            res.writeHead(200, { "Content-Type": "application/json" });
-            res.end(JSON.stringify(result));
-          });
+          dispatchGetUpdates(req, res, token, botBody);
           return;
         }
         const result = handleBotRequest(token, method, botBody);
@@ -485,4 +597,10 @@ if (require.main === module) {
   });
 }
 
-module.exports = { resetState, injectMessage, handleGetUpdates };
+module.exports = {
+  resetState,
+  injectMessage,
+  handleGetUpdates,
+  getHealthSnapshot,
+  ACTIVE_GRACE_MS,
+};

--- a/packages/web/e2e/telegram/disconnect-stops-poller.spec.ts
+++ b/packages/web/e2e/telegram/disconnect-stops-poller.spec.ts
@@ -1,0 +1,132 @@
+/**
+ * E2E regression for Issue #476 Gap 1: disconnecting a Telegram bot must
+ * promptly stop its poller, not leave it running for an indeterminate time
+ * while OpenClaw's inotify watcher eventually notices the config change.
+ *
+ * Background: `updateTelegramChannelConfig()` (packages/web/src/lib/openclaw-
+ * config/targeted.ts), shared by the per-agent `DELETE
+ * /api/agents/[agentId]/channels/telegram` route and the org-wide `DELETE
+ * /api/settings/telegram/all` route, only wrote the config file and called
+ * `restartState.notifyRestart()` for UI purposes — the actual OpenClaw reload
+ * relied entirely on the container's file-watcher noticing the write. That
+ * left a latency gap during which a disconnected bot's channel worker could
+ * keep polling `getUpdates` against Telegram, which is the root cause of the
+ * cross-instance getUpdates 409 flap that originally motivated #476: a stale
+ * poller from a disconnected/removed bot instance kept fighting a fresh one
+ * for the same long-poll slot.
+ *
+ * This spec measures the gap directly: connect a bot, confirm it's actively
+ * polling the mock, disconnect it via the per-agent route, and assert the
+ * poller goes quiet (drops out of the mock's `activePollingTokens`, a
+ * freshness-based signal distinct from the ever-growing `pollingTokens` set)
+ * within a bounded window.
+ */
+
+import { test, expect } from "@playwright/test";
+import {
+  login,
+  getAgentId,
+  connectBot,
+  disconnectBot,
+  resetMockTelegram,
+  waitForPinchy,
+  waitForMockTelegram,
+  waitForOpenClawConnected,
+  waitForTelegramPolling,
+  waitForBotPolling,
+  waitForBotStoppedPolling,
+  seedSetup,
+  pinchyPost,
+  pinchyGet,
+} from "./helpers";
+import { waitForAgentDispatchable } from "../shared/dispatch-probe";
+
+// Smithers' own bot token — same literal as agent-create-no-restart.spec.ts so
+// a prior suite's connectBot(Smithers, ...) in the same run is a no-op here
+// (targeted-write dedup: "same token already configured" → file write skipped,
+// nothing destabilizes an already-live poller). Smithers must have a bot
+// connected before a NON-personal agent (our second agent below) is allowed
+// to connect one (`hasMainTelegramBot()` guard in the per-agent route).
+const MAIN_BOT_TOKEN = "123456:ABC-test-token-for-e2e";
+
+// Distinct token for the throwaway second agent this spec disconnects. Kept
+// separate from MAIN_BOT_TOKEN and telegram-flow.spec.ts's SECOND_BOT_TOKEN
+// so this spec's connect/disconnect cycle doesn't collide with other specs'
+// bot state when the suite runs as a whole.
+const BOT_TOKEN = "555444:GHI-disconnect-stops-poller-e2e";
+
+test.describe.serial("Telegram disconnect stops the poller (#476 Gap 1)", () => {
+  let agentId: string;
+
+  test.beforeAll(async ({}, testInfo) => {
+    testInfo.setTimeout(300000); // 5 min — services can be slow in CI
+    await waitForPinchy();
+    await waitForMockTelegram();
+    await seedSetup();
+    await waitForOpenClawConnected(120000);
+    await login();
+
+    // Ensure Smithers (the main bot) is configured — required before a
+    // non-personal agent's bot can connect at all (hasMainTelegramBot()).
+    const smithersId = await getAgentId();
+    await connectBot(smithersId, MAIN_BOT_TOKEN);
+    await waitForTelegramPolling();
+
+    // Smithers is Pinchy's main bot; the per-agent disconnect route refuses
+    // to remove it individually ("Use 'Remove Telegram for everyone'"). Use a
+    // SECOND, non-personal agent instead, same pattern as the Multi-Bot suite
+    // in telegram-flow.spec.ts.
+    //
+    // Created via the real POST /api/agents route (NOT a raw DB insert like
+    // helpers.ts's createAgent()) with a unique per-run name, and confirmed
+    // dispatchable before connecting a bot. This matters specifically BECAUSE
+    // of the #476 Gap 1 fix: updateTelegramChannelConfig now routes through
+    // config.apply when a WS client is connected, and OpenClaw's config.apply
+    // RPC validates `bindings[].agentId` against the runtime's already-loaded
+    // `agents.list` — unlike the old file+inotify path, which never validated
+    // synchronously. A raw-SQL-inserted (or previously-created-but-never-
+    // dispatchable) agent is absent from `agents.list`, so config.apply
+    // legitimately rejects the binding ("Unknown agent id ... not in
+    // agents.list") and the bot never starts polling. Going through the real
+    // creation route (which regenerates config and lands the agent in OC's
+    // runtime) avoids that class of failure — the same reason
+    // agent-create-no-restart.spec.ts uses waitForAgentDispatchable before
+    // dispatching to a freshly created agent. A fresh name per run (rather
+    // than reusing a fixed name via getAgentByName) sidesteps a stale
+    // never-dispatchable row surviving from an earlier interrupted run.
+    const createRes = await pinchyPost("/api/agents", {
+      // Name field is capped at 30 chars — keep the prefix short.
+      name: `Gap1Poller-${Date.now()}`,
+      templateId: "custom",
+    });
+    const body = await createRes.text();
+    if (createRes.status >= 300) {
+      throw new Error(`create Gap1 Poller Test Bot failed: ${createRes.status} ${body}`);
+    }
+    const agent = JSON.parse(body) as { id: string; name: string };
+    agentId = agent.id;
+
+    await waitForAgentDispatchable(
+      (id) => pinchyGet(`/api/health/openclaw?agentId=${id}`),
+      agentId,
+      { deadlineMs: 90_000 }
+    );
+  });
+
+  test.beforeEach(async () => {
+    await resetMockTelegram();
+  });
+
+  test("poller stops within 15s of disconnecting the bot", async () => {
+    const result = await connectBot(agentId, BOT_TOKEN);
+    expect(result.botUsername).toBeTruthy();
+    await waitForBotPolling(BOT_TOKEN);
+
+    await disconnectBot(agentId);
+
+    // The critical assertion: the poller must go quiet promptly, not linger
+    // until an eventual, unbounded inotify-triggered restart catches up.
+    // waitForBotStoppedPolling throws (failing the test) on timeout.
+    await waitForBotStoppedPolling(BOT_TOKEN, 15000);
+  });
+});

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -503,6 +503,37 @@ export async function waitForBotPolling(token: string, timeout = 120000): Promis
   throw new Error(`Bot ${token.slice(0, 6)}... did not start polling within ${timeout}ms`);
 }
 
+/**
+ * Wait until a specific bot token has STOPPED polling — the counterpart to
+ * `waitForBotPolling`. Uses `activePollingTokens`, which the mock derives from
+ * whether the token currently has a getUpdates request in flight (plus a short
+ * settle grace), NOT `pollingTokens` (which only ever grows and never forgets a
+ * token once it has polled once — see config/telegram-mock/server.js). Tracking
+ * the live connection is what lets the stop surface within seconds: when
+ * OpenClaw tears the worker down it closes the getUpdates connection, the mock
+ * settles the poll, and the token drops out within the grace — rather than
+ * lingering for a full 30s long-poll timeout. Used by the Issue #476 Gap 1
+ * disconnect-latency regression: after disconnecting a bot, its poller must
+ * actually stop hitting the mock's getUpdates within a bounded time, not linger
+ * until an unrelated inotify-triggered restart eventually catches up.
+ */
+export async function waitForBotStoppedPolling(token: string, timeout = 15000): Promise<void> {
+  const start = Date.now();
+  while (Date.now() - start < timeout) {
+    try {
+      const res = await fetch(`${MOCK_TELEGRAM_URL}/control/health`);
+      const data = await res.json();
+      if (Array.isArray(data.activePollingTokens) && !data.activePollingTokens.includes(token)) {
+        return;
+      }
+    } catch {
+      // Not ready yet — mock momentarily unreachable, keep polling.
+    }
+    await new Promise((r) => setTimeout(r, 500));
+  }
+  throw new Error(`Bot ${token.slice(0, 6)}... did not stop polling within ${timeout}ms`);
+}
+
 // ── Multi-user helpers (Chats E2E #508) ─────────────────────────────────
 //
 // The Chats feature's authorization boundary is "one user can only ever see

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -5040,6 +5040,213 @@ describe("restart-state integration", () => {
     expect(restartState.notifyRestart).not.toHaveBeenCalled();
   });
 
+  describe("updateTelegramChannelConfig push-path routing (#476 Gap 1)", () => {
+    // Background: updateTelegramChannelConfig previously called
+    // writeConfigAtomic() directly and relied ENTIRELY on OpenClaw's inotify
+    // watcher to notice the change — even when a live WS client was
+    // available. That left a latency gap where a disconnected/removed bot's
+    // poller could keep hitting Telegram's getUpdates for however long
+    // inotify took to notice, which is the root cause of the cross-instance
+    // getUpdates 409 flap #476 was filed for. Routing through
+    // pushConfigInBackground (already used by regenerateOpenClawConfig) gets
+    // the diff to OpenClaw via the synchronous WS config.apply RPC the
+    // instant a client is connected, while preserving the exact same
+    // file+inotify fallback when no client is available (cold start, WS
+    // down) — the file-write behavior asserted by the tests above must be
+    // unaffected in that fallback case.
+
+    it("uses config.apply (not a synchronous writeConfigAtomic) when a WS client is connected", async () => {
+      mockConfigGet.mockResolvedValue({ hash: "abc123" });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ gateway: { mode: "local", bind: "lan" } })
+      );
+
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+
+      // Unlike the no-client path, the write must NOT be synchronous —
+      // control returns to the caller before config.apply has been awaited.
+      expect(mockedWriteFileSync).not.toHaveBeenCalled();
+
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+
+      expect(mockConfigApply).toHaveBeenCalledOnce();
+      const appliedPayload = JSON.parse(String(mockConfigApply.mock.calls[0][0])) as {
+        channels?: { telegram?: { accounts?: Record<string, { botToken: string }> } };
+      };
+      expect(appliedPayload.channels?.telegram?.accounts?.["agent-99"]?.botToken).toBe(
+        "tg-secret-token"
+      );
+      // No direct openclaw.json file write — config.apply's inner
+      // writeConfigFile is responsible for persisting to disk.
+      const openclawWrite = mockedWriteFileSync.mock.calls.find(
+        (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json")
+      );
+      expect(openclawWrite).toBeUndefined();
+    });
+
+    it("still calls restartState.notifyRestart when routed through config.apply", async () => {
+      // The UI overlay contract (poll /api/health/openclaw until "restarting"
+      // clears) must hold regardless of which transport delivered the change.
+      // notifyRestart is now driven by the push's onChangeApplied callback, so
+      // on the WS path it fires when config.apply actually lands — after the
+      // background coroutine settles, not synchronously with the call.
+      const { restartState } = await import("@/server/restart-state");
+      mockConfigGet.mockResolvedValue({ hash: "abc123" });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ gateway: { mode: "local", bind: "lan" } })
+      );
+
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+      expect(restartState.notifyRestart).toHaveBeenCalledOnce();
+    });
+
+    it("does NOT call restartState.notifyRestart on a no-op repeat via config.apply", async () => {
+      // The plain file-content dedup in updateTelegramChannelConfig cannot catch
+      // this: config.apply persists an OC-enriched file, so the on-disk bytes
+      // never match the raw payload and a repeated identical call slips past the
+      // dedup. The push's own no-op guard (supplemented payload ≡ OC runtime) is
+      // what must suppress the spurious notifyRestart — otherwise the UI overlay
+      // strands on a restart that never happens (#476 Gap 1).
+      const { restartState } = await import("@/server/restart-state");
+
+      // Phase 1: first apply lands the account; capture exactly what OC's
+      // runtime now holds (the payload we sent to config.apply).
+      mockConfigGet.mockResolvedValue({
+        hash: "h1",
+        config: { gateway: { mode: "local", bind: "lan" } },
+      });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ gateway: { mode: "local", bind: "lan" } })
+      );
+
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+      expect(restartState.notifyRestart).toHaveBeenCalledOnce();
+      const ocRuntime = JSON.parse(String(mockConfigApply.mock.calls[0][0])) as Record<
+        string,
+        unknown
+      >;
+
+      // Phase 2: OC's runtime now equals what we applied. Keep the on-disk file
+      // byte-different (just the gateway block) so the caller's file dedup does
+      // NOT fire and the request reaches the push — whose no-op guard must skip
+      // the apply AND therefore never invoke onChangeApplied/notifyRestart.
+      vi.clearAllMocks();
+      mockConfigGet.mockResolvedValue({ hash: "h2", config: ocRuntime });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ gateway: { mode: "local", bind: "lan" } })
+      );
+
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+      await drainBackgroundCoroutine();
+
+      expect(mockConfigApply).not.toHaveBeenCalled();
+      expect(restartState.notifyRestart).not.toHaveBeenCalled();
+    });
+
+    it("falls back to the synchronous file write (writeConfigAtomic) when no WS client is available", async () => {
+      // beforeEach's top-level guard resets mockGetClient to throw ("no WS
+      // client") — this is the cold-start / WS-down case. Must remain fully
+      // synchronous and unchanged: the file must be on disk before
+      // updateTelegramChannelConfig returns, so a caller that immediately
+      // reads openclaw.json (or a route that returns success right after)
+      // sees the write.
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({ gateway: { mode: "local", bind: "lan" } })
+      );
+
+      updateTelegramChannelConfig("agent-99", { botToken: "tg-secret-token" });
+
+      expect(mockedWriteFileSync).toHaveBeenCalled();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written) as {
+        channels?: { telegram?: { accounts?: Record<string, { botToken: string }> } };
+      };
+      expect(config.channels?.telegram?.accounts?.["agent-99"]?.botToken).toBe("tg-secret-token");
+      expect(mockConfigApply).not.toHaveBeenCalled();
+    });
+
+    it("falls back to file write on removal (accountId, null) too, preserving the disconnect path", async () => {
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({
+          gateway: { mode: "local", bind: "lan" },
+          channels: {
+            telegram: {
+              enabled: true,
+              dmPolicy: "pairing",
+              accounts: { "agent-99": { botToken: "tg-secret-token" } },
+            },
+          },
+          bindings: [
+            { agentId: "agent-99", match: { channel: "telegram", accountId: "agent-99" } },
+          ],
+        })
+      );
+
+      updateTelegramChannelConfig("agent-99", null);
+
+      expect(mockedWriteFileSync).toHaveBeenCalled();
+      const written = mockedWriteFileSync.mock.calls[0][1] as string;
+      const config = JSON.parse(written) as { channels?: unknown };
+      // Last account removed — entire telegram channel block goes away.
+      expect(config.channels).toBeUndefined();
+    });
+
+    it("uses config.apply on removal (accountId, null) when a WS client is connected", async () => {
+      mockConfigGet.mockResolvedValue({ hash: "abc123" });
+      mockConfigApply.mockResolvedValue(undefined);
+      mockGetClient.mockReturnValue({
+        config: { get: mockConfigGet, apply: mockConfigApply },
+      });
+      mockedReadFileSync.mockReturnValue(
+        JSON.stringify({
+          gateway: { mode: "local", bind: "lan" },
+          channels: {
+            telegram: {
+              enabled: true,
+              dmPolicy: "pairing",
+              accounts: { "agent-99": { botToken: "tg-secret-token" } },
+            },
+          },
+          bindings: [
+            { agentId: "agent-99", match: { channel: "telegram", accountId: "agent-99" } },
+          ],
+        })
+      );
+
+      updateTelegramChannelConfig("agent-99", null);
+
+      await vi.waitFor(() => expect(mockConfigApply).toHaveBeenCalledOnce());
+      await drainBackgroundCoroutine();
+
+      const appliedPayload = JSON.parse(String(mockConfigApply.mock.calls[0][0])) as {
+        channels?: unknown;
+      };
+      expect(appliedPayload.channels).toBeUndefined();
+    });
+  });
+
   it("should include Telegram channel config with accounts format when bot token is configured", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom([

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -1,6 +1,6 @@
 import { readFileSync, existsSync } from "fs";
 import { CONFIG_PATH, OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS } from "./paths";
-import { writeConfigAtomic, readExistingConfig } from "./write";
+import { writeConfigAtomic, readExistingConfig, pushConfigInBackground } from "./write";
 import { restartState } from "@/server/restart-state";
 import { getOrCreateGatewayToken } from "@/lib/gateway-token-source";
 
@@ -153,17 +153,50 @@ export function updateTelegramChannelConfig(
     // File doesn't exist
   }
 
-  writeConfigAtomic(newContent);
-
-  // channels.telegram and bindings sit in OC's restart-trigger set — every
-  // mutation here causes inotify → full Gateway restart. Mark restart-state so
-  // /api/health/openclaw returns "restarting" and the client overlay stays up
-  // until OC's Telegram polling is actually back (server.ts calls notifyReady()
-  // on Gateway reconnect, closing the loop). Co-located with the write so any
-  // future caller inherits the invariant; gated by the dedup above so spurious
-  // no-op writes don't strand the UI until RestartProvider's 30 s client-side
-  // timeout flips it into the "this is taking longer than expected" error state.
-  restartState.notifyRestart();
+  // Issue #476 Gap 1: route through pushConfigInBackground (the same
+  // WS config.apply path regenerateOpenClawConfig uses) instead of an
+  // unconditional writeConfigAtomic. Previously this ALWAYS wrote the file
+  // directly and relied entirely on OpenClaw's inotify watcher to notice the
+  // change — even when a live WS client was connected. That left an
+  // unbounded latency gap between "Pinchy removed/rotated a Telegram
+  // account" and "OpenClaw actually stops polling that token", during which
+  // a disconnected bot's channel worker kept hitting Telegram's getUpdates —
+  // the root cause of the cross-instance getUpdates 409 flap #476 was filed
+  // for. When a WS client is available, pushConfigInBackground delivers the
+  // diff via the synchronous config.apply RPC, so OpenClaw reloads (or, for
+  // a channels diff, restarts) immediately rather than waiting for a
+  // filesystem-watch tick. When no client is available (cold start, WS
+  // down), pushConfigInBackground's own no-client branch falls straight
+  // back to a SYNCHRONOUS writeConfigAtomic — identical to this function's
+  // previous unconditional behavior — so there is no regression for
+  // installs where OpenClaw isn't reachable over the gateway WS yet.
+  //
+  // This does NOT reintroduce the restart cascade agent-create-no-restart.spec.ts
+  // and telegram-flow.spec.ts guard against: `channels` has no entry in OC's
+  // BASE_RELOAD_RULES, so a structural channels diff is restart-class
+  // regardless of transport (file+inotify or WS config.apply) — routing
+  // through config.apply changes WHEN OC learns about the diff, not WHETHER
+  // it restarts for it. See write.ts's pushConfigInBackground for the
+  // no-op/rate-limit/stale-hash handling this delegates to.
+  //
+  // channels.telegram and bindings sit in OC's restart-trigger set, so a real
+  // mutation here causes a Gateway restart (via config.apply, or inotify in the
+  // no-client fallback). Mark restart-state so /api/health/openclaw returns
+  // "restarting" and the client overlay stays up until OC's Telegram polling is
+  // back (server.ts calls notifyReady() on Gateway reconnect, closing the loop).
+  //
+  // notifyRestart is driven by `onChangeApplied` — it fires ONLY when the push
+  // actually applies/writes a change, never on a semantic no-op. The plain
+  // file-content dedup above cannot cover the WS path: config.apply persists an
+  // OC-enriched file that never byte-matches `newContent`, so a repeated
+  // identical connect/disconnect would slip past the dedup and, if we notified
+  // unconditionally here, strand the UI overlay for a restart that never happens
+  // (until RestartProvider's 30 s client-side "taking longer than expected"
+  // timeout). Delegating to the push's own no-op guard (supplemented payload ≡
+  // OC runtime) keeps the overlay honest. (#476 Gap 1)
+  pushConfigInBackground(newContent, {
+    onChangeApplied: () => restartState.notifyRestart(),
+  });
 }
 
 /**

--- a/packages/web/src/lib/openclaw-config/write.ts
+++ b/packages/web/src/lib/openclaw-config/write.ts
@@ -170,7 +170,29 @@ const WS_DISCONNECTED_ERROR_FRAGMENT = "Not connected to OpenClaw Gateway";
 const NOT_CONNECTED_MAX_WAIT_MS = 60_000;
 const NOT_CONNECTED_RETRY_DELAY_MS = 2_000;
 
-export function pushConfigInBackground(newContent: string): void {
+/**
+ * Options for {@link pushConfigInBackground}.
+ *
+ * `onChangeApplied` fires exactly once, on the terminal path where the new
+ * config actually reached OpenClaw's runtime or the on-disk file — i.e. a
+ * successful `config.apply`, or any `writeConfigAtomic` fallback (no client,
+ * rate-limit budget exhausted, retries exhausted). It deliberately does NOT
+ * fire when the push is a semantic no-op (skipped because the supplemented
+ * payload already equals OC's runtime) or when a newer push superseded this
+ * one. Callers use it to drive side effects that must only happen when a real
+ * change lands — e.g. `restartState.notifyRestart()` for the Telegram channel
+ * writer, which must not strand the UI overlay on a no-op (#476 Gap 1). The
+ * previous file-content dedup in the caller could not see this: `config.apply`
+ * persists an OC-enriched file that never byte-matches the caller's payload, so
+ * a repeated identical call no longer deduped and fired notifyRestart on a
+ * genuine no-op.
+ */
+export interface PushConfigOptions {
+  onChangeApplied?: () => void;
+}
+
+export function pushConfigInBackground(newContent: string, options: PushConfigOptions = {}): void {
+  const { onChangeApplied } = options;
   const generation = ++_pushGeneration;
 
   // Make the in-flight push observable (health endpoint `configPushesPending`,
@@ -195,6 +217,7 @@ export function pushConfigInBackground(newContent: string): void {
         `[openclaw-config] push gen=${String(generation)}: no WS client → file write (inotify; reload may lag)`
       );
       writeConfigAtomic(newContent);
+      onChangeApplied?.();
       return;
     }
 
@@ -322,6 +345,7 @@ export function pushConfigInBackground(newContent: string): void {
         console.log(
           `[openclaw-config] push gen=${String(generation)}: applied via WS config.apply (in-process, synchronous runtime refresh)${rateLimitAttempts > 0 ? ` after ${String(rateLimitAttempts)} rate-limit wait(s)` : ""}`
         );
+        onChangeApplied?.();
         return;
       } catch (err) {
         const message = err instanceof Error ? err.message : String(err);
@@ -358,6 +382,7 @@ export function pushConfigInBackground(newContent: string): void {
             message
           );
           writeConfigAtomic(lastSupplemented ?? supplementPayloadWithFileFields(newContent));
+          onChangeApplied?.();
           return;
         }
 
@@ -397,6 +422,7 @@ export function pushConfigInBackground(newContent: string): void {
           // All retries exhausted — fall back to file write so inotify picks up
           // the change. Same meta-preservation logic as the rate-limit path above.
           writeConfigAtomic(lastSupplemented ?? supplementPayloadWithFileFields(newContent));
+          onChangeApplied?.();
           return;
         }
         await new Promise((resolve) => setTimeout(resolve, backoffsMs[i]));


### PR DESCRIPTION
Part of #476 — **gap 1** (the last of the three; gaps 2+3 are #628).

## Problem
`updateTelegramChannelConfig()` wrote `openclaw.json` and relied **entirely** on OpenClaw's inotify watcher to notice the change — even when a live WS client was connected. That left an unbounded latency gap between *Pinchy removed/rotated a Telegram bot* and *OpenClaw actually stops polling that token*, during which the disconnected bot's channel worker kept hitting Telegram's `getUpdates`. That window is the root cause of the cross-instance `getUpdates`-409 flap #476 was filed for.

## Fix
Route the write through `pushConfigInBackground` — the same WS `config.apply` path `regenerateOpenClawConfig` already uses. When a client is connected, the diff reaches OpenClaw via the synchronous `config.apply` RPC and the poller stops within **~1s** instead of waiting for a filesystem-watch tick. With **no** client (cold start / WS down), `pushConfigInBackground`'s own no-client branch falls back to the same synchronous `writeConfigAtomic` as before — no regression. Applies to **both** removal paths (per-agent DELETE and org-wide `/all`) since they share this function.

This does **not** reintroduce the restart cascade #193 guards against: `channels` has no `BASE_RELOAD_RULES` entry, so a channels diff is restart-class regardless of transport — `config.apply` changes *when* OpenClaw learns of the diff, not *whether* it restarts for it.

## Verified end-to-end against the real OpenClaw Docker stack
- **New `e2e/telegram/disconnect-stops-poller.spec.ts`**: measured **>15s (RED, pre-fix image) → ~1s (GREEN, post-fix)**. The oracle is a freshness window (`activePollingTokens`) added to the mock Telegram server so *poller stopped* is observable at all (`pollingTokens` was add-only).
- **Guards stay green**: `agent-create-no-restart` (#193 — no cascade) and the full `telegram-flow` suite.
- **Unit** (`openclaw-config.test.ts`): `config.apply` chosen when a WS client is present; synchronous file-write fallback when not; `notifyRestart` preserved.

## Note
Gap 1 was the deferred prerequisite for #477 (auto-disable). With gaps 2+3 (#628) and this, **#476 is fully addressed**.

Closes #476.