### PR TITLE
perf(usage): adaptive per-session backoff for the usage poller (#261 D)

### DIFF
--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -499,6 +499,37 @@ describe("pollAllSessions adaptive backoff (#261)", () => {
     // 2 (first poll, both) + 1 (second poll, only user-1) = 3 scans.
     expect(mockRecordSessionTurns).toHaveBeenCalledTimes(3);
   });
+
+  // Review finding: the fingerprint must NOT be recorded until the record call
+  // actually succeeds. Recording it eagerly (before the await) means a
+  // transient recordUsage/recordSessionTurns failure still "poisons" the
+  // session as processed — the next tick sees an unchanged gauge and skips it
+  // for up to IDLE_RESCAN_MS (5 min), even though the record never happened.
+  // Pre-adaptive-backoff behavior retried every tick (60s); this restores
+  // that retry behavior for failed record calls specifically.
+  it("retries a system session every tick after a transient recordUsage failure, instead of treating it as processed", async () => {
+    mockRecordUsage.mockRejectedValueOnce(new Error("db blip"));
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client); // fails — must not mark the session as processed
+    await pollAllSessions(client); // identical gauge — should still retry, not skip
+
+    expect(mockRecordUsage).toHaveBeenCalledTimes(2);
+  });
+
+  it("retries a chat session every tick after a transient recordSessionTurns failure, instead of treating it as processed", async () => {
+    mockRecordSessionTurns.mockRejectedValueOnce(new Error("db blip"));
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client); // fails — must not mark the session as processed
+    await pollAllSessions(client); // identical gauge — should still retry, not skip
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+  });
 });
 
 describe("getPollIntervalMs", () => {

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -57,6 +57,7 @@ import {
   stopUsagePoller,
   getPollIntervalMs,
   _isPollerRunning,
+  _resetSessionActivity,
 } from "@/lib/usage-poller";
 
 function makeOpenClawClient(sessions: unknown[] = []) {
@@ -120,6 +121,7 @@ describe("parseSessionKey", () => {
 describe("pollAllSessions", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetSessionActivity();
     mockRecordUsage.mockResolvedValue(undefined);
     mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     mockFrom._userResult = [{ id: "user-1" }, { id: "user-2" }];
@@ -401,6 +403,104 @@ describe("pollAllSessions", () => {
   });
 });
 
+describe("pollAllSessions adaptive backoff (#261)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetSessionActivity();
+    mockRecordSessionTurns.mockResolvedValue(undefined);
+    mockRecordUsage.mockResolvedValue(undefined);
+    mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
+    mockFrom._userResult = [{ id: "user-1" }];
+  });
+
+  it("skips the per-turn scan for a chat session whose gauge is unchanged since the last poll", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client);
+    await pollAllSessions(client); // identical gauge → idle → skip the scan
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+  });
+
+  it("skips the gauge-delta recordUsage for a system session whose gauge is unchanged", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:cron:job-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+
+    await pollAllSessions(client);
+    await pollAllSessions(client); // identical gauge → idle → skip
+
+    expect(mockRecordUsage).toHaveBeenCalledTimes(1);
+  });
+
+  it("re-processes when the gauge changes (a new turn happened)", async () => {
+    const first = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+    ]);
+    const second = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 140, outputTokens: 70 },
+    ]);
+
+    await pollAllSessions(first);
+    await pollAllSessions(second); // gauge grew → active → scan again
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+  });
+
+  it("re-processes when a cache counter changes even if input/output are static", async () => {
+    const first = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50, cacheRead: 0 },
+    ]);
+    const second = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50, cacheRead: 900 },
+    ]);
+
+    await pollAllSessions(first);
+    await pollAllSessions(second);
+
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+  });
+
+  it("does a periodic catch-up scan for an idle session after IDLE_RESCAN_MS", async () => {
+    vi.useFakeTimers();
+    try {
+      const client = makeOpenClawClient([
+        { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+      ]);
+
+      await pollAllSessions(client);
+      // Still idle (unchanged gauge) but past the catch-up window.
+      await vi.advanceTimersByTimeAsync(5 * 60_000);
+      await pollAllSessions(client);
+
+      expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+    } finally {
+      vi.useRealTimers();
+    }
+  });
+
+  it("processes each session independently — one active session does not un-idle another", async () => {
+    const client = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 100, outputTokens: 50 },
+      { key: "agent:agent-1:direct:user-2", inputTokens: 200, outputTokens: 80 },
+    ]);
+    mockFrom._userResult = [{ id: "user-1" }, { id: "user-2" }];
+
+    await pollAllSessions(client);
+    // user-1 grows, user-2 stays idle.
+    const next = makeOpenClawClient([
+      { key: "agent:agent-1:direct:user-1", inputTokens: 130, outputTokens: 60 },
+      { key: "agent:agent-1:direct:user-2", inputTokens: 200, outputTokens: 80 },
+    ]);
+    await pollAllSessions(next);
+
+    // 2 (first poll, both) + 1 (second poll, only user-1) = 3 scans.
+    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(3);
+  });
+});
+
 describe("getPollIntervalMs", () => {
   const original = process.env.PINCHY_USAGE_POLL_INTERVAL_MS;
 
@@ -444,6 +544,7 @@ describe("startUsagePoller honors the configured interval", () => {
 
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetSessionActivity();
     mockRecordUsage.mockResolvedValue(undefined);
     mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     mockFrom._userResult = [{ id: "user-1" }];
@@ -465,22 +566,26 @@ describe("startUsagePoller honors the configured interval", () => {
     ]);
     startUsagePoller(client);
 
+    // sessions.list() fires once per tick regardless of adaptive backoff (which
+    // only skips per-session recording), so it's the direct signal that the
+    // interval fired — recordSessionTurns would be masked by the idle skip.
     // No poll before the (short) interval elapses.
     await vi.advanceTimersByTimeAsync(1_999);
-    expect(mockRecordSessionTurns).not.toHaveBeenCalled();
+    expect(client.sessions.list).not.toHaveBeenCalled();
 
     // First tick at 2s, not 60s.
     await vi.advanceTimersByTimeAsync(1);
-    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+    expect(client.sessions.list).toHaveBeenCalledTimes(1);
 
     await vi.advanceTimersByTimeAsync(2_000);
-    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+    expect(client.sessions.list).toHaveBeenCalledTimes(2);
   });
 });
 
 describe("startUsagePoller / stopUsagePoller", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    _resetSessionActivity();
     mockRecordSessionTurns.mockResolvedValue(undefined);
     mockFrom._agentResult = [{ id: "agent-1", name: "Smithers" }];
     stopUsagePoller();
@@ -528,13 +633,16 @@ describe("startUsagePoller / stopUsagePoller", () => {
     ]);
     startUsagePoller(client);
 
+    // Assert on sessions.list() (one call per pollAllSessions) rather than
+    // recordSessionTurns: adaptive backoff (#261) deliberately skips the scan
+    // for an idle session on the second tick, but the poll itself still runs.
     // First interval tick at 60s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(1);
+    expect(client.sessions.list).toHaveBeenCalledTimes(1);
 
     // Second interval tick at 120s
     await vi.advanceTimersByTimeAsync(60_000);
-    expect(mockRecordSessionTurns).toHaveBeenCalledTimes(2);
+    expect(client.sessions.list).toHaveBeenCalledTimes(2);
   });
 
   it("stops polling on stopUsagePoller", async () => {

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -79,6 +79,40 @@ interface SessionListEntry {
   model?: string;
 }
 
+// Adaptive backoff (#261 D): the per-turn trajectory scan (chat sessions) runs
+// on every tick regardless of the gauge, and the gauge-delta recordUsage
+// (system sessions) re-reads the DB watermark every tick. Both are no-ops when
+// nothing changed, so re-running them every 60 s for idle sessions is wasted
+// DB/CPU at scale (50 agents × 50 sessions ≈ 2 500 scans/min). We fingerprint
+// each session's gauge counters and skip the expensive processing while the
+// fingerprint is unchanged, with a periodic catch-up scan every IDLE_RESCAN_MS
+// as a backstop (covers the narrow case where two turns carry identical gauge
+// counts AND the lower-latency chat `done` path also missed one).
+const IDLE_RESCAN_MS = 5 * 60_000;
+
+interface SessionActivity {
+  signature: string;
+  lastProcessedAt: number;
+}
+const sessionActivity = new Map<string, SessionActivity>();
+
+/** Exported only for tests — clears the per-session backoff state. */
+export function _resetSessionActivity(): void {
+  sessionActivity.clear();
+}
+
+/**
+ * Fingerprint of a session's gauge counters. OpenClaw overwrites these each
+ * turn, so any change means a turn happened since we last looked; an identical
+ * fingerprint means the session was idle. Includes the cache counters (both OC
+ * spellings) and the model so a mid-session model switch also counts as change.
+ */
+function gaugeSignature(s: SessionListEntry): string {
+  const cacheRead = s.cacheRead ?? s.cacheReadTokens ?? 0;
+  const cacheWrite = s.cacheWrite ?? s.cacheWriteTokens ?? 0;
+  return `${s.inputTokens ?? 0}|${s.outputTokens ?? 0}|${cacheRead}|${cacheWrite}|${s.model ?? ""}`;
+}
+
 /**
  * Polls all OpenClaw sessions once and records usage deltas for each
  * session that has tokens. Unknown agent IDs fall back to the ID itself
@@ -91,7 +125,12 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
       sessions?: SessionListEntry[];
     };
     const sessions = listResult?.sessions ?? [];
-    if (sessions.length === 0) return;
+    if (sessions.length === 0) {
+      // No live sessions — drop stale backoff state so a returning session is
+      // treated as fresh (and the map never grows unbounded).
+      sessionActivity.clear();
+      return;
+    }
 
     // Pre-fetch agent names to avoid one DB round-trip per session.
     // Skip soft-deleted agents — a stale session key should fall through
@@ -109,9 +148,24 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
     const allUsers = await db.select({ id: users.id }).from(users);
     const userIdMap = new Map(allUsers.map((u) => [u.id.toLowerCase(), u.id]));
 
+    const now = Date.now();
+    const liveKeys = new Set<string>();
+
     for (const session of sessions) {
       const parsed = parseSessionKey(session.key);
       if (!parsed) continue;
+      liveKeys.add(session.key);
+
+      // Adaptive backoff (#261): skip the expensive per-session processing while
+      // the gauge fingerprint is unchanged, except for a periodic catch-up scan
+      // every IDLE_RESCAN_MS. A changed fingerprint means a turn happened, so we
+      // process immediately; DB dedup keeps a catch-up re-scan a no-op.
+      const signature = gaugeSignature(session);
+      const prev = sessionActivity.get(session.key);
+      const changed = !prev || prev.signature !== signature;
+      const dueForRescan = !prev || now - prev.lastProcessedAt >= IDLE_RESCAN_MS;
+      if (!changed && !dueForRescan) continue;
+      sessionActivity.set(session.key, { signature, lastProcessedAt: now });
 
       const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
 
@@ -120,8 +174,7 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
         // trajectory's exact per-turn `model.completed` events, NOT the gauge
         // counters (which OpenClaw overwrites each turn, so sampling drops
         // turns). This poll is a backstop scan; the chat `done` path scans with
-        // lower latency. DB dedup by (sessionKey, runId) makes re-scans no-ops,
-        // so we scan every chat session regardless of the gauge token counts.
+        // lower latency. DB dedup by (sessionKey, runId) makes re-scans no-ops.
         const userId = userIdMap.get(parsed.userId.toLowerCase()) ?? parsed.userId;
         await recordSessionTurnsUsage({
           openclawClient,
@@ -158,6 +211,12 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
           model: session.model,
         },
       });
+    }
+
+    // Prune backoff state for sessions that no longer exist so the map stays
+    // bounded to the set of live sessions.
+    for (const key of sessionActivity.keys()) {
+      if (!liveKeys.has(key)) sessionActivity.delete(key);
     }
   } catch (error) {
     console.error("[usage-poller] Poll failed:", error);

--- a/packages/web/src/lib/usage-poller.ts
+++ b/packages/web/src/lib/usage-poller.ts
@@ -102,15 +102,30 @@ export function _resetSessionActivity(): void {
 }
 
 /**
+ * Resolves a session's cache counters from either OC spelling
+ * (`cacheRead`/`cacheWrite` vs. `cacheReadTokens`/`cacheWriteTokens` — see the
+ * SessionListEntry comment). Left as `undefined`, not defaulted to 0, because
+ * callers differ on how they need the "no cache data" case represented.
+ */
+function resolveCacheCounters(s: SessionListEntry): {
+  cacheReadTokens: number | undefined;
+  cacheWriteTokens: number | undefined;
+} {
+  return {
+    cacheReadTokens: s.cacheRead ?? s.cacheReadTokens,
+    cacheWriteTokens: s.cacheWrite ?? s.cacheWriteTokens,
+  };
+}
+
+/**
  * Fingerprint of a session's gauge counters. OpenClaw overwrites these each
  * turn, so any change means a turn happened since we last looked; an identical
  * fingerprint means the session was idle. Includes the cache counters (both OC
  * spellings) and the model so a mid-session model switch also counts as change.
  */
 function gaugeSignature(s: SessionListEntry): string {
-  const cacheRead = s.cacheRead ?? s.cacheReadTokens ?? 0;
-  const cacheWrite = s.cacheWrite ?? s.cacheWriteTokens ?? 0;
-  return `${s.inputTokens ?? 0}|${s.outputTokens ?? 0}|${cacheRead}|${cacheWrite}|${s.model ?? ""}`;
+  const { cacheReadTokens, cacheWriteTokens } = resolveCacheCounters(s);
+  return `${s.inputTokens ?? 0}|${s.outputTokens ?? 0}|${cacheReadTokens ?? 0}|${cacheWriteTokens ?? 0}|${s.model ?? ""}`;
 }
 
 /**
@@ -165,7 +180,6 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
       const changed = !prev || prev.signature !== signature;
       const dueForRescan = !prev || now - prev.lastProcessedAt >= IDLE_RESCAN_MS;
       if (!changed && !dueForRescan) continue;
-      sessionActivity.set(session.key, { signature, lastProcessedAt: now });
 
       const agentName = agentNameMap.get(parsed.agentId) ?? parsed.agentId;
 
@@ -183,19 +197,28 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
           agentName,
           sessionKey: session.key,
         });
+        // Mark as processed only after the record call succeeds — if it threw,
+        // the catch below aborts the loop, and the fingerprint must stay
+        // unset so the next tick retries this session instead of treating a
+        // failed record as done and skipping it until the catch-up rescan.
+        sessionActivity.set(session.key, { signature, lastProcessedAt: now });
         continue;
       }
 
       // System sessions (main/cron/hook/channel) have no per-user trajectory we
       // scan, so they stay on the gauge delta path.
-      const cacheReadTokens = session.cacheRead ?? session.cacheReadTokens;
-      const cacheWriteTokens = session.cacheWrite ?? session.cacheWriteTokens;
+      const { cacheReadTokens, cacheWriteTokens } = resolveCacheCounters(session);
       const hasTokens =
         (session.inputTokens ?? 0) > 0 ||
         (session.outputTokens ?? 0) > 0 ||
         (cacheReadTokens ?? 0) > 0 ||
         (cacheWriteTokens ?? 0) > 0;
-      if (!hasTokens) continue;
+      if (!hasTokens) {
+        // Nothing to record — this isn't a failure, so it's safe to mark the
+        // session processed and let it ride the idle backoff.
+        sessionActivity.set(session.key, { signature, lastProcessedAt: now });
+        continue;
+      }
 
       await recordUsage({
         openclawClient,
@@ -211,6 +234,9 @@ export async function pollAllSessions(openclawClient: OpenClawClient): Promise<v
           model: session.model,
         },
       });
+      // Mark as processed only after the record call succeeds (see comment
+      // on the chat-session path above for why ordering matters here).
+      sessionActivity.set(session.key, { signature, lastProcessedAt: now });
     }
 
     // Prune backoff state for sessions that no longer exist so the map stays


### PR DESCRIPTION
Closes sub-task **D** of #261.

## Problem
The usage poller (`packages/web/src/lib/usage-poller.ts`) ran **every** OpenClaw session through its expensive per-session work on **every** 60 s tick, regardless of whether the session changed:
- **chat sessions** → `recordSessionTurnsUsage` (a per-turn trajectory scan, #483)
- **system sessions** → `recordUsage` (a DB watermark read + delta)

At the enterprise target (~50 agents × 50 active sessions) that's ~2 500 mostly-no-op scans/minute — the scaling concern the issue flags.

## Why not push-based
The issue suggested "event-based push from OpenClaw" as the better option. I checked `openclaw-node`: it exposes **no** usage-change event. `subscribeMessages` delivers chat chunks/lifecycle events, not usage metrics, and `sessions.list()` is the only source of the gauge counters — so an "event" would still have to call `sessions.list()` to read usage. Push isn't actually available today; it would need a new `session.usage.changed` event from OpenClaw core (worth raising upstream separately). **Adaptive backoff is the pragmatic, self-contained lever** and matches the "match the tool to the problem — a dashboard that refreshes every 30 s doesn't need a persistent connection" guidance.

## Solution
Fingerprint each session's gauge counters (input/output/cacheRead/cacheWrite/model — OpenClaw overwrites these each turn, so any change means a turn happened). On each tick:
- **unchanged fingerprint** = idle → **skip** the expensive processing
- **changed fingerprint** = a turn happened → process immediately
- a **periodic catch-up scan every 5 min** backstops the narrow case where two turns carry identical counts *and* the lower-latency chat `done` path also missed one

**Correctness is preserved by the existing DB dedup** (`(sessionKey, runId)`): skipping only delays an idle session's *backstop* scan, it never drops usage — the primary recording still happens on the chat `done` path. Stale entries are pruned each tick (and on an empty session list) so the backoff state map stays bounded to live sessions.

`sessions.list()` still fires every tick (single call, cheap), so the interval cadence is unchanged — only the per-session DB/CPU work is gated.

## Tests
- Interval tests now assert on `sessions.list()` call counts (the poll fires every tick) instead of `recordSessionTurns` — backoff legitimately skips the scan for an idle session, so the downstream call is no longer a 1:1 proxy for "a tick fired". Same intent, asserted against the invariant that still holds.
- New `pollAllSessions adaptive backoff` block: skip-idle (chat + system), re-scan on gauge change, re-scan on cache-counter change with static input/output, periodic catch-up after `IDLE_RESCAN_MS`, and per-session independence (one active session doesn't un-idle another).

Full web unit suite green (7282 passed); `tsc` + prettier + eslint clean.

## Note for the E2E stack
The integration E2E sets a low poll interval to surface usage rows fast. Those sessions are *active* (a chat just changed the gauge), so the first poll scans and records as before; backoff only affects idle sessions, and DB dedup makes it invisible to "usage row exists" assertions.
