### PR TITLE
ci(format): gate docs & workflow formatting on docs PRs, not as code-PR collateral

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,8 +100,10 @@ jobs:
       - name: Format check (web)
         run: pnpm --filter @pinchy/web format:check
 
-      - name: Format check (docs & workflows)
-        run: pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"
+      # Docs & workflow formatting is checked by the dedicated `docs-format.yml`
+      # workflow, which (unlike this one) is NOT paths-ignored for docs, so it
+      # runs on the docs PRs it guards instead of only firing as collateral
+      # here on unrelated code changes.
 
       - name: Typecheck plugins
         # The pinchy-* plugins run via tsx with no ahead-of-time type checking

--- a/.github/workflows/docs-format.yml
+++ b/.github/workflows/docs-format.yml
@@ -1,0 +1,48 @@
+# Prettier check for docs & workflow files.
+#
+# The main CI workflow (`ci.yml`) is deliberately `paths-ignore: [docs/**,
+# **/*.md, ...]` so its heavy build/test/e2e matrix does not run on docs-only
+# changes. But that also meant its "Format check (docs & workflows)" step never
+# ran on the docs PRs it exists to guard — it only fired as collateral on
+# unrelated code PRs, where a pre-existing docs-formatting slip surfaced as a
+# confusing failure attributed to unrelated code (observed: an unformatted
+# .mdx merged via a docs-only PR, then reddened a plugin PR's CI).
+#
+# This dedicated workflow closes that gap: it runs the exact same prettier
+# check, but triggers on the docs/workflow paths themselves (the inverse of
+# ci.yml's ignore), so docs formatting is validated on the PR that changes it.
+# It is intentionally lightweight (checkout + setup + one prettier run).
+name: Docs & Workflow Format
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - "docs/src/**/*.mdx"
+      - "docs/src/**/*.md"
+      - ".github/**/*.yml"
+  push:
+    branches: [main]
+    paths:
+      - "docs/src/**/*.mdx"
+      - "docs/src/**/*.md"
+      - ".github/**/*.yml"
+
+# Cancel superseded PR runs; never cancel on main so post-merge runs complete.
+concurrency:
+  group: docs-format-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+jobs:
+  docs-format:
+    name: Format check (docs & workflows)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+
+      - uses: ./.github/actions/setup-pnpm
+
+      # Same command as ci.yml used to run inline — kept identical so the two
+      # never drift in prettier version, config resolution, or plugins.
+      - name: Format check (docs & workflows)
+        run: pnpm -C packages/web exec prettier --check "../../docs/src/**/*.{mdx,md}" "../../.github/**/*.yml"


### PR DESCRIPTION
## Problem

`ci.yml` is deliberately `paths-ignore: [docs/**, "**/*.md", ...]` so its heavy build/test/e2e matrix does not run on docs-only changes. But its **inline `Format check (docs & workflows)` step lived inside that same paths-ignored workflow** — so it **never ran on the docs PRs it exists to guard**.

Instead it only fired as *collateral* on unrelated code PRs (which trigger `ci.yml`), where it scans `docs/**` and surfaces any pre-existing docs-formatting slip as a **confusing failure attributed to unrelated code**.

This actually happened today:
- An unformatted `.mdx` (`*emphasis*` vs prettier's `_emphasis_`) merged via **docs-only PR #692** → `ci.yml` skipped entirely → the format step never validated it.
- It then **reddened plugin PR #693's CI** on a step that had nothing to do with #693's changes. (Fixed for now by #694, which reformatted the file.)

## Fix

- **New `.github/workflows/docs-format.yml`** — triggers on the docs/workflow **paths themselves** (`docs/src/**/*.{mdx,md}`, `.github/**/*.yml`), the inverse of `ci.yml`'s ignore. Runs the **byte-identical** prettier command via the same `setup-pnpm` action, so the two can't drift in version/config/plugins. Lightweight: checkout + setup + one prettier run.
- **Removed** the now-redundant inline step from `ci.yml`.

## Result

- Docs formatting is validated **on the PR that changes docs** (the gap that let #692 through is closed — incl. direct pushes to `main`, via the `push` trigger).
- Code PRs **no longer fail on unrelated pre-existing docs drift**.
- The heavy matrix still skips docs-only changes (unchanged).

## Notes

- Verified new `docs-format.yml` + edited `ci.yml` + the full docs/workflow scope all pass the pinned prettier 3.9.4.
- Optional follow-up (repo settings, not this PR): if you want docs formatting to *block* merges, add this new check to branch protection — but mind the paths-filter + required-check footgun (a required check that doesn't run on non-matching PRs can block them), so pair it with GitHub's "skipped ⇒ success" handling.
- This PR touches `.github/**/*.yml`, so the new workflow will run on the PR itself — a nice self-test.