### PR TITLE
docs(audit): document automatic background chain verification

### DIFF
--- a/docs/src/content/docs/concepts/audit-trail.mdx
+++ b/docs/src/content/docs/concepts/audit-trail.mdx
@@ -186,10 +186,11 @@ Before Pinchy 0.5.4, integration lifecycle events were logged under `config.chan
 
 ### Audit trail access
 
-| Event Type             | Description                                                                                                                                                                                                                                                                                                                                                                    |
-| ---------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-| `audit.exported`       | An admin downloaded an audit-trail export (CSV or PDF). The detail records the chosen format, applied filters, and row count — but never the exported data itself.                                                                                                                                                                                                             |
-| `diagnostics.exported` | An admin exported a chat-diagnostics bundle for a single agent. The detail records `agent.{id,name}`, the captured `scope` (anchor turn and included turn range), the bundle's `byteSize`, the number of `droppedTurns`, and whether the bundle was `truncated` to fit the size cap. The chat content itself is sanitized before export and is never written to the audit row. |
+| Event Type              | Description                                                                                                                                                                                                                                                                                                                                                                                |
+| ----------------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+| `audit.exported`        | An admin downloaded an audit-trail export (CSV or PDF). The detail records the chosen format, applied filters, and row count — but never the exported data itself.                                                                                                                                                                                                                         |
+| `audit.integrity_check` | The periodic background verification job checked a range of the hash chain (see [Automatic verification](#automatic-verification)). Detail records the scanned range (`scannedFrom`/`scannedTo`), the `invalidCount`/`chainBreakCount`, and capped `invalidIds`/`chainBreakIds` lists. `outcome: "success"` means the scanned window was intact; `"failure"` means tampering was detected. |
+| `diagnostics.exported`  | An admin exported a chat-diagnostics bundle for a single agent. The detail records `agent.{id,name}`, the captured `scope` (anchor turn and included turn range), the bundle's `byteSize`, the number of `droppedTurns`, and whether the bundle was `truncated` to fit the size cap. The chat content itself is sanitized before export and is never written to the audit row.             |
 
 ### What is NOT logged
 
@@ -254,7 +255,17 @@ Because each signature covers the previous one, tampering is detectable in every
 
 ## How to verify integrity
 
-Admins can verify the integrity of the audit log in two ways:
+Pinchy verifies the audit log **automatically in the background**, and admins can also verify it **on demand** at any time.
+
+### Automatic verification
+
+A background job re-verifies the hash chain on a schedule, so a break introduced through direct database access — bypassing the append-only triggers — is caught on its own, rather than only when someone happens to open the Verify page. Each run:
+
+- verifies only the rows appended since the last run — an incremental checkpoint keeps this cheap as the log grows — and seeds the check with the previous run's last signature, so the boundary link between two runs is never left unchecked;
+- writes an `audit.integrity_check` entry recording the scanned range and any violations found;
+- on a detected break, also emits a structured `audit_integrity_violation` line to stderr, so an external log monitor can alert on it even if no admin is watching the UI.
+
+The job runs shortly after startup and then every 6 hours by default; set the `AUDIT_VERIFY_INTERVAL_MS` environment variable (in milliseconds) to change the cadence. It is enabled by default and needs no configuration.
 
 ### Via the admin UI
 


### PR DESCRIPTION
## Summary

Docs follow-up for #691, which shipped the periodic incremental hash-chain verification job but left the audit-trail concept page describing verification as **manual-only** (admin UI + API). This closes that gap.

## Changes

- **New "Automatic verification" subsection** under *How to verify integrity*: explains that a background job re-verifies the chain on a schedule so a break introduced via direct DB access (bypassing the append-only triggers) is caught on its own — incremental checkpoint, boundary-link seeding (the seam between runs is never left unchecked), an `audit.integrity_check` row per run, and a structured `audit_integrity_violation` stderr line on a detected break. Documents the 6h default cadence and the `AUDIT_VERIFY_INTERVAL_MS` override.
- **New event type** `audit.integrity_check` added to the reference table.

All facts verified against the merged #691 code (`audit-verify-job.ts`, `server.ts`). `AUDIT_PSEUDONYM_CACHE_MAX` is intentionally left out — it's internal tuning, not operator-facing config.

Existing `### Via the admin UI` / `### Via the API` headings are unchanged, so their anchors stay stable.

## Verification

- `prettier --check` (same command as the `docs-format.yml` CI gate) — clean
- `pnpm -C docs build` (astro) — 63 pages built, no MDX errors
- Generated HTML confirmed: `id="automatic-verification"` anchor exists and the in-page link resolves to it; `audit.integrity_check` renders in both the table and the prose
- `check:tables` docs guard — clean