### PR TITLE
feat(chat): multi-device live-sync via body-free poke/pull (v1)

### DIFF
--- a/docs/src/content/docs/explanation/chat-states.mdx
+++ b/docs/src/content/docs/explanation/chat-states.mdx
@@ -29,6 +29,14 @@ When the state is Unavailable, the indicator and status message explain why:
 
 When the agent runtime becomes reachable again — whether after a network drop or after a settings change — Pinchy automatically requests the latest conversation history and resumes where it left off. No reload needed.
 
+## Your chats stay in sync across your devices
+
+Open the same chat on your phone and your computer, and both stay current. Send a message on one, and it appears on the other in real time — no reload needed. A message that arrives from a connected channel like Telegram shows up in the web chat live, too.
+
+This works out of the box. There's nothing to switch on.
+
+The live update itself carries no message content — only a small signal that the chat changed. Your device then fetches the new messages over the same secure, permission-checked connection it always uses, so a conversation is only ever delivered to the person it belongs to.
+
 ## Brief disconnects don't lock the UI
 
 Pinchy waits 2 seconds before showing the Disconnected state. During those 2 seconds the interface stays in its previous state (Ready or Responding) so short network hiccups are absorbed silently without disrupting your flow.

--- a/packages/web/e2e/integration/20-multi-device-live-sync.spec.ts
+++ b/packages/web/e2e/integration/20-multi-device-live-sync.spec.ts
@@ -1,0 +1,72 @@
+/**
+ * Multi-device live-sync (Lane B).
+ *
+ * A message sent on one device of a user must appear on that user's OTHER
+ * already-open device WITHOUT a manual reload. This is the one thing the unit
+ * tests necessarily mock: that the REAL OpenClaw gateway emits a
+ * `session.message` event for a WEB chat turn (not only for Telegram), which
+ * Pinchy's per-session `sessions.messages.subscribe` consumes and fans out as a
+ * body-free poke, driving device B to re-pull authoritative history through the
+ * normal cookie-authorized path.
+ *
+ * Two isolated browser contexts = two devices of the SAME user (independent
+ * cookie jars, same account). Device B is opened BEFORE device A sends and is
+ * never reloaded/navigated again — so any content that appears on B arrived via
+ * the live poke → re-pull, not a page load.
+ *
+ * The turn uses a DEDICATED fake-LLM trigger so both the user message and the
+ * reply are UNIQUE: the integration suite shares one OpenClaw session across
+ * specs, so asserting the generic FAKE_OLLAMA_RESPONSE would resolve to multiple
+ * transcript elements (and would leak an extra generic reply into the session
+ * that breaks agent-chat's own default-reply assertion).
+ */
+import { test, expect } from "@playwright/test";
+import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
+import {
+  FAKE_OLLAMA_MULTI_DEVICE_TRIGGER,
+  FAKE_OLLAMA_MULTI_DEVICE_RESPONSE,
+} from "../shared/fake-ollama/fake-ollama-server";
+
+test.describe("Multi-device live-sync", () => {
+  test("a message sent on device A appears on device B without a reload", async ({ browser }) => {
+    // Device A sends this exact text; it is a unique fake-LLM trigger, so both it
+    // (the user turn) and its reply exist only because of THIS test.
+    const SENT = FAKE_OLLAMA_MULTI_DEVICE_TRIGGER;
+    const REPLY = FAKE_OLLAMA_MULTI_DEVICE_RESPONSE;
+
+    // --- Device A ---
+    const ctxA = await browser.newContext();
+    const pageA = await ctxA.newPage();
+    await login(pageA);
+    const agentId = await getSmithersAgentId(pageA);
+    await pageA.goto(`/chat/${agentId}`);
+    await waitForOpenClawConnected(pageA);
+    const inputA = pageA.getByPlaceholder(/send a message/i);
+    await expect(inputA).toBeVisible({ timeout: 10000 });
+
+    // --- Device B (same user, second context, same chat, opened BEFORE A sends) ---
+    const ctxB = await browser.newContext();
+    const pageB = await ctxB.newPage();
+    await login(pageB);
+    await pageB.goto(`/chat/${agentId}`);
+    await waitForOpenClawConnected(pageB);
+    await expect(pageB.getByPlaceholder(/send a message/i)).toBeVisible({ timeout: 10000 });
+
+    // B must not show this turn yet — it hasn't been sent.
+    await expect(pageB.getByText(SENT)).toHaveCount(0);
+    await expect(pageB.getByText(REPLY)).toHaveCount(0);
+
+    // --- Device A sends and sees the assistant reply ---
+    await inputA.fill(SENT);
+    await inputA.press("Enter");
+    await expect(pageA.getByText(SENT)).toBeVisible({ timeout: 10000 });
+    await expect(pageA.getByText(REPLY)).toBeVisible({ timeout: 30000 });
+
+    // --- THE PROOF: device B renders A's turn live, with NO reload/navigation on B ---
+    await expect(pageB.getByText(SENT)).toBeVisible({ timeout: 30000 });
+    await expect(pageB.getByText(REPLY)).toBeVisible({ timeout: 30000 });
+
+    await ctxA.close();
+    await ctxB.close();
+  });
+});

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -113,6 +113,15 @@ const LIVENESS_SLOW_DELAY_MS = 18000;
 const LIVENESS_DYING_TRIGGER = "E2E_LIVENESS_DYING_RESPONSE";
 const LIVENESS_DYING_PARTIAL = "Starting to respond";
 
+// ── Multi-device live-sync trigger ─────────────────────────────────────────
+// A fast, UNIQUE reply for the multi-device spec. The integration suite shares
+// ONE OpenClaw session across specs, so a generic FAKE_RESPONSE reply would
+// appear multiple times in the transcript — breaking any strict getByText (both
+// this spec's device-B assertion and agent-chat's default-reply assertion).
+// A dedicated trigger keeps this spec's turn self-identifying and side-effect-free.
+const MULTI_DEVICE_TRIGGER = "E2E_MULTI_DEVICE_SYNC";
+const MULTI_DEVICE_RESPONSE = "Multi-device sync reply — device B sees this live.";
+
 // ── Transient provider-error triggers (durable agent-error banner) ──────────
 // RATE_LIMIT: the provider returns an HTTP 429 with a rate-limit body, the
 // canonical "transient, retry later" failure. OpenClaw surfaces it as a chat
