### PR TITLE
docs: v0.8.0 follow-ups — skills concept page + integration lifecycle/errors

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -173,6 +173,7 @@ export default defineConfig({
             { label: 'Philosophy', slug: 'concepts/philosophy' },
             { label: 'Agent Memory', slug: 'explanation/agent-memory' },
             { label: 'Instructions vs. Memory', slug: 'explanation/instructions-vs-memory' },
+            { label: 'Skills & Templates', slug: 'explanation/skills-and-templates' },
             { label: 'Chat Connection States', slug: 'explanation/chat-states' },
             { label: 'Agent Settings', slug: 'concepts/agent-settings' },
             { label: 'Agent Permissions', slug: 'concepts/agent-permissions' },

--- a/docs/src/content/docs/concepts/integrations.mdx
+++ b/docs/src/content/docs/concepts/integrations.mdx
@@ -151,12 +151,22 @@ To re-sync: go to **Settings → Integrations**, open the connection's `…` men
 Re-syncing may remove models that are no longer accessible. Agents that were configured to use those models will lose access to them.
 :::
 
+## While a connection is being set up
+
+OAuth connections (Gmail, Microsoft 365) have a brief **pending** phase between clicking **Connect** and finishing the provider's sign-in. Pinchy handles that window for you:
+
+- **The list updates itself.** The Integrations list polls while a connection is pending, so it flips to **connected** — or to an error — on its own, without a page reload.
+- **You can cancel a half-finished setup.** A pending row's button reads **Cancel setup** rather than Delete; use it if you started a connection you no longer want.
+- **Abandoned attempts clean themselves up.** A pending record that never completes is swept automatically after 15 minutes, so a closed browser tab or an abandoned sign-in doesn't leave a stray row behind.
+
+If the sign-in itself fails — most often a wrong Client Secret at the token-exchange step — Pinchy shows a **persistent error banner** on the Integrations tab that names the specific cause and the fix (for example, correcting the Client Secret under **Connected apps**). It stays until you dismiss it, rather than vanishing like a toast, because your attention is usually still on the provider's sign-in screen when it lands.
+
 ## When credentials expire or get revoked
 
 Pinchy detects permanent authentication failures — an expired API key, a revoked OAuth grant, a changed password — and surfaces them in two places:
 
 - The integration card on **Settings → Integrations** changes from a green checkmark to a red warning, with the failure reason from the upstream service.
-- The **Settings** entry in the sidebar shows a red `!` badge when one or more integrations need attention.
+- The **Settings** entry in the sidebar shows a red `!` badge when one or more integrations need attention. Opening Settings from that badge takes you straight to the **Integrations** tab — which carries its own error dot — so you land on the failing connection instead of hunting for it.
 
 To recover, open the integration's `…` menu and choose **Edit credentials** (or click **Reconnect** on the failed card). Update the affected field — for example, paste in a new API key. Non-secret fields stay pre-filled; secret fields are empty by default and left unchanged if you leave them blank. Pinchy validates the new credentials against the upstream service before saving, and clears the failed state on success. The connection keeps the same ID, so any agent permissions stay attached automatically.
 
@@ -175,6 +185,12 @@ A full reconnect is only needed if the app was permanently deleted rather than j
 :::note
 "App not configured" is computed on each page load, not stored — Pinchy doesn't persist this state anywhere. It appears the moment the app's credentials are missing and disappears the moment they're restored, with no manual step to clear it.
 :::
+
+### When the ENCRYPTION_KEY changed
+
+Integration credentials are encrypted at rest with the server's `ENCRYPTION_KEY`. If that key changes — an infrastructure migration, a mistaken rotation, a server rebuilt from scratch without the original key — Pinchy can no longer decrypt the connections written under the old key. Each one surfaces a red **"can't be read"** card on **Settings → Integrations**, noting that it was encrypted with a different `ENCRYPTION_KEY` than the one the server uses now.
+
+Unlike **"App not configured"**, this state does **not** clear on its own — there's no way to recover the old ciphertext without the old key. The only path forward is to **delete** the unreadable connection and **re-add** it under the current key. Keep `ENCRYPTION_KEY` stable across restarts and migrations to avoid this in the first place — see [Secrets](/security/secrets/).
 
 ## Security
 

--- a/docs/src/content/docs/explanation/skills-and-templates.mdx
+++ b/docs/src/content/docs/explanation/skills-and-templates.mdx
@@ -1,0 +1,42 @@
+---
+title: Skills, Templates, and Capabilities
+description: How a Pinchy skill teaches an agent to use its tools for a specific job — and how templates attach them.
+---
+
+import { Aside } from "@astrojs/starlight/components";
+
+An agent's behaviour comes from three separate layers, and it helps to keep them straight:
+
+- **Tools** are what an agent _can_ do — the operations it's allowed to call (search the web, read email, write an Odoo record). Tools are governed by [permissions](/concepts/agent-permissions/).
+- **Instructions** are who the agent _is_ and the rules it follows — its SOUL.md and AGENTS.md. See [Instructions vs. Memory](/explanation/instructions-vs-memory/).
+- **Skills** are _how_ the agent uses its tools for a particular job — a reusable workflow guide for a capability, like "monitor a market" or "triage a mailbox."
+
+A skill doesn't grant a tool and it isn't a personality. It's a playbook: a `SKILL.md` file that walks the agent through doing one thing well with the tools it already has.
+
+## How a skill reaches an agent
+
+Skills are attached through **templates**. When you create an agent from a template that includes a skill, Pinchy:
+
+1. Materializes the skill body into the agent's workspace at `skills/<skill-id>/SKILL.md`.
+2. Emits `skills: ["<skill-id>"]` in that agent's OpenClaw configuration.
+3. Lets OpenClaw load the `SKILL.md` into the agent's system prompt automatically — the workspace copy takes precedence over any bundled skill of the same name.
+
+Because Pinchy writes the skill files at config-regenerate time — alongside the AGENTS.md and SOUL.md bootstrap files — the skill travels with the agent and stays in sync with its configuration.
+
+<Aside type="note">
+  Skills are **template-driven today**: you get them by choosing a template, not
+  by ticking them individually in an agent's settings. Authoring custom skills
+  and assigning them per agent is on the roadmap — [master issue
+  #543](https://github.com/heypinchy/pinchy/issues/543) tracks the skill layer.
+</Aside>
+
+## The skills that ship today
+
+| Skill        | Attached by                                                                                   | What it teaches                                                                  |
+| ------------ | --------------------------------------------------------------------------------------------- | -------------------------------------------------------------------------------- |
+| `web-search` | [Market & News Monitor](/guides/create-market-monitor-agent/)                                 | A workflow for researching a topic with the web-search tools and reporting back. |
+| `email`      | [Email Assistant templates](/guides/connect-email/#email-agent-templates-use-the-email-skill) | A workflow for triaging, reading, and drafting mail with the email tools.        |
+
+## Why an allow-list of skills
+
+OpenClaw ships dozens of bundled "desktop" skills (1Password, Apple Notes, and the like) that make no sense for a governed enterprise agent. Pinchy's `skills: [...]` entry is an **allow-list**: it enables exactly the Pinchy-authored skills an agent's template attached, and nothing else. That's the same fail-closed principle Pinchy applies to [tools](/concepts/agent-permissions/#how-permissions-reach-openclaw) — list only what's trusted, and deny the rest by default.

--- a/docs/src/content/docs/guides/create-market-monitor-agent.mdx
+++ b/docs/src/content/docs/guides/create-market-monitor-agent.mdx
@@ -61,4 +61,4 @@ Market & News Monitor was the first template built on Pinchy's skill layer (mast
 
 The [Email Assistant templates](/guides/connect-email/#email-agent-templates-use-the-email-skill) work the same way, attaching an `email` skill instead of `web-search`.
 
-You can read more about how skills work in [Skills, Templates, and Capabilities](/explanation/skills-and-templates/) (forthcoming).
+You can read more about how skills work in [Skills, Templates, and Capabilities](/explanation/skills-and-templates/).

--- a/packages/web/src/lib/docs-paths.generated.ts
+++ b/packages/web/src/lib/docs-paths.generated.ts
@@ -16,6 +16,7 @@ export const DOCS_PATHS = [
   "explanation/agent-memory",
   "explanation/chat-states",
   "explanation/instructions-vs-memory",
+  "explanation/skills-and-templates",
   "getting-started",
   "glossary/ai-agent-audit-trail",
   "glossary/ai-agent-governance",


### PR DESCRIPTION
## Why

Follow-ups from the pre-release **docs audit across all 329 commits since v0.7.0** (the "anything else to document?" pass). Unlike #683, **nothing here was wrong** — these are coverage additions for user-facing behavior that shipped without docs. Per "do it all now," they land before the v0.8.0 cut so the published docs are complete.

## Changes

**New page — `explanation/skills-and-templates.mdx`** (the biggest gap: a `create-market-monitor-agent.mdx` link pointed at a "(forthcoming)" page that 404'd):
- What a skill is — a `SKILL.md` workflow guide, distinct from tools (what an agent *can* do) and instructions (who it *is*).
- How templates attach skills: materialized to `<workspace>/skills/<id>/SKILL.md`, emitted as an **allow-list** in `openclaw.json` (excluding OpenClaw's bundled desktop skills), auto-loaded by OpenClaw.
- The `web-search` and `email` skills shipping today.
- Honest scope note: **template-driven, not yet user-selectable** ([#543](https://github.com/heypinchy/pinchy/issues/543)).
- Wired into the sidebar (`astro.config.mjs`) and the regenerated `docs-paths.generated.ts` so the `pinchy-docs` plugin serves it; the market-monitor link is now real (no "forthcoming").

**`concepts/integrations.mdx`** — three additions:
- **"While a connection is being set up"** — the pending phase: live polling (no reload), **Cancel setup**, 15-minute auto-sweep of abandoned attempts, and the persistent setup-failure banner.
- **"When the ENCRYPTION_KEY changed"** — the "can't be read" state and its only recovery (delete + re-add under the current key).
- **Error trail** — the sidebar needs-attention badge deep-links to the Integrations tab.

## Verification

Every claim checked against source: `workspace.ts` (skill materialization + allow-list), `sidebar.tsx:52` (`?tab=integrations` deep-link), `oauth/start` route (15-min sweep), `settings-integrations.tsx:320` ("can't be read" copy + delete recovery). Docs build green (60 pages); `docs-link` test (63) + `test:scripts` guards green.

> Note: the audit also confirmed the diagnostics-export doc (`reporting-issues.mdx`) is already thorough (config snapshot + own-chats scope) — no change needed there. The lower-value UX items (error-banner enumeration, etc.) are intentionally not documented.

Lands before the v0.8.0 cut.