### PR TITLE
feat: Share to Pinchy (Web Share Target) — share photos, PDFs, links & contacts into an agent chat

### DIFF
--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -160,6 +160,7 @@ export default defineConfig({
             { label: 'Connect Odoo', slug: 'guides/connect-odoo' },
             { label: 'Upload Files in Chat', slug: 'guides/file-uploads' },
             { label: 'Install as an App', slug: 'guides/install-as-app' },
+            { label: 'Share to Pinchy from Your Phone', slug: 'guides/share-to-pinchy' },
             { label: 'Set Up Web Search', slug: 'guides/web-search-setup' },
             { label: 'Message Delivery & Retry', slug: 'guides/retry-messages' },
             { label: 'Slash Commands in Chat', slug: 'guides/slash-commands' },

--- a/docs/src/content/docs/guides/install-as-app.mdx
+++ b/docs/src/content/docs/guides/install-as-app.mdx
@@ -46,3 +46,9 @@ the app full-screen, with a branded splash on launch.
 Offline mode and push notifications are not part of this release. The installed
 app still needs an active connection to your Pinchy server, just like the
 browser version.
+
+## What's next
+
+Once Pinchy is installed on Android, you can send photos, PDFs, and links to
+an agent straight from your phone's Share sheet. See
+[Share to Pinchy from Your Phone](/guides/share-to-pinchy/).

--- a/docs/src/content/docs/guides/share-to-pinchy.mdx
+++ b/docs/src/content/docs/guides/share-to-pinchy.mdx
@@ -1,0 +1,36 @@
+---
+title: Share to Pinchy from Your Phone
+description: Send photos, PDFs, contacts, and links from any app straight into a Pinchy agent's chat using your phone's Share sheet.
+---
+
+Once Pinchy is installed on your phone, it shows up in the system **Share** sheet — the same menu you use to send a photo to a friend or a link to a chat app. Pick Pinchy, pick an agent, and the content lands in that agent's chat, ready for you to add a note and send.
+
+:::caution[Android only, for now]
+Share to Pinchy works on **Android** in Chrome, Edge, and other Chromium-based browsers. It does not work on iPhone or iPad — iOS does not let installed web apps register as share targets, which is a platform limitation of iOS itself, not something Pinchy can configure around. A native iOS app is the planned path to close this gap.
+:::
+
+## Requirements
+
+- **Android**, with Chrome, Edge, or another Chromium-based browser.
+- Pinchy must be **installed** as an app first — Share Target only shows up for installed PWAs, not for a browser tab. See [Install as an App](/guides/install-as-app/) if you haven't done that yet.
+
+## What you can share
+
+| Content                                              | What happens                                  |
+| ---------------------------------------------------- | --------------------------------------------- |
+| Images (JPEG, PNG, WebP, GIF, HEIC)                  | Attached to the chat, same as a manual upload |
+| PDFs                                                 | Attached to the chat                          |
+| Text files (`.txt`, `.csv`, `.md`, `.json`, `.yaml`) | Attached to the chat                          |
+| Contact cards (vCard)                                | Attached to the chat                          |
+| Shared text or links                                 | Pre-filled into the message composer          |
+
+The same **15 MB per-file** limit as regular chat attachments applies — see [Upload Files in Chat](/guides/file-uploads/) for the full picture of how Pinchy handles each file type once it's in a conversation.
+
+## How to share
+
+1. In any app — your phone's photo gallery, a browser, a contacts app — tap **Share**.
+2. Choose **Pinchy** from the share sheet.
+3. Pinchy opens and asks **"Which agent?"** Tap the agent you want to send this to.
+4. The shared content lands in that agent's chat composer. Add a note if you want, then send it yourself — Pinchy never sends it automatically. This gives you a chance to add context before the agent sees it.
+
+That's it — the agent processes the attachment exactly as if you'd uploaded it directly in chat.

--- a/packages/web/public/manifest.webmanifest
+++ b/packages/web/public/manifest.webmanifest
@@ -17,5 +17,36 @@
       "type": "image/png",
       "purpose": "maskable"
     }
-  ]
+  ],
+  "share_target": {
+    "action": "/share-target",
+    "method": "POST",
+    "enctype": "multipart/form-data",
+    "params": {
+      "title": "title",
+      "text": "text",
+      "url": "url",
+      "files": [
+        {
+          "name": "files",
+          "accept": [
+            "application/pdf",
+            "image/jpeg",
+            "image/png",
+            "image/webp",
+            "image/gif",
+            "image/heic",
+            "image/heif",
+            "text/vcard",
+            "text/plain",
+            "text/csv",
+            "text/markdown",
+            "application/json",
+            "text/yaml",
+            "text/x-vcard"
+          ]
+        }
+      ]
+    }
+  }
 }

--- a/packages/web/public/sw-share-target.js
+++ b/packages/web/public/sw-share-target.js
@@ -66,16 +66,4 @@ async function handleShareTarget(request) {
   });
 }
 
-async function clearShare(id) {
-  const cache = await caches.open("share-target");
-  const keys = await cache.keys();
-  const prefix = `/__share/${id}/`;
-  await Promise.all(
-    keys
-      .filter((key) => new URL(key.url).pathname.startsWith(prefix))
-      .map((key) => cache.delete(key))
-  );
-}
-
 globalThis.handleShareTarget = handleShareTarget;
-globalThis.clearShare = clearShare;

--- a/packages/web/public/sw-share-target.js
+++ b/packages/web/public/sw-share-target.js
@@ -11,7 +11,9 @@
 // updating both):
 //   Cache name: "share-target"
 //   meta -> /__share/<id>/meta
-//     JSON body: { files: [{ index, name, type }], title, text, url }
+//     JSON body: { files: [{ index, name, type }], title, text, url, createdAt }
+//     createdAt (epoch ms) lets sweepStaleShares() reclaim entries the user
+//     previewed but never sent — Cache Storage has no TTL of its own.
 //   file -> /__share/<id>/file/<index>
 //     Body: the raw file blob.
 //     Headers: Content-Type: <mime>, X-Filename: <encodeURIComponent(name)>
