### PR TITLE
fix(models): emit cost.cacheRead/cacheWrite for openai/google so OpenClaw accepts the catalog

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-builtin-models.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-builtin-models.test.ts
@@ -90,4 +90,25 @@ describe("getModelCatalogForProvider", () => {
       }
     }
   });
+
+  // OpenClaw's per-agent model-catalog schema (openclaw-plugin-model-catalog-v1)
+  // REQUIRES cost.cacheRead and cost.cacheWrite on every model. A provider whose
+  // catalog omits them fails schema validation, and OpenClaw then drops the WHOLE
+  // provider from that agent's effective catalog — which silently kills any tool
+  // that resolves a model from it (the built-in `pdf`/vision tool defaults to
+  // openai/gpt-5.5). On staging this manifested as `pdf failed: Unknown model:
+  // openai/gpt-5.5`, so invoice PDFs were never read and the agent booked an
+  // unverified lump sum while reporting success. anthropic already declared both
+  // fields; openai/google did not. This guard pins every emitted model to the
+  // schema so the omission can't recur for a new provider or model.
+  it("every built-in model declares numeric cost.cacheRead and cost.cacheWrite (OpenClaw catalog schema)", () => {
+    for (const provider of ["anthropic", "openai", "google"] as const) {
+      const models = getModelCatalogForProvider(provider);
+      expect(models.length).toBeGreaterThan(0);
+      for (const m of models) {
+        expect(typeof m.cost.cacheRead, `${provider}/${m.id} cost.cacheRead`).toBe("number");
+        expect(typeof m.cost.cacheWrite, `${provider}/${m.id} cost.cacheWrite`).toBe("number");
+      }
+    }
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -893,6 +893,37 @@ describe("regenerateOpenClawConfig", () => {
     expect(config?.env?.GEMINI_API_KEY).toBeUndefined();
   });
 
+  it("emits cost.cacheRead/cacheWrite on every provider model (OpenClaw catalog schema)", async () => {
+    // Regression guard for the staging PDF-tool break: OpenClaw's per-agent
+    // model-catalog schema requires cost.cacheRead and cost.cacheWrite on every
+    // model. When openai's emitted models omitted them, OpenClaw rejected the
+    // whole openai catalog ("Invalid models.json schema") and the built-in
+    // `pdf`/vision tool (default openai/gpt-5.5) failed with "Unknown model".
+    // This asserts the EMITTED config (not just the source catalog), so a future
+    // build.ts change that strips the cache-cost fields is caught here too.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-decrypted";
+      if (key === "openai_api_key") return "sk-openai-decrypted";
+      if (key === "default_provider") return "anthropic";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const providers = config?.models?.providers ?? {};
+
+    for (const providerName of ["anthropic", "openai"]) {
+      const models = providers[providerName]?.models ?? [];
+      expect(models.length, `${providerName} has models`).toBeGreaterThan(0);
+      for (const m of models) {
+        expect(typeof m.cost?.cacheRead, `${providerName}/${m.id} cost.cacheRead`).toBe("number");
+        expect(typeof m.cost?.cacheWrite, `${providerName}/${m.id} cost.cacheWrite`).toBe("number");
+      }
+    }
+  });
+
   it("includes default baseUrl in anthropic provider config when ANTHROPIC_BASE_URL is unset", async () => {
     delete process.env.ANTHROPIC_BASE_URL;
     mockedGetSetting.mockImplementation(async (key: string) => {

--- a/packages/web/src/lib/openclaw-builtin-models.ts
+++ b/packages/web/src/lib/openclaw-builtin-models.ts
@@ -17,11 +17,21 @@ export interface OpenClawModelDefinition {
   reasoning: boolean;
   vision: boolean;
   input: string[];
+  // cacheRead/cacheWrite are REQUIRED, not optional: OpenClaw's per-agent
+  // model-catalog schema (openclaw-plugin-model-catalog-v1) rejects any model
+  // whose cost omits them, then drops the ENTIRE provider from that agent's
+  // effective catalog. That silently breaks every tool that resolves a model
+  // from it — including the built-in `pdf`/vision tool, which defaults to
+  // openai/gpt-5.5 (staging symptom: `pdf failed: Unknown model: openai/gpt-5.5`,
+  // so invoice PDFs were never read and the agent booked an unverified lump sum
+  // while reporting success). Keeping the fields required makes an omission a
+  // compile error here, not a runtime schema failure surfaced only when an
+  // agent's per-agent catalog happens to be regenerated.
   cost: {
     input: number;
     output: number;
-    cacheRead?: number;
-    cacheWrite?: number;
+    cacheRead: number;
+    cacheWrite: number;
   };
 }
 
@@ -58,6 +68,12 @@ const ANTHROPIC_MODELS: OpenClawModelDefinition[] = [
   },
 ];
 
+// cacheRead/cacheWrite are set to 0 here (not modeled), matching the ZERO_COST
+// convention used for ollama-cloud in build.ts. Unlike Anthropic — which
+// publishes distinct cache-tier rates we carry above — we do not freeze a
+// synthetic OpenAI/Google cache discount, because a hardcoded price silently
+// goes stale between releases. The schema only requires the fields to be
+// present; accurate, refreshable provider pricing is tracked in #677.
 const OPENAI_MODELS: OpenClawModelDefinition[] = [
   {
     id: "gpt-5.5",
@@ -67,7 +83,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 2.5, output: 10 },
+    cost: { input: 2.5, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gpt-5.4",
@@ -77,7 +93,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 2.5, output: 10 },
+    cost: { input: 2.5, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gpt-5.4-mini",
@@ -87,7 +103,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.15, output: 0.6 },
+    cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 },
   },
 ];
 
@@ -100,7 +116,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: true,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 1.25, output: 10 },
+    cost: { input: 1.25, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gemini-2.5-flash",
@@ -110,7 +126,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: true,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.15, output: 0.6 },
+    cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gemini-2.5-flash-lite",
@@ -120,7 +136,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.1, output: 0.4 },
+    cost: { input: 0.1, output: 0.4, cacheRead: 0, cacheWrite: 0 },
   },
 ];
 