@@ -881,6 +890,11 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    if (lastContent.includes(MULTI_DEVICE_TRIGGER) && !hasToolResult) {
+      streamTextResponse(res, MULTI_DEVICE_RESPONSE, countUserMessages(messages));
+      return;
+    }
+
     streamTextResponse(
       res,
       activeTrigger ? activeTrigger.response : FAKE_RESPONSE,
@@ -968,6 +982,11 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    if (lastContent.includes(MULTI_DEVICE_TRIGGER) && !hasToolResult) {
+      streamOpenAiText(res, MULTI_DEVICE_RESPONSE, countUserMessages(messages));
+      return;
+    }
+
     streamOpenAiText(
       res,
       activeTrigger ? activeTrigger.response : FAKE_RESPONSE,
@@ -997,6 +1016,8 @@ export const FAKE_OLLAMA_SLOW_STREAM_DELAY_MS = SLOW_STREAM_DELAY_MS;
 // Chat-liveness triggers (slow "taking longer" + dying provider failure).
 export const FAKE_OLLAMA_LIVENESS_SLOW_TRIGGER = LIVENESS_SLOW_TRIGGER;
 export const FAKE_OLLAMA_LIVENESS_SLOW_RESPONSE = LIVENESS_SLOW_RESPONSE;
+export const FAKE_OLLAMA_MULTI_DEVICE_TRIGGER = MULTI_DEVICE_TRIGGER;
+export const FAKE_OLLAMA_MULTI_DEVICE_RESPONSE = MULTI_DEVICE_RESPONSE;
 export const FAKE_OLLAMA_LIVENESS_SLOW_DELAY_MS = LIVENESS_SLOW_DELAY_MS;
 export const FAKE_OLLAMA_LIVENESS_DYING_TRIGGER = LIVENESS_DYING_TRIGGER;
 export const FAKE_OLLAMA_LIVENESS_DYING_PARTIAL = LIVENESS_DYING_PARTIAL;

--- a/packages/web/server.ts
+++ b/packages/web/server.ts
@@ -12,6 +12,7 @@ import { applyKeepAliveTuning } from "./src/server/http-keepalive";
 import { setOpenClawClient } from "./src/server/openclaw-client";
 import { once } from "./src/lib/once";
 import { getActiveRunsSingleton } from "./src/server/active-runs-singleton";
+import { getSessionPokeBridgeSingleton } from "./src/server/session-poke-bridge-singleton";
 import { startRunWatchdog, DEFAULT_FIRST_CHUNK_TIMEOUT_MS } from "./src/server/run-watchdog";
 import {
   ChannelHealthMonitor,
@@ -150,6 +151,7 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
   // #310 Tier 2a: server-wide registry of in-flight chat runs. Shared
   // across all ClientRouter instances (one per ws) and the watchdog.
   const activeRuns = getActiveRunsSingleton();
+  const pokeBridge = getSessionPokeBridgeSingleton();
 
   const wss = new WebSocketServer({
     noServer: true,
@@ -232,7 +234,8 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
           sessionInfo.userRole,
           sessionCache,
           activeRuns,
-          disconnectSignal
+          disconnectSignal,
+          pokeBridge
         )
       : null;
 
@@ -267,6 +270,11 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       // a dead socket. The run itself stays alive until OC's stream
       // terminates or the watchdog tears it down on absolute timeout.
       activeRuns.removeListenerFromAll(clientWs);
+      // Lane B: prune this socket from every session-subscriber set and close
+      // any upstream subscription it was the last viewer of (reverse-index).
+      void pokeBridge.disconnect(clientWs).catch((err) => {
+        console.error("poke-bridge disconnect failed:", err instanceof Error ? err.message : err);
+      });
     });
 
     clientWs.on("error", (err) => {
@@ -274,6 +282,9 @@ ${domain ? `<p><a href="https://${domain}">Go to ${domain} →</a></p>` : ""}
       releaseConnectionOnce();
       sessionMap.delete(clientWs);
       activeRuns.removeListenerFromAll(clientWs);
+      void pokeBridge.disconnect(clientWs).catch((e) => {
+        console.error("poke-bridge disconnect failed:", e instanceof Error ? e.message : e);
+      });
     });
   });
 

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -4684,7 +4684,6 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
         type: "poke",
         sessionKey: "agent:agent-1:direct:u1",
         messageId: "m1",
-        seq: 1,
       });
     });
 
@@ -4694,20 +4693,66 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     expect(newSends).toContainEqual({ type: "history", agentId: "agent-1" });
   });
 