@@ -28,6 +30,7 @@ async function handleShareTarget(request) {
     title: String(form.get("title") || ""),
     text: String(form.get("text") || ""),
     url: String(form.get("url") || ""),
+    createdAt: Date.now(),
   };
 
   for (let index = 0; index < files.length; index++) {

--- a/packages/web/public/sw-share-target.js
+++ b/packages/web/public/sw-share-target.js
@@ -1,0 +1,81 @@
+/* global caches, crypto */
+// Handles the Web Share Target API POST that the installed PWA receives at
+// /share-target (manifest `share_target` entry, method: POST, enctype:
+// multipart/form-data, files field name "files"). Lives outside the Service
+// Worker file itself (sw.js) so it can be `importScripts()`-ed by the SW
+// AND imported directly by vitest — plain JS, no imports/exports, no
+// top-level side effects beyond attaching functions to globalThis.
+//
+// Cache contract (see packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
+// and the /share page client that reads this back — do not change without
+// updating both):
+//   Cache name: "share-target"
+//   meta -> /__share/<id>/meta
+//     JSON body: { files: [{ index, name, type }], title, text, url }
+//   file -> /__share/<id>/file/<index>
+//     Body: the raw file blob.
+//     Headers: Content-Type: <mime>, X-Filename: <encodeURIComponent(name)>
+
+async function handleShareTarget(request) {
+  const form = await request.formData();
+  const id = crypto.randomUUID();
+  const cache = await caches.open("share-target");
+
+  const files = form.getAll("files").filter((value) => value && typeof value !== "string");
+
+  const meta = {
+    files: [],
+    title: String(form.get("title") || ""),
+    text: String(form.get("text") || ""),
+    url: String(form.get("url") || ""),
+  };
+
+  for (let index = 0; index < files.length; index++) {
+    // `index` is a bounded loop counter over `files.length`, never
+    // user-controlled input — safe array access.
+    // eslint-disable-next-line security/detect-object-injection
+    const file = files[index];
+    const name = file.name || `file-${index}`;
+    const type = file.type || "application/octet-stream";
+    meta.files.push({ index, name, type });
+    await cache.put(
+      `/__share/${id}/file/${index}`,
+      new Response(file, {
+        headers: {
+          "Content-Type": type,
+          "X-Filename": encodeURIComponent(name),
+        },
+      })
+    );
+  }
+
+  await cache.put(
+    `/__share/${id}/meta`,
+    new Response(JSON.stringify(meta), {
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+
+  // Manual 303 Response rather than Response.redirect(): POST-to-GET
+  // redirects after a share-target submission must be a real 303 so the
+  // browser re-requests /share as a GET, and constructing it directly here
+  // avoids relying on Response.redirect()'s cross-environment quirks.
+  return new Response(null, {
+    status: 303,
+    headers: { Location: `/share?share_id=${id}` },
+  });
+}
+
+async function clearShare(id) {
+  const cache = await caches.open("share-target");
+  const keys = await cache.keys();
+  const prefix = `/__share/${id}/`;
+  await Promise.all(
+    keys
+      .filter((key) => new URL(key.url).pathname.startsWith(prefix))
+      .map((key) => cache.delete(key))
+  );
+}
+
+globalThis.handleShareTarget = handleShareTarget;
+globalThis.clearShare = clearShare;

--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -9,19 +9,13 @@ self.addEventListener("install", () => {
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(
-    (async () => {
-      await self.clients.claim();
-      try {
-        const cache = await caches.open("share-target");
-        const keys = await cache.keys();
-        await Promise.all(keys.map((k) => cache.delete(k)));
-      } catch {
-        // Best-effort sweep of orphaned share-target cache entries; failures
-        // here must not block activation.
-      }
-    })()
-  );
+  // No cache sweep here: this handler runs immediately on every deploy
+  // (skipWaiting() + clients.claim() below hand over without waiting for
+  // open tabs to close), so a deploy landing while a user has an unconsumed
+  // share would wipe it before the chat page gets a chance to read it. The
+  // normal consume path already clears the entry via clearSharedPayload,
+  // and abandoned entries fall off via the browser's own cache eviction.
+  event.waitUntil(self.clients.claim());
 });
 
 // MUST NOT call event.respondWith() outside the guarded branch below; doing

--- a/packages/web/public/sw.js
+++ b/packages/web/public/sw.js
@@ -1,17 +1,36 @@
-// Pinchy PWA service worker (install stub).
-// Intentionally minimal: no caching, no fetch interception.
-// Exists so Chrome/Edge classify Pinchy as installable.
+// Pinchy PWA service worker.
+// Minimal: only intercepts the Web Share Target POST; everything else
+// passes through untouched.
+
+importScripts("/sw-share-target.js");
 
 self.addEventListener("install", () => {
   self.skipWaiting();
 });
 
 self.addEventListener("activate", (event) => {
-  event.waitUntil(self.clients.claim());
+  event.waitUntil(
+    (async () => {
+      await self.clients.claim();
+      try {
+        const cache = await caches.open("share-target");
+        const keys = await cache.keys();
+        await Promise.all(keys.map((k) => cache.delete(k)));
+      } catch {
+        // Best-effort sweep of orphaned share-target cache entries; failures
+        // here must not block activation.
+      }
+    })()
+  );
 });
 
-// MUST NOT call event.respondWith(); doing so would intercept all requests
-// and break the explicit "no caching" contract of this stub SW.
-self.addEventListener("fetch", () => {
-  // No-op. Required for installability check, but does not intercept.
+// MUST NOT call event.respondWith() outside the guarded branch below; doing
+// so would intercept all requests and break the "no caching" contract of
+// this SW for everything except the share target.
+self.addEventListener("fetch", (event) => {
+  const url = new URL(event.request.url);
+  if (event.request.method === "POST" && url.pathname === "/share-target") {
+    event.respondWith(handleShareTarget(event.request));
+  }
+  // all other requests: pass through (no respondWith)
 });

--- a/packages/web/src/__tests__/api/share-target-fallback.test.ts
+++ b/packages/web/src/__tests__/api/share-target-fallback.test.ts
@@ -1,0 +1,40 @@
+// @vitest-environment node
+//
+// jsdom's Request/FormData polyfill hangs on `request.formData()` for a
+// multipart body (see sibling share-target/SW tests for the same fix) — run
+// this route test under Node's native fetch implementation instead.
+import { describe, it, expect } from "vitest";
+import { POST } from "@/app/share-target/route";
+
+// Task 6 of "Share to Pinchy": if a device is still running the OLD no-op
+// service worker for a moment after a release (until the new one activates),
+// the browser's `POST /share-target` reaches the network instead of the SW.
+// Without this route that's a 404 and the shared file is silently lost. This
+// route can't recover the file server-side — it drains the body so the
+// connection closes cleanly and redirects the user to retry sharing.
+describe("POST /share-target (SW-miss fallback)", () => {
+  it("redirects to /share?error=retry with no body", async () => {
+    const request = new Request("https://app.example/share-target", { method: "POST" });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toContain("/share?error=retry");
+  });
+
+  it("redirects to /share?error=retry when draining a multipart body", async () => {
+    const formData = new FormData();
+    formData.set("title", "Shared title");
+    formData.set("file", new File(["file contents"], "shared.txt", { type: "text/plain" }));
+
+    const request = new Request("https://app.example/share-target", {
+      method: "POST",
+      body: formData,
+    });
+
+    const response = await POST(request);
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toContain("/share?error=retry");
+  });
+});

--- a/packages/web/src/__tests__/app/app-layout.test.ts
+++ b/packages/web/src/__tests__/app/app-layout.test.ts
@@ -1,0 +1,138 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import React from "react";
+
+class RedirectError extends Error {
+  constructor(public url: string) {
+    super(`NEXT_REDIRECT: ${url}`);
+  }
+}
+
+const {
+  mockRedirect,
+  mockHeaders,
+  mockCookies,
+  mockGetSession,
+  mockIsSetupComplete,
+  mockIsProviderConfigured,
+  mockGetVisibleAgents,
+} = vi.hoisted(() => ({
+  mockRedirect: vi.fn().mockImplementation((url: string) => {
+    throw new RedirectError(url);
+  }),
+  mockHeaders: vi.fn(),
+  mockCookies: vi.fn().mockResolvedValue(undefined),
+  mockGetSession: vi.fn(),
+  mockIsSetupComplete: vi.fn().mockResolvedValue(true),
+  mockIsProviderConfigured: vi.fn().mockResolvedValue(true),
+  mockGetVisibleAgents: vi.fn().mockResolvedValue([]),
+}));
+
+vi.mock("next/navigation", () => ({
+  redirect: mockRedirect,
+}));
+
+vi.mock("next/headers", () => ({
+  headers: mockHeaders,
+  cookies: mockCookies,
+}));
+
+vi.mock("@/lib/auth", () => ({
+  getSession: mockGetSession,
+}));
+
+vi.mock("@/lib/setup", () => ({
+  isSetupComplete: mockIsSetupComplete,
+  isProviderConfigured: mockIsProviderConfigured,
+}));
+
+vi.mock("@/lib/visible-agents", () => ({
+  getVisibleAgents: mockGetVisibleAgents,
+}));
+
+// The layout also renders a bunch of UI providers/components. None of them
+// matter for this auth-guard test, so stub them out to keep this focused
+// and avoid dragging in unrelated rendering concerns.
+vi.mock("@/components/sidebar", () => ({ AppSidebar: () => null }));
+vi.mock("@/components/app-shell", () => ({
+  AppShell: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/agents-provider", () => ({
+  AgentsProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/ui/sidebar", () => ({
+  SidebarProvider: ({ children }: { children: React.ReactNode }) => children,
+  SidebarInset: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/enterprise-banner", () => ({ EnterpriseBanner: () => null }));
+vi.mock("@/components/insecure-banner", () => ({ InsecureBanner: () => null }));
+vi.mock("@/components/dev-toolbar", () => ({ DevToolbar: () => null }));
+vi.mock("@/components/chat-session-provider", () => ({
+  ChatSessionProvider: ({ children }: { children: React.ReactNode }) => children,
+}));
+vi.mock("@/components/chat-session-mounts", () => ({ ChatSessionMounts: () => null }));
+
+import AppLayout from "@/app/(app)/layout";
+
+function headersWithPathname(pathname: string | null) {
+  const h = new Headers();
+  if (pathname) h.set("x-pathname", pathname);
+  return h;
+}
+
+describe("(app) layout auth guard", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockIsSetupComplete.mockResolvedValue(true);
+    mockIsProviderConfigured.mockResolvedValue(true);
+    mockGetVisibleAgents.mockResolvedValue([]);
+    mockCookies.mockResolvedValue(undefined);
+    mockRedirect.mockImplementation((url: string) => {
+      throw new RedirectError(url);
+    });
+  });
+
+  it("redirects to /login with the encoded returnTo destination when there is no session", async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockHeaders.mockResolvedValue(headersWithPathname("/share?share_id=abc"));
+
+    const children = React.createElement("div", null, "child");
+
+    await expect(AppLayout({ children })).rejects.toThrow(
+      "NEXT_REDIRECT: /login?returnTo=%2Fshare%3Fshare_id%3Dabc"
+    );
+  });
+
+  it("falls back to returnTo=/ when the captured pathname header is missing", async () => {
+    mockGetSession.mockResolvedValue(null);
+    mockHeaders.mockResolvedValue(headersWithPathname(null));
+
+    const children = React.createElement("div", null, "child");
+
+    await expect(AppLayout({ children })).rejects.toThrow("NEXT_REDIRECT: /login?returnTo=%2F");
+  });
+
+  it("redirects to /login even when a session has no user (defense in depth)", async () => {
+    mockGetSession.mockResolvedValue({ session: { expiresAt: "2026-03-01" } });
+    mockHeaders.mockResolvedValue(headersWithPathname("/agents"));
+
+    const children = React.createElement("div", null, "child");
+
+    await expect(AppLayout({ children })).rejects.toThrow(
+      "NEXT_REDIRECT: /login?returnTo=%2Fagents"
+    );
+  });
+
+  it("renders children without redirecting when a session is present", async () => {
+    mockGetSession.mockResolvedValue({
+      user: { id: "1", role: "member" },
+      session: { expiresAt: "2026-03-01" },
+    });
+    mockHeaders.mockResolvedValue(headersWithPathname("/agents"));
+
+    const children = React.createElement("div", { "data-testid": "child" }, "content");
+    const result = await AppLayout({ children });
+
+    expect(result).toBeTruthy();
+    expect(mockRedirect).not.toHaveBeenCalled();
+  });
+});

--- a/packages/web/src/__tests__/app/login-page.test.tsx
+++ b/packages/web/src/__tests__/app/login-page.test.tsx
@@ -15,9 +15,13 @@ vi.mock("@/lib/auth-client", () => ({
 }));
 
 const mockPush = vi.fn();
+const mockSearchParamsGet = vi.fn();
 vi.mock("next/navigation", () => ({
   useRouter: () => ({
     push: mockPush,
+  }),
+  useSearchParams: () => ({
+    get: mockSearchParamsGet,
   }),
 }));
 
@@ -34,6 +38,7 @@ vi.mock("next/image", () => ({
 describe("Login Page", () => {
   beforeEach(() => {
     vi.clearAllMocks();
+    mockSearchParamsGet.mockReturnValue(null);
   });
 
   it("should render the Pinchy logo", () => {
@@ -127,6 +132,42 @@ describe("Login Page", () => {
   it("should redirect to / on successful login", async () => {
     const user = userEvent.setup();
     mockSignInEmail.mockResolvedValue({ error: null });
+
+    render(<LoginPage />);
+
+    await user.type(screen.getByLabelText(/email/i), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "mypassword");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/");
+    });
+  });
+
+  it("should redirect to a safe returnTo destination on successful login", async () => {
+    const user = userEvent.setup();
+    mockSignInEmail.mockResolvedValue({ error: null });
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "returnTo" ? "/share?share_id=abc" : null
+    );
+
+    render(<LoginPage />);
+
+    await user.type(screen.getByLabelText(/email/i), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "mypassword");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+
+    await waitFor(() => {
+      expect(mockPush).toHaveBeenCalledWith("/share?share_id=abc");
+    });
+  });
+
+  it("should fall back to / when returnTo is an unsafe, open-redirect-shaped value", async () => {
+    const user = userEvent.setup();
+    mockSignInEmail.mockResolvedValue({ error: null });
+    mockSearchParamsGet.mockImplementation((key: string) =>
+      key === "returnTo" ? "//evil.com" : null
+    );
 
     render(<LoginPage />);
 

--- a/packages/web/src/__tests__/lib/pwa/manifest.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/manifest.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "vitest";
 import { readFileSync, existsSync } from "fs";
 import { resolve, join } from "path";
+import { ALLOWED_ATTACHMENT_MIMES, ALLOWED_TEXT_MIMES } from "@/lib/upload-validation";
 
 const PUBLIC_DIR = resolve(__dirname, "../../../../public");
 const MANIFEST_PATH = join(PUBLIC_DIR, "manifest.webmanifest");
@@ -29,5 +30,41 @@ describe("manifest.webmanifest", () => {
       const path = join(PUBLIC_DIR, icon.src.replace(/^\//, ""));
       expect(existsSync(path), `icon missing: ${icon.src}`).toBe(true);
     }
+  });
+
+  it("declares a share_target that POSTs shared files to /share-target", () => {
+    const shareTarget = manifest.share_target as {
+      action: string;
+      method: string;
+      enctype: string;
+      params: { files: Array<{ name: string; accept: string[] }> };
+    };
+    expect({
+      action: shareTarget.action,
+      method: shareTarget.method,
+      enctype: shareTarget.enctype,
+    }).toEqual({
+      action: "/share-target",
+      method: "POST",
+      enctype: "multipart/form-data",
+    });
+    expect(shareTarget.params.files[0].name).toBe("files");
+  });
+
+  it("shares exactly the union of the attachment upload allow-lists (shareable == attachable)", () => {
+    const shareTarget = manifest.share_target as {
+      params: { files: Array<{ accept: string[] }> };
+    };
+    const manifestAccept = shareTarget.params.files[0].accept;
+
+    // text/vcard is deliberately listed in BOTH ALLOWED_ATTACHMENT_MIMES and
+    // ALLOWED_TEXT_MIMES (see upload-validation.ts for why), so a naive
+    // concat would contain it twice. De-dup via Set on both sides so the
+    // duplicate can't spuriously fail (or silently pass) this comparison.
+    const expectedAccept = [
+      ...new Set([...ALLOWED_ATTACHMENT_MIMES, ...ALLOWED_TEXT_MIMES]),
+    ].sort();
+
+    expect([...new Set(manifestAccept)].sort()).toEqual(expectedAccept);
   });
 });

--- a/packages/web/src/__tests__/lib/pwa/service-worker.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/service-worker.test.ts
@@ -18,4 +18,35 @@ describe("service worker stub", () => {
   it("registers a fetch listener (required for Chrome installability check)", () => {
     expect(source).toMatch(/addEventListener\s*\(\s*['"]fetch['"]/);
   });
+
+  it("imports the share-target handler module", () => {
+    expect(source).toMatch(/importScripts\s*\(\s*["']\/sw-share-target\.js["']\s*\)/);
+  });
+
+  it("only intercepts POST /share-target, delegating to handleShareTarget, and lets everything else pass through", () => {
+    expect(source).toMatch(/\/share-target/);
+    expect(source).toMatch(/handleShareTarget/);
+
+    const fetchStart = source.search(/addEventListener\s*\(\s*["']fetch["']/);
+    expect(fetchStart).toBeGreaterThanOrEqual(0);
+    const fetchBody = source.slice(fetchStart);
+
+    // The only respondWith() call must live inside an if-block that guards
+    // on both the POST method and the /share-target path -- this is what
+    // would fail if someone made the handler intercept every request.
+    const guardMatch = fetchBody.match(
+      /if\s*\([^{]*method\s*===\s*["']POST["'][^{]*\/share-target[^{]*\)\s*\{([\s\S]*?)\}/
+    );
+    expect(guardMatch).not.toBeNull();
+    const guardedBlock = guardMatch![1];
+    expect(guardedBlock).toMatch(/respondWith\s*\(\s*handleShareTarget/);
+
+    const bodyOutsideGuard = fetchBody.replace(guardMatch![0], "");
+    expect(bodyOutsideGuard).not.toMatch(/respondWith\s*\(/);
+  });
+
+  it("keeps claiming clients and sweeps orphaned share-target cache entries on activate", () => {
+    expect(source).toMatch(/clients\.claim\s*\(/);
+    expect(source).toMatch(/caches\.open\s*\(\s*["']share-target["']\s*\)/);
+  });
 });

--- a/packages/web/src/__tests__/lib/pwa/service-worker.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/service-worker.test.ts
@@ -45,8 +45,8 @@ describe("service worker stub", () => {
     expect(bodyOutsideGuard).not.toMatch(/respondWith\s*\(/);
   });
 
-  it("keeps claiming clients and sweeps orphaned share-target cache entries on activate", () => {
+  it("claims clients on activate but does NOT sweep the share-target cache (a deploy landing mid-share must not wipe an unconsumed one — the consume path already clears it, and abandoned entries are evicted by the browser)", () => {
     expect(source).toMatch(/clients\.claim\s*\(/);
-    expect(source).toMatch(/caches\.open\s*\(\s*["']share-target["']\s*\)/);
+    expect(source).not.toMatch(/caches\.open\s*\(\s*["']share-target["']\s*\)/);
   });
 });

--- a/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
@@ -1,0 +1,166 @@
+// @vitest-environment node
+//
+// This module deals with real multipart FormData/Request/Response bodies.
+// jsdom's fetch polyfill does not implement Request.formData() reliably
+// (observed: it hangs indefinitely), so this file opts out of the default
+// jsdom environment in favor of Node's native fetch implementation.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+
+// sw-share-target.js is a plain-JS module with no imports/exports (it runs
+// inside Service Worker scope, which cannot import from src/). It only
+// defines functions and attaches them to globalThis, so importing it here
+// for that side effect is safe to do directly in a vitest (Node) context.
+import "../../../../public/sw-share-target.js";
+
+const handleShareTarget = (
+  globalThis as unknown as { handleShareTarget: (request: Request) => Promise<Response> }
+).handleShareTarget;
+const clearShare = (globalThis as unknown as { clearShare: (id: string) => Promise<void> })
+  .clearShare;
+
+/**
+ * Minimal in-memory stand-in for the Cache Storage API (`caches.open`).
+ * Keyed by request URL, mirroring how the real Cache API dedupes entries.
+ * `keys()` returns `Request` objects (as the spec requires) built from
+ * same-origin absolute URLs so `new URL(key.url).pathname` works exactly
+ * like it would against a real Cache.
+ */
+function createMockCache() {
+  const store = new Map<string, Response>();
+  return {
+    store,
+    async put(request: RequestInfo, response: Response) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      store.set(absolute, response);
+    },
+    async match(request: RequestInfo) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      return store.get(absolute);
+    },
+    async keys() {
+      return Array.from(store.keys()).map((url) => new Request(url));
+    },
+    async delete(request: RequestInfo) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      return store.delete(absolute);
+    },
+  };
+}
+
+const FIXED_ID = "11111111-1111-1111-1111-111111111111";
+
+describe("sw-share-target", () => {
+  let mockCache: ReturnType<typeof createMockCache>;
+
+  beforeEach(() => {
+    mockCache = createMockCache();
+    vi.stubGlobal("caches", {
+      open: vi.fn(async (name: string) => {
+        expect(name).toBe("share-target");
+        return mockCache;
+      }),
+    });
+    vi.stubGlobal("crypto", {
+      ...globalThis.crypto,
+      randomUUID: vi.fn(() => FIXED_ID),
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  function buildRequest(form: FormData) {
+    return new Request("https://pinchy.example/share-target", {
+      method: "POST",
+      body: form,
+    });
+  }
+
+  async function readMeta(id: string) {
+    const metaResponse = await mockCache.match(`/__share/${id}/meta`);
+    expect(metaResponse).toBeDefined();
+    return metaResponse!.json();
+  }
+
+  it("stashes a single shared file + text and redirects to /share?share_id=<id>", async () => {
+    const form = new FormData();
+    const file = new File(["fake-jpeg-bytes"], "invoice.jpg", { type: "image/jpeg" });
+    form.set("files", file);
+    form.set("text", "Look at this invoice");
+
+    const response = await handleShareTarget(buildRequest(form));
+
+    expect(response.status).toBe(303);
+    expect(response.headers.get("Location")).toBe(`/share?share_id=${FIXED_ID}`);
+
+    const fileResponse = await mockCache.match(`/__share/${FIXED_ID}/file/0`);
+    expect(fileResponse).toBeDefined();
+    expect(fileResponse!.headers.get("Content-Type")).toBe("image/jpeg");
+    expect(decodeURIComponent(fileResponse!.headers.get("X-Filename")!)).toBe("invoice.jpg");
+    const bytes = await fileResponse!.arrayBuffer();
+    expect(new TextDecoder().decode(bytes)).toBe("fake-jpeg-bytes");
+
+    const meta = await readMeta(FIXED_ID);
+    expect(meta).toEqual({
+      files: [{ index: 0, name: "invoice.jpg", type: "image/jpeg" }],
+      title: "",
+      text: "Look at this invoice",
+      url: "",
+    });
+  });
+
+  it("stashes multiple shared files at distinct indices", async () => {
+    const form = new FormData();
+    form.append("files", new File(["one"], "a.png", { type: "image/png" }));
+    form.append("files", new File(["two"], "b.pdf", { type: "application/pdf" }));
+    form.set("title", "Two files");
+    form.set("url", "https://example.com/source");
+
+    const response = await handleShareTarget(buildRequest(form));
+    expect(response.status).toBe(303);
+
+    const file0 = await mockCache.match(`/__share/${FIXED_ID}/file/0`);
+    const file1 = await mockCache.match(`/__share/${FIXED_ID}/file/1`);
+    expect(file0).toBeDefined();
+    expect(file1).toBeDefined();
+    expect(decodeURIComponent(file0!.headers.get("X-Filename")!)).toBe("a.png");
+    expect(decodeURIComponent(file1!.headers.get("X-Filename")!)).toBe("b.pdf");
+
+    const meta = await readMeta(FIXED_ID);
+    expect(meta).toEqual({
+      files: [
+        { index: 0, name: "a.png", type: "image/png" },
+        { index: 1, name: "b.pdf", type: "application/pdf" },
+      ],
+      title: "Two files",
+      text: "",
+      url: "https://example.com/source",
+    });
+  });
+
+  it("clearShare removes only the entries for the given share id", async () => {
+    const formA = new FormData();
+    formA.set("files", new File(["a"], "a.png", { type: "image/png" }));
+    await handleShareTarget(buildRequest(formA));
+    const idA = FIXED_ID;
+
+    const idB = "22222222-2222-2222-2222-222222222222";
+    (globalThis.crypto.randomUUID as ReturnType<typeof vi.fn>).mockReturnValueOnce(idB);
+    const formB = new FormData();
+    formB.set("files", new File(["b"], "b.png", { type: "image/png" }));
+    await handleShareTarget(buildRequest(formB));
+
+    expect(mockCache.store.size).toBe(4); // 2 files + 2 metas
+
+    await clearShare(idA);
+
+    expect(await mockCache.match(`/__share/${idA}/file/0`)).toBeUndefined();
+    expect(await mockCache.match(`/__share/${idA}/meta`)).toBeUndefined();
+    expect(await mockCache.match(`/__share/${idB}/file/0`)).toBeDefined();
+    expect(await mockCache.match(`/__share/${idB}/meta`)).toBeDefined();
+  });
+});

--- a/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
@@ -15,8 +15,6 @@ import "../../../../public/sw-share-target.js";
 const handleShareTarget = (
   globalThis as unknown as { handleShareTarget: (request: Request) => Promise<Response> }
 ).handleShareTarget;
-const clearShare = (globalThis as unknown as { clearShare: (id: string) => Promise<void> })
-  .clearShare;
 
 /**
  * Minimal in-memory stand-in for the Cache Storage API (`caches.open`).
@@ -140,27 +138,5 @@ describe("sw-share-target", () => {
       text: "",
       url: "https://example.com/source",
     });
-  });
-
-  it("clearShare removes only the entries for the given share id", async () => {
-    const formA = new FormData();
-    formA.set("files", new File(["a"], "a.png", { type: "image/png" }));
-    await handleShareTarget(buildRequest(formA));
-    const idA = FIXED_ID;
-
-    const idB = "22222222-2222-2222-2222-222222222222";
-    (globalThis.crypto.randomUUID as ReturnType<typeof vi.fn>).mockReturnValueOnce(idB);
-    const formB = new FormData();
-    formB.set("files", new File(["b"], "b.png", { type: "image/png" }));
-    await handleShareTarget(buildRequest(formB));
-
-    expect(mockCache.store.size).toBe(4); // 2 files + 2 metas
-
-    await clearShare(idA);
-
-    expect(await mockCache.match(`/__share/${idA}/file/0`)).toBeUndefined();
-    expect(await mockCache.match(`/__share/${idA}/meta`)).toBeUndefined();
-    expect(await mockCache.match(`/__share/${idB}/file/0`)).toBeDefined();
-    expect(await mockCache.match(`/__share/${idB}/meta`)).toBeDefined();
   });
 });

--- a/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
+++ b/packages/web/src/__tests__/lib/pwa/sw-share-target.test.ts
@@ -49,6 +49,7 @@ function createMockCache() {
 }
 
 const FIXED_ID = "11111111-1111-1111-1111-111111111111";
+const FIXED_TIME = 1_700_000_000_000;
 
 describe("sw-share-target", () => {
   let mockCache: ReturnType<typeof createMockCache>;
@@ -65,10 +66,12 @@ describe("sw-share-target", () => {
       ...globalThis.crypto,
       randomUUID: vi.fn(() => FIXED_ID),
     });
+    vi.spyOn(Date, "now").mockReturnValue(FIXED_TIME);
   });
 
   afterEach(() => {
     vi.unstubAllGlobals();
+    vi.restoreAllMocks();
   });
 
   function buildRequest(form: FormData) {
@@ -108,6 +111,7 @@ describe("sw-share-target", () => {
       title: "",
       text: "Look at this invoice",
       url: "",
+      createdAt: FIXED_TIME,
     });
   });
 
@@ -137,6 +141,7 @@ describe("sw-share-target", () => {
       title: "Two files",
       text: "",
       url: "https://example.com/source",
+      createdAt: FIXED_TIME,
     });
   });
 });

--- a/packages/web/src/__tests__/lib/return-to.test.ts
+++ b/packages/web/src/__tests__/lib/return-to.test.ts
@@ -4,6 +4,7 @@ import { isSafeReturnTo, buildLoginRedirectPath } from "@/lib/return-to";
 describe("isSafeReturnTo", () => {
   it.each([
     ["/share?share_id=abc", true],
+    ["/share?share_id=abc#frag", true],
     ["/agents", true],
     ["/chat/x?keep", true],
     ["//evil.com", false],
@@ -11,6 +12,17 @@ describe("isSafeReturnTo", () => {
     ["javascript:alert(1)", false],
     ["/\\evil.com", false],
     ["\\\\evil.com", false],
+    // Control chars (tab/CR/LF) are stripped by WHATWG URL parsing, which
+    // can merge a later "/" into the leading position and change the
+    // origin — e.g. new URL("/\t/evil.com", base).origin becomes
+    // https://evil.com. A parse-based guard must reject these.
+    ["/\t/evil.com", false],
+    ["/\n/evil.com", false],
+    ["/\r/evil.com", false],
+    ["/\t/evil", false],
+    // Encoded double-slash: stays same-origin but is suspicious path
+    // traversal shaping; the parse-based guard rejects it.
+    ["/%2F%2Fevil.com", false],
     ["", false],
     [null, false],
     [undefined, false],

--- a/packages/web/src/__tests__/lib/return-to.test.ts
+++ b/packages/web/src/__tests__/lib/return-to.test.ts
@@ -1,0 +1,38 @@
+import { describe, it, expect } from "vitest";
+import { isSafeReturnTo, buildLoginRedirectPath } from "@/lib/return-to";
+
+describe("isSafeReturnTo", () => {
+  it.each([
+    ["/share?share_id=abc", true],
+    ["/agents", true],
+    ["/chat/x?keep", true],
+    ["//evil.com", false],
+    ["https://evil.com", false],
+    ["javascript:alert(1)", false],
+    ["/\\evil.com", false],
+    ["\\\\evil.com", false],
+    ["", false],
+    [null, false],
+    [undefined, false],
+  ])("isSafeReturnTo(%j) -> %s", (value, expected) => {
+    expect(isSafeReturnTo(value)).toBe(expected);
+  });
+});
+
+describe("buildLoginRedirectPath", () => {
+  it("encodes a safe destination into the returnTo query param", () => {
+    expect(buildLoginRedirectPath("/share?share_id=abc")).toBe(
+      "/login?returnTo=%2Fshare%3Fshare_id%3Dabc"
+    );
+  });
+
+  it("falls back to / when the destination is missing", () => {
+    expect(buildLoginRedirectPath(null)).toBe("/login?returnTo=%2F");
+    expect(buildLoginRedirectPath(undefined)).toBe("/login?returnTo=%2F");
+  });
+
+  it("falls back to / when the destination is unsafe", () => {
+    expect(buildLoginRedirectPath("//evil.com")).toBe("/login?returnTo=%2F");
+    expect(buildLoginRedirectPath("https://evil.com")).toBe("/login?returnTo=%2F");
+  });
+});

--- a/packages/web/src/__tests__/lib/share-target/share-cache.test.ts
+++ b/packages/web/src/__tests__/lib/share-target/share-cache.test.ts
@@ -1,0 +1,270 @@
+// @vitest-environment node
+//
+// This module reads real Blob/File bodies out of Response objects retrieved
+// from the Cache API. jsdom's fetch polyfill is unreliable for this kind of
+// body handling (see src/__tests__/lib/pwa/sw-share-target.test.ts and
+// src/__tests__/lib/license.test.ts for the same precedent — jsdom hangs or
+// misbehaves on real Request/Response bodies), so this file opts out of the
+// default jsdom environment in favor of Node's native fetch implementation.
+import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
+import { readSharedPayload, clearSharedPayload } from "@/lib/share-target/share-cache";
+
+/**
+ * Minimal in-memory stand-in for the Cache Storage API (`caches.open`),
+ * mirroring the one used in sw-share-target.test.ts. Keyed by absolute URL,
+ * `keys()` returns `Request` objects (as the real Cache API does) built from
+ * same-origin absolute URLs so `new URL(key.url).pathname` works exactly
+ * like it would against a real Cache.
+ */
+function createMockCache() {
+  const store = new Map<string, Response>();
+  return {
+    store,
+    async put(request: RequestInfo, response: Response) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      store.set(absolute, response);
+    },
+    async match(request: RequestInfo) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      const response = store.get(absolute);
+      // Real Cache API responses can be read once; clone so repeated
+      // match() calls in a single test (or across readSharedPayload's own
+      // meta + per-file matches) each get a fresh, unconsumed body.
+      return response ? response.clone() : undefined;
+    },
+    async keys() {
+      return Array.from(store.keys()).map((url) => new Request(url));
+    },
+    async delete(request: RequestInfo) {
+      const url = typeof request === "string" ? request : request.url;
+      const absolute = new URL(url, "https://pinchy.example").toString();
+      return store.delete(absolute);
+    },
+  };
+}
+
+async function seedShare(
+  mockCache: ReturnType<typeof createMockCache>,
+  id: string,
+  options: {
+    title?: string;
+    text?: string;
+    url?: string;
+    fileName?: string;
+    fileType?: string;
+    fileBody?: string;
+  } = {}
+) {
+  const fileName = options.fileName ?? "photo.jpg";
+  const fileType = options.fileType ?? "image/jpeg";
+  const fileBody = options.fileBody ?? "fake-image-bytes";
+
+  await mockCache.put(
+    `/__share/${id}/file/0`,
+    new Response(fileBody, {
+      headers: {
+        "Content-Type": fileType,
+        "X-Filename": encodeURIComponent(fileName),
+      },
+    })
+  );
+
+  const meta = {
+    files: [{ index: 0, name: fileName, type: fileType }],
+    title: options.title ?? "Shared title",
+    text: options.text ?? "Shared text",
+    url: options.url ?? "https://example.com/shared",
+  };
+
+  await mockCache.put(
+    `/__share/${id}/meta`,
+    new Response(JSON.stringify(meta), {
+      headers: { "Content-Type": "application/json" },
+    })
+  );
+}
+
+describe("share-cache", () => {
+  let mockCache: ReturnType<typeof createMockCache>;
+
+  beforeEach(() => {
+    mockCache = createMockCache();
+    vi.stubGlobal("caches", {
+      open: async () => mockCache,
+    });
+  });
+
+  afterEach(() => {
+    vi.unstubAllGlobals();
+  });
+
+  describe("readSharedPayload", () => {
+    it("reads back the file, title, text, and url written by the service worker", async () => {
+      const id = "share-1";
+      await seedShare(mockCache, id, {
+        title: "My Title",
+        text: "My Text",
+        url: "https://example.com/page",
+        fileName: "vacation photo.jpg",
+        fileType: "image/jpeg",
+        fileBody: "binary-jpeg-content",
+      });
+
+      const payload = await readSharedPayload(id);
+
+      expect(payload).not.toBeNull();
+      expect(payload!.title).toBe("My Title");
+      expect(payload!.text).toBe("My Text");
+      expect(payload!.url).toBe("https://example.com/page");
+      expect(payload!.files).toHaveLength(1);
+      const file = payload!.files[0];
+      expect(file).toBeInstanceOf(File);
+      expect(file.name).toBe("vacation photo.jpg");
+      expect(file.type).toBe("image/jpeg");
+      expect(file.size).toBe(new TextEncoder().encode("binary-jpeg-content").length);
+      expect(await file.text()).toBe("binary-jpeg-content");
+    });
+
+    it("falls back to empty strings when meta omits title/text/url", async () => {
+      const id = "share-empty-meta";
+      await mockCache.put(
+        `/__share/${id}/meta`,
+        new Response(JSON.stringify({ files: [] }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      const payload = await readSharedPayload(id);
+
+      expect(payload).toEqual({ files: [], title: "", text: "", url: "" });
+    });
+
+    it("decodes the filename from the X-Filename header rather than the meta name when they differ", async () => {
+      const id = "share-header-name";
+      await mockCache.put(
+        `/__share/${id}/file/0`,
+        new Response("content", {
+          headers: {
+            "Content-Type": "text/plain",
+            "X-Filename": encodeURIComponent("hello world.txt"),
+          },
+        })
+      );
+      await mockCache.put(
+        `/__share/${id}/meta`,
+        new Response(
+          JSON.stringify({
+            files: [{ index: 0, name: "stale-name.txt", type: "text/plain" }],
+            title: "",
+            text: "",
+            url: "",
+          }),
+          { headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+      const payload = await readSharedPayload(id);
+
+      expect(payload!.files[0].name).toBe("hello world.txt");
+    });
+
+    it("falls back to the meta entry's name when the X-Filename header is absent", async () => {
+      const id = "share-no-header";
+      await mockCache.put(`/__share/${id}/file/0`, new Response("content"));
+      await mockCache.put(
+        `/__share/${id}/meta`,
+        new Response(
+          JSON.stringify({
+            files: [{ index: 0, name: "fallback-name.txt", type: "text/plain" }],
+            title: "",
+            text: "",
+            url: "",
+          }),
+          { headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+      const payload = await readSharedPayload(id);
+
+      expect(payload!.files[0].name).toBe("fallback-name.txt");
+    });
+
+    it("skips a file entry whose blob is missing from the cache", async () => {
+      const id = "share-missing-file";
+      // Meta references file index 0, but no file/0 entry was ever put.
+      await mockCache.put(
+        `/__share/${id}/meta`,
+        new Response(
+          JSON.stringify({
+            files: [{ index: 0, name: "ghost.txt", type: "text/plain" }],
+            title: "",
+            text: "",
+            url: "",
+          }),
+          { headers: { "Content-Type": "application/json" } }
+        )
+      );
+
+      const payload = await readSharedPayload(id);
+
+      expect(payload!.files).toHaveLength(0);
+    });
+
+    it("returns null when the meta entry is missing (unknown id)", async () => {
+      const payload = await readSharedPayload("unknown-id");
+      expect(payload).toBeNull();
+    });
+
+    it("returns null when the Cache API is unavailable (SSR/unsupported)", async () => {
+      vi.unstubAllGlobals();
+      const original = globalThis.caches;
+      // @ts-expect-error - simulating an environment without Cache API
+      delete globalThis.caches;
+
+      try {
+        const payload = await readSharedPayload("any-id");
+        expect(payload).toBeNull();
+      } finally {
+        globalThis.caches = original;
+      }
+    });
+  });
+
+  describe("clearSharedPayload", () => {
+    it("deletes exactly the entries for the given id and leaves other ids intact", async () => {
+      await seedShare(mockCache, "share-a");
+      await seedShare(mockCache, "share-b");
+
+      expect(mockCache.store.size).toBe(4);
+
+      await clearSharedPayload("share-a");
+
+      const remainingKeys = Array.from(mockCache.store.keys()).map((url) => new URL(url).pathname);
+      expect(remainingKeys).toHaveLength(2);
+      expect(remainingKeys.every((path) => path.startsWith("/__share/share-b/"))).toBe(true);
+
+      // share-a is really gone: reading it back returns null.
+      const payload = await readSharedPayload("share-a");
+      expect(payload).toBeNull();
+
+      // share-b is untouched: reading it back still works.
+      const otherPayload = await readSharedPayload("share-b");
+      expect(otherPayload).not.toBeNull();
+    });
+
+    it("does nothing when the Cache API is unavailable (SSR/unsupported)", async () => {
+      vi.unstubAllGlobals();
+      const original = globalThis.caches;
+      // @ts-expect-error - simulating an environment without Cache API
+      delete globalThis.caches;
+
+      try {
+        await expect(clearSharedPayload("any-id")).resolves.toBeUndefined();
+      } finally {
+        globalThis.caches = original;
+      }
+    });
+  });
+});

--- a/packages/web/src/__tests__/lib/share-target/share-cache.test.ts
+++ b/packages/web/src/__tests__/lib/share-target/share-cache.test.ts
@@ -7,7 +7,11 @@
 // misbehaves on real Request/Response bodies), so this file opts out of the
 // default jsdom environment in favor of Node's native fetch implementation.
 import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
-import { readSharedPayload, clearSharedPayload } from "@/lib/share-target/share-cache";
+import {
+  readSharedPayload,
+  clearSharedPayload,
+  sweepStaleShares,
+} from "@/lib/share-target/share-cache";
 
 /**
  * Minimal in-memory stand-in for the Cache Storage API (`caches.open`),
@@ -55,6 +59,7 @@ async function seedShare(
     fileName?: string;
     fileType?: string;
     fileBody?: string;
+    createdAt?: number;
   } = {}
 ) {
   const fileName = options.fileName ?? "photo.jpg";
@@ -71,12 +76,15 @@ async function seedShare(
     })
   );
 
-  const meta = {
+  const meta: Record<string, unknown> = {
     files: [{ index: 0, name: fileName, type: fileType }],
     title: options.title ?? "Shared title",
     text: options.text ?? "Shared text",
     url: options.url ?? "https://example.com/shared",
   };
+  if (options.createdAt !== undefined) {
+    meta.createdAt = options.createdAt;
+  }
 
   await mockCache.put(
     `/__share/${id}/meta`,
@@ -262,6 +270,59 @@ describe("share-cache", () => {
 
       try {
         await expect(clearSharedPayload("any-id")).resolves.toBeUndefined();
+      } finally {
+        globalThis.caches = original;
+      }
+    });
+  });
+
+  describe("sweepStaleShares", () => {
+    it("deletes shares older than maxAge and leaves fresh ones intact", async () => {
+      await seedShare(mockCache, "old", { createdAt: 1000 });
+      await seedShare(mockCache, "fresh", { createdAt: 9000 });
+      expect(mockCache.store.size).toBe(4);
+
+      // now=10000, maxAge=2000 → "old" (age 9000) is stale, "fresh" (age 1000) survives.
+      await sweepStaleShares(2000, 10000);
+
+      const paths = Array.from(mockCache.store.keys()).map((url) => new URL(url).pathname);
+      expect(paths).toHaveLength(2);
+      expect(paths.every((path) => path.startsWith("/__share/fresh/"))).toBe(true);
+
+      expect(await readSharedPayload("old")).toBeNull();
+      expect(await readSharedPayload("fresh")).not.toBeNull();
+    });
+
+    it("reclaims an entry whose meta predates the createdAt field", async () => {
+      await mockCache.put(
+        `/__share/legacy/meta`,
+        new Response(JSON.stringify({ files: [] }), {
+          headers: { "Content-Type": "application/json" },
+        })
+      );
+
+      await sweepStaleShares(2000, 10000);
+
+      expect(mockCache.store.size).toBe(0);
+    });
+
+    it("keeps an entry exactly at the age boundary (not strictly older)", async () => {
+      await seedShare(mockCache, "boundary", { createdAt: 8000 });
+
+      // age === maxAge is NOT "older than", so it stays.
+      await sweepStaleShares(2000, 10000);
+
+      expect(await readSharedPayload("boundary")).not.toBeNull();
+    });
+
+    it("does nothing when the Cache API is unavailable (SSR/unsupported)", async () => {
+      vi.unstubAllGlobals();
+      const original = globalThis.caches;
+      // @ts-expect-error - simulating an environment without Cache API
+      delete globalThis.caches;
+
+      try {
+        await expect(sweepStaleShares(2000, 10000)).resolves.toBeUndefined();
       } finally {
         globalThis.caches = original;
       }

--- a/packages/web/src/__tests__/lib/upload-validation.test.ts
+++ b/packages/web/src/__tests__/lib/upload-validation.test.ts
@@ -201,14 +201,8 @@ describe("text file support", () => {
   });
 });
 
-// Unlike the other text formats above, a vCard body DOES have "magic bytes":
-// file-type's content sniffer recognizes any `BEGIN:VCARD…END:VCARD` payload
-// and always reports it as the single canonical `{ mime: "text/vcard" }`,
-// regardless of the vCard VERSION or what the uploading client claimed. So
-// vCard lives in `ALLOWED_ATTACHMENT_MIMES` (the detected-mime allowlist),
-// not `ALLOWED_TEXT_MIMES` — the no-magic-bytes branch is unreachable for
-// real vCard content. The agent still reads the file natively via
-// `pinchy_read`, no parser needed.
+// See isKnownMimeAlias in upload-validation.ts for why vCard is content-
+// sniffed as text/vcard, lives in both allowlists, and aliases text/x-vcard.
 describe("vCard support", () => {
   const VCARD = Buffer.from(
     "BEGIN:VCARD\nVERSION:3.0\nFN:Maria Huber\nEMAIL:maria@example.com\nEND:VCARD\n",
@@ -219,12 +213,9 @@ describe("vCard support", () => {
     await expect(validateUploadBuffer(VCARD, "text/vcard")).resolves.toBe("text/vcard");
   });
 
-  // RFC 6350 registered `text/vcard`, obsoleting the pre-standard `x-token`
-  // `text/x-vcard` — but real-world clients (older macOS/Outlook export
-  // flows) still commonly claim the legacy spelling for identical content.
-  // file-type's sniffer always normalizes to `text/vcard`, so without this
-  // alias the exact-match mismatch check below would reject every
-  // legacy-labelled vCard as spoofed content, even though it's genuine.
+  // Legacy x-token spelling still claimed by real clients; the sniffer
+  // normalizes to text/vcard, so the alias preserves the caller's string
+  // instead of failing the mismatch check. See isKnownMimeAlias.
   it("accepts valid vCard content claimed as the legacy text/x-vcard MIME", async () => {
     await expect(validateUploadBuffer(VCARD, "text/x-vcard")).resolves.toBe("text/x-vcard");
   });

--- a/packages/web/src/__tests__/lib/upload-validation.test.ts
+++ b/packages/web/src/__tests__/lib/upload-validation.test.ts
@@ -127,6 +127,7 @@ describe("validateUploadBuffer", () => {
     expect(ALLOWED_ATTACHMENT_MIMES.has("image/gif")).toBe(true);
     expect(ALLOWED_ATTACHMENT_MIMES.has("image/heic")).toBe(true);
     expect(ALLOWED_ATTACHMENT_MIMES.has("image/heif")).toBe(true);
+    expect(ALLOWED_ATTACHMENT_MIMES.has("text/vcard")).toBe(true);
   });
 
   // Audio is intentionally NOT in the whitelist yet — see #321 for the
@@ -165,6 +166,8 @@ describe("text file support", () => {
     expect(ALLOWED_TEXT_MIMES.has("text/markdown")).toBe(true);
     expect(ALLOWED_TEXT_MIMES.has("application/json")).toBe(true);
     expect(ALLOWED_TEXT_MIMES.has("text/yaml")).toBe(true);
+    expect(ALLOWED_TEXT_MIMES.has("text/vcard")).toBe(true);
+    expect(ALLOWED_TEXT_MIMES.has("text/x-vcard")).toBe(true);
   });
 
   it("accepts valid UTF-8 CSV content", async () => {
@@ -195,5 +198,53 @@ describe("text file support", () => {
 
   it("rejects known binary (PDF magic bytes) claiming text/csv", async () => {
     await expect(validateUploadBuffer(PDF_HEADER, "text/csv")).rejects.toThrow(/mismatch/i);
+  });
+});
+
+// Unlike the other text formats above, a vCard body DOES have "magic bytes":
+// file-type's content sniffer recognizes any `BEGIN:VCARD…END:VCARD` payload
+// and always reports it as the single canonical `{ mime: "text/vcard" }`,
+// regardless of the vCard VERSION or what the uploading client claimed. So
+// vCard lives in `ALLOWED_ATTACHMENT_MIMES` (the detected-mime allowlist),
+// not `ALLOWED_TEXT_MIMES` — the no-magic-bytes branch is unreachable for
+// real vCard content. The agent still reads the file natively via
+// `pinchy_read`, no parser needed.
+describe("vCard support", () => {
+  const VCARD = Buffer.from(
+    "BEGIN:VCARD\nVERSION:3.0\nFN:Maria Huber\nEMAIL:maria@example.com\nEND:VCARD\n",
+    "utf-8"
+  );
+
+  it("accepts valid vCard content claimed as text/vcard", async () => {
+    await expect(validateUploadBuffer(VCARD, "text/vcard")).resolves.toBe("text/vcard");
+  });
+
+  // RFC 6350 registered `text/vcard`, obsoleting the pre-standard `x-token`
+  // `text/x-vcard` — but real-world clients (older macOS/Outlook export
+  // flows) still commonly claim the legacy spelling for identical content.
+  // file-type's sniffer always normalizes to `text/vcard`, so without this
+  // alias the exact-match mismatch check below would reject every
+  // legacy-labelled vCard as spoofed content, even though it's genuine.
+  it("accepts valid vCard content claimed as the legacy text/x-vcard MIME", async () => {
+    await expect(validateUploadBuffer(VCARD, "text/x-vcard")).resolves.toBe("text/x-vcard");
+  });
+
+  it("still rejects genuine mismatches for vCard-shaped content", async () => {
+    await expect(validateUploadBuffer(VCARD, "application/pdf")).rejects.toThrow(/mismatch/i);
+  });
+
+  // Real-world vCard 2.1 exporters (older Nokia/Symbian and legacy CRM tools)
+  // emit lowercase property names. file-type's sniffer only matches the
+  // uppercase `BEGIN:VCARD` form, so this content is NOT detected and falls
+  // through to the ALLOWED_TEXT_MIMES branch instead.
+  it("accepts lowercase begin:vcard content via the no-magic-bytes text branch", async () => {
+    const lowercaseVcard = Buffer.from(
+      "begin:vcard\nversion:2.1\nfn:Maria Huber\nend:vcard\n",
+      "utf-8"
+    );
+    await expect(validateUploadBuffer(lowercaseVcard, "text/vcard")).resolves.toBe("text/vcard");
+    await expect(validateUploadBuffer(lowercaseVcard, "text/x-vcard")).resolves.toBe(
+      "text/x-vcard"
+    );
   });
 });

--- a/packages/web/src/__tests__/proxy.test.ts
+++ b/packages/web/src/__tests__/proxy.test.ts
@@ -1,0 +1,31 @@
+import { describe, it, expect } from "vitest";
+import { NextRequest } from "next/server";
+import { proxy } from "@/proxy";
+
+describe("proxy", () => {
+  it("stamps the request path + query onto the x-pathname header", () => {
+    const request = new NextRequest("https://app.example.com/share?share_id=abc");
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-request-x-pathname")).toBe("/share?share_id=abc");
+  });
+
+  it("does not let a client-supplied x-pathname header leak through unchanged", () => {
+    const request = new NextRequest("https://app.example.com/agents", {
+      headers: { "x-pathname": "//evil.com" },
+    });
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-request-x-pathname")).toBe("/agents");
+  });
+
+  it("captures a bare path with no query string", () => {
+    const request = new NextRequest("https://app.example.com/agents");
+
+    const response = proxy(request);
+
+    expect(response.headers.get("x-middleware-request-x-pathname")).toBe("/agents");
+  });
+});

--- a/packages/web/src/__tests__/proxy.test.ts
+++ b/packages/web/src/__tests__/proxy.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { NextRequest } from "next/server";
-import { proxy } from "@/proxy";
+import { proxy, config } from "@/proxy";
 
 describe("proxy", () => {
   it("stamps the request path + query onto the x-pathname header", () => {
@@ -27,5 +27,15 @@ describe("proxy", () => {
     const response = proxy(request);
 
     expect(response.headers.get("x-middleware-request-x-pathname")).toBe("/agents");
+  });
+
+  it("excludes the service worker + manifest static assets from the matcher", () => {
+    const [pattern] = config.matcher;
+    // These are served straight from /public and never need the returnTo
+    // header; running the proxy on them is pointless and inconsistent with
+    // the deliberate sw.js exclusion.
+    expect(pattern).toContain("sw.js");
+    expect(pattern).toContain("sw-share-target.js");
+    expect(pattern).toContain("manifest.webmanifest");
   });
 });

--- a/packages/web/src/__tests__/server/attachment-pipeline.test.ts
+++ b/packages/web/src/__tests__/server/attachment-pipeline.test.ts
@@ -81,6 +81,33 @@ describe("buildAttachmentBlock", () => {
     expect(block).not.toContain("analyze with `image`");
   });
 
+  it("routes vCards to `pinchy_read` (both text/vcard and legacy text/x-vcard)", async () => {
+    // vCard (.vcf) contact files are plain UTF-8 text — the agent reads them
+    // natively with pinchy_read, no dedicated parser needed. Two MIME
+    // spellings exist in the wild: the registered `text/vcard` and the
+    // legacy `text/x-vcard` some contact-export flows still emit.
+    const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
+    const block = buildAttachmentBlock([
+      {
+        relativePath: "uploads/contact.vcf",
+        absolutePath: "/root/.openclaw/workspaces/test/uploads/contact.vcf",
+        mimeType: "text/vcard",
+        sizeBytes: 200,
+        contentHash: "d".repeat(64),
+        reused: false,
+      },
+      {
+        relativePath: "uploads/contact2.vcf",
+        absolutePath: "/root/.openclaw/workspaces/test/uploads/contact2.vcf",
+        mimeType: "text/x-vcard",
+        sizeBytes: 200,
+        contentHash: "e".repeat(64),
+        reused: false,
+      },
+    ]);
+    expect(block.match(/analyze with `pinchy_read`/g)).toHaveLength(2);
+  });
+
   it("returns empty string when no uploads", async () => {
     const { buildAttachmentBlock } = await import("@/server/attachment-pipeline");
     expect(buildAttachmentBlock([])).toBe("");

--- a/packages/web/src/app/(app)/layout.tsx
+++ b/packages/web/src/app/(app)/layout.tsx
@@ -1,6 +1,7 @@
 import { redirect } from "next/navigation";
-import { cookies } from "next/headers";
-import { requireAuth } from "@/lib/require-auth";
+import { cookies, headers } from "next/headers";
+import { getSession } from "@/lib/auth";
+import { buildLoginRedirectPath } from "@/lib/return-to";
 import { isSetupComplete, isProviderConfigured } from "@/lib/setup";
 import { getVisibleAgents } from "@/lib/visible-agents";
 import { AppSidebar } from "@/components/sidebar";
@@ -19,7 +20,14 @@ export default async function AppLayout({ children }: { children: React.ReactNod
   const setupComplete = await isSetupComplete();
   if (!setupComplete) redirect("/setup");
 
-  const session = await requireAuth();
+  const headersList = await headers();
+  const session = await getSession({ headers: headersList });
+  if (!session?.user) {
+    // Send the user to login and back to where they were headed once they
+    // sign in again. `x-pathname` is stamped by src/proxy.ts and
+    // re-validated by buildLoginRedirectPath (open-redirect guard).
+    redirect(buildLoginRedirectPath(headersList.get("x-pathname")));
+  }
 
   const providerConfigured = await isProviderConfigured();
   if (!providerConfigured) redirect("/setup/provider");

--- a/packages/web/src/app/(app)/share/page.tsx
+++ b/packages/web/src/app/(app)/share/page.tsx
@@ -1,0 +1,18 @@
+import type { Metadata } from "next";
+import { requireAuth } from "@/lib/require-auth";
+import { getVisibleAgents } from "@/lib/visible-agents";
+import { SharePicker } from "@/components/share/share-picker";
+
+export const metadata: Metadata = {
+  title: "Share",
+};
+
+export default async function SharePage() {
+  const session = await requireAuth();
+  const userId = session?.user?.id;
+  const userRole = session?.user?.role ?? "member";
+
+  const visibleAgents = await getVisibleAgents(userId!, userRole);
+
+  return <SharePicker agents={visibleAgents} />;
+}

--- a/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
+++ b/packages/web/src/app/api/agents/[agentId]/uploads/route.ts
@@ -91,10 +91,12 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
     return NextResponse.json({ error: message }, { status: 400 });
   }
 
-  // MIME validation.
-  let detectedMime: string;
+  // MIME validation. Note: for a legacy text/x-vcard upload this is the
+  // client's claimed string (an accepted alias), not the sniffed MIME —
+  // hence "validated" rather than "detected". See isKnownMimeAlias.
+  let validatedMime: string;
   try {
-    detectedMime = await validateUploadBuffer(buffer, file.type);
+    validatedMime = await validateUploadBuffer(buffer, file.type);
   } catch (err) {
     await appendAuditLog({
       ...auditBase,
@@ -129,7 +131,7 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
         agentId,
         draftId,
         filename: staged.filename,
-        mimeType: detectedMime,
+        mimeType: validatedMime,
         sizeBytes: buffer.length,
         contentHash: staged.contentHash,
         status: "staged",
@@ -155,7 +157,7 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
     detail: {
       uploadId: row.id,
       filename: staged.filename,
-      mimeType: detectedMime,
+      mimeType: validatedMime,
       sizeBytes: buffer.length,
       contentHash: staged.contentHash,
       agent: { id: agentId, name: agent.name },
@@ -164,7 +166,7 @@ export const POST = withAuth<Params>(async (req, { params }, session) => {
   });
 
   return NextResponse.json(
-    { id: row.id, filename: staged.filename, mimeType: detectedMime, sizeBytes: buffer.length },
+    { id: row.id, filename: staged.filename, mimeType: validatedMime, sizeBytes: buffer.length },
     { status: 201 }
   );
 });

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -1,11 +1,12 @@
 "use client";
 
-import { useState } from "react";
+import { Suspense, useState } from "react";
 import { authClient } from "@/lib/auth-client";
-import { useRouter } from "next/navigation";
+import { useRouter, useSearchParams } from "next/navigation";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
+import { isSafeReturnTo } from "@/lib/return-to";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/password-input";
 import { Input } from "@/components/ui/input";
@@ -27,7 +28,20 @@ const loginSchema = z.object({
 type LoginFormValues = z.infer<typeof loginSchema>;
 
 export default function LoginPage() {
+  // useSearchParams() opts the render into a Suspense boundary (Next.js
+  // requires one so the rest of the page can still be statically
+  // prerendered) — see
+  // https://nextjs.org/docs/messages/missing-suspense-with-csr-bailout
+  return (
+    <Suspense>
+      <LoginForm />
+    </Suspense>
+  );
+}
+
+function LoginForm() {
   const router = useRouter();
+  const searchParams = useSearchParams();
   const [error, setError] = useState("");
   const [loading, setLoading] = useState(false);
 
@@ -49,7 +63,8 @@ export default function LoginPage() {
       if (error) {
         setError("Invalid email or password");
       } else {
-        router.push("/");
+        const returnTo = searchParams.get("returnTo");
+        router.push(isSafeReturnTo(returnTo) ? returnTo : "/");
       }
     } catch {
       setError("Login failed. Please try again.");

--- a/packages/web/src/app/share-target/route.ts
+++ b/packages/web/src/app/share-target/route.ts
@@ -1,0 +1,20 @@
+import { NextResponse } from "next/server";
+
+// audit-exempt: SW-miss graceful fallback; drains the body but persists nothing and changes no state — only redirects the user to retry.
+//
+// This route only exists for the brief window right after a release where a
+// device is still running the OLD no-op service worker until the new one
+// (which intercepts `POST /share-target` client-side, see Tasks 3-4) has
+// activated. In that window the share reaches the network instead of the SW.
+// We cannot recover the shared file server-side here, so the goal is a clean
+// redirect back to the share page rather than a bare 404 swallowing the
+// share silently.
+export async function POST(request: Request): Promise<Response> {
+  try {
+    await request.formData();
+  } catch {
+    // Best-effort drain only — nothing to recover or validate here.
+  }
+
+  return NextResponse.redirect(new URL("/share?error=retry", request.url), 303);
+}

--- a/packages/web/src/components/assistant-ui/__tests__/share-intake-merge.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/share-intake-merge.test.tsx
@@ -1,0 +1,115 @@
+// Behavioural guard for the share prefill against the REAL assistant-ui
+// composer: ShareIntake and DraftPersistence both write the same composer's
+// text, so a shared payload arriving into a chat that already has a restored
+// draft must APPEND to it, not clobber it. The overwrite bug is invisible to
+// the hook-level use-share-intake.test.tsx (which mocks setComposerText), so
+// this file drives the real `useComposerRuntime` getState/setText path where
+// the merge actually happens.
+import { render, act, waitFor } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useEffect, type FC } from "react";
+import {
+  AssistantRuntimeProvider,
+  ComposerPrimitive,
+  useComposerRuntime,
+  useExternalStoreRuntime,
+  type ThreadMessageLike,
+  type ComposerRuntime,
+} from "@assistant-ui/react";
+import { ShareIntake } from "@/components/assistant-ui/thread";
+import { AddPendingUploadContext } from "@/components/chat";
+
+const { readSharedPayload, clearSharedPayload } = vi.hoisted(() => ({
+  readSharedPayload: vi.fn(),
+  clearSharedPayload: vi.fn(),
+}));
+
+vi.mock("@/lib/share-target/share-cache", () => ({
+  readSharedPayload,
+  clearSharedPayload,
+}));
+
+const replace = vi.fn();
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/chat/a1",
+  useSearchParams: () => new URLSearchParams("keep=&share=abc"),
+}));
+
+let composerApi: ComposerRuntime | null = null;
+const CaptureComposer: FC = () => {
+  const composer = useComposerRuntime();
+  useEffect(() => {
+    composerApi = composer;
+  }, [composer]);
+  return null;
+};
+
+const Harness: FC = () => {
+  const runtime = useExternalStoreRuntime({
+    messages: [] as ThreadMessageLike[],
+    isRunning: false,
+    convertMessage: (m: ThreadMessageLike) => m,
+    onNew: async () => {},
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <ComposerPrimitive.Root>
+        <CaptureComposer />
+        <AddPendingUploadContext.Provider value={() => {}}>
+          <ShareIntake />
+        </AddPendingUploadContext.Provider>
+        <ComposerPrimitive.Input aria-label="Message input" />
+      </ComposerPrimitive.Root>
+    </AssistantRuntimeProvider>
+  );
+};
+
+describe("ShareIntake text prefill (real composer)", () => {
+  beforeEach(() => {
+    readSharedPayload.mockReset();
+    clearSharedPayload.mockReset();
+    replace.mockReset();
+    composerApi = null;
+  });
+
+  it("appends the shared text to an existing draft instead of overwriting it", async () => {
+    // Hold the read open so we can seed the composer with a restored draft
+    // BEFORE the shared payload lands — the exact ordering DraftPersistence
+    // produces in the no-attachment case.
+    let resolveRead: (v: unknown) => void = () => {};
+    readSharedPayload.mockReturnValue(
+      new Promise((r) => {
+        resolveRead = r;
+      })
+    );
+
+    render(<Harness />);
+    await waitFor(() => expect(composerApi).not.toBeNull());
+
+    act(() => {
+      composerApi!.setText("my own draft");
+    });
+
+    await act(async () => {
+      resolveRead({ files: [], title: "", text: "shared note", url: "" });
+      await Promise.resolve();
+    });
+
+    await waitFor(() => {
+      expect(composerApi!.getState().text).toBe("my own draft\nshared note");
+    });
+    expect(clearSharedPayload).toHaveBeenCalledWith("abc");
+  });
+
+  it("sets the shared text directly when the composer is empty", async () => {
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "shared note", url: "" });
+
+    render(<Harness />);
+
+    await waitFor(() => {
+      expect(composerApi!.getState().text).toBe("shared note");
+    });
+  });
+});

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -122,6 +122,16 @@ vi.mock("@assistant-ui/react", () => ({
   })),
 }));
 
+// Composer now also mounts ShareIntake (use-share-intake.ts), which reads
+// next/navigation directly. None of these tests exercise a `?share=` URL, so
+// a bare "no params" stub keeps the intake a no-op here, exactly like a real
+// chat visited without a share id.
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace: vi.fn() }),
+  usePathname: () => "/chat/test-agent",
+  useSearchParams: () => new URLSearchParams(),
+}));
+
 vi.mock("@/lib/draft-store", () => ({
   getDraft: vi.fn(() => null),
   saveDraft: vi.fn(),

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -48,6 +48,7 @@ import {
   RetryContinueContext,
   ChatStatusContext,
   PendingUploadsContext,
+  AddPendingUploadContext,
   RemovePendingUploadContext,
   RetryPendingUploadContext,
 } from "@/components/chat";
@@ -60,6 +61,7 @@ import { RetryButton } from "@/components/chat/retry-button";
 import { DuplicateRetryConfirm } from "@/components/chat/duplicate-retry-confirm";
 import { useComposerRuntime } from "@assistant-ui/react";
 import { getDraft, saveDraft, draftKey } from "@/lib/draft-store";
+import { useShareIntake } from "@/components/share/use-share-intake";
 
 function formatTimestamp(iso: string): string {
   const date = new Date(iso);
@@ -340,6 +342,28 @@ export const DraftPersistence: FC = () => {
   return null;
 };
 
+/**
+ * Mounts the /share hand-off (use-share-intake.ts) inside the composer so it
+ * can reach both the two-phase upload pipeline (`AddPendingUploadContext`,
+ * provided higher up by chat.tsx) and the live composer runtime (`setText`,
+ * only resolvable here — `useComposerRuntime` needs to be inside
+ * `ComposerPrimitive.Root`, which chat.tsx sits above). Text prefill is
+ * best-effort: `composerRuntime` is `null` until assistant-ui's composer
+ * context mounts, in which case the shared files still attach and only the
+ * text/url prefill is skipped for that render.
+ */
+const ShareIntake: FC = () => {
+  const addPendingUpload = useContext(AddPendingUploadContext);
+  const composerRuntime = useComposerRuntime({ optional: true });
+
+  useShareIntake({
+    addPendingUpload,
+    setComposerText: composerRuntime ? (text) => composerRuntime.setText(text) : undefined,
+  });
+
+  return null;
+};
+
 function UploadChip({ upload }: { upload: PendingUpload }) {
   const removePendingUpload = useContext(RemovePendingUploadContext);
   const retryPendingUpload = useContext(RetryPendingUploadContext);
@@ -441,6 +465,7 @@ export const Composer: FC = () => {
       onKeyDownCapture={slashMenu.onKeyDownCapture}
     >
       <DraftPersistence />
+      <ShareIntake />
       <SlashCommandMenuList menu={slashMenu} />
       <PinchyDropZone className="aui-composer-attachment-dropzone flex w-full flex-col rounded-2xl border border-input bg-background px-1 pt-2 outline-none transition-shadow has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-ring/20">
         <PendingUploadChips />

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -351,14 +351,27 @@ export const DraftPersistence: FC = () => {
  * best-effort: `composerRuntime` is `null` until assistant-ui's composer
  * context mounts, in which case the shared files still attach and only the
  * text/url prefill is skipped for that render.
+ *
+ * The prefill MERGES rather than overwrites: DraftPersistence restores a
+ * saved draft into the same composer (synchronously in the no-attachment
+ * case), so a plain `setText(prefill)` would silently clobber whatever the
+ * user had already typed. We append instead. (Residual known edge: if the
+ * saved draft carries file attachments, its async restore can still land
+ * after this read — a narrow case we deliberately don't try to fully
+ * coordinate here.)
  */
-const ShareIntake: FC = () => {
+export const ShareIntake: FC = () => {
   const addPendingUpload = useContext(AddPendingUploadContext);
   const composerRuntime = useComposerRuntime({ optional: true });
 
   useShareIntake({
     addPendingUpload,
-    setComposerText: composerRuntime ? (text) => composerRuntime.setText(text) : undefined,
+    setComposerText: composerRuntime
+      ? (prefill) => {
+          const existing = composerRuntime.getState().text;
+          composerRuntime.setText(existing ? `${existing}\n${prefill}` : prefill);
+        }
+      : undefined,
   });
 
   return null;

--- a/packages/web/src/components/share/__tests__/share-picker.test.tsx
+++ b/packages/web/src/components/share/__tests__/share-picker.test.tsx
@@ -79,6 +79,15 @@ describe("SharePicker", () => {
     expect(await screen.findByText(/nothing to share/i)).toBeInTheDocument();
   });
 
+  it("shows the empty state when the cache read fails", async () => {
+    readSharedPayload.mockRejectedValueOnce(new Error("cache read failed"));
+
+    render(<SharePicker agents={agents} />);
+
+    expect(await screen.findByText(/nothing to share/i)).toBeInTheDocument();
+    expect(screen.getByRole("link", { name: /back to your agents/i })).toBeInTheDocument();
+  });
+
   it("shows the shared file's name when a file payload is present", async () => {
     readSharedPayload.mockResolvedValue({
       files: [new File(["x"], "invoice.pdf", { type: "application/pdf" })],

--- a/packages/web/src/components/share/__tests__/share-picker.test.tsx
+++ b/packages/web/src/components/share/__tests__/share-picker.test.tsx
@@ -1,0 +1,109 @@
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import "@testing-library/jest-dom";
+import { SharePicker } from "../share-picker";
+import type { Agent } from "@/components/agent-list";
+
+const { readSharedPayload } = vi.hoisted(() => ({
+  readSharedPayload: vi.fn(),
+}));
+
+vi.mock("@/lib/share-target/share-cache", () => ({
+  readSharedPayload,
+}));
+
+const push = vi.fn();
+const mockSearchParams = { current: new URLSearchParams("share_id=abc") };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ push, replace: vi.fn() }),
+  useSearchParams: () => mockSearchParams.current,
+}));
+
+const agents: Agent[] = [
+  {
+    id: "a1",
+    name: "Buchhaltung",
+    isPersonal: true,
+    model: "gpt",
+    tagline: null,
+    starterPrompts: [],
+    avatarSeed: null,
+  },
+  {
+    id: "a2",
+    name: "Smithers",
+    isPersonal: true,
+    model: "gpt",
+    tagline: null,
+    starterPrompts: [],
+    avatarSeed: null,
+  },
+];
+
+describe("SharePicker", () => {
+  beforeEach(() => {
+    mockSearchParams.current = new URLSearchParams("share_id=abc");
+    readSharedPayload.mockReset();
+    push.mockReset();
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("lists agents and navigates to the chosen agent's chat carrying the share id", async () => {
+    readSharedPayload.mockResolvedValue({
+      files: [],
+      title: "",
+      text: "please book this",
+      url: "",
+    });
+
+    render(<SharePicker agents={agents} />);
+
+    expect(await screen.findByText("Buchhaltung")).toBeInTheDocument();
+    expect(screen.getByText("Smithers")).toBeInTheDocument();
+
+    await userEvent.click(screen.getByText("Buchhaltung"));
+
+    expect(push).toHaveBeenCalledWith("/chat/a1?share=abc");
+  });
+
+  it("shows an empty state when the share id is unknown", async () => {
+    readSharedPayload.mockResolvedValue(null);
+
+    render(<SharePicker agents={agents} />);
+
+    expect(await screen.findByText(/nothing to share/i)).toBeInTheDocument();
+  });
+
+  it("shows the shared file's name when a file payload is present", async () => {
+    readSharedPayload.mockResolvedValue({
+      files: [new File(["x"], "invoice.pdf", { type: "application/pdf" })],
+      title: "",
+      text: "",
+      url: "",
+    });
+
+    render(<SharePicker agents={agents} />);
+
+    expect(await screen.findByText("invoice.pdf")).toBeInTheDocument();
+  });
+
+  it("shows an image preview element for a shared image", async () => {
+    readSharedPayload.mockResolvedValue({
+      files: [new File(["x"], "photo.jpg", { type: "image/jpeg" })],
+      title: "",
+      text: "",
+      url: "",
+    });
+    vi.stubGlobal("URL", Object.assign(URL, { createObjectURL: vi.fn(() => "blob:mock-url") }));
+
+    render(<SharePicker agents={agents} />);
+
+    const img = await screen.findByRole("img", { name: /photo.jpg/i });
+    expect(img).toHaveAttribute("src", "blob:mock-url");
+  });
+});

--- a/packages/web/src/components/share/__tests__/share-picker.test.tsx
+++ b/packages/web/src/components/share/__tests__/share-picker.test.tsx
@@ -53,7 +53,14 @@ describe("SharePicker", () => {
     vi.restoreAllMocks();
   });
 
-  it("lists agents and navigates to the chosen agent's chat carrying the share id", async () => {
+  // Navigates with `?keep&share=<id>`, not just `?share=<id>`: a bare
+  // `/chat/<agentId>` redirects server-side to the user's most-recently-
+  // interacted chat (see chat/[agentId]/page.tsx), and a Next.js redirect()
+  // drops the query string — so `share` would be lost before any client
+  // code could read it whenever the agent already has chat history. `?keep`
+  // skips that redirect so the page renders <Chat> directly with `share`
+  // intact for use-share-intake.ts to pick up.
+  it("lists agents and navigates to the chosen agent's chat carrying the share id, keeping the default chat", async () => {
     readSharedPayload.mockResolvedValue({
       files: [],
       title: "",
@@ -68,7 +75,7 @@ describe("SharePicker", () => {
 
     await userEvent.click(screen.getByText("Buchhaltung"));
 
-    expect(push).toHaveBeenCalledWith("/chat/a1?share=abc");
+    expect(push).toHaveBeenCalledWith("/chat/a1?keep&share=abc");
   });
 
   it("shows an empty state when the share id is unknown", async () => {

--- a/packages/web/src/components/share/__tests__/share-picker.test.tsx
+++ b/packages/web/src/components/share/__tests__/share-picker.test.tsx
@@ -1,16 +1,18 @@
-import { render, screen } from "@testing-library/react";
+import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import "@testing-library/jest-dom";
 import { SharePicker } from "../share-picker";
 import type { Agent } from "@/components/agent-list";
 
-const { readSharedPayload } = vi.hoisted(() => ({
+const { readSharedPayload, sweepStaleShares } = vi.hoisted(() => ({
   readSharedPayload: vi.fn(),
+  sweepStaleShares: vi.fn(),
 }));
 
 vi.mock("@/lib/share-target/share-cache", () => ({
   readSharedPayload,
+  sweepStaleShares,
 }));
 
 const push = vi.fn();
@@ -46,6 +48,8 @@ describe("SharePicker", () => {
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams("share_id=abc");
     readSharedPayload.mockReset();
+    sweepStaleShares.mockReset();
+    sweepStaleShares.mockResolvedValue(undefined);
     push.mockReset();
   });
 
@@ -84,6 +88,28 @@ describe("SharePicker", () => {
     render(<SharePicker agents={agents} />);
 
     expect(await screen.findByText(/nothing to share/i)).toBeInTheDocument();
+  });
+
+  it("sweeps stale previewed-but-unsent shares on mount", async () => {
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "hi", url: "" });
+
+    render(<SharePicker agents={agents} />);
+
+    await waitFor(() => expect(sweepStaleShares).toHaveBeenCalledTimes(1));
+    expect(sweepStaleShares).toHaveBeenCalledWith(60 * 60 * 1000);
+  });
+
+  it("shows a retry-specific empty state when the SW-miss fallback redirected with ?error=retry", async () => {
+    // The server fallback route (share-target/route.ts) redirects here with
+    // ?error=retry and no share_id when a stale SW let the POST hit the
+    // network. That's a distinct situation from an expired/unknown share, so
+    // the copy should tell the user the share was interrupted, not "expired".
+    mockSearchParams.current = new URLSearchParams("error=retry");
+
+    render(<SharePicker agents={agents} />);
+
+    expect(await screen.findByText(/sharing didn't go through/i)).toBeInTheDocument();
+    expect(readSharedPayload).not.toHaveBeenCalled();
   });
 
   it("shows the empty state when the cache read fails", async () => {

--- a/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
+++ b/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
@@ -1,0 +1,135 @@
+// Behavioural guard for the share → composer intake: the /share picker
+// hands off to `/chat/<agentId>?keep&share=<id>` (see share-picker.tsx), and
+// this hook is what actually reads that payload back out of the cache and
+// feeds it into the composer — files via the same two-phase upload pipeline
+// as a manual attachment pick, and any shared text/url as a text prefill
+// (shared LINKS carry no file, so the prefill is their only path into the
+// composer). It must run exactly once per share id and never crash the chat
+// on a corrupted/expired cache entry, and it must strip only the `share`
+// param off the URL afterwards — `?keep` has to survive, or the chat page's
+// server-side redirect-to-most-recent-chat would kick back in on any
+// subsequent navigation that re-hits the bare route.
+import { render } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { useShareIntake } from "../use-share-intake";
+
+const { readSharedPayload, clearSharedPayload } = vi.hoisted(() => ({
+  readSharedPayload: vi.fn(),
+  clearSharedPayload: vi.fn(),
+}));
+
+vi.mock("@/lib/share-target/share-cache", () => ({
+  readSharedPayload,
+  clearSharedPayload,
+}));
+
+const replace = vi.fn();
+const mockSearchParams = { current: new URLSearchParams("keep=&share=abc") };
+
+vi.mock("next/navigation", () => ({
+  useRouter: () => ({ replace }),
+  usePathname: () => "/chat/a1",
+  useSearchParams: () => mockSearchParams.current,
+}));
+
+function Harness({
+  addPendingUpload,
+  setComposerText,
+}: {
+  addPendingUpload: (file: File) => void;
+  setComposerText?: (text: string) => void;
+}) {
+  useShareIntake({ addPendingUpload, setComposerText });
+  return null;
+}
+
+describe("useShareIntake", () => {
+  beforeEach(() => {
+    mockSearchParams.current = new URLSearchParams("keep=&share=abc");
+    readSharedPayload.mockReset();
+    clearSharedPayload.mockReset();
+    replace.mockReset();
+  });
+
+  it("attaches every shared file and prefills the composer with text + url, then clears the cache", async () => {
+    const file1 = new File(["a"], "one.pdf", { type: "application/pdf" });
+    const file2 = new File(["b"], "two.pdf", { type: "application/pdf" });
+    readSharedPayload.mockResolvedValue({
+      files: [file1, file2],
+      title: "ignored",
+      text: "please book this",
+      url: "https://example.com/thing",
+    });
+
+    const addPendingUpload = vi.fn();
+    const setComposerText = vi.fn();
+
+    render(<Harness addPendingUpload={addPendingUpload} setComposerText={setComposerText} />);
+
+    await vi.waitFor(() => {
+      expect(clearSharedPayload).toHaveBeenCalledWith("abc");
+    });
+
+    expect(addPendingUpload).toHaveBeenCalledTimes(2);
+    expect(addPendingUpload).toHaveBeenNthCalledWith(1, file1);
+    expect(addPendingUpload).toHaveBeenNthCalledWith(2, file2);
+    expect(setComposerText).toHaveBeenCalledWith("please book this\nhttps://example.com/thing");
+  });
+
+  it("strips only `share` from the URL, keeping `keep`", async () => {
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "", url: "" });
+
+    render(<Harness addPendingUpload={vi.fn()} />);
+
+    await vi.waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+
+    const [target] = replace.mock.calls[0];
+    expect(target).toContain("/chat/a1?");
+    expect(target).toContain("keep");
+    expect(target).not.toContain("share=");
+  });
+
+  it("does nothing when there is no share param", () => {
+    mockSearchParams.current = new URLSearchParams("keep=");
+
+    render(<Harness addPendingUpload={vi.fn()} />);
+
+    expect(readSharedPayload).not.toHaveBeenCalled();
+    expect(replace).not.toHaveBeenCalled();
+  });
+
+  it("does not crash and still strips the share param when the cache read rejects", async () => {
+    readSharedPayload.mockRejectedValue(new Error("cache read failed"));
+    const addPendingUpload = vi.fn();
+
+    render(<Harness addPendingUpload={addPendingUpload} />);
+
+    await vi.waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+
+    expect(addPendingUpload).not.toHaveBeenCalled();
+    expect(clearSharedPayload).not.toHaveBeenCalled();
+  });
+
+  it("runs only once even if the component rerenders", async () => {
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "hi", url: "" });
+    const setComposerText = vi.fn();
+
+    const { rerender } = render(
+      <Harness addPendingUpload={vi.fn()} setComposerText={setComposerText} />
+    );
+
+    await vi.waitFor(() => {
+      expect(setComposerText).toHaveBeenCalledTimes(1);
+    });
+
+    rerender(<Harness addPendingUpload={vi.fn()} setComposerText={setComposerText} />);
+    rerender(<Harness addPendingUpload={vi.fn()} setComposerText={setComposerText} />);
+
+    expect(readSharedPayload).toHaveBeenCalledTimes(1);
+    expect(setComposerText).toHaveBeenCalledTimes(1);
+  });
+});

--- a/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
+++ b/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
@@ -130,6 +130,31 @@ describe("useShareIntake", () => {
     expect(replace).toHaveBeenCalledTimes(1);
   });
 
+  it("processes a second, different share id even without a remount", async () => {
+    // The run-once guard keys on the share id, not a bare boolean: if a fresh
+    // `?share=<id>` arrives into an already-mounted intake (a future routing
+    // change could do this), it must still fire rather than silently no-op.
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "first", url: "" });
+    const setComposerText = vi.fn();
+
+    const { rerender } = render(
+      <Harness addPendingUpload={vi.fn()} setComposerText={setComposerText} />
+    );
+
+    await vi.waitFor(() => {
+      expect(setComposerText).toHaveBeenCalledWith("first");
+    });
+
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "second", url: "" });
+    mockSearchParams.current = new URLSearchParams("keep=&share=def");
+    rerender(<Harness addPendingUpload={vi.fn()} setComposerText={setComposerText} />);
+
+    await vi.waitFor(() => {
+      expect(setComposerText).toHaveBeenCalledWith("second");
+    });
+    expect(readSharedPayload).toHaveBeenCalledTimes(2);
+  });
+
   it("does nothing when there is no share param", () => {
     mockSearchParams.current = new URLSearchParams("keep=");
 

--- a/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
+++ b/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
@@ -12,6 +12,7 @@
 import { render } from "@testing-library/react";
 import { StrictMode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { toast } from "sonner";
 import { useShareIntake } from "../use-share-intake";
 
 const { readSharedPayload, clearSharedPayload } = vi.hoisted(() => ({
@@ -23,6 +24,8 @@ vi.mock("@/lib/share-target/share-cache", () => ({
   readSharedPayload,
   clearSharedPayload,
 }));
+
+vi.mock("sonner", () => ({ toast: { success: vi.fn(), error: vi.fn() } }));
 
 const replace = vi.fn();
 const mockSearchParams = { current: new URLSearchParams("keep=&share=abc") };
@@ -50,6 +53,7 @@ describe("useShareIntake", () => {
     readSharedPayload.mockReset();
     clearSharedPayload.mockReset();
     replace.mockReset();
+    vi.mocked(toast.error).mockReset();
   });
 
   it("attaches every shared file and prefills the composer with text + url, then clears the cache", async () => {
@@ -133,9 +137,10 @@ describe("useShareIntake", () => {
 
     expect(readSharedPayload).not.toHaveBeenCalled();
     expect(replace).not.toHaveBeenCalled();
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
-  it("does not crash and still strips the share param when the cache read rejects", async () => {
+  it("does not crash, still strips the share param, and toasts once when the cache read rejects", async () => {
     readSharedPayload.mockRejectedValue(new Error("cache read failed"));
     const addPendingUpload = vi.fn();
 
@@ -147,6 +152,39 @@ describe("useShareIntake", () => {
 
     expect(addPendingUpload).not.toHaveBeenCalled();
     expect(clearSharedPayload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "We couldn't load the shared file. Please try sharing again."
+    );
+  });
+
+  it("toasts once when the cache read resolves to null (expired/consumed entry)", async () => {
+    readSharedPayload.mockResolvedValue(null);
+    const addPendingUpload = vi.fn();
+
+    render(<Harness addPendingUpload={addPendingUpload} />);
+
+    await vi.waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+
+    expect(addPendingUpload).not.toHaveBeenCalled();
+    expect(toast.error).toHaveBeenCalledTimes(1);
+    expect(toast.error).toHaveBeenCalledWith(
+      "We couldn't load the shared file. Please try sharing again."
+    );
+  });
+
+  it("does not toast when the shared payload loads successfully", async () => {
+    readSharedPayload.mockResolvedValue({ files: [], title: "", text: "hi", url: "" });
+
+    render(<Harness addPendingUpload={vi.fn()} />);
+
+    await vi.waitFor(() => {
+      expect(replace).toHaveBeenCalled();
+    });
+
+    expect(toast.error).not.toHaveBeenCalled();
   });
 
   it("runs only once even if the component rerenders", async () => {

--- a/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
+++ b/packages/web/src/components/share/__tests__/use-share-intake.test.tsx
@@ -10,6 +10,7 @@
 // server-side redirect-to-most-recent-chat would kick back in on any
 // subsequent navigation that re-hits the bare route.
 import { render } from "@testing-library/react";
+import { StrictMode } from "react";
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { useShareIntake } from "../use-share-intake";
 
@@ -89,6 +90,40 @@ describe("useShareIntake", () => {
     expect(target).toContain("/chat/a1?");
     expect(target).toContain("keep");
     expect(target).not.toContain("share=");
+  });
+
+  it("still fires under StrictMode's synchronous mount → cleanup → mount double-invoke", async () => {
+    // Next 16 defaults reactStrictMode: true, so `next dev` runs the mount
+    // effect, its cleanup, then the effect again — synchronously, before the
+    // readSharedPayload promise resolves. A cleanup that cancels the in-flight
+    // read would leave the feature a permanent no-op in dev. Guard against
+    // that regression by reproducing the double-invoke here.
+    const file = new File(["a"], "one.pdf", { type: "application/pdf" });
+    readSharedPayload.mockResolvedValue({
+      files: [file],
+      title: "",
+      text: "please book this",
+      url: "",
+    });
+
+    const addPendingUpload = vi.fn();
+    const setComposerText = vi.fn();
+
+    render(
+      <StrictMode>
+        <Harness addPendingUpload={addPendingUpload} setComposerText={setComposerText} />
+      </StrictMode>
+    );
+
+    await vi.waitFor(() => {
+      expect(clearSharedPayload).toHaveBeenCalledWith("abc");
+    });
+
+    expect(addPendingUpload).toHaveBeenCalledTimes(1);
+    expect(addPendingUpload).toHaveBeenCalledWith(file);
+    expect(setComposerText).toHaveBeenCalledTimes(1);
+    expect(setComposerText).toHaveBeenCalledWith("please book this");
+    expect(replace).toHaveBeenCalledTimes(1);
   });
 
   it("does nothing when there is no share param", () => {

--- a/packages/web/src/components/share/share-picker.tsx
+++ b/packages/web/src/components/share/share-picker.tsx
@@ -111,9 +111,18 @@ export function SharePicker({ agents }: SharePickerProps) {
     // is nothing to fetch or to set here.
     if (!shareId) return;
     let cancelled = false;
-    readSharedPayload(shareId).then((result) => {
-      if (!cancelled) setPayload(result);
-    });
+    readSharedPayload(shareId).then(
+      (result) => {
+        if (!cancelled) setPayload(result);
+      },
+      // A cache read can throw (corrupted entry, malformed JSON, private-
+      // browsing Cache API restrictions, quota/security errors). Treat any
+      // failure the same as "nothing to share" so the user always gets the
+      // friendly empty state with a way back, never a permanently blank page.
+      () => {
+        if (!cancelled) setPayload(null);
+      }
+    );
     return () => {
       cancelled = true;
     };

--- a/packages/web/src/components/share/share-picker.tsx
+++ b/packages/web/src/components/share/share-picker.tsx
@@ -148,7 +148,7 @@ export function SharePicker({ agents }: SharePickerProps) {
             <li key={agent.id}>
               <button
                 type="button"
-                onClick={() => router.push(`/chat/${agent.id}?share=${shareId}`)}
+                onClick={() => router.push(`/chat/${agent.id}?keep&share=${shareId}`)}
                 className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
               >
                 {/* eslint-disable-next-line @next/next/no-img-element */}

--- a/packages/web/src/components/share/share-picker.tsx
+++ b/packages/web/src/components/share/share-picker.tsx
@@ -1,0 +1,159 @@
+"use client";
+
+import { useEffect, useState } from "react";
+import Link from "next/link";
+import { useRouter, useSearchParams } from "next/navigation";
+import { FileText } from "lucide-react";
+import { type Agent, sortAgents } from "@/components/agent-list";
+import { getAgentAvatarSvg } from "@/lib/avatar";
+import { readSharedPayload, type SharedPayload } from "@/lib/share-target/share-cache";
+
+interface SharePickerProps {
+  agents: Agent[];
+}
+
+/** Loading sentinel distinct from "checked and found nothing" (`null`). */
+const LOADING = Symbol("loading");
+
+function FilePreviewThumb({ file }: { file: File }) {
+  const [src, setSrc] = useState<string | null>(null);
+  const [failed, setFailed] = useState(false);
+  const isImage = file.type.startsWith("image/");
+
+  useEffect(() => {
+    if (!isImage || typeof URL === "undefined" || typeof URL.createObjectURL !== "function") {
+      return;
+    }
+    const objectUrl = URL.createObjectURL(file);
+    // setTimeout(0) is required: calling setState synchronously inside an
+    // effect body triggers the react-hooks/set-state-in-effect ESLint rule
+    // (see use-chat-status.ts for the same pattern). The negligible delay
+    // is imperceptible; cleanup revokes the URL and cancels the timer.
+    const t = setTimeout(() => setSrc(objectUrl), 0);
+    return () => {
+      clearTimeout(t);
+      URL.revokeObjectURL(objectUrl);
+    };
+  }, [file, isImage]);
+
+  if (isImage && src && !failed) {
+    return (
+      // eslint-disable-next-line @next/next/no-img-element
+      <img
+        src={src}
+        alt={file.name}
+        className="size-16 shrink-0 rounded-lg border object-cover"
+        onError={() => setFailed(true)}
+      />
+    );
+  }
+
+  return (
+    <div className="flex size-16 shrink-0 items-center justify-center rounded-lg border bg-muted">
+      <FileText className="size-6 text-muted-foreground" />
+    </div>
+  );
+}
+
+function SharePreview({ payload }: { payload: SharedPayload }) {
+  const { files, title, text, url } = payload;
+
+  if (files.length > 0) {
+    return (
+      <div className="flex flex-wrap gap-3">
+        {files.map((file, index) => (
+          <div key={`${file.name}-${index}`} className="flex items-center gap-3">
+            <FilePreviewThumb file={file} />
+            <span className="max-w-48 truncate text-sm text-muted-foreground" title={file.name}>
+              {file.name}
+            </span>
+          </div>
+        ))}
+      </div>
+    );
+  }
+
+  const excerpt = [title, text, url].filter(Boolean).join(" — ");
+  if (!excerpt) return null;
+
+  return <p className="line-clamp-3 text-sm text-muted-foreground">{excerpt}</p>;
+}
+
+function EmptyState() {
+  return (
+    <div className="flex flex-col items-center gap-3 py-16 text-center">
+      <h1 className="text-lg font-semibold">Nothing to share</h1>
+      <p className="max-w-sm text-sm text-muted-foreground">
+        We couldn&apos;t find what you shared — it may have expired, or the share didn&apos;t come
+        through. Try sharing again.
+      </p>
+      <Link
+        href="/agents"
+        className="text-sm font-medium text-primary underline-offset-4 hover:underline"
+      >
+        Back to your agents
+      </Link>
+    </div>
+  );
+}
+
+export function SharePicker({ agents }: SharePickerProps) {
+  const router = useRouter();
+  const searchParams = useSearchParams();
+  const shareId = searchParams.get("share_id");
+  const [payload, setPayload] = useState<SharedPayload | null | typeof LOADING>(
+    shareId ? LOADING : null
+  );
+
+  useEffect(() => {
+    // No id at all (unknown/expired share, or the `?error=retry` fallback) —
+    // the initial `useState` above already reflects this as `null`, so there
+    // is nothing to fetch or to set here.
+    if (!shareId) return;
+    let cancelled = false;
+    readSharedPayload(shareId).then((result) => {
+      if (!cancelled) setPayload(result);
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [shareId]);
+
+  if (payload === LOADING) {
+    return null;
+  }
+
+  if (!payload) {
+    return <EmptyState />;
+  }
+
+  const sortedAgents = sortAgents(agents);
+
+  return (
+    <div className="mx-auto flex max-w-lg flex-col gap-6 p-4 md:p-8">
+      <SharePreview payload={payload} />
+      <div>
+        <h1 className="mb-3 text-lg font-semibold">Which agent?</h1>
+        <ul className="flex flex-col gap-1">
+          {sortedAgents.map((agent) => (
+            <li key={agent.id}>
+              <button
+                type="button"
+                onClick={() => router.push(`/chat/${agent.id}?share=${shareId}`)}
+                className="flex w-full items-center gap-3 rounded-lg px-3 py-2 text-left transition-colors hover:bg-accent hover:text-accent-foreground"
+              >
+                {/* eslint-disable-next-line @next/next/no-img-element */}
+                <img
+                  src={getAgentAvatarSvg({ avatarSeed: agent.avatarSeed, name: agent.name })}
+                  alt=""
+                  className="size-9 shrink-0 rounded-full"
+                />
+                <span className="truncate font-semibold">{agent.name}</span>
+              </button>
+            </li>
+          ))}
+        </ul>
+      </div>
+    </div>
+  );
+}

--- a/packages/web/src/components/share/share-picker.tsx
+++ b/packages/web/src/components/share/share-picker.tsx
@@ -6,7 +6,11 @@ import { useRouter, useSearchParams } from "next/navigation";
 import { FileText } from "lucide-react";
 import { type Agent, sortAgents } from "@/components/agent-list";
 import { getAgentAvatarSvg } from "@/lib/avatar";
-import { readSharedPayload, type SharedPayload } from "@/lib/share-target/share-cache";
+import {
+  readSharedPayload,
+  sweepStaleShares,
+  type SharedPayload,
+} from "@/lib/share-target/share-cache";
 
 interface SharePickerProps {
   agents: Agent[];
@@ -79,14 +83,25 @@ function SharePreview({ payload }: { payload: SharedPayload }) {
   return <p className="line-clamp-3 text-sm text-muted-foreground">{excerpt}</p>;
 }
 
-function EmptyState() {
+function EmptyState({ reason }: { reason?: "retry" }) {
+  // `retry` means the SW-miss server fallback (share-target/route.ts) sent us
+  // here because a stale service worker let the POST hit the network — the
+  // share was interrupted rather than expired, so say so honestly.
+  const { heading, body } =
+    reason === "retry"
+      ? {
+          heading: "Sharing didn't go through",
+          body: "Something interrupted the share before it reached Pinchy. Please try sharing again.",
+        }
+      : {
+          heading: "Nothing to share",
+          body: "We couldn't find what you shared — it may have expired, or the share didn't come through. Try sharing again.",
+        };
+
   return (
     <div className="flex flex-col items-center gap-3 py-16 text-center">
-      <h1 className="text-lg font-semibold">Nothing to share</h1>
-      <p className="max-w-sm text-sm text-muted-foreground">
-        We couldn&apos;t find what you shared — it may have expired, or the share didn&apos;t come
-        through. Try sharing again.
-      </p>
+      <h1 className="text-lg font-semibold">{heading}</h1>
+      <p className="max-w-sm text-sm text-muted-foreground">{body}</p>
       <Link
         href="/agents"
         className="text-sm font-medium text-primary underline-offset-4 hover:underline"
@@ -101,9 +116,18 @@ export function SharePicker({ agents }: SharePickerProps) {
   const router = useRouter();
   const searchParams = useSearchParams();
   const shareId = searchParams.get("share_id");
+  const shareError = searchParams.get("error");
   const [payload, setPayload] = useState<SharedPayload | null | typeof LOADING>(
     shareId ? LOADING : null
   );
+
+  useEffect(() => {
+    // Reclaim shares the user previewed here but never sent — Cache Storage
+    // has no TTL of its own, so orphaned entries (potentially 15 MB photos)
+    // would otherwise linger until quota pressure. One hour comfortably
+    // outlasts any real share → pick flow.
+    sweepStaleShares(60 * 60 * 1000).catch(() => {});
+  }, []);
 
   useEffect(() => {
     // No id at all (unknown/expired share, or the `?error=retry` fallback) —
@@ -133,7 +157,7 @@ export function SharePicker({ agents }: SharePickerProps) {
   }
 
   if (!payload) {
-    return <EmptyState />;
+    return <EmptyState reason={shareError === "retry" ? "retry" : undefined} />;
   }
 
   const sortedAgents = sortAgents(agents);

--- a/packages/web/src/components/share/use-share-intake.ts
+++ b/packages/web/src/components/share/use-share-intake.ts
@@ -2,6 +2,7 @@
 
 import { useEffect, useRef } from "react";
 import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { toast } from "sonner";
 import { clearSharedPayload, readSharedPayload } from "@/lib/share-target/share-cache";
 
 interface UseShareIntakeArgs {
@@ -34,6 +35,11 @@ interface UseShareIntakeArgs {
  * calling the setters or `router.replace` after an unmount, so the only cost
  * in the genuine unmount-mid-read case is a harmless no-op — far better than
  * never firing at all.
+ *
+ * When a `share` id IS present but the payload can't be loaded (a rejected
+ * read, or a resolved-but-null entry — e.g. expired/already consumed), this
+ * surfaces a toast: it's a transient, retryable error per AGENTS.md (the
+ * user can simply re-share), not a silent no-op.
  */
 export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIntakeArgs) {
   const router = useRouter();
@@ -58,11 +64,14 @@ export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIn
             setComposerText?.(prefill);
           }
           await clearSharedPayload(shareId);
+        } else {
+          toast.error("We couldn't load the shared file. Please try sharing again.");
         }
       } catch {
         // Corrupted entry, malformed JSON, or Cache API restrictions — treat
         // like "nothing to attach" and still fall through to the URL cleanup
         // below so the chat is never left in a permanently-replaying state.
+        toast.error("We couldn't load the shared file. Please try sharing again.");
       }
 
       const params = new URLSearchParams(searchParams.toString());

--- a/packages/web/src/components/share/use-share-intake.ts
+++ b/packages/web/src/components/share/use-share-intake.ts
@@ -18,8 +18,11 @@ interface UseShareIntakeArgs {
  * text prefill the user can edit before sending — a shared LINK carries no
  * file, so the prefill is its only path into the composer.
  *
- * Runs at most once per share id (guarded solely by a ref) and never throws
- * even if the cache read fails — a corrupted or already-cleared entry is
+ * Runs at most once per share id: a ref remembers the id it already handled,
+ * so a StrictMode double-invoke (or a re-render) is a no-op, while a genuinely
+ * different `?share=<id>` arriving into the same mounted intake still fires.
+ * Never throws even if the cache read fails — a corrupted or already-cleared
+ * entry is
  * treated like "nothing to attach" rather than crashing the chat. Either
  * way, the `share` param is stripped from the URL afterwards so a refresh
  * doesn't replay the intake. Every OTHER param (notably `?keep`, which is
@@ -45,12 +48,12 @@ export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIn
   const router = useRouter();
   const pathname = usePathname();
   const searchParams = useSearchParams();
-  const handledRef = useRef(false);
+  const handledRef = useRef<string | null>(null);
 
   useEffect(() => {
     const shareId = searchParams.get("share");
-    if (!shareId || handledRef.current) return;
-    handledRef.current = true;
+    if (!shareId || handledRef.current === shareId) return;
+    handledRef.current = shareId;
 
     (async () => {
       try {

--- a/packages/web/src/components/share/use-share-intake.ts
+++ b/packages/web/src/components/share/use-share-intake.ts
@@ -17,13 +17,23 @@ interface UseShareIntakeArgs {
  * text prefill the user can edit before sending — a shared LINK carries no
  * file, so the prefill is its only path into the composer.
  *
- * Runs at most once per share id (guarded by a ref) and never throws even
- * if the cache read fails — a corrupted or already-cleared entry is treated
- * like "nothing to attach" rather than crashing the chat. Either way, the
- * `share` param is stripped from the URL afterwards so a refresh doesn't
- * replay the intake. Every OTHER param (notably `?keep`, which is what let
- * this route render `<Chat>` instead of redirecting to the most recent chat
- * — see chat/[agentId]/page.tsx) is preserved.
+ * Runs at most once per share id (guarded solely by a ref) and never throws
+ * even if the cache read fails — a corrupted or already-cleared entry is
+ * treated like "nothing to attach" rather than crashing the chat. Either
+ * way, the `share` param is stripped from the URL afterwards so a refresh
+ * doesn't replay the intake. Every OTHER param (notably `?keep`, which is
+ * what let this route render `<Chat>` instead of redirecting to the most
+ * recent chat — see chat/[agentId]/page.tsx) is preserved.
+ *
+ * Deliberately NO cleanup-cancellation flag: React StrictMode (Next 16's
+ * dev default) runs the mount effect, its cleanup, then the effect again —
+ * synchronously, before `readSharedPayload` resolves. A `cancelled` flag set
+ * in cleanup would abort the single in-flight read (the re-run bails on the
+ * already-committed `handledRef`), leaving the feature a permanent no-op in
+ * dev. So we let the one committed run finish. React 18+ does not warn on
+ * calling the setters or `router.replace` after an unmount, so the only cost
+ * in the genuine unmount-mid-read case is a harmless no-op — far better than
+ * never firing at all.
  */
 export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIntakeArgs) {
   const router = useRouter();
@@ -36,12 +46,10 @@ export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIn
     if (!shareId || handledRef.current) return;
     handledRef.current = true;
 
-    let cancelled = false;
-
     (async () => {
       try {
         const payload = await readSharedPayload(shareId);
-        if (payload && !cancelled) {
+        if (payload) {
           for (const file of payload.files) {
             addPendingUpload(file);
           }
@@ -57,15 +65,10 @@ export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIn
         // below so the chat is never left in a permanently-replaying state.
       }
 
-      if (cancelled) return;
       const params = new URLSearchParams(searchParams.toString());
       params.delete("share");
       const query = params.toString();
       router.replace(query ? `${pathname}?${query}` : pathname);
     })();
-
-    return () => {
-      cancelled = true;
-    };
   }, [searchParams, router, pathname, addPendingUpload, setComposerText]);
 }

--- a/packages/web/src/components/share/use-share-intake.ts
+++ b/packages/web/src/components/share/use-share-intake.ts
@@ -1,0 +1,71 @@
+"use client";
+
+import { useEffect, useRef } from "react";
+import { usePathname, useRouter, useSearchParams } from "next/navigation";
+import { clearSharedPayload, readSharedPayload } from "@/lib/share-target/share-cache";
+
+interface UseShareIntakeArgs {
+  addPendingUpload: (file: File) => void;
+  setComposerText?: (text: string) => void;
+}
+
+/**
+ * Picks up a shared payload cached by the /share picker (`?share=<id>` on
+ * the chat URL — see share-picker.tsx) and feeds it into the composer:
+ * files go through the same two-phase upload pipeline as a manual
+ * attachment pick (`addPendingUpload`), and any shared text/url becomes a
+ * text prefill the user can edit before sending — a shared LINK carries no
+ * file, so the prefill is its only path into the composer.
+ *
+ * Runs at most once per share id (guarded by a ref) and never throws even
+ * if the cache read fails — a corrupted or already-cleared entry is treated
+ * like "nothing to attach" rather than crashing the chat. Either way, the
+ * `share` param is stripped from the URL afterwards so a refresh doesn't
+ * replay the intake. Every OTHER param (notably `?keep`, which is what let
+ * this route render `<Chat>` instead of redirecting to the most recent chat
+ * — see chat/[agentId]/page.tsx) is preserved.
+ */
+export function useShareIntake({ addPendingUpload, setComposerText }: UseShareIntakeArgs) {
+  const router = useRouter();
+  const pathname = usePathname();
+  const searchParams = useSearchParams();
+  const handledRef = useRef(false);
+
+  useEffect(() => {
+    const shareId = searchParams.get("share");
+    if (!shareId || handledRef.current) return;
+    handledRef.current = true;
+
+    let cancelled = false;
+
+    (async () => {
+      try {
+        const payload = await readSharedPayload(shareId);
+        if (payload && !cancelled) {
+          for (const file of payload.files) {
+            addPendingUpload(file);
+          }
+          const prefill = [payload.text, payload.url].filter(Boolean).join("\n");
+          if (prefill) {
+            setComposerText?.(prefill);
+          }
+          await clearSharedPayload(shareId);
+        }
+      } catch {
+        // Corrupted entry, malformed JSON, or Cache API restrictions — treat
+        // like "nothing to attach" and still fall through to the URL cleanup
+        // below so the chat is never left in a permanently-replaying state.
+      }
+
+      if (cancelled) return;
+      const params = new URLSearchParams(searchParams.toString());
+      params.delete("share");
+      const query = params.toString();
+      router.replace(query ? `${pathname}?${query}` : pathname);
+    })();
+
+    return () => {
+      cancelled = true;
+    };
+  }, [searchParams, router, pathname, addPendingUpload, setComposerText]);
+}

--- a/packages/web/src/lib/attachment-mime.ts
+++ b/packages/web/src/lib/attachment-mime.ts
@@ -17,6 +17,11 @@ export const EXTENSION_TO_MIME: Record<string, string> = {
   ".json": "application/json",
   ".yaml": "text/yaml",
   ".yml": "text/yaml",
+  // vCard (.vcf) is normally content-sniffed as `text/vcard` (it has "magic
+  // bytes" — see ALLOWED_ATTACHMENT_MIMES in upload-validation.ts), so this
+  // entry is defense-in-depth for the rare edge case where a vCard body
+  // doesn't start exactly with `BEGIN:VCARD` and file-type can't sniff it.
+  ".vcf": "text/vcard",
 };
 
 /**
@@ -49,4 +54,7 @@ export const INPUT_ACCEPT_ATTRIBUTE = [
   "text/yaml",
   ".yaml",
   ".yml",
+  "text/vcard",
+  "text/x-vcard",
+  ".vcf",
 ].join(",");

--- a/packages/web/src/lib/return-to.ts
+++ b/packages/web/src/lib/return-to.ts
@@ -1,0 +1,36 @@
+/**
+ * Guards against open redirects when honoring a `returnTo` destination after
+ * login. Only a same-origin, path-relative destination is accepted:
+ *
+ * - Must start with a single "/" — so it resolves against our own origin.
+ * - Must not start with "//" — browsers treat a leading "//host" as
+ *   protocol-relative, i.e. a redirect to a different origin.
+ * - Must not start with "/\" — some browsers normalize a leading backslash
+ *   to a forward slash, turning "/\evil.com" into "//evil.com".
+ *
+ * Absolute URLs with a scheme (`https://...`), `javascript:` URIs, bare
+ * backslash strings (`\\evil.com`), and empty/missing values are all
+ * rejected by the leading "must start with /" check. Callers should fall
+ * back to a safe default (e.g. "/") when this returns false.
+ */
+export function isSafeReturnTo(value: string | null | undefined): value is string {
+  if (!value) return false;
+  if (!value.startsWith("/")) return false;
+  if (value.startsWith("//")) return false;
+  if (value.startsWith("/\\")) return false;
+  return true;
+}
+
+/** Fallback destination when no safe `returnTo` is available. */
+const DEFAULT_DEST = "/";
+
+/**
+ * Builds the `/login?returnTo=...` path the (app) layout redirects to when a
+ * request has no session. `dest` is the path+query captured for the current
+ * request (see the `x-pathname` header set in `src/proxy.ts`); it falls
+ * back to `/` when missing or unsafe.
+ */
+export function buildLoginRedirectPath(dest: string | null | undefined): string {
+  const safeDest = isSafeReturnTo(dest) ? dest : DEFAULT_DEST;
+  return `/login?returnTo=${encodeURIComponent(safeDest)}`;
+}

--- a/packages/web/src/lib/return-to.ts
+++ b/packages/web/src/lib/return-to.ts
@@ -1,24 +1,44 @@
 /**
  * Guards against open redirects when honoring a `returnTo` destination after
- * login. Only a same-origin, path-relative destination is accepted:
+ * login. Only a same-origin, path-relative destination is accepted. Callers
+ * should fall back to a safe default (e.g. "/") when this returns false.
  *
- * - Must start with a single "/" — so it resolves against our own origin.
- * - Must not start with "//" — browsers treat a leading "//host" as
- *   protocol-relative, i.e. a redirect to a different origin.
- * - Must not start with "/\" — some browsers normalize a leading backslash
- *   to a forward slash, turning "/\evil.com" into "//evil.com".
+ * A prefix-only check is NOT enough: WHATWG URL parsing (and browsers)
+ * strip ASCII tab/CR/LF from anywhere in the string, which can merge a
+ * later "/" into the leading position. For example `"/\t/evil.com"` parses
+ * to `//evil.com`, i.e. the protocol-relative `https://evil.com/` — a
+ * classic post-login phishing redirect. Next's client router turns
+ * `router.push("/\t/evil.com")` into a hard navigation to that origin.
+ *
+ * So we reject the obvious protocol-relative / backslash tricks up front,
+ * then resolve the value against a sentinel origin and require that:
+ *
+ * - the resolved origin is unchanged (control-char stripping, encoded
+ *   tricks, etc. that escape our origin are rejected), and
+ * - the decoded pathname does not itself start with "//" or "/\", which
+ *   would be a protocol-relative redirect smuggled through as `%2F%2F`.
  *
  * Absolute URLs with a scheme (`https://...`), `javascript:` URIs, bare
- * backslash strings (`\\evil.com`), and empty/missing values are all
- * rejected by the leading "must start with /" check. Callers should fall
- * back to a safe default (e.g. "/") when this returns false.
+ * backslash strings (`\\evil.com`), and empty/missing values never make it
+ * past the leading checks or the origin comparison.
  */
 export function isSafeReturnTo(value: string | null | undefined): value is string {
   if (!value) return false;
-  if (!value.startsWith("/")) return false;
-  if (value.startsWith("//")) return false;
-  if (value.startsWith("/\\")) return false;
-  return true;
+  if (!value.startsWith("/") || value.startsWith("//") || value.startsWith("/\\")) {
+    return false;
+  }
+  try {
+    const base = "http://internal.invalid";
+    const url = new URL(value, base);
+    if (url.origin !== base || !url.pathname.startsWith("/")) return false;
+    // Reject encoded slash tricks: a decoded path that starts with "//" or
+    // "/\" is a protocol-relative redirect in disguise (e.g. "/%2F%2Fevil.com").
+    const decodedPath = decodeURIComponent(url.pathname);
+    if (decodedPath.startsWith("//") || decodedPath.startsWith("/\\")) return false;
+    return true;
+  } catch {
+    return false;
+  }
 }
 
 /** Fallback destination when no safe `returnTo` is available. */

--- a/packages/web/src/lib/share-target/share-cache.ts
+++ b/packages/web/src/lib/share-target/share-cache.ts
@@ -1,0 +1,94 @@
+// Reads and clears the shared payload the service worker's share-target
+// handler stashes in the Cache API before redirecting to /share?share_id=<id>
+// (see public/sw-share-target.js for the writer and the exact contract this
+// module reads back).
+//
+// Cache contract (do not change without updating both):
+//   Cache name: "share-target"
+//   meta -> /__share/<id>/meta
+//     JSON body: { files: [{ index, name, type }], title, text, url }
+//   file -> /__share/<id>/file/<index>
+//     Body: the raw file blob.
+//     Headers: Content-Type: <mime>, X-Filename: <encodeURIComponent(name)>
+
+const CACHE_NAME = "share-target";
+
+interface ShareMetaFile {
+  index: number;
+  name: string;
+  type: string;
+}
+
+interface ShareMeta {
+  files?: ShareMetaFile[];
+  title?: string;
+  text?: string;
+  url?: string;
+}
+
+export interface SharedPayload {
+  files: File[];
+  title: string;
+  text: string;
+  url: string;
+}
+
+/**
+ * Reads the shared payload for `id` back out of the "share-target" cache.
+ * Returns `null` when the Cache API is unavailable (SSR, unsupported
+ * browser) or when no meta entry exists for `id` (unknown/already-cleared
+ * share).
+ */
+export async function readSharedPayload(id: string): Promise<SharedPayload | null> {
+  if (typeof caches === "undefined") {
+    return null;
+  }
+
+  const cache = await caches.open(CACHE_NAME);
+  const metaResponse = await cache.match(`/__share/${id}/meta`);
+  if (!metaResponse) {
+    return null;
+  }
+
+  const meta = (await metaResponse.json()) as ShareMeta;
+  const files: File[] = [];
+
+  for (const entry of meta.files ?? []) {
+    const fileResponse = await cache.match(`/__share/${id}/file/${entry.index}`);
+    if (!fileResponse) {
+      continue;
+    }
+
+    const blob = await fileResponse.blob();
+    const encodedName = fileResponse.headers.get("X-Filename");
+    const name = encodedName ? decodeURIComponent(encodedName) : entry.name;
+    files.push(new File([blob], name, { type: entry.type }));
+  }
+
+  return {
+    files,
+    title: meta.title ?? "",
+    text: meta.text ?? "",
+    url: meta.url ?? "",
+  };
+}
+
+/**
+ * Deletes every cache entry belonging to `id` (the meta entry and all of
+ * its file entries). No-op when the Cache API is unavailable.
+ */
+export async function clearSharedPayload(id: string): Promise<void> {
+  if (typeof caches === "undefined") {
+    return;
+  }
+
+  const cache = await caches.open(CACHE_NAME);
+  const keys = await cache.keys();
+  const prefix = `/__share/${id}/`;
+
+  await Promise.all(
+    keys
+      .filter((key) => new URL(key.url).pathname.startsWith(prefix))
+      .map((key) => cache.delete(key))
+  );
+}

--- a/packages/web/src/lib/share-target/share-cache.ts
+++ b/packages/web/src/lib/share-target/share-cache.ts
@@ -6,7 +6,7 @@
 // Cache contract (do not change without updating both):
 //   Cache name: "share-target"
 //   meta -> /__share/<id>/meta
-//     JSON body: { files: [{ index, name, type }], title, text, url }
+//     JSON body: { files: [{ index, name, type }], title, text, url, createdAt }
 //   file -> /__share/<id>/file/<index>
 //     Body: the raw file blob.
 //     Headers: Content-Type: <mime>, X-Filename: <encodeURIComponent(name)>
@@ -24,6 +24,8 @@ interface ShareMeta {
   title?: string;
   text?: string;
   url?: string;
+  /** Epoch ms the share was written by the service worker. */
+  createdAt?: number;
 }
 
 export interface SharedPayload {
@@ -89,6 +91,64 @@ export async function clearSharedPayload(id: string): Promise<void> {
   await Promise.all(
     keys
       .filter((key) => new URL(key.url).pathname.startsWith(prefix))
+      .map((key) => cache.delete(key))
+  );
+}
+
+const META_PATH_RE = /^\/__share\/([^/]+)\/meta$/;
+const SHARE_ID_FROM_PATH_RE = /^\/__share\/([^/]+)\//;
+
+/**
+ * Reclaims shares older than `maxAgeMs` — the ones a user previewed on /share
+ * but never sent (Cache Storage entries otherwise live until quota pressure
+ * evicts them, which for 15 MB photos can mean they linger indefinitely). The
+ * activate-time sweep is deliberately absent (a deploy landing mid-share must
+ * not wipe an unconsumed one — see sw.js), so this age-gated sweep runs from
+ * the /share page instead. `now` is injectable for deterministic tests.
+ *
+ * An entry whose meta is missing `createdAt` (written by an older SW build) or
+ * is unreadable is treated as stale: only the current SW writes fresh entries,
+ * and it always stamps `createdAt`, so a timestamp-less entry is safe to drop.
+ */
+export async function sweepStaleShares(maxAgeMs: number, now: number = Date.now()): Promise<void> {
+  if (typeof caches === "undefined") {
+    return;
+  }
+
+  const cache = await caches.open(CACHE_NAME);
+  const keys = await cache.keys();
+
+  const staleIds = new Set<string>();
+  for (const key of keys) {
+    const match = new URL(key.url).pathname.match(META_PATH_RE);
+    if (!match) continue;
+    const id = match[1];
+
+    let createdAt: number | undefined;
+    const metaResponse = await cache.match(key);
+    if (metaResponse) {
+      try {
+        createdAt = ((await metaResponse.json()) as ShareMeta).createdAt;
+      } catch {
+        // Corrupted meta — reclaim it.
+      }
+    }
+
+    if (createdAt === undefined || now - createdAt > maxAgeMs) {
+      staleIds.add(id);
+    }
+  }
+
+  if (staleIds.size === 0) {
+    return;
+  }
+
+  await Promise.all(
+    keys
+      .filter((key) => {
+        const idMatch = new URL(key.url).pathname.match(SHARE_ID_FROM_PATH_RE);
+        return idMatch ? staleIds.has(idMatch[1]) : false;
+      })
       .map((key) => cache.delete(key))
   );
 }

--- a/packages/web/src/lib/upload-validation.ts
+++ b/packages/web/src/lib/upload-validation.ts
@@ -67,12 +67,8 @@ export function sanitizeFilename(raw: string): string {
 // Audio is intentionally absent — see #321. Adding audio MIMEs here without
 // also wiring transcription means the agent receives a file it cannot read.
 //
-// text/vcard is ALSO listed in ALLOWED_TEXT_MIMES below: file-type's content
-// sniffer recognizes a properly-formatted `BEGIN:VCARD…END:VCARD` payload and
-// always returns `{ mime: "text/vcard" }` here, but some real-world vCard
-// exports (lowercase `begin:vcard`, leading blank line/CRLF) aren't sniffed
-// and fall through to the no-magic-bytes branch instead. Both allowlists
-// carry the type; see the ALLOWED_TEXT_MIMES comment for the fallback case.
+// text/vcard is ALSO listed in ALLOWED_TEXT_MIMES below; see isKnownMimeAlias
+// for why vCard lives in both allowlists.
 export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
   "application/pdf",
   "image/jpeg",
@@ -87,13 +83,9 @@ export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
 // Text formats have no magic bytes, so fileTypeFromBuffer returns undefined.
 // These are validated by UTF-8 null-byte guard instead.
 //
-// text/vcard and text/x-vcard are also listed here even though a *properly*
-// formatted vCard (uppercase `BEGIN:VCARD`, no leading bytes) IS sniffed via
-// content and handled by ALLOWED_ATTACHMENT_MIMES above. Real-world exporters
-// still produce vCards file-type's sniffer misses — lowercase `begin:vcard`
-// (older vCard 2.1 tools) or a leading blank line/CRLF — which fall through
-// to this no-magic-bytes branch instead. Both allowlists carry the type
-// deliberately; they cover different fallback paths for the same format.
+// text/vcard and text/x-vcard are also listed here (vCard is normally sniffed
+// by content — see ALLOWED_ATTACHMENT_MIMES above); see isKnownMimeAlias for
+// why vCard lives in both allowlists.
 export const ALLOWED_TEXT_MIMES = new Set<string>([
   "text/plain",
   "text/csv",
@@ -104,15 +96,27 @@ export const ALLOWED_TEXT_MIMES = new Set<string>([
   "text/x-vcard",
 ]);
 
-// RFC 6350 registered `text/vcard`, obsoleting the pre-standard `x-token`
-// `text/x-vcard` — but real-world clients (older macOS/Outlook export flows)
-// still commonly claim the legacy spelling for identical content. file-type's
-// sniffer always normalizes vCard content to the single canonical
-// `text/vcard`, so the exact-match mismatch check below would otherwise
-// reject every legacy-labelled vCard as spoofed content even though it's
-// genuine. This is the only MIME alias in this module — deliberately, so a
-// future addition needs the same justification (a registered synonym for the
-// exact same wire format, not merely "close enough").
+// Authoritative note on why vCard is handled specially and lives in BOTH
+// allowlists above (the ALLOWED_ATTACHMENT_MIMES / ALLOWED_TEXT_MIMES comments
+// point here):
+//
+//   - file-type content-sniffs a properly-formatted `BEGIN:VCARD…END:VCARD`
+//     payload and always returns the single canonical `{ mime: "text/vcard" }`
+//     — regardless of vCard VERSION or what the client claimed. So a normal
+//     vCard is verified through the detected-mime path (ALLOWED_ATTACHMENT_MIMES).
+//   - Some real-world exports the sniffer misses (lowercase `begin:vcard` from
+//     older 2.1 tools, or a leading blank line/CRLF) fall through to the
+//     no-magic-bytes branch, so vCard is also in ALLOWED_TEXT_MIMES.
+//   - RFC 6350 registered `text/vcard`, obsoleting the pre-standard `x-token`
+//     `text/x-vcard` — but real-world clients (older macOS/Outlook export
+//     flows) still commonly claim the legacy spelling for identical content.
+//     Since the sniffer normalizes to `text/vcard`, the exact-match mismatch
+//     check below would otherwise reject every legacy-labelled vCard as
+//     spoofed content even though it's genuine.
+//
+// This is the only MIME alias in this module — deliberately, so a future
+// addition needs the same justification (a registered synonym for the exact
+// same wire format, not merely "close enough").
 function isKnownMimeAlias(detectedMime: string, claimedMime: string): boolean {
   return detectedMime === "text/vcard" && claimedMime === "text/x-vcard";
 }
@@ -137,8 +141,11 @@ export async function validateUploadBuffer(buffer: Buffer, claimedMime: string):
   if (!ALLOWED_ATTACHMENT_MIMES.has(detected.mime)) {
     throw new Error(`File type ${detected.mime} not supported`);
   }
-  if (detected.mime !== claimedMime && !isKnownMimeAlias(detected.mime, claimedMime)) {
-    throw new Error(`File type mismatch: claimed ${claimedMime}, content is ${detected.mime}`);
+  if (detected.mime !== claimedMime) {
+    if (!isKnownMimeAlias(detected.mime, claimedMime)) {
+      throw new Error(`File type mismatch: claimed ${claimedMime}, content is ${detected.mime}`);
+    }
+    return claimedMime; // preserve legacy spelling only for the alias case
   }
-  return claimedMime;
+  return detected.mime;
 }

--- a/packages/web/src/lib/upload-validation.ts
+++ b/packages/web/src/lib/upload-validation.ts
@@ -66,6 +66,13 @@ export function sanitizeFilename(raw: string): string {
 
 // Audio is intentionally absent — see #321. Adding audio MIMEs here without
 // also wiring transcription means the agent receives a file it cannot read.
+//
+// text/vcard is ALSO listed in ALLOWED_TEXT_MIMES below: file-type's content
+// sniffer recognizes a properly-formatted `BEGIN:VCARD…END:VCARD` payload and
+// always returns `{ mime: "text/vcard" }` here, but some real-world vCard
+// exports (lowercase `begin:vcard`, leading blank line/CRLF) aren't sniffed
+// and fall through to the no-magic-bytes branch instead. Both allowlists
+// carry the type; see the ALLOWED_TEXT_MIMES comment for the fallback case.
 export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
   "application/pdf",
   "image/jpeg",
@@ -74,17 +81,41 @@ export const ALLOWED_ATTACHMENT_MIMES = new Set<string>([
   "image/gif",
   "image/heic",
   "image/heif",
+  "text/vcard",
 ]);
 
 // Text formats have no magic bytes, so fileTypeFromBuffer returns undefined.
 // These are validated by UTF-8 null-byte guard instead.
+//
+// text/vcard and text/x-vcard are also listed here even though a *properly*
+// formatted vCard (uppercase `BEGIN:VCARD`, no leading bytes) IS sniffed via
+// content and handled by ALLOWED_ATTACHMENT_MIMES above. Real-world exporters
+// still produce vCards file-type's sniffer misses — lowercase `begin:vcard`
+// (older vCard 2.1 tools) or a leading blank line/CRLF — which fall through
+// to this no-magic-bytes branch instead. Both allowlists carry the type
+// deliberately; they cover different fallback paths for the same format.
 export const ALLOWED_TEXT_MIMES = new Set<string>([
   "text/plain",
   "text/csv",
   "text/markdown",
   "application/json",
   "text/yaml",
+  "text/vcard",
+  "text/x-vcard",
 ]);
+
+// RFC 6350 registered `text/vcard`, obsoleting the pre-standard `x-token`
+// `text/x-vcard` — but real-world clients (older macOS/Outlook export flows)
+// still commonly claim the legacy spelling for identical content. file-type's
+// sniffer always normalizes vCard content to the single canonical
+// `text/vcard`, so the exact-match mismatch check below would otherwise
+// reject every legacy-labelled vCard as spoofed content even though it's
+// genuine. This is the only MIME alias in this module — deliberately, so a
+// future addition needs the same justification (a registered synonym for the
+// exact same wire format, not merely "close enough").
+function isKnownMimeAlias(detectedMime: string, claimedMime: string): boolean {
+  return detectedMime === "text/vcard" && claimedMime === "text/x-vcard";
+}
 
 export async function validateUploadBuffer(buffer: Buffer, claimedMime: string): Promise<string> {
   const detected = await fileTypeFromBuffer(
@@ -106,8 +137,8 @@ export async function validateUploadBuffer(buffer: Buffer, claimedMime: string):
   if (!ALLOWED_ATTACHMENT_MIMES.has(detected.mime)) {
     throw new Error(`File type ${detected.mime} not supported`);
   }
-  if (detected.mime !== claimedMime) {
+  if (detected.mime !== claimedMime && !isKnownMimeAlias(detected.mime, claimedMime)) {
     throw new Error(`File type mismatch: claimed ${claimedMime}, content is ${detected.mime}`);
   }
-  return detected.mime;
+  return claimedMime;
 }

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -1,0 +1,35 @@
+import { NextResponse, type NextRequest } from "next/server";
+
+/**
+ * Server components (like the `(app)/layout.tsx` auth guard) have no direct
+ * way to read the current request's path + query string. Proxy (Next's
+ * successor to "middleware", same API) runs on every matched request and
+ * does see it, so we stamp it onto a header that downstream server
+ * components can read via `headers()`.
+ *
+ * This lets an expired-session redirect to `/login` carry a `returnTo` back
+ * to wherever the user was headed — see `src/lib/return-to.ts` for the
+ * open-redirect guard applied to that value before it's ever used.
+ *
+ * Any client-supplied `x-pathname` request header is overwritten below by
+ * the value Next itself parsed from the request URL, so this cannot be used
+ * to spoof the captured destination.
+ */
+export function proxy(request: NextRequest) {
+  const requestHeaders = new Headers(request.headers);
+  requestHeaders.set("x-pathname", request.nextUrl.pathname + request.nextUrl.search);
+
+  return NextResponse.next({
+    request: {
+      headers: requestHeaders,
+    },
+  });
+}
+
+export const config = {
+  matcher: [
+    // Skip Next internals, API routes (which have their own auth checks),
+    // and static assets — none of them need the returnTo redirect.
+    "/((?!api|_next/static|_next/image|favicon.ico|sw.js).*)",
+  ],
+};

--- a/packages/web/src/proxy.ts
+++ b/packages/web/src/proxy.ts
@@ -29,7 +29,8 @@ export function proxy(request: NextRequest) {
 export const config = {
   matcher: [
     // Skip Next internals, API routes (which have their own auth checks),
-    // and static assets — none of them need the returnTo redirect.
-    "/((?!api|_next/static|_next/image|favicon.ico|sw.js).*)",
+    // and static assets (service workers + manifest) — none of them need the
+    // returnTo redirect header.
+    "/((?!api|_next/static|_next/image|favicon.ico|sw.js|sw-share-target.js|manifest.webmanifest).*)",
   ],
 };

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -262,6 +262,8 @@ const PINCHY_READ_TEXT_MIMES = new Set([
   "text/markdown",
   "application/json",
   "text/yaml",
+  "text/vcard",
+  "text/x-vcard",
 ]);
 
 /**


### PR DESCRIPTION
## What does this PR do?

Lets an **installed Android PWA** register as an OS **Share** target. Share a photo, PDF, text file, link, or contact (vCard) from any app → pick **Pinchy** in the share sheet → pick an agent → the content lands in that agent's chat composer (not auto-sent — you add a note and send). This is the realistic PWA equivalent of WhatsApp's "share to a contact": a Pinchy tile in the sheet, then an in-app agent picker.

### How it works
1. The manifest declares a `share_target`; the browser POSTs a multipart form to `/share-target`.
2. The **service worker** intercepts that POST, caches the payload (Cache API), and 303-redirects to `/share?share_id=<id>`.
3. The `/share` page (under `(app)`, auth-gated) shows a preview + an agent picker in sidebar order (`sortAgents`).
4. Selecting an agent navigates to `/chat/<agentId>?keep&share=<id>` — `?keep` is required so the chat route's "redirect to most-recent chat" doesn't drop the query string.
5. A run-once chat-intake hook pulls the payload from the cache and feeds files into the **existing** `addPendingUpload` pipeline, prefills the composer text (merged with any draft), clears the cache, and strips the `share` param. No new upload/attach code.

### Notable design points
- **Android only.** Web Share Target is Chromium-only; a PWA cannot be an iOS share target (documented honestly in the docs; native app is the future path).
- **"Shareable == attachable":** the manifest `accept` list is pinned by a drift test to the union of the upload allow-lists (`ALLOWED_ATTACHMENT_MIMES ∪ ALLOWED_TEXT_MIMES`).
- **vCard newly accepted** (`text/vcard` + legacy `text/x-vcard`) — plain text the agent reads natively via `pinchy_read`, no parser. (`file-type` sniffs vCard as `text/vcard`, handled with a narrowly-scoped MIME alias.)
- **Server fallback route** `/share-target` redirects gracefully (no 404) if a stale service worker misses the POST during a deploy window.
- **App-wide `returnTo` (bonus):** the `(app)` layout now sends unauthenticated users to `/login?returnTo=<dest>` and login returns them there — so a share (or any deep link) survives a session-expiry redirect. Guarded against open redirects via URL parsing.

### Reviews caught & fixed 3 serious bugs before merge
- **StrictMode no-op:** the intake's `handledRef` + `cancelled`-cleanup combo made the feature silently do nothing under React StrictMode (dev). Fixed to rely on the ref alone; regression test reproduces the double-invoke.
- **Blank screen on cache-read failure:** now shows the empty state instead of hanging.
- **CRITICAL open redirect:** the first `returnTo` guard used string-prefix checks; `"/\t/evil.com"` (browser strips the tab → `//evil.com`) passed and hard-navigated to a cross-origin URL after login. Replaced with a parse-based guard (`new URL(value, sentinelBase)`, origin must equal the sentinel) + adversarial control-char/encoded-slash tests.

## Type of change

- [x] ✨ New feature
- [x] 🐛 Bug fix (open-redirect hardening; app-wide login returnTo)
- [x] 📝 Documentation
- [x] ♻️ Refactor (vCard allow-list, dead-code removal)

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (TDD throughout; unit suite 7653 passed / 13 skipped, integration `test:db` 172 passed)
- [x] I've updated the documentation (new "Share to Pinchy from your phone" how-to)
- [x] All existing tests pass (unit + integration + `next build` + tsc + lint + format:check + check-test-deletions all green)

## Test plan / reviewer notes

- ⚠️ **Manual device gate before merge:** Web Share Target can't be unit/E2E tested (OS integration, installed + production only). On a real **Android** device: install the PWA, share a photo/PDF/link/vCard → confirm Pinchy appears → pick an agent → the item lands in the composer, not auto-sent. Include the logged-out case (share while session expired → login → returns to `/share` with payload intact).
- New `proxy.ts` (Next 16.2.9 renamed `middleware.ts` → `proxy.ts`) stamps an `x-pathname` header used by the auth gate.
- No DB schema/migration changes.