### PR TITLE
feat: org timezone setting (Background Jobs foundation, #704)

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -209,6 +209,7 @@ export default defineConfig({
           label: 'Reference',
           items: [
             { label: 'API Reference', slug: 'reference/api' },
+            { label: 'Organization Timezone', slug: 'reference/organization-timezone' },
             { label: 'SBOM', slug: 'reference/sbom' },
           ],
         },

--- a/docs/src/content/docs/reference/organization-timezone.mdx
+++ b/docs/src/content/docs/reference/organization-timezone.mdx
@@ -1,0 +1,54 @@
+---
+title: Organization Timezone
+description: The org-wide timezone setting used for scheduled jobs and briefing delivery times.
+---
+
+Pinchy stores a single, org-wide IANA timezone. Background jobs — scheduled briefings, automations, and anything else that runs on a clock — use this value to decide _when_ to fire.
+
+The setting is shared across the whole organization. Individual users don't have their own timezone; everyone sees scheduled events anchored to the same wall-clock time.
+
+## Where to find it
+
+**Settings → Organization → Timezone**
+
+The Organization tab is **admin-only**. Non-admin users won't see it.
+
+## Default behavior
+
+Pinchy captures the admin's browser timezone during initial setup (via `Intl.DateTimeFormat().resolvedOptions().timeZone`) and stores it as the org timezone. If the browser doesn't report one, Pinchy falls back to `UTC`.
+
+You can change it any time after setup — there's no special migration step.
+
+## Format
+
+The selector lists every IANA timezone your runtime knows about, sourced from [`Intl.supportedValuesOf("timeZone")`](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Intl/supportedValuesOf). Examples:
+
+- `Europe/Vienna`
+- `America/New_York`
+- `Asia/Tokyo`
+- `UTC`
+
+Pinchy validates the value against `Intl.DateTimeFormat` before saving. Invalid timezones are rejected with a `400` and an inline error.
+
+## What uses the timezone today
+
+Today, only the **Background Jobs** infrastructure reads this value. End-user features that schedule work — briefings, automations — will land in later milestones (see [issue #138](https://github.com/heypinchy/pinchy/issues/138)). Setting the timezone now means those features will pick up the correct value when they ship.
+
+## Audit trail
+
+Every change is recorded as a `settings.updated` event with a from/to diff:
+
+```json
+{
+  "eventType": "settings.updated",
+  "resource": "settings",
+  "detail": {
+    "changes": {
+      "timezone": { "from": "UTC", "to": "Europe/Vienna" }
+    }
+  },
+  "outcome": "success"
+}
+```
+
+See [Audit Trail](/concepts/audit-trail/) for how to query and export audit events.

--- a/docs/src/content/docs/reference/organization-timezone.mdx
+++ b/docs/src/content/docs/reference/organization-timezone.mdx
@@ -32,7 +32,7 @@ Pinchy validates the value against `Intl.DateTimeFormat` before saving. Invalid 
 
 ## What uses the timezone today
 
-Today, only the **Background Jobs** infrastructure reads this value. End-user features that schedule work — briefings, automations — will land in later milestones (see [issue #138](https://github.com/heypinchy/pinchy/issues/138)). Setting the timezone now means those features will pick up the correct value when they ship.
+No feature consumes this value yet. It is the foundation for scheduled background work — briefings and inbox automations — which will read it when they ship (see the [Background Jobs foundation, #704](https://github.com/heypinchy/pinchy/issues/704), and [Scheduled Briefings, #138](https://github.com/heypinchy/pinchy/issues/138)). Setting the timezone now means those features pick up the correct value from day one.
 
 ## Audit trail
 

--- a/packages/web/src/__tests__/api/settings-timezone.test.ts
+++ b/packages/web/src/__tests__/api/settings-timezone.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next/headers", () => ({
+  headers: vi.fn().mockResolvedValue(new Headers()),
+}));
+
+vi.mock("@/lib/auth", () => {
+  const mockGetSession = vi.fn();
+  return {
+    getSession: mockGetSession,
+    auth: {
+      api: {
+        getSession: mockGetSession,
+      },
+    },
+  };
+});
+
+vi.mock("@/lib/settings", () => ({
+  getAllSettings: vi.fn().mockResolvedValue([]),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+  getSetting: vi.fn().mockResolvedValue(null),
+}));
+
+vi.mock("@/lib/settings-timezone");
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: vi.fn().mockResolvedValue(undefined),
+}));
+
+import { auth } from "@/lib/auth";
+import * as tz from "@/lib/settings-timezone";
+import * as audit from "@/lib/audit";
+import { after } from "next/server";
+
+describe("POST /api/settings — timezone", () => {
+  let POST: typeof import("@/app/api/settings/route").POST;
+
+  beforeEach(async () => {
+    vi.clearAllMocks();
+    const mod = await import("@/app/api/settings/route");
+    POST = mod.POST;
+
+    vi.mocked(auth.api.getSession).mockResolvedValue({
+      user: { id: "admin-1", role: "admin" },
+      expires: "",
+    } as any);
+  });
+
+  it("updates org.timezone and logs audit event with from/to diff", async () => {
+    vi.mocked(tz.getOrgTimezone).mockResolvedValue("UTC");
+    vi.mocked(tz.setOrgTimezone).mockResolvedValue(undefined);
+
+    const req = new Request("http://test/api/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ key: "org.timezone", value: "Europe/Vienna" }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(tz.setOrgTimezone).toHaveBeenCalledWith("Europe/Vienna");
+    expect(after).toHaveBeenCalledTimes(1);
+    expect(audit.appendAuditLog).toHaveBeenCalledWith(
+      expect.objectContaining({
+        eventType: "settings.updated",
+        detail: { changes: { timezone: { from: "UTC", to: "Europe/Vienna" } } },
+        outcome: "success",
+      })
+    );
+  });
+
+  it("rejects invalid timezone with 400", async () => {
+    vi.mocked(tz.getOrgTimezone).mockResolvedValue("UTC");
+    vi.mocked(tz.setOrgTimezone).mockRejectedValue(new Error("invalid IANA timezone: X"));
+
+    const req = new Request("http://test/api/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ key: "org.timezone", value: "X" }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(400);
+    const body = await res.json();
+    expect(body).toEqual({ error: expect.stringMatching(/invalid/i) });
+  });
+});

--- a/packages/web/src/__tests__/api/settings-timezone.test.ts
+++ b/packages/web/src/__tests__/api/settings-timezone.test.ts
@@ -107,4 +107,21 @@ describe("POST /api/settings — timezone", () => {
     });
     await expect(POST(req as any)).rejects.toThrow(/db down/);
   });
+
+  it("does not write an audit event when the timezone is unchanged (from === to)", async () => {
+    vi.mocked(tz.getOrgTimezone).mockResolvedValue("Europe/Vienna");
+    vi.mocked(tz.setOrgTimezone).mockResolvedValue(undefined);
+
+    const req = new Request("http://test/api/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ key: "org.timezone", value: "Europe/Vienna" }),
+    });
+    const res = await POST(req as any);
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
+    // A no-op save (same value) must not spam the audit log with from===to rows.
+    expect(after).not.toHaveBeenCalled();
+    expect(audit.appendAuditLog).not.toHaveBeenCalled();
+  });
 });

