### PR TITLE
feat(settings): quiet sidebar, sticky nav, mobile drill-down

### DIFF
--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -107,7 +107,7 @@ vi.mock("@/components/settings-profile", () => ({
 }));
 
 vi.mock("next/navigation", () => ({
-  useRouter: vi.fn().mockReturnValue({ replace: vi.fn() }),
+  useRouter: vi.fn().mockReturnValue({ replace: vi.fn(), push: vi.fn() }),
   useSearchParams: vi.fn().mockReturnValue(new URLSearchParams()),
   usePathname: vi.fn().mockReturnValue("/settings"),
 }));
@@ -561,6 +561,19 @@ describe("Settings Page", () => {
       expect(router.replace).toHaveBeenCalledWith("/settings", { scroll: false });
     });
 
+    it("preserves unrelated query params when the back control is clicked", async () => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile&foo=bar"));
+      setupAdminFetchMocks();
+
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      const backButton = await screen.findByRole("button", { name: /back to settings/i });
+      await userEvent.click(backButton);
+
+      const router = useRouter();
+      expect(router.replace).toHaveBeenCalledWith("/settings?foo=bar", { scroll: false });
+    });
+
     it("keeps the active tab indicator on the sidebar variant", async () => {
       setupAdminFetchMocks();
 
@@ -568,6 +581,28 @@ describe("Settings Page", () => {
 
       const contextTab = await screen.findByRole("tab", { name: /context/i });
       expect(contextTab).toHaveAttribute("data-state", "active");
+    });
+
+    // Drift guard: the mobile back-header label (from TAB_LABELS) must match the
+    // active sidebar trigger's text, so renaming a tab can't leave a stale label.
+    // Covers the "AI Provider" disambiguation, the trickiest label.
+    it.each([
+      ["profile", "Profile"],
+      ["provider", "AI Provider"],
+    ])("mobile back header label matches the '%s' tab trigger", async (tab, expected) => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams(`tab=${tab}`));
+      setupAdminFetchMocks();
+
+      const { container } = render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      const backButton = await screen.findByRole("button", { name: /back to settings/i });
+      const headerLabel = backButton.parentElement?.querySelector("span")?.textContent?.trim();
+      const activeTrigger = container
+        .querySelector('[role="tab"][data-state="active"]')
+        ?.textContent?.trim();
+
+      expect(headerLabel).toBe(expected);
+      expect(headerLabel).toBe(activeTrigger);
     });
   });
 });

--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
+import { useRouter, useSearchParams } from "next/navigation";
 import { SettingsPageContent as SettingsPage } from "@/components/settings-page-content";
 
 let capturedProviderProps: {
@@ -167,6 +168,7 @@ describe("Settings Page", () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
     vi.clearAllMocks();
+    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams());
     capturedProviderProps = {};
     capturedOnDirtyChangeProvider = undefined;
     capturedOnDirtyChangeContext = undefined;
@@ -522,6 +524,50 @@ describe("Settings Page", () => {
         expect(global.fetch).toHaveBeenCalledWith("/api/users/me/context");
         expect(global.fetch).not.toHaveBeenCalledWith("/api/settings/providers");
       });
+    });
+  });
+
+  describe("Mobile drill-down navigation", () => {
+    it("does not show a back control when no tab is explicitly selected", async () => {
+      setupAdminFetchMocks();
+
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      await waitFor(() => screen.getByTestId("mock-settings-context"));
+      expect(screen.queryByRole("button", { name: /back to settings/i })).not.toBeInTheDocument();
+    });
+
+    it("shows a back control when a tab is explicitly selected via the URL param", async () => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile"));
+      setupAdminFetchMocks();
+
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: /back to settings/i })).toBeInTheDocument();
+      });
+    });
+
+    it("clears the tab param when the back control is clicked", async () => {
+      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile"));
+      setupAdminFetchMocks();
+
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      const backButton = await screen.findByRole("button", { name: /back to settings/i });
+      await userEvent.click(backButton);
+
+      const router = useRouter();
+      expect(router.replace).toHaveBeenCalledWith("/settings", { scroll: false });
+    });
+
+    it("keeps the active tab indicator on the sidebar variant", async () => {
+      setupAdminFetchMocks();
+
+      render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
+
+      const contextTab = await screen.findByRole("tab", { name: /context/i });
+      expect(contextTab).toHaveAttribute("data-state", "active");
     });
   });
 });

