### PR TITLE
feat(pinchy-odoo): governance gating + many2many + read-side line refs for nested command tuples (#615)

### DIFF
--- a/config/odoo-mock/server.js
+++ b/config/odoo-mock/server.js
@@ -388,6 +388,16 @@ const MODEL_FIELDS = {
       readonly: false,
       relation: "account.move.line",
     },
+    // many2many relation to exercise nested command-tuple resolution +
+    // permission gating for join-table fields (issue #615 follow-up),
+    // parallel to the one2many line_ids above.
+    tax_ids: {
+      string: "Taxes",
+      type: "many2many",
+      required: false,
+      readonly: false,
+      relation: "account.tax",
+    },
   },
   // Chart-of-accounts model, seeded with a cross-company name collision (see
   // getDefaultRecords) mirroring the account.journal collision above — needed
@@ -444,6 +454,32 @@ const MODEL_FIELDS = {
       required: false,
       readonly: false,
       relation: "account.move",
+    },
+    company_id: {
+      string: "Company",
+      type: "many2one",
+      required: false,
+      readonly: false,
+      relation: "res.company",
+    },
+  },
+  // Tax model — the many2many relation of account.move#tax_ids. Field
+  // metadata drives the same generic many2one write-value validation as
+  // account.move.line above, so a nested m2o inside a many2many command
+  // tuple is validated the same way.
+  "account.tax": {
+    id: { string: "ID", type: "integer", required: false, readonly: true },
+    name: {
+      string: "Tax Name",
+      type: "char",
+      required: true,
+      readonly: false,
+    },
+    amount: {
+      string: "Amount",
+      type: "float",
+      required: false,
+      readonly: false,
     },
     company_id: {
       string: "Company",
@@ -684,6 +720,10 @@ function getDefaultRecords() {
       },
     ],
     "account.move.line": [],
+    "account.tax": [
+      { id: 1, name: "VAT 19%", amount: 19.0, company_id: [1, "Helmcraft GmbH"] },
+      { id: 2, name: "VAT 7%", amount: 7.0, company_id: [1, "Helmcraft GmbH"] },
+    ],
   };
 }
 
@@ -938,6 +978,76 @@ function expandOne2ManyCommands(
   return { ids };
 }
 
+/**
+ * Expand many2many command tuples, mirroring Odoo's Command semantics for a
+ * join-table relation (contrast with `expandOne2ManyCommands` above, which
+ * has a required back-reference to the parent — m2m has none):
+ *   [0, 0, {vals}]   create a new target record, validating + storing it,
+ *                    then adding it to the relation set
+ *   [1, id, {vals}]  update an existing target record, validating first
+ *   [2, id]          delete: remove the target record entirely (not modeled
+ *                    here beyond dropping it from the relation set — no
+ *                    separate model-wide deletion, matching the faithful-
+ *                    but-minimal #615 scope)
+ *   [3, id]          unlink: remove from the relation set only
+ *   [4, id]          link: add an existing id to the relation set
+ *   [5]              clear: empty the relation set
+ *   [6, 0, [ids]]    replace: set the relation set to exactly these ids
+ *
+ * No back-reference or company_id inheritance — a many2many target row
+ * belongs to no single parent. Returns `{ error }` on the first invalid
+ * nested many2one value, or `{ ids }` — the ids to store on the parent's
+ * many2many field — on success. `currentIds` is the field's existing value
+ * on the record being written (needed for 3/4/5/6 to compute the new set).
+ */
+function expandMany2ManyCommands(relationModel, commands, currentIds) {
+  let ids = [...(currentIds || [])];
+
+  for (const cmd of commands) {
+    if (!Array.isArray(cmd)) continue;
+    const [op, cmdId, cmdValues] = cmd;
+
+    if (op === 0 || op === 1) {
+      const targetValues = { ...(cmdValues || {}) };
+      const validationError = validateMany2OneValues(
+        relationModel,
+        targetValues,
+      );
+      if (validationError) return { error: validationError };
+
+      if (op === 0) {
+        ensureModel(relationModel);
+        const newId = nextIds.get(relationModel) || 1;
+        nextIds.set(relationModel, newId + 1);
+        store.get(relationModel).push({ id: newId, ...targetValues });
+        ids.push(newId);
+      } else {
+        // op === 1: update existing target, keep it in the relation set
+        ensureModel(relationModel);
+        const existing = store
+          .get(relationModel)
+          .find((r) => r.id === cmdId);
+        if (existing) Object.assign(existing, targetValues);
+        if (!ids.includes(cmdId)) ids.push(cmdId);
+      }
+    } else if (op === 2 || op === 3) {
+      // delete / unlink: drop from the relation set
+      ids = ids.filter((id) => id !== cmdId);
+    } else if (op === 4) {
+      // link: add if not already present
+      if (!ids.includes(cmdId)) ids.push(cmdId);
+    } else if (op === 5) {
+      // clear
+      ids = [];
+    } else if (op === 6) {
+      // replace with exactly this id list
+      ids = Array.isArray(cmdValues) ? [...cmdValues] : [];
+    }
+  }
+
+  return { ids };
+}
+
 // ---------------------------------------------------------------------------
 // Helper: pick fields from record
 // ---------------------------------------------------------------------------
@@ -1162,17 +1272,25 @@ function handleJsonRpc(body) {
         const topLevelError = validateMany2OneValues(model, values);
         if (topLevelError) return topLevelError;
 
-        // Separate one2many command-tuple fields (e.g. account.move#line_ids)
-        // from plain scalar/m2o values — those need expansion AFTER the
-        // parent record exists, since lines back-reference the parent id.
+        // Separate one2many AND many2many command-tuple fields (e.g.
+        // account.move#line_ids, #tax_ids) from plain scalar/m2o values —
+        // those need expansion AFTER the parent record exists (one2many
+        // lines back-reference the parent id; many2many is expanded at the
+        // same point purely for symmetry/ordering, though it needs no
+        // back-ref).
         const modelSchema = MODEL_FIELDS[model] || {};
         const one2manyFields = Object.entries(modelSchema).filter(
           ([name, def]) =>
             def.type === "one2many" && Array.isArray(values[name]),
         );
+        const many2manyFields = Object.entries(modelSchema).filter(
+          ([name, def]) =>
+            def.type === "many2many" && Array.isArray(values[name]),
+        );
 
         const scalarValues = { ...values };
         for (const [name] of one2manyFields) delete scalarValues[name];
+        for (const [name] of many2manyFields) delete scalarValues[name];
 
         const newId = nextIds.get(model) || 1;
         nextIds.set(model, newId + 1);
@@ -1190,6 +1308,22 @@ function handleJsonRpc(body) {
           if (expansion.error) {
             // Roll back the just-created parent — Odoo creates are atomic;
             // a failed nested line means the whole create fails.
+            store.set(
+              model,
+              store.get(model).filter((r) => r.id !== newId),
+            );
+            return expansion.error;
+          }
+          newRecord[name] = expansion.ids;
+        }
+
+        for (const [name, def] of many2manyFields) {
+          const expansion = expandMany2ManyCommands(
+            def.relation,
+            values[name],
+            [],
+          );
+          if (expansion.error) {
             store.set(
               model,
               store.get(model).filter((r) => r.id !== newId),

--- a/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration.test.ts
@@ -934,3 +934,195 @@ describe("pinchy-odoo multi-company journal resolution (bare ref + scoped lookup
     });
   });
 });
