### PR TITLE
feat(inbox-agent): production RunAgent adapter — isolated OpenClaw runs

### DIFF
--- a/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
@@ -1,8 +1,10 @@
 // Real-DB integration tests for the Inbox Agent dispatcher (Slice D). The
 // dispatcher is the loop from design §6: for each new email × matching workflow,
-// filter (deterministic) → claim (ledger) → isolated agent run → finalize ledger
-// → notify (activity feed). The run itself is injected (`runAgent`) so the whole
-// lifecycle is testable on the current OpenClaw pin without spawning a real run.
+// filter (deterministic) → claim (ledger) → isolated agent run → notify
+// (activity feed) → finalize ledger (notify-before-finalize is load-bearing,
+// see dispatch.ts). The run is injected (`runAgent`) so the lifecycle is
+// testable without a real OpenClaw run; the last describe block wires the
+// production adapter (`createOpenClawRunAgent`) against a mock gateway client.
 import { describe, it, expect } from "vitest";
 import { and, eq } from "drizzle-orm";
 
@@ -17,7 +19,9 @@ import {
 } from "@/db/schema";
 import { dispatchEmails } from "@/lib/email-workflows/dispatch";
 import type { RunAgent, WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+import { createOpenClawRunAgent } from "@/lib/email-workflows/run-adapter";
 import type { DispatchableEmail } from "@/lib/email-workflows/types";
+import { inboxSessionKey } from "@/lib/session-key";
 
 let userCounter = 0;
 async function seedUser() {
@@ -104,9 +108,9 @@ async function ledgerRow(workflowId: string, providerMessageId: string) {
 describe("dispatchEmails — fan-out lifecycle", () => {
   it("claims, runs, finalizes and notifies for a matching email", async () => {
     const workflow = await workflowForDispatch();
-    const seen: DispatchableEmail[] = [];
+    const seen: { email: DispatchableEmail; ledgerId: string }[] = [];
     const runAgent: RunAgent = async (ctx) => {
-      seen.push(ctx.email);
+      seen.push({ email: ctx.email, ledgerId: ctx.ledgerId });
       return doneRun(ctx);
     };
 
@@ -114,11 +118,14 @@ describe("dispatchEmails — fan-out lifecycle", () => {
 
     // Ran exactly once, on the matching email.
     expect(seen).toHaveLength(1);
-    expect(seen[0].providerMessageId).toBe("msg-1");
+    expect(seen[0].email.providerMessageId).toBe("msg-1");
     expect(summary).toMatchObject({ claimed: 1, succeeded: 1, failed: 0 });
 
     // Ledger finalized with the run's terminal status + outcome.
     const row = await ledgerRow(workflow.id, "msg-1");
+    // The run received the claim's ledger row id — the adapter keys the
+    // isolated OpenClaw session by it, so this correlation must be exact.
+    expect(seen[0].ledgerId).toBe(row.id);
     expect(row.status).toBe("done");
     expect(row.outcome).toEqual({ odooModel: "account.move", odooId: 7 });
     expect(row.runId).toBe("run-x");
@@ -296,5 +303,52 @@ describe("dispatchEmails — delivery failure", () => {
       .from(notifications)
       .where(eq(notifications.agentId, workflow.agentId));
     expect(notes).toHaveLength(0);
+  });
+});
+
+describe("dispatchEmails × createOpenClawRunAgent — production adapter end-to-end", () => {
+  it("streams a real-shaped OpenClaw run into a finalized ledger row and a feed notification", async () => {
+    const workflow = await workflowForDispatch();
+    const chatCalls: { message: string; options: Record<string, unknown> }[] = [];
+    const client = {
+      chat: (message: string, options: Record<string, unknown>) => {
+        chatCalls.push({ message, options });
+        return (async function* () {
+          yield { type: "agent_start" as const, text: "", runId: "run-real" };
+          yield {
+            type: "text" as const,
+            text:
+              'Filed it.\n\n```json\n{"status":"done","title":"Invoice 4711 filed",' +
+              '"content":"Drafted supplier bill.","outcome":{"odooModel":"account.move","odooId":9}}\n```',
+            runId: "run-real",
+          };
+          yield { type: "done" as const, text: "", runId: "run-real" };
+        })();
+      },
+      chatAbort: async () => undefined,
+    };
+    const runAgent = createOpenClawRunAgent({
+      client: client as never,
+      loadAgentModel: async () => "ollama-cloud/gemini-3-flash",
+      waitForAgentReady: async () => true,
+    });
+
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent });
+
+    expect(summary).toMatchObject({ claimed: 1, succeeded: 1, failed: 0, deferred: 0 });
+
+    // The ledger row carries the run's report verbatim, and the run was
+    // addressed at the isolated inbox session keyed by exactly this row.
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("done");
+    expect(row.outcome).toEqual({ odooModel: "account.move", odooId: 9 });
+    expect(row.runId).toBe("run-real");
+    expect(chatCalls).toHaveLength(1);
+    expect(chatCalls[0].options.sessionKey).toBe(inboxSessionKey(workflow.agentId, row.id));
+
+    // The feed entry is the agent's own headline, not a synthesized one.
+    const [note] = await db.select().from(notifications).where(eq(notifications.sourceId, row.id));
+    expect(note.title).toBe("Invoice 4711 filed");
+    expect(note.status).toBe("success");
   });
 });

--- a/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-dispatch.integration.test.ts
@@ -17,7 +17,7 @@ import {
   notificationRecipients,
   processedEmails,
 } from "@/db/schema";
-import { dispatchEmails } from "@/lib/email-workflows/dispatch";
+import { dispatchEmails, RunDeferredError } from "@/lib/email-workflows/dispatch";
 import type { RunAgent, WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
 import { createOpenClawRunAgent } from "@/lib/email-workflows/run-adapter";
 import type { DispatchableEmail } from "@/lib/email-workflows/types";
@@ -269,6 +269,53 @@ describe("dispatchEmails — run failure", () => {
     expect(summary).toMatchObject({ claimed: 2, succeeded: 1, failed: 1 });
     expect((await ledgerRow(workflow.id, "bad")).status).toBe("failed");
     expect((await ledgerRow(workflow.id, "good")).status).toBe("done");
+  });
+});
+
+describe("dispatchEmails — deferred run", () => {
+  it("leaves the row processing (not failed) when the run signals RunDeferredError", async () => {
+    const workflow = await workflowForDispatch();
+    // A run that never started because the agent wasn't in the runtime yet —
+    // a purely transient infra gap. It must be retryable by the reconciliation
+    // sweep, not a terminal `failed` that the sweep can never re-discover.
+    const runAgent: RunAgent = async () => {
+      throw new RunDeferredError("agent not in the OpenClaw runtime yet");
+    };
+
+    const summary = await dispatchEmails({ workflow, emails: [email()], runAgent });
+
+    expect(summary).toMatchObject({ claimed: 1, succeeded: 0, failed: 0, deferred: 1 });
+
+    // Recoverable, exactly like a notify/finalize failure: the row stays
+    // `processing` and is never finalized.
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("processing");
+    expect(row.finalizedAt).toBeNull();
+
+    // A deferral is silent — no failure notification reaches the recipient,
+    // because the email hasn't actually failed; the sweep will retry it.
+    const notes = await db.select().from(notifications).where(eq(notifications.sourceId, row.id));
+    expect(notes).toHaveLength(0);
+  });
+
+  it("isolates a deferred run — the rest of the batch still processes", async () => {
+    const workflow = await workflowForDispatch();
+    const runAgent: RunAgent = async (ctx) => {
+      if (ctx.email.providerMessageId === "wait") {
+        throw new RunDeferredError("not ready");
+      }
+      return doneRun(ctx);
+    };
+
+    const summary = await dispatchEmails({
+      workflow,
+      emails: [email({ providerMessageId: "wait" }), email({ providerMessageId: "go" })],
+      runAgent,
+    });
+
+    expect(summary).toMatchObject({ claimed: 2, succeeded: 1, failed: 0, deferred: 1 });
+    expect((await ledgerRow(workflow.id, "wait")).status).toBe("processing");
+    expect((await ledgerRow(workflow.id, "go")).status).toBe("done");
   });
 });
 

--- a/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
+++ b/packages/web/src/__tests__/lib/chats/classify-sessions.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect } from "vitest";
 import { classifyUserSessions, type RawSession } from "@/lib/chats/classify-sessions";
+import { inboxSessionKey } from "@/lib/session-key";
 
 const AGENT = "agt_1";
 
@@ -142,6 +143,25 @@ describe("classifyUserSessions", () => {
       {
         key: `agent:${AGENT}:subagent:u-1`,
         sessionId: "ses_8",
+        lastInteractionAt: 1,
+      },
+    ];
+
+    const result = classifyUserSessions(sessions, "u-1", new Set());
+
+    expect(result).toEqual([]);
+  });
+
+  it("excludes an :inbox: key — an Inbox-Agent run must never surface as a user chat (#139)", () => {
+    // Derived from the real helper so a key-format change can't silently
+    // desynchronize this pin from what the dispatcher actually creates.
+    // Worst-case crafted: the ledger segment EQUALS the requesting userId, so
+    // this test only survives on the namespace check (`:direct:`), not on the
+    // principal comparison accidentally saving us.
+    const sessions: RawSession[] = [
+      {
+        key: inboxSessionKey(AGENT, "u-1"),
+        sessionId: "ses_inbox",
         lastInteractionAt: 1,
       },
     ];

--- a/packages/web/src/__tests__/lib/email-workflows/report.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/report.test.ts
@@ -1,0 +1,120 @@
+// The inbox run's result contract (#139): the agent ends its reply with one
+// fenced JSON block { status, title, content, outcome? }. parseInboxReport is
+// the pure extractor/validator the OpenClaw run adapter uses — it never
+// throws; it returns a Result so the adapter can feed the error back to the
+// model in a single correction turn before failing the run honestly.
+import { describe, it, expect } from "vitest";
+
+import { parseInboxReport } from "@/lib/email-workflows/report";
+
+const validReport = {
+  status: "done",
+  title: "1 invoice filed",
+  content: "Drafted supplier bill for Invoice 4711 in Odoo.",
+};
+
+function fenced(json: unknown, lang = "json"): string {
+  return "```" + lang + "\n" + JSON.stringify(json, null, 2) + "\n```";
+}
+
+describe("parseInboxReport", () => {
+  it("extracts a fenced json block after prose", () => {
+    const text = `I read the email and filed the invoice.\n\n${fenced(validReport)}`;
+
+    const result = parseInboxReport(text);
+
+    expect(result).toEqual({
+      ok: true,
+      report: {
+        status: "done",
+        title: "1 invoice filed",
+        content: "Drafted supplier bill for Invoice 4711 in Odoo.",
+      },
+    });
+  });
+
+  it("takes the LAST fenced block when several are present", () => {
+    const first = fenced({ status: "no_action", title: "draft", content: "thinking out loud" });
+    const last = fenced(validReport);
+    const result = parseInboxReport(`${first}\n\nActually, I did file it:\n\n${last}`);
+
+    expect(result.ok && result.report.status).toBe("done");
+    expect(result.ok && result.report.title).toBe("1 invoice filed");
+  });
+
+  it("accepts a fence without a language tag", () => {
+    const result = parseInboxReport(fenced(validReport, ""));
+    expect(result.ok).toBe(true);
+  });
+
+  it("accepts a bare JSON reply with no fence (correction-turn shape)", () => {
+    const result = parseInboxReport(`  ${JSON.stringify(validReport)}  `);
+    expect(result.ok && result.report.title).toBe("1 invoice filed");
+  });
+
+  it("passes a valid outcome through and strips unknown keys", () => {
+    const result = parseInboxReport(
+      fenced({
+        ...validReport,
+        outcome: { odooModel: "account.move", odooId: 7, link: "https://odoo/x", note: "draft" },
+        confidence: 0.9, // not part of the contract — must be stripped
+      })
+    );
+
+    expect(result.ok && result.report.outcome).toEqual({
+      odooModel: "account.move",
+      odooId: 7,
+      link: "https://odoo/x",
+      note: "draft",
+    });
+    expect(result.ok && "confidence" in result.report).toBe(false);
+  });
+
+  it("reports no_action", () => {
+    const result = parseInboxReport(
+      fenced({ status: "no_action", title: "Nothing to file", content: "No invoice attached." })
+    );
+    expect(result.ok && result.report.status).toBe("no_action");
+  });
+
+  it("fails with a schema hint when status is not in the enum", () => {
+    const result = parseInboxReport(fenced({ ...validReport, status: "finished" }));
+
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toMatch(/status/);
+  });
+
+  it("fails when the title is empty after trimming", () => {
+    const result = parseInboxReport(fenced({ ...validReport, title: "   " }));
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toMatch(/title/);
+  });
+
+  it("fails when there is no JSON anywhere", () => {
+    const result = parseInboxReport("I filed the invoice, all good!");
+    expect(result.ok).toBe(false);
+    expect(!result.ok && result.error).toMatch(/JSON/i);
+  });
+
+  it("fails on malformed JSON inside the fence", () => {
+    const result = parseInboxReport('```json\n{ "status": "done", \n```');
+    expect(result.ok).toBe(false);
+  });
+
+  it("trims title and content", () => {
+    const result = parseInboxReport(
+      fenced({ status: "done", title: "  spaced  ", content: "  body  " })
+    );
+    expect(result.ok && result.report.title).toBe("spaced");
+    expect(result.ok && result.report.content).toBe("body");
+  });
+
+  it("truncates a runaway title and content instead of failing the run", () => {
+    const result = parseInboxReport(
+      fenced({ status: "done", title: "t".repeat(500), content: "c".repeat(20000) })
+    );
+
+    expect(result.ok && result.report.title.length).toBe(200);
+    expect(result.ok && result.report.content.length).toBe(8000);
+  });
+});

--- a/packages/web/src/__tests__/lib/email-workflows/run-adapter.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/run-adapter.test.ts
@@ -6,7 +6,7 @@
 import { describe, it, expect, vi, afterEach } from "vitest";
 
 import { createOpenClawRunAgent } from "@/lib/email-workflows/run-adapter";
-import type { WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+import { RunDeferredError, type WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
 import type { DispatchableEmail } from "@/lib/email-workflows/types";
 import { inboxSessionKey } from "@/lib/session-key";
 
@@ -198,16 +198,22 @@ describe("createOpenClawRunAgent — failure semantics", () => {
     expect(client.chat).not.toHaveBeenCalled();
   });
 
-  it("throws before chatting when the agent never becomes ready in the runtime", async () => {
+  it("DEFERS (not fails) when the agent never becomes ready — a transient infra gap must be retryable", async () => {
     const client = makeClient();
 
-    await expect(
-      makeAdapter(client, { waitForAgentReady: async () => false })({
-        workflow,
-        email,
-        ledgerId: "l",
-      })
-    ).rejects.toThrow(/runtime/);
+    // RunDeferredError is the sentinel the dispatcher treats as "leave the row
+    // processing for the reconciliation sweep", NOT as a terminal run failure.
+    // The agent simply isn't in the runtime yet (a config reload can lag a
+    // restart by 10–30 s); failing the email terminally would strand it, since
+    // the sweep only retries `processing`/`deferred` rows, never `failed` ones.
+    const promise = makeAdapter(client, { waitForAgentReady: async () => false })({
+      workflow,
+      email,
+      ledgerId: "l",
+    });
+
+    await expect(promise).rejects.toBeInstanceOf(RunDeferredError);
+    await expect(promise).rejects.toThrow(/runtime/);
     expect(client.chat).not.toHaveBeenCalled();
   });
 });

--- a/packages/web/src/__tests__/lib/email-workflows/run-adapter.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/run-adapter.test.ts
@@ -1,0 +1,266 @@
+// Unit tests for the production RunAgent adapter (#139): one isolated OpenClaw
+// run per claimed email. The OpenClaw client is mocked at the chat()/chatAbort()
+// seam (same pattern as client-router.test.ts) — chunk shapes mirror what real
+// Gateways emit, including the verified gotchas: `done` also follows `error`,
+// and tool activity never appears as chunks.
+import { describe, it, expect, vi, afterEach } from "vitest";
+
+import { createOpenClawRunAgent } from "@/lib/email-workflows/run-adapter";
+import type { WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+import type { DispatchableEmail } from "@/lib/email-workflows/types";
+import { inboxSessionKey } from "@/lib/session-key";
+
+const workflow: WorkflowForDispatch = {
+  id: "wf-1",
+  agentId: "agent-1",
+  connectionId: "conn-1",
+  name: "File invoices",
+  filter: {},
+  action: "Draft a supplier bill in Odoo from the attached invoice.",
+  recipientUserIds: ["u-1"],
+};
+
+const email: DispatchableEmail = {
+  providerMessageId: "msg-77",
+  from: "vendor@supplier.com",
+  to: ["ap@acme.com"],
+  subject: "Invoice 4711",
+  folder: "INBOX",
+  attachments: [{ contentType: "application/pdf", filename: "invoice.pdf" }],
+  receivedAt: new Date("2026-07-14T09:00:00Z"),
+};
+
+const report = {
+  status: "done",
+  title: "1 invoice filed",
+  content: "Drafted supplier bill for Invoice 4711.",
+  outcome: { odooModel: "account.move", odooId: 7 },
+};
+
+type Chunk = { type: string; text: string; runId: string };
+
+function stream(...chunks: Chunk[]) {
+  return (async function* () {
+    for (const chunk of chunks) yield chunk;
+  })();
+}
+
+function reportText(payload: unknown = report): string {
+  return "All done.\n\n```json\n" + JSON.stringify(payload) + "\n```";
+}
+
+function makeClient() {
+  return {
+    chat: vi.fn(),
+    chatAbort: vi.fn().mockResolvedValue(undefined),
+  };
+}
+
+function makeAdapter(
+  client: ReturnType<typeof makeClient>,
+  overrides: {
+    loadAgentModel?: (agentId: string) => Promise<string | null>;
+    waitForAgentReady?: (agentId: string) => Promise<boolean>;
+    timeoutMs?: number;
+  } = {}
+) {
+  return createOpenClawRunAgent({
+    // The adapter only touches chat/chatAbort; the structural cast keeps the
+    // mock honest about that seam.
+    client: client as never,
+    loadAgentModel: overrides.loadAgentModel ?? (async () => "ollama-cloud/gemini-3-flash"),
+    waitForAgentReady: overrides.waitForAgentReady ?? (async () => true),
+    ...(overrides.timeoutMs !== undefined ? { timeoutMs: overrides.timeoutMs } : {}),
+  });
+}
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe("createOpenClawRunAgent — happy path", () => {
+  it("runs one isolated chat and maps the report to a RunAgentResult", async () => {
+    const client = makeClient();
+    // The JSON block arrives split across chunks, as real streams deliver it.
+    const text = reportText();
+    client.chat.mockReturnValueOnce(
+      stream(
+        { type: "agent_start", text: "", runId: "run-9" },
+        { type: "text", text: text.slice(0, 30), runId: "run-9" },
+        { type: "text", text: text.slice(30), runId: "run-9" },
+        { type: "done", text: "", runId: "run-9" }
+      )
+    );
+
+    const result = await makeAdapter(client)({ workflow, email, ledgerId: "ledger-5" });
+
+    expect(result).toEqual({
+      status: "done",
+      title: "1 invoice filed",
+      content: "Drafted supplier bill for Invoice 4711.",
+      outcome: { odooModel: "account.move", odooId: 7 },
+      runId: "run-9",
+    });
+  });
+
+  it("addresses the run at the isolated inbox session with the agent's real model", async () => {
+    const client = makeClient();
+    client.chat.mockReturnValueOnce(stream({ type: "text", text: reportText(), runId: "r" }));
+
+    await makeAdapter(client)({ workflow, email, ledgerId: "ledger-5" });
+
+    const [message, options] = client.chat.mock.calls[0];
+    expect(options).toMatchObject({
+      sessionKey: inboxSessionKey("agent-1", "ledger-5"),
+      agentId: "agent-1",
+      // Split on the FIRST '/': without the explicit pair the Gateway resolves
+      // capability checks against the gateway-wide default model (#324).
+      provider: "ollama-cloud",
+      model: "gemini-3-flash",
+    });
+    expect(options.extraSystemPrompt).toContain('"status"');
+    expect(options.extraSystemPrompt).toContain("no_action");
+    // The task carries the workflow action plus the deterministic email
+    // metadata; the agent reads the full email itself via its email tools.
+    expect(message).toContain(workflow.action);
+    expect(message).toContain("msg-77");
+    expect(message).toContain("Invoice 4711");
+    expect(message).toContain("vendor@supplier.com");
+  });
+
+  it("keeps the model id's own slashes intact when splitting provider/model", async () => {
+    const client = makeClient();
+    client.chat.mockReturnValueOnce(stream({ type: "text", text: reportText(), runId: "r" }));
+
+    await makeAdapter(client, { loadAgentModel: async () => "openrouter/meta/llama-3-70b" })({
+      workflow,
+      email,
+      ledgerId: "l",
+    });
+
+    expect(client.chat.mock.calls[0][1]).toMatchObject({
+      provider: "openrouter",
+      model: "meta/llama-3-70b",
+    });
+  });
+
+  it("strips OpenClaw's <final> envelope before parsing the report", async () => {
+    const client = makeClient();
+    client.chat.mockReturnValueOnce(
+      stream({ type: "text", text: `<final>${reportText()}</final>`, runId: "r" })
+    );
+
+    const result = await makeAdapter(client)({ workflow, email, ledgerId: "l" });
+
+    expect(result.status).toBe("done");
+  });
+
+  it("maps a no_action report", async () => {
+    const client = makeClient();
+    client.chat.mockReturnValueOnce(
+      stream({
+        type: "text",
+        text: reportText({ status: "no_action", title: "Nothing to file", content: "No invoice." }),
+        runId: "r",
+      })
+    );
+
+    const result = await makeAdapter(client)({ workflow, email, ledgerId: "l" });
+
+    expect(result.status).toBe("no_action");
+    expect(result.title).toBe("Nothing to file");
+  });
+});
+
+describe("createOpenClawRunAgent — failure semantics", () => {
+  it("throws on an error chunk even though a done chunk follows (done ≠ success)", async () => {
+    const client = makeClient();
+    // Verified real-Gateway sequence for a failed run: error, THEN done.
+    client.chat.mockReturnValueOnce(
+      stream(
+        { type: "agent_start", text: "", runId: "r" },
+        { type: "error", text: "provider rejected the request schema or tool payload", runId: "r" },
+        { type: "done", text: "", runId: "r" }
+      )
+    );
+
+    await expect(makeAdapter(client)({ workflow, email, ledgerId: "l" })).rejects.toThrow(
+      /provider rejected/
+    );
+  });
+
+  it("throws when the agent has no model configured", async () => {
+    const client = makeClient();
+
+    await expect(
+      makeAdapter(client, { loadAgentModel: async () => null })({ workflow, email, ledgerId: "l" })
+    ).rejects.toThrow(/model/);
+    expect(client.chat).not.toHaveBeenCalled();
+  });
+
+  it("throws before chatting when the agent never becomes ready in the runtime", async () => {
+    const client = makeClient();
+
+    await expect(
+      makeAdapter(client, { waitForAgentReady: async () => false })({
+        workflow,
+        email,
+        ledgerId: "l",
+      })
+    ).rejects.toThrow(/runtime/);
+    expect(client.chat).not.toHaveBeenCalled();
+  });
+});
+
+describe("createOpenClawRunAgent — correction turn", () => {
+  it("feeds the parse error back once in the same session and accepts the corrected reply", async () => {
+    const client = makeClient();
+    client.chat
+      .mockReturnValueOnce(
+        stream({ type: "text", text: "I filed the invoice, all good!", runId: "run-1" })
+      )
+      .mockReturnValueOnce(stream({ type: "text", text: JSON.stringify(report), runId: "run-2" }));
+
+    const result = await makeAdapter(client)({ workflow, email, ledgerId: "ledger-5" });
+
+    expect(result.title).toBe("1 invoice filed");
+    expect(client.chat).toHaveBeenCalledTimes(2);
+    const [correctionMessage, correctionOptions] = client.chat.mock.calls[1];
+    // Same isolated session, so the model still has its own context.
+    expect(correctionOptions.sessionKey).toBe(inboxSessionKey("agent-1", "ledger-5"));
+    expect(correctionMessage).toMatch(/JSON/);
+  });
+
+  it("fails the run when the correction turn is also invalid", async () => {
+    const client = makeClient();
+    client.chat
+      .mockReturnValueOnce(stream({ type: "text", text: "no json here", runId: "r1" }))
+      .mockReturnValueOnce(stream({ type: "text", text: "still no json", runId: "r2" }));
+
+    await expect(makeAdapter(client)({ workflow, email, ledgerId: "l" })).rejects.toThrow(
+      /report/i
+    );
+    expect(client.chat).toHaveBeenCalledTimes(2);
+  });
+});
+
+describe("createOpenClawRunAgent — watchdog", () => {
+  it("aborts a hung run via chatAbort and throws", async () => {
+    vi.useFakeTimers();
+    const client = makeClient();
+    client.chat.mockReturnValueOnce(
+      (async function* () {
+        yield { type: "agent_start", text: "", runId: "run-hung" };
+        // The stream never ends — a zombie run.
+        await new Promise(() => {});
+      })()
+    );
+
+    const pending = makeAdapter(client, { timeoutMs: 1000 })({ workflow, email, ledgerId: "l" });
+    const expectation = expect(pending).rejects.toThrow(/timed out/);
+    await vi.advanceTimersByTimeAsync(1500);
+    await expectation;
+
+    expect(client.chatAbort).toHaveBeenCalledWith(inboxSessionKey("agent-1", "l"), "run-hung");
+  });
+});

--- a/packages/web/src/__tests__/lib/session-key.test.ts
+++ b/packages/web/src/__tests__/lib/session-key.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect } from "vitest";
 
-import { directSessionKey } from "@/lib/session-key";
+import { directSessionKey, inboxSessionKey } from "@/lib/session-key";
 
 describe("directSessionKey", () => {
   it("builds the legacy per-user direct key", () => {
@@ -15,5 +15,15 @@ describe("directSessionKey", () => {
 
   it("omits the chat segment when chatId is undefined", () => {
     expect(directSessionKey("a", "b", undefined)).toBe("agent:a:direct:b");
+  });
+});
+
+describe("inboxSessionKey", () => {
+  it("builds an isolated per-ledger-row key that is not a direct key", () => {
+    const key = inboxSessionKey("agent-1", "ledger-42");
+    expect(key).toBe("agent:agent-1:inbox:ledger-42");
+    // Never collides with the user-chat namespace: `:direct:` must not appear,
+    // so chat listing (which keys on `:direct:`) can never surface an inbox run.
+    expect(key).not.toContain(":direct:");
   });
 });

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -26,6 +26,26 @@ export interface WorkflowForDispatch {
   recipientUserIds: string[];
 }
 
+/**
+ * A run signalling that it never actually started because of a *transient*
+ * condition (e.g. the agent isn't in the OpenClaw runtime yet — a config reload
+ * can lag a gateway restart by 10–30 s). The dispatcher treats this exactly
+ * like a delivery failure: the claim's row is left `processing` for the
+ * reconciliation sweep to retry, NOT finalized `failed`. A terminal `failed`
+ * would strand the email — the sweep only re-discovers `processing`/`deferred`
+ * rows — turning a momentary infra gap into permanent, silent loss.
+ *
+ * Reserve this for conditions that self-heal on retry. A misconfiguration (no
+ * model) or a run that started and then failed is a genuine failure: throw a
+ * plain Error so the row finalizes `failed` and the recipient is notified.
+ */
+export class RunDeferredError extends Error {
+  constructor(message: string) {
+    super(message);
+    this.name = "RunDeferredError";
+  }
+}
+
 /** The terminal outcome of an isolated agent run (non-failure paths). */
 export interface RunAgentResult {
   status: "done" | "no_action";
@@ -137,6 +157,11 @@ export async function dispatchEmails(params: {
       try {
         result = await runAgent({ workflow, email, ledgerId });
       } catch (err) {
+        // A deferral is not a run failure: the run never really started (a
+        // transient infra gap). Rethrow to the outer catch so the row stays
+        // `processing` for the reconciliation sweep, rather than finalizing
+        // `failed` + notifying — which would strand the email permanently.
+        if (err instanceof RunDeferredError) throw err;
         runError = err;
       }
 
@@ -172,8 +197,9 @@ export async function dispatchEmails(params: {
         summary.failed++;
       }
     } catch (err) {
-      // Delivery or finalize threw after the claim. Leave the row `processing`
-      // for the reconciliation sweep; never abort the batch.
+      // A deferral (RunDeferredError), or delivery/finalize threw after the
+      // claim. Leave the row `processing` for the reconciliation sweep; never
+      // abort the batch.
       summary.deferred++;
       console.error(
         `dispatchEmails: deferred email ${email.providerMessageId} (workflow ${workflow.id}) after claim — left processing for the reconciliation sweep`,

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -38,13 +38,16 @@ export interface RunAgentResult {
 
 /**
  * Runs the workflow's action against one email in an isolated context. Injected
- * so the dispatcher's lifecycle is testable without a real OpenClaw run; the
- * production adapter (spawns a run via the agent's tools/permissions) lands in a
- * later slice, gated on the OpenClaw bump.
+ * so the dispatcher's lifecycle is testable without a real OpenClaw run. The
+ * production adapter is `createOpenClawRunAgent` (run-adapter.ts): it runs on
+ * the current OpenClaw pin — no version bump required. `ledgerId` is the claim's
+ * `processed_emails` row id; the adapter keys the isolated OpenClaw session by
+ * it so run ↔ ledger correlation is one string comparison.
  */
 export type RunAgent = (ctx: {
   workflow: WorkflowForDispatch;
   email: DispatchableEmail;
+  ledgerId: string;
 }) => Promise<RunAgentResult>;
 
 export interface DispatchSummary {
@@ -132,7 +135,7 @@ export async function dispatchEmails(params: {
       let result: RunAgentResult | null = null;
       let runError: unknown;
       try {
-        result = await runAgent({ workflow, email });
+        result = await runAgent({ workflow, email, ledgerId });
       } catch (err) {
         runError = err;
       }

--- a/packages/web/src/lib/email-workflows/report.ts
+++ b/packages/web/src/lib/email-workflows/report.ts
@@ -1,0 +1,101 @@
+import { z } from "zod";
+
+import type { ProcessedEmailOutcome } from "@/lib/email-workflows/types";
+
+/**
+ * The inbox run's result contract (#139): the agent must end its reply with
+ * one fenced JSON block matching this schema. This module is the pure
+ * extractor/validator; the OpenClaw run adapter feeds a failure back to the
+ * model as a single correction turn before failing the run.
+ *
+ * Design note: OpenClaw does not stream `tool_use` args through `chat()` (the
+ * declared chunk type exists but real Gateways never emit it), so a report
+ * *tool* would be invisible to the adapter. The final assistant text is the
+ * native result channel — hence a JSON block, not a tool call.
+ */
+
+const TITLE_MAX = 200;
+const CONTENT_MAX = 8000;
+
+const outcomeSchema = z.object({
+  odooModel: z.string().optional(),
+  odooId: z.number().int().optional(),
+  link: z.string().optional(),
+  note: z.string().optional(),
+});
+
+const reportSchema = z.object({
+  status: z.enum(["done", "no_action"]),
+  // A runaway model reply must not fail the run — truncate, don't reject.
+  // Emptiness after trimming DOES reject: a blank feed entry is useless noise.
+  title: z
+    .string()
+    .trim()
+    .min(1, "title must not be empty")
+    .transform((s) => s.slice(0, TITLE_MAX)),
+  content: z
+    .string()
+    .trim()
+    .min(1, "content must not be empty")
+    .transform((s) => s.slice(0, CONTENT_MAX)),
+  outcome: outcomeSchema.optional(),
+});
+
+export interface InboxReport {
+  status: "done" | "no_action";
+  title: string;
+  content: string;
+  outcome?: ProcessedEmailOutcome;
+}
+
+export type ParseInboxReportResult =
+  { ok: true; report: InboxReport } | { ok: false; error: string };
+
+/**
+ * Extract and validate the report from a run's final assistant text.
+ *
+ * Deterministic extraction rule: the LAST fenced code block wins (models often
+ * think out loud in earlier blocks); if the text has no fence at all, the whole
+ * trimmed text is tried as bare JSON — that is exactly the shape a correction
+ * turn ("reply with only the JSON") produces. Never throws: the error string is
+ * written to be shown to the model, so it names the offending field.
+ */
+export function parseInboxReport(text: string): ParseInboxReportResult {
+  const raw = extractCandidate(text);
+  if (raw === null) {
+    return { ok: false, error: "No JSON found: end your reply with one fenced ```json block." };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch (err) {
+    return {
+      ok: false,
+      error: `The report block is not valid JSON: ${err instanceof Error ? err.message : String(err)}`,
+    };
+  }
+
+  const result = reportSchema.safeParse(parsed);
+  if (!result.success) {
+    const issues = result.error.issues
+      .map((issue) => `${issue.path.join(".") || "report"}: ${issue.message}`)
+      .join("; ");
+    return { ok: false, error: `The report does not match the schema — ${issues}` };
+  }
+
+  return { ok: true, report: result.data };
+}
+
+/** The last fenced block's body, or the whole text if it looks like bare JSON. */
+function extractCandidate(text: string): string | null {
+  const fences = [...text.matchAll(/```[^\n`]*\n([\s\S]*?)```/g)];
+  if (fences.length > 0) {
+    return fences[fences.length - 1][1];
+  }
+  const trimmed = text.trim();
+  if (trimmed.startsWith("{")) {
+    return trimmed;
+  }
+  return null;
+}

--- a/packages/web/src/lib/email-workflows/run-adapter.ts
+++ b/packages/web/src/lib/email-workflows/run-adapter.ts
@@ -1,0 +1,194 @@
+import type { OpenClawClient } from "openclaw-node";
+
+import type { RunAgent, WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+import { parseInboxReport } from "@/lib/email-workflows/report";
+import type { DispatchableEmail } from "@/lib/email-workflows/types";
+import { inboxSessionKey } from "@/lib/session-key";
+import { stripFinalEnvelope } from "@/server/silent-reply-buffer";
+
+/**
+ * The production RunAgent (#139): one isolated OpenClaw run per claimed email.
+ *
+ * Native capabilities only, on the current OpenClaw pin — no version bump:
+ * - Isolation via the session model: each run lives at
+ *   `agent:<id>:inbox:<ledgerId>` (see {@link inboxSessionKey}), so it never
+ *   surfaces as a user chat and the daily session reset garbage-collects it.
+ * - The task rides in as a normal chat turn; the agent reads the full email
+ *   itself through its email tools, so its own permissions govern the run.
+ * - The result comes back as the final assistant text ending in one fenced
+ *   JSON block ({@link parseInboxReport}). NOT a tool call: real Gateways do
+ *   not emit `tool_use` chunks through `chat()`, so a report tool would be
+ *   invisible here — the final text is the native result channel.
+ *
+ * Failure semantics match the dispatcher's contract: any throw is a *run*
+ * failure (finalize `failed` + failure notification), never a stuck ledger row.
+ * A hung run is aborted via `chatAbort` after `timeoutMs` so a wedged provider
+ * can't stall the whole batch. One verified Gateway gotcha is load-bearing:
+ * `done` is also emitted AFTER `error`, so success is keyed on "no error chunk
+ * seen", never on `done`.
+ */
+export interface OpenClawRunAgentDeps {
+  /** The gateway client; only the chat/abort seam is used. */
+  client: Pick<OpenClawClient, "chat" | "chatAbort">;
+  /**
+   * The agent's `provider/model` ref from Pinchy's DB. Passed explicitly to
+   * the Gateway because its `agent` RPC otherwise resolves capability checks
+   * against the gateway-wide default model (#324).
+   */
+  loadAgentModel: (agentId: string) => Promise<string | null>;
+  /**
+   * Runtime-readiness gate (`waitForAgentInRuntime`): a config reload can lag
+   * behind the DB, and dispatching into that window fails with "unknown agent
+   * id" — which would terminally fail the email instead of retrying.
+   */
+  waitForAgentReady: (agentId: string) => Promise<boolean>;
+  /** Watchdog for a single turn; default 5 minutes. */
+  timeoutMs?: number;
+}
+
+const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+
+const REPORT_CONTRACT = `You are executing an automated inbox workflow run. No human reads this conversation or can answer questions — decide and act using your tools.
+End your reply with exactly one fenced \`\`\`json code block of this shape:
+{"status": "done" | "no_action", "title": "<short headline for the activity feed>", "content": "<what you did or found>", "outcome": {"odooModel": "<model>", "odooId": <record id>, "link": "<url>", "note": "<text>"}}
+Use "status": "no_action" when the email needs nothing done. "outcome" is optional — include it when you created or changed a record. The JSON block must be the last thing in your reply.`;
+
+export function createOpenClawRunAgent(deps: OpenClawRunAgentDeps): RunAgent {
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+
+  return async ({ workflow, email, ledgerId }) => {
+    const model = await deps.loadAgentModel(workflow.agentId);
+    if (!model) {
+      throw new Error(`agent ${workflow.agentId} has no model configured`);
+    }
+    if (!(await deps.waitForAgentReady(workflow.agentId))) {
+      throw new Error(`agent ${workflow.agentId} is not in the OpenClaw runtime`);
+    }
+
+    const sessionKey = inboxSessionKey(workflow.agentId, ledgerId);
+    const options: Record<string, unknown> = {
+      sessionKey,
+      agentId: workflow.agentId,
+      extraSystemPrompt: REPORT_CONTRACT,
+    };
+    // Split on the FIRST '/' only: provider before, model after — model ids can
+    // themselves contain '/' (same convention as the WS router, #324).
+    const slashIdx = model.indexOf("/");
+    if (slashIdx > 0 && slashIdx < model.length - 1) {
+      options.provider = model.slice(0, slashIdx);
+      options.model = model.slice(slashIdx + 1);
+    }
+
+    const first = await collectTurn(deps.client, taskMessage(workflow, email), options, {
+      sessionKey,
+      timeoutMs,
+    });
+    let runId = first.runId;
+    let parsed = parseInboxReport(first.text);
+
+    if (!parsed.ok) {
+      // One correction turn in the SAME session — the model keeps its context
+      // and only has to restate the result in the required shape.
+      const second = await collectTurn(deps.client, correctionMessage(parsed.error), options, {
+        sessionKey,
+        timeoutMs,
+      });
+      runId = second.runId ?? runId;
+      parsed = parseInboxReport(second.text);
+      if (!parsed.ok) {
+        throw new Error(`run did not produce a valid report: ${parsed.error}`);
+      }
+    }
+
+    return {
+      status: parsed.report.status,
+      title: parsed.report.title,
+      content: parsed.report.content,
+      outcome: parsed.report.outcome,
+      runId,
+    };
+  };
+}
+
+function taskMessage(workflow: WorkflowForDispatch, email: DispatchableEmail): string {
+  const attachments =
+    email.attachments.length === 0
+      ? "none"
+      : email.attachments
+          .map((a) => (a.filename ? `${a.filename} (${a.contentType})` : a.contentType))
+          .join(", ");
+  return `Automated inbox workflow "${workflow.name}".
+
+Task: ${workflow.action}
+
+Email to process — read the full message with your email tools using the provider message id:
+- Provider message id: ${email.providerMessageId}
+- From: ${email.from}
+- Subject: ${email.subject}
+- Received: ${email.receivedAt.toISOString()}
+- Folder: ${email.folder ?? "unknown"}
+- Attachments: ${attachments}`;
+}
+
+function correctionMessage(parseError: string): string {
+  return `Your last reply did not contain a valid report. ${parseError}
+Reply with ONLY the fenced \`\`\`json report block — no other text.`;
+}
+
+/** Sentinel so the watchdog is distinguishable from stream errors. */
+class TurnTimeout extends Error {}
+
+/**
+ * Drain one chat turn: accumulate text, capture the runId, remember a terminal
+ * error chunk. The stream is consumed to completion (`done` also follows
+ * `error`), then the error — if any — is thrown.
+ */
+async function collectTurn(
+  client: Pick<OpenClawClient, "chat" | "chatAbort">,
+  message: string,
+  options: Record<string, unknown>,
+  run: { sessionKey: string; timeoutMs: number }
+): Promise<{ text: string; runId?: string }> {
+  const generator = client.chat(message, options);
+  let buffer = "";
+  let runId: string | undefined;
+  let errorText: string | null = null;
+
+  const consume = async () => {
+    for await (const chunk of generator) {
+      runId ??= chunk.runId;
+      if (chunk.type === "text") {
+        buffer += chunk.text;
+      } else if (chunk.type === "error") {
+        errorText = chunk.text || "OpenClaw run failed";
+      }
+    }
+  };
+
+  let timer: ReturnType<typeof setTimeout> | undefined;
+  const watchdog = new Promise<never>((_, reject) => {
+    timer = setTimeout(() => reject(new TurnTimeout()), run.timeoutMs);
+  });
+
+  try {
+    await Promise.race([consume(), watchdog]);
+  } catch (err) {
+    if (err instanceof TurnTimeout) {
+      // Kill the zombie run server-side; the local generator is abandoned.
+      try {
+        await client.chatAbort(run.sessionKey, runId);
+      } catch {
+        // Best-effort: the run may already be gone.
+      }
+      throw new Error(`inbox run timed out after ${run.timeoutMs} ms`);
+    }
+    throw err;
+  } finally {
+    clearTimeout(timer);
+  }
+
+  if (errorText !== null) {
+    throw new Error(errorText);
+  }
+  return { text: stripFinalEnvelope(buffer), runId };
+}

--- a/packages/web/src/lib/email-workflows/run-adapter.ts
+++ b/packages/web/src/lib/email-workflows/run-adapter.ts
@@ -1,5 +1,6 @@
-import type { OpenClawClient } from "openclaw-node";
+import type { ChatOptions, OpenClawClient } from "openclaw-node";
 
+import { RunDeferredError } from "@/lib/email-workflows/dispatch";
 import type { RunAgent, WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
 import { parseInboxReport } from "@/lib/email-workflows/report";
 import type { DispatchableEmail } from "@/lib/email-workflows/types";
@@ -62,11 +63,13 @@ export function createOpenClawRunAgent(deps: OpenClawRunAgentDeps): RunAgent {
       throw new Error(`agent ${workflow.agentId} has no model configured`);
     }
     if (!(await deps.waitForAgentReady(workflow.agentId))) {
-      throw new Error(`agent ${workflow.agentId} is not in the OpenClaw runtime`);
+      // Transient: the agent hasn't landed in the runtime yet (a config reload
+      // lagging a restart). Defer, don't fail — the sweep retries `processing`.
+      throw new RunDeferredError(`agent ${workflow.agentId} is not in the OpenClaw runtime yet`);
     }
 
     const sessionKey = inboxSessionKey(workflow.agentId, ledgerId);
-    const options: Record<string, unknown> = {
+    const options: ChatOptions = {
       sessionKey,
       agentId: workflow.agentId,
       extraSystemPrompt: REPORT_CONTRACT,
@@ -146,7 +149,7 @@ class TurnTimeout extends Error {}
 async function collectTurn(
   client: Pick<OpenClawClient, "chat" | "chatAbort">,
   message: string,
-  options: Record<string, unknown>,
+  options: ChatOptions,
   run: { sessionKey: string; timeoutMs: number }
 ): Promise<{ text: string; runId?: string }> {
   const generator = client.chat(message, options);

--- a/packages/web/src/lib/session-key.ts
+++ b/packages/web/src/lib/session-key.ts
@@ -11,3 +11,16 @@ export function directSessionKey(agentId: string, userId: string, chatId?: strin
   const base = `agent:${agentId}:direct:${userId}`;
   return chatId ? `${base}:${chatId}` : base;
 }
+
+/**
+ * The OpenClaw session key for one isolated Inbox-Agent run (#139).
+ *
+ * Keyed by the `processed_emails` ledger row so run ↔ ledger correlation is
+ * one string comparison, and deliberately NOT in the `:direct:` namespace —
+ * chat listing keys on `:direct:`, so an inbox run can never surface as a user
+ * conversation. Sessions in this namespace are throwaway: OpenClaw's daily
+ * session reset garbage-collects them.
+ */
+export function inboxSessionKey(agentId: string, ledgerId: string): string {
+  return `agent:${agentId}:inbox:${ledgerId}`;
+}


### PR DESCRIPTION
## Summary

The production `RunAgent` adapter for the Inbox Agent dispatcher (#139, foundation #704): `createOpenClawRunAgent` runs one claimed email through a real, isolated OpenClaw agent run — **native capabilities only, on the current pin 2026.6.11** (no version bump; the stale "gated on the OpenClaw bump" comment is corrected).

## Design

| Concern | Native mechanism |
|---|---|
| Isolation | Session model: each run lives at `agent:<id>:inbox:<ledgerId>` (`inboxSessionKey`); never in the `:direct:` namespace, so it can never surface as a user chat (classify-sessions pin, **mutation-verified**). Daily session reset GCs the sessions. |
| Task delivery | Normal chat turn + `extraSystemPrompt`; the agent reads the full email itself via its email tools, so its own permissions govern the run. |
| Result | Final assistant text ending in one fenced JSON block `{status,title,content,outcome?}` (`parseInboxReport`: zod-validated, last fence wins, runaway text truncated, envelope-stripped). **Deliberately not a tool call**: real Gateways do not emit `tool_use` chunks through `chat()` (verified against the live stack 2026-06-19), and gemini-3 over ollama-cloud breaks tool calls — the final text is the native result channel. |
| Recovery | One correction turn in the same session when the report is invalid, then an honest run failure (dispatcher finalizes `failed` + notifies). |
| Errors | Verified gotcha wired in: `done` is also emitted **after** `error` → success keys on "no error chunk seen", never on `done`. |
| Hangs | Watchdog timeout (default 5 min) aborts via native `chatAbort` — no zombie runs, no stalled batches. |
| Model | `provider/model` split on the **first** slash and passed explicitly so the Gateway doesn't fall back to its default model (#324). |

`RunAgent` ctx gains `ledgerId` (additive): the dispatcher passes the claim's row id, so run ↔ ledger correlation is one string comparison. Pinned by an integration assertion **and** an end-to-end test wiring `dispatchEmails × createOpenClawRunAgent` against a mock gateway client (real-shaped chunk stream → finalized ledger row + feed notification).

## TDD

Every piece RED-first; the two behavior pins (classify-sessions exclusion, ledgerId correlation) were additionally **mutation-verified** (deliberately broke the code, watched exactly those tests fail, reverted).

## Gates

- `test` (unit): 8063 passed — full suite run 4× total; one unnamed test failed in the very first run only and never reproduced (3 further full runs + 15× stress of the new files all green). Flagging for transparency; if it resurfaces in CI I'll chase it by name.
- `test:db`: 204 passed (ephemeral throwaway postgres)
- `build`: ✓ compiled successfully
- `lint`: 0 errors (626 pre-existing warnings, none new)
- `format:check`: clean

## Not in this slice

The dispatch trigger (internal cron route), recipient/scope resolution, and the reconciliation sweep that retries `deferred` rows — each lands as its own slice on top of this. Docs land with the user-facing slice (consistent with #712/#713).