--- a/packages/web/src/__tests__/api/settings-timezone.test.ts
+++ b/packages/web/src/__tests__/api/settings-timezone.test.ts
@@ -22,7 +22,16 @@ vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
 }));
 
-vi.mock("@/lib/settings-timezone");
+// Keep the real, pure `isValidIanaTimezone` so the invalid → 400 case is driven
+// by the actual validator path; only the I/O helpers are stubbed.
+vi.mock("@/lib/settings-timezone", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/settings-timezone")>();
+  return {
+    ...actual,
+    getOrgTimezone: vi.fn(),
+    setOrgTimezone: vi.fn(),
+  };
+});
 vi.mock("@/lib/audit", () => ({
   appendAuditLog: vi.fn().mockResolvedValue(undefined),
 }));
@@ -57,6 +66,7 @@ describe("POST /api/settings — timezone", () => {
     });
     const res = await POST(req as any);
     expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({ success: true });
     expect(tz.setOrgTimezone).toHaveBeenCalledWith("Europe/Vienna");
     expect(after).toHaveBeenCalledTimes(1);
     expect(audit.appendAuditLog).toHaveBeenCalledWith(
@@ -68,18 +78,33 @@ describe("POST /api/settings — timezone", () => {
     );
   });
 
-  it("rejects invalid timezone with 400", async () => {
+  it("rejects invalid timezone with 400 before touching persistence", async () => {
     vi.mocked(tz.getOrgTimezone).mockResolvedValue("UTC");
-    vi.mocked(tz.setOrgTimezone).mockRejectedValue(new Error("invalid IANA timezone: X"));
 
     const req = new Request("http://test/api/settings", {
       method: "POST",
       headers: { "content-type": "application/json" },
-      body: JSON.stringify({ key: "org.timezone", value: "X" }),
+      body: JSON.stringify({ key: "org.timezone", value: "Not/AZone" }),
     });
     const res = await POST(req as any);
     expect(res.status).toBe(400);
     const body = await res.json();
     expect(body).toEqual({ error: expect.stringMatching(/invalid/i) });
+    // Validation happens before persistence, so setSetting is never reached.
+    expect(tz.setOrgTimezone).not.toHaveBeenCalled();
+  });
+
+  it("propagates a persistence failure instead of masking it as a 400", async () => {
+    vi.mocked(tz.getOrgTimezone).mockResolvedValue("UTC");
+    // Valid zone, but the DB write fails: this must surface as a genuine error
+    // (→ 500 via the framework), never be reported to the client as a 400.
+    vi.mocked(tz.setOrgTimezone).mockRejectedValue(new Error("db down"));
+
+    const req = new Request("http://test/api/settings", {
+      method: "POST",
+      headers: { "content-type": "application/json" },
+      body: JSON.stringify({ key: "org.timezone", value: "Europe/Vienna" }),
+    });
+    await expect(POST(req as any)).rejects.toThrow(/db down/);
   });
 });

--- a/packages/web/src/__tests__/api/setup.test.ts
+++ b/packages/web/src/__tests__/api/setup.test.ts
@@ -87,6 +87,8 @@ vi.mock("@/lib/settings", () => ({
   getSetting: vi.fn().mockResolvedValue(null),
 }));
 
+vi.mock("@/lib/settings-timezone");
+
 vi.mock("@/lib/providers", () => ({
   PROVIDERS: {},
 }));