+
+describe("pinchy-odoo nested one2many + many2many governance against real mock-odoo", () => {
+  const accountingAgentId = "agent-accounting-nested";
+  const accountingConnectionId = "conn-accounting-nested";
+
+  beforeAll(async () => {
+    await fetch(`http://127.0.0.1:${mockOdoo.controlPort}/control/reset`, {
+      method: "POST",
+    });
+    credentialsByConnectionId.set(accountingConnectionId, {
+      url: `http://127.0.0.1:${mockOdoo.jsonRpcPort}`,
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    });
+  });
+
+  function ref(model: string, id: number, label: string): string {
+    return encodeRef({
+      integrationType: "odoo",
+      connectionId: accountingConnectionId,
+      model,
+      id,
+      label,
+    });
+  }
+
+  it("creates an account.move with an inline line_ids create tuple resolving a bare-ref account_id, with only account.move:create granted", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: { "account.move": ["read", "create"] },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const accountRef = ref("account.account", 40, "Bank");
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH");
+    const result = await createTool.execute("create-move-inline-line", {
+      model: "account.move",
+      values: {
+        ref: "Inline line create",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        line_ids: [[0, 0, { account_id: accountRef, debit: 42 }]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const { id } = JSON.parse(result.content[0].text) as { id: number };
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    const move = moves.find((m) => m.id === id);
+    expect(move).toBeDefined();
+    expect(Array.isArray(move!.line_ids)).toBe(true);
+    expect((move!.line_ids as number[]).length).toBe(1);
+
+    const lines = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move.line`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    const createdLine = lines.find(
+      (l) => l.id === (move!.line_ids as number[])[0],
+    );
+    expect(createdLine).toMatchObject({ account_id: 40, debit: 42 });
+  });
+
+  it("rejects a nested line_ids [2,id] delete tuple when the agent lacks account.move.line:delete", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: { "account.move": ["read", "write"] },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const writeTool = findTool(tools, "odoo_write", accountingAgentId);
+
+    const result = await writeTool.execute("write-move-delete-line", {
+      model: "account.move",
+      ids: [1],
+      values: { line_ids: [[2, 1]] },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/delete/i);
+  });
+
+  it("allows a nested line_ids [2,id] delete tuple once account.move.line:delete is granted", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: {
+        "account.move": ["read", "write"],
+        "account.move.line": ["delete"],
+      },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const writeTool = findTool(tools, "odoo_write", accountingAgentId);
+
+    const result = await writeTool.execute("write-move-delete-line-ok", {
+      model: "account.move",
+      ids: [1],
+      values: { line_ids: [[2, 1]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+
+  it("resolves bare refs inside a many2many tax_ids create tuple and materializes the join set", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: {
+        "account.move": ["read", "create"],
+        "account.tax": ["read"],
+      },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const taxRef = ref("account.tax", 1, "VAT 19%");
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH");
+    const result = await createTool.execute("create-move-m2m", {
+      model: "account.move",
+      values: {
+        ref: "M2M tax test",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        tax_ids: [[4, taxRef]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    const { id } = JSON.parse(result.content[0].text) as { id: number };
+    const moves = (await fetch(
+      `http://127.0.0.1:${mockOdoo.controlPort}/control/records?model=account.move`,
+    ).then((res) => res.json())) as Array<Record<string, unknown>>;
+    const move = moves.find((m) => m.id === id);
+    expect(move).toMatchObject({ tax_ids: [1] });
+  });
+
+  it("rejects a many2many [0,0,{...}] create tuple when the agent lacks account.tax:create", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: { "account.move": ["read", "create"] },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH");
+    const result = await createTool.execute("create-move-m2m-reject", {
+      model: "account.move",
+      values: {
+        ref: "M2M tax reject test",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        tax_ids: [[0, 0, { name: "New Tax", amount: 5 }]],
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.tax/);
+    expect(result.content[0].text).toMatch(/create/i);
+  });
+
+  it("allows a many2many [4,<ref>] link tuple with no account.tax grant at all (join-table-only op)", async () => {
+    const config = {
+      connectionId: accountingConnectionId,
+      permissions: { "account.move": ["read", "create"] },
+    };
+    const tools = createApi({ [accountingAgentId]: config });
+    const createTool = findTool(tools, "odoo_create", accountingAgentId);
+
+    const taxRef = ref("account.tax", 2, "VAT 7%");
+    const companyRef = ref("res.company", 1, "Helmcraft GmbH");
+    const result = await createTool.execute("create-move-m2m-link-nogrant", {
+      model: "account.move",
+      values: {
+        ref: "M2M link no-grant test",
+        date: "2026-01-01",
+        move_type: "entry",
+        company_id: { ref: companyRef },
+        journal_id: "Miscellaneous Operations",
+        tax_ids: [[4, taxRef]],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
@@ -230,6 +230,90 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
   });
 });
 
+// Hardening B: when the line model's schema comes back empty, the nested m2o
+// resolution loop inside normalizeMany2OneValues has nothing to check ref
+// shapes against and silently returns the values dict UNCHANGED — including
+// any unresolved refs. A pure raw-id tuple ([6,0,[1,2,3]]) is harmless in
+// that case (nothing needed resolving anyway), but a ref-shaped value inside
+// a create/update tuple (e.g. a bare _pinchy_ref) reaching Odoo unresolved is
+// a silent data-corruption risk. Fail loud instead.
+describe("normalizeMany2OneValues — fail loud on empty line schema when resolution is needed (Hardening B)", () => {
+  function makeEmptySchemaClient() {
+    const client = {
+      async fields(model: string) {
+        if (model === "account.move") return FIELDS["account.move"];
+        // account.move.line schema comes back EMPTY — simulates a broken
+        // connection / stale cache / an Odoo model the plugin can't
+        // introspect.
+        return {};
+      },
+      async searchRead() {
+        return [];
+      },
+    };
+    return client as unknown as OdooClient;
+  }
+
+  it("throws naming the field and relation when a create tuple carries a bare _pinchy_ref and the line schema is empty", async () => {
+    const client = makeEmptySchemaClient();
+    const bareRef =
+      "pinchy_ref:v1:doesnotneedtobevalid-the-schema-check-happens-first";
+    const values = {
+      line_ids: [[0, 0, { account_id: bareRef }]],
+    };
+
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/line_ids/);
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/account\.move\.line/);
+  });
+
+  it("throws naming the field and relation when a create tuple carries a {ref} object and the line schema is empty", async () => {
+    const client = makeEmptySchemaClient();
+    const values = {
+      line_ids: [[0, 0, { account_id: { ref: "pinchy_ref:v1:whatever" } }]],
+    };
+
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/line_ids.*account\.move\.line/s);
+  });
+
+  it("passes a pure raw-id tuple ([6,0,[1,2]]) through unchanged when the line schema is empty (no resolution needed)", async () => {
+    const client = makeEmptySchemaClient();
+    const values = { line_ids: [[6, 0, [1, 2]]] };
+
+    const result = await normalizeMany2OneValues(
+      client,
+      "conn-1",
+      "account.move",
+      values,
+      FULL_LINE_PERMISSIONS,
+    );
+    expect(result.values.line_ids).toEqual([[6, 0, [1, 2]]]);
+  });
+});
+
 describe("normalizeMany2OneValues — nested-permission gating (governance priority)", () => {
   // Codes that modify EXISTING nested one2many records require a grant on
   // the line model: 1 (update) needs write; 2 (delete)/3 (unlink)/5

--- a/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
@@ -75,6 +75,13 @@ function makeMockClient() {
   return { client: client as unknown as OdooClient, calls, fieldsCalls };
 }
 
+// Permissions with account.move.line grants for every op the nested walker
+// checks — used by tests in this file that aren't specifically exercising
+// permission gating (Feature 1 below), so they keep passing as before.
+const FULL_LINE_PERMISSIONS = {
+  "account.move.line": ["create", "write", "delete"],
+};
+
 describe("normalizeMany2OneValues — nested one2many command tuples (#615)", () => {
   it("resolves m2o fields inside create command tuples with the parent's company scope", async () => {
     const { client, calls } = makeMockClient();
@@ -84,7 +91,13 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
     };
 
     const result = (
-      await normalizeMany2OneValues(client, "conn-1", "account.move", values)
+      await normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      )
     ).values;
 
     // company_id resolved to the res.company id.
@@ -111,7 +124,13 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
     };
 
     const result = (
-      await normalizeMany2OneValues(client, "conn-1", "account.move", values)
+      await normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      )
     ).values;
     expect(result.line_ids).toEqual([[4, 42], [5], [6, 0, [1, 2, 3]], [2, 9]]);
   });
@@ -123,7 +142,13 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
     };
 
     const result = (
-      await normalizeMany2OneValues(client, "conn-1", "account.move", values)
+      await normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      )
     ).values;
     expect(result.line_ids).toEqual([[1, 77, { account_id: 5, credit: 50 }]]);
   });
@@ -145,7 +170,13 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
     };
 
     const result = (
-      await normalizeMany2OneValues(client, "conn-1", "account.move", values)
+      await normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        FULL_LINE_PERMISSIONS,
+      )
     ).values as { line_ids: unknown[] };
 
     // Top-level line's account_id resolved.
@@ -181,7 +212,13 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
       ],
     };
 
