### PR TITLE
feat(openclaw-config): disable OpenClaw workspace terminals for governance

### DIFF
--- a/config/openclaw.json
+++ b/config/openclaw.json
@@ -5,6 +5,9 @@
     "controlUi": {
       "enabled": false,
       "allowedOrigins": ["http://localhost:18789", "http://127.0.0.1:18789"]
+    },
+    "terminal": {
+      "enabled": false
     }
   },
   "discovery": {

--- a/docs/src/content/docs/guides/hardening.mdx
+++ b/docs/src/content/docs/guides/hardening.mdx
@@ -378,6 +378,16 @@ OpenClaw 2026.5.12+ refuses to bind on a non-loopback interface without a `gatew
 
 **Failure mode to watch for.** If `boot-inits.ts` cannot reach the database at startup (DB outage, mis-configured `DATABASE_URL`), the seed step logs a FATAL line and Pinchy refuses to start — better to fail fast than to leave OpenClaw stuck. If you see `pinchy-openclaw` restart-looping with `Refusing to bind gateway to lan without auth` _and_ Pinchy itself is healthy, the seed wrote successfully but OpenClaw is reading from a different config path — verify the `openclaw-config` volume mount.
 
+## Workspace terminals (disabled)
+
+OpenClaw 2026.7.1 introduced **workspace terminals** — a PTY-backed interactive shell that authenticated admins can open inside an agent's workspace, controlled by `gateway.terminal.enabled` in `openclaw.json`. Fully sandboxed agents are blocked from it, but for anyone else it is a direct shell on the gateway host with the gateway process environment.
+
+**Pinchy pins this off** (`gateway.terminal.enabled: false`) on every config it generates. An interactive shell is an uncontrolled side channel: it runs commands that never pass through Pinchy's agent-permission allow-lists and never land in the [audit trail](/concepts/audit-trail/). Leaving it on would undercut the exact governance guarantees Pinchy exists to provide — every agent action being permission-checked and recorded.
+
+This is enforced in three places so no code path can re-enable it by omission: the config Pinchy regenerates from the database, the pre-start seed that runs before OpenClaw boots, and the image's baked-in `config/openclaw.json`. OpenClaw's own default for this flag is also `false`, so Pinchy's setting is defense-in-depth against a future default change or a hand-edited config — not a correction of an unsafe default.
+
+We expect to bring workspace terminals back as a first-class, **RBAC-scoped and audited** feature — gated behind a role grant and writing an audit row per session — rather than the ungoverned admin shell OpenClaw ships upstream. Until then, it stays off. If you have a specific need for it, [open an issue](https://github.com/heypinchy/pinchy/issues) describing the use case.
+
 ## Backup & recovery
 
 :::note

--- a/packages/web/src/__tests__/integration/openclaw-config-validates-against-oc.test.ts
+++ b/packages/web/src/__tests__/integration/openclaw-config-validates-against-oc.test.ts
@@ -100,5 +100,12 @@ describe("openclaw.json emitted by Pinchy validates under OpenClaw's own loader"
     expect(() => loadConfig()).not.toThrow();
     // openclaw ESM cold import is slow in a full-suite run; 30s ceiling avoids
     // false-positive timeouts while still catching genuine hangs.
+
+    // Governance guard: Pinchy disables workspace terminals. Reading the value
+    // back off OC's own parsed config proves two things at once — the key is a
+    // real, schema-recognized field in this OpenClaw version (a stripped unknown
+    // key would come back undefined), and Pinchy actually emits it as false.
+    const loaded = loadConfig() as { gateway?: { terminal?: { enabled?: unknown } } };
+    expect(loaded.gateway?.terminal?.enabled).toBe(false);
   }, 30_000);
 });

--- a/packages/web/src/__tests__/lib/openclaw-config-gateway.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-gateway.test.ts
@@ -53,4 +53,24 @@ describe("buildGatewayBlock", () => {
     expect(controlUi.theme).toBe("dark");
     expect(controlUi.enabled).toBe(false);
   });
+
+  it("disables workspace terminals (governance: uncontrolled side channel)", () => {
+    const terminal = buildGatewayBlock({}, "tok").terminal as Record<string, unknown>;
+    expect(terminal.enabled).toBe(false);
+  });
+
+  it("forces terminal.enabled:false even when the existing config enabled it", () => {
+    const terminal = buildGatewayBlock({ terminal: { enabled: true } }, "tok").terminal as Record<
+      string,
+      unknown
+    >;
+    expect(terminal.enabled).toBe(false);
+  });
+
+  it("preserves enriched terminal siblings while forcing enabled:false", () => {
+    const terminal = buildGatewayBlock({ terminal: { shell: "/bin/bash", enabled: true } }, "tok")
+      .terminal as Record<string, unknown>;
+    expect(terminal.shell).toBe("/bin/bash");
+    expect(terminal.enabled).toBe(false);
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -392,7 +392,15 @@ describe("regenerateOpenClawConfig", () => {
     //     in its UI; the schema says "Keep disabled when canvas workflows
     //     are inactive to reduce exposed local services."
     //
-    // All three are written by regenerateOpenClawConfig() BEFORE the first
+    //   - gateway.terminal.enabled (OpenClaw 2026.7.1+): lets authenticated
+    //     admins open an interactive shell in an agent workspace. OC defaults it
+    //     to false, but Pinchy pins it off explicitly — it's an uncontrolled side
+    //     channel that bypasses Pinchy's permission checks and audit trail (the
+    //     governance surface Pinchy exists to own), and emitting it keeps the
+    //     config-reload diff empty since OC materializes the block in its compare
+    //     config. Disabled until it can return as an RBAC-scoped, audited feature.
+    //
+    // All four are written by regenerateOpenClawConfig() BEFORE the first
     // gateway boot (OpenClaw's depends_on Pinchy's healthcheck ensures this).
     // The paths are restart-classified by OpenClaw, so writing them once at
     // startup avoids any SIGUSR1 on the first Pinchy regenerate.
@@ -401,12 +409,13 @@ describe("regenerateOpenClawConfig", () => {
     const written = mockedWriteFileSync.mock.calls[0][1] as string;
     const config = JSON.parse(written) as {
       update?: { checkOnStart?: boolean };
-      gateway?: { controlUi?: { enabled?: boolean } };
+      gateway?: { controlUi?: { enabled?: boolean }; terminal?: { enabled?: boolean } };
       canvasHost?: { enabled?: boolean };
     };
     expect(config.update?.checkOnStart).toBe(false);
     expect(config.gateway?.controlUi?.enabled).toBe(false);
     expect(config.canvasHost?.enabled).toBe(false);
+    expect(config.gateway?.terminal?.enabled).toBe(false);
   });
 
   it("emits gateway.controlUi.allowedOrigins so OpenClaw's in-memory seed never diffs", async () => {
@@ -4179,6 +4188,10 @@ describe("seedRestartClassOverridesIfMissing", () => {
     expect(written.discovery?.mdns?.mode).toBe("off");
     expect(written.update?.checkOnStart).toBe(false);
     expect(written.canvasHost?.enabled).toBe(false);
+    // Workspace terminals (OpenClaw 2026.7.1+) are a restart-class gateway field;
+    // seed them off up front so the first regenerate isn't a missing-then-added
+    // diff that triggers a SIGUSR1 restart.
+    expect(written.gateway?.terminal?.enabled).toBe(false);
   });
 
   it("returns false (no write) when file already has all overrides — production case", () => {
@@ -4192,6 +4205,7 @@ describe("seedRestartClassOverridesIfMissing", () => {
           enabled: false,
           allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"],
         },
+        terminal: { enabled: false },
       },
       discovery: { mdns: { mode: "off" } },
       update: { checkOnStart: false },
@@ -4233,6 +4247,36 @@ describe("seedRestartClassOverridesIfMissing", () => {
       "http://localhost:18789",
       "http://127.0.0.1:18789",
     ]);
+  });
+
+  it("seeds gateway.terminal.enabled:false when the file omits it (2026.7.1 upgrade case)", () => {
+    // Pre-2026.7.1 configs have no gateway.terminal block. On upgrade, Pinchy's
+    // next regenerate adds gateway.terminal.enabled — a missing-then-added change
+    // on the restart-class `gateway` path that triggers a SIGUSR1 restart cascade.
+    // The seed must add it up front even when every other override is correct.
+    const existing = {
+      gateway: {
+        mode: "local",
+        bind: "lan",
+        controlUi: {
+          enabled: false,
+          allowedOrigins: ["http://localhost:18789", "http://127.0.0.1:18789"],
+        },
+      },
+      discovery: { mdns: { mode: "off" } },
+      update: { checkOnStart: false },
+      canvasHost: { enabled: false },
+    };
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+
+    const changed = seedRestartClassOverridesIfMissing();
+
+    expect(changed).toBe(true);
+    const writtenAtomic = mockedWriteFileSync.mock.calls.find(
+      (c) => typeof c[0] === "string" && (c[0] as string).includes("openclaw.json.tmp")
+    );
+    const written = JSON.parse(String(writtenAtomic![1]));
+    expect(written.gateway.terminal.enabled).toBe(false);
   });
 
   it("preserves existing fields outside the four restart-class paths", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config/openclaw-baked-in-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/openclaw-baked-in-config.test.ts
@@ -80,4 +80,18 @@ describe("config/openclaw.json (baked-in config)", () => {
     expect(canvasHost, "config.canvasHost must exist").toBeDefined();
     expect(canvasHost!.enabled).toBe(false);
   });
+
+  it("has gateway.terminal.enabled: false — governance + prevents restart-triggering diff on first config.apply", () => {
+    // OpenClaw 2026.7.1+ adds gateway.terminal.enabled, an interactive workspace
+    // shell for admins. OC defaults it to false, but materializes the block in its
+    // parsed compare config even when the file omits it — so baking it in keeps
+    // the first config.apply a no-op diff for the restart-class `gateway` path
+    // (instead of a missing-then-added diff that cascades into a SIGUSR1 restart).
+    // Pinchy also pins it off as explicit governance: an uncontrolled side channel
+    // that bypasses permission checks + audit trail.
+    const gateway = config.gateway as Record<string, unknown>;
+    const terminal = gateway.terminal as Record<string, unknown> | undefined;
+    expect(terminal, "config.gateway.terminal must exist").toBeDefined();
+    expect(terminal!.enabled).toBe(false);
+  });
 });

--- a/packages/web/src/lib/openclaw-config/gateway.ts
+++ b/packages/web/src/lib/openclaw-config/gateway.ts
@@ -20,6 +20,13 @@ import { OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS } from "./paths";
  * it); otherwise we seed the same origins OC would. See
  * OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in paths.ts for the full rationale.
  *
+ * Workspace terminals (OpenClaw 2026.7.1+, `gateway.terminal.enabled`) are
+ * disabled. An interactive shell in an agent workspace is an uncontrolled side
+ * channel that bypasses Pinchy's permission checks and audit trail — exactly the
+ * governance surface Pinchy exists to own. We force it off until it can be
+ * re-introduced as an RBAC-scoped, audited feature. Enriched sibling fields on
+ * the `terminal` block survive; only `enabled` is Pinchy-managed.
+ *
  * Pure given its inputs — `existingGateway` is spread through so any
  * OpenClaw-enriched sibling fields survive the regenerate untouched.
  */
@@ -28,6 +35,7 @@ export function buildGatewayBlock(
   gatewayTokenValue: string | null | undefined
 ): Record<string, unknown> {
   const existingControlUi = (existingGateway.controlUi as Record<string, unknown>) || {};
+  const existingTerminal = (existingGateway.terminal as Record<string, unknown>) || {};
   return {
     ...existingGateway,
     mode: "local",
@@ -42,6 +50,10 @@ export function buildGatewayBlock(
       allowedOrigins: Array.isArray(existingControlUi.allowedOrigins)
         ? existingControlUi.allowedOrigins
         : OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
+    },
+    terminal: {
+      ...existingTerminal,
+      enabled: false,
     },
   };
 }

--- a/packages/web/src/lib/openclaw-config/targeted.ts
+++ b/packages/web/src/lib/openclaw-config/targeted.ts
@@ -341,6 +341,7 @@ export function seedRestartClassOverridesIfMissing(): boolean {
 
   const gateway = (existing.gateway as Record<string, unknown>) || {};
   const controlUi = (gateway.controlUi as Record<string, unknown>) || {};
+  const terminal = (gateway.terminal as Record<string, unknown>) || {};
   const discovery = (existing.discovery as Record<string, unknown>) || {};
   const mdns = (discovery.mdns as Record<string, unknown>) || {};
   const update = (existing.update as Record<string, unknown>) || {};
@@ -352,6 +353,13 @@ export function seedRestartClassOverridesIfMissing(): boolean {
   // field and trigger a restart-class diff. Seed it up front. See
   // OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS in paths.ts for the full rationale.
   const needsAllowedOrigins = !Array.isArray(controlUi.allowedOrigins);
+  // Workspace terminals (OpenClaw 2026.7.1+, gateway.terminal.enabled). OC's own
+  // default is false, but it *materializes* gateway.terminal={enabled:false} in
+  // its parsed compare config even when the file omits it. So an on-disk config
+  // that omits terminal makes the next regenerate a missing-then-added diff on
+  // the restart-class `gateway` path → SIGUSR1 restart cascade. Pin it off up
+  // front (also the explicit governance posture — see gateway.ts).
+  const needsTerminalOff = terminal.enabled !== false;
   const needsMdnsOff = mdns.mode !== "off";
   const needsUpdateCheck = update.checkOnStart !== false;
   const needsCanvasHostOff = canvasHost.enabled !== false;
@@ -359,6 +367,7 @@ export function seedRestartClassOverridesIfMissing(): boolean {
   if (
     !needsControlUi &&
     !needsAllowedOrigins &&
+    !needsTerminalOff &&
     !needsMdnsOff &&
     !needsUpdateCheck &&
     !needsCanvasHostOff
@@ -377,6 +386,7 @@ export function seedRestartClassOverridesIfMissing(): boolean {
           ? controlUi.allowedOrigins
           : OPENCLAW_CONTROL_UI_ALLOWED_ORIGINS,
       },
+      terminal: { ...terminal, enabled: false },
     },
     discovery: { ...discovery, mdns: { ...mdns, mode: "off" } },
     update: { ...update, checkOnStart: false },


### PR DESCRIPTION
## What does this PR do?

OpenClaw 2026.7.1 introduced **workspace terminals** — a PTY-backed interactive shell that authenticated admins can open inside an agent's workspace, gated by `gateway.terminal.enabled` in `openclaw.json`. That is an uncontrolled side channel for Pinchy's governance model: commands run through it never pass the agent-permission allow-lists and never land in the audit trail.

This PR pins `gateway.terminal.enabled: false` on every config Pinchy generates, at all three config paths (mirroring the existing `controlUi`/`canvasHost` hardening):

- `buildGatewayBlock` — full regen from the DB
- `seedRestartClassOverridesIfMissing` — pre-start seed that runs before OpenClaw boots
- `config/openclaw.json` — baked into the Docker image

Closes #

## Why three places / why emit it at all

OC's own default for the flag is already `false`, so this is **defense-in-depth**, not a fix for an unsafe default. But OC *materializes* `gateway.terminal={enabled:false}` in its parsed compare config even when the file omits the block (verified with a `loadConfig()` probe). So a config that omits `terminal` makes the next regenerate a **missing-then-added diff on the restart-class `gateway` path → SIGUSR1 restart cascade** (same failure class as `controlUi.allowedOrigins`). Emitting it keeps the first `config.apply` a no-op diff.

## Verification against the real 2026.7.1 schema

- The integration test loads the emitted config through OpenClaw's own `loadConfig()` **and reads the value back** — proving the key is schema-recognized (not a stripped unknown key) and that Pinchy emits it as `false`.
- A `loadConfig()` probe confirmed OC adds **no sibling defaults** to the terminal block (parsed = exactly `{enabled:false}`), so `normalize.ts` needs no supplement.
- `validate-built-config.ts` / `sanitizeOpenClawConfig` are unaffected — the gateway block is validated by OC's own loader, not a Pinchy-side schema guard.

## Docs

New **"Workspace terminals (disabled)"** section in the hardening guide: the governance rationale, that it's defense-in-depth against a future default change, and that it will return as an RBAC-scoped, audited feature.

## Type of change

- [x] ✨ New feature
- [x] 📝 Documentation
- [x] 🧪 Tests

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (TDD — red before green)
- [x] I've updated the documentation
- [x] All existing tests pass

## Test plan

- `pnpm test` — 8179 passed, 13 skipped (exit 0)
- `pnpm build` — exit 0 (includes packages/web typecheck)
- Prettier check on changed web + docs files clean

> Note: The OpenClaw 2026.7.1 bump this depends on is already merged (`99859531d`).