### PR TITLE
fix(models): vision-model fallback chain so an unreachable pdf/image primary degrades gracefully

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-builtin-models.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-builtin-models.test.ts
@@ -90,4 +90,25 @@ describe("getModelCatalogForProvider", () => {
       }
     }
   });
+
+  // OpenClaw's per-agent model-catalog schema (openclaw-plugin-model-catalog-v1)
+  // REQUIRES cost.cacheRead and cost.cacheWrite on every model. A provider whose
+  // catalog omits them fails schema validation, and OpenClaw then drops the WHOLE
+  // provider from that agent's effective catalog — which silently kills any tool
+  // that resolves a model from it (the built-in `pdf`/vision tool defaults to
+  // openai/gpt-5.5). On staging this manifested as `pdf failed: Unknown model:
+  // openai/gpt-5.5`, so invoice PDFs were never read and the agent booked an
+  // unverified lump sum while reporting success. anthropic already declared both
+  // fields; openai/google did not. This guard pins every emitted model to the
+  // schema so the omission can't recur for a new provider or model.
+  it("every built-in model declares numeric cost.cacheRead and cost.cacheWrite (OpenClaw catalog schema)", () => {
+    for (const provider of ["anthropic", "openai", "google"] as const) {
+      const models = getModelCatalogForProvider(provider);
+      expect(models.length).toBeGreaterThan(0);
+      for (const m of models) {
+        expect(typeof m.cost.cacheRead, `${provider}/${m.id} cost.cacheRead`).toBe("number");
+        expect(typeof m.cost.cacheWrite, `${provider}/${m.id} cost.cacheWrite`).toBe("number");
+      }
+    }
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -893,6 +893,37 @@ describe("regenerateOpenClawConfig", () => {
     expect(config?.env?.GEMINI_API_KEY).toBeUndefined();
   });
 
+  it("emits cost.cacheRead/cacheWrite on every provider model (OpenClaw catalog schema)", async () => {
+    // Regression guard for the staging PDF-tool break: OpenClaw's per-agent
+    // model-catalog schema requires cost.cacheRead and cost.cacheWrite on every
+    // model. When openai's emitted models omitted them, OpenClaw rejected the
+    // whole openai catalog ("Invalid models.json schema") and the built-in
+    // `pdf`/vision tool (default openai/gpt-5.5) failed with "Unknown model".
+    // This asserts the EMITTED config (not just the source catalog), so a future
+    // build.ts change that strips the cache-cost fields is caught here too.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "anthropic_api_key") return "sk-ant-decrypted";
+      if (key === "openai_api_key") return "sk-openai-decrypted";
+      if (key === "default_provider") return "anthropic";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const providers = config?.models?.providers ?? {};
+
+    for (const providerName of ["anthropic", "openai"]) {
+      const models = providers[providerName]?.models ?? [];
+      expect(models.length, `${providerName} has models`).toBeGreaterThan(0);
+      for (const m of models) {
+        expect(typeof m.cost?.cacheRead, `${providerName}/${m.id} cost.cacheRead`).toBe("number");
+        expect(typeof m.cost?.cacheWrite, `${providerName}/${m.id} cost.cacheWrite`).toBe("number");
+      }
+    }
+  });
+
   it("includes default baseUrl in anthropic provider config when ANTHROPIC_BASE_URL is unset", async () => {
     delete process.env.ANTHROPIC_BASE_URL;
     mockedGetSetting.mockImplementation(async (key: string) => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -7165,4 +7165,25 @@ describe("regenerateOpenClawConfig imageModel.primary (#416)", () => {
     const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
     expect(config.agents?.defaults?.imageModel).toBeUndefined();
   });
+
+  it("emits pdfModel AND imageModel with a { primary, fallbacks } chain across vision providers (#2)", async () => {
+    // Regression guard for the staging PDF break: a single pdfModel had NO
+    // fallback, so an unreachable primary (invalid OpenAI key → 401) silently
+    // killed PDF/vision even though the stack had an ollama-cloud vision model.
+    // With openai + ollama-cloud both configured, the emitted selector must
+    // carry the ollama-cloud model as a fallback so OpenClaw retries it — and
+    // pdf + image share one resolution (identical primary/fallbacks).
+    mockedGetSetting.mockImplementation(async (key: string) =>
+      key === "openai_api_key" || key === "ollama_cloud_api_key" ? "test-key" : null
+    );
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    const expected = {
+      primary: "openai/gpt-5.4-mini",
+      fallbacks: ["ollama-cloud/gemini-3-flash-preview"],
+    };
+    expect(config.agents.defaults.pdfModel).toEqual(expected);
+    expect(config.agents.defaults.imageModel).toEqual(expected);
+  });
 });

--- a/packages/web/src/__tests__/lib/vision-model-chain.test.ts
+++ b/packages/web/src/__tests__/lib/vision-model-chain.test.ts
@@ -1,0 +1,95 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+
+// Mocked I/O deps for the vision-model chain resolvers. The chain builders in
+// default-media-models are pure preference logic over these — mock the edges.
+const getSetting = vi.fn<(key: string) => Promise<string | null>>();
+const getDefaultModel = vi.fn<(provider: string) => Promise<string | null>>();
+const fetchProviderModels = vi.fn<() => Promise<{ id: string; models: { id: string }[] }[]>>();
+const isModelVisionCapable = vi.fn<(model: string) => boolean>();
+
+vi.mock("@/lib/settings", () => ({ getSetting: (k: string) => getSetting(k) }));
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: (p: string) => getDefaultModel(p),
+  fetchProviderModels: () => fetchProviderModels(),
+}));
+vi.mock("@/lib/model-vision", () => ({
+  isModelVisionCapable: (m: string) => isModelVisionCapable(m),
+}));
+vi.mock("@/lib/model-capabilities/cache", () => ({
+  ensureModelCapabilityCacheLoaded: () => Promise.resolve(),
+}));
+
+import { resolveDefaultVisionModelChain } from "@/lib/openclaw-config/default-media-models";
+
+// Staging shape: OpenAI key present (invalid at runtime, but present at
+// config-gen), ollama-cloud key present, anthropic/google unconfigured.
+function stubStagingProviders() {
+  getSetting.mockImplementation(async (key: string) =>
+    key === "openai_api_key" || key === "ollama_cloud_api_key" ? "sk-present" : null
+  );
+  getDefaultModel.mockImplementation(async (provider: string) =>
+    provider === "openai"
+      ? "openai/gpt-5.5"
+      : provider === "ollama-cloud"
+        ? "ollama-cloud/kimi-k2.6"
+        : null
+  );
+  // Live ollama-cloud catalog includes the curated vision model.
+  fetchProviderModels.mockResolvedValue([
+    { id: "ollama-cloud", models: [{ id: "ollama-cloud/gemini-3-flash-preview" }] },
+  ]);
+  // Chat default kimi-k2.6 is NOT vision-capable; gpt-5.5 is.
+  isModelVisionCapable.mockImplementation((m: string) => m === "openai/gpt-5.5");
+}
+
+afterEach(() => {
+  vi.clearAllMocks();
+});
+
+describe("resolveDefaultVisionModelChain", () => {
+  it("returns an ordered chain across configured providers so OpenClaw can fall back", async () => {
+    stubStagingProviders();
+    const chain = await resolveDefaultVisionModelChain();
+    // openai (vision-fallback tier) leads; ollama-cloud follows as the graceful
+    // fallback when the openai call fails (e.g. an invalid/expired key — the
+    // staging symptom). This is the whole point of #2: a single pdfModel had no
+    // fallback, so an unreachable primary silently killed PDF/vision.
+    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/gemini-3-flash-preview"]);
+  });
+
+  it("resolves ollama-cloud to its curated VISION model, not the chat default", async () => {
+    // Regression guard: the old resolver used getDefaultModel('ollama-cloud')
+    // (kimi-k2.6, chat model, not reliably vision-capable) for the PDF slot.
+    // The chain must use the curated image model (gemini-3-flash-preview).
+    getSetting.mockImplementation(async (key: string) =>
+      key === "ollama_cloud_api_key" ? "sk-present" : null
+    );
+    getDefaultModel.mockResolvedValue("ollama-cloud/kimi-k2.6");
+    fetchProviderModels.mockResolvedValue([
+      { id: "ollama-cloud", models: [{ id: "ollama-cloud/gemini-3-flash-preview" }] },
+    ]);
+    isModelVisionCapable.mockReturnValue(false);
+    const chain = await resolveDefaultVisionModelChain();
+    expect(chain).toEqual(["ollama-cloud/gemini-3-flash-preview"]);
+  });
+
+  it("returns an empty chain on a text-only stack", async () => {
+    getSetting.mockResolvedValue(null);
+    getDefaultModel.mockResolvedValue(null);
+    fetchProviderModels.mockResolvedValue([]);
+    isModelVisionCapable.mockReturnValue(false);
+    expect(await resolveDefaultVisionModelChain()).toEqual([]);
+  });
+
+  it("serves BOTH the pdf and image tools from one resolution (build.ts emits it to both)", async () => {
+    // The pdf and image tools share this chain — build.ts resolves it once and
+    // emits it as pdfModel AND imageModel, so the live ollama-cloud catalog is
+    // fetched a single time per config-gen (regression: two resolvers each
+    // fetching consumed the #416 mockResolvedValueOnce and diverged the pick).
+    stubStagingProviders();
+    fetchProviderModels.mockClear();
+    const chain = await resolveDefaultVisionModelChain();
+    expect(chain).toEqual(["openai/gpt-5.5", "ollama-cloud/gemini-3-flash-preview"]);
+    expect(fetchProviderModels).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/lib/openclaw-builtin-models.ts
+++ b/packages/web/src/lib/openclaw-builtin-models.ts
@@ -17,11 +17,21 @@ export interface OpenClawModelDefinition {
   reasoning: boolean;
   vision: boolean;
   input: string[];
+  // cacheRead/cacheWrite are REQUIRED, not optional: OpenClaw's per-agent
+  // model-catalog schema (openclaw-plugin-model-catalog-v1) rejects any model
+  // whose cost omits them, then drops the ENTIRE provider from that agent's
+  // effective catalog. That silently breaks every tool that resolves a model
+  // from it — including the built-in `pdf`/vision tool, which defaults to
+  // openai/gpt-5.5 (staging symptom: `pdf failed: Unknown model: openai/gpt-5.5`,
+  // so invoice PDFs were never read and the agent booked an unverified lump sum
+  // while reporting success). Keeping the fields required makes an omission a
+  // compile error here, not a runtime schema failure surfaced only when an
+  // agent's per-agent catalog happens to be regenerated.
   cost: {
     input: number;
     output: number;
-    cacheRead?: number;
-    cacheWrite?: number;
+    cacheRead: number;
+    cacheWrite: number;
   };
 }
 
@@ -58,6 +68,12 @@ const ANTHROPIC_MODELS: OpenClawModelDefinition[] = [
   },
 ];
 
+// cacheRead/cacheWrite are set to 0 here (not modeled), matching the ZERO_COST
+// convention used for ollama-cloud in build.ts. Unlike Anthropic — which
+// publishes distinct cache-tier rates we carry above — we do not freeze a
+// synthetic OpenAI/Google cache discount, because a hardcoded price silently
+// goes stale between releases. The schema only requires the fields to be
+// present; accurate, refreshable provider pricing is tracked in #677.
 const OPENAI_MODELS: OpenClawModelDefinition[] = [
   {
     id: "gpt-5.5",
@@ -67,7 +83,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 2.5, output: 10 },
+    cost: { input: 2.5, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gpt-5.4",
@@ -77,7 +93,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 2.5, output: 10 },
+    cost: { input: 2.5, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gpt-5.4-mini",
@@ -87,7 +103,7 @@ const OPENAI_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.15, output: 0.6 },
+    cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 },
   },
 ];
 
@@ -100,7 +116,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: true,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 1.25, output: 10 },
+    cost: { input: 1.25, output: 10, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gemini-2.5-flash",
@@ -110,7 +126,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: true,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.15, output: 0.6 },
+    cost: { input: 0.15, output: 0.6, cacheRead: 0, cacheWrite: 0 },
   },
   {
     id: "gemini-2.5-flash-lite",
@@ -120,7 +136,7 @@ const GOOGLE_MODELS: OpenClawModelDefinition[] = [
     reasoning: false,
     vision: true,
     input: ["text", "image"],
-    cost: { input: 0.1, output: 0.4 },
+    cost: { input: 0.1, output: 0.4, cacheRead: 0, cacheWrite: 0 },
   },
 ];
 

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -49,7 +49,7 @@ import {
   BUILTIN_PROVIDER_BASE_URL_ENV_VARS,
   BUILTIN_PROVIDER_API,
 } from "./provider-defaults";