--- a/packages/web/src/__tests__/app/settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/settings-page.test.tsx
@@ -67,6 +67,10 @@ vi.mock("@/components/settings-groups", () => ({
   },
 }));
 
+vi.mock("@/components/timezone-settings", () => ({
+  TimezoneSettings: () => <div data-testid="mock-timezone-settings">Timezone</div>,
+}));
+
 vi.mock("@/components/settings-context", () => ({
   SettingsContext: ({
     userContext,

--- a/packages/web/src/__tests__/app/setup-page.test.tsx
+++ b/packages/web/src/__tests__/app/setup-page.test.tsx
@@ -242,15 +242,17 @@ describe("Setup Form", () => {
     await user.click(screen.getByRole("button", { name: /create account/i }));
 
     await waitFor(() => {
-      expect(global.fetch).toHaveBeenCalledWith("/api/setup", {
-        method: "POST",
-        headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name: "Admin User",
-          email: "admin@test.com",
-          password: "Br1ghtNova!2",
-        }),
+      const setupCall = (global.fetch as ReturnType<typeof vi.fn>).mock.calls.find(
+        ([url]) => url === "/api/setup"
+      );
+      expect(setupCall).toBeDefined();
+      const body = JSON.parse(setupCall![1].body);
+      expect(body).toMatchObject({
+        name: "Admin User",
+        email: "admin@test.com",
+        password: "Br1ghtNova!2",
       });
+      expect(typeof body.browserTimezone).toBe("string");
     });
   });
 

--- a/packages/web/src/__tests__/components/timezone-settings.test.tsx
+++ b/packages/web/src/__tests__/components/timezone-settings.test.tsx
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { render, screen, waitFor } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+import { TimezoneSettings } from "@/components/timezone-settings";
+import { toast } from "sonner";
+
+vi.mock("sonner", () => ({
+  toast: { success: vi.fn(), error: vi.fn() },
+}));
+
+describe("TimezoneSettings", () => {
+  let fetchSpy: ReturnType<typeof vi.spyOn>;
+
+  beforeEach(() => {
+    fetchSpy = vi.spyOn(global, "fetch").mockImplementation(vi.fn());
+    vi.clearAllMocks();
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  it("renders after fetching settings from /api/settings", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ key: "org.timezone", value: "UTC" }],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    expect(global.fetch).toHaveBeenCalledWith("/api/settings");
+  });
+
+  it("renders a Save button", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+  });
+
+  it("shows Europe/Vienna timezone option in the dropdown", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ key: "org.timezone", value: "UTC" }],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    // Open the dropdown to verify timezones are available
+    await userEvent.click(screen.getByRole("combobox"));
+    // Find the Europe/Vienna option by its text content
+    await waitFor(() => {
+      expect(screen.getByText("Europe/Vienna")).toBeInTheDocument();
+    });
+  });
+
+  it("POSTs the saved timezone to /api/settings when Save is clicked", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ key: "org.timezone", value: "UTC" }],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("combobox")).toBeInTheDocument();
+    });
+
+    // Open dropdown and select a different timezone
+    await userEvent.click(screen.getByRole("combobox"));
+    const option = await screen.findByRole("option", { name: "Europe/Vienna" });
+    await userEvent.click(option);
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/settings",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ key: "org.timezone", value: "Europe/Vienna" }),
+        })
+      );
+    });
+  });
+
+  it("POSTs the current timezone (UTC default) to /api/settings when no org.timezone setting exists", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(global.fetch).toHaveBeenLastCalledWith(
+        "/api/settings",
+        expect.objectContaining({
+          method: "POST",
+          body: JSON.stringify({ key: "org.timezone", value: "UTC" }),
+        })
+      );
+    });
+  });
+
+  it("shows success toast after saving", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ key: "org.timezone", value: "UTC" }],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ ok: true }),
+    } as Response);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(toast.success).toHaveBeenCalledWith("Settings saved");
+    });
+  });
+
+  it("shows inline error when save fails", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [{ key: "org.timezone", value: "UTC" }],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({ error: "Invalid timezone" }),
+    } as Response);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid timezone")).toBeInTheDocument();
+    });
+
+    expect(toast.success).not.toHaveBeenCalled();
+  });
+
+  it("shows fallback inline error when save fails without message", async () => {
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: true,
+      json: async () => [],
+    } as Response);
+
+    render(<TimezoneSettings />);
+
+    await waitFor(() => {
+      expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+    });
+
+    vi.mocked(global.fetch).mockResolvedValueOnce({
+      ok: false,
+      json: async () => ({}),
+    } as Response);
+
+    await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+    await waitFor(() => {
+      expect(screen.getByText("Failed to save timezone")).toBeInTheDocument();
+    });
+  });
+});

--- a/packages/web/src/__tests__/components/timezone-settings.test.tsx
+++ b/packages/web/src/__tests__/components/timezone-settings.test.tsx
@@ -184,6 +184,88 @@ describe("TimezoneSettings", () => {
     expect(toast.success).not.toHaveBeenCalled();
   });
 
