### PR TITLE
feat(telegram): auto-disable recently-added bots on sustained getUpdates-409 conflict (#477 layer 2)

### DIFF
--- a/docs/src/content/docs/guides/telegram-setup.mdx
+++ b/docs/src/content/docs/guides/telegram-setup.mdx
@@ -64,6 +64,10 @@ Pinchy's main Telegram bot must already be set up in **Settings → Telegram** (
 Each bot token can only be used by one agent. If you try to use the same token for two agents on this deployment, Pinchy will reject it.
 
 This check is per-deployment, though — Pinchy can't see a _different_ Pinchy (a staging stack, a local dev stack) polling the same token. Telegram allows only one poller per bot, so if two deployments share a token they fight over it: one wins each round, the other gets a `getUpdates` 409 "Conflict: terminated by other getUpdates request", and the bot drops messages while OpenClaw crash-restarts the channel. **Give each environment its own bot token.** If it does happen anyway, Pinchy's channel-health watchdog catches it — a **Degraded** badge appears on the agent's Telegram settings and `channel.degraded` / `channel.polling_failed` rows land in the [audit trail](/concepts/audit-trail/).
+
+If the conflict is sustained and the bot on this deployment was **connected recently** (within the last 24 hours), we go a step further: we automatically disable it. The idea is that the newcomer backs off so the deployment that's been running the token for a while doesn't get disrupted by an environment that just showed up. When we auto-disable an account, we stop polling for it, clear its Telegram user pairings, and record a `channel.auto_disabled` audit row — a persistent, actionable message appears on the agent's Telegram settings explaining what happened. The disable survives a restart, so you won't see the bot quietly come back the next time Pinchy starts. Once you've stopped the token elsewhere (or switched to a separate one), click **Reconnect** to clear the disabled state and try again.
+
+A long-standing connection is never auto-disabled this way — only the side that just showed up. If you'd rather handle conflicts manually, set `TELEGRAM_CONFLICT_AUTO_DISABLE=false` in your deployment's environment; the **Degraded** badge and audit trail keep working as before, we just won't disable anything automatically.
 :::
 
 ## How Permissions Work

--- a/packages/web/e2e/telegram/channel-health.spec.ts
+++ b/packages/web/e2e/telegram/channel-health.spec.ts
@@ -26,12 +26,15 @@ import {
   setMockConflict409,
   pollAuditForChannelEvent,
   resetMockTelegram,
+  getTelegramChannelStatus,
 } from "./helpers";
 
-// Distinct bot ids (8101… vs 8102…) so the within-deployment duplicate-token
-// guard is satisfied and these tokens don't collide with other telegram specs.
+// Distinct bot ids (8101… vs 8102… vs 8103…) so the within-deployment
+// duplicate-token guard is satisfied and these tokens don't collide with
+// other telegram specs.
 const MAIN_BOT_TOKEN = "8101000001:AAEchannelHealthMainBot0000000000000";
 const CONFLICT_BOT_TOKEN = "8102000002:AAEchannelHealthConflictBot00000000";
+const AUTO_DISABLE_BOT_TOKEN = "8103000003:AAEchannelHealthAutoDisableBot000000";
 
 test.describe("channel-health watchdog", () => {
   test.beforeAll(async () => {
@@ -97,6 +100,44 @@ test.describe("channel-health watchdog", () => {
       expect(recovered.outcome).toBe("success");
 
       await disconnectBot(agent.id);
+      await disconnectBot(smithers);
+    }
+  );
+
+  // #477 layer 2: a RECENTLY-connected bot (this one — connected seconds ago
+  // by this very test) hitting the getUpdates-409 conflict gets auto-disabled
+  // once the conflict is sustained past the polling_failed threshold — the
+  // newcomer backs off automatically instead of both instances looping
+  // forever. Reuses the same conflict-injection mechanism as the test above;
+  // distinct bot id so the two specs don't collide.
+  test(
+    "auto-disables a recently-connected bot on a sustained getUpdates-409 conflict",
+    { tag: "@channel-restart" },
+    async () => {
+      const smithers = await getAgentId();
+      await connectBot(smithers, MAIN_BOT_TOKEN);
+      await waitForBotPolling(MAIN_BOT_TOKEN);
+
+      const existing = await getAgentByName("ChannelHealthAutoDisableBot");
+      const agent = existing ?? (await createAgent("ChannelHealthAutoDisableBot"));
+      await connectBot(agent.id, AUTO_DISABLE_BOT_TOKEN);
+      await waitForBotPolling(AUTO_DISABLE_BOT_TOKEN);
+
+      // Second deployment polls the same token → sustained 409 for this bot.
+      await setMockConflict409(AUTO_DISABLE_BOT_TOKEN, true);
+
+      const autoDisabled = await pollAuditForChannelEvent("channel.auto_disabled", agent.id);
+      expect(autoDisabled.outcome).toBe("success");
+      expect(autoDisabled.resource).toBe(`agent:${agent.id}`);
+      expect(autoDisabled.detail.channel).toBe("telegram");
+      expect(String(autoDisabled.detail.lastError)).toContain(
+        "terminated by other getUpdates request"
+      );
+
+      const status = await getTelegramChannelStatus(agent.id);
+      expect(status.conflictDisabled).toBe(true);
+
+      await setMockConflict409(AUTO_DISABLE_BOT_TOKEN, false);
       await disconnectBot(smithers);
     }
   );

--- a/packages/web/e2e/telegram/helpers.ts
+++ b/packages/web/e2e/telegram/helpers.ts
@@ -142,6 +142,24 @@ export async function disconnectBot(agentId: string): Promise<void> {
   }
 }
 
+export interface TelegramChannelStatus {
+  configured: boolean;
+  hint?: string;
+  mainBotConfigured?: boolean;
+  conflictDisabled?: boolean;
+  conflictDisabledAt?: string;
+  lastError?: string;
+}
+
+/** GET an agent's telegram channel status (#477 layer 2: includes conflictDisabled). */
+export async function getTelegramChannelStatus(agentId: string): Promise<TelegramChannelStatus> {
+  const res = await pinchyGet(`/api/agents/${agentId}/channels/telegram`);
+  if (!res.ok) {
+    throw new Error(`getTelegramChannelStatus failed: ${res.status} ${await res.text()}`);
+  }
+  return res.json();
+}
+
 // ── Telegram link helpers ──────────────────────────────────────────────
 
 export async function linkTelegram(pairingCode: string): Promise<Response> {

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -18,6 +18,7 @@ import {
   startChannelHealthWatchdog,
   CHANNEL_HEALTH_INTERVAL_MS,
   DEFAULT_TERMINAL_AFTER_CONSECUTIVE_DEGRADED,
+  parseRecentlyAddedWindowMs,
 } from "./src/server/channel-health-watchdog";
 import { setChannelHealthMonitor } from "./src/server/channel-health-singleton";
 import { appendAuditLog, safeProviderError } from "./src/lib/audit";
@@ -487,8 +488,9 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       .trim()
       .toLowerCase();
     const autoDisableEnabled = !["false", "0", "no"].includes(autoDisableEnvRaw);
-    const recentlyAddedWindowMs =
-      Number(process.env.TELEGRAM_CONFLICT_RECENT_WINDOW_MS) || 86_400_000;
+    const recentlyAddedWindowMs = parseRecentlyAddedWindowMs(
+      process.env.TELEGRAM_CONFLICT_RECENT_WINDOW_MS
+    );
 
     const stopChannelHealth = startChannelHealthWatchdog(
       channelHealthMonitor,

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -20,11 +20,14 @@ import {
   DEFAULT_TERMINAL_AFTER_CONSECUTIVE_DEGRADED,
 } from "./src/server/channel-health-watchdog";
 import { setChannelHealthMonitor } from "./src/server/channel-health-singleton";
-import { appendAuditLog } from "./src/lib/audit";
+import { appendAuditLog, safeProviderError } from "./src/lib/audit";
 import { recordAuditFailure } from "./src/lib/audit-deferred";
 import { db, closeDb } from "./src/db";
-import { agents } from "./src/db/schema";
-import { eq } from "drizzle-orm";
+import { agents, auditLog } from "./src/db/schema";
+import { eq, and, desc } from "drizzle-orm";
+import { getSetting, setSetting } from "./src/lib/settings";
+import { updateTelegramChannelConfig } from "./src/lib/openclaw-config";
+import { clearAllowStoreForAccount } from "./src/lib/telegram-allow-store";
 import { WsRateLimiter } from "./src/server/ws-rate-limit";
 import { setupOpenClawDisconnectHandler } from "./src/server/openclaw-disconnect-handler";
 import {
@@ -458,6 +461,35 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
     // healthy→degraded→failed→recovered transitions so operators finally see it.
     const channelHealthMonitor = new ChannelHealthMonitor();
     setChannelHealthMonitor(channelHealthMonitor);
+
+    // Shared with the auto-disable audit below so the {id,name} snapshot is
+    // resolved the same way regardless of which event triggered it.
+    const resolveAccountName = async (
+      _channel: string,
+      accountId: string
+    ): Promise<string | null> => {
+      try {
+        const a = await db.query.agents.findFirst({
+          where: eq(agents.id, accountId),
+          columns: { name: true },
+        });
+        return a?.name ?? null;
+      } catch {
+        return null;
+      }
+    };
+
+    // #477 layer 2: env-flag opt-out for auto-disable (degraded/polling_failed
+    // audits still fire regardless — this only gates the disable action).
+    // "false"/"0"/"no" (case-insensitive) turn it off; anything else, including
+    // unset, defaults to enabled.
+    const autoDisableEnvRaw = (process.env.TELEGRAM_CONFLICT_AUTO_DISABLE ?? "")
+      .trim()
+      .toLowerCase();
+    const autoDisableEnabled = !["false", "0", "no"].includes(autoDisableEnvRaw);
+    const recentlyAddedWindowMs =
+      Number(process.env.TELEGRAM_CONFLICT_RECENT_WINDOW_MS) || 86_400_000;
+
     const stopChannelHealth = startChannelHealthWatchdog(
       channelHealthMonitor,
       {
@@ -468,17 +500,7 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
           restartState.isRestarting
             ? Promise.reject(new Error("openclaw restarting"))
             : ocForWatchdog.channels.status(),
-        resolveAccountName: async (_channel, accountId) => {
-          try {
-            const a = await db.query.agents.findFirst({
-              where: eq(agents.id, accountId),
-              columns: { name: true },
-            });
-            return a?.name ?? null;
-          } catch {
-            return null;
-          }
-        },
+        resolveAccountName,
         writeAudit: async (entry) => {
           try {
             await appendAuditLog(entry);
@@ -488,6 +510,73 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
         },
         now: () => Date.now(),
         terminalAfterConsecutiveDegraded: DEFAULT_TERMINAL_AFTER_CONSECUTIVE_DEGRADED,
+        autoDisableEnabled,
+        recentlyAddedWindowMs,
+        // Age of the account's connection = time since its `channel.created`
+        // audit row (the most recent one for this resource — a reconnect
+        // after a prior disable resets the clock, which is correct: a fresh
+        // reconnect IS a newcomer again). Null when no such row exists.
+        getConnectionAgeMs: async (_channel, accountId) => {
+          try {
+            const [row] = await db
+              .select({ timestamp: auditLog.timestamp })
+              .from(auditLog)
+              .where(
+                and(
+                  eq(auditLog.eventType, "channel.created"),
+                  eq(auditLog.resource, `agent:${accountId}`)
+                )
+              )
+              .orderBy(desc(auditLog.timestamp))
+              .limit(1);
+            if (!row) return null;
+            return Date.now() - row.timestamp.getTime();
+          } catch {
+            return null;
+          }
+        },
+        // #477 layer 2: disable the account so it survives a restart (build.ts
+        // skips it on regen), stop the poller promptly via the same
+        // config.apply/reload path connect/disconnect already use, and clear
+        // its allow-store. Non-request context — try/catch + recordAuditFailure
+        // per AGENTS.md, not a bare .catch(console.error).
+        autoDisableConflictedAccount: async (channel, accountId, lastError) => {
+          // Defensive: skip if already disabled (e.g. a race with a manual
+          // disconnect, or the monitor somehow re-entering for the same episode).
+          const already = await getSetting(`telegram_conflict_disabled:${accountId}`);
+          if (already) return;
+
+          await setSetting(
+            `telegram_conflict_disabled:${accountId}`,
+            JSON.stringify({
+              reason: "polling_conflict",
+              lastError: safeProviderError(lastError),
+              disabledAt: new Date().toISOString(),
+            })
+          );
+          updateTelegramChannelConfig(accountId, null);
+          clearAllowStoreForAccount(accountId);
+
+          const name = await resolveAccountName(channel, accountId);
+          const entry = {
+            actorType: "system" as const,
+            actorId: "channel-watchdog",
+            eventType: "channel.auto_disabled" as const,
+            resource: `agent:${accountId}`,
+            outcome: "success" as const,
+            detail: {
+              channel,
+              account: { id: accountId, name },
+              reason: "polling_conflict",
+              lastError: safeProviderError(lastError),
+            },
+          };
+          try {
+            await appendAuditLog(entry);
+          } catch (err) {
+            recordAuditFailure(err, entry);
+          }
+        },
       },
       Number(process.env.CHANNEL_HEALTH_INTERVAL_MS) || CHANNEL_HEALTH_INTERVAL_MS
     );

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -124,7 +124,35 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toEqual({ configured: true, hint: "xY9z", mainBotConfigured: true });
+    expect(data).toEqual({
+      configured: true,
+      hint: "xY9z",
+      mainBotConfigured: true,
+      conflictDisabled: false,
+    });
+  });
+
+  it("surfaces conflictDisabled: true when the disabled marker is set (#477 layer 2)", async () => {
+    vi.mocked(getSetting).mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "123456:ABC-some-token-xY9z";
+      if (key === "telegram_conflict_disabled:agent-1")
+        return JSON.stringify({
+          reason: "polling_conflict",
+          lastError: "Conflict: terminated by other getUpdates request",
+          disabledAt: "2026-07-08T00:00:00.000Z",
+        });
+      return null;
+    });
+
+    const response = await GET(new Request("http://localhost"), {
+      params: mockParams,
+    });
+    const data = await response.json();
+
+    expect(response.status).toBe(200);
+    expect(data.conflictDisabled).toBe(true);
+    expect(data.conflictDisabledAt).toBe("2026-07-08T00:00:00.000Z");
+    expect(data.lastError).toBe("Conflict: terminated by other getUpdates request");
   });
 
   it("returns mainBotConfigured: true when the main bot exists", async () => {
@@ -155,7 +183,10 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
 
   it("still returns hint and mainBotConfigured when agent has its own bot", async () => {
     mockHasMainTelegramBot.mockResolvedValueOnce(true);
-    vi.mocked(getSetting).mockResolvedValueOnce("123456:ABC-some-token-xY9z");
+    vi.mocked(getSetting).mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "123456:ABC-some-token-xY9z";
+      return null;
+    });
 
     const response = await GET(new Request("http://localhost"), {
       params: mockParams,
@@ -163,7 +194,12 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     const data = await response.json();
 
     expect(response.status).toBe(200);
-    expect(data).toEqual({ configured: true, hint: "xY9z", mainBotConfigured: true });
+    expect(data).toEqual({
+      configured: true,
+      hint: "xY9z",
+      mainBotConfigured: true,
+      conflictDisabled: false,
+    });
   });
 
   it("returns 401 when not authenticated", async () => {
@@ -232,6 +268,15 @@ describe("POST /api/agents/[agentId]/channels/telegram", () => {
         }),
       })
     );
+  });
+
+  it("clears the conflict-disabled marker on a successful connect, so [Reconnect] re-enables the account (#477 layer 2)", async () => {
+    const response = await POST(makeRequest({ botToken: "123456:ABC-token" }), {
+      params: mockParams,
+    });
+
+    expect(response.status).toBe(200);
+    expect(deleteSetting).toHaveBeenCalledWith("telegram_conflict_disabled:agent-1");
   });
 
   it("does not mutate channels.telegram on validation failure", async () => {
@@ -394,6 +439,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
 
     expect(deleteSetting).toHaveBeenCalledWith("telegram_bot_token:agent-1");
     expect(deleteSetting).toHaveBeenCalledWith("telegram_bot_username:agent-1");
+    expect(deleteSetting).toHaveBeenCalledWith("telegram_conflict_disabled:agent-1");
     expect(mockClearAllowStoreForAccount).toHaveBeenCalledWith("agent-1");
     expect(mockUpdateTelegramChannelConfig).toHaveBeenCalled();
     expect(appendAuditLog).toHaveBeenCalledWith(

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -179,5 +179,55 @@ describe("AgentTelegramSettings", () => {
       expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
       expect(screen.getByRole("button", { name: /^Connect$/i })).toBeInTheDocument();
     });
+
+    it("shows the Connected confirmation (not a fresh empty connect form) after a successful reconnect", async () => {
+      // First GET → auto-disabled. POST connect → success. The follow-up
+      // fetchConfig GET → no longer disabled (marker cleared server-side). The
+      // user must land on the Connected state, not back on an empty token form:
+      // regression where `showReconnectForm` stayed true forever after Reconnect.
+      let telegramGetCount = 0;
+      global.fetch = vi.fn().mockImplementation((url: string, init?: RequestInit) => {
+        if (typeof url === "string" && url.includes("/channels/telegram")) {
+          if (init?.method === "POST") {
+            return Promise.resolve({
+              ok: true,
+              json: () => Promise.resolve({ botUsername: "acme_bot", botId: "123" }),
+            });
+          }
+          telegramGetCount++;
+          const disabled = telegramGetCount === 1;
+          return Promise.resolve({
+            ok: true,
+            json: () =>
+              Promise.resolve({
+                configured: true,
+                hint: "xY9z",
+                mainBotConfigured: true,
+                conflictDisabled: disabled,
+                ...(disabled
+                  ? { lastError: "Conflict: terminated by other getUpdates request" }
+                  : {}),
+              }),
+          });
+        }
+        return Promise.resolve({ ok: false });
+      });
+
+      render(<AgentTelegramSettings agentId="agent-1" />);
+
+      const reconnectButton = await screen.findByRole("button", { name: /reconnect/i });
+      await userEvent.click(reconnectButton);
+
+      await userEvent.type(screen.getByLabelText(/Bot Token/i), "123456:ABC-fresh-token");
+      await userEvent.click(screen.getByRole("button", { name: /^Connect$/i }));
+
+      // The connected state owns the Disconnect action; the empty connect form
+      // owns the Bot Token field. After a successful reconnect the user must be
+      // back on the connected view, not stranded on the token form.
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /disconnect/i })).toBeInTheDocument();
+      });
+      expect(screen.queryByLabelText(/Bot Token/i)).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
+++ b/packages/web/src/__tests__/components/agent-telegram-settings.test.tsx
@@ -1,6 +1,7 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import "@testing-library/jest-dom";
 import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
 import { AgentTelegramSettings } from "@/components/agent-telegram-settings";
 
 vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
@@ -117,6 +118,66 @@ describe("AgentTelegramSettings", () => {
 
     await waitFor(() => {
       expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
+    });
+  });
+
+  // #477 layer 2: an account auto-disabled after a sustained getUpdates-409
+  // conflict must show a PERSISTENT inline actionable state (not a toast —
+  // this is a permanent condition per the project's error/notification
+  // policy), with a way to re-enable it.
+  describe("conflict auto-disabled state (#477 layer 2)", () => {
+    it("renders a persistent disabled message with a Reconnect button when conflictDisabled is true", async () => {
+      global.fetch = mockFetch({
+        configured: true,
+        hint: "xY9z",
+        mainBotConfigured: true,
+        conflictDisabled: true,
+        lastError: "Conflict: terminated by other getUpdates request",
+      });
+
+      render(<AgentTelegramSettings agentId="agent-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/disabled/i)).toBeInTheDocument();
+      });
+      expect(
+        screen.getByText(/another deployment|separate token|stopped it there/i)
+      ).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /reconnect/i })).toBeInTheDocument();
+    });
+
+    it("does not render the disabled banner when conflictDisabled is false", async () => {
+      global.fetch = mockFetch({
+        configured: true,
+        hint: "xY9z",
+        mainBotConfigured: true,
+        conflictDisabled: false,
+      });
+
+      render(<AgentTelegramSettings agentId="agent-1" />);
+
+      await waitFor(() => {
+        expect(screen.getByText(/Connected/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByRole("button", { name: /reconnect/i })).not.toBeInTheDocument();
+    });
+
+    it("clicking Reconnect reveals the connect flow so the user can re-submit a token", async () => {
+      global.fetch = mockFetch({
+        configured: true,
+        hint: "xY9z",
+        mainBotConfigured: true,
+        conflictDisabled: true,
+        lastError: "Conflict: terminated by other getUpdates request",
+      });
+
+      render(<AgentTelegramSettings agentId="agent-1" />);
+
+      const reconnectButton = await screen.findByRole("button", { name: /reconnect/i });
+      await userEvent.click(reconnectButton);
+
+      expect(screen.getByLabelText(/Bot Token/i)).toBeInTheDocument();
+      expect(screen.getByRole("button", { name: /^Connect$/i })).toBeInTheDocument();
     });
   });
 });

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -20,3 +20,22 @@ describe("AuditLogEntry agent.memory_changed", () => {
     expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>();
   });
 });
