### PR TITLE
feat(inbox-agent): dispatcher fan-out core (#139)

### DIFF
--- a/packages/web/src/__tests__/email-workflows/match.test.ts
+++ b/packages/web/src/__tests__/email-workflows/match.test.ts
@@ -1,0 +1,77 @@
+// Unit tests for the deterministic email-filter predicate (Inbox Agent #139,
+// dispatcher Slice D). `matchesFilter` is the pure gate the dispatcher runs
+// before claiming an email: no LLM, no I/O — see design §6. Semantics: AND
+// across fields, OR within an array field, all string comparisons
+// case-insensitive; an unset or empty field is no constraint.
+import { describe, it, expect } from "vitest";
+
+import { matchesFilter } from "@/lib/email-workflows/match";
+import type { DispatchableEmail } from "@/lib/email-workflows/types";
+
+function email(overrides: Partial<DispatchableEmail> = {}): DispatchableEmail {
+  return {
+    providerMessageId: "msg-1",
+    from: "alice@vendor.com",
+    to: ["accounting@acme.com"],
+    subject: "Invoice 4711 for July",
+    folder: "INBOX",
+    attachments: [{ contentType: "application/pdf", filename: "invoice.pdf" }],
+    receivedAt: new Date("2026-07-14T09:00:00Z"),
+    ...overrides,
+  };
+}
+
+describe("matchesFilter", () => {
+  it("matches any email when the filter is empty", () => {
+    expect(matchesFilter(email(), {})).toBe(true);
+  });
+
+  it("matches from on any listed sender, case-insensitively", () => {
+    expect(matchesFilter(email(), { from: ["bob@x.com", "ALICE@VENDOR.COM"] })).toBe(true);
+    expect(matchesFilter(email(), { from: ["bob@x.com"] })).toBe(false);
+  });
+
+  it("matches toDomain when any recipient is in one of the domains", () => {
+    expect(
+      matchesFilter(email({ to: ["ceo@other.com", "ap@acme.com"] }), { toDomain: ["acme.com"] })
+    ).toBe(true);
+    expect(matchesFilter(email({ to: ["ceo@other.com"] }), { toDomain: ["acme.com"] })).toBe(false);
+  });
+
+  it("matches subjectContains on any listed substring, case-insensitively", () => {
+    expect(matchesFilter(email(), { subjectContains: ["quote", "invoice"] })).toBe(true);
+    expect(matchesFilter(email(), { subjectContains: ["receipt"] })).toBe(false);
+  });
+
+  it("matches hasAttachment against the presence of attachments", () => {
+    expect(matchesFilter(email(), { hasAttachment: true })).toBe(true);
+    expect(matchesFilter(email({ attachments: [] }), { hasAttachment: true })).toBe(false);
+    expect(matchesFilter(email({ attachments: [] }), { hasAttachment: false })).toBe(true);
+    expect(matchesFilter(email(), { hasAttachment: false })).toBe(false);
+  });
+
+  it("matches attachmentType when any attachment has that content type", () => {
+    expect(matchesFilter(email(), { attachmentType: "application/pdf" })).toBe(true);
+    expect(matchesFilter(email(), { attachmentType: "image/png" })).toBe(false);
+  });
+
+  it("matches folder case-insensitively", () => {
+    expect(matchesFilter(email(), { folder: "inbox" })).toBe(true);
+    expect(matchesFilter(email(), { folder: "Archive" })).toBe(false);
+  });
+
+  it("ANDs across fields — one failing field rejects the whole filter", () => {
+    // subject matches, but sender does not → overall reject.
+    expect(matchesFilter(email(), { subjectContains: ["invoice"], from: ["nobody@x.com"] })).toBe(
+      false
+    );
+    // both hold → accept.
+    expect(
+      matchesFilter(email(), { subjectContains: ["invoice"], from: ["alice@vendor.com"] })
+    ).toBe(true);
+  });
+
+  it("treats an empty array field as no constraint, not match-nothing", () => {
+    expect(matchesFilter(email(), { from: [], subjectContains: [] })).toBe(true);
+  });
+});

--- a/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
@@ -138,6 +138,30 @@ describe("dispatchEmails — fan-out lifecycle", () => {
     expect(recips.map((r) => r.userId)).toEqual(workflow.recipientUserIds);
   });
 
+  it("finalizes no_action and still notifies when the run reports nothing to do", async () => {
+    const workflow = await workflowForDispatch();
+    const noActionRun: RunAgent = async () => ({
+      status: "no_action",
+      title: "Nothing to file",
+      content: "No matching invoices in this batch.",
+    });
+
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent: noActionRun });
+
+    expect(summary).toMatchObject({ claimed: 1, succeeded: 1, failed: 0 });
+
+    // no_action is a terminal, successful outcome: the ledger records it (so a
+    // resync never re-runs it) and the feed still gets a "checked, nothing to do"
+    // entry — the run owns the title/content, so it is never empty noise.
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("no_action");
+    expect(row.finalizedAt).not.toBeNull();
+
+    const [note] = await db.select().from(notifications).where(eq(notifications.sourceId, row.id));
+    expect(note.status).toBe("success");
+    expect(note.title).toBe("Nothing to file");
+  });
+
   it("skips a non-matching email without claiming or running it", async () => {
     const workflow = await workflowForDispatch();
     let ran = 0;
@@ -238,5 +262,39 @@ describe("dispatchEmails — run failure", () => {
     expect(summary).toMatchObject({ claimed: 2, succeeded: 1, failed: 1 });
     expect((await ledgerRow(workflow.id, "bad")).status).toBe("failed");
     expect((await ledgerRow(workflow.id, "good")).status).toBe("done");
+  });
+});
+
+describe("dispatchEmails — delivery failure", () => {
+  it("keeps a claimed email recoverable (processing) and does not abort the batch when notify fails", async () => {
+    // A recipient id that is not a real user makes notify() fail on the FK when
+    // it fans out — a realistic transient/misconfig delivery failure. The guard
+    // above only rejects an *empty* recipient list, so a single ghost id gets
+    // past it and reaches the insert.
+    const workflow = await workflowForDispatch({ recipientUserIds: ["ghost-user-does-not-exist"] });
+
+    // Two matching emails: if the first email's delivery failure aborted the
+    // loop, the second would never be claimed. It must not.
+    const summary = await dispatchEmails({
+      workflow,
+      emails: [email({ providerMessageId: "a" }), email({ providerMessageId: "b" })],
+      runAgent: doneRun,
+    });
+
+    // Both emails were attempted; neither counts as succeeded, both deferred.
+    expect(summary).toMatchObject({ claimed: 2, succeeded: 0, failed: 0, deferred: 2 });
+
+    // Crucial: notify runs BEFORE finalize, so a notify failure leaves the row
+    // in `processing` — recoverable by the reconciliation sweep — rather than a
+    // `done` row with no notification, which no sweep could ever find again.
+    expect((await ledgerRow(workflow.id, "a")).status).toBe("processing");
+    expect((await ledgerRow(workflow.id, "b")).status).toBe("processing");
+
+    // notify's transaction rolled back, so no orphan notification leaked.
+    const notes = await db
+      .select()
+      .from(notifications)
+      .where(eq(notifications.agentId, workflow.agentId));
+    expect(notes).toHaveLength(0);
   });
 });