+  it("does not throw an unhandled rejection and falls back to UTC when the preload fetch fails", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+    try {
+      vi.mocked(global.fetch).mockRejectedValueOnce(new Error("network down"));
+
+      render(<TimezoneSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+      });
+
+      // Let any pending microtasks / unhandled rejections surface.
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      // The failed preload must leave the component on the sane UTC default,
+      // provable through the payload it POSTs on Save.
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenLastCalledWith(
+          "/api/settings",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ key: "org.timezone", value: "UTC" }),
+          })
+        );
+      });
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+
+    expect(rejections).toEqual([]);
+  });
+
+  it("does not throw and falls back to UTC when /api/settings returns an unexpected (non-array) shape", async () => {
+    const rejections: unknown[] = [];
+    const onRejection = (reason: unknown) => rejections.push(reason);
+    process.on("unhandledRejection", onRejection);
+    try {
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as Response);
+
+      render(<TimezoneSettings />);
+
+      await waitFor(() => {
+        expect(screen.getByRole("button", { name: "Save" })).toBeInTheDocument();
+      });
+
+      await new Promise((resolve) => setTimeout(resolve, 0));
+
+      vi.mocked(global.fetch).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ ok: true }),
+      } as Response);
+
+      await userEvent.click(screen.getByRole("button", { name: "Save" }));
+
+      await waitFor(() => {
+        expect(global.fetch).toHaveBeenLastCalledWith(
+          "/api/settings",
+          expect.objectContaining({
+            method: "POST",
+            body: JSON.stringify({ key: "org.timezone", value: "UTC" }),
+          })
+        );
+      });
+    } finally {
+      process.off("unhandledRejection", onRejection);
+    }
+
+    expect(rejections).toEqual([]);
+  });
+
   it("shows fallback inline error when save fails without message", async () => {
     vi.mocked(global.fetch).mockResolvedValueOnce({
       ok: true,

--- a/packages/web/src/__tests__/components/timezone-settings.test.tsx
+++ b/packages/web/src/__tests__/components/timezone-settings.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
-import { TimezoneSettings } from "@/components/timezone-settings";
+import { TimezoneSettings, getSupportedTimezones } from "@/components/timezone-settings";
 import { toast } from "sonner";
 
 vi.mock("sonner", () => ({
@@ -264,6 +264,18 @@ describe("TimezoneSettings", () => {
     }
 
     expect(rejections).toEqual([]);
+  });
+
+  it("getSupportedTimezones falls back to ['UTC'] when the runtime lacks Intl.supportedValuesOf", () => {
+    const original = Intl.supportedValuesOf;
+    try {
+      // Simulate an older runtime (pre-ES2022) where the API is absent, so the
+      // "use client" module can't throw at import time.
+      (Intl as { supportedValuesOf?: unknown }).supportedValuesOf = undefined;
+      expect(getSupportedTimezones()).toEqual(["UTC"]);
+    } finally {
+      Intl.supportedValuesOf = original;
+    }
   });
 
   it("shows fallback inline error when save fails without message", async () => {

--- a/packages/web/src/__tests__/settings-timezone.test.ts
+++ b/packages/web/src/__tests__/settings-timezone.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect, beforeEach, vi } from "vitest";
+import { getOrgTimezone, setOrgTimezone } from "@/lib/settings-timezone";
+import * as settings from "@/lib/settings";
+
+vi.mock("@/lib/settings");
+
+describe("org timezone", () => {
+  beforeEach(() => vi.resetAllMocks());
+
+  it("returns stored timezone when set", async () => {
+    vi.mocked(settings.getSetting).mockResolvedValue("Europe/Vienna");
+    expect(await getOrgTimezone()).toBe("Europe/Vienna");
+    expect(settings.getSetting).toHaveBeenCalledWith("org.timezone");
+  });
+
+  it("returns 'UTC' as default when nothing set", async () => {
+    vi.mocked(settings.getSetting).mockResolvedValue(null);
+    expect(await getOrgTimezone()).toBe("UTC");
+  });
+
+  it("rejects invalid IANA timezones", async () => {
+    await expect(setOrgTimezone("NotATimezone")).rejects.toThrow(/invalid/i);
+  });
+
+  it("persists valid IANA timezone", async () => {
+    await setOrgTimezone("Europe/Vienna");
+    expect(settings.setSetting).toHaveBeenCalledWith("org.timezone", "Europe/Vienna");
+  });
+});

--- a/packages/web/src/__tests__/setup-finalize.test.ts
+++ b/packages/web/src/__tests__/setup-finalize.test.ts
@@ -1,0 +1,89 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const { findFirstMock } = vi.hoisted(() => ({
+  findFirstMock: vi.fn(),
+}));
+
+vi.mock("@/lib/settings-timezone");
+
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      users: { findFirst: findFirstMock },
+      agents: { findFirst: vi.fn().mockResolvedValue(undefined) },
+    },
+    insert: vi.fn().mockImplementation(() => ({
+      values: vi.fn().mockReturnValue({
+        returning: vi
+          .fn()
+          .mockResolvedValue([
+            { id: "agent-1", name: "Smithers", model: "test/model", createdAt: new Date() },
+          ]),
+      }),
+    })),
+    update: vi.fn().mockReturnValue({
+      set: vi.fn().mockReturnValue({
+        where: vi.fn().mockResolvedValue(undefined),
+      }),
+    }),
+  },
+}));
+
+vi.mock("@/lib/auth", () => ({
+  auth: {
+    api: {
+      signUpEmail: vi.fn().mockResolvedValue({
+        user: { id: "user-1", email: "a@x.com" },
+      }),
+    },
+  },
+}));
+
+vi.mock("@/lib/workspace", () => ({
+  ensureWorkspace: vi.fn(),
+  writeWorkspaceFile: vi.fn(),
+  writeWorkspaceFileInternal: vi.fn(),
+  writeIdentityFile: vi.fn(),
+}));
+
+vi.mock("@/lib/context-sync", () => ({
+  getContextForAgent: vi.fn().mockResolvedValue(""),
+}));
+
+vi.mock("@/lib/smithers-soul", () => ({
+  SMITHERS_SOUL_MD: "# Smithers",
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/providers", () => ({
+  PROVIDERS: {},
+}));
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn().mockResolvedValue("ollama-local/test-model"),
+}));
+
+import { createAdmin } from "@/lib/setup";
+import * as tz from "@/lib/settings-timezone";
+
+describe("createAdmin — timezone", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findFirstMock.mockResolvedValue(undefined);
+    vi.mocked(tz.setOrgTimezone).mockResolvedValue(undefined);
+  });
+
+  it("persists browser timezone as org timezone", async () => {
+    await createAdmin("A", "a@x.com", "password123", "Europe/Vienna");
+    expect(tz.setOrgTimezone).toHaveBeenCalledWith("Europe/Vienna");
+  });
+
+  it("falls back to UTC when browser timezone is missing", async () => {
+    await createAdmin("A", "a@x.com", "password123", undefined);
+    expect(tz.setOrgTimezone).toHaveBeenCalledWith("UTC");
+  });
+});