-    await normalizeMany2OneValues(client, "conn-1", "account.move", values);
+    await normalizeMany2OneValues(
+      client,
+      "conn-1",
+      "account.move",
+      values,
+      FULL_LINE_PERMISSIONS,
+    );
 
     const countOf = (model: string) =>
       fieldsCalls.filter((m) => m === model).length;
@@ -190,5 +227,176 @@ describe("normalizeMany2OneValues — nested one2many command tuples (#615)", ()
     expect(countOf("account.move")).toBe(1);
     expect(countOf("account.move.line")).toBe(1);
     expect(countOf("account.account")).toBe(1);
+  });
+});
+
+describe("normalizeMany2OneValues — nested-permission gating (governance priority)", () => {
+  // Codes that modify EXISTING nested one2many records require a grant on
+  // the line model: 1 (update) needs write; 2 (delete)/3 (unlink)/5
+  // (clear)/6 (replace) need delete — Odoo cascade-deletes orphaned lines
+  // when a one2many with a required inverse is cleared or replaced (Odoo
+  // "[FIX] fields: setting a one2many field deletes all its lines" #13082).
+  // Inline create (0) needs no separate line grant: it's part of the
+  // parent's atomic create, already gated by the top-level `create` check.
+  const NO_LINE_PERMISSIONS = { "account.move": ["write"] };
+  const WRITE_ONLY_LINE_PERMISSIONS = {
+    "account.move": ["write"],
+    "account.move.line": ["write"],
+  };
+  const DELETE_ONLY_LINE_PERMISSIONS = {
+    "account.move": ["write"],
+    "account.move.line": ["delete"],
+  };
+
+  it("rejects [2,id] delete without account.move.line:delete", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[2, 1]] };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/delete/i);
+  });
+
+  it("rejects [3,id] unlink without account.move.line:delete", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[3, 1]] };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/delete/i);
+  });
+
+  it("rejects [5] clear without account.move.line:delete", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[5]] };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/delete/i);
+  });
+
+  it("rejects [6,0,[]] replace without account.move.line:delete", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[6, 0, []]] };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/delete/i);
+  });
+
+  it("allows [2,id]/[3,id]/[5]/[6,0,[]] with account.move.line:delete granted", async () => {
+    const { client } = makeMockClient();
+    for (const cmd of [[2, 1], [3, 1], [5], [6, 0, []]]) {
+      const values = { line_ids: [cmd] };
+      const result = await normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        DELETE_ONLY_LINE_PERMISSIONS,
+      );
+      expect(result.values.line_ids).toEqual([cmd]);
+    }
+  });
+
+  it("rejects [1,id,{...}] update without account.move.line:write", async () => {
+    const { client } = makeMockClient();
+    const values = {
+      line_ids: [[1, 77, { account_id: "Main Bank", credit: 50 }]],
+    };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/write/i);
+  });
+
+  it("allows [1,id,{...}] update with account.move.line:write granted", async () => {
+    const { client } = makeMockClient();
+    const values = {
+      line_ids: [[1, 77, { account_id: "Main Bank", credit: 50 }]],
+    };
+    const result = await normalizeMany2OneValues(
+      client,
+      "conn-1",
+      "account.move",
+      values,
+      WRITE_ONLY_LINE_PERMISSIONS,
+    );
+    expect(result.values.line_ids).toEqual([
+      [1, 77, { account_id: 5, credit: 50 }],
+    ]);
+  });
+
+  it("allows inline [0,0,{...}] create with only the parent's create grant (no line grant needed)", async () => {
+    const { client } = makeMockClient();
+    const values = {
+      line_ids: [[0, 0, { account_id: "Main Bank", debit: 100 }]],
+    };
+    // Only account.move:create is granted — no account.move.line permission
+    // at all — and inline create still succeeds.
+    const result = await normalizeMany2OneValues(
+      client,
+      "conn-1",
+      "account.move",
+      values,
+      { "account.move": ["create"] },
+    );
+    expect(result.values.line_ids).toEqual([
+      [0, 0, { account_id: 5, debit: 100 }],
+    ]);
+  });
+
+  it("allows [4,id] link without any account.move.line grant", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[4, 42]] };
+    const result = await normalizeMany2OneValues(
+      client,
+      "conn-1",
+      "account.move",
+      values,
+      NO_LINE_PERMISSIONS,
+    );
+    expect(result.values.line_ids).toEqual([[4, 42]]);
+  });
+
+  it("error message names the missing operation, relation model, parent field, and command code", async () => {
+    const { client } = makeMockClient();
+    const values = { line_ids: [[2, 1]] };
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(
+      /Agent missing delete grant on account\.move\.line.*line_ids.*command 2/,
+    );
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/nested-m2o.test.ts
@@ -483,4 +483,37 @@ describe("normalizeMany2OneValues — nested-permission gating (governance prior
       /Agent missing delete grant on account\.move\.line.*line_ids.*command 2/,
     );
   });
+
+  it("throws the PERMISSION error, not the empty-schema error, when both apply (authz wins)", async () => {
+    // account.move schema present, account.move.line schema EMPTY, AND the
+    // agent lacks account.move.line:delete. The permission gap must surface
+    // (fail fast on authz before the schema round trip), not Hardening B's
+    // empty-schema error. The target id is ref-shaped (not a raw number) so
+    // `commandTuplesNeedResolution` is true and the empty-schema pre-check
+    // actually has something to fire on — a plain numeric id wouldn't
+    // exercise the race at all.
+    const client = {
+      async fields(model: string) {
+        if (model === "account.move") return FIELDS["account.move"];
+        return {}; // account.move.line schema comes back empty
+      },
+      async searchRead() {
+        return [];
+      },
+    } as unknown as OdooClient;
+    const values = {
+      line_ids: [
+        [2, "pinchy_ref:v1:doesnotneedtobevalid-the-schema-check-happens-first"],
+      ],
+    }; // delete needs account.move.line:delete
+    await expect(
+      normalizeMany2OneValues(
+        client,
+        "conn-1",
+        "account.move",
+        values,
+        NO_LINE_PERMISSIONS,
+      ),
+    ).rejects.toThrow(/Agent missing delete grant on account\.move\.line/);
+  });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -3864,6 +3864,283 @@ describe("cross-company write guard", () => {
   });
 });
 
