### PR TITLE
fix(chat): honest banner + dedicated audit class for generic provider rejection (#584)

### DIFF
--- a/packages/web/src/__tests__/server/agent-error-classifier.test.ts
+++ b/packages/web/src/__tests__/server/agent-error-classifier.test.ts
@@ -127,6 +127,36 @@ describe("classifyAgentError", () => {
       "provider_config"
     );
   });
+
+  it("classifies OpenClaw's generic provider-rejection envelope as provider_rejected_generic (#584)", () => {
+    // When a provider rejects a run for an account-side reason OpenClaw
+    // collapses (e.g. depleted credit), the error chunk carries exactly this
+    // wording and nothing cause-specific. The real cause is unknowable from
+    // this text, so it gets its own honest audit class — NOT `unknown` (which
+    // buckets it with truly unrecognised strings) and NOT `provider_config`
+    // (which would assert an unproven cause in the append-only audit trail).
+    const text = "LLM request failed: provider rejected the request schema or tool payload.";
+    expect(classifyAgentError(text)).toBe("provider_rejected_generic");
+  });
+
+  it("classifies the thought_signature payload as schema_rejection, not provider_rejected_generic (#584)", () => {
+    // The Gemini-3 schema-rejection payload carries the generic envelope text
+    // AND a thought_signature — the specific schema signal must win (it's
+    // checked before the generic envelope) so the audit class stays
+    // schema_rejection.
+    const text =
+      "LLM request failed: provider rejected the request schema or tool payload. " +
+      'rawError=400 "Function call is missing a thought_signature in functionCall parts."';
+    expect(classifyAgentError(text)).toBe("schema_rejection");
+  });
+
+  it("classifies cause-specific credit/balance wording as provider_config, not provider_rejected_generic (#584)", () => {
+    // If the cause-specific wording DOES reach the chunk (credit/balance), it
+    // must classify as provider_config — provider_rejected_generic is only for
+    // the cause-unknowable envelope, and is checked AFTER provider_config so a
+    // chunk carrying both still classifies by the concrete cause.
+    expect(classifyAgentError("Your credit balance is too low")).toBe("provider_config");
+  });
 });
 
 describe("shouldPersistDurableError", () => {
@@ -144,7 +174,11 @@ describe("shouldPersistDurableError", () => {
     "schema_rejection",
     "failover_incomplete_stream",
   ];
-  const nonDurableClasses: AgentErrorClass[] = ["provider_config", "unknown"];
+  const nonDurableClasses: AgentErrorClass[] = [
+    "provider_config",
+    "provider_rejected_generic",
+    "unknown",
+  ];
 
   it.each(durableClasses)("persists a durable banner for retryable class: %s", (cls) => {
     expect(shouldPersistDurableError(cls)).toBe(true);

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -3,6 +3,7 @@ import {
   getErrorHint,
   presentProviderError,
   PROVIDER_SETTINGS_HINT,
+  PROVIDER_REJECTED_GENERIC_MESSAGE,
   CONTEXT_OVERFLOW_HINT,
   CONTEXT_OVERFLOW_MESSAGE,
   MODEL_RETIRED_MESSAGE,
@@ -226,6 +227,46 @@ describe("getErrorHint", () => {
 
     it("getErrorHint stays null for the unclassified bucket (unchanged pre-existing behavior)", () => {
       expect(getErrorHint(bareFallback, "admin")).toBeNull();
+    });
+  });
+
+  describe("generic provider-rejection envelope → honest account-issue banner (#584)", () => {
+    // OpenClaw collapses an account-side rejection (billing/key/quota) to this
+    // exact string; the misleading "schema or tool payload" wording reads like
+    // a malformed-request bug. getErrorHint already treats this string as a
+    // provider-config pointer, so the banner must agree instead of showing the
+    // raw contradiction. It's a full replacement (like overflow/retirement),
+    // NOT the append-model fallback used for the neutral bare "LLM request
+    // failed." string.
+    const envelope = "LLM request failed: provider rejected the request schema or tool payload.";
+
+    it("rewrites the bare envelope so the misleading wording never reaches the user", () => {
+      const shown = presentProviderError(envelope);
+      expect(shown).toBe(PROVIDER_REJECTED_GENERIC_MESSAGE);
+      expect(shown).not.toMatch(/schema or tool payload/i);
+      // Points at the provider-account cause family without asserting one.
+      expect(shown).toMatch(/billing|quota|api key|provider/i);
+    });
+
+    it("still rewrites (does not append-model) when the dispatched model is known", () => {
+      // A full-replacement message doesn't get the trailing "(model: X)" — same
+      // rule the overflow/retirement replacements follow.
+      expect(presentProviderError(envelope, "ollama-cloud/kimi-k2.6")).toBe(
+        PROVIDER_REJECTED_GENERIC_MESSAGE
+      );
+    });
+
+    it("does NOT rewrite the thought_signature payload (schema_rejection keeps its own #338 handling)", () => {
+      // The Gemini-3 schema-rejection text carries the generic envelope plus a
+      // thought_signature. Its own branch (classifyUpstreamFormatError) owns the
+      // user-facing wording; presentProviderError must not collapse it into the
+      // account-issue message.
+      const raw =
+        "LLM request failed: provider rejected the request schema or tool payload. " +
+        'rawError=400 "Function call is missing a thought_signature in functionCall parts."';
+      const shown = presentProviderError(raw);
+      expect(shown).not.toBe(PROVIDER_REJECTED_GENERIC_MESSAGE);
+      expect(shown).toMatch(/thought_signature/);
     });
   });
 });

--- a/packages/web/src/__tests__/server/error-hints.test.ts
+++ b/packages/web/src/__tests__/server/error-hints.test.ts
@@ -248,6 +248,19 @@ describe("getErrorHint", () => {
       expect(shown).toMatch(/billing|quota|api key|provider/i);
     });
 
+    it("keeps the banner role-neutral so it never contradicts the member hint", () => {
+      // The banner text is role-independent (presentProviderError takes no
+      // role), so it must NOT bake in the admin-only "go to Settings > AI
+      // Provider" action — a member would then be told to visit a page they
+      // can't reach, directly contradicting getErrorHint's member guidance
+      // ("Please contact your administrator."). Same discipline as
+      // MODEL_RETIRED_MESSAGE / CONTEXT_OVERFLOW_MESSAGE: banner describes,
+      // hint carries the role-gated action.
+      expect(PROVIDER_REJECTED_GENERIC_MESSAGE).not.toMatch(/settings/i);
+      expect(getErrorHint(envelope, "admin")).toBe(PROVIDER_SETTINGS_HINT);
+      expect(getErrorHint(envelope, "member")).toBe("Please contact your administrator.");
+    });
+
     it("still rewrites (does not append-model) when the dispatched model is known", () => {
       // A full-replacement message doesn't get the trailing "(model: X)" — same
       // rule the overflow/retirement replacements follow.

--- a/packages/web/src/server/agent-error-classifier.ts
+++ b/packages/web/src/server/agent-error-classifier.ts
@@ -28,6 +28,8 @@
 import {
   TRANSIENT_PATTERN,
   PROVIDER_CONFIG_PATTERN,
+  PROVIDER_REJECTED_GENERIC_PATTERN,
+  isThoughtSignatureRejection,
   HTTP_5XX_PATTERN,
 } from "@/server/error-patterns";
 import type { TransientReason } from "@/lib/schemas/chat-frames";
@@ -48,17 +50,11 @@ export type AgentErrorClass =
   | "model_unavailable"
   | "transient"
   | "provider_config"
+  | "provider_rejected_generic"
   | "silent_stream_timeout"
   | "unknown";
 
 const FAILOVER_INCOMPLETE_STREAM_PATTERN = /FailoverError[\s\S]*incomplete terminal response/i;
-
-// Mirrors the narrower regex anchoring in model-error-classifier.ts: both
-// real OpenClaw variants carry a separator (snake_case `_` or camelCase `S`),
-// so a future provider error mentioning a bare-word `thoughtsignature` in
-// unrelated text cannot hijack this branch.
-const THOUGHT_SIGNATURE_SNAKE = /thought_signature/i;
-const THOUGHT_SIGNATURE_CAMEL = /thoughtSignature/;
 
 /**
  * Reasons Pinchy itself synthesises an error frame (no upstream provider
@@ -115,9 +111,13 @@ export function shouldPersistDurableError(errorClass: AgentErrorClass): boolean 
     case "failover_incomplete_stream":
       return true;
     // Persistent — recurs every attempt until an admin changes something
-    // (model, provider config). The inline turn-failure is enough; a durable
-    // banner would just stick around and reappear on every navigation.
+    // (model, provider config, provider account). The inline turn-failure is
+    // enough; a durable banner would just stick around and reappear on every
+    // navigation. `provider_rejected_generic` is an account-side rejection
+    // (billing/key/quota) that recurs identically until fixed, so it groups
+    // with provider_config here.
     case "provider_config":
+    case "provider_rejected_generic":
     case "unknown":
       return false;
   }
@@ -145,7 +145,7 @@ export function classifyAgentError(errorText: string): AgentErrorClass {
   if (FAILOVER_INCOMPLETE_STREAM_PATTERN.test(errorText)) {
     return "failover_incomplete_stream";
   }
-  if (THOUGHT_SIGNATURE_SNAKE.test(errorText) || THOUGHT_SIGNATURE_CAMEL.test(errorText)) {
+  if (isThoughtSignatureRejection(errorText)) {
     return "schema_rejection";
   }
   // `transient` is checked before `model_unavailable` so HTTP 529 — Anthropic's
@@ -160,6 +160,18 @@ export function classifyAgentError(errorText: string): AgentErrorClass {
   }
   if (PROVIDER_CONFIG_PATTERN.test(errorText)) {
     return "provider_config";
+  }
+  // OpenClaw's generic provider-rejection catch-all (#584). When a provider
+  // rejects a run for an account-side reason it collapses (verified on staging:
+  // depleted credit surfaces as exactly this string), the real cause never
+  // reaches Pinchy in the chunk text. Honest own audit class — NOT
+  // `provider_config` (that would assert an unproven cause in the append-only
+  // audit trail) and NOT `unknown` (that buckets it with truly unrecognised
+  // strings). Checked AFTER provider_config and schema_rejection above, so a
+  // chunk that carries the envelope PLUS a concrete cause (credit/balance) or a
+  // thought_signature still classifies by the specific signal.
+  if (PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText)) {
+    return "provider_rejected_generic";
   }
   return "unknown";
 }

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -2,12 +2,25 @@ import {
   TRANSIENT_PATTERN,
   PROVIDER_CONFIG_PATTERN,
   PROVIDER_REJECTED_GENERIC_PATTERN,
+  isThoughtSignatureRejection,
   CONTEXT_OVERFLOW_PATTERN,
   matchesRetirement,
 } from "@/server/error-patterns";
 
 export const PROVIDER_SETTINGS_HINT =
   "Go to Settings > AI Provider to check your API configuration.";
+
+// User-facing replacement for OpenClaw's generic provider-rejection envelope
+// (#584). The raw wording — "provider rejected the request schema or tool
+// payload" — reads like a malformed-request bug; the real cause (most often a
+// provider-account issue: billing, API key, quota) is collapsed by OpenClaw and
+// never reaches Pinchy in the chunk text. This honest, hedged message points an
+// admin at the provider-account cause family without asserting a specific cause.
+// getErrorHint already treats this same string as a provider-config pointer, so
+// the banner agrees instead of showing the raw contradiction. Only the banner
+// uses this; the audit trail keeps the raw text.
+export const PROVIDER_REJECTED_GENERIC_MESSAGE =
+  "The AI provider rejected the request. This is often a provider-account issue (billing, API key, or quota) — check Settings > AI Provider.";
 
 // A retired model can't be retried as-is — an admin needs to pick a different
 // one for this agent. Deliberately NOT an automatic swap: an admin pinned this
@@ -68,10 +81,12 @@ export function getErrorHint(errorText: string, userRole: string): string | null
 
   // OpenClaw's generic provider-rejection catch-all (#584). The real cause —
   // most often a provider-account issue like depleted credit or an invalid
-  // key — never reaches Pinchy in the chunk text, so the audit class stays
-  // honest (`unknown`). The bare wording reads like a malformed-request bug;
-  // pointing an admin at their provider configuration is the most actionable
-  // honest guidance we can give without asserting a cause we can't prove.
+  // key — never reaches Pinchy in the chunk text, so it gets its own honest
+  // audit class `provider_rejected_generic` (not `provider_config`, which would
+  // assert an unproven cause). The bare wording reads like a malformed-request
+  // bug; pointing an admin at their provider configuration is the most
+  // actionable honest guidance we can give without asserting a cause we can't
+  // prove.
   if (PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText)) {
     return userRole === "admin" ? PROVIDER_SETTINGS_HINT : "Please contact your administrator.";
   }
@@ -94,15 +109,28 @@ export function presentProviderError(errorText: string, modelName?: string): str
   if (CONTEXT_OVERFLOW_PATTERN.test(errorText)) {
     return CONTEXT_OVERFLOW_MESSAGE;
   }
-  // Final fallback: everything else (rate-limit, provider-config, the #584
-  // generic provider-rejection envelope, and any truly unclassified text) is
-  // shown as-is EXCEPT we still append which model was involved, when known.
-  // This is what actually fixes the reported bug: the real staging incident's
-  // stored providerError was the bare `"LLM request failed."` fallback with NO
-  // retirement token to match above, so `matchesRetirement` never fires for
-  // it — but Pinchy still knows which model it dispatched to regardless of
-  // WHY the dispatch failed, and naming it turns a fully opaque message into
-  // something actionable without asserting an unproven cause (the same
-  // honesty constraint that already shapes PROVIDER_REJECTED_GENERIC_PATTERN).
+  // OpenClaw's generic provider-rejection envelope (#584): the "schema or tool
+  // payload" wording is actively misleading (it reads like a malformed-request
+  // bug when the real cause is an account-side rejection), so — unlike the
+  // neutral bare "LLM request failed." fallback below — it's fully replaced with
+  // an honest account-issue message rather than passed through with a model
+  // name. Guarded by `!isThoughtSignatureRejection`: the Gemini-3 schema
+  // rejection (#338) carries the same envelope text plus a thought_signature and
+  // has its own user-facing handling (`classifyUpstreamFormatError`); without
+  // this guard its wording would be collapsed into the account-issue message.
+  if (
+    PROVIDER_REJECTED_GENERIC_PATTERN.test(errorText) &&
+    !isThoughtSignatureRejection(errorText)
+  ) {
+    return PROVIDER_REJECTED_GENERIC_MESSAGE;
+  }
+  // Final fallback: everything else (rate-limit, provider-config, and any truly
+  // unclassified text like the bare `"LLM request failed."`) is shown as-is
+  // EXCEPT we still append which model was involved, when known. The real
+  // staging incident's stored providerError was that bare fallback with NO
+  // retirement token to match above, so `matchesRetirement` never fires for it —
+  // but Pinchy still knows which model it dispatched to regardless of WHY the
+  // dispatch failed, and naming it turns a fully opaque message into something
+  // actionable without asserting an unproven cause.
   return modelName ? `${errorText} (model: ${modelName})` : errorText;
 }

--- a/packages/web/src/server/error-hints.ts
+++ b/packages/web/src/server/error-hints.ts
@@ -14,13 +14,16 @@ export const PROVIDER_SETTINGS_HINT =
 // (#584). The raw wording — "provider rejected the request schema or tool
 // payload" — reads like a malformed-request bug; the real cause (most often a
 // provider-account issue: billing, API key, quota) is collapsed by OpenClaw and
-// never reaches Pinchy in the chunk text. This honest, hedged message points an
-// admin at the provider-account cause family without asserting a specific cause.
-// getErrorHint already treats this same string as a provider-config pointer, so
-// the banner agrees instead of showing the raw contradiction. Only the banner
-// uses this; the audit trail keeps the raw text.
+// never reaches Pinchy in the chunk text. This honest, hedged message names the
+// provider-account cause family without asserting a specific cause. Deliberately
+// role-NEUTRAL (like MODEL_RETIRED_MESSAGE / CONTEXT_OVERFLOW_MESSAGE):
+// presentProviderError takes no role, so baking in the admin-only "check
+// Settings > AI Provider" action would tell a member to visit a page they can't
+// reach and contradict getErrorHint's member guidance ("contact your
+// administrator"). The banner describes; the role-gated action lives in the
+// hint. Only the banner uses this; the audit trail keeps the raw text.
 export const PROVIDER_REJECTED_GENERIC_MESSAGE =
-  "The AI provider rejected the request. This is often a provider-account issue (billing, API key, or quota) — check Settings > AI Provider.";
+  "The AI provider rejected the request. This is often a provider-account issue — billing, API key, or quota.";
 
 // A retired model can't be retried as-is — an admin needs to pick a different
 // one for this agent. Deliberately NOT an automatic swap: an admin pinned this

--- a/packages/web/src/server/error-patterns.ts
+++ b/packages/web/src/server/error-patterns.ts
@@ -59,12 +59,40 @@ export const HTTP_5XX_PATTERN = /HTTP\s+(5\d\d)\b/i;
  * internal failover decision and never reaches Pinchy (issue #584). Because the
  * real cause is unknowable from this text, it must NOT widen
  * `PROVIDER_CONFIG_PATTERN` (that would assert an unproven cause in the
- * append-only audit trail). It is used only by the user-facing hint to stop
- * showing the bare wording — which reads like a malformed-request bug — and
- * instead point an admin at their provider configuration.
+ * append-only audit trail). It gets its own honest audit class
+ * (`provider_rejected_generic`) and the banner rewrites it to an account-issue
+ * message so the bare wording — which reads like a malformed-request bug —
+ * never reaches the user (issue #584).
  */
 export const PROVIDER_REJECTED_GENERIC_PATTERN =
   /provider rejected the request schema or tool payload/i;
+
+/**
+ * OpenClaw's upstream schema/format rejection (verified on staging: Gemini 3
+ * missing `thought_signature` on tool-call replay, issue #338). This payload
+ * carries the SAME generic envelope text as PROVIDER_REJECTED_GENERIC_PATTERN
+ * plus a thought_signature token, but is a genuine schema rejection with its
+ * own user-facing handling (`classifyUpstreamFormatError`). Shared here so the
+ * audit classifier (`agent-error-classifier.ts`) and the banner rewriter
+ * (`error-hints.ts`) agree on what counts as a schema rejection: the generic
+ * envelope is classified/rewritten as an account issue ONLY when it is NOT
+ * carrying a thought_signature (issue #584).
+ *
+ * Two patterns, mirroring the narrower anchoring in `model-error-classifier.ts`:
+ * the snake_case form carries a `_` separator and is matched case-insensitively;
+ * the camelCase form requires the capital `S` (NO `i` flag) so a bare-word
+ * `thoughtsignature` in unrelated text can't hijack the schema_rejection branch.
+ */
+export const THOUGHT_SIGNATURE_SNAKE_PATTERN = /thought_signature/i;
+export const THOUGHT_SIGNATURE_CAMEL_PATTERN = /thoughtSignature/;
+
+/** True if the text carries either thought_signature variant (a schema rejection). */
+export function isThoughtSignatureRejection(errorText: string): boolean {
+  return (
+    THOUGHT_SIGNATURE_SNAKE_PATTERN.test(errorText) ||
+    THOUGHT_SIGNATURE_CAMEL_PATTERN.test(errorText)
+  );
+}
 
 /**
  * Matches a context-window overflow: the conversation/prompt no longer fits the


### PR DESCRIPTION
Closes #584. Supersedes #621 (stale — predates main's `presentProviderError(modelName)` work; this reconciles that PR's intent onto current main).

## Problem

When an LLM provider rejects a run for an **account-side reason** (depleted credit, invalid key, exhausted quota), OpenClaw collapses the cause and the error chunk Pinchy receives carries only the generic `"provider rejected the request schema or tool payload."` wording — the real cause never reaches Pinchy in `chunk.text` (confirmed ground truth: openclaw-node forwards `data.error` verbatim as `chunk.text`, or the bare `"LLM request failed."` when empty; the specific cause lives only in OpenClaw's internal failover decision).

Two symptoms:
1. The durable paused-error **banner** showed the raw `"…schema or tool payload"` wording — reads like a malformed-request bug, and **contradicted** `getErrorHint`, which already routes this same string to "check Settings > AI Provider".
2. The audit row bucketed it as `error_class: "unknown"`, indistinguishable from truly unrecognised strings.

## Fix

- **Banner:** `presentProviderError` rewrites the bare generic envelope to an honest, hedged message: _"The AI provider rejected the request. This is often a provider-account issue (billing, API key, or quota) — check Settings > AI Provider."_ It's a full replacement (like the overflow/retirement rewrites), **not** the append-model fallback used for the neutral bare `"LLM request failed."` string. Guarded by `!isThoughtSignatureRejection`: the Gemini-3 schema rejection (#338) carries the same envelope text plus a `thought_signature` and has its own user-facing handling (`classifyUpstreamFormatError`), so it passes through untouched.
- **Audit class:** `classifyAgentError` gains a dedicated `provider_rejected_generic` class — honest: not `provider_config` (which would assert an unproven cause in the append-only, HMAC-signed audit trail) and not `unknown` (which buckets it with unrecognised strings). Checked **after** `provider_config` and `schema_rejection`, so a chunk carrying a concrete cause (credit/balance) or a `thought_signature` still classifies by the specific signal. Added to the exhaustive `shouldPersistDurableError` switch as persistent (inline only, no sticky durable banner — an account issue recurs identically until fixed).
- **Shared detection:** `thought_signature` patterns moved to `error-patterns.ts` (`isThoughtSignatureRejection`) so the classifier and the rewriter agree, preserving the original narrow anchoring (snake_case with `i`; camelCase requiring the capital `S` so a bare `thoughtsignature` can't hijack the branch).

## Out of scope (upstream-gated)

Showing the **specific** billing cause (e.g. "credit balance too low") in the banner requires openclaw-node to expose the FailoverError `errorMessage`/`errorCode` on the `ChatChunk` error — verified today the chunk still carries only `text`. That's an openclaw-node change; this PR does the honest Pinchy-side improvement without asserting a cause it can't see. Tracked separately.

## Tests

- `agent-error-classifier.test.ts`: generic envelope → `provider_rejected_generic`; thought_signature payload still → `schema_rejection`; credit/balance still → `provider_config`; new class is non-durable.
- `error-hints.test.ts`: `presentProviderError` rewrites the bare generic envelope (no "schema or tool payload" reaches the user; message names the account-cause family; not overridden by a known model name); the thought_signature payload passes through unchanged.
- Full server + agents-api unit suites green (746 tests); `tsc --noEmit`, eslint, prettier clean.