--- a/packages/web/src/__tests__/setup-finalize.test.ts
+++ b/packages/web/src/__tests__/setup-finalize.test.ts
@@ -4,7 +4,15 @@ const { findFirstMock } = vi.hoisted(() => ({
   findFirstMock: vi.fn(),
 }));
 
-vi.mock("@/lib/settings-timezone");
+// Keep the real isValidIanaTimezone so the createAdmin validation is exercised
+// for real (not a mocked tautology); only setOrgTimezone is stubbed.
+vi.mock("@/lib/settings-timezone", async (importActual) => {
+  const actual = await importActual<typeof import("@/lib/settings-timezone")>();
+  return {
+    ...actual,
+    setOrgTimezone: vi.fn(),
+  };
+});
 
 vi.mock("@/db", () => ({
   db: {
@@ -85,5 +93,14 @@ describe("createAdmin — timezone", () => {
   it("falls back to UTC when browser timezone is missing", async () => {
     await createAdmin("A", "a@x.com", "password123", undefined);
     expect(tz.setOrgTimezone).toHaveBeenCalledWith("UTC");
+  });
+
+  it("falls back to UTC when browser timezone is not a valid IANA zone", async () => {
+    // A malformed/spoofed timezone must never block admin creation: it must
+    // still create the admin and store UTC instead of throwing.
+    const result = await createAdmin("A", "a@example.com", "password123", "Not/AZone");
+    expect(result).toEqual({ id: "user-1", email: "a@x.com" });
+    expect(tz.setOrgTimezone).toHaveBeenCalledWith("UTC");
+    expect(tz.setOrgTimezone).not.toHaveBeenCalledWith("Not/AZone");
   });
 });

--- a/packages/web/src/app/api/settings/route.ts
+++ b/packages/web/src/app/api/settings/route.ts
@@ -40,16 +40,23 @@ export async function POST(request: NextRequest) {
     }
     const previous = await getOrgTimezone();
     await setOrgTimezone(value);
-    after(() =>
-      appendAuditLog({
-        actorType: "user",
-        actorId: sessionOrError.user.id!,
-        eventType: "settings.updated",
-        resource: "settings",
-        detail: { changes: { timezone: { from: previous, to: value } } },
-        outcome: "success",
-      })
-    );
+    // The generic branch below intentionally logs a value-less `config.changed`
+    // because it also handles secret keys (api_key*), where a from/to diff would
+    // leak the secret into the audit detail. The timezone is not a secret, so it
+    // gets the richer `settings.updated` diff — but only when it actually changed,
+    // so a no-op save doesn't spam the audit log with from===to rows.
+    if (previous !== value) {
+      after(() =>
+        appendAuditLog({
+          actorType: "user",
+          actorId: sessionOrError.user.id!,
+          eventType: "settings.updated",
+          resource: "settings",
+          detail: { changes: { timezone: { from: previous, to: value } } },
+          outcome: "success",
+        })
+      );
+    }
     return NextResponse.json({ success: true });
   }
 

--- a/packages/web/src/app/api/settings/route.ts
+++ b/packages/web/src/app/api/settings/route.ts
@@ -2,7 +2,7 @@ import { NextRequest, NextResponse, after } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { getAllSettings, setSetting } from "@/lib/settings";
-import { getOrgTimezone, setOrgTimezone } from "@/lib/settings-timezone";
+import { getOrgTimezone, setOrgTimezone, isValidIanaTimezone } from "@/lib/settings-timezone";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -32,12 +32,14 @@ export async function POST(request: NextRequest) {
   const { key, value } = parsed.data;
 
   if (key === "org.timezone") {
-    const previous = await getOrgTimezone();
-    try {
-      await setOrgTimezone(value);
-    } catch (e) {
-      return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+    // Validate client input first (400). Persistence failures below are NOT
+    // caught here, so a genuine DB error surfaces as a 500 rather than being
+    // misreported to the client as bad input.
+    if (!isValidIanaTimezone(value)) {
+      return NextResponse.json({ error: `invalid IANA timezone: ${value}` }, { status: 400 });
     }
+    const previous = await getOrgTimezone();
+    await setOrgTimezone(value);
     after(() =>
       appendAuditLog({
         actorType: "user",
@@ -48,7 +50,7 @@ export async function POST(request: NextRequest) {
         outcome: "success",
       })
     );
-    return NextResponse.json({ ok: true });
+    return NextResponse.json({ success: true });
   }
 
   await setSetting(key, value, key.includes("api_key"));

--- a/packages/web/src/app/api/settings/route.ts
+++ b/packages/web/src/app/api/settings/route.ts
@@ -2,6 +2,7 @@ import { NextRequest, NextResponse, after } from "next/server";
 import { z } from "zod";
 import { requireAdmin } from "@/lib/api-auth";
 import { getAllSettings, setSetting } from "@/lib/settings";
+import { getOrgTimezone, setOrgTimezone } from "@/lib/settings-timezone";
 import { appendAuditLog } from "@/lib/audit";
 import { parseRequestBody } from "@/lib/api-validation";
 
@@ -29,6 +30,26 @@ export async function POST(request: NextRequest) {
   const parsed = await parseRequestBody(setSettingSchema, request);
   if ("error" in parsed) return parsed.error;
   const { key, value } = parsed.data;
+
+  if (key === "org.timezone") {
+    const previous = await getOrgTimezone();
+    try {
+      await setOrgTimezone(value);
+    } catch (e) {
+      return NextResponse.json({ error: (e as Error).message }, { status: 400 });
+    }
+    after(() =>
+      appendAuditLog({
+        actorType: "user",
+        actorId: sessionOrError.user.id!,
+        eventType: "settings.updated",
+        resource: "settings",
+        detail: { changes: { timezone: { from: previous, to: value } } },
+        outcome: "success",
+      })
+    );
+    return NextResponse.json({ ok: true });
+  }
 
   await setSetting(key, value, key.includes("api_key"));
 

--- a/packages/web/src/app/api/setup/route.ts
+++ b/packages/web/src/app/api/setup/route.ts
@@ -24,20 +24,21 @@ const setupSchema = z.object({
     .refine((v) => v.length > 0, "Name is required"),
   email: z.string().email("A valid email address is required"),
   password: z.string(),
+  browserTimezone: z.string().optional(),
 });
 
 export async function POST(request: NextRequest) {
   try {
     const parsed = await parseRequestBody(setupSchema, request);
     if ("error" in parsed) return parsed.error;
-    const { name, email, password } = parsed.data;
+    const { name, email, password, browserTimezone } = parsed.data;
 
     const passwordError = validatePassword(password);
     if (passwordError) {
       return NextResponse.json({ error: passwordError }, { status: 400 });
     }
 
-    const user = await createAdmin(name, email, password);
+    const user = await createAdmin(name, email, password, browserTimezone);
     // Write OpenClaw config with the newly created Smithers agent so OpenClaw
     // knows about it when the container restarts or the file watcher picks it up.
     // If this fails, surface the error: the admin record was created, but the

--- a/packages/web/src/components/settings-page-content.tsx
+++ b/packages/web/src/components/settings-page-content.tsx
@@ -15,6 +15,7 @@ import { SettingsIntegrations } from "@/components/settings-integrations";
 import { SettingsLicense } from "@/components/settings-license";
 import { TelegramLinkSettings } from "@/components/telegram-link-settings";
 import { SettingsSecurity } from "@/components/settings-security";
+import { TimezoneSettings } from "@/components/timezone-settings";
 import { SecretsProvenanceCard } from "@/components/secrets-provenance-card";
 import { SettingsSupport } from "@/components/settings-support";
 import { useIntegrationHealth } from "@/hooks/use-integration-health";
@@ -173,6 +174,7 @@ export function SettingsPageContent({
                 <TabsTrigger value="integrations">
                   Integrations {needsAttentionCount > 0 && <ErrorDot />}
                 </TabsTrigger>
+                <TabsTrigger value="organization">Organization</TabsTrigger>
                 <div
                   role="presentation"
                   className="px-2 pt-3 pb-1 text-xs font-semibold uppercase tracking-wide text-muted-foreground"
@@ -259,6 +261,12 @@ export function SettingsPageContent({
           {isAdmin && (
             <TabsContent value="integrations" keepMounted>
               <SettingsIntegrations oauthError={oauthError} />
+            </TabsContent>
+          )}
+
+          {isAdmin && (
+            <TabsContent value="organization" keepMounted>
+              <TimezoneSettings />
             </TabsContent>
           )}
 

--- a/packages/web/src/components/setup-form.tsx
+++ b/packages/web/src/components/setup-form.tsx
@@ -127,6 +127,7 @@ export function SetupForm() {
           name: values.name,
           email: values.email,
           password: values.password,
+          browserTimezone: Intl.DateTimeFormat().resolvedOptions().timeZone,
         }),
       });
 

--- a/packages/web/src/components/timezone-settings.tsx
+++ b/packages/web/src/components/timezone-settings.tsx
@@ -1,0 +1,100 @@
+"use client";
+
+import { useState, useEffect } from "react";
+import { toast } from "sonner";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Button } from "@/components/ui/button";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+
+const TIMEZONES: string[] = Intl.supportedValuesOf("timeZone");
+
+export function TimezoneSettings() {
+  const [timezone, setTimezone] = useState("UTC");
+  const [loading, setLoading] = useState(true);
+  const [saving, setSaving] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    async function load() {
+      try {
+        const res = await fetch("/api/settings");
+        if (res.ok) {
+          const settings: { key: string; value: string }[] = await res.json();
+          const tz = settings.find((s) => s.key === "org.timezone");
+          if (tz) {
+            setTimezone(tz.value);
+          }
+        }
+      } finally {
+        setLoading(false);
+      }
+    }
+    load();
+  }, []);
+
+  async function handleSave() {
+    setSaving(true);
+    setError(null);
+    try {
+      const res = await fetch("/api/settings", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ key: "org.timezone", value: timezone }),
+      });
+      if (!res.ok) {
+        const data = await res.json();
+        setError(data.error || "Failed to save timezone");
+        return;
+      }
+      toast.success("Settings saved");
+    } catch {
+      setError("Failed to save timezone");
+    } finally {
+      setSaving(false);
+    }
+  }
+
+  if (loading) return null;
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Organization Timezone</CardTitle>
+      </CardHeader>
+      <CardContent className="space-y-4">
+        <p className="text-sm text-muted-foreground">
+          Set the timezone used for scheduled jobs and briefing delivery times.
+        </p>
+
+        <div className="space-y-2">
+          <Label htmlFor="timezone-select">Timezone</Label>
+          <Select value={timezone} onValueChange={setTimezone}>
+            <SelectTrigger id="timezone-select" className="w-full max-w-sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {TIMEZONES.map((tz) => (
+                <SelectItem key={tz} value={tz}>
+                  {tz}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+
+        <Button onClick={handleSave} disabled={saving}>
+          {saving ? "Saving..." : "Save"}
+        </Button>
+
+        {error && <p className="text-sm text-destructive">{error}</p>}
+      </CardContent>
+    </Card>
+  );
+}

--- a/packages/web/src/components/timezone-settings.tsx
+++ b/packages/web/src/components/timezone-settings.tsx
@@ -23,15 +23,27 @@ export function TimezoneSettings() {
 
   useEffect(() => {
     async function load() {
+      // Best-effort preload: any fetch failure or unexpected response shape
+      // falls back to the UTC default already in state, never throwing.
       try {
         const res = await fetch("/api/settings");
         if (res.ok) {
-          const settings: { key: string; value: string }[] = await res.json();
-          const tz = settings.find((s) => s.key === "org.timezone");
-          if (tz) {
-            setTimezone(tz.value);
+          const settings: unknown = await res.json();
+          if (Array.isArray(settings)) {
+            const tz = settings.find(
+              (s): s is { key: string; value: string } =>
+                typeof s === "object" &&
+                s !== null &&
+                (s as { key?: unknown }).key === "org.timezone" &&
+                typeof (s as { value?: unknown }).value === "string"
+            );
+            if (tz) {
+              setTimezone(tz.value);
+            }
           }
         }
+      } catch {
+        // Preload is non-critical; keep the UTC default.
       } finally {
         setLoading(false);
       }

--- a/packages/web/src/components/timezone-settings.tsx
+++ b/packages/web/src/components/timezone-settings.tsx
@@ -13,7 +13,18 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 
-const TIMEZONES: string[] = Intl.supportedValuesOf("timeZone");
+// `Intl.supportedValuesOf` is ES2022; on an older runtime that lacks it, reading
+// it at module load would throw and break the whole settings bundle. Fall back to
+// a minimal list so the component still renders (validation still happens server-side).
+export function getSupportedTimezones(): string[] {
+  try {
+    return Intl.supportedValuesOf("timeZone");
+  } catch {
+    return ["UTC"];
+  }
+}
+
+const TIMEZONES: string[] = getSupportedTimezones();
 
 export function TimezoneSettings() {
   const [timezone, setTimezone] = useState("UTC");

--- a/packages/web/src/hooks/use-tab-param.ts
+++ b/packages/web/src/hooks/use-tab-param.ts
@@ -12,6 +12,7 @@ export const SETTINGS_TABS = [
   "users",
   "groups",
   "integrations",
+  "organization",
   "license",
   "security",
 ] as const;

--- a/packages/web/src/lib/settings-timezone.ts
+++ b/packages/web/src/lib/settings-timezone.ts
@@ -1,0 +1,24 @@
+import { getSetting, setSetting } from "@/lib/settings";
+
+const TIMEZONE_KEY = "org.timezone";
+
+export async function getOrgTimezone(): Promise<string> {
+  const value = await getSetting(TIMEZONE_KEY);
+  return value ?? "UTC";
+}
+
+export async function setOrgTimezone(timezone: string): Promise<void> {
+  if (!isValidIanaTimezone(timezone)) {
+    throw new Error(`invalid IANA timezone: ${timezone}`);
+  }
+  await setSetting(TIMEZONE_KEY, timezone);
+}
+
+function isValidIanaTimezone(tz: string): boolean {
+  try {
+    new Intl.DateTimeFormat("en-US", { timeZone: tz });
+    return true;
+  } catch {
+    return false;
+  }
+}

--- a/packages/web/src/lib/settings-timezone.ts
+++ b/packages/web/src/lib/settings-timezone.ts
@@ -14,7 +14,7 @@ export async function setOrgTimezone(timezone: string): Promise<void> {
   await setSetting(TIMEZONE_KEY, timezone);
 }
 
-function isValidIanaTimezone(tz: string): boolean {
+export function isValidIanaTimezone(tz: string): boolean {
   try {
     new Intl.DateTimeFormat("en-US", { timeZone: tz });
     return true;

--- a/packages/web/src/lib/setup.ts
+++ b/packages/web/src/lib/setup.ts
@@ -4,6 +4,7 @@ import { eq } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { seedDefaultAgent } from "@/db/seed";
 import { getSetting } from "@/lib/settings";
+import { setOrgTimezone } from "@/lib/settings-timezone";
 
 export async function isProviderConfigured(): Promise<boolean> {
   const provider = await getSetting("default_provider");
@@ -17,7 +18,12 @@ export async function isSetupComplete(): Promise<boolean> {
   return adminUser !== undefined;
 }
 
-export async function createAdmin(name: string, email: string, password: string) {
+export async function createAdmin(
+  name: string,
+  email: string,
+  password: string,
+  browserTimezone?: string
+) {
   const existing = await db.query.users.findFirst({
     where: eq(users.role, "admin"),
   });
@@ -39,6 +45,8 @@ export async function createAdmin(name: string, email: string, password: string)
     await db.update(users).set({ role: "admin" }).where(eq(users.id, result.user.id));
 
     await seedDefaultAgent(result.user.id);
+
+    await setOrgTimezone(browserTimezone ?? "UTC");
   } catch (error) {
     // Clean up the orphaned user if post-signup steps fail
     try {

--- a/packages/web/src/lib/setup.ts
+++ b/packages/web/src/lib/setup.ts
@@ -4,7 +4,7 @@ import { eq } from "drizzle-orm";
 import { auth } from "@/lib/auth";
 import { seedDefaultAgent } from "@/db/seed";
 import { getSetting } from "@/lib/settings";
-import { setOrgTimezone } from "@/lib/settings-timezone";
+import { setOrgTimezone, isValidIanaTimezone } from "@/lib/settings-timezone";
 
 export async function isProviderConfigured(): Promise<boolean> {
   const provider = await getSetting("default_provider");
@@ -46,7 +46,11 @@ export async function createAdmin(
 
     await seedDefaultAgent(result.user.id);
 
-    await setOrgTimezone(browserTimezone ?? "UTC");
+    // A malformed or spoofed browserTimezone must never block account
+    // creation: validate before storing and fall back to UTC on invalid input
+    // so setOrgTimezone is only ever called with a valid zone here.
+    const tz = browserTimezone && isValidIanaTimezone(browserTimezone) ? browserTimezone : "UTC";
+    await setOrgTimezone(tz);
   } catch (error) {
     // Clean up the orphaned user if post-signup steps fail
     try {


### PR DESCRIPTION
First standalone slice of the **Background Jobs foundation (#704)**, harvested from the closed #151. Runs on the current OpenClaw pin — **no dependency on 2026.7.1**.

## What

An org-wide IANA timezone setting:

- **Setup capture** — the setup wizard sends the admin's browser timezone (`Intl.DateTimeFormat().resolvedOptions().timeZone`); finalization stores it as `org.timezone`, falling back to `UTC` when absent or invalid (a malformed/spoofed value can never block admin creation).
- **Settings API** — `POST /api/settings` validates `org.timezone` against `Intl.DateTimeFormat`. Invalid input → structured `400` (client, rendered inline); a genuine persistence failure → `500` (server), deliberately not masked as a `400`. Every change is audited: `settings.updated`, `outcome: "success"`, `detail.changes.timezone.{from,to}` (no PII).
- **UI** — an admin-only **Organization** tab in Settings with an IANA timezone selector (`Intl.supportedValuesOf`); inline error on save failure, success toast (no mixing). The preload tolerates fetch errors / unexpected shapes and falls back to UTC without throwing.
- **Docs** — a Reference page for the setting.

Nothing consumes `org.timezone` yet — it is the foundation the scheduled features (#704 cron layer, #138 briefings, the inbox agent #139) will read when they ship.

## Harvest provenance

Ported the org-timezone commits from `origin/background-jobs` (the closed #151), reconciled against ~3 months of `main` divergence (the settings page was reorganized; the settings/setup routes now use `parseRequestBody` + zod, which was kept rather than reverting to raw `request.json()`). Two small robustness fixes were added on top during review: the `400`/`500` split, and the UTC fallback for invalid setup/preload timezones.

## Gate status (local)

- **Web unit/RTL/API suite:** green (7748 passing) — except a **pre-existing, environmental** failure in the IMAP/email suites caused by a stale worktree `node_modules` missing `nodemailer` (declared in `package.json`, not installed here). Unrelated to this change; no touched file imports it. Not fixed here to avoid a host `pnpm install` that could clobber live dev-container plugin volumes.
- **`test:db` (real Postgres):** green (172 tests).
- **Lint / format:** clean.
- **Branch-scoped `tsc --noEmit`:** no branch-owned type errors (only the pre-existing nodemailer/IMAP noise).
- **Full `pnpm build`:** blocked locally by the same environmental stale-install; **CI's fresh install + build is authoritative** for the full typecheck.

Reviewed task-by-task (spec + code quality) and holistically over the full diff during subagent-driven execution.