--- a/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
@@ -1,0 +1,242 @@
+// Real-DB integration tests for the Inbox Agent dispatcher (Slice D). The
+// dispatcher is the loop from design §6: for each new email × matching workflow,
+// filter (deterministic) → claim (ledger) → isolated agent run → finalize ledger
+// → notify (activity feed). The run itself is injected (`runAgent`) so the whole
+// lifecycle is testable on the current OpenClaw pin without spawning a real run.
+import { describe, it, expect } from "vitest";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  users,
+  emailWorkflows,
+  notifications,
+  notificationRecipients,
+  processedEmails,
+} from "@/db/schema";
+import { dispatchEmails } from "@/lib/email-workflows/dispatch";
+import type { RunAgent, WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+import type { DispatchableEmail } from "@/lib/email-workflows/types";
+
+let userCounter = 0;
+async function seedUser() {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `dispatch-${userCounter++}@test.local`, name: "Owner" })
+    .returning();
+  return row;
+}
+
+async function seedAgent() {
+  const [row] = await db
+    .insert(agents)
+    .values({ name: "Penny", model: "ollama-cloud/gemini-3-flash", greetingMessage: "Hi" })
+    .returning();
+  return row;
+}
+
+async function seedWorkflow(agentId: string) {
+  const [row] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId,
+      name: "File invoices",
+      filter: { hasAttachment: true, attachmentType: "application/pdf" },
+      action: "Draft a supplier bill in Odoo from the attached invoice.",
+    })
+    .returning();
+  return row;
+}
+
+async function workflowForDispatch(
+  overrides: Partial<WorkflowForDispatch> = {}
+): Promise<WorkflowForDispatch> {
+  const agent = await seedAgent();
+  const user = await seedUser();
+  const wf = await seedWorkflow(agent.id);
+  return {
+    id: wf.id,
+    agentId: agent.id,
+    connectionId: "conn-1",
+    name: wf.name,
+    filter: wf.filter,
+    action: wf.action,
+    recipientUserIds: [user.id],
+    ...overrides,
+  };
+}
+
+function email(overrides: Partial<DispatchableEmail> = {}): DispatchableEmail {
+  return {
+    providerMessageId: "msg-1",
+    from: "vendor@supplier.com",
+    to: ["ap@acme.com"],
+    subject: "Invoice 4711",
+    folder: "INBOX",
+    attachments: [{ contentType: "application/pdf", filename: "invoice.pdf" }],
+    receivedAt: new Date("2026-07-14T09:00:00Z"),
+    ...overrides,
+  };
+}
+
+const doneRun: RunAgent = async () => ({
+  status: "done",
+  outcome: { odooModel: "account.move", odooId: 7 },
+  runId: "run-x",
+  title: "1 invoice filed",
+  content: "Drafted a supplier bill in Odoo.",
+});
+
+async function ledgerRow(workflowId: string, providerMessageId: string) {
+  const [row] = await db
+    .select()
+    .from(processedEmails)
+    .where(
+      and(
+        eq(processedEmails.workflowId, workflowId),
+        eq(processedEmails.providerMessageId, providerMessageId)
+      )
+    );
+  return row;
+}
+
+describe("dispatchEmails — fan-out lifecycle", () => {
+  it("claims, runs, finalizes and notifies for a matching email", async () => {
+    const workflow = await workflowForDispatch();
+    const seen: DispatchableEmail[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      seen.push(ctx.email);
+      return doneRun(ctx);
+    };
+
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent });
+
+    // Ran exactly once, on the matching email.
+    expect(seen).toHaveLength(1);
+    expect(seen[0].providerMessageId).toBe("msg-1");
+    expect(summary).toMatchObject({ claimed: 1, succeeded: 1, failed: 0 });
+
+    // Ledger finalized with the run's terminal status + outcome.
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("done");
+    expect(row.outcome).toEqual({ odooModel: "account.move", odooId: 7 });
+    expect(row.runId).toBe("run-x");
+    expect(row.finalizedAt).not.toBeNull();
+
+    // Notification fanned out to the recipient, provenance points at the ledger row.
+    const [note] = await db.select().from(notifications).where(eq(notifications.sourceId, row.id));
+    expect(note.agentId).toBe(workflow.agentId);
+    expect(note.sourceType).toBe("inbox");
+    expect(note.status).toBe("success");
+    expect(note.title).toBe("1 invoice filed");
+
+    const recips = await db
+      .select()
+      .from(notificationRecipients)
+      .where(eq(notificationRecipients.notificationId, note.id));
+    expect(recips.map((r) => r.userId)).toEqual(workflow.recipientUserIds);
+  });
+
+  it("skips a non-matching email without claiming or running it", async () => {
+    const workflow = await workflowForDispatch();
+    let ran = 0;
+    const runAgent: RunAgent = async (ctx) => {
+      ran++;
+      return doneRun(ctx);
+    };
+
+    // No PDF attachment → fails the workflow filter.
+    const summary = await dispatchEmails({
+      workflow,
+      emails: [email({ attachments: [] })],
+      runAgent,
+    });
+
+    expect(ran).toBe(0);
+    expect(summary).toMatchObject({ claimed: 0, skippedFilter: 1, succeeded: 0 });
+    expect(await ledgerRow(workflow.id, "msg-1")).toBeUndefined();
+  });
+
+  it("skips an already-claimed email (idempotent re-dispatch)", async () => {
+    const workflow = await workflowForDispatch();
+    let ran = 0;
+    const runAgent: RunAgent = async (ctx) => {
+      ran++;
+      return doneRun(ctx);
+    };
+
+    // First dispatch processes it.
+    await dispatchEmails({ workflow, emails: [email()], runAgent });
+    // A resync re-discovers the same email; the ledger claim rejects it.
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent });
+
+    expect(ran).toBe(1); // not run again
+    expect(summary).toMatchObject({ claimed: 0, skippedAlreadyClaimed: 1 });
+
+    const notes = await db
+      .select()
+      .from(notifications)
+      .where(eq(notifications.agentId, workflow.agentId));
+    expect(notes).toHaveLength(1); // no duplicate notification
+  });
+
+  it("refuses a workflow with no recipients before claiming anything", async () => {
+    const workflow = await workflowForDispatch({ recipientUserIds: [] });
+
+    await expect(
+      dispatchEmails({ workflow, emails: [email()], runAgent: doneRun })
+    ).rejects.toThrow(/recipient/i);
+
+    // Fail-fast: nothing was claimed.
+    expect(await ledgerRow(workflow.id, "msg-1")).toBeUndefined();
+  });
+});
+
+describe("dispatchEmails — run failure", () => {
+  it("finalizes as failed and notifies when the run throws", async () => {
+    const workflow = await workflowForDispatch();
+    const runAgent: RunAgent = async () => {
+      throw new Error("Odoo unreachable: ECONNREFUSED");
+    };
+
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent });
+
+    expect(summary).toMatchObject({ claimed: 1, succeeded: 0, failed: 1 });
+
+    // Ledger is finalized failed — never left stuck in `processing` (§8).
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("failed");
+    expect(row.finalizedAt).not.toBeNull();
+
+    // A failure notification reaches the recipient, carrying the error.
+    const [note] = await db.select().from(notifications).where(eq(notifications.sourceId, row.id));
+    expect(note.status).toBe("failure");
+    expect(note.sourceType).toBe("inbox");
+    expect(note.errorMessage).toBe("Odoo unreachable: ECONNREFUSED");
+
+    const recips = await db
+      .select()
+      .from(notificationRecipients)
+      .where(eq(notificationRecipients.notificationId, note.id));
+    expect(recips.map((r) => r.userId)).toEqual(workflow.recipientUserIds);
+  });
+
+  it("isolates a failed run — the rest of the batch still processes", async () => {
+    const workflow = await workflowForDispatch();
+    const runAgent: RunAgent = async (ctx) => {
+      if (ctx.email.providerMessageId === "bad") throw new Error("boom");
+      return doneRun(ctx);
+    };
+
+    const summary = await dispatchEmails({
+      workflow,
+      emails: [email({ providerMessageId: "bad" }), email({ providerMessageId: "good" })],
+      runAgent,
+    });
+
+    expect(summary).toMatchObject({ claimed: 2, succeeded: 1, failed: 1 });
+    expect((await ledgerRow(workflow.id, "bad")).status).toBe("failed");
+    expect((await ledgerRow(workflow.id, "good")).status).toBe("done");
+  });
+});

