### PR TITLE
fix(odoo): validate selection values (move_type) + guard duplicate invoices on create

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -710,6 +710,76 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
     });
   });
 
+  it("#5: rejects an out-of-set move_type with the valid options, not an opaque Odoo error", async () => {
+    // Staging: the agent guessed move_type "in_bill" (not a real Odoo move_type;
+    // vendor bills are "in_invoice"). Validate against the model's selection and
+    // surface the valid keys so the agent self-corrects without a blind retry.
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const result = await createTool.execute("create-bad-move-type", {
+      model: "account.move",
+      values: { move_type: "in_bill", ref: "BAD-MT-001" },
+    });
+
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    expect(text).toContain("account.move.move_type");
+    expect(text).toContain("in_bill");
+    // The valid options are surfaced (vendor bill = in_invoice) so no guessing.
+    expect(text).toContain("in_invoice");
+
+    // Nothing was written — the guard fires before the create.
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.some((m) => m.ref === "BAD-MT-001")).toBe(false);
+  });
+
+  it("#3: refuses a second account.move with a ref that already exists (duplicate-invoice guard)", async () => {
+    // Staging: the agent couldn't find the existing bill (searched with the
+    // invalid move_type "in_bill" → empty) and booked a DUPLICATE (move_id 40
+    // duplicated move_id 39, both ref 083000981540). The guard surfaces the
+    // existing move instead of silently double-booking.
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const readTool = findTool(tools, "odoo_read", accountingAgentId);
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const readResult = await readTool.execute("read-journal-dup", {
+      model: "account.journal",
+      filters: [["id", "=", 17]],
+      fields: ["name"],
+    });
+    const journalRef = JSON.parse(readResult.content[0].text).records[0]._pinchy_ref;
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH");
+    const values = {
+      ref: "DUP-INV-777",
+      move_type: "in_invoice",
+      company_id: { ref: companyRef },
+      journal_id: journalRef,
+    };
+
+    const first = await createTool.execute("create-dup-first", {
+      model: "account.move",
+      values,
+    });
+    expect(first.isError).toBeFalsy();
+
+    const second = await createTool.execute("create-dup-second", {
+      model: "account.move",
+      values,
+    });
+    expect(second.isError).toBe(true);
+    expect(second.content[0].text).toContain("already exists");
+    expect(second.content[0].text).toContain("DUP-INV-777");
+
+    // Exactly one move with that ref exists — no duplicate was written.
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.filter((m) => m.ref === "DUP-INV-777")).toHaveLength(1);
+  });
+
   it("scopes a journal name lookup by company_id, resolving the multi-company collision (Layer 2)", async () => {
     const tools = createApi({ [accountingAgentId]: accountingConfig });
     const createTool = findTool(tools, "odoo_create", accountingAgentId);

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -780,6 +780,63 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
     expect(moves.filter((m) => m.ref === "DUP-INV-777")).toHaveLength(1);
   });
 