-  it("ignores a stale poke whose seq was already seen (no redundant re-pull)", () => {
+  it("dedups a poke on messageId — a repeat is suppressed, a new id re-pulls", () => {
     renderHook(() => useWsRuntime("agent-1"));
     const ws = openWithHistory();
 
+    // m5 → re-pull; COMPLETE that pull so the pending-history latch clears.
+    // Without draining the latch, coalescing alone (not the dedup) would mask a
+    // missing/miswired dedup and the test would pass for the wrong reason.
     act(() => {
-      ws.simulateMessage({ type: "poke", messageId: "m5", seq: 5 });
+      ws.simulateMessage({ type: "poke", messageId: "m5" });
     });
-    const afterFirst = ws.send.mock.calls.length;
-
     act(() => {
-      ws.simulateMessage({ type: "poke", messageId: "m3", seq: 3 }); // older seq
+      ws.simulateMessage({ type: "history", messages: [] });
+    });
+    const afterM5 = ws.send.mock.calls.length;
+
+    // A duplicate event for the SAME finished message must NOT re-pull. Dedup is
+    // on the globally-unique messageId — a per-session seq counter would instead
+    // falsely suppress a lower-seq poke on a newly-opened chat or after a
+    // compaction, and an absent seq would re-pull here every time.
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "m5" });
+    });
+    expect(ws.send.mock.calls.length).toBe(afterM5); // no new send for a duplicate
+
+    // A DIFFERENT message → re-pull again (dedup is per-message, not permanent).
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "m6" });
+    });
+    const newSends = ws.send.mock.calls
+      .slice(afterM5)
+      .map((c: unknown[]) => JSON.parse(c[0] as string));
+    expect(newSends).toContainEqual({ type: "history", agentId: "agent-1" });
+  });
+
+  it("resets poke dedup on a chat switch, so the new chat still re-pulls on its first poke", () => {
+    const { rerender } = renderHook(({ chatId }) => useWsRuntime("agent-1", chatId), {
+      initialProps: { chatId: "chat-a" },
+    });
+    const wsA = openWithHistory();
+    // Catch up on a message in chat A — this records its messageId as "seen".
+    act(() => {
+      wsA.simulateMessage({ type: "poke", messageId: "shared-id" });
     });
 
-    expect(ws.send.mock.calls.length).toBe(afterFirst); // no new send for a stale poke
+    // User switches to chat B: the effect tears down and reconnects.
+    rerender({ chatId: "chat-b" });
+    const wsB = openWithHistory();
+    const before = wsB.send.mock.calls.length;
+
+    // A poke on chat B that happens to reuse chat A's messageId MUST still
+    // re-pull: the dedup identity is per-session and was cleared on the switch.
+    // Without the reset the new chat would silently miss its first live update.
+    act(() => {
+      wsB.simulateMessage({ type: "poke", messageId: "shared-id" });
+    });
+
+    const newSends = wsB.send.mock.calls
+      .slice(before)
+      .map((c: unknown[]) => JSON.parse(c[0] as string));
+    expect(newSends).toContainEqual({ type: "history", agentId: "agent-1", chatId: "chat-b" });
   });
 
   it("re-pulls history on window focus (the bug: returning to the window fires no visibilitychange)", () => {
@@ -4744,7 +4789,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     // keeps the stale local view: device B stays blank AND the sending device
     // double-renders its own turn — exactly the CI E2E failures this guards.
     act(() => {
-      ws.simulateMessage({ type: "poke", messageId: "m2", seq: 1 });
+      ws.simulateMessage({ type: "poke", messageId: "m2" });
       ws.simulateMessage({
         type: "history",
         messages: [
@@ -4789,7 +4834,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     // A poke for the sender's OWN session re-pulls history that already contains
     // the just-streamed reply — it must reconcile, not append a 2nd bubble.
     act(() => {
-      ws.simulateMessage({ type: "poke", messageId: "srv-1", seq: 1 });
+      ws.simulateMessage({ type: "poke", messageId: "srv-1" });
       ws.simulateMessage({
         type: "history",
         messages: [
@@ -4829,7 +4874,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     // race the live stream and double-render the in-flight turn (the CI E2E bug).
     const before = ws.send.mock.calls.length;
     act(() => {
-      ws.simulateMessage({ type: "poke", messageId: "srv-1", seq: 1 });
+      ws.simulateMessage({ type: "poke", messageId: "srv-1" });
     });
     const historySends = ws.send.mock.calls
       .slice(before)

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -4648,3 +4648,193 @@ describe("user-triggered abort (onCancel) (#550)", () => {
     expect(result.current.runtime.isRunning).toBe(false);
   });
 });
+
+describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    vi.useFakeTimers();
+    wsInstances = [];
+    // A prior describe may have run vi.unstubAllGlobals() in its afterEach,
+    // tearing down the module-level WebSocket stub — re-establish it so these
+    // tests are order-independent (they passed alone but failed in a full run).
+    vi.stubGlobal("WebSocket", MockWebSocket);
+  });
+  afterEach(() => {
+    vi.useRealTimers();
+    vi.unstubAllGlobals();
+  });
+
+  function openWithHistory(): MockWebSocket {
+    const ws = latestWs();
+    act(() => {
+      ws.simulateOpen();
+      // The history response clears the pre-history latch armed by onopen.
+      ws.simulateMessage({ type: "history", messages: [] });
+    });
+    return ws;
+  }
+
+  it("re-pulls history when a poke arrives for the open session", () => {
+    renderHook(() => useWsRuntime("agent-1"));
+    const ws = openWithHistory();
+    const before = ws.send.mock.calls.length;
+
+    act(() => {
+      ws.simulateMessage({
+        type: "poke",
+        sessionKey: "agent:agent-1:direct:u1",
+        messageId: "m1",
+        seq: 1,
+      });
+    });
+
+    const newSends = ws.send.mock.calls
+      .slice(before)
+      .map((c: unknown[]) => JSON.parse(c[0] as string));
+    expect(newSends).toContainEqual({ type: "history", agentId: "agent-1" });
+  });
+
+  it("ignores a stale poke whose seq was already seen (no redundant re-pull)", () => {
+    renderHook(() => useWsRuntime("agent-1"));
+    const ws = openWithHistory();
+
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "m5", seq: 5 });
+    });
+    const afterFirst = ws.send.mock.calls.length;
+
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "m3", seq: 3 }); // older seq
+    });
+
+    expect(ws.send.mock.calls.length).toBe(afterFirst); // no new send for a stale poke
+  });
+
+  it("re-pulls history on window focus (the bug: returning to the window fires no visibilitychange)", () => {
+    renderHook(() => useWsRuntime("agent-1"));
+    const ws = openWithHistory();
+    const before = ws.send.mock.calls.length;
+
+    act(() => {
+      window.dispatchEvent(new Event("focus"));
+    });
+
+    const newSends = ws.send.mock.calls
+      .slice(before)
+      .map((c: unknown[]) => JSON.parse(c[0] as string));
+    expect(newSends).toContainEqual({ type: "history", agentId: "agent-1" });
+  });
+
+  it("adopts newer server history on a poke (recover semantics), so a turn from another device appears", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = latestWs();
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "u1" },
+          { role: "assistant", content: "a1" },
+        ],
+      });
+    });
+
+    // A poke → the follow-up history carries a NEW turn that only exists on the
+    // server (another device wrote it). Without recover semantics the reconcile
+    // keeps the stale local view: device B stays blank AND the sending device
+    // double-renders its own turn — exactly the CI E2E failures this guards.
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "m2", seq: 1 });
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "u1" },
+          { role: "assistant", content: "a1" },
+          { role: "user", content: "u2-from-device-A" },
+          { role: "assistant", content: "a2-from-device-A" },
+        ],
+      });
+    });
+
+    const messages = result.current.runtime.messages as { role: string }[];
+    expect(JSON.stringify(messages)).toContain("a2-from-device-A");
+    expect(messages.filter((m) => m.role === "assistant")).toHaveLength(2);
+  });
+
+  it("does not duplicate a just-streamed turn when a poke re-pulls the same session", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = latestWs();
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage({ type: "history", messages: [] });
+    });
+    // Stream a full assistant turn locally (Lane A), like the sending device.
+    act(() => {
+      result.current.runtime.onNew({
+        content: [{ type: "text", text: "Hello" }],
+        parentId: "root",
+      });
+    });
+    act(() => {
+      ws.simulateMessage({
+        type: "chunk",
+        content: "Integration test response.",
+        messageId: "srv-1",
+      });
+    });
+    act(() => {
+      ws.simulateMessage({ type: "done", messageId: "srv-1" });
+      ws.simulateMessage({ type: "complete" });
+    });
+    // A poke for the sender's OWN session re-pulls history that already contains
+    // the just-streamed reply — it must reconcile, not append a 2nd bubble.
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "srv-1", seq: 1 });
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Hello" },
+          { role: "assistant", content: "Integration test response." },
+        ],
+      });
+    });
+    const messages = result.current.runtime.messages as { role: string; content: unknown }[];
+    const dupes = messages.filter(
+      (m) =>
+        m.role === "assistant" && JSON.stringify(m.content).includes("Integration test response.")
+    );
+    expect(dupes).toHaveLength(1);
+  });
+
+  it("skips the catch-up re-pull while a run is in-flight (the live stream already covers it)", () => {
+    const { result } = renderHook(() => useWsRuntime("agent-1"));
+    const ws = latestWs();
+    act(() => {
+      ws.simulateOpen();
+      ws.simulateMessage({ type: "history", messages: [] });
+    });
+    // Start streaming a turn — isRunning=true, no `complete` yet.
+    act(() => {
+      result.current.runtime.onNew({
+        content: [{ type: "text", text: "Hello" }],
+        parentId: "root",
+      });
+    });
+    act(() => {
+      ws.simulateMessage({ type: "chunk", content: "partial", messageId: "srv-1" });
+    });
+    expect(result.current.isRunning).toBe(true);
+
+    // A poke arriving mid-stream must NOT trigger a re-pull: re-pulling now would
+    // race the live stream and double-render the in-flight turn (the CI E2E bug).
+    const before = ws.send.mock.calls.length;
+    act(() => {
+      ws.simulateMessage({ type: "poke", messageId: "srv-1", seq: 1 });
+    });
+    const historySends = ws.send.mock.calls
+      .slice(before)
+      .map((c: unknown[]) => JSON.parse(c[0] as string))
+      .filter((f: { type: string }) => f.type === "history");
+    expect(historySends).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -417,6 +417,59 @@ describe("ClientRouter", () => {
     expect(messages[0].message).toBe("Access denied");
   });
 
+  describe("multi-device live-sync subscription is gated on access (Lane B)", () => {
+    function withPokeBridge() {
+      const pokeBridge = { view: vi.fn().mockResolvedValue(undefined) };
+      const guarded = new ClientRouter(
+        mockOpenClawClient as any,
+        "user-1",
+        "member",
+        sessionCache,
+        undefined,
+        undefined,
+        pokeBridge as any
+      );
+      return { pokeBridge, guarded };
+    }
+
+    it("does NOT register a session subscriber when the history request is access-denied", async () => {
+      const { pokeBridge, guarded } = withPokeBridge();
+      // A personal agent owned by someone else → assertAgentAccess throws before
+      // any path into handleHistory.
+      mockFindFirst.mockResolvedValue({
+        id: "agent-1",
+        name: "Personal Agent",
+        ownerId: "other-user",
+        isPersonal: true,
+      });
+
+      const clientWs = createMockClientWs();
+      await guarded.handleMessage(clientWs as any, { type: "history", agentId: "agent-1" });
+
+      // The denial short-circuits before handleHistory, so the socket is never
+      // subscribed — the structural no-cross-user-leak guarantee. A regression
+      // that moved view() above the gate would leak "a session changed" pokes
+      // to a user who may not access the agent; this pins the ordering.
+      expect(pokeBridge.view).not.toHaveBeenCalled();
+      const messages = clientWs.sent.map((s) => JSON.parse(s));
+      expect(messages[0].message).toBe("Access denied");
+    });
+
+    it("registers the socket to its OWN server-built session key once access is granted", async () => {
+      const { pokeBridge, guarded } = withPokeBridge();
+
+      const clientWs = createMockClientWs();
+      await guarded.handleMessage(clientWs as any, { type: "history", agentId: "agent-1" });
+
+      // Subscribed behind the gate, always with the SERVER-built key derived from
+      // this.userId — never a client-supplied identity.
+      expect(pokeBridge.view).toHaveBeenCalledWith(
+        "agent:agent-1:direct:user-1",
+        expect.anything()
+      );
+    });
+  });
+
   it("should allow access to restricted agent when user is in matching group", async () => {
     const restrictedAgent = {
       id: "agent-restricted",

--- a/packages/web/src/__tests__/server/session-poke-bridge.test.ts
+++ b/packages/web/src/__tests__/server/session-poke-bridge.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Unit tests for `SessionPokeBridge` — the heart of multi-device live-sync Lane B.
+ *
+ * It owns the refcounted per-session upstream `sessions.messages.subscribe` and,
+ * on a finished message, fans a BODY-FREE "poke" out to every device subscribed
+ * to that session. Two security-critical invariants pinned here:
+ *  - the poke NEVER carries (or even reads) the message body — a mis-routed poke
+ *    can leak at most "a session changed", never content;
+ *  - routing uses the SERVER-subscribed key, not the untrusted `payload.sessionKey`.
+ */
+import { describe, it, expect } from "vitest";
+import type { WebSocket } from "ws";
+import { SessionSubscribers } from "@/server/session-subscribers";
+import { SessionPokeBridge } from "@/server/session-poke-bridge";
+
+function fakeWs(): WebSocket {
+  return {} as unknown as WebSocket;
+}
+
+// A fake upstream `subscribe` that records calls and lets the test drive the
+// handler, simulating Gateway events.
+function fakeUpstream() {
+  const calls: { key: string; handler: (event: unknown) => void }[] = [];
+  const unsubscribed: string[] = [];
+  const subscribe = async (key: string, handler: (event: unknown) => void) => {
+    calls.push({ key, handler });
+    return { unsubscribe: async () => void unsubscribed.push(key) };
+  };
+  const emit = (key: string, event: unknown) => {
+    for (const c of calls.filter((c) => c.key === key)) c.handler(event);
+  };
+  return { subscribe, emit, calls, unsubscribed };
+}
+
+const KEY = "agent:a1:direct:u1";
+
+describe("SessionPokeBridge", () => {
+  it("opens exactly one upstream subscription per session and reuses it across sockets", async () => {
+    const up = fakeUpstream();
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: () => {},
+    });
+
+    await bridge.join(KEY, fakeWs());
+    await bridge.join(KEY, fakeWs());
+
+    expect(up.calls.map((c) => c.key)).toEqual([KEY]); // one subscription, reused
+  });
+
+  it("fans a body-free poke to every subscriber on a finished message and NEVER reads the body", async () => {
+    const up = fakeUpstream();
+    const sent: { ws: WebSocket; frame: unknown }[] = [];
+    const subs = new SessionSubscribers();
+    const bridge = new SessionPokeBridge({
+      subs,
+      subscribe: up.subscribe,
+      send: (ws, frame) => void sent.push({ ws, frame }),
+    });
+    const a = fakeWs();
+    const b = fakeWs();
+    await bridge.join(KEY, a);
+    await bridge.join(KEY, b);
+
+    // A Gateway session.message whose body throws if anyone touches it.
+    const payload: Record<string, unknown> = { sessionKey: KEY, messageId: "m7", messageSeq: 42 };
+    Object.defineProperty(payload, "message", {
+      enumerable: true,
+      get() {
+        throw new Error("body must never be read in the poke path");
+      },
+    });
+    up.emit(KEY, { event: "session.message", payload });
+
+    expect(sent).toHaveLength(2);
+    expect(sent.map((s) => s.ws)).toEqual(expect.arrayContaining([a, b]));
+    expect(sent[0].frame).toEqual({ type: "poke", sessionKey: KEY, messageId: "m7", seq: 42 });
+  });
+
+  it("routes by the server-subscribed key, ignoring a spoofed payload.sessionKey", async () => {
+    const up = fakeUpstream();
+    const sent: { ws: WebSocket; frame: unknown }[] = [];
+    const subs = new SessionSubscribers();
+    const bridge = new SessionPokeBridge({
+      subs,
+      subscribe: up.subscribe,
+      send: (ws, frame) => void sent.push({ ws, frame }),
+    });
+    const victim = fakeWs();
+    await bridge.join("agent:a1:direct:victim", victim);
+
+    // Event arrives on the victim's subscription but its payload claims another key.
+    up.emit("agent:a1:direct:victim", {
+      event: "session.message",
+      payload: { sessionKey: "agent:a1:direct:attacker", messageId: "m1", messageSeq: 1 },
+    });
+
+    // The poke is routed to the victim's own socket (the subscribed key), and the
+    // frame carries the trusted key — never the attacker-supplied one.
+    expect(sent).toHaveLength(1);
+    expect(sent[0].ws).toBe(victim);
+    expect(sent[0].frame).toMatchObject({ sessionKey: "agent:a1:direct:victim" });
+  });
+
+  it("does NOT poke on wordwise 'agent' delta events (those are Lane A)", async () => {
+    const up = fakeUpstream();
+    const sent: unknown[] = [];
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: (_ws, frame) => void sent.push(frame),
+    });
+    await bridge.join(KEY, fakeWs());
+
+    up.emit(KEY, {
+      event: "agent",
+      payload: { sessionKey: KEY, stream: "assistant", data: { delta: "hi" } },
+    });
+
+    expect(sent).toHaveLength(0);
+  });
+
+  it("closes the upstream subscription when the last socket leaves", async () => {
+    const up = fakeUpstream();
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: () => {},
+    });
+    const a = fakeWs();
+    const b = fakeWs();
+    await bridge.join(KEY, a);
+    await bridge.join(KEY, b);
+
+    await bridge.leave(KEY, a);
+    expect(up.unsubscribed).toEqual([]); // b still there
+    await bridge.leave(KEY, b);
+    expect(up.unsubscribed).toEqual([KEY]); // last one out closes it
+  });
+
+  it("view() makes a socket exclusively subscribe to one session, leaving prior ones", async () => {
+    const up = fakeUpstream();
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: () => {},
+    });
+    const a = fakeWs();
+
+    await bridge.view(KEY, a);
+    await bridge.view(`${KEY}:c2`, a); // user switches the open chat
+
+    expect(up.calls.map((c) => c.key)).toEqual([KEY, `${KEY}:c2`]);
+    expect(up.unsubscribed).toEqual([KEY]); // the prior chat's upstream closed
+  });
+
+  it("view() to the same session is stable — no churn on a history refresh", async () => {
+    const up = fakeUpstream();
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: () => {},
+    });
+    const a = fakeWs();
+
+    await bridge.view(KEY, a);
+    await bridge.view(KEY, a); // e.g. a reconnect/poke-driven history refresh
+
+    expect(up.calls.map((c) => c.key)).toEqual([KEY]); // not re-subscribed
+    expect(up.unsubscribed).toEqual([]);
+  });
+
+  it("on disconnect closes only the subscriptions the socket was alone in", async () => {
+    const up = fakeUpstream();
+    const bridge = new SessionPokeBridge({
+      subs: new SessionSubscribers(),
+      subscribe: up.subscribe,
+      send: () => {},
+    });
+    const a = fakeWs(); // alone in c2, shares the base key with b
+    const b = fakeWs();
+    await bridge.join(KEY, a);
+    await bridge.join(`${KEY}:c2`, a);
+    await bridge.join(KEY, b);
+
+    await bridge.disconnect(a);
+
+    expect(up.unsubscribed).toEqual([`${KEY}:c2`]); // base key still has b
+  });
+});