+// Nested-permission gating for one2many command tuples (Feature 1) and
+// many2many command-tuple resolution (Feature 2), exercised through the
+// actual odoo_create / odoo_write tools rather than normalizeMany2OneValues
+// directly. See __tests__/nested-m2o.test.ts for the lower-level unit
+// coverage of the same logic.
+describe("odoo_create / odoo_write — nested governance (one2many + many2many)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const MOVE_WITH_LINES_AND_TAXES: OdooField[] = [
+    { name: "id", type: "integer", required: false, readonly: true },
+    {
+      name: "line_ids",
+      type: "one2many",
+      relation: "account.move.line",
+      required: false,
+      readonly: false,
+    },
+    {
+      name: "tax_ids",
+      type: "many2many",
+      relation: "account.tax",
+      required: false,
+      readonly: false,
+    },
+  ];
+  const MOVE_LINE_FIELDS: OdooField[] = [
+    { name: "id", type: "integer", required: false, readonly: true },
+    {
+      name: "account_id",
+      type: "many2one",
+      relation: "account.account",
+      required: true,
+      readonly: false,
+    },
+  ];
+  // account.tax reuses the same account_id many2one shape purely so the
+  // m2m create-tuple tests below can exercise nested m2o resolution inside
+  // a many2many command dict — it isn't a realistic account.tax field.
+  const TAX_FIELDS: OdooField[] = [
+    { name: "id", type: "integer", required: false, readonly: true },
+    {
+      name: "account_id",
+      type: "many2one",
+      relation: "account.account",
+      required: false,
+      readonly: false,
+    },
+  ];
+
+  function stubMoveFields() {
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") return MOVE_WITH_LINES_AND_TAXES;
+      if (model === "account.move.line") return MOVE_LINE_FIELDS;
+      if (model === "account.tax") return TAX_FIELDS;
+      return [];
+    });
+  }
+
+  it("rejects a nested one2many [2,id] delete when the agent lacks account.move.line:delete", async () => {
+    stubMoveFields();
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["write"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-nested-delete", {
+      model: "account.move",
+      ids: [1],
+      values: { line_ids: [[2, 1]] },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/delete/i);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("allows a nested one2many [2,id] delete once account.move.line:delete is granted", async () => {
+    stubMoveFields();
+    mockWrite.mockResolvedValue(true);
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["write"],
+          "account.move.line": ["delete"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-nested-delete-ok", {
+      model: "account.move",
+      ids: [1],
+      values: { line_ids: [[2, 1]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("account.move", [1], {
+      line_ids: [[2, 1]],
+    });
+  });
+
+  it("allows an inline [0,0,{...}] line create with only the parent's create grant", async () => {
+    stubMoveFields();
+    mockCreate.mockResolvedValue(55);
+    const accountRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 5,
+      label: "Fake Account",
+    });
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-inline-create", {
+      model: "account.move",
+      values: { line_ids: [[0, 0, { account_id: accountRef }]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+
+  it("rejects a nested [1,id,{...}] update when the agent lacks account.move.line:write", async () => {
+    stubMoveFields();
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["write"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-nested-update", {
+      model: "account.move",
+      ids: [1],
+      values: { line_ids: [[1, 7, { account_id: 5 }]] },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move\.line/);
+    expect(result.content[0].text).toMatch(/write/i);
+    expect(mockWrite).not.toHaveBeenCalled();
+  });
+
+  it("resolves a bare _pinchy_ref inside a many2many [0,0,{...}] create tuple", async () => {
+    stubMoveFields();
+    mockCreate.mockResolvedValue(60);
+    const accountRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.account",
+      id: 5,
+      label: "Fake Account",
+    });
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["create"],
+          "account.tax": ["create"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-m2m-create", {
+      model: "account.move",
+      values: {
+        tax_ids: [[0, 0, { account_id: accountRef }]],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("account.move", {
+      tax_ids: [[0, 0, { account_id: 5 }]],
+    });
+  });
+
+  it("rejects a many2many [0,0,{...}] create when the agent lacks account.tax:create", async () => {
+    stubMoveFields();
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-m2m-reject", {
+      model: "account.move",
+      values: { tax_ids: [[0, 0, { account_id: 5 }]] },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.tax/);
+    expect(result.content[0].text).toMatch(/create/i);
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  it("decodes a bare ref in a many2many [4,<ref>] link tuple's id position, no target grant needed", async () => {
+    stubMoveFields();
+    mockCreate.mockResolvedValue(61);
+    const taxRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.tax",
+      id: 9,
+      label: "VAT 19%",
+    });
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        // No account.tax grant at all — link (4) needs none.
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-m2m-link", {
+      model: "account.move",
+      values: { tax_ids: [[4, taxRef]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("account.move", {
+      tax_ids: [[4, 9]],
+    });
+  });
+
+  it("decodes refs in a many2many [6,0,[<ref>]] replace tuple's id list, no target grant needed", async () => {
+    stubMoveFields();
+    mockCreate.mockResolvedValue(62);
+    const taxRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.tax",
+      id: 9,
+      label: "VAT 19%",
+    });
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-m2m-replace", {
+      model: "account.move",
+      values: { tax_ids: [[6, 0, [taxRef]]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalledWith("account.move", {
+      tax_ids: [[6, 0, [9]]],
+    });
+  });
+
+  it("does not require a target grant for many2many codes 3/4/5/6 (join-table-only ops)", async () => {
+    stubMoveFields();
+    mockCreate.mockResolvedValue(63);
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["create"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("call-m2m-nogr", {
+      model: "account.move",
+      values: {
+        tax_ids: [[3, 1], [4, 2], [5], [6, 0, [3, 4]]],
+      },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+});
+
 // The agent-facing output (odoo_read / odoo_create) emits `_pinchy_ref` as a
 // BARE string, and the prose tells the model to "pass the `_pinchy_ref`
 // verbatim". For dedicated ref params (odoo_attach_file.targetRef,

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -859,6 +859,78 @@ describe("assertNoCrossCompanyRefs", () => {
       }),
     ).not.toThrow();
   });
+
+  // Hardening A: the guard now recurses into one2many command tuples
+  // (line_ids: [[0, 0, { account_id: <ref> }]]) instead of only checking
+  // top-level fields of `values`.
+  describe("nested command-tuple recursion (Hardening A)", () => {
+    it("rejects a cross-company account_id nested inside a [0,0,{...}] create tuple, naming the line_ids[i].field path", () => {
+      try {
+        assertNoCrossCompanyRefs({
+          company_id: tagged("res.company", 1, 1, "GmbH A"),
+          line_ids: [
+            [0, 0, { account_id: tagged("account.account", 5, 2, "GmbH B") }],
+          ],
+        });
+        throw new Error("did not throw");
+      } catch (err) {
+        expect(String(err)).toMatch(/cross-company/i);
+        expect(String(err)).toMatch(/line_ids\[0\]\.account_id/);
+      }
+    });
+
+    it("does NOT reject a line self-consistently scoped to another company via its own company_id", () => {
+      // The line declares company_id: B and account_id: B — internally
+      // consistent even though the parent's company_id is A. The guard must
+      // re-derive the intended company from the LINE's own company_id.
+      expect(() =>
+        assertNoCrossCompanyRefs({
+          company_id: tagged("res.company", 1, 1, "GmbH A"),
+          line_ids: [
+            [
+              0,
+              0,
+              {
+                company_id: tagged("res.company", 2, 2, "GmbH B"),
+                account_id: tagged("account.account", 5, 2, "GmbH B"),
+              },
+            ],
+          ],
+        }),
+      ).not.toThrow();
+    });
+
+    it("rejects a cross-company ref in a [2,<ref>] delete id position", () => {
+      expect(() =>
+        assertNoCrossCompanyRefs({
+          company_id: tagged("res.company", 1, 1, "GmbH A"),
+          line_ids: [[2, tagged("account.move.line", 9, 2, "GmbH B")]],
+        }),
+      ).toThrow(/cross-company/i);
+    });
+
+    it("rejects a cross-company ref in a [1,<ref>,{...}] update id position", () => {
+      expect(() =>
+        assertNoCrossCompanyRefs({
+          company_id: tagged("res.company", 1, 1, "GmbH A"),
+          line_ids: [[1, tagged("account.move.line", 9, 2, "GmbH B"), {}]],
+        }),
+      ).toThrow(/cross-company/i);
+    });
+
+    it("does not throw for nested tuples with no cross-company refs", () => {
+      expect(() =>
+        assertNoCrossCompanyRefs({
+          company_id: tagged("res.company", 1, 1, "GmbH A"),
+          line_ids: [
+            [0, 0, { account_id: tagged("account.account", 5, 1, "GmbH A") }],
+            [4, 42],
+            [6, 0, [1, 2, 3]],
+          ],
+        }),
+      ).not.toThrow();
+    });
+  });
 });
 
 describe("formatMultiMatchError", () => {
@@ -1428,6 +1500,294 @@ describe("odoo_read", () => {
     expect(decodeRef(data.records[0]._pinchy_ref).label).toBe("Fancy Display");
     expect(decodeRef(data.records[1]._pinchy_ref).label).toBe("Only Name");
     expect(decodeRef(data.records[2]._pinchy_ref).label).toBe("res.partner#3");
+  });
+});
+
+// Feature 3: one2many line refs. odoo_read on a model with a one2many field
+// (e.g. account.move.line_ids) previously returned a bare array of child
+// ids — an agent had no way to target a SPECIFIC line in a later edit
+// command tuple without first guessing the id shape. wrapOne2ManyValue wraps
+// each child id into `{ _pinchy_ref, id, model }` so the agent can paste the
+// `_pinchy_ref` (or the whole object, or the whole array) back into a
+// Command tuple's id position.
+describe("odoo_read — one2many line refs (Feature 3)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  });
+
+  const MOVE_WITH_LINES: OdooField[] = [
+    { name: "id", type: "integer" },
+    { name: "name", type: "char" },
+    {
+      name: "line_ids",
+      type: "one2many",
+      relation: "account.move.line",
+      string: "Lines",
+    },
+    {
+      name: "partner_id",
+      type: "many2one",
+      relation: "res.partner",
+      string: "Partner",
+    },
+    {
+      name: "tag_ids",
+      type: "many2many",
+      relation: "account.account.tag",
+      string: "Tags",
+    },
+  ];
+
+  it("wraps a one2many field's child ids into { _pinchy_ref, id, model } objects", async () => {
+    mockFields.mockResolvedValue(MOVE_WITH_LINES);
+    mockSearchRead.mockResolvedValue({
+      records: [
+        {
+          id: 40,
+          name: "INV/2026/001",
+          line_ids: [101, 102],
+          partner_id: [7, "Acme Inc"],
+        },
+      ],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    const result = await tool.execute("call-o2m-read", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "line_ids", "partner_id"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    const data = JSON.parse(result.content[0].text);
+    const record = data.records[0];
+
+    expect(record.line_ids).toHaveLength(2);
+    for (const [i, id] of [101, 102].entries()) {
+      const line = record.line_ids[i];
+      expect(line).toEqual({
+        _pinchy_ref: expect.stringMatching(/^pinchy_ref:v1:/),
+        id,
+        model: "account.move.line",
+      });
+      const decoded = decodeRef(line._pinchy_ref);
+      expect(decoded.model).toBe("account.move.line");
+      expect(decoded.id).toBe(id);
+    }
+
+    // m2o fields still wrap as { ref, label, model } — o2m wrapping doesn't
+    // clobber the existing m2o wrap.
+    expect(record.partner_id).toEqual({
+      ref: expect.stringMatching(/^pinchy_ref:v1:/),
+      label: "Acme Inc",
+      model: "res.partner",
+    });
+  });
+
+  it("leaves an empty one2many array as []", async () => {
+    mockFields.mockResolvedValue(MOVE_WITH_LINES);
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 40, name: "INV/2026/001", line_ids: [] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    const result = await tool.execute("call-o2m-empty", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "line_ids"],
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.records[0].line_ids).toEqual([]);
+  });
+
+  it("leaves a many2many field as a raw id array (out of scope for wrapOne2ManyValue)", async () => {
+    mockFields.mockResolvedValue(MOVE_WITH_LINES);
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 40, name: "INV/2026/001", tag_ids: [3, 4] }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: { "account.move": ["read"] },
+      },
+    });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+    const result = await tool.execute("call-m2m-read", {
+      model: "account.move",
+      filters: [],
+      fields: ["name", "tag_ids"],
+    });
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.records[0].tag_ids).toEqual([3, 4]);
+  });
+
+  it("round-trips a pasted line _pinchy_ref STRING into a [1, ref, {...}] update command tuple", async () => {
+    const lineRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move.line",
+      id: 101,
+      label: "account.move.line#101",
+    });
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") return MOVE_WITH_LINES;
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer" },
+          { name: "debit", type: "float" },
+        ];
+      }
+      return [];
+    });
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["write"],
+          "account.move.line": ["write"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-o2m-roundtrip-str", {
+      model: "account.move",
+      ids: [40],
+      values: { line_ids: [[1, lineRef, { debit: 5 }]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("account.move", [40], {
+      line_ids: [[1, 101, { debit: 5 }]],
+    });
+  });
+
+  it("round-trips a pasted WHOLE line object into a [1, {...}, {...}] update command tuple", async () => {
+    const lineRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.move.line",
+      id: 102,
+      label: "account.move.line#102",
+    });
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") return MOVE_WITH_LINES;
+      if (model === "account.move.line") {
+        return [
+          { name: "id", type: "integer" },
+          { name: "credit", type: "float" },
+        ];
+      }
+      return [];
+    });
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["write"],
+          "account.move.line": ["write"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-o2m-roundtrip-obj", {
+      model: "account.move",
+      ids: [40],
+      values: {
+        line_ids: [
+          [
+            1,
+            { _pinchy_ref: lineRef, id: 102, model: "account.move.line" },
+            { credit: 7 },
+          ],
+        ],
+      },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("account.move", [40], {
+      line_ids: [[1, 102, { credit: 7 }]],
+    });
+  });
+
+  it("round-trips the VERBATIM read line_ids array pasted into a [6, 0, <array>] replace command", async () => {
+    const line1 = {
+      _pinchy_ref: encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "account.move.line",
+        id: 201,
+        label: "account.move.line#201",
+      }),
+      id: 201,
+      model: "account.move.line",
+    };
+    const line2 = {
+      _pinchy_ref: encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "account.move.line",
+        id: 202,
+        label: "account.move.line#202",
+      }),
+      id: 202,
+      model: "account.move.line",
+    };
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") return MOVE_WITH_LINES;
+      if (model === "account.move.line") return [{ name: "id", type: "integer" }];
+      return [];
+    });
+    mockWrite.mockResolvedValue(true);
+
+    const tools = createApi({
+      [agentId]: {
+        ...agentConfig,
+        permissions: {
+          "account.move": ["write"],
+          "account.move.line": ["delete"],
+        },
+      },
+    });
+    const tool = findTool(tools, "odoo_write", agentId)!;
+    const result = await tool.execute("call-o2m-roundtrip-array", {
+      model: "account.move",
+      ids: [40],
+      values: { line_ids: [[6, 0, [line1, line2]]] },
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalledWith("account.move", [40], {
+      line_ids: [[6, 0, [201, 202]]],
+    });
   });
 });
 

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1146,6 +1146,7 @@ export async function normalizeMany2OneValues(
   connectionId: string,
   model: string,
   values: Record<string, unknown>,
+  permissions: Permissions,
   depth = 0,
   inheritedScope: number | null = null,
   fieldsCache: FieldsCache = new Map(),
@@ -1199,28 +1200,37 @@ export async function normalizeMany2OneValues(
     );
   }
 
