### PR TITLE
test(telegram): fix flaky OpenClaw-history-fallback poll (poll for the exact message)

### DIFF
--- a/packages/web/e2e/telegram/chats.spec.ts
+++ b/packages/web/e2e/telegram/chats.spec.ts
@@ -382,10 +382,11 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
   test("a listed Telegram chat stays readable even when Pinchy captured nothing (OpenClaw history fallback)", async () => {
     // Send a FRESH message so the per-peer OpenClaw session has history (the
     // earlier `/new` reset it). Capture mirrors it into channel_messages.
+    const HIDDEN_MSG = "Message that we will hide from Pinchy's own store";
     await sendTelegramMessage({
       token: BOT_TOKEN,
       chatId: TG_PEER_ID,
-      text: "Message that we will hide from Pinchy's own store",
+      text: HIDDEN_MSG,
       userId: TG_PEER_ID,
       username: TG_USERNAME,
       firstName: "ChatsE2E",
@@ -416,8 +417,17 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
 
     // ...and STILL readable: the mirror falls back to the peer's OpenClaw session
     // history. A source switch that blanks pre-existing conversations fails here.
+    // Poll until the EXACT message we sent is back through the fallback — not
+    // merely until the transcript is non-empty. OpenClaw can surface the
+    // assistant's reply (or an older turn) a beat before the just-sent user
+    // message is queryable, so a loop that exits on "any message" races the
+    // specific-text assertion below — the intermittent failure this guards. If
+    // the fallback genuinely drops the message, this now fails deterministically
+    // (the loop exhausts its budget) instead of flaking.
+    const fallbackHasSentMessage = (r: { status: number; messages: { text: string }[] }) =>
+      r.status === 200 && r.messages.some((m) => m.text.includes(HIDDEN_MSG));
     let after = await getTelegramChatAs(adminCookie, agentId);
-    for (let i = 0; i < 20 && (after.status !== 200 || after.messages.length === 0); i++) {
+    for (let i = 0; i < 20 && !fallbackHasSentMessage(after); i++) {
       await new Promise((r) => setTimeout(r, 1000));
       after = await getTelegramChatAs(adminCookie, agentId);
     }
@@ -430,9 +440,7 @@ test.describe.serial("Chats — per-task session model (#508)", () => {
     // It renders the ACTUAL conversation, not just "something non-empty": the
     // exact message we sent must come back through the history fallback.
     expect(
-      after.messages.some((m) =>
-        m.text.includes("Message that we will hide from Pinchy's own store")
-      ),
+      after.messages.some((m) => m.text.includes(HIDDEN_MSG)),
       "the fallback must render the real message text from OpenClaw history"
     ).toBe(true);
 


### PR DESCRIPTION
## What

Fixes an intermittent failure in the Telegram OpenClaw-history-fallback migration test (`e2e/telegram/chats.spec.ts:382`, "a listed Telegram chat stays readable even when Pinchy captured nothing").

## Why

The retry loop exited as soon as the transcript was **non-empty** (`messages.length > 0`), but the final assertion requires the **specific** message just sent (`"Message that we will hide from Pinchy's own store"`). OpenClaw can surface the assistant reply — or an older turn — a beat before the just-sent user message is queryable in session history, so the loop exits early and races the specific-text assertion.

It surfaced on the **post-merge `main` run** of #700 ([run 29205761466](https://github.com/heypinchy/pinchy/actions/runs/29205761466), job "Telegram E2E Tests"), where it was the only red job in 24. That PR touches **no** Telegram/channel/capture code — verified: the failing path is the `getTelegramChatAs` HTTP route, unrelated to #700's WS/poke changes; the parent commit `cf031fd93` was green; the only delta is #700's Telegram-agnostic commits. Classic latent flake, hit by unlucky timing.

## Fix

Align the poll exit condition with the assertion: wait until the **exact** sent text is back through the fallback (same 20s budget). If the fallback genuinely drops the message, the loop now exhausts and the test fails **deterministically** instead of flaking. The assertions themselves are unchanged — **no test weakened**, none removed (net-zero test count).

## Verification

- Prettier + ESLint clean on the file.
- The flake is timing-dependent and cannot be deterministically reproduced locally (and the local Telegram E2E stack collides with parallel sessions' ports), so **CI is the verifier** — the "Telegram E2E Tests" job exercises this exact path against the production image.