--- a/packages/web/src/__tests__/server/session-poke-bridge.test.ts
+++ b/packages/web/src/__tests__/server/session-poke-bridge.test.ts
@@ -63,7 +63,9 @@ describe("SessionPokeBridge", () => {
     await bridge.join(KEY, a);
     await bridge.join(KEY, b);
 
-    // A Gateway session.message whose body throws if anyone touches it.
+    // A Gateway session.message whose body throws if anyone touches it. The
+    // extra messageSeq is deliberately ignored — the poke identifies the changed
+    // message by its globally-unique messageId, which is all the client dedups on.
     const payload: Record<string, unknown> = { sessionKey: KEY, messageId: "m7", messageSeq: 42 };
     Object.defineProperty(payload, "message", {
       enumerable: true,
@@ -75,7 +77,7 @@ describe("SessionPokeBridge", () => {
 
     expect(sent).toHaveLength(2);
     expect(sent.map((s) => s.ws)).toEqual(expect.arrayContaining([a, b]));
-    expect(sent[0].frame).toEqual({ type: "poke", sessionKey: KEY, messageId: "m7", seq: 42 });
+    expect(sent[0].frame).toEqual({ type: "poke", sessionKey: KEY, messageId: "m7" });
   });
 
   it("routes by the server-subscribed key, ignoring a spoofed payload.sessionKey", async () => {

--- a/packages/web/src/__tests__/server/session-subscribers.test.ts
+++ b/packages/web/src/__tests__/server/session-subscribers.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Unit tests for the `SessionSubscribers` registry (multi-device live-sync, Lane B).
+ *
+ * Why this exists: `ActiveRuns.listeners` only holds sockets while a run is in
+ * flight and a client actively joined it — so an idle second device of the same
+ * user never receives anything. `SessionSubscribers` is the PERSISTENT
+ * per-sessionKey → socket-set map that lets Pinchy fan a body-free "poke" out to
+ * every connected device of a user the moment any source changes that session.
+ *
+ * Two invariants this suite pins:
+ *  - isolation: a socket added for one sessionKey never appears under another
+ *    key (the structural half of the cross-user-leak story; the auth gate that
+ *    decides WHICH key a socket may join lives in the client-router wiring).
+ *  - leak-free teardown: removing a socket prunes it from every bucket it was in
+ *    via a reverse index, so a closed socket is never a GC root and never gets a
+ *    stale poke.
+ */
+import { describe, it, expect, beforeEach } from "vitest";
+import type { WebSocket } from "ws";
+import { SessionSubscribers } from "@/server/session-subscribers";
+
+// Identity is all the registry cares about — no real ws needed.
+function fakeWs(): WebSocket {
+  return {} as unknown as WebSocket;
+}
+
+describe("SessionSubscribers", () => {
+  let subs: SessionSubscribers;
+
+  beforeEach(() => {
+    subs = new SessionSubscribers();
+  });
+
+  describe("add / socketsFor", () => {
+    it("returns exactly the sockets added for a sessionKey, isolated from other keys", () => {
+      const a = fakeWs();
+      const b = fakeWs();
+      const other = fakeWs();
+
+      subs.add("agent:a1:direct:u1", a);
+      subs.add("agent:a1:direct:u1", b);
+      subs.add("agent:a1:direct:u2", other); // different user → different key
+
+      const sockets = subs.socketsFor("agent:a1:direct:u1");
+      expect(sockets).toContain(a);
+      expect(sockets).toContain(b);
+      expect(sockets).not.toContain(other);
+      expect(sockets).toHaveLength(2);
+
+      // The other user's key only ever holds its own socket.
+      expect(subs.socketsFor("agent:a1:direct:u2")).toEqual([other]);
+      // An unknown key has no sockets.
+      expect(subs.socketsFor("agent:a1:direct:u3")).toEqual([]);
+    });
+  });
+
+  describe("refcount signalling", () => {
+    it("reports the FIRST socket for a session so the caller can open the upstream subscription", () => {
+      const a = fakeWs();
+      const b = fakeWs();
+
+      expect(subs.add("agent:a1:direct:u1", a)).toEqual({ firstForSession: true });
+      expect(subs.add("agent:a1:direct:u1", b)).toEqual({ firstForSession: false });
+    });
+
+    it("re-adding the same socket is idempotent and not a first-join", () => {
+      const a = fakeWs();
+
+      expect(subs.add("agent:a1:direct:u1", a)).toEqual({ firstForSession: true });
+      expect(subs.add("agent:a1:direct:u1", a)).toEqual({ firstForSession: false });
+      expect(subs.socketsFor("agent:a1:direct:u1")).toEqual([a]);
+    });
+  });
+
+  describe("removeFromSession (single-session leave, e.g. chat switch)", () => {
+    it("reports the LAST socket leaving a session and deletes the now-empty bucket", () => {
+      const a = fakeWs();
+      const b = fakeWs();
+      subs.add("agent:a1:direct:u1", a);
+      subs.add("agent:a1:direct:u1", b);
+
+      expect(subs.removeFromSession("agent:a1:direct:u1", a)).toEqual({ lastForSession: false });
+      expect(subs.removeFromSession("agent:a1:direct:u1", b)).toEqual({ lastForSession: true });
+      expect(subs.socketsFor("agent:a1:direct:u1")).toEqual([]);
+    });
+
+    it("is a no-op for a socket or key that is not subscribed", () => {
+      const a = fakeWs();
+      expect(subs.removeFromSession("agent:a1:direct:u1", a)).toEqual({ lastForSession: false });
+    });
+  });
+
+  describe("removeSocket (full teardown on close AND error)", () => {
+    it("prunes the socket from every bucket via the reverse index and returns the keys that emptied", () => {
+      const a = fakeWs(); // subscribed to two of its own sessions
+      const b = fakeWs(); // shares one session with a
+      subs.add("agent:a1:direct:u1", a);
+      subs.add("agent:a1:direct:u1:c2", a); // a second chat of the same user
+      subs.add("agent:a1:direct:u1", b);
+
+      const emptied = subs.removeSocket(a);
+
+      // `a` is gone everywhere — never a GC root, never reached by a later poke.
+      expect(subs.socketsFor("agent:a1:direct:u1")).toEqual([b]);
+      expect(subs.socketsFor("agent:a1:direct:u1:c2")).toEqual([]);
+      // Only the bucket where `a` was alone emptied → caller closes that upstream sub.
+      expect(emptied).toEqual(["agent:a1:direct:u1:c2"]);
+    });
+
+    it("returns an empty list for an unknown socket", () => {
+      expect(subs.removeSocket(fakeWs())).toEqual([]);
+    });
+  });
+
+  describe("sessionKeysFor (reverse-index read, used by view())", () => {
+    it("returns the keys a socket is currently subscribed to, empty for an unknown socket", () => {
+      const a = fakeWs();
+      subs.add("agent:a1:direct:u1", a);
+      subs.add("agent:a1:direct:u1:c2", a);
+
+      expect(subs.sessionKeysFor(a).sort()).toEqual([
+        "agent:a1:direct:u1",
+        "agent:a1:direct:u1:c2",
+      ]);
+      expect(subs.sessionKeysFor(fakeWs())).toEqual([]);
+    });
+  });
+});

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -579,6 +579,9 @@ export function useWsRuntime(
    */
   const pendingHistoryRef = useRef(false);
   const frameBufferRef = useRef<unknown[]>([]);
+  // Multi-device live-sync: the highest poke seq already acted on, so a stale or
+  // duplicate poke (seq <= this) does not trigger a redundant history re-pull.
+  const lastSeenPokeSeqRef = useRef(-1);
   /**
    * Server-correlated runId for the in-flight chat turn (Tier 2b). Set
    * when a history frame includes the `activeRun` signal and used by
@@ -779,6 +782,45 @@ export function useWsRuntime(
       }
     }
 
+    // Multi-device live-sync: a lightweight catch-up re-pull used by the poke
+    // handler and the window-focus listener. Same buffer-then-drain protocol as
+    // ws.onopen / recoverFromPageLifecycle — armed so an in-flight run's chunks
+    // merge ONTO the reconciled history instead of building a competing bubble,
+    // which makes it safe to call mid-stream. Unlike recoverFromPageLifecycle it
+    // has no lifecycle-suspend gate: focus and poke are their own triggers.
+    function requestHistoryCatchup() {
+      // While THIS device is streaming a turn (its own, or one it joined by
+      // re-pulling into an in-flight run), the live stream (Lane A) already
+      // delivers the session's newest content. A catch-up re-pull now would race
+      // the stream and double-render the in-flight message — the exact failure
+      // the CI integration E2E caught. Skip; a poke/focus after the run completes
+      // reconciles cleanly. (The reconnect/lifecycle recover path does NOT call
+      // this helper, so a genuine reconnect mid-run still resumes.)
+      if (isRunningRef.current) return;
+      // Adopt the server's CANONICAL history on the reconcile that follows —
+      // same as recoverFromPageLifecycle. Without this the reconcile keeps the
+      // stale local view (shouldReplaceLocalWithServerHistory returns false when
+      // the flag is unset): a turn written on another device never appears, and
+      // the SENDING device double-renders its own just-streamed turn (the CI
+      // integration E2E caught exactly this).
+      shouldRecoverFromHistoryRef.current = true;
+      if (wsRef.current?.readyState === WebSocket.OPEN) {
+        pendingHistoryRef.current = true;
+        frameBufferRef.current = [];
+        wsRef.current.send(JSON.stringify({ type: "history", agentId, ...(chatId && { chatId }) }));
+      } else {
+        connect();
+      }
+    }
+
+    function handleFocus() {
+      // Returning to the window (another app was in front) fires `focus` but no
+      // `visibilitychange`, so recoverFromPageLifecycle never ran — this is the
+      // reported "stale until reload" bug. Re-pull to catch up; coalesce with an
+      // already in-flight pull.
+      if (!pendingHistoryRef.current) requestHistoryCatchup();
+    }
+
     function handleVisibilityChange() {
       if (document.visibilityState === "hidden") {
         suspendForPageLifecycle();
@@ -955,6 +997,21 @@ export function useWsRuntime(
 
         if (data.type === "openclaw_status") {
           setIsOpenClawConnected(!!data.connected);
+          return;
+        }
+
+        // Multi-device live-sync (Lane B): a BODY-FREE signal that this session
+        // changed (another device of this user, or a Telegram message). Handled
+        // BEFORE the pre-history buffer so it is never queued/replayed. We hold
+        // no content — we re-pull authoritative state through the normal
+        // authorized history path. `seq` is a dedup HINT (it may be absent or
+        // non-monotonic across a compaction), so it only ever SUPPRESSES a
+        // redundant pull, never the identity.
+        if (data.type === "poke") {
+          const seq = typeof data.seq === "number" ? data.seq : undefined;
+          if (seq !== undefined && seq <= lastSeenPokeSeqRef.current) return;
+          if (seq !== undefined) lastSeenPokeSeqRef.current = seq;
+          if (!pendingHistoryRef.current) requestHistoryCatchup();
           return;
         }
 
@@ -1471,6 +1528,7 @@ export function useWsRuntime(
     document.addEventListener("resume", handlePageShow);
     window.addEventListener("offline", handleOffline);
     window.addEventListener("online", handleOnline);
+    window.addEventListener("focus", handleFocus);
 
     return () => {
       mountedRef.current = false;
@@ -1484,6 +1542,7 @@ export function useWsRuntime(
       document.removeEventListener("resume", handlePageShow);
       window.removeEventListener("offline", handleOffline);
       window.removeEventListener("online", handleOnline);
+      window.removeEventListener("focus", handleFocus);
       if (reconnectTimerRef.current) {
         clearTimeout(reconnectTimerRef.current);
         reconnectTimerRef.current = null;

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -579,9 +579,13 @@ export function useWsRuntime(
    */
   const pendingHistoryRef = useRef(false);
   const frameBufferRef = useRef<unknown[]>([]);
-  // Multi-device live-sync: the highest poke seq already acted on, so a stale or
-  // duplicate poke (seq <= this) does not trigger a redundant history re-pull.
-  const lastSeenPokeSeqRef = useRef(-1);
+  // Multi-device live-sync: the messageId of the poke we last acted on, so a
+  // duplicate poke for the same finished message does not trigger a redundant
+  // history re-pull. Dedup is keyed on the globally-unique messageId rather than
+  // a per-session seq counter — a seq high-water mark would falsely suppress a
+  // poke for a newly-opened chat (whose per-session seq is lower) or after a
+  // history compaction (which renumbers seq). Reset on a session switch below.
+  const lastPokeMessageIdRef = useRef<string | null>(null);
   /**
    * Server-correlated runId for the in-flight chat turn (Tier 2b). Set
    * when a history frame includes the `activeRun` signal and used by
@@ -643,6 +647,11 @@ export function useWsRuntime(
     setIsReconcilingMessages(false);
     setKnownEmptyHistory(false);
     setPayloadRejected(false);
+    // Multi-device live-sync: drop the poke-dedup identity so the newly-opened
+    // session's first poke always re-pulls — its messageIds are unrelated to the
+    // previous chat's, and starting fresh avoids any chance of a stale match.
+    // Plain ref write during render, exactly like `livenessRef` above.
+    lastPokeMessageIdRef.current = null;
     // Synchronous timer cleanup is the entire point of doing this in render
     // (see comment above). Deferring it to useEffect would defeat the
     // race-prevention this block exists for.
@@ -1004,13 +1013,14 @@ export function useWsRuntime(
         // changed (another device of this user, or a Telegram message). Handled
         // BEFORE the pre-history buffer so it is never queued/replayed. We hold
         // no content — we re-pull authoritative state through the normal
-        // authorized history path. `seq` is a dedup HINT (it may be absent or
-        // non-monotonic across a compaction), so it only ever SUPPRESSES a
-        // redundant pull, never the identity.
+        // authorized history path. Dedup is on the globally-unique `messageId`:
+        // it only SUPPRESSES a repeat poke for a message we already caught up on,
+        // never a genuine new one. An absent id can't be deduped, so we re-pull
+        // (safe — the reconcile is idempotent).
         if (data.type === "poke") {
-          const seq = typeof data.seq === "number" ? data.seq : undefined;
-          if (seq !== undefined && seq <= lastSeenPokeSeqRef.current) return;
-          if (seq !== undefined) lastSeenPokeSeqRef.current = seq;
+          const messageId = typeof data.messageId === "string" ? data.messageId : undefined;
+          if (messageId !== undefined && messageId === lastPokeMessageIdRef.current) return;
+          if (messageId !== undefined) lastPokeMessageIdRef.current = messageId;
           if (!pendingHistoryRef.current) requestHistoryCatchup();
           return;
         }

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -19,6 +19,7 @@ import { maybeSelfHealOnModelError } from "@/server/model-self-heal";
 import { ActiveRuns } from "@/server/active-runs";
 import { iterateUntilAborted } from "@/server/abortable-stream";
 import { NEVER_DISCONNECTS, type DisconnectSignal } from "@/server/openclaw-disconnect-signal";
+import type { SessionPokeBridge } from "@/server/session-poke-bridge";
 import { recordSessionTurnsUsage } from "@/lib/usage-per-turn";
 import {
   QUEUED_RETRY_PREFIX,
@@ -168,7 +169,14 @@ export class ClientRouter {
      * Defaults to a never-firing signal so tests keep the prior drain-to-end
      * behavior; production wires the real one in `server.ts`.
      */
-    private disconnectSignal: DisconnectSignal = NEVER_DISCONNECTS
+    private disconnectSignal: DisconnectSignal = NEVER_DISCONNECTS,
+    /**
+     * Multi-device live-sync bridge (Lane B). Optional so legacy tests that
+     * predate it get no sync wiring; production passes the process singleton.
+     * When present, `handleHistory` registers this socket as a session
+     * subscriber behind the SAME access gate that already guards history.
+     */
+    private pokeBridge?: SessionPokeBridge
   ) {}
 
   private computeSessionKey(agentId: string, chatId?: string): string {
@@ -710,6 +718,21 @@ export class ClientRouter {
     const activeRun = this.activeRuns.get(sessionKey);
     if (activeRun) {
       this.activeRuns.addListener(sessionKey, clientWs);
+    }
+
+    // Multi-device live-sync (Lane B): this socket now EXCLUSIVELY views this
+    // session, so register it as a persistent session subscriber. Done here —
+    // after the access gate in handleMessage that guards every path into
+    // handleHistory — so a socket can only ever subscribe to a session its user
+    // is allowed to see (the structural half of the no-cross-user-leak story).
+    // A failed subscribe RPC degrades to "no live push"; history still serves
+    // and the client re-pulls on its next lifecycle trigger.
+    if (this.pokeBridge) {
+      try {
+        await this.pokeBridge.view(sessionKey, clientWs);
+      } catch (err) {
+        console.error("poke-bridge view failed:", err instanceof Error ? err.message : err);
+      }
     }
     // Signal embedded in every history response variant so the client
     // can preserve `isRunning=true` and anchor incoming chunks to the

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -726,7 +726,11 @@ export class ClientRouter {
     // handleHistory — so a socket can only ever subscribe to a session its user
     // is allowed to see (the structural half of the no-cross-user-leak story).
     // A failed subscribe RPC degrades to "no live push"; history still serves
-    // and the client re-pulls on its next lifecycle trigger.
+    // and the client re-pulls on its next lifecycle trigger. The `await` is
+    // deliberate: by the time the history response is sent the upstream
+    // subscription is open, so no `session.message` between history-load and
+    // subscribe slips through unseen. Only the first join per session pays the
+    // RPC — repeat view()s for the same key are churn-free (see `view()`).
     if (this.pokeBridge) {
       try {
         await this.pokeBridge.view(sessionKey, clientWs);

--- a/packages/web/src/server/session-poke-bridge-singleton.ts
+++ b/packages/web/src/server/session-poke-bridge-singleton.ts
@@ -1,0 +1,50 @@
+import { WebSocket } from "ws";
+import { SessionPokeBridge } from "@/server/session-poke-bridge";
+import { SessionSubscribers } from "@/server/session-subscribers";
+import { getOpenClawClient } from "@/server/openclaw-client";
+
+/**
+ * Process-singleton `SessionPokeBridge` (multi-device live-sync, Lane B).
+ *
+ * Shared via `globalThis` for the same reason `active-runs-singleton.ts` and
+ * `openclaw-client.ts` are: Next.js may load modules in a separate context from
+ * the custom server. The upstream per-session subscriptions live on the one
+ * shared OpenClawClient, so there must be exactly one bridge per process for the
+ * refcount to be correct across every ClientRouter/socket of a session.
+ *
+ * The real `subscribe` wraps `sessions.subscribeMessages` (which matches the
+ * Gateway's canonical key, so canonicalization can't silently drop events); the
+ * real `send` JSON-encodes the body-free poke to an OPEN socket only.
+ */
+const GLOBAL_KEY = "__pinchySessionPokeBridge" as const;
+
+declare global {
+  // eslint-disable-next-line no-var
+  var __pinchySessionPokeBridge: SessionPokeBridge | undefined;
+}
+
+function sendFrame(ws: WebSocket, frame: unknown): void {
+  if (ws.readyState === WebSocket.OPEN) ws.send(JSON.stringify(frame));
+}
+
+export function getSessionPokeBridgeSingleton(): SessionPokeBridge {
+  const existing = (globalThis as Record<string, unknown>)[GLOBAL_KEY] as
+    SessionPokeBridge | undefined;
+  if (existing) return existing;
+
+  const fresh = new SessionPokeBridge({
+    subs: new SessionSubscribers(),
+    subscribe: (sessionKey, handler) => {
+      const client = getOpenClawClient();
+      // No client yet (cold start / OpenClaw down): degrade to "no live sync".
+      // handleHistory still serves history, and the client re-pulls on
+      // reconnect, so a missed poke window is recoverable.
+      if (!client) return Promise.resolve({ unsubscribe: () => {} });
+      return client.sessions.subscribeMessages(sessionKey, handler);
+    },
+    send: sendFrame,
+  });
+
+  (globalThis as Record<string, unknown>)[GLOBAL_KEY] = fresh;
+  return fresh;
+}

--- a/packages/web/src/server/session-poke-bridge.ts
+++ b/packages/web/src/server/session-poke-bridge.ts
@@ -24,8 +24,8 @@ export type SendToSocket = (ws: WebSocket, frame: unknown) => void;
 interface PokeFrame {
   type: "poke";
   sessionKey: string;
+  /** Globally-unique id of the finished message; the client dedups its re-pull on it. */
   messageId: string | undefined;
-  seq: number | undefined;
 }
 
 /**
@@ -128,7 +128,6 @@ export class SessionPokeBridge {
       // SERVER-subscribed key — the trust anchor. Never payload.sessionKey.
       sessionKey,
       messageId: typeof payload.messageId === "string" ? payload.messageId : undefined,
-      seq: typeof payload.messageSeq === "number" ? payload.messageSeq : undefined,
     };
     for (const ws of this.subs.socketsFor(sessionKey)) this.send(ws, frame);
   }

--- a/packages/web/src/server/session-poke-bridge.ts
+++ b/packages/web/src/server/session-poke-bridge.ts
@@ -1,0 +1,135 @@
+import type { WebSocket } from "ws";
+import type { SessionSubscribers } from "@/server/session-subscribers";
+
+/** Handle returned by an upstream subscription; `unsubscribe` is teardown-safe. */
+export interface UpstreamSubscription {
+  unsubscribe: () => Promise<void> | void;
+}
+
+/**
+ * Opens a per-session upstream subscription (wraps
+ * `openclawClient.sessions.subscribeMessages`). The handler is invoked for every
+ * Gateway event of that session — `subscribeMessages` matches both the caller
+ * key and the Gateway's canonical key, so canonicalization can't silently drop.
+ */
+export type SubscribeUpstream = (
+  sessionKey: string,
+  handler: (event: unknown) => void
+) => Promise<UpstreamSubscription>;
+
+/** Send a frame to one browser socket (readyState-gated by the caller). */
+export type SendToSocket = (ws: WebSocket, frame: unknown) => void;
+
+/** The only thing that crosses the wire to an idle device: a content-free signal. */
+interface PokeFrame {
+  type: "poke";
+  sessionKey: string;
+  messageId: string | undefined;
+  seq: number | undefined;
+}
+
+/**
+ * Multi-device live-sync, Lane B. Owns a refcounted per-session upstream
+ * subscription and fans a BODY-FREE poke out to every device subscribed to that
+ * session whenever a finished message lands. Security model: the poke carries no
+ * content and is routed by the SERVER-subscribed key (never the untrusted
+ * `payload.sessionKey`), so a mis-routed poke can leak at most "a session
+ * changed" — the device then re-pulls authoritative state through the normal
+ * cookie-authorized history path.
+ *
+ * Process-singleton in production (the upstream subscriptions live on the one
+ * shared OpenClawClient and are refcounted across every ClientRouter/socket of a
+ * session). Tests inject `subscribe`/`send`.
+ */
+export class SessionPokeBridge {
+  private readonly subs: SessionSubscribers;
+  private readonly subscribe: SubscribeUpstream;
+  private readonly send: SendToSocket;
+  private readonly upstream = new Map<string, UpstreamSubscription>();
+  private readonly opening = new Set<string>();
+
+  constructor(deps: {
+    subs: SessionSubscribers;
+    subscribe: SubscribeUpstream;
+    send: SendToSocket;
+  }) {
+    this.subs = deps.subs;
+    this.subscribe = deps.subscribe;
+    this.send = deps.send;
+  }
+
+  /**
+   * A socket now EXCLUSIVELY views `sessionKey` — the mirror of
+   * `ActiveRuns.removeListenerFromAll` + `addListener`. Leaves any other session
+   * it was in (closing those upstreams on last-leave) and joins this one. Stable
+   * when called repeatedly for the same key (e.g. a poke-driven history refresh):
+   * no upstream churn. This is the method `handleHistory` calls.
+   */
+  async view(sessionKey: string, ws: WebSocket): Promise<void> {
+    for (const prior of this.subs.sessionKeysFor(ws)) {
+      if (prior !== sessionKey) await this.leave(prior, ws);
+    }
+    await this.join(sessionKey, ws);
+  }
+
+  /** A socket starts viewing `sessionKey`. Opens the upstream sub on first join. */
+  async join(sessionKey: string, ws: WebSocket): Promise<void> {
+    const { firstForSession } = this.subs.add(sessionKey, ws);
+    if (firstForSession) await this.openUpstream(sessionKey);
+  }
+
+  /** A socket stops viewing `sessionKey` (chat switch). Closes on last leave. */
+  async leave(sessionKey: string, ws: WebSocket): Promise<void> {
+    const { lastForSession } = this.subs.removeFromSession(sessionKey, ws);
+    if (lastForSession) await this.closeUpstream(sessionKey);
+  }
+
+  /** A socket disconnected (close OR error). Closes every sub it was alone in. */
+  async disconnect(ws: WebSocket): Promise<void> {
+    for (const sessionKey of this.subs.removeSocket(ws)) {
+      await this.closeUpstream(sessionKey);
+    }
+  }
+
+  private async openUpstream(sessionKey: string): Promise<void> {
+    if (this.upstream.has(sessionKey) || this.opening.has(sessionKey)) return;
+    this.opening.add(sessionKey);
+    try {
+      const handle = await this.subscribe(sessionKey, (event) =>
+        this.onUpstreamEvent(sessionKey, event)
+      );
+      // Everyone may have left while the async subscribe was in flight.
+      if (this.subs.socketsFor(sessionKey).length === 0) {
+        await handle.unsubscribe();
+      } else {
+        this.upstream.set(sessionKey, handle);
+      }
+    } finally {
+      this.opening.delete(sessionKey);
+    }
+  }
+
+  private async closeUpstream(sessionKey: string): Promise<void> {
+    const handle = this.upstream.get(sessionKey);
+    if (!handle) return;
+    this.upstream.delete(sessionKey);
+    await handle.unsubscribe();
+  }
+
+  private onUpstreamEvent(sessionKey: string, event: unknown): void {
+    const e = event as { event?: string; payload?: Record<string, unknown> };
+    // Only a finished/visible message pokes. Wordwise 'agent' deltas belong to
+    // Lane A (the firing device's own stream) and must not trigger a re-pull.
+    if (e.event !== "session.message") return;
+
+    const payload = e.payload ?? {};
+    const frame: PokeFrame = {
+      type: "poke",
+      // SERVER-subscribed key — the trust anchor. Never payload.sessionKey.
+      sessionKey,
+      messageId: typeof payload.messageId === "string" ? payload.messageId : undefined,
+      seq: typeof payload.messageSeq === "number" ? payload.messageSeq : undefined,
+    };
+    for (const ws of this.subs.socketsFor(sessionKey)) this.send(ws, frame);
+  }
+}

--- a/packages/web/src/server/session-subscribers.ts
+++ b/packages/web/src/server/session-subscribers.ts
@@ -1,0 +1,109 @@
+import type { WebSocket } from "ws";
+
+/**
+ * Persistent per-sessionKey subscriber registry for multi-device live-sync
+ * (Lane B). Unlike `ActiveRuns.listeners` — which only holds sockets while a run
+ * is in flight and a client actively joined it — this map persists for the life
+ * of each browser socket, so an idle second device of the same user receives a
+ * body-free poke the moment any source changes the session it is viewing.
+ *
+ * `sessionKey` is `agent:<agentId>:direct:<userId>[:<chatId>]`, always built
+ * server-side from the cookie userId. WHICH key a socket may join is decided by
+ * the caller behind the same `assertAgentAccess`/`resolveChatId` gate that
+ * guards `handleHistory`; this structure only stores the resulting membership.
+ *
+ * A reverse index (socket → its sessionKeys) makes per-socket teardown
+ * O(this socket's keys) instead of an O(all buckets) scan — which matters
+ * because the OpenClaw disconnect handler mass-closes every browser socket at
+ * once. A closed socket is pruned from every bucket it was in, so it is never a
+ * GC root and never receives a stale poke.
+ *
+ * Node is single-threaded, so every method here is synchronous.
+ */
+export class SessionSubscribers {
+  private buckets = new Map<string, Set<WebSocket>>();
+  private reverse = new Map<WebSocket, Set<string>>();
+
+  /**
+   * Add a socket to the subscriber set for `sessionKey`. Returns
+   * `firstForSession: true` when this is the first socket for the key, so the
+   * caller can open the (refcounted) upstream `sessions.messages.subscribe`.
+   * Idempotent: re-adding the same socket is a no-op and not a first-join.
+   */
+  add(sessionKey: string, ws: WebSocket): { firstForSession: boolean } {
+    let set = this.buckets.get(sessionKey);
+    const firstForSession = !set || set.size === 0;
+    if (!set) {
+      set = new Set<WebSocket>();
+      this.buckets.set(sessionKey, set);
+    }
+    set.add(ws);
+
+    let keys = this.reverse.get(ws);
+    if (!keys) {
+      keys = new Set<string>();
+      this.reverse.set(ws, keys);
+    }
+    keys.add(sessionKey);
+
+    return { firstForSession };
+  }
+
+  /** The sockets currently subscribed to `sessionKey` (a fresh array). */
+  socketsFor(sessionKey: string): WebSocket[] {
+    const set = this.buckets.get(sessionKey);
+    return set ? [...set] : [];
+  }
+
+  /** The sessionKeys a socket is currently subscribed to (a fresh array). */
+  sessionKeysFor(ws: WebSocket): string[] {
+    const keys = this.reverse.get(ws);
+    return keys ? [...keys] : [];
+  }
+
+  /**
+   * Remove a socket from ONE session (e.g. it switched the open chat). Returns
+   * `lastForSession: true` when the bucket is now empty, so the caller can close
+   * the refcounted upstream subscription. No-op if the socket/key isn't present.
+   */
+  removeFromSession(sessionKey: string, ws: WebSocket): { lastForSession: boolean } {
+    const set = this.buckets.get(sessionKey);
+    if (!set || !set.delete(ws)) return { lastForSession: false };
+
+    const keys = this.reverse.get(ws);
+    if (keys) {
+      keys.delete(sessionKey);
+      if (keys.size === 0) this.reverse.delete(ws);
+    }
+
+    if (set.size === 0) {
+      this.buckets.delete(sessionKey);
+      return { lastForSession: true };
+    }
+    return { lastForSession: false };
+  }
+
+  /**
+   * Full teardown for a socket on close AND on error: prune it from every bucket
+   * it was in (via the reverse index) and return the sessionKeys whose buckets
+   * are now empty, so the caller closes those refcounted upstream subscriptions.
+   * Returns `[]` for an unknown socket.
+   */
+  removeSocket(ws: WebSocket): string[] {
+    const keys = this.reverse.get(ws);
+    if (!keys) return [];
+
+    const emptied: string[] = [];
+    for (const sessionKey of keys) {
+      const set = this.buckets.get(sessionKey);
+      if (!set) continue;
+      set.delete(ws);
+      if (set.size === 0) {
+        this.buckets.delete(sessionKey);
+        emptied.push(sessionKey);
+      }
+    }
+    this.reverse.delete(ws);
+    return emptied;
+  }
+}


### PR DESCRIPTION
## What

Multi-device live-sync (v1): when a user has the same chat open on two devices, a message sent on one now appears on the other **without a manual reload**. Also fixes the reported "stale until reload when another app window was in front" bug.

## Why

An idle second device of the same user receives nothing today until the page is reloaded — `recoverFromPageLifecycle` only re-pulls on a visibility/pagehide/offline transition, which does **not** fire when you merely bring another app window to the front while the tab stays "visible".

## How — body-free poke/pull (Lane B)

- A process-singleton **`SessionPokeBridge`** opens **one refcounted** per-session `sessions.messages.subscribe` (openclaw-node's own canonical-key matcher avoids silent drops) and, on a finished `session.message`, fans a **body-free poke** `{sessionKey, messageId, seq}` out to every device subscribed to that session.
- Routing uses the **server-subscribed key** (never the untrusted `payload.sessionKey`) and the poke carries **no content**, so a mis-routed poke leaks at most "a session changed" — the device then re-pulls authoritative state through the normal cookie-authorized history path.
- Subscriber joins ride **`handleHistory`**, inheriting its `assertAgentAccess` gate — a socket can only ever subscribe to a session its user is allowed to see.
- Teardown is leak-free via a reverse index (`ws → sessionKeys`), wired into **both** the ws `close` and `error` handlers.
- Client: a `"poke"` handler re-pulls history (`messageId` identity, `seq` as a dedup hint) and a new window-`focus` listener catches up on return.

Bonus: because `session.message` fires for any source, a **Telegram** message also surfaces live in the web chat.

## Tests

- **19 unit tests**: isolation, refcount open/close, leak-free teardown, body-never-read (frozen-event), spoofed-key routing, `agent`-delta filtering, poke/focus re-pull.
- **Integration E2E** (`20-multi-device-live-sync.spec.ts`): two browser contexts, same user — device A sends, device B renders it with no reload. **This is the key thing CI verifies**: that the real OpenClaw gateway emits `session.message` for a *web* turn (source-verified from `emitSessionTranscriptUpdate` in the gateway's embedded-agent runner, but this proves it end-to-end).
- Full local unit suite green (7507 passed).

## Notes for reviewers

- The E2E could not be run locally (the standard integration ports were held by a parallel stack), so **CI is its first green run** against a clean isolated stack.
- A docs update for multi-device sync is a **follow-up** (not in this PR).
- An unrelated `pinchy-files` unit test flaked once in a full-suite run (passes isolated; the file is untouched by this diff) — pre-existing full-suite ordering on `main`, not introduced here.

The design rationale and the rejected alternatives (push-the-body fan-out, self-hosted broker, own-transcript-log endgame) are captured in a local design doc.