+  it("#3: allows the same ref in a DIFFERENT company (dedup is company-scoped, not global)", async () => {
+    // The duplicate guard must scope by company_id. Two legally separate
+    // companies (Helmcraft GmbH / Clemens Helm) can each legitimately book a
+    // supplier invoice that carries the same supplier invoice number — the
+    // guard must not reject company 2's booking as a duplicate of company 1's.
+    const tools = createApi({ [accountingAgentId]: accountingConfig });
+    const readTool = findTool(tools, "odoo_read", accountingAgentId);
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const journal1 = JSON.parse(
+      (
+        await readTool.execute("read-journal-xc-1", {
+          model: "account.journal",
+          filters: [["id", "=", 17]],
+          fields: ["name"],
+        })
+      ).content[0].text,
+    ).records[0]._pinchy_ref;
+    const journal2 = JSON.parse(
+      (
+        await readTool.execute("read-journal-xc-2", {
+          model: "account.journal",
+          filters: [["id", "=", 24]],
+          fields: ["name"],
+        })
+      ).content[0].text,
+    ).records[0]._pinchy_ref;
+
+    const first = await createTool.execute("create-xc-first", {
+      model: "account.move",
+      values: {
+        ref: "XCOMPANY-REF-1",
+        move_type: "in_invoice",
+        company_id: { ref: ref("res.company", 1, "Helmcraft GmbH", 1, "Helmcraft GmbH") },
+        journal_id: journal1,
+      },
+    });
+    expect(first.isError).toBeFalsy();
+
+    const second = await createTool.execute("create-xc-second", {
+      model: "account.move",
+      values: {
+        ref: "XCOMPANY-REF-1",
+        move_type: "in_invoice",
+        company_id: { ref: ref("res.company", 2, "Clemens Helm", 2, "Clemens Helm") },
+        journal_id: journal2,
+      },
+    });
+    expect(second.isError).toBeFalsy();
+
+    // Both companies' moves persisted — one per company, same ref.
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    expect(moves.filter((m) => m.ref === "XCOMPANY-REF-1")).toHaveLength(2);
+  });
+
   it("scopes a journal name lookup by company_id, resolving the multi-company collision (Layer 2)", async () => {
     const tools = createApi({ [accountingAgentId]: accountingConfig });
     const createTool = findTool(tools, "odoo_create", accountingAgentId);

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -46,8 +46,74 @@ import plugin, {
   formatMultiMatchError,
   assertNoCrossCompanyRefs,
   relationHasCompanyId,
+  findInvalidSelectionValues,
+  formatInvalidSelectionError,
   PRODUCT_REF_DISAMBIGUATION_HINT,
 } from "../index";
+
+const MOVE_FIELDS: OdooField[] = [
+  {
+    name: "move_type",
+    type: "selection",
+    selection: [
+      ["entry", "Journal Entry"],
+      ["out_invoice", "Customer Invoice"],
+      ["in_invoice", "Vendor Bill"],
+      ["in_refund", "Vendor Credit Note"],
+    ],
+  },
+  { name: "ref", type: "char" },
+  { name: "partner_id", type: "many2one", relation: "res.partner" },
+];
+
+describe("findInvalidSelectionValues", () => {
+  it("flags an out-of-set selection value and lists the valid options", () => {
+    // The staging duplicate: the agent used move_type "in_bill" (not a real
+    // Odoo move_type) — vendor bills are "in_invoice". On write Odoo errors
+    // opaquely; in a read domain it silently matches nothing.
+    const invalid = findInvalidSelectionValues(MOVE_FIELDS, {
+      move_type: "in_bill",
+      ref: "083000981540",
+    });
+    expect(invalid).toEqual([
+      {
+        field: "move_type",
+        value: "in_bill",
+        validValues: ["entry", "out_invoice", "in_invoice", "in_refund"],
+      },
+    ]);
+  });
+
+  it("accepts a valid selection value", () => {
+    expect(
+      findInvalidSelectionValues(MOVE_FIELDS, { move_type: "in_invoice", ref: "X" }),
+    ).toEqual([]);
+  });
+
+  it("ignores non-selection fields, unknown fields, and non-primitive values", () => {
+    expect(
+      findInvalidSelectionValues(MOVE_FIELDS, {
+        ref: "anything", // char field, not validated
+        unknown_field: "whatever", // not in schema
+        partner_id: { ref: "pinchy_ref:v1:abc" }, // relational, not a scalar
+      }),
+    ).toEqual([]);
+  });
+
+  it("skips selection fields with an empty/dynamic option set (cannot validate)", () => {
+    const fields: OdooField[] = [{ name: "state", type: "selection", selection: [] }];
+    expect(findInvalidSelectionValues(fields, { state: "whatever" })).toEqual([]);
+  });
+
+  it("formats a helpful error naming the field and valid enum values", () => {
+    const msg = formatInvalidSelectionError("account.move", [
+      { field: "move_type", value: "in_bill", validValues: ["in_invoice", "in_refund"] },
+    ]);
+    expect(msg).toContain("account.move.move_type");
+    expect(msg).toContain("in_bill");
+    expect(msg).toContain("in_invoice, in_refund");
+  });
+});
 
 interface AgentTool {
   name: string;

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -911,6 +911,55 @@ export function assertNoCrossCompanyRefs(
 }
 
 /**
+ * Validate `selection`-type field values in `values` against the model's field
+ * schema. An Odoo selection field only accepts its declared option keys; an
+ * out-of-set value is a silent footgun:
+ *   - on create/write Odoo rejects it with an opaque server error;
+ *   - in a read/count DOMAIN it matches nothing, so the agent wrongly concludes
+ *     the record doesn't exist and books a DUPLICATE — the staging incident:
+ *     it searched account.move with move_type="in_bill" (not a valid move_type;
+ *     vendor bills are "in_invoice"), found nothing, then created move_id 40
+ *     duplicating move_id 39.
+ *
+ * Returns the offending entries with the valid option keys so the caller can
+ * throw a helpful error naming the enum instead of forwarding a bad value.
+ * Skips fields with an empty/dynamic selection set (can't validate) and
+ * non-primitive values (relational command tuples, refs).
+ */
+export function findInvalidSelectionValues(
+  fields: OdooField[],
+  values: Record<string, unknown>,
+): Array<{ field: string; value: string; validValues: string[] }> {
+  const byName = new Map(fields.map((f) => [f.name, f]));
+  const invalid: Array<{ field: string; value: string; validValues: string[] }> = [];
+  for (const [name, raw] of Object.entries(values)) {
+    const field = byName.get(name);
+    if (!field || field.type !== "selection") continue;
+    const options = field.selection ?? [];
+    if (options.length === 0) continue;
+    if (typeof raw !== "string" && typeof raw !== "number") continue;
+    const value = String(raw);
+    const validValues = options.map(([optValue]) => optValue);
+    if (!validValues.includes(value)) invalid.push({ field: name, value, validValues });
+  }
+  return invalid;
+}
+
+/** Human-readable error for invalid selection values, listing the valid keys. */
+export function formatInvalidSelectionError(
+  model: string,
+  invalid: Array<{ field: string; value: string; validValues: string[] }>,
+): string {
+  return invalid
+    .map(
+      (e) =>
+        `Invalid value "${e.value}" for ${model}.${e.field}. ` +
+        `Valid values: ${e.validValues.join(", ")}.`,
+    )
+    .join(" ");
+}
+
+/**
  * Decode the company tag (id + label) from a `{ ref }` shape in one pass.
  * Returns null when the value is not a tagged ref, when decoding fails, or
  * when the payload lacks a `companyId` tag (legacy / untagged refs). The
@@ -2107,6 +2156,61 @@ const plugin = {
                   } else {
                     values = params.values as Record<string, unknown>;
                   }
+
+                  // #5: reject out-of-set selection values (e.g. move_type
+                  // "in_bill", which is not a real Odoo move_type) with the valid
+                  // options, instead of forwarding a bad enum to Odoo where it
+                  // surfaces as an opaque server error the agent has to guess at.
+                  const modelFields = normalizeFields(await client.fields(model));
+                  const invalidSelections = findInvalidSelectionValues(modelFields, values);
+                  if (invalidSelections.length > 0) {
+                    throw new Error(formatInvalidSelectionError(model, invalidSelections));
+                  }
+
+                  // #3: duplicate-invoice guard. An account.move (vendor/customer
+                  // invoice) is keyed by its `ref` — the supplier's invoice
+                  // number. Agents that fail to find an existing bill (e.g. a
+                  // search with an invalid move_type returns empty) otherwise book
+                  // a DUPLICATE: on staging the agent created move_id 40 duplicating
+                  // move_id 39, both ref 083000981540. Before creating, surface any
+                  // existing move that already carries the same ref (+ move_type +
+                  // partner) so the agent updates it or confirms a deliberate
+                  // second entry rather than silently double-booking.
+                  if (
+                    model === "account.move" &&
+                    typeof values.ref === "string" &&
+                    values.ref.trim() &&
+                    checkPermission(config.permissions, model, "read")
+                  ) {
+                    const dupDomain: OdooDomain = [["ref", "=", values.ref]];
+                    if (typeof values.move_type === "string") {
+                      dupDomain.push(["move_type", "=", values.move_type]);
+                    }
+                    if (typeof values.partner_id === "number") {
+                      dupDomain.push(["partner_id", "=", values.partner_id]);
+                    }
+                    const existing = getSearchReadRecords(
+                      await client.searchRead("account.move", dupDomain, {
+                        fields: ["id", "name", "state"],
+                        limit: 1,
+                      }),
+                    );
+                    if (existing.length > 0) {
+                      const dup = existing[0] as { id: number; name?: string; state?: string };
+                      throw new Error(
+                        `A record already exists in account.move with ref "${values.ref}"` +
+                          (typeof values.move_type === "string"
+                            ? ` (move_type "${values.move_type}")`
+                            : "") +
+                          `: id ${dup.id}` +
+                          (dup.name ? ` "${dup.name}"` : "") +
+                          (dup.state ? `, state "${dup.state}"` : "") +
+                          `. To avoid a duplicate, update it with odoo_write, or confirm you ` +
+                          `intend a second entry before creating.`,
+                      );
+                    }
+                  }
+
                   return client.create(model, values);
                 },
               );

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1109,9 +1109,9 @@ async function normalizeMany2OneValues(
   connectionId: string,
   model: string,
   values: Record<string, unknown>,
-): Promise<Record<string, unknown>> {
+): Promise<{ values: Record<string, unknown>; fields: OdooField[] }> {
   const fields = normalizeFields(await client.fields(model));
-  if (fields.length === 0) return values;
+  if (fields.length === 0) return { values, fields };
 
   const normalized = { ...values };
 
@@ -1156,7 +1156,7 @@ async function normalizeMany2OneValues(
       scopeCompanyId,
     );
   }
-  return normalized;
+  return { values: normalized, fields };
 }
 
 // The canonical Odoo external id for the built-in "To-Do" activity type.
@@ -2139,15 +2139,21 @@ const plugin = {
                 config,
                 async (client) => {
                   let values: Record<string, unknown>;
+                  // The model's field schema, fetched once during many2one
+                  // normalization and reused for #5 selection validation below
+                  // (avoids a second client.fields round-trip on every create).
+                  let modelFields: OdooField[] | null = null;
                   if (isRecord(params.values)) {
                     const cleaned = unquoteFieldKeys(params.values);
                     assertNoCrossCompanyRefs(cleaned);
-                    values = await normalizeMany2OneValues(
+                    const normalized = await normalizeMany2OneValues(
                       client,
                       config.connectionId,
                       model,
                       cleaned,
                     );
+                    values = normalized.values;
+                    modelFields = normalized.fields;
                     values = await ensureActivityResModelId(
                       client,
                       model,
@@ -2161,10 +2167,16 @@ const plugin = {
                   // "in_bill", which is not a real Odoo move_type) with the valid
                   // options, instead of forwarding a bad enum to Odoo where it
                   // surfaces as an opaque server error the agent has to guess at.
-                  const modelFields = normalizeFields(await client.fields(model));
-                  const invalidSelections = findInvalidSelectionValues(modelFields, values);
-                  if (invalidSelections.length > 0) {
-                    throw new Error(formatInvalidSelectionError(model, invalidSelections));
+                  if (modelFields) {
+                    const invalidSelections = findInvalidSelectionValues(
+                      modelFields,
+                      values,
+                    );
+                    if (invalidSelections.length > 0) {
+                      throw new Error(
+                        formatInvalidSelectionError(model, invalidSelections),
+                      );
+                    }
                   }
 
                   // #3: duplicate-invoice guard. An account.move (vendor/customer
@@ -2185,6 +2197,14 @@ const plugin = {
                     const dupDomain: OdooDomain = [["ref", "=", values.ref]];
                     if (typeof values.move_type === "string") {
                       dupDomain.push(["move_type", "=", values.move_type]);
+                    }
+                    // Scope by company: the same supplier invoice number can be
+                    // booked legitimately by two separate companies in one Odoo
+                    // instance, so a global ref match would falsely reject the
+                    // second company's entry. company_id is a resolved integer
+                    // here (normalizeMany2OneValues ran above).
+                    if (typeof values.company_id === "number") {
+                      dupDomain.push(["company_id", "=", values.company_id]);
                     }
                     if (typeof values.partner_id === "number") {
                       dupDomain.push(["partner_id", "=", values.partner_id]);
@@ -2979,12 +2999,14 @@ const plugin = {
                   if (isRecord(params.values)) {
                     const cleaned = unquoteFieldKeys(params.values);
                     assertNoCrossCompanyRefs(cleaned);
-                    values = await normalizeMany2OneValues(
-                      client,
-                      config.connectionId,
-                      model,
-                      cleaned,
-                    );
+                    values = (
+                      await normalizeMany2OneValues(
+                        client,
+                        config.connectionId,
+                        model,
+                        cleaned,
+                      )
+                    ).values;
                     values = await ensureActivityResModelId(
                       client,
                       model,


### PR DESCRIPTION
## Problem (found in the intensive v0.8.0 staging test of email→Odoo)

Two accounting-reliability bugs in the invoice-booking flow:

**#5 — invalid selection values forwarded verbatim.** The agent guessed `move_type: "in_bill"` for a vendor bill (the real value is `in_invoice`). On create Odoo returns an opaque error the agent has to guess at; in a read **domain** the bad value matches nothing *silently*.

**#3 — duplicate vendor bills.** Because the agent couldn't find the existing bill (it searched `account.move` with the invalid `move_type: "in_bill"` → empty), it booked a **duplicate**: staging created `move_id 40` duplicating `move_id 39`, both `ref 083000981540`.

## Fix
- **Selection validation (#5):** `odoo_create` validates selection-field values against the model's schema and rejects an out-of-set value **naming the valid options** (`entry, out_invoice, in_invoice`), so the agent self-corrects without a blind retry.
- **Duplicate-invoice guard (#3):** before creating an `account.move` that carries a `ref` (the supplier's invoice number), it looks for an existing move with the same `ref` (+ `move_type` + `partner`) and surfaces it — the agent updates the existing record or confirms a deliberate second entry instead of silently double-booking. Gated on read permission.

## Tests (TDD, red→green)
- Pure helpers `findInvalidSelectionValues` / `formatInvalidSelectionError` — unit tested (out-of-set detection, valid-value listing, non-selection/dynamic/non-primitive skips).
- Integration (in-process mock-odoo): invalid `move_type` → error with options + nothing written; duplicate `ref` → error surfacing the existing move + exactly one record persists. **Both verified red with the guards disabled.**
- Full pinchy-odoo suite 294 green; `tsc`/`typecheck:plugins` clean. (Plugins carry no prettier config by design — not run on plugin files.)

## Follow-up (not blocking)
Extend selection validation to `odoo_write` and to read/count **domain filters**, and cache `client.fields` per (connection, model).

Two of three blockers from the intensive staging test (#3 duplicate guard, #5 move_type validation). Blocks the v0.8.0 cut.