-import { resolveDefaultPdfModel, resolveDefaultImageModel } from "./default-media-models";
+import { resolveDefaultVisionModelChain } from "./default-media-models";
 import { deepMerge } from "./deep-merge";
 import { buildGatewayBlock } from "./gateway";
 import { EMAIL_CONNECTION_TYPES } from "@/lib/integrations/oauth-providers";
@@ -373,22 +373,27 @@ export async function regenerateOpenClawConfig() {
     pinchyDefaults.model = { primary: await getDefaultModel(defaultProvider) };
   }
 
-  // Auto-set pdfModel to the best vision-capable model available.
-  // The built-in `pdf` tool registers only when this resolves — without it,
-  // agents on text-only models (e.g. deepseek-v4-flash) get no PDF capability.
-  const pdfModel = await resolveDefaultPdfModel();
-  if (pdfModel) {
-    pinchyDefaults.pdfModel = { primary: pdfModel };
-  }
-
-  // Auto-set imageModel for the built-in `image` tool. Without this,
-  // OpenClaw falls through to provider image defaults and may pick a
-  // vision-flagged model whose runtime API rejects images (e.g.
-  // devstral-small-2 on ollama-cloud, #416). The explicit pin removes that
-  // failure mode and lets ops override via settings if needed.
-  const imageModel = await resolveDefaultImageModel();
-  if (imageModel) {
-    pinchyDefaults.imageModel = { primary: imageModel };
+  // Vision-model chain for the built-in `pdf` and `image` tools. Both use the
+  // SAME per-provider resolution (identical preference + logic), so resolve it
+  // ONCE — this also avoids fetching the live ollama-cloud catalog twice per
+  // config-gen. Emitted as { primary, fallbacks } so OpenClaw retries the next
+  // provider when the primary is unreachable (invalid/expired key, retired
+  // model) instead of hard-failing — see resolveDefaultVisionModelChain for the
+  // staging incident (openai/gpt-5.5 → 401, no fall-through to ollama-cloud).
+  const visionChain = await resolveDefaultVisionModelChain();
+  const visionSelector =
+    visionChain.length > 0
+      ? {
+          primary: visionChain[0],
+          ...(visionChain.length > 1 ? { fallbacks: visionChain.slice(1) } : {}),
+        }
+      : undefined;
+  if (visionSelector) {
+    // pdf tool registers only when this resolves — text-only stacks get no PDF.
+    pinchyDefaults.pdfModel = visionSelector;
+    // Without imageModel, OpenClaw falls through to provider image defaults and
+    // may pick a vision-flagged model whose API rejects images (#416).
+    pinchyDefaults.imageModel = visionSelector;
   }
 
   // Build agents list with OpenClaw-side workspace paths, tools.allow, and plugin configs
@@ -691,7 +696,9 @@ export async function regenerateOpenClawConfig() {
     // Haiku), NOT the per-agent chat model — matching the old pdfModel/imageModel
     // behaviour. Omitted when no vision provider is configured; the plugin then
     // falls back to the agent's own model.
-    const visionModel = await resolveDefaultImageModel();
+    // Reuse the already-resolved vision chain's primary so the live ollama-cloud
+    // catalog isn't fetched again for pinchy-files.
+    const visionModel = visionChain[0] ?? null;
     entries["pinchy-files"] = {
       enabled: true,
       config: {

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -42,10 +42,6 @@ const PDF_MODEL_PREFERENCE: readonly ProviderName[] = [
   "ollama-cloud", // vision fallback
 ];
 
-export async function resolveDefaultPdfModel(): Promise<string | null> {
-  return (await resolveDefaultVisionModelChain())[0] ?? null;
-}
-
 /**
  * Ordered chain of vision-capable models for the built-in `pdf` AND `image`
  * tools: the best vision model of every configured provider, in

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -43,26 +43,62 @@ const PDF_MODEL_PREFERENCE: readonly ProviderName[] = [
 ];
 
 export async function resolveDefaultPdfModel(): Promise<string | null> {
-  // Guard against a regenerate call landing before bootInits has loaded the
-  // cache. `isModelVisionCapable` is sync and would otherwise return false
-  // for every model, silently picking the last (untyped) provider in the
-  // preference order.
+  return (await resolveDefaultVisionModelChain())[0] ?? null;
+}
+
+/**
+ * Ordered chain of vision-capable models for the built-in `pdf` AND `image`
+ * tools: the best vision model of every configured provider, in
+ * `PDF_MODEL_PREFERENCE` order. Both tools share this resolution (their
+ * preferences are identical), so build.ts resolves it ONCE and emits it as
+ * `pdfModel`/`imageModel = { primary: chain[0], fallbacks: rest }`.
+ *
+ * OpenClaw resolves primary+fallbacks into an ordered candidate list and retries
+ * the next one when a model is unreachable (`agents.defaults.pdfModel.fallbacks`,
+ * resolveAgentModelFallbackValues). The old single-model `pdfModel` had NO
+ * fallback, so an invalid/expired primary key silently killed all PDF/vision —
+ * the staging symptom was `pdf failed: PDF model failed (openai/gpt-5.5): 401
+ * Incorrect API key`, with no fall-through to the ollama-cloud vision model the
+ * stack already had.
+ */
+export async function resolveDefaultVisionModelChain(): Promise<string[]> {
+  return resolveVisionModelChain(PDF_MODEL_PREFERENCE);
+}
+
+/**
+ * Collect the best vision model of each configured provider, in the given
+ * preference order (deduped). ollama-cloud resolves to its curated VISION model
+ * (`pickOllamaCloudImageModel` — gemini-3-flash-preview …), NEVER the chat
+ * default: the pdf resolver previously used `getDefaultModel('ollama-cloud')`
+ * (kimi-k2.6, a chat model that is not reliably vision-capable), so ollama-cloud
+ * never qualified as a PDF fallback even when the stack had a real vision model.
+ * Native providers use their default model, gated by `isModelVisionCapable`.
+ */
+async function resolveVisionModelChain(preference: readonly ProviderName[]): Promise<string[]> {
+  // Guard against a regenerate landing before bootInits loaded the capability
+  // cache — `isModelVisionCapable` is sync and would otherwise report false for
+  // every model, silently dropping native providers from the chain.
   await ensureModelCapabilityCacheLoaded();
-  for (const provider of PDF_MODEL_PREFERENCE) {
-    // `provider` is a typed ProviderName from the const tuple above, never
-    // user input — `PROVIDERS[provider]` is safe key access on a finite map.
+  const chain: string[] = [];
+  for (const provider of preference) {
+    // `provider` is a typed ProviderName from a const tuple, never user input —
+    // `PROVIDERS[provider]` is safe key access on a finite map.
     // eslint-disable-next-line security/detect-object-injection
     const key = await getSetting(PROVIDERS[provider].settingsKey);
     if (!key) continue;
+    if (provider === "ollama-cloud") {
+      const picked = await pickOllamaCloudImageModel();
+      if (picked && !chain.includes(picked)) chain.push(picked);
+      continue;
+    }
     const model = await getDefaultModel(provider);
     if (!model) continue;
-    // Native PDF providers (anthropic, google) are always vision-capable,
-    // so the check is a no-op there. For the fallback tier the check
-    // guards against a provider whose default model isn't actually
-    // vision-capable (e.g. a future text-only model winning the slot).
-    if (isModelVisionCapable(model)) return model;
+    // Native PDF/vision providers (anthropic, google) are always vision-capable,
+    // so the check is a no-op there; for the openai fallback tier it guards a
+    // future text-only default from winning the slot.
+    if (isModelVisionCapable(model) && !chain.includes(model)) chain.push(model);
   }
-  return null;
+  return chain;
 }
 
 /**
@@ -161,20 +197,7 @@ async function pickOllamaCloudImageModel(): Promise<string | null> {
 }
 
 export async function resolveDefaultImageModel(): Promise<string | null> {
-  for (const provider of IMAGE_MODEL_PREFERENCE) {
-    // eslint-disable-next-line security/detect-object-injection
-    const key = await getSetting(PROVIDERS[provider].settingsKey);
-    if (!key) continue;
-    if (provider === "ollama-cloud") {
-      const picked = await pickOllamaCloudImageModel();
-      if (picked) return picked;
-      continue;
-    }
-    const model = await getDefaultModel(provider);
-    if (!model) continue;
-    if (isModelVisionCapable(model)) return model;
-  }
-  return null;
+  return (await resolveDefaultVisionModelChain())[0] ?? null;
 }
 
 function providerImageRank(provider: string): number {


### PR DESCRIPTION
## Problem (found in the intensive v0.8.0 staging re-test of email→Odoo)

The built-in `pdf`/`image` tools were pinned to a SINGLE model (`agents.defaults.pdfModel = { primary }`). When that primary is unreachable — invalid/expired provider key, retired model — OpenClaw hard-fails with no fallback:

```
pdf failed: PDF model failed (openai/gpt-5.5): 401 Incorrect API key provided
```

Staging's OpenAI key is invalid, so PDF/vision was dead **even though the stack had a working ollama-cloud vision model** (gemini-3-flash-preview). The agent then booked the Hetzner invoice from the **email body only**, losing the real line items.

## Fix
OpenClaw's model selectors accept `{ primary, fallbacks[] }` and the pdf/image tools resolve primary+fallbacks into an ordered candidate list, retrying the next on failure (`agents.defaults.pdfModel.fallbacks`). We just weren't emitting fallbacks.

- `resolveDefaultVisionModelChain()` returns the best vision model of **every** configured provider in preference order; build.ts emits `pdfModel`/`imageModel = { primary: chain[0], fallbacks: rest }`.
- Latent bug fixed: the pdf resolver used `getDefaultModel('ollama-cloud')` (kimi-k2.6, a chat model not reliably vision-capable), so ollama-cloud never qualified as a PDF model. The chain now resolves ollama-cloud to its curated **vision** model (`pickOllamaCloudImageModel`) for both tools.
- pdf + image share one resolution (identical preference), resolved **once** per config-gen — no redundant live-catalog fetches.

**Result:** on an ollama-cloud-first stack (Pinchy's offline-first target), vision works without a valid OpenAI key — the chain falls through openai → ollama-cloud.

## Tests (TDD, red→green)
- `vision-model-chain.test.ts`: ordering across providers, ollama-cloud→vision-model resolution (not the chat default), empty on text-only stacks, single live-catalog fetch.
- `openclaw-config.test.ts`: emission guard — the written `openclaw.json` carries `pdfModel`/`imageModel { primary, fallbacks }`; the existing #416 imageModel tests stay green.
- `tsc`, prettier, eslint clean; related config/media suites green (212).

One of three blockers from the intensive staging test (#2 vision fallback). Verified end-to-end on staging after deploy (openai 401 → ollama-cloud reads the PDF). Blocks the v0.8.0 cut.