### PR DESCRIPTION
## Problem (found during v0.8.0 staging test of the email→Odoo invoice flow)

OpenClaw 2026.6.x's per-agent model-catalog schema (`openclaw-plugin-model-catalog-v1`) **requires** `cost.cacheRead` and `cost.cacheWrite` on every model. Our `OPENAI_MODELS` and `GOOGLE_MODELS` built-in catalogs declared only `{ input, output }`.

Result on staging: OpenClaw rejected the **whole** openai provider for any agent whose per-agent catalog got regenerated —

```
[agents/model-registry] model catalog load issue: Invalid models.json schema:
  - providers.openai.models.0.cost.cacheRead: must have required properties cacheRead, cacheWrite
File: /root/.openclaw/agents/<id>/agent/plugins/openai/catalog.json
```

— and dropped it from that agent's effective catalog (`{"providers":{}}`). The built-in `pdf`/vision tool defaults to `openai/gpt-5.5`, so it then failed with `pdf failed: Unknown model: openai/gpt-5.5`.

### Why this is severe (silent false success on financial data)
Testing the invoice email → Odoo flow: the agent **downloaded** the PDF fine (the email short-handle fix works), but **every** `pdf` extraction failed. It never read the invoice, booked a single lump sum to "Expenses", attached the raw PDF, and told the user *"entered … 35,08 € … incl. PDF attachment"* — a confident success with an unverified amount and the invoice's real 3-project / 12-line structure lost. The total matched only because it appeared in the email text.

Only 1 of 14 staging agents was broken — the one edited today, i.e. whose per-agent catalog had just regenerated. Every agent breaks the moment its catalog regenerates (edit/save, fresh deploy), because the openai pdf/image model is the default.

## Fix
- Add `cacheRead`/`cacheWrite` to `OPENAI_MODELS` and `GOOGLE_MODELS`. Set to `0` (not a synthetic discount), matching the ollama-cloud `ZERO_COST` convention — a hardcoded cache price goes stale between releases, and the schema only needs the fields present. Anthropic keeps its published cache-tier rates.
- Make `cost.cacheRead`/`cacheWrite` **required** in `OpenClawModelDefinition` → omission is now a compile error, not a runtime schema failure surfaced only on catalog regeneration.
- Two guard layers (TDD, both watched RED→GREEN):
  - source-catalog test: every built-in model declares the fields;
  - emission test: the **written** `openclaw.json` carries them (catches a future `build.ts` change that strips `cost`).

## Verification
- `openclaw-builtin-models.test.ts` + `openclaw-config.test.ts`: green (both new guards red on the pre-fix source, green after).
- `tsc --noEmit`, prettier, eslint: clean. Related config/provider/seed suites: 354 + 292 green.

## Follow-up (out of scope)
Refreshable/live provider pricing instead of hardcoded per-release cost numbers — separate concern the cache-cost `0` choice defers to rather than freezing stale rates.

Blocks the v0.8.0 cut (known bug in the email→Odoo flow being validated).