--- a/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
@@ -77,8 +77,10 @@ describe("email ledger — claimEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    expect(await claimEmail(key)).toBe(true); // first caller wins
-    expect(await claimEmail(key)).toBe(false); // re-claim rejected (idempotent)
+    // The winner gets the new ledger row's id (the dispatcher uses it as the
+    // notification's sourceId); a re-claim gets null.
+    expect(await claimEmail(key)).toEqual(expect.any(String)); // first caller wins
+    expect(await claimEmail(key)).toBeNull(); // re-claim rejected (idempotent)
   });
 
   it("lets a different workflow claim the same email independently", async () => {
@@ -87,9 +89,9 @@ describe("email ledger — claimEmail", () => {
     const wfB = await seedWorkflow(agent.id);
     const msg = { connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    expect(await claimEmail({ workflowId: wfA.id, ...msg })).toBe(true);
+    expect(await claimEmail({ workflowId: wfA.id, ...msg })).toEqual(expect.any(String));
     // Per-rule scope (D3): the same email is claimable once per workflow.
-    expect(await claimEmail({ workflowId: wfB.id, ...msg })).toBe(true);
+    expect(await claimEmail({ workflowId: wfB.id, ...msg })).toEqual(expect.any(String));
   });
 
   it("is atomic under concurrent claims — exactly one winner", async () => {
@@ -144,7 +146,7 @@ describe("email ledger — finalizeEmail", () => {
     // Simulate the reconciliation sweep finding the same provider message again
     // after a cursor loss: the ledger — not the cursor — is the source of truth,
     // so the already-finalized email must NOT be re-processed.
-    expect(await claimEmail(key)).toBe(false);
+    expect(await claimEmail(key)).toBeNull();
   });
 
   it("throws when finalizing an email that was never claimed", async () => {

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -53,15 +53,34 @@ export interface DispatchSummary {
   claimed: number;
   succeeded: number;
   failed: number;
+  /**
+   * Claimed emails whose delivery (notify) or finalize threw. Their ledger row
+   * is intentionally left `processing` for the reconciliation sweep to retry —
+   * see the ordering note below. Distinct from `failed`, which is a *run* that
+   * threw but was itself delivered and finalized as `failed`.
+   */
+  deferred: number;
 }
 
 /**
  * Dispatch a connection's batch of emails through one workflow (design §6):
  * per email — filter (deterministic) → claim (atomic ledger) → isolated run →
- * finalize ledger → notify. Claimed-but-failed runs finalize as `failed` and
- * still notify, so a run crash never leaves the ledger stuck in `processing`
- * (§8 at-least-once). Runs are independent: one email's failure never aborts the
- * rest of the batch.
+ * notify → finalize ledger.
+ *
+ * **notify runs before finalize on purpose.** The ledger row only leaves
+ * `processing` once its notification is durably persisted, so we get real
+ * at-least-once delivery (§8): if notify or finalize throws, the row stays
+ * `processing` and the reconciliation sweep (later slice) re-discovers and
+ * retries it. The rejected alternative — finalize `done` first, then notify —
+ * would, on a notify failure, strand a `done` row with no notification that no
+ * sweep could ever find: a silent, permanent loss. At-least-once may deliver a
+ * duplicate notification on a retry; that is the accepted trade against loss.
+ *
+ * A run that throws is itself an outcome, not a delivery failure: it finalizes
+ * `failed` and still notifies (a run crash never leaves the ledger stuck in
+ * `processing`). Runs are independent: one email's failure — run, delivery, or
+ * finalize — never aborts the rest of the batch. A post-claim throw is caught,
+ * counted as `deferred`, and logged; the loop moves on.
  *
  * A workflow with no recipients is a caller bug (a run nobody would ever see):
  * we reject it up front, before any claim, mirroring notify()'s own guard.
@@ -82,6 +101,7 @@ export async function dispatchEmails(params: {
     claimed: 0,
     succeeded: 0,
     failed: 0,
+    deferred: 0,
   };
 
   for (const email of emails) {
@@ -103,37 +123,59 @@ export async function dispatchEmails(params: {
     }
     summary.claimed++;
 
+    // Everything below the claim is isolated per email: a run crash, a notify
+    // failure, or a finalize failure must not abort the batch. On a post-claim
+    // throw the row stays `processing` (recoverable) and we move on.
     try {
-      const result = await runAgent({ workflow, email });
-      await finalizeEmail({
-        ...claimKey,
-        status: result.status,
-        outcome: result.outcome,
-        runId: result.runId,
-      });
-      await notify({
-        agentId: workflow.agentId,
-        title: result.title,
-        content: result.content,
-        status: "success",
-        sourceType: "inbox",
-        sourceId: ledgerId,
-        recipientUserIds: workflow.recipientUserIds,
-      });
-      summary.succeeded++;
+      // The run itself is the one step whose failure is a normal outcome
+      // (finalize `failed` + notify), not a reason to leave the row processing.
+      let result: RunAgentResult | null = null;
+      let runError: unknown;
+      try {
+        result = await runAgent({ workflow, email });
+      } catch (err) {
+        runError = err;
+      }
+
+      if (result) {
+        await notify({
+          agentId: workflow.agentId,
+          title: result.title,
+          content: result.content,
+          status: "success",
+          sourceType: "inbox",
+          sourceId: ledgerId,
+          recipientUserIds: workflow.recipientUserIds,
+        });
+        await finalizeEmail({
+          ...claimKey,
+          status: result.status,
+          outcome: result.outcome,
+          runId: result.runId,
+        });
+        summary.succeeded++;
+      } else {
+        await notify({
+          agentId: workflow.agentId,
+          title: `${workflow.name}: processing failed`,
+          content: `Could not process "${email.subject}".`,
+          status: "failure",
+          errorMessage: runError instanceof Error ? runError.message : String(runError),
+          sourceType: "inbox",
+          sourceId: ledgerId,
+          recipientUserIds: workflow.recipientUserIds,
+        });
+        await finalizeEmail({ ...claimKey, status: "failed" });
+        summary.failed++;
+      }
     } catch (err) {
-      await finalizeEmail({ ...claimKey, status: "failed" });
-      await notify({
-        agentId: workflow.agentId,
-        title: `${workflow.name}: processing failed`,
-        content: `Could not process "${email.subject}".`,
-        status: "failure",
-        errorMessage: err instanceof Error ? err.message : String(err),
-        sourceType: "inbox",
-        sourceId: ledgerId,
-        recipientUserIds: workflow.recipientUserIds,
-      });
-      summary.failed++;
+      // Delivery or finalize threw after the claim. Leave the row `processing`
+      // for the reconciliation sweep; never abort the batch.
+      summary.deferred++;
+      console.error(
+        `dispatchEmails: deferred email ${email.providerMessageId} (workflow ${workflow.id}) after claim — left processing for the reconciliation sweep`,
+        err
+      );
     }
   }
 

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -1,0 +1,141 @@
+import { claimEmail, finalizeEmail } from "@/lib/email-workflows/ledger";
+import { matchesFilter } from "@/lib/email-workflows/match";
+import { notify } from "@/lib/notifications/store";
+import type {
+  DispatchableEmail,
+  EmailWorkflowFilter,
+  ProcessedEmailOutcome,
+} from "@/lib/email-workflows/types";
+
+/**
+ * A workflow as the dispatcher needs it for one connection's batch: the filter
+ * to gate on, the agent that owns the run, and the resolved notification
+ * recipients (scope resolution lives upstream, per design §7).
+ */
+export interface WorkflowForDispatch {
+  /** email_workflows.id — the claim's workflow scope (FK into the ledger). */
+  id: string;
+  agentId: string;
+  /** The mailbox this batch of emails came from. */
+  connectionId: string;
+  name: string;
+  filter: EmailWorkflowFilter;
+  /** Prose instruction handed to the run. */
+  action: string;
+  /** Resolved feed recipients; must be non-empty. */
+  recipientUserIds: string[];
+}
+
+/** The terminal outcome of an isolated agent run (non-failure paths). */
+export interface RunAgentResult {
+  status: "done" | "no_action";
+  outcome?: ProcessedEmailOutcome;
+  runId?: string;
+  /** Human-readable feed headline + body the run produced. */
+  title: string;
+  content: string;
+}
+
+/**
+ * Runs the workflow's action against one email in an isolated context. Injected
+ * so the dispatcher's lifecycle is testable without a real OpenClaw run; the
+ * production adapter (spawns a run via the agent's tools/permissions) lands in a
+ * later slice, gated on the OpenClaw bump.
+ */
+export type RunAgent = (ctx: {
+  workflow: WorkflowForDispatch;
+  email: DispatchableEmail;
+}) => Promise<RunAgentResult>;
+
+export interface DispatchSummary {
+  skippedFilter: number;
+  skippedAlreadyClaimed: number;
+  claimed: number;
+  succeeded: number;
+  failed: number;
+}
+
+/**
+ * Dispatch a connection's batch of emails through one workflow (design §6):
+ * per email — filter (deterministic) → claim (atomic ledger) → isolated run →
+ * finalize ledger → notify. Claimed-but-failed runs finalize as `failed` and
+ * still notify, so a run crash never leaves the ledger stuck in `processing`
+ * (§8 at-least-once). Runs are independent: one email's failure never aborts the
+ * rest of the batch.
+ *
+ * A workflow with no recipients is a caller bug (a run nobody would ever see):
+ * we reject it up front, before any claim, mirroring notify()'s own guard.
+ */
+export async function dispatchEmails(params: {
+  workflow: WorkflowForDispatch;
+  emails: DispatchableEmail[];
+  runAgent: RunAgent;
+}): Promise<DispatchSummary> {
+  const { workflow, emails, runAgent } = params;
+  if (workflow.recipientUserIds.length === 0) {
+    throw new Error("dispatchEmails: workflow has no notification recipients");
+  }
+
+  const summary: DispatchSummary = {
+    skippedFilter: 0,
+    skippedAlreadyClaimed: 0,
+    claimed: 0,
+    succeeded: 0,
+    failed: 0,
+  };
+
+  for (const email of emails) {
+    if (!matchesFilter(email, workflow.filter)) {
+      summary.skippedFilter++;
+      continue;
+    }
+
+    const claimKey = {
+      workflowId: workflow.id,
+      connectionId: workflow.connectionId,
+      providerMessageId: email.providerMessageId,
+      messageIdHeader: email.messageIdHeader,
+    };
+    const ledgerId = await claimEmail(claimKey);
+    if (ledgerId === null) {
+      summary.skippedAlreadyClaimed++;
+      continue;
+    }
+    summary.claimed++;
+
+    try {
+      const result = await runAgent({ workflow, email });
+      await finalizeEmail({
+        ...claimKey,
+        status: result.status,
+        outcome: result.outcome,
+        runId: result.runId,
+      });
+      await notify({
+        agentId: workflow.agentId,
+        title: result.title,
+        content: result.content,
+        status: "success",
+        sourceType: "inbox",
+        sourceId: ledgerId,
+        recipientUserIds: workflow.recipientUserIds,
+      });
+      summary.succeeded++;
+    } catch (err) {
+      await finalizeEmail({ ...claimKey, status: "failed" });
+      await notify({
+        agentId: workflow.agentId,
+        title: `${workflow.name}: processing failed`,
+        content: `Could not process "${email.subject}".`,
+        status: "failure",
+        errorMessage: err instanceof Error ? err.message : String(err),
+        sourceType: "inbox",
+        sourceId: ledgerId,
+        recipientUserIds: workflow.recipientUserIds,
+      });
+      summary.failed++;
+    }
+  }
+
+  return summary;
+}

--- a/packages/web/src/lib/email-workflows/ledger.ts
+++ b/packages/web/src/lib/email-workflows/ledger.ts
@@ -11,8 +11,9 @@ export interface ClaimInput {
 }
 
 /**
- * Atomically claim an email for a workflow. Returns true iff THIS caller won the
- * claim and should process the email; false if it was already claimed.
+ * Atomically claim an email for a workflow. Returns the new ledger row's id iff
+ * THIS caller won the claim and should process the email; null if it was already
+ * claimed. The dispatcher uses the returned id as the notification's `sourceId`.
  *
  * The claim is an `INSERT ... ON CONFLICT DO NOTHING` on the unique key
  * `(workflowId, connectionId, providerMessageId)` — the same idempotency pattern
@@ -20,7 +21,7 @@ export interface ClaimInput {
  * sweep re-discovers the email, but the ledger rejects the re-claim, so it is
  * never processed twice. The dedup decision is deterministic code, never the LLM.
  */
-export async function claimEmail(input: ClaimInput): Promise<boolean> {
+export async function claimEmail(input: ClaimInput): Promise<string | null> {
   const rows = await db
     .insert(processedEmails)
     .values({
@@ -38,7 +39,7 @@ export async function claimEmail(input: ClaimInput): Promise<boolean> {
       ],
     })
     .returning({ id: processedEmails.id });
-  return rows.length > 0;
+  return rows[0]?.id ?? null;
 }
 
 export type FinalizeStatus = "done" | "no_action" | "failed";

--- a/packages/web/src/lib/email-workflows/match.ts
+++ b/packages/web/src/lib/email-workflows/match.ts
@@ -1,0 +1,45 @@
+import type { DispatchableEmail, EmailWorkflowFilter } from "@/lib/email-workflows/types";
+
+const domainOf = (address: string) => address.slice(address.lastIndexOf("@") + 1).toLowerCase();
+
+/**
+ * Deterministic gate the dispatcher runs before claiming an email (design §6):
+ * no LLM, no I/O. Semantics — AND across fields, OR within an array field, all
+ * string comparisons case-insensitive. An unset or empty field imposes no
+ * constraint (so a workflow with `subjectContains: []` never silently drops all
+ * mail); an empty filter matches every email.
+ */
+export function matchesFilter(email: DispatchableEmail, filter: EmailWorkflowFilter): boolean {
+  const { from, toDomain, subjectContains, hasAttachment, attachmentType, folder } = filter;
+
+  if (from?.length) {
+    const sender = email.from.toLowerCase();
+    if (!from.some((f) => f.toLowerCase() === sender)) return false;
+  }
+
+  if (toDomain?.length) {
+    const wanted = toDomain.map((d) => d.toLowerCase());
+    const recipientDomains = email.to.map(domainOf);
+    if (!recipientDomains.some((d) => wanted.includes(d))) return false;
+  }
+
+  if (subjectContains?.length) {
+    const subject = email.subject.toLowerCase();
+    if (!subjectContains.some((s) => subject.includes(s.toLowerCase()))) return false;
+  }
+
+  if (hasAttachment !== undefined && email.attachments.length > 0 !== hasAttachment) {
+    return false;
+  }
+
+  if (attachmentType) {
+    const wanted = attachmentType.toLowerCase();
+    if (!email.attachments.some((a) => a.contentType.toLowerCase() === wanted)) return false;
+  }
+
+  if (folder && email.folder?.toLowerCase() !== folder.toLowerCase()) {
+    return false;
+  }
+
+  return true;
+}

--- a/packages/web/src/lib/email-workflows/types.ts
+++ b/packages/web/src/lib/email-workflows/types.ts
@@ -25,9 +25,13 @@ export interface EmailAttachment {
  * `email_search`/`email_read`, never from the LLM.
  */
 export interface DispatchableEmail {
-  /** Provider immutable id (Graph id / Gmail message id) — part of the claim key. */
+  /** Provider immutable id (Graph id / Gmail message id) — the dedup/claim key. */
   providerMessageId: string;
-  /** RFC 5322 `Message-ID`, the secondary key. */
+  /**
+   * RFC 5322 `Message-ID`, stored for cross-provider traceability. NOT part of
+   * the claim's uniqueness — dedup is `(workflowId, connectionId,
+   * providerMessageId)` only (see {@link claimEmail}).
+   */
   messageIdHeader?: string;
   /** Normalized sender address (no display name). */
   from: string;

--- a/packages/web/src/lib/email-workflows/types.ts
+++ b/packages/web/src/lib/email-workflows/types.ts
@@ -14,6 +14,31 @@ export interface ProcessedEmailOutcome {
   note?: string;
 }
 
+export interface EmailAttachment {
+  contentType: string;
+  filename?: string;
+}
+
+/**
+ * A mailbox message as the dispatcher sees it: the deterministic fields the
+ * filter runs against plus the claim keys. Sourced from `pinchy-email`'s
+ * `email_search`/`email_read`, never from the LLM.
+ */
+export interface DispatchableEmail {
+  /** Provider immutable id (Graph id / Gmail message id) — part of the claim key. */
+  providerMessageId: string;
+  /** RFC 5322 `Message-ID`, the secondary key. */
+  messageIdHeader?: string;
+  /** Normalized sender address (no display name). */
+  from: string;
+  /** Normalized recipient addresses (To + Cc). */
+  to: string[];
+  subject: string;
+  folder?: string;
+  attachments: EmailAttachment[];
+  receivedAt: Date;
+}
+
 // Status domains live in db/enums.ts (single source of truth, DB CHECK-enforced).
 // Re-exported here under the domain-facing names for lib/email-workflows consumers.
 export {


### PR DESCRIPTION
## What

Slice D of the Inbox Agent (#139) / Background-Jobs foundation (#704): the deterministic **dispatcher** loop from the design (§6), wired to the Slice-B ledger and Slice-C notifications.

Per email × matching workflow:

**filter (deterministic) → claim (atomic ledger) → isolated agent run → finalize ledger → notify (activity feed)**

Runs on the **current OpenClaw pin (2026.6.11)** — no 2026.7.1-beta dependency. The real per-email OpenClaw run (`RunAgent` adapter), the internal cron-event route, and the event-trigger come in later slices.

## Changes

- **`matchesFilter(email, filter)`** — pure, deterministic gate (`from` / `toDomain` / `subjectContains` / `hasAttachment` / `attachmentType` / `folder`). AND across fields, OR within an array field, case-insensitive; an unset/empty field is no constraint.
- **`dispatchEmails({ workflow, emails, runAgent })`** — the lifecycle. The run is **injected** (`RunAgent`) so the whole claim→finalize→notify path is testable without spawning a real OpenClaw run; the production adapter lands in a later slice.
- **Failure path** — a run that throws finalizes the ledger row `failed` and still notifies, so a crash never leaves it stuck in `processing` (design §8, at-least-once). Runs are isolated: one email's failure never aborts the batch.
- **Empty-recipient guard** — a workflow with no recipients is rejected up front, before any claim (mirrors `notify()`'s own guard).
- **`claimEmail` now returns the claimed ledger row id** (`string | null`) instead of a bool, so the notification's `sourceId` points at the ledger row. No other callers; ledger claim tests updated.

## Design decisions

- **Injected `RunAgent`** keeps Slice D fully deterministic and version-independent — the OpenClaw-bound run adapter is a clean seam for the next slice.
- **`sourceType: "inbox"` + `sourceId` = ledger row id** — source-agnostic provenance, consistent with the Slice-C notifications foundation (no FK).
- **Single-workflow batch** — `dispatchEmails` handles one workflow's email batch; the workflow×workflow fan-out is the caller's (route/sweep) loop.

## Tests

- **9 unit** (`matchesFilter`): every field + AND/OR/case-insensitive/empty-array semantics.
- **6 real-DB integration** (`email-dispatch.integration.test.ts`): happy-path lifecycle + provenance, filter skip (no claim), idempotent re-dispatch (no duplicate notification), recipient guard, failure finalize+notify, batch isolation. Failure tests verified non-blind (temporarily broke the `catch` → confirmed RED).

## Gates

- `test` (unit) — 8038 passed
- `test:db` (integration, ephemeral throwaway PG) — 201 passed
- `build` — compiled (typecheck clean)
- `lint` — 0 errors (626 pre-existing warnings, none new)
- `format:check` — clean

## Docs

No user-facing surface yet (pure lib/orchestration) — product docs land with the Automations UI slice, consistent with Slices B/C.