-  // One nesting level down (#615): resolve m2o fields inside one2many command
-  // tuples (e.g. account.move `line_ids: [[0, 0, { account_id: "…" }]]`). The
-  // nested m2o values get the same ref decoding + company scoping as top-level
-  // fields, inheriting the parent's `scopeCompanyId` (the lines belong to the
-  // same company). Bounded to depth 1 — Odoo's command tuples can nest
-  // arbitrarily, but one level covers the account.move line_ids case; deeper
-  // nesting is left to a future change to avoid unbounded recursion through
-  // self-referential models.
+  // One nesting level down (#615; many2many follow-up): resolve m2o fields
+  // inside one2many AND many2many command tuples (e.g. account.move
+  // `line_ids: [[0, 0, { account_id: "…" }]]`, or a many2many `tax_ids: [[4,
+  // "…"]]`). The nested m2o values get the same ref decoding + company
+  // scoping as top-level fields, inheriting the parent's `scopeCompanyId`
+  // (the lines belong to the same company). Bounded to depth 1 — Odoo's
+  // command tuples can nest arbitrarily, but one level covers the
+  // account.move line_ids case; deeper nesting is left to a future change to
+  // avoid unbounded recursion through self-referential models.
   if (depth < 1) {
     for (const field of fields) {
-      if (field.type !== "one2many" || !field.relation) continue;
+      const kind =
+        field.type === "one2many"
+          ? "one2many"
+          : field.type === "many2many"
+            ? "many2many"
+            : null;
+      if (kind === null || !field.relation) continue;
       if (!(field.name in normalized)) continue;
       const commands = normalized[field.name];
       if (!Array.isArray(commands)) continue;
-      normalized[field.name] = await normalizeOne2ManyCommands(
+      normalized[field.name] = await normalizeCommandTuples(
         client,
         connectionId,
-        field.relation,
+        field,
         commands,
         scopeCompanyId,
+        permissions,
         depth,
         fieldsCache,
+        kind,
       );
     }
   }
@@ -1228,45 +1238,166 @@ export async function normalizeMany2OneValues(
   return { values: normalized, fields };
 }
 
+// Odoo Command codes on a one2many that modify EXISTING nested records and
+// therefore require a grant on the line model. Inline create (0) is part of
+// the parent's atomic create — already gated by the top-level `create`
+// check — so it needs no separate line-model grant. Link (4) only rewires
+// the parent's relation set and creates/destroys nothing. Clear (5) and
+// replace (6), however, are bulk forms of unlink (3): for a one2many with a
+// REQUIRED inverse many2one (e.g. account.move.line.move_id), Odoo deletes
+// every orphaned child record when the relation set is cleared or replaced
+// (Odoo "[FIX] fields: setting a one2many field deletes all its lines"
+// #13082). They are therefore gated exactly like 2/3 — an agent needs the
+// `delete` grant on the line model to clear or replace a one2many, not just
+// `write` on the parent.
+const NESTED_OP_BY_CODE: Record<number, "write" | "delete"> = {
+  1: "write",
+  2: "delete",
+  3: "delete",
+  5: "delete",
+  6: "delete",
+};
+
+// many2many Command permission map. Unlike one2many, m2m is a join table
+// with no required inverse — clearing or replacing the set never
+// cascade-deletes target rows, it only rewires the join table. So only the
+// codes that actually create/write/delete a TARGET record need a grant: 0
+// create needs `create` on the target (relation) model, 1 update needs
+// `write`, 2 delete needs `delete`. Codes 3 (unlink), 4 (link), 5 (clear), 6
+// (replace) only rewire the join table and need no grant (contrast with
+// `NESTED_OP_BY_CODE`, where o2m codes 2/3/5/6 all need `delete` because
+// Odoo cascade-deletes orphaned children — see the comment above that map).
+const M2M_OP_BY_CODE: Record<number, "create" | "write" | "delete"> = {
+  0: "create",
+  1: "write",
+  2: "delete",
+};
+
 /**
- * Resolve m2o fields inside the value dicts of one2many command tuples.
- * Only the create (`[0, 0, {values}]`) and update (`[1, id, {values}]`)
- * commands carry a value dict; every other command (`[2,id]` delete, `[3,id]`
- * unlink, `[4,id]` link, `[5]` clear, `[6,0,[ids]]` set) passes through
- * unchanged. Recurses via `normalizeMany2OneValues` at depth+1, passing the
- * parent's `scopeCompanyId` as the inherited scope so the nested m2o lookups
- * are company-scoped even when the line doesn't restate company_id.
+ * Resolve a Command tuple's id position (tuple[1], or an element of the
+ * code-6 id list). Raw numeric ids — the standard Odoo wire format used by
+ * every pre-existing caller — pass straight through unchanged; `false`/`null`
+ * (code 6's "clear" id slot) also pass through. Only a ref-shaped value
+ * (`_pinchy_ref` bare string, `{ref}` object, or a name/code lookup string)
+ * is resolved via `resolveRelationValue`, so a line ref captured by
+ * `odoo_read` can be pasted back into an edit tuple's id position.
  */
-async function normalizeOne2ManyCommands(
+async function resolveCommandTargetId(
   client: OdooClient,
   connectionId: string,
-  relationModel: string,
+  relationField: OdooField,
+  idValue: unknown,
+  scopeCompanyId: number | null,
+  fieldsCache: FieldsCache,
+): Promise<unknown> {
+  if (typeof idValue === "number") return idValue;
+  if (idValue === false || idValue == null) return idValue;
+  return resolveRelationValue(
+    client,
+    connectionId,
+    relationField,
+    idValue,
+    scopeCompanyId,
+    fieldsCache,
+  );
+}
+
+/**
+ * Unified walker for one2many AND many2many Command tuples. Only the create
+ * (`[0, 0, {values}]`) and update (`[1, id, {values}]`) commands carry a
+ * value dict whose m2o fields get resolved recursively via
+ * `normalizeMany2OneValues` at depth+1, inheriting the parent's
+ * `scopeCompanyId`. Every code's id position(s) — `tuple[1]` for codes
+ * 1-4, each element of code 6's id list — is ref-decoded via
+ * `resolveCommandTargetId` so a ref captured by `odoo_read` can be pasted
+ * back into an edit. `[5]` clear carries no id at all and passes through
+ * unchanged.
+ *
+ * Governance: before doing any ref work for a tuple, the command's op code
+ * is checked against `NESTED_OP_BY_CODE` (one2many) or `M2M_OP_BY_CODE`
+ * (many2many) — see the doc comments above those maps for which codes need
+ * which grant, and why the two relation kinds differ.
+ */
+async function normalizeCommandTuples(
+  client: OdooClient,
+  connectionId: string,
+  relationField: OdooField,
   commands: unknown[],
   scopeCompanyId: number | null,
+  permissions: Permissions,
   depth: number,
   fieldsCache: FieldsCache,
+  kind: "one2many" | "many2many",
 ): Promise<unknown[]> {
+  const relationModel = relationField.relation as string;
+  const opByCode = kind === "one2many" ? NESTED_OP_BY_CODE : M2M_OP_BY_CODE;
   const out: unknown[] = [];
   for (const cmd of commands) {
-    if (!Array.isArray(cmd)) {
+    if (!Array.isArray(cmd) || typeof cmd[0] !== "number") {
       out.push(cmd);
       continue;
     }
-    const op = cmd[0];
-    const values = cmd[2];
-    if ((op === 0 || op === 1) && isRecord(values)) {
-      const resolved = (
+    const code = cmd[0];
+    const op = opByCode[code];
+    if (op !== undefined && !checkPermission(permissions, relationModel, op)) {
+      // Pinchy-allowlist rejection (not an Odoo server AccessError): phrase
+      // it as a permission gap, not an Odoo-side sync issue.
+      throw new Error(
+        `Agent missing ${op} grant on ${relationModel} ` +
+          `(nested via ${relationField.name} command ${code}). ` +
+          `Add ${op} on ${relationModel} to this agent's permissions.`,
+      );
+    }
+
+    if ((code === 0 || code === 1) && isRecord(cmd[2])) {
+      const resolvedValues = (
         await normalizeMany2OneValues(
           client,
           connectionId,
           relationModel,
-          values,
+          cmd[2],
+          permissions,
           depth + 1,
           scopeCompanyId,
           fieldsCache,
         )
       ).values;
-      out.push([op, cmd[1], resolved]);
+      const resolvedId =
+        code === 1
+          ? await resolveCommandTargetId(
+              client,
+              connectionId,
+              relationField,
+              cmd[1],
+              scopeCompanyId,
+              fieldsCache,
+            )
+          : cmd[1];
+      out.push([code, resolvedId, resolvedValues]);
+    } else if ((code === 2 || code === 3 || code === 4) && cmd.length >= 2) {
+      const resolvedId = await resolveCommandTargetId(
+        client,
+        connectionId,
+        relationField,
+        cmd[1],
+        scopeCompanyId,
+        fieldsCache,
+      );
+      out.push([code, resolvedId, ...cmd.slice(2)]);
+    } else if (code === 6 && Array.isArray(cmd[2])) {
+      const resolvedIds = await Promise.all(
+        (cmd[2] as unknown[]).map((id) =>
+          resolveCommandTargetId(
+            client,
+            connectionId,
+            relationField,
+            id,
+            scopeCompanyId,
+            fieldsCache,
+          ),
+        ),
+      );
+      out.push([code, cmd[1], resolvedIds]);
     } else {
       out.push(cmd);
     }
@@ -2266,6 +2397,7 @@ const plugin = {
                       config.connectionId,
                       model,
                       cleaned,
+                      config.permissions,
                     );
                     values = normalized.values;
                     modelFields = normalized.fields;
@@ -3120,6 +3252,7 @@ const plugin = {
                         config.connectionId,
                         model,
                         cleaned,
+                        config.permissions,
                       )
                     ).values;
                     values = await ensureActivityResModelId(

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1469,6 +1469,25 @@ async function normalizeCommandTuples(
   const relationModel = relationField.relation as string;
   const opByCode = kind === "one2many" ? NESTED_OP_BY_CODE : M2M_OP_BY_CODE;
 
+  // Governance first: check every tuple's op against the allowlist BEFORE any
+  // I/O (schema fetch) or ref resolution. A missing grant is the agent's to
+  // fix and must surface as a permission error even when the line schema also
+  // happens to be unavailable — and it lets an under-permissioned request fail
+  // fast without a schema round trip.
+  for (const cmd of commands) {
+    if (!Array.isArray(cmd) || typeof cmd[0] !== "number") continue;
+    const op = opByCode[cmd[0]];
+    if (op !== undefined && !checkPermission(permissions, relationModel, op)) {
+      // Pinchy-allowlist rejection (not an Odoo server AccessError): phrase
+      // it as a permission gap, not an Odoo-side sync issue.
+      throw new Error(
+        `Agent missing ${op} grant on ${relationModel} ` +
+          `(nested via ${relationField.name} command ${cmd[0]}). ` +
+          `Add ${op} on ${relationModel} to this agent's permissions.`,
+      );
+    }
+  }
+
   // An empty line schema means the nested m2o resolution inside
   // `normalizeMany2OneValues` has nothing to resolve against and would
   // otherwise silently return the values dict UNCHANGED (Hardening B). When
@@ -1492,16 +1511,6 @@ async function normalizeCommandTuples(
       continue;
     }
     const code = cmd[0];
-    const op = opByCode[code];
-    if (op !== undefined && !checkPermission(permissions, relationModel, op)) {
-      // Pinchy-allowlist rejection (not an Odoo server AccessError): phrase
-      // it as a permission gap, not an Odoo-side sync issue.
-      throw new Error(
-        `Agent missing ${op} grant on ${relationModel} ` +
-          `(nested via ${relationField.name} command ${code}). ` +
-          `Add ${op} on ${relationModel} to this agent's permissions.`,
-      );
-    }
 
     if ((code === 0 || code === 1) && isRecord(cmd[2])) {
       const resolvedValues = (

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -884,8 +884,20 @@ function refToId(
   field: OdooField,
   value: Record<string, unknown>,
 ): number | null {
-  if (typeof value.ref !== "string") return null;
-  return decodeAndValidateRef(connectionId, field, value.ref);
+  // Accept BOTH wire shapes: the m2o wrapper's `{ ref }` (wrapMany2OneValue)
+  // and the one2many wrapper's `{ _pinchy_ref }` (wrapOne2ManyValue). Without
+  // this an agent pasting a whole read-emitted o2m line object — or the
+  // read `line_ids` array verbatim — into a Command tuple id position would
+  // hit the "Raw numeric IDs are not accepted" guard below, because only the
+  // bare string decoded, not the object carrying it.
+  const refString =
+    typeof value.ref === "string"
+      ? value.ref
+      : typeof value._pinchy_ref === "string"
+        ? value._pinchy_ref
+        : null;
+  if (refString === null) return null;
+  return decodeAndValidateRef(connectionId, field, refString);
 }
 
 /**
@@ -907,11 +919,13 @@ function refToId(
  * prefix in `detail`. Admins can grep / filter for that string — no separate
  * audit pipeline is needed here.
  *
- * Scope: only top-level fields of `values` are inspected. Nested 2many/o2m
- * command tuples (e.g. `invoice_line_ids: [[0, 0, { account_id: ... }]]`)
- * are not walked — that broader check would require following Odoo's
- * Command structure, which is out of scope for this guard. Odoo's
- * server-side `company_id` constraint remains the ultimate authority.
+ * Scope: top-level fields of `values` AND nested one2many/many2many command
+ * tuples (e.g. `line_ids: [[0, 0, { account_id: <ref> }]]`) are inspected.
+ * A line-level ref whose company tag disagrees with the parent's (or its
+ * own line-level `company_id`, when the line declares one) is rejected with
+ * the same "Cross-company write rejected" prefix and a path like
+ * `line_ids[0].account_id`. Odoo's server-side `company_id` constraint
+ * remains the ultimate authority.
  */
 export function assertNoCrossCompanyRefs(
   values: Record<string, unknown>,
@@ -922,17 +936,96 @@ export function assertNoCrossCompanyRefs(
 
   for (const [field, value] of Object.entries(values)) {
     if (field === "company_id") continue;
-    const sibling = readRefCompanyTag(value);
-    if (sibling === null) continue;
+    assertNoCrossCompanyValue(value, intended, intendedLabel, field, 0);
+  }
+}
+
+// Depth cap for the cross-company guard's tuple recursion — a defensive
+// bound against a pathologically deep/self-referential nested structure,
+// mirroring the bound `normalizeMany2OneValues` already applies to its own
+// nested walk (one level today). Generous enough for any real Odoo o2m/m2m
+// nesting while still stopping unbounded recursion.
+const MAX_CROSS_COMPANY_DEPTH = 8;
+
+/**
+ * Recursive companion to {@link assertNoCrossCompanyRefs}. Checks a single
+ * value: if it carries a company-tagged ref, compare against `intended`;
+ * if it is a one2many/many2many command-tuple array, descend into the
+ * create (0) and update (1) tuples' values dicts and check each field.
+ * `path` is threaded for actionable error messages (e.g.
+ * `line_ids[0].account_id`).
+ */
+function assertNoCrossCompanyValue(
+  value: unknown,
+  intended: { id: number; label: string | null },
+  intendedLabel: string,
+  path: string,
+  depth: number,
+): void {
+  if (depth >= MAX_CROSS_COMPANY_DEPTH) return;
+  const sibling = readRefCompanyTag(value);
+  if (sibling !== null) {
     if (sibling.id !== intended.id) {
       const otherLabel = sibling.label ?? `id=${sibling.id}`;
       throw new Error(
         `Cross-company write rejected: values.company_id points to "${intendedLabel}" ` +
-          `but values.${field} points to a record in "${otherLabel}". ` +
-          `Re-resolve ${field} in the right company first.`,
+          `but values.${path} points to a record in "${otherLabel}". ` +
+          `Re-resolve ${path} in the right company first.`,
       );
     }
+    return;
   }
+  if (!Array.isArray(value)) return;
+  value.forEach((tuple, i) => {
+    if (!Array.isArray(tuple)) return;
+    // Odoo Command tuple: [code, ...]. 0 (create) and 1 (update) carry a
+    // values dict at index 2 with refs to check.
+    if ((tuple[0] === 0 || tuple[0] === 1) && isRecord(tuple[2])) {
+      const lineDict = tuple[2] as Record<string, unknown>;
+      // A line may declare its OWN company_id; normalizeMany2OneValues
+      // re-scopes that line's m2o lookups to it, so the guard must use the
+      // SAME baseline or it false-rejects a self-consistent line. Fall back
+      // to the parent's company when the line declares none.
+      const lineTag = readRefCompanyTag(lineDict.company_id);
+      const lineIntended = lineTag ?? intended;
+      const lineIntendedLabel = lineTag
+        ? (lineTag.label ?? `id=${lineTag.id}`)
+        : intendedLabel;
+      for (const [k, v] of Object.entries(lineDict)) {
+        if (k === "company_id") continue; // the scoping anchor itself
+        assertNoCrossCompanyValue(
+          v,
+          lineIntended,
+          lineIntendedLabel,
+          `${path}[${i}].${k}`,
+          depth + 1,
+        );
+      }
+    }
+    // Codes 1 (update), 2 (delete), 3 (unlink), 4 (link) all carry a
+    // company-taggable id at tuple[1]. (0 has no id; 6 is handled below.)
+    if (tuple[0] === 1 || tuple[0] === 2 || tuple[0] === 3 || tuple[0] === 4) {
+      assertNoCrossCompanyValue(
+        tuple[1],
+        intended,
+        intendedLabel,
+        `${path}[${i}]`,
+        depth + 1,
+      );
+    }
+    // replace (6, 0, [ids]) — check every id in the replacement list.
+    if (tuple[0] === 6 && Array.isArray(tuple[2])) {
+      (tuple[2] as unknown[]).forEach((id, j) => {
+        assertNoCrossCompanyValue(
+          id,
+          intended,
+          intendedLabel,
+          `${path}[${i}][${j}]`,
+          depth + 1,
+        );
+      });
+    }
+  });
 }
 
 /**
@@ -994,17 +1087,22 @@ export function formatInvalidSelectionError(
 function readRefCompanyTag(
   value: unknown,
 ): { id: number; label: string | null } | null {
-  // Accept the ref in either wire form the agent may pass: the structured
-  // `{ ref: "…" }` object OR a bare `_pinchy_ref` string (the form odoo_read
-  // emits and the prose tells the agent to copy verbatim). Without the
-  // bare-string branch, Layer 1's bare-ref support would let a bare ref slip
-  // past the cross-company guard entirely.
-  const refString =
-    isRecord(value) && typeof value.ref === "string"
+  // Accept the ref in any wire form the agent may pass: the m2o wrapper's
+  // `{ ref: "…" }` object, the one2many wrapper's `{ _pinchy_ref: "…" }`
+  // object (so a pasted whole o2m line object is visible to this guard too),
+  // OR a bare `_pinchy_ref` string (the form odoo_read emits and the prose
+  // tells the agent to copy verbatim). Without the bare-string branch,
+  // Layer 1's bare-ref support would let a bare ref slip past the
+  // cross-company guard entirely.
+  const refString = isRecord(value)
+    ? typeof value.ref === "string"
       ? value.ref
-      : isIntegrationRef(value)
-        ? value
-        : null;
+      : typeof value._pinchy_ref === "string"
+        ? value._pinchy_ref
+        : null
+    : isIntegrationRef(value)
+      ? value
+      : null;
   if (refString === null) return null;
   try {
     const payload = decodeRef(refString);
@@ -1303,6 +1401,45 @@ async function resolveCommandTargetId(
 }
 
 /**
+ * A single value is "ref-shaped" when it needs decoding before it can reach
+ * Odoo: a bare `_pinchy_ref` string, or a `{ref}`/`{_pinchy_ref}` object.
+ * Used by {@link commandTuplesNeedResolution} to decide whether an empty
+ * line schema is actually a problem for a given set of tuples.
+ */
+function isRefShaped(value: unknown): boolean {
+  if (isIntegrationRef(value)) return true;
+  return (
+    isRecord(value) &&
+    (typeof value.ref === "string" || typeof value._pinchy_ref === "string")
+  );
+}
+
+/**
+ * True when at least one command tuple in `tuples` actually needs relation
+ * resolution: a code-0/1 values dict containing a ref-shaped value, or an id
+ * position (tuple[1], or an element of a code-6 id list) that is neither a
+ * raw number nor `false`/`null` (Odoo's own wire shapes, which never need
+ * resolution). Pure raw-id tuples such as `[6, 0, [1, 2, 3]]` return false
+ * here — they carry nothing for the line schema to resolve against, so an
+ * empty/unavailable line schema is harmless for them.
+ */
+function commandTuplesNeedResolution(tuples: unknown[]): boolean {
+  const idNeedsResolution = (id: unknown): boolean =>
+    typeof id !== "number" && id !== false && id != null;
+  return tuples.some((tuple) => {
+    if (!Array.isArray(tuple)) return false;
+    const code = tuple[0];
+    if ((code === 0 || code === 1) && isRecord(tuple[2])) {
+      if (Object.values(tuple[2]).some(isRefShaped)) return true;
+    }
+    if (code === 6 && Array.isArray(tuple[2])) {
+      return (tuple[2] as unknown[]).some(idNeedsResolution);
+    }
+    return idNeedsResolution(tuple[1]);
+  });
+}
+
+/**
  * Unified walker for one2many AND many2many Command tuples. Only the create
  * (`[0, 0, {values}]`) and update (`[1, id, {values}]`) commands carry a
  * value dict whose m2o fields get resolved recursively via
@@ -1331,6 +1468,23 @@ async function normalizeCommandTuples(
 ): Promise<unknown[]> {
   const relationModel = relationField.relation as string;
   const opByCode = kind === "one2many" ? NESTED_OP_BY_CODE : M2M_OP_BY_CODE;
+
+  // An empty line schema means the nested m2o resolution inside
+  // `normalizeMany2OneValues` has nothing to resolve against and would
+  // otherwise silently return the values dict UNCHANGED (Hardening B). When
+  // the tuples carry only raw ids (no ref-shaped value anywhere), that's
+  // fine — Odoo's own wire format expects raw ids and there's nothing to
+  // resolve. But if resolution IS needed, silently no-op-ing here would let
+  // a bare ref reach Odoo undecoded — fail loud instead.
+  const lineFields = await loadFields(client, relationModel, fieldsCache);
+  if (lineFields.length === 0 && commandTuplesNeedResolution(commands)) {
+    throw new Error(
+      `Cannot resolve references in "${relationField.name}" (relation "${relationModel}"): ` +
+        `the schema for ${relationModel} came back empty, so many2one refs in its ` +
+        `command tuples cannot be decoded. Re-check the connection to Odoo and try again.`,
+    );
+  }
+
   const out: unknown[] = [];
   for (const cmd of commands) {
     if (!Array.isArray(cmd) || typeof cmd[0] !== "number") {
@@ -1680,6 +1834,51 @@ function wrapMany2OneValue(
   } satisfies OdooRefValue;
 }
 
+/**
+ * Wrap each child id of a one2many field into a thin ref-carrying object so
+ * the agent can target that specific line (e.g. to edit or remove it) by
+ * pasting the `_pinchy_ref` into a Command tuple's id position — decoded
+ * back to a numeric id by `resolveCommandTargetId`. Odoo's read/search_read
+ * only ever returns o2m fields as a bare array of child ids (no name or
+ * company tag comes back at read time), so the label is the best we can do
+ * without an extra round trip: `<relation>#<id>`.
+ *
+ * Scope is one2many ONLY — many2many fields are left as raw id arrays
+ * (out of scope for this change).
+ *
+ * Only transforms a non-empty array whose elements are all numbers. Empty
+ * arrays stay `[]` (nothing to wrap). Anything else (shouldn't happen for
+ * o2m on read, but the field loop is generic) passes through unchanged —
+ * defensive, never throws.
+ */
+function wrapOne2ManyValue(
+  connectionId: string,
+  field: OdooField,
+  value: unknown,
+): unknown {
+  if (
+    field.type !== "one2many" ||
+    !field.relation ||
+    !Array.isArray(value) ||
+    value.length === 0 ||
+    !value.every((item) => typeof item === "number")
+  ) {
+    return value;
+  }
+  const relation = field.relation;
+  return value.map((id) => ({
+    _pinchy_ref: encodeRef({
+      integrationType: "odoo",
+      connectionId,
+      model: relation,
+      id: id as number,
+      label: `${relation}#${id}`,
+    }),
+    id,
+    model: relation,
+  }));
+}
+
 function wrapReadResult(
   connectionId: string,
   model: string,
@@ -1729,6 +1928,7 @@ function wrapReadResult(
       const field = byName.get(name);
       if (field) {
         wrapped[name] = wrapMany2OneValue(connectionId, field, value);
+        wrapped[name] = wrapOne2ManyValue(connectionId, field, wrapped[name]);
       }
     }
     return wrapped;


### PR DESCRIPTION
## Context

`main` already resolves nested many2one inside one2many command tuples (#615, merged via #627) — a deliberately simple, depth-1, one2many-only implementation, plus `move_type` selection validation and a company-scoped duplicate-invoice guard.

This PR builds **on top of that base** (does not replace it) and adds the governance/capability layer a parallel effort (PR #616) had explored. #616 was a structurally-incompatible parallel re-implementation of the same #615 core; rather than force-rebase it (which would have dropped main's selection/duplicate-invoice fixes), the genuinely net-new value is ported cleanly onto main's structure here. **#616 is superseded by this PR.**

## What this adds (three capabilities `main` lacks)

1. **Nested-permission gating (governance).** Nested one2many/many2many command tuples are now checked against the line/target model's Pinchy allowlist:
   - o2m: `1`→`write`, `2/3/5/6`→`delete` (Odoo #13082 — clearing/replacing a required-inverse one2many cascade-deletes children).
   - m2m: `0`→`create`, `1`→`write`, `2`→`delete` (join table; `3/4/5/6` need no grant).
   - Inline create `[0,0,{…}]` still needs no line grant (part of the parent's atomic create).
   - **Closes a gap on `main`**: an agent with `account.move:write` but not `account.move.line:delete` could previously delete lines via a nested `[2,id]`/`[5]`/`[6]` tuple — Pinchy's allowlist didn't apply to nested destructive ops.
2. **many2many command-tuple resolution.** The nested walker now also descends `many2many` fields, resolving m2o refs in nested values and decoding ref/name ids in tuple id positions (`resolveCommandTargetId`) for both relation kinds.
3. **Read-side one2many line refs + round-trip.** `odoo_read` wraps each one2many child id as `{ _pinchy_ref, id, model }`, so an agent can target a specific existing line in an edit tuple. `refToId`/`readRefCompanyTag` decode both `ref` and `_pinchy_ref`, so a read-emitted line object (or the whole `line_ids` array) round-trips into a command-tuple id position. (many2many read values stay raw id arrays — out of scope.)

Plus hardening: the cross-company guard now recurses into command tuples (re-deriving the intended company from a line's own `company_id`, checking id positions of codes 1/2/3/4 and code-6 lists); and the walker fails loud when a line relation's schema is unavailable and a tuple actually needs resolution, instead of silently passing an undecoded ref to Odoo.

Keeps `main`'s deliberate **depth-1 bound** — deeper nesting stays out of scope. Preserves `main`'s `move_type` validation and duplicate-invoice guard.

## Tests (TDD)

- Full `pinchy-odoo` suite: **339 passed** (from 325 base; +14 read-side/hardening on top of the write-side gating/m2m tests).
- `tsc --noEmit` clean · `scripts/typecheck-plugins.mjs`: all 8 plugins clean · `test:scripts` green.
- Mock gains `account.tax` + a `tax_ids` many2many for faithful m2m coverage.

Refs #615. Supersedes #616.