--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -3,7 +3,14 @@ import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { useRouter, useSearchParams } from "next/navigation";
+import type { ReadonlyURLSearchParams } from "next/navigation";
 import { SettingsPageContent as SettingsPage } from "@/components/settings-page-content";
+
+// useSearchParams() is typed as ReadonlyURLSearchParams; a plain URLSearchParams
+// is structurally not assignable (the readonly type drops the mutating methods)
+// but is a valid value at runtime, so the mocks cast through it.
+const readonlySearchParams = (init?: string) =>
+  new URLSearchParams(init) as unknown as ReadonlyURLSearchParams;
 
 let capturedProviderProps: {
   onSuccess?: () => void;
@@ -168,7 +175,7 @@ describe("Settings Page", () => {
   beforeEach(() => {
     fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
     vi.clearAllMocks();
-    vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams());
+    vi.mocked(useSearchParams).mockReturnValue(readonlySearchParams());
     capturedProviderProps = {};
     capturedOnDirtyChangeProvider = undefined;
     capturedOnDirtyChangeContext = undefined;
@@ -538,7 +545,7 @@ describe("Settings Page", () => {
     });
 
     it("shows a back control when a tab is explicitly selected via the URL param", async () => {
-      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile"));
+      vi.mocked(useSearchParams).mockReturnValue(readonlySearchParams("tab=profile"));
       setupAdminFetchMocks();
 
       render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
@@ -549,7 +556,7 @@ describe("Settings Page", () => {
     });
 
     it("clears the tab param when the back control is clicked", async () => {
-      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile"));
+      vi.mocked(useSearchParams).mockReturnValue(readonlySearchParams("tab=profile"));
       setupAdminFetchMocks();
 
       render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
@@ -562,7 +569,7 @@ describe("Settings Page", () => {
     });
 
     it("preserves unrelated query params when the back control is clicked", async () => {
-      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams("tab=profile&foo=bar"));
+      vi.mocked(useSearchParams).mockReturnValue(readonlySearchParams("tab=profile&foo=bar"));
       setupAdminFetchMocks();
 
       render(<SettingsPage isAdmin={isCurrentTestAdmin} />);
@@ -590,7 +597,7 @@ describe("Settings Page", () => {
       ["profile", "Profile"],
       ["provider", "AI Provider"],
     ])("mobile back header label matches the '%s' tab trigger", async (tab, expected) => {
-      vi.mocked(useSearchParams).mockReturnValue(new URLSearchParams(`tab=${tab}`));
+      vi.mocked(useSearchParams).mockReturnValue(readonlySearchParams(`tab=${tab}`));
       setupAdminFetchMocks();
 
       const { container } = render(<SettingsPage isAdmin={isCurrentTestAdmin} />);

--- a/packages/web/src/__tests__/hooks/use-tab-param.test.ts
+++ b/packages/web/src/__tests__/hooks/use-tab-param.test.ts
@@ -4,11 +4,12 @@ import { renderHook, act } from "@testing-library/react";
 // Mock next/navigation
 const mockSearchParams = new URLSearchParams();
 const mockReplace = vi.fn();
+const mockPush = vi.fn();
 
 vi.mock("next/navigation", () => ({
   useSearchParams: () => mockSearchParams,
   usePathname: () => "/settings",
-  useRouter: () => ({ replace: mockReplace }),
+  useRouter: () => ({ replace: mockReplace, push: mockPush }),
 }));
 
 import { useTabParam, SETTINGS_TABS, AGENT_SETTINGS_TABS } from "@/hooks/use-tab-param";
@@ -17,6 +18,7 @@ describe("useTabParam", () => {
   beforeEach(() => {
     mockSearchParams.delete("tab");
     mockReplace.mockClear();
+    mockPush.mockClear();
   });
 
   it("returns the default tab when no URL param is present", () => {
@@ -143,6 +145,46 @@ describe("useTabParam", () => {
     });
 
     expect(mockReplace).toHaveBeenCalledWith("/settings", { scroll: false });
+  });
+
+  it("pushes a history entry when entering a tab from the menu (pushOnEnter, not yet explicit)", () => {
+    // No `?tab=` param → not explicit → this is a drill-in from the menu level.
+    const { result } = renderHook(() =>
+      useTabParam("context", SETTINGS_TABS, undefined, { pushOnEnter: true })
+    );
+
+    act(() => {
+      result.current[1]("license");
+    });
+
+    expect(mockPush).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
+    expect(mockReplace).not.toHaveBeenCalled();
+  });
+
+  it("replaces (no history spam) when switching tabs while already explicit (pushOnEnter)", () => {
+    mockSearchParams.set("tab", "profile");
+
+    const { result } = renderHook(() =>
+      useTabParam("context", SETTINGS_TABS, undefined, { pushOnEnter: true })
+    );
+
+    act(() => {
+      result.current[1]("license");
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
+    expect(mockPush).not.toHaveBeenCalled();
+  });
+
+  it("never pushes when pushOnEnter is not set", () => {
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+
+    act(() => {
+      result.current[1]("license");
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=license", { scroll: false });
+    expect(mockPush).not.toHaveBeenCalled();
   });
 });
 

--- a/packages/web/src/__tests__/hooks/use-tab-param.test.ts
+++ b/packages/web/src/__tests__/hooks/use-tab-param.test.ts
@@ -96,6 +96,54 @@ describe("useTabParam", () => {
 
     expect(result.current[0]).toBe("context");
   });
+
+  it("reports isExplicit as false when no tab param is present", () => {
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+
+    expect(result.current[2]).toBe(false);
+  });
+
+  it("reports isExplicit as true when a valid tab param is present", () => {
+    mockSearchParams.set("tab", "license");
+
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+
+    expect(result.current[2]).toBe(true);
+  });
+
+  it("reports isExplicit as false when the tab param is invalid", () => {
+    mockSearchParams.set("tab", "nonexistent");
+
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+
+    expect(result.current[2]).toBe(false);
+  });
+
+  it("keeps the tab param on the default tab when keepParamForDefault is set", () => {
+    const { result } = renderHook(() =>
+      useTabParam("context", SETTINGS_TABS, undefined, { keepParamForDefault: true })
+    );
+
+    act(() => {
+      result.current[1]("context");
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/settings?tab=context", {
+      scroll: false,
+    });
+  });
+
+  it("still removes the tab param on the default tab when keepParamForDefault is not set", () => {
+    mockSearchParams.set("tab", "license");
+
+    const { result } = renderHook(() => useTabParam("context", SETTINGS_TABS));
+
+    act(() => {
+      result.current[1]("context");
+    });
+
+    expect(mockReplace).toHaveBeenCalledWith("/settings", { scroll: false });
+  });
 });
 
 describe("tab constants", () => {

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
-import { usePathname, useRouter } from "next/navigation";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { useTabParam, SETTINGS_TABS, type SettingsTab } from "@/hooks/use-tab-param";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
@@ -77,11 +77,15 @@ export function SettingsPageContent({
   const { data: session } = authClient.useSession();
   const pathname = usePathname();
   const router = useRouter();
+  const searchParams = useSearchParams();
   const visibleTabs: SettingsTab[] = isAdmin
     ? [...SETTINGS_TABS]
     : ["context", "profile", "telegram", "support"];
   const [activeTab, setActiveTab, isTabExplicit] = useTabParam("context", visibleTabs, initialTab, {
     keepParamForDefault: true,
+    // Drilling into a tab on mobile pushes a history entry so the browser
+    // Back button (and back gesture) returns to the menu, not off the page.
+    pushOnEnter: true,
   });
   // Mark the (admin-only) Integrations tab when a connection needs attention, so
   // the error trail continues from the sidebar badge down to the exact tab.
@@ -91,8 +95,13 @@ export function SettingsPageContent({
   // (level 1) vs. a selected tab's content with a back header (level 2).
   // Desktop always shows the split layout regardless of this flag.
   const goToMenu = useCallback(() => {
-    router.replace(pathname, { scroll: false });
-  }, [pathname, router]);
+    // Only drop `tab`; keep any unrelated query params (e.g. an OAuth `?error=`)
+    // so the back control doesn't silently discard page state.
+    const params = new URLSearchParams(searchParams.toString());
+    params.delete("tab");
+    const query = params.toString();
+    router.replace(query ? `${pathname}?${query}` : pathname, { scroll: false });
+  }, [pathname, router, searchParams]);
 
   const [status, setStatus] = useState<ProviderStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -197,7 +206,7 @@ export function SettingsPageContent({
           <TabsList
             variant="sidebar"
             className={cn(
-              "h-fit w-full shrink-0 flex-col items-stretch gap-0.5 md:sticky md:top-0 md:w-56 md:self-start md:overflow-y-auto md:max-h-[calc(100dvh-4rem)]",
+              "h-fit w-full shrink-0 flex-col items-stretch gap-0.5 md:sticky md:top-8 md:w-56 md:self-start md:overflow-y-auto md:max-h-[calc(100dvh-4rem)]",
               isTabExplicit ? "hidden md:flex" : "flex md:flex"
             )}
           >

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -1,9 +1,11 @@
 "use client";
 
 import { useState, useEffect, useCallback } from "react";
+import { usePathname, useRouter } from "next/navigation";
 import { authClient } from "@/lib/auth-client";
 import { useTabParam, SETTINGS_TABS, type SettingsTab } from "@/hooks/use-tab-param";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { cn } from "@/lib/utils";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { ProviderKeyForm } from "@/components/provider-key-form";
 import { SettingsUsers } from "@/components/settings-users";
@@ -44,6 +46,23 @@ function ErrorDot() {
   );
 }
 
+// Display labels for the mobile drill-down back header. Kept in sync with
+// the TabsTrigger labels below (the "AI Provider" label disambiguates the
+// LLM provider tab from OAuth "providers" like Google/Microsoft).
+const TAB_LABELS: Record<SettingsTab, string> = {
+  context: "Context",
+  profile: "Profile",
+  telegram: "Telegram",
+  support: "Support",
+  provider: "AI Provider",
+  users: "Users",
+  groups: "Groups",
+  integrations: "Integrations",
+  organization: "Organization",
+  license: "License",
+  security: "Security",
+};
+
 export function SettingsPageContent({
   initialTab,
   isAdmin,
@@ -56,13 +75,24 @@ export function SettingsPageContent({
   oauthError?: string;
 }) {
   const { data: session } = authClient.useSession();
+  const pathname = usePathname();
+  const router = useRouter();
   const visibleTabs: SettingsTab[] = isAdmin
     ? [...SETTINGS_TABS]
     : ["context", "profile", "telegram", "support"];
-  const [activeTab, setActiveTab] = useTabParam("context", visibleTabs, initialTab);
+  const [activeTab, setActiveTab, isTabExplicit] = useTabParam("context", visibleTabs, initialTab, {
+    keepParamForDefault: true,
+  });
   // Mark the (admin-only) Integrations tab when a connection needs attention, so
   // the error trail continues from the sidebar badge down to the exact tab.
   const { needsAttentionCount } = useIntegrationHealth(isAdmin);
+
+  // On mobile, `isTabExplicit` drives a two-level drill-down: the sidebar list
+  // (level 1) vs. a selected tab's content with a back header (level 2).
+  // Desktop always shows the split layout regardless of this flag.
+  const goToMenu = useCallback(() => {
+    router.replace(pathname, { scroll: false });
+  }, [pathname, router]);
 
   const [status, setStatus] = useState<ProviderStatus | null>(null);
   const [loading, setLoading] = useState(true);
@@ -133,8 +163,14 @@ export function SettingsPageContent({
     setProfileDirty(isDirty);
   }, []);
 
+  // No `overflow-y-auto` here: AppShell's wrapper (`flex-1 overflow-y-auto`)
+  // is already the real, height-bounded page scroller. A second nested
+  // `overflow-y-auto` on an auto-height div still counts as a CSS scroll
+  // container even though it never overflows itself, which makes it the
+  // (non-scrolling) containing block for `position: sticky` below and
+  // silently breaks the sticky sidebar. Keep this single-scroller structure.
   return (
-    <div className="overflow-y-auto">
+    <div>
       <div className="p-4 md:p-8 max-w-5xl">
         <h1 className="text-2xl font-bold mb-6">Settings</h1>
 
@@ -142,15 +178,32 @@ export function SettingsPageContent({
           value={activeTab}
           onValueChange={setActiveTab}
           orientation="vertical"
-          className="flex-col md:flex-row"
+          className="flex-col md:flex-row md:gap-10"
         >
+          {isTabExplicit && (
+            <div className="flex items-center gap-2 pb-2 md:hidden">
+              <button
+                type="button"
+                onClick={goToMenu}
+                aria-label="Back to settings"
+                className="text-muted-foreground hover:text-foreground -ml-1 rounded-md px-1 py-1 text-sm font-medium"
+              >
+                &lsaquo; Settings
+              </button>
+              <span className="text-sm font-medium">{TAB_LABELS[activeTab]}</span>
+            </div>
+          )}
+
           <TabsList
-            variant="line"
-            className="h-fit w-full shrink-0 flex-col items-stretch gap-0.5 md:w-56 md:border-r md:pr-2"
+            variant="sidebar"
+            className={cn(
+              "h-fit w-full shrink-0 flex-col items-stretch gap-0.5 md:sticky md:top-0 md:w-56 md:self-start md:overflow-y-auto md:max-h-[calc(100dvh-4rem)]",
+              isTabExplicit ? "hidden md:flex" : "flex md:flex"
+            )}
           >
             <div
               role="presentation"
-              className="px-2 pt-1 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+              className="text-muted-foreground/70 px-2 pt-1 pb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase"
             >
               Personal
             </div>
@@ -162,7 +215,7 @@ export function SettingsPageContent({
               <>
                 <div
                   role="presentation"
-                  className="px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                  className="text-muted-foreground/70 px-2 pt-6 pb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase"
                 >
                   Administration
                 </div>
@@ -177,7 +230,7 @@ export function SettingsPageContent({
                 <TabsTrigger value="organization">Organization</TabsTrigger>
                 <div
                   role="presentation"
-                  className="px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
+                  className="text-muted-foreground/70 px-2 pt-6 pb-1 text-[0.6875rem] font-semibold tracking-[0.08em] uppercase"
                 >
                   Security &amp; Compliance
                 </div>
@@ -187,97 +240,99 @@ export function SettingsPageContent({
             )}
           </TabsList>
 
-          {isAdmin && (
-            <TabsContent value="security">
-              <div className="space-y-6">
-                <SettingsSecurity />
-                <SecretsProvenanceCard />
-              </div>
-            </TabsContent>
-          )}
+          <div className={cn("min-w-0 flex-1", isTabExplicit ? "block" : "hidden md:block")}>
+            {isAdmin && (
+              <TabsContent value="security">
+                <div className="space-y-6">
+                  <SettingsSecurity />
+                  <SecretsProvenanceCard />
+                </div>
+              </TabsContent>
+            )}
 
-          <TabsContent value="context" keepMounted>
-            <SettingsContext
-              userContext={userContext}
-              orgContext={orgContext}
-              isAdmin={isAdmin}
-              onDirtyChange={handleContextDirtyChange}
-            />
-          </TabsContent>
-
-          <TabsContent value="profile" keepMounted>
-            <SettingsProfile
-              userName={session?.user?.name ?? ""}
-              onDirtyChange={handleProfileDirtyChange}
-            />
-          </TabsContent>
-
-          <TabsContent value="telegram">
-            <TelegramLinkSettings isAdmin={isAdmin} />
-          </TabsContent>
-
-          <TabsContent value="support">
-            <SettingsSupport />
-          </TabsContent>
-
-          {isAdmin && (
-            <TabsContent value="provider" keepMounted>
-              <Card>
-                <CardHeader>
-                  <CardTitle>LLM Provider</CardTitle>
-                </CardHeader>
-                <CardContent>
-                  {loading ? (
-                    <p>Loading...</p>
-                  ) : (
-                    <ProviderKeyForm
-                      onSuccess={fetchStatus}
-                      submitLabel="Save"
-                      configuredProviders={status?.providers}
-                      defaultProvider={status?.defaultProvider}
-                      onDirtyChange={handleProviderDirtyChange}
-                    />
-                  )}
-                </CardContent>
-              </Card>
-            </TabsContent>
-          )}
-
-          {isAdmin && (
-            <TabsContent value="users" keepMounted>
-              <SettingsUsers
-                currentUserId={session?.user?.id ?? ""}
-                refreshKey={enterpriseRefreshKey}
+            <TabsContent value="context" keepMounted>
+              <SettingsContext
+                userContext={userContext}
+                orgContext={orgContext}
+                isAdmin={isAdmin}
+                onDirtyChange={handleContextDirtyChange}
               />
             </TabsContent>
-          )}
 
-          {isAdmin && (
-            <TabsContent value="groups" keepMounted>
-              <SettingsGroups refreshKey={enterpriseRefreshKey} isAdmin={isAdmin} />
-            </TabsContent>
-          )}
-
-          {isAdmin && (
-            <TabsContent value="integrations" keepMounted>
-              <SettingsIntegrations oauthError={oauthError} />
-            </TabsContent>
-          )}
-
-          {isAdmin && (
-            <TabsContent value="organization" keepMounted>
-              <TimezoneSettings />
-            </TabsContent>
-          )}
-
-          {isAdmin && (
-            <TabsContent value="license" keepMounted>
-              <SettingsLicense
-                onEnterpriseActivated={handleEnterpriseActivated}
-                initialLicense={initialLicense}
+            <TabsContent value="profile" keepMounted>
+              <SettingsProfile
+                userName={session?.user?.name ?? ""}
+                onDirtyChange={handleProfileDirtyChange}
               />
             </TabsContent>
-          )}
+
+            <TabsContent value="telegram">
+              <TelegramLinkSettings isAdmin={isAdmin} />
+            </TabsContent>
+
+            <TabsContent value="support">
+              <SettingsSupport />
+            </TabsContent>
+
+            {isAdmin && (
+              <TabsContent value="provider" keepMounted>
+                <Card>
+                  <CardHeader>
+                    <CardTitle>LLM Provider</CardTitle>
+                  </CardHeader>
+                  <CardContent>
+                    {loading ? (
+                      <p>Loading...</p>
+                    ) : (
+                      <ProviderKeyForm
+                        onSuccess={fetchStatus}
+                        submitLabel="Save"
+                        configuredProviders={status?.providers}
+                        defaultProvider={status?.defaultProvider}
+                        onDirtyChange={handleProviderDirtyChange}
+                      />
+                    )}
+                  </CardContent>
+                </Card>
+              </TabsContent>
+            )}
+
+            {isAdmin && (
+              <TabsContent value="users" keepMounted>
+                <SettingsUsers
+                  currentUserId={session?.user?.id ?? ""}
+                  refreshKey={enterpriseRefreshKey}
+                />
+              </TabsContent>
+            )}
+
+            {isAdmin && (
+              <TabsContent value="groups" keepMounted>
+                <SettingsGroups refreshKey={enterpriseRefreshKey} isAdmin={isAdmin} />
+              </TabsContent>
+            )}
+
+            {isAdmin && (
+              <TabsContent value="integrations" keepMounted>
+                <SettingsIntegrations oauthError={oauthError} />
+              </TabsContent>
+            )}
+
+            {isAdmin && (
+              <TabsContent value="organization" keepMounted>
+                <TimezoneSettings />
+              </TabsContent>
+            )}
+
+            {isAdmin && (
+              <TabsContent value="license" keepMounted>
+                <SettingsLicense
+                  onEnterpriseActivated={handleEnterpriseActivated}
+                  initialLicense={initialLicense}
+                />
+              </TabsContent>
+            )}
+          </div>
         </Tabs>
       </div>
     </div>

--- a/packages/web/src/components/ui/tabs.tsx
+++ b/packages/web/src/components/ui/tabs.tsx
@@ -29,6 +29,7 @@ const tabsListVariants = cva(
       variant: {
         default: "bg-muted",
         line: "gap-1 bg-transparent",
+        sidebar: "gap-0.5 bg-transparent",
       },
     },
     defaultVariants: {
@@ -61,6 +62,7 @@ function TabsTrigger({ className, ...props }: React.ComponentProps<typeof TabsPr
         "group-data-[variant=line]/tabs-list:bg-transparent group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:border-transparent dark:group-data-[variant=line]/tabs-list:data-[state=active]:bg-transparent",
         "data-[state=active]:bg-background dark:data-[state=active]:text-foreground dark:data-[state=active]:border-input dark:data-[state=active]:bg-input/30 data-[state=active]:text-foreground",
         "after:bg-foreground after:absolute after:opacity-0 after:transition-opacity group-data-[orientation=horizontal]/tabs:after:inset-x-0 group-data-[orientation=horizontal]/tabs:after:bottom-[-5px] group-data-[orientation=horizontal]/tabs:after:h-0.5 group-data-[orientation=vertical]/tabs:after:inset-y-0 group-data-[orientation=vertical]/tabs:after:-right-1 group-data-[orientation=vertical]/tabs:after:w-0.5 group-data-[variant=line]/tabs-list:data-[state=active]:after:opacity-100",
+        "group-data-[variant=sidebar]/tabs-list:text-muted-foreground group-data-[variant=sidebar]/tabs-list:hover:bg-muted/50 group-data-[variant=sidebar]/tabs-list:hover:text-foreground group-data-[variant=sidebar]/tabs-list:data-[state=active]:rounded-md group-data-[variant=sidebar]/tabs-list:data-[state=active]:border-transparent group-data-[variant=sidebar]/tabs-list:data-[state=active]:bg-muted group-data-[variant=sidebar]/tabs-list:data-[state=active]:text-foreground dark:group-data-[variant=sidebar]/tabs-list:data-[state=active]:bg-muted dark:group-data-[variant=sidebar]/tabs-list:data-[state=active]:border-transparent",
         className
       )}
       {...props}

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -45,17 +45,24 @@ export type AgentSettingsTab = (typeof AGENT_SETTINGS_TABS)[number];
  * "the default tab was explicitly selected" (e.g. a mobile drill-down
  * menu) should pass `keepParamForDefault: true` so selecting the
  * default tab still writes `?tab=<default>` instead of clearing it.
+ *
+ * `pushOnEnter: true` makes the first selection out of the menu level
+ * (i.e. while not yet `isExplicit`) a `router.push` instead of `replace`,
+ * so the browser Back button returns to the menu in a mobile drill-down.
+ * Switching between tabs afterwards still uses `replace` to avoid piling
+ * up one history entry per tab click.
  */
 export function useTabParam<T extends string>(
   defaultTab: T,
   validTabs: readonly T[],
   initialTab?: string | null,
-  options?: { keepParamForDefault?: boolean }
+  options?: { keepParamForDefault?: boolean; pushOnEnter?: boolean }
 ): readonly [T, (tab: string) => void, boolean] {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
   const keepParamForDefault = options?.keepParamForDefault ?? false;
+  const pushOnEnter = options?.pushOnEnter ?? false;
 
   const rawTab = (searchParams.get("tab") ?? initialTab ?? null) as T | null;
   const isExplicit = Boolean(rawTab && validTabs.includes(rawTab));
@@ -73,11 +80,25 @@ export function useTabParam<T extends string>(
       }
 
       const query = params.toString();
-      router.replace(query ? `${pathname}?${query}` : pathname, {
-        scroll: false,
-      });
+      const url = query ? `${pathname}?${query}` : pathname;
+      // Drilling in from the menu (not yet explicit) gets its own history
+      // entry so Back returns to the menu; every later switch replaces.
+      if (pushOnEnter && !isExplicit) {
+        router.push(url, { scroll: false });
+      } else {
+        router.replace(url, { scroll: false });
+      }
     },
-    [defaultTab, keepParamForDefault, pathname, router, searchParams, validTabs]
+    [
+      defaultTab,
+      isExplicit,
+      keepParamForDefault,
+      pushOnEnter,
+      pathname,
+      router,
+      searchParams,
+      validTabs,
+    ]
   );
 
   return [tab, setTab, isExplicit] as const;

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -38,25 +38,35 @@ export type AgentSettingsTab = (typeof AGENT_SETTINGS_TABS)[number];
  * Accepts an optional `initialTab` from server-side searchParams to
  * avoid SSR/hydration flicker. Falls back to useSearchParams() for
  * client-side navigation.
+ *
+ * The third return value, `isExplicit`, is true when the resolved tab
+ * came from an explicit (valid) `?tab=` param rather than the fallback
+ * default. Consumers that need to distinguish "no selection yet" from
+ * "the default tab was explicitly selected" (e.g. a mobile drill-down
+ * menu) should pass `keepParamForDefault: true` so selecting the
+ * default tab still writes `?tab=<default>` instead of clearing it.
  */
 export function useTabParam<T extends string>(
   defaultTab: T,
   validTabs: readonly T[],
-  initialTab?: string | null
-): [T, (tab: string) => void] {
+  initialTab?: string | null,
+  options?: { keepParamForDefault?: boolean }
+): readonly [T, (tab: string) => void, boolean] {
   const searchParams = useSearchParams();
   const pathname = usePathname();
   const router = useRouter();
+  const keepParamForDefault = options?.keepParamForDefault ?? false;
 
-  const urlTab = (searchParams.get("tab") ?? initialTab ?? null) as T | null;
-  const tab = urlTab && validTabs.includes(urlTab) ? urlTab : defaultTab;
+  const rawTab = (searchParams.get("tab") ?? initialTab ?? null) as T | null;
+  const isExplicit = Boolean(rawTab && validTabs.includes(rawTab));
+  const tab = isExplicit ? (rawTab as T) : defaultTab;
 
   const setTab = useCallback(
     (newTab: string) => {
       if (!validTabs.includes(newTab as T)) return;
 
       const params = new URLSearchParams(searchParams.toString());
-      if (newTab === defaultTab) {
+      if (newTab === defaultTab && !keepParamForDefault) {
         params.delete("tab");
       } else {
         params.set("tab", newTab);
@@ -67,8 +77,8 @@ export function useTabParam<T extends string>(
         scroll: false,
       });
     },
-    [defaultTab, pathname, router, searchParams, validTabs]
+    [defaultTab, keepParamForDefault, pathname, router, searchParams, validTabs]
   );
 
-  return [tab, setTab];
+  return [tab, setTab, isExplicit] as const;
 }


### PR DESCRIPTION
## What does this PR do?

Refines the Settings vertical-menu layout after the recent switch from horizontal tabs. The UI primitives were still the old tab building blocks, which produced four visible seams. Three coordinated changes fix them:

**1 · Quiet sidebar (line clash + section headers).** New `sidebar` variant in `tabs.tsx`: the active item is a filled pill (`bg-muted`) instead of an indicator bar, and the menu↔content divider (`md:border-r`) is dropped — the card border becomes the only line style. Section headers are restyled (smaller, more letter-spacing, quieter than inactive items, more top spacing) so the group hierarchy reads at a glance. The `default`/`line` variants (used by agent-settings) are untouched.

**2 · Sticky sidebar, content-only scroll.** The nav is `md:sticky md:top-0` with its own `max-h` + `overflow-y-auto` fallback: normally the menu stays put while only the content scrolls; on short viewports the menu scrolls independently instead of clipping its end. This required removing the inert `overflow-y-auto` from the page's outer div — `AppShell`'s `flex-1 overflow-y-auto` is the real page scroller, and a nested (non-overflowing) scroll container silently breaks `position: sticky`.

**3 · Mobile drill-down.** Two-level navigation (menu list → detail with a "‹ Settings" back control) driven by the `?tab=` param, matching the OS settings pattern instead of stacking the full menu above the content. `useTabParam` gains `keepParamForDefault` + an `isExplicit` return value so the default tab (Context) is reachable on mobile; browser-back and deep links keep working. Desktop stays split-layout throughout.

Design exploration (interactive before/after mockups): https://claude.ai/code/artifact/c5113bad-a20c-48f1-b71d-18d029ead511

## Type of change

- [x] ✨ New feature

## Reviewer notes

- The `overflow-y-auto` removal is deliberate — see the sticky rationale above. `showTabBar` is true for `/settings`, so AppShell is the bounded scroller on both desktop and mobile.
- Same drill-down/sidebar pattern could later apply to the agent-settings tabs (still horizontal) for a consistent settings system — out of scope here.
- Not yet visually verified in the running app (needs the Docker stack + auth); sticky behavior was verified via a static repro, and the build/typecheck passes.

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (+4 settings-page cases for the mobile back control, +6 `use-tab-param` cases for `isExplicit`/`keepParamForDefault`)
- [ ] I've updated the documentation (no product-behavior docs cover the settings chrome)
- [x] All existing tests pass (full web suite green; `pnpm build`, lint, `format:check` green)