+
+describe("AuditLogEntry channel.auto_disabled (#477 layer 2)", () => {
+  it("accepts the expected detail shape", () => {
+    const entry: AuditLogEntry = {
+      actorType: "system",
+      actorId: "channel-watchdog",
+      eventType: "channel.auto_disabled",
+      resource: "agent:agent-123",
+      outcome: "success",
+      detail: {
+        channel: "telegram",
+        account: { id: "agent-123", name: "Support Bot" },
+        reason: "polling_conflict",
+        lastError: "Conflict: terminated by other getUpdates request",
+      },
+    };
+    expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>();
+  });
+});

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -5359,6 +5359,80 @@ describe("restart-state integration", () => {
     ]);
   });
 
+  // #477 layer 2: config regeneration must skip an auto-disabled account even
+  // though its bot token still exists in settings — this is what makes the
+  // disable survive a Pinchy restart / full config regen (not just the
+  // targeted config write at disable time). "Test Migrations Against
+  // Pre-Existing Data": simulates the pre-existing state (token + disabled
+  // marker both present) that a real restart would encounter.
+  it("should skip a telegram account whose telegram_conflict_disabled marker is set, even though its bot token still exists", async () => {
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "agent-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "123456:ABC-token";
+      if (key === "telegram_bot_username:agent-1") return "acme_smithers_bot";
+      if (key === "telegram_conflict_disabled:agent-1")
+        return JSON.stringify({
+          reason: "polling_conflict",
+          lastError: "Conflict: terminated by other getUpdates request",
+          disabledAt: new Date().toISOString(),
+        });
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.channels?.telegram?.accounts?.["agent-1"]).toBeUndefined();
+    expect(
+      (config.bindings ?? []).some(
+        (b: { match?: { accountId?: string } }) => b.match?.accountId === "agent-1"
+      )
+    ).toBe(false);
+  });
+
+  it("should include the telegram account when the token exists and no disabled marker is set (inverse of the auto-disable skip)", async () => {
+    mockedDb.select.mockReturnValue({
+      from: mockFrom([
+        {
+          id: "agent-1",
+          name: "Smithers",
+          model: "anthropic/claude-haiku-4-5-20251001",
+          allowedTools: [],
+          createdAt: new Date(),
+        },
+      ]),
+    } as never);
+
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "telegram_bot_token:agent-1") return "123456:ABC-token";
+      if (key === "telegram_bot_username:agent-1") return "acme_smithers_bot";
+      if (key === "telegram_conflict_disabled:agent-1") return null;
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+
+    expect(config.channels.telegram.accounts).toEqual({
+      "agent-1": { botToken: "123456:ABC-token" },
+    });
+  });
+
   it("should generate per-user peer bindings for personal agents (Smithers)", async () => {
     // Personal agent (Smithers) with bot token: each linked user should get
     // a peer-specific binding routing to their OWN personal Smithers agent.

--- a/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
+++ b/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
@@ -20,6 +20,8 @@ import {
 describe("ChannelHealthMonitor", () => {
   let writeAudit: ReturnType<typeof vi.fn>;
   let getChannelStatus: ReturnType<typeof vi.fn>;
+  let autoDisableConflictedAccount: ReturnType<typeof vi.fn>;
+  let getConnectionAgeMs: ReturnType<typeof vi.fn>;
   let monitor: ChannelHealthMonitor;
   let clock: number;
   let deps: ChannelHealthDeps;
@@ -27,6 +29,9 @@ describe("ChannelHealthMonitor", () => {
   beforeEach(() => {
     writeAudit = vi.fn().mockResolvedValue(undefined);
     getChannelStatus = vi.fn();
+    autoDisableConflictedAccount = vi.fn().mockResolvedValue(undefined);
+    // Default: recently-added (1 hour old), well inside the 24h window.
+    getConnectionAgeMs = vi.fn().mockResolvedValue(60 * 60 * 1000);
     clock = 1_000_000;
     monitor = new ChannelHealthMonitor();
     deps = {
@@ -35,6 +40,10 @@ describe("ChannelHealthMonitor", () => {
       writeAudit,
       now: () => clock,
       terminalAfterConsecutiveDegraded: 3,
+      autoDisableConflictedAccount,
+      getConnectionAgeMs,
+      autoDisableEnabled: true,
+      recentlyAddedWindowMs: 86_400_000,
     };
   });
 
@@ -164,5 +173,113 @@ describe("ChannelHealthMonitor", () => {
     const degraded = auditsOfType("channel.degraded");
     expect(degraded).toHaveLength(1);
     expect(degraded[0].detail.account.id).toBe("acct-2");
+  });
+
+  // Auto-disable (#477 layer 2): a RECENTLY-ADDED account whose lastError is
+  // the Telegram getUpdates-409 conflict signal gets auto-disabled the moment
+  // it crosses into polling_failed — the newcomer backs off so the incumbent
+  // survives. Long-standing connections, non-conflict failures, and a disabled
+  // feature flag must never trigger it.
+  describe("auto-disable on sustained polling conflict", () => {
+    it("calls autoDisableConflictedAccount exactly once when polling_failed fires for a recently-added conflicted account", async () => {
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps); // 1 (degraded)
+      await monitor.tick(deps); // 2
+      expect(autoDisableConflictedAccount).not.toHaveBeenCalled();
+      await monitor.tick(deps); // 3 -> terminal, fires auto-disable
+      await monitor.tick(deps); // 4 -> must NOT re-fire
+      expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(1);
+      expect(autoDisableConflictedAccount).toHaveBeenCalledWith(
+        "telegram",
+        "29ea51b1-67af-4fad-8864-f550c7543333",
+        expect.stringContaining("terminated by other getUpdates request")
+      );
+    });
+
+    it("does NOT auto-disable a long-standing connection (age >= window) but still audits channel.polling_failed", async () => {
+      getConnectionAgeMs.mockResolvedValue(86_400_000); // exactly at the window boundary
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal
+      expect(autoDisableConflictedAccount).not.toHaveBeenCalled();
+      expect(auditsOfType("channel.polling_failed")).toHaveLength(1);
+    });
+
+    it("does NOT auto-disable when connection age is unknown (null)", async () => {
+      getConnectionAgeMs.mockResolvedValue(null);
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal
+      expect(autoDisableConflictedAccount).not.toHaveBeenCalled();
+      expect(auditsOfType("channel.polling_failed")).toHaveLength(1);
+    });
+
+    it("does NOT auto-disable when lastError doesn't match the conflict signal", async () => {
+      const status = degradedTelegramStatus(2) as Record<string, unknown>;
+      (
+        status.channelAccounts as Record<string, Array<Record<string, unknown>>>
+      ).telegram[0].lastError = "ETIMEDOUT: connection reset";
+      (status.channels as Record<string, Record<string, unknown>>).telegram.lastError =
+        "ETIMEDOUT: connection reset";
+      getChannelStatus.mockResolvedValue(status);
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal
+      expect(autoDisableConflictedAccount).not.toHaveBeenCalled();
+      expect(auditsOfType("channel.polling_failed")).toHaveLength(1);
+    });
+
+    it("matches the conflict signal case-insensitively", async () => {
+      const status = degradedTelegramStatus(2) as Record<string, unknown>;
+      const upper = "CONFLICT: TERMINATED BY OTHER GETUPDATES REQUEST";
+      (
+        status.channelAccounts as Record<string, Array<Record<string, unknown>>>
+      ).telegram[0].lastError = upper;
+      getChannelStatus.mockResolvedValue(status);
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal
+      expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(1);
+    });
+
+    it("never calls autoDisableConflictedAccount when autoDisableEnabled is false", async () => {
+      deps.autoDisableEnabled = false;
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal
+      expect(autoDisableConflictedAccount).not.toHaveBeenCalled();
+      expect(auditsOfType("channel.polling_failed")).toHaveLength(1);
+    });
+
+    it("swallows a rejecting autoDisableConflictedAccount without poisoning the tick", async () => {
+      autoDisableConflictedAccount.mockRejectedValue(new Error("db down"));
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await expect(monitor.tick(deps)).resolves.toBeUndefined(); // terminal tick
+      expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(1);
+      // The polling_failed audit still landed despite the auto-disable rejection.
+      expect(auditsOfType("channel.polling_failed")).toHaveLength(1);
+    });
+
+    it("does not re-fire auto-disable on a fresh degradation episode after recovery", async () => {
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal -> fires once
+      expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(1);
+
+      getChannelStatus.mockResolvedValue(healthyTelegramStatus());
+      await monitor.tick(deps); // recovered
+
+      getChannelStatus.mockResolvedValue(degradedTelegramStatus(2));
+      await monitor.tick(deps);
+      await monitor.tick(deps);
+      await monitor.tick(deps); // terminal again in the new episode
+      expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(2);
+    });
   });
 });

--- a/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
+++ b/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
@@ -10,7 +10,12 @@
  *   degraded → healthy                emit one `channel.recovered`
  */
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { ChannelHealthMonitor, type ChannelHealthDeps } from "@/server/channel-health-watchdog";
+import {
+  ChannelHealthMonitor,
+  type ChannelHealthDeps,
+  parseRecentlyAddedWindowMs,
+  DEFAULT_RECENTLY_ADDED_WINDOW_MS,
+} from "@/server/channel-health-watchdog";
 import {
   healthyTelegramStatus,
   degradedTelegramStatus,
@@ -281,5 +286,35 @@ describe("ChannelHealthMonitor", () => {
       await monitor.tick(deps); // terminal again in the new episode
       expect(autoDisableConflictedAccount).toHaveBeenCalledTimes(2);
     });
+  });
+});
+
+// #477 layer 2: the recently-added window env var must be parsed so an explicit
+// `0` (operator turning the recently-added gate off) is honored, instead of the
+// `Number(x) || DEFAULT` footgun that silently reverts 0 to the 24h default.
+describe("parseRecentlyAddedWindowMs", () => {
+  it("returns the default when the env var is unset", () => {
+    expect(parseRecentlyAddedWindowMs(undefined)).toBe(DEFAULT_RECENTLY_ADDED_WINDOW_MS);
+  });
+
+  it("returns the default for an empty or whitespace value", () => {
+    expect(parseRecentlyAddedWindowMs("")).toBe(DEFAULT_RECENTLY_ADDED_WINDOW_MS);
+    expect(parseRecentlyAddedWindowMs("   ")).toBe(DEFAULT_RECENTLY_ADDED_WINDOW_MS);
+  });
+
+  it("returns the default for a non-numeric value", () => {
+    expect(parseRecentlyAddedWindowMs("abc")).toBe(DEFAULT_RECENTLY_ADDED_WINDOW_MS);
+  });
+
+  it("returns the default for a negative value", () => {
+    expect(parseRecentlyAddedWindowMs("-5")).toBe(DEFAULT_RECENTLY_ADDED_WINDOW_MS);
+  });
+
+  it("honors an explicit 0 instead of falling back to the default", () => {
+    expect(parseRecentlyAddedWindowMs("0")).toBe(0);
+  });
+
+  it("returns a valid positive numeric value", () => {
+    expect(parseRecentlyAddedWindowMs("60000")).toBe(60000);
   });
 });

--- a/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/channels/telegram/route.ts
@@ -42,7 +42,38 @@ export async function GET(req: Request, { params }: { params: Promise<{ agentId:
   }
 
   const hint = botToken.slice(-4);
-  return NextResponse.json({ configured: true, hint, mainBotConfigured });
+
+  // #477 layer 2: surface the auto-disable state so the UI can show a
+  // persistent, actionable banner instead of silently looking "connected"
+  // while config regeneration is actually skipping this account.
+  const disabledRaw = await getSetting(`telegram_conflict_disabled:${agentId}`);
+  let conflictDisabled = false;
+  let conflictDisabledAt: string | undefined;
+  let lastError: string | undefined;
+  if (disabledRaw) {
+    try {
+      const parsed = JSON.parse(disabledRaw) as {
+        reason?: string;
+        lastError?: string;
+        disabledAt?: string;
+      };
+      conflictDisabled = true;
+      conflictDisabledAt = parsed.disabledAt;
+      lastError = parsed.lastError;
+    } catch {
+      // Malformed marker — treat as disabled (fail safe) without the extra detail.
+      conflictDisabled = true;
+    }
+  }
+
+  return NextResponse.json({
+    configured: true,
+    hint,
+    mainBotConfigured,
+    conflictDisabled,
+    ...(conflictDisabledAt ? { conflictDisabledAt } : {}),
+    ...(lastError ? { lastError } : {}),
+  });
 }
 
 export async function POST(req: NextRequest, { params }: { params: Promise<{ agentId: string }> }) {
@@ -96,6 +127,10 @@ export async function POST(req: NextRequest, { params }: { params: Promise<{ age
   // DB first (source of truth)
   await setSetting(`telegram_bot_token:${agentId}`, botToken, true);
   await setSetting(`telegram_bot_username:${agentId}`, validation.botUsername!, false);
+  // #477 layer 2: a successful (re)connect clears any prior auto-disable, so
+  // the next config regen includes this account again — this is the
+  // [Reconnect] path referenced in the disabled-state UI.
+  await deleteSetting(`telegram_conflict_disabled:${agentId}`);
 
   // Update only Telegram channel config (targeted write — preserves OpenClaw-enriched
   // fields like agents.defaults to avoid hot-reloads that break polling).
@@ -147,6 +182,9 @@ export const DELETE = withAuth<{ params: Promise<{ agentId: string }> }>(
 
     await deleteSetting(`telegram_bot_token:${agentId}`);
     await deleteSetting(`telegram_bot_username:${agentId}`);
+    // #477 layer 2: no orphan disabled-marker left behind for a bot that's
+    // been fully disconnected and may later be reconnected with a fresh token.
+    await deleteSetting(`telegram_conflict_disabled:${agentId}`);
 
     // Clear only this account's allow-from store (other agents' bots are unaffected)
     clearAllowStoreForAccount(agentId);

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -28,6 +28,13 @@ interface TelegramConfig {
   hint?: string;
   botUsername?: string;
   mainBotConfigured?: boolean;
+  /** #477 layer 2: true when the watchdog auto-disabled this account after a
+   * sustained Telegram getUpdates-409 conflict (another deployment polling
+   * the same bot token). Survives restarts — config regen skips this account
+   * until [Reconnect] clears it. */
+  conflictDisabled?: boolean;
+  conflictDisabledAt?: string;
+  lastError?: string;
 }
 
 interface AgentTelegramSettingsProps {
@@ -69,6 +76,11 @@ export function AgentTelegramSettings({
     degraded: boolean;
     lastError: string | null;
   }>({ degraded: false, lastError: null });
+  // #477 layer 2: once the user clicks [Reconnect] on the auto-disabled
+  // banner, show the normal connect form so they can re-submit a token (their
+  // own or a fresh, environment-specific one) — the POST clears the disabled
+  // marker on success.
+  const [showReconnectForm, setShowReconnectForm] = useState(false);
 
   const fetchConfig = useCallback(async () => {
     try {
@@ -207,10 +219,30 @@ export function AgentTelegramSettings({
   // Smithers (`isSmithers`) is exempt because it IS the main bot being set up —
   // otherwise first-time setup would show an empty state pointing to itself.
   const mainBotMissing = config?.mainBotConfigured === false && !isConfigured && !isSmithers;
+  // #477 layer 2: a persistent, actionable condition — never a toast (the
+  // project's error/notification policy reserves toasts for transient,
+  // retryable errors). Suppressed once the user clicks Reconnect so the
+  // normal connect form takes over.
+  const conflictDisabled = isConfigured && config?.conflictDisabled === true && !showReconnectForm;
 
   const content = (
     <div className="space-y-4">
-      {mainBotMissing ? (
+      {conflictDisabled ? (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <TriangleAlert className="size-5 text-destructive shrink-0" />
+            <span className="text-sm font-medium">Disabled</span>
+            {config?.hint && <Badge variant="secondary">····{config.hint}</Badge>}
+          </div>
+          <p className="text-sm text-muted-foreground">
+            This bot token is being polled by another deployment. Reconnect once you&apos;ve stopped
+            it there or switched to a separate token.
+          </p>
+          <Button type="button" onClick={() => setShowReconnectForm(true)}>
+            Reconnect
+          </Button>
+        </div>
+      ) : mainBotMissing ? (
         <div className="space-y-4 text-center py-6">
           <div className="space-y-2">
             <p className="text-sm font-medium">Telegram isn&apos;t set up yet</p>
@@ -226,7 +258,7 @@ export function AgentTelegramSettings({
             </Link>
           </Button>
         </div>
-      ) : isConfigured ? (
+      ) : isConfigured && !showReconnectForm ? (
         <>
           <div className="flex items-center gap-2">
             {channelHealth.degraded ? (

--- a/packages/web/src/components/agent-telegram-settings.tsx
+++ b/packages/web/src/components/agent-telegram-settings.tsx
@@ -172,6 +172,11 @@ export function AgentTelegramSettings({
       const data = await res.json();
       setConnectedUsername(data.botUsername || null);
       setBotToken("");
+      // A successful (re)connect clears the auto-disable marker server-side, so
+      // leave the reconnect form and let the refreshed config drop us back into
+      // the normal connected view — otherwise the user is stranded on an empty
+      // token form after connecting (#477 layer 2).
+      setShowReconnectForm(false);
       triggerRestart();
       toast.success("Telegram bot connected");
       fetchConfig();

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -59,6 +59,7 @@ export type AuditEventType =
   | "channel.degraded"
   | "channel.polling_failed"
   | "channel.recovered"
+  | "channel.auto_disabled"
   | "chat.retry_triggered"
   | "chat.agent_error"
   | "chat.silent_stream"
@@ -359,6 +360,19 @@ export type AuditLogEntry =
         lastError: string | null;
         reconnectAttempts: number;
         consecutiveDegradedChecks: number;
+      };
+    })
+  | (AuditLogBase & {
+      // #477 layer 2: a recently-added account whose sustained polling_failed
+      // matches the Telegram getUpdates-409 conflict signal gets auto-disabled
+      // (config removed, allow-store cleared, disabled marker persisted) so the
+      // newcomer backs off instead of both instances fighting forever.
+      eventType: "channel.auto_disabled";
+      detail: {
+        channel: string;
+        account: { id: string; name: string | null };
+        reason: string;
+        lastError: string | null;
       };
     })
   | (AuditLogBase & {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1217,7 +1217,13 @@ export async function regenerateOpenClawConfig() {
 
   for (const agent of liveAgents) {
     const botToken = await getSetting(`telegram_bot_token:${agent.id}`);
-    if (botToken) {
+    // #477 layer 2: an account auto-disabled after a sustained getUpdates-409
+    // conflict must stay excluded across a full config regen (restart, agent
+    // create, etc.) — not just at the moment of the targeted disable write.
+    // The bot token is deliberately left in settings (so [Reconnect] can
+    // re-enable it later); this guard is what makes the disable durable.
+    const conflictDisabled = await getSetting(`telegram_conflict_disabled:${agent.id}`);
+    if (botToken && !conflictDisabled) {
       accounts[agent.id] = { botToken };
       if (agent.isPersonal) {
         // Personal agents: per-user peer bindings will be added below

--- a/packages/web/src/server/channel-health-watchdog.ts
+++ b/packages/web/src/server/channel-health-watchdog.ts
@@ -64,6 +64,43 @@ export interface ChannelHealthDeps {
   writeAudit: (entry: ChannelHealthAuditPayload) => Promise<void>;
   now: () => number;
   terminalAfterConsecutiveDegraded: number;
+  /**
+   * Auto-disable (#477 layer 2): persist the disabled marker, remove the
+   * account from config, and clear its allow-store + audit the action. Called
+   * at most once per degradation episode, only when the trigger conditions in
+   * `isAutoDisableConflict` all hold. A rejection is swallowed by the caller
+   * so one bad account can't poison the tick.
+   */
+  autoDisableConflictedAccount: (
+    channel: string,
+    accountId: string,
+    lastError: string
+  ) => Promise<void>;
+  /**
+   * Age of the account's connection in ms (time since it was first
+   * connected/created), or null when unknown. Used to distinguish a
+   * recently-added newcomer (should back off) from a long-standing incumbent
+   * (should not auto-disable itself out of a conflict it didn't cause).
+   */
+  getConnectionAgeMs: (channel: string, accountId: string) => Promise<number | null>;
+  /** Feature flag — when false, auto-disable never fires (degraded/polling_failed audits still do). */
+  autoDisableEnabled: boolean;
+  /** An account younger than this (ms) at the time of the conflict is eligible for auto-disable. */
+  recentlyAddedWindowMs: number;
+}
+
+/**
+ * Telegram's getUpdates 409 conflict text — the ONLY polling_failed reason
+ * that triggers auto-disable. Matched case-insensitively on a substring so
+ * minor upstream wording changes (capitalization, surrounding context) don't
+ * silently break the match. Other polling_failed causes (network errors,
+ * invalid token, etc.) must NOT auto-disable — they aren't multi-instance
+ * conflicts and disabling on them would just make an outage worse.
+ */
+const CONFLICT_SIGNAL = "terminated by other getupdates";
+
+function isConflictSignal(lastError: string | null): boolean {
+  return lastError !== null && lastError.toLowerCase().includes(CONFLICT_SIGNAL);
 }
 
 export interface ChannelHealthSnapshotEntry extends ChannelAccountHealth {
@@ -133,6 +170,7 @@ export class ChannelHealthMonitor {
         if (t.consecutiveDegraded >= deps.terminalAfterConsecutiveDegraded && !t.auditedFailed) {
           t.auditedFailed = true;
           await this.audit(deps, "channel.polling_failed", "failure", h, t.consecutiveDegraded);
+          await this.maybeAutoDisable(deps, h);
         }
       } else {
         if (t.state === "degraded") {
@@ -150,6 +188,36 @@ export class ChannelHealthMonitor {
     // disconnected) — drop their tracker so a future reconnect starts clean.
     for (const key of [...this.trackers.keys()]) {
       if (!seen.has(key)) this.trackers.delete(key);
+    }
+  }
+
+  /**
+   * Fire auto-disable at most once per degradation episode (guarded by the
+   * caller's `!t.auditedFailed` check — this runs exactly at the healthy→
+   * polling_failed edge). All conditions must hold:
+   *   1. autoDisableEnabled
+   *   2. lastError matches the Telegram getUpdates-409 conflict signal
+   *   3. the account is recently-added (age < recentlyAddedWindowMs)
+   * A long-standing connection or an unknown age is left alone — it stays
+   * degraded/polling_failed with the existing audit only, so the newcomer
+   * backs off and the incumbent survives.
+   */
+  private async maybeAutoDisable(deps: ChannelHealthDeps, h: ChannelAccountHealth): Promise<void> {
+    if (!deps.autoDisableEnabled) return;
+    if (!isConflictSignal(h.lastError)) return;
+
+    let ageMs: number | null;
+    try {
+      ageMs = await deps.getConnectionAgeMs(h.channel, h.accountId);
+    } catch {
+      ageMs = null;
+    }
+    if (ageMs === null || ageMs >= deps.recentlyAddedWindowMs) return;
+
+    try {
+      await deps.autoDisableConflictedAccount(h.channel, h.accountId, h.lastError ?? "");
+    } catch (err) {
+      console.error("[channel-health] autoDisableConflictedAccount failed:", err);
     }
   }
 

--- a/packages/web/src/server/channel-health-watchdog.ts
+++ b/packages/web/src/server/channel-health-watchdog.ts
@@ -103,6 +103,22 @@ function isConflictSignal(lastError: string | null): boolean {
   return lastError !== null && lastError.toLowerCase().includes(CONFLICT_SIGNAL);
 }
 
+/** Default recently-added window: 24h. */
+export const DEFAULT_RECENTLY_ADDED_WINDOW_MS = 86_400_000;
+
+/**
+ * Parse `TELEGRAM_CONFLICT_RECENT_WINDOW_MS`. A missing, empty, non-numeric, or
+ * negative value falls back to the 24h default, but an explicit `0` is honored
+ * (an operator turning the recently-added gate off) — unlike `Number(x) ||
+ * DEFAULT`, which would silently revert 0 back to the default.
+ */
+export function parseRecentlyAddedWindowMs(raw: string | undefined): number {
+  if (raw === undefined || raw.trim() === "") return DEFAULT_RECENTLY_ADDED_WINDOW_MS;
+  const n = Number(raw);
+  if (!Number.isFinite(n) || n < 0) return DEFAULT_RECENTLY_ADDED_WINDOW_MS;
+  return n;
+}
+
 export interface ChannelHealthSnapshotEntry extends ChannelAccountHealth {
   /** When this account first went degraded in the current episode, else null. */
   degradedSince: number | null;


### PR DESCRIPTION
Part of #477 (Telegram multi-instance bot-polling conflict) — **layer 2: auto-disable on sustained runtime conflict**. Independent of the layer-1 PR (#685); both target `main` and can merge in any order.

## What
When the channel-health watchdog escalates a Telegram account to `polling_failed` **and** all of the following hold, the account is auto-disabled:
1. `lastError` matches the Telegram getUpdates-409 conflict signal (`"terminated by other getUpdates"`, case-insensitive).
2. The connection is **recently-added** — its most recent `channel.created` audit row is < 24h old.
3. The `TELEGRAM_CONFLICT_AUTO_DISABLE` opt-out is not set to `false`/`0`/`no`.

Auto-disable = remove the account from OpenClaw config (poller stops promptly via the #476 config.apply/reload path), clear its allow-store, persist a `telegram_conflict_disabled:<agentId>` marker, and emit a `channel.auto_disabled` audit row.

**The recently-added heuristic makes the newcomer back off so the incumbent survives** — and prevents the failure mode where two instances auto-disable each other and the bot goes dark everywhere. Long-standing connections, non-conflict failures, unknown age, and the opt-out all keep the existing degraded/`polling_failed` behavior with a manual **[Disconnect]** only.

## Restart-survival (the crux)
The disable must outlive a restart, or the next `regenerateOpenClawConfig` would re-add the account and restart the fight. `build.ts` now skips any account carrying the `telegram_conflict_disabled:<id>` marker when assembling telegram accounts/bindings — the bot token is deliberately left in `settings` so **[Reconnect]** can re-enable it. Covered by a "pre-existing data" style test (seed token + marker → regen emits no account/binding).

## Reconnect / UI
- The connect route clears the marker on a successful (re)connect; disconnect clears it too (no orphan marker).
- GET surfaces `conflictDisabled`; the agent's Telegram settings render a **persistent, inline** actionable "Disabled" banner with a **Reconnect** action (never a toast — per the error/notification policy this is a permanent, actionable condition).

## Tests
- **Watchdog unit** (8 new): fires once at the `polling_failed` edge; not before, not re-fired same episode; re-arms on a fresh episode after recovery; long-standing / null-age / non-conflict / opt-out never fire but `polling_failed` still audits; a rejecting auto-disable is swallowed without poisoning the tick; case-insensitive signal match.
- **Restart-survival** (`openclaw-config.test.ts`): marker present → account+binding excluded from regen; absent → included.
- **Route**: (re)connect + disconnect clear the marker; GET surfaces `conflictDisabled`.
- **Component**: disabled banner + Reconnect flow.
- **audit.ts**: `channel.auto_disabled` type-shape.
- **E2E** (`channel-health.spec.ts`): fresh (recently-added) bot + sustained 409 → `channel.auto_disabled` audit + `conflictDisabled:true`. Tagged `@channel-restart` (CI-excluded, runs locally/nightly) consistent with the sibling degraded→polling_failed→recovered test, since auto-disable triggers a channel reload; the trigger logic itself is fully covered by the deterministic unit tests above.

## Config / opt-out
- `TELEGRAM_CONFLICT_AUTO_DISABLE` (default on; `false`/`0`/`no` → degraded-only, no auto-action).
- `TELEGRAM_CONFLICT_RECENT_WINDOW_MS` (default 24h).

## Known limitation
Auto-disable is evaluated once per degradation episode at the `polling_failed` edge. If `autoDisableConflictedAccount` fails there during a conflict that never flaps back to healthy, it won't retry until the episode re-arms on recovery. In practice getUpdates-409 conflicts oscillate (both instances fight), so the episode re-arms naturally; and the config-removal path (`pushConfigInBackground`) never throws, leaving the DB `setSetting` as the only realistic failure surface. Documented rather than over-engineered.

## Gates
Full `pnpm -C packages/web test` (7349 passed), `tsc --noEmit`, `eslint`, `prettier --check`, `pnpm test:scripts` (drift guards), and `docs build` all green. Re-verified after rebasing onto `main` (decoupled from the layer-1 branch).