### PR TITLE
fix(attachments): read chat PDFs/images via pinchy_read, drop built-in pdf/image tools

### DIFF
--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -831,27 +831,33 @@ describe("regenerateOpenClawConfig", () => {
   });
 
   // Locks the combined chat-attachment security contract (PR #316 review #3),
-  // re-expressed for the fail-closed allowlist posture (#605):
+  // re-expressed for the fail-closed allowlist posture (#605) and corrected
+  // after the 2026-07-14 prod incident:
   //
-  //   1. `pdf` and `image` MUST be available to every agent — they're the
-  //      built-in tools the upload hint instructs the agent to call. If
-  //      either is missing from `tools.allow`, the entire attachment feature
-  //      silently breaks: the agent receives a path it cannot read.
+  //   1. The pinchy-files `pinchy_read` tool MUST be available to every agent —
+  //      it is the tool the upload hint instructs the agent to call, and it
+  //      reads the file straight from the workspace. If it is missing from
+  //      `tools.allow`, the attachment feature silently breaks.
   //
-  //   2. `image_generate` MUST stay out of the allowlist. It produces new
+  //   2. OpenClaw's built-in `pdf` / `image` media tools MUST stay OUT of the
+  //      allowlist. They fail with "Local media file not found" on workspace
+  //      upload paths, so they cannot serve attachments; keeping them reachable
+  //      gave weaker models a wrongly-named trap they picked over `pinchy_read`
+  //      (prod incident 2026-07-14). See tool-registry.ts § INTENDED_BUILTIN_TOOLS.
+  //
+  //   3. `image_generate` MUST stay out of the allowlist. It produces new
   //      content (token cost, output side-effects) and belongs behind explicit
-  //      admin opt-in. This is the explicit boundary documented in
-  //      tool-registry.ts § INTENDED_BUILTIN_TOOLS.
+  //      admin opt-in.
   //
-  //   3. `tools.fs.workspaceOnly === true` MUST be set. Without it, `pdf`
-  //      and `image` have unrestricted host-filesystem access — an agent
-  //      could read /etc/passwd via the `pdf` tool.
+  //   4. `tools.fs.workspaceOnly === true` MUST be set — the pinchy-files tools
+  //      have unrestricted host-filesystem access without it, so an agent could
+  //      otherwise read /etc/passwd.
   //
-  // The three together are the guarantee: agents can read user uploads,
-  // confined to the workspace, but cannot generate new content without
-  // admin permission. Regression in any one of them silently changes the
-  // security posture for every Pinchy install.
-  it("locks the chat-attachment security contract: pdf/image allowed + workspace-confined + image_generate excluded", async () => {
+  // Together these guarantee: agents can read user uploads via `pinchy_read`,
+  // confined to the workspace, cannot reach the broken/ambiguous media built-ins,
+  // and cannot generate new content without admin permission. Regression in any
+  // one of them silently changes the security posture for every Pinchy install.
+  it("locks the chat-attachment security contract: pinchy_read allowed + pdf/image excluded + workspace-confined + image_generate excluded", async () => {
     const agentsData = [
       {
         id: "security-contract-agent",
@@ -871,14 +877,17 @@ describe("regenerateOpenClawConfig", () => {
     );
     const allow = (agentEntry.tools?.allow ?? []) as string[];
 
-    // (1) pdf/image MUST be reachable (present in the allowlist).
-    expect(allow).toContain("pdf");
-    expect(allow).toContain("image");
+    // (1) pinchy_read — the actual attachment reader — MUST be reachable.
+    expect(allow).toContain("pinchy_read");
 
-    // (2) image_generate MUST stay out of the allowlist (admin-only).
+    // (2) the built-in pdf/image media tools MUST be excluded (prod incident 2026-07-14).
+    expect(allow).not.toContain("pdf");
+    expect(allow).not.toContain("image");
+
+    // (3) image_generate MUST stay out of the allowlist (admin-only).
     expect(allow).not.toContain("image_generate");
 
-    // (3) workspace confinement MUST be active.
+    // (4) workspace confinement MUST be active.
     expect(agentEntry.tools.fs).toEqual({ workspaceOnly: true });
   });
 

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -136,12 +136,18 @@ describe("getToolsByCategory", () => {
 });
 
 describe("computeAllowedTools", () => {
-  it("allows the OpenClaw built-in `pdf` tool — it powers chat-attachment PDF reading", () => {
-    expect(computeAllowedTools()).toContain("pdf");
-  });
-
-  it("allows the OpenClaw built-in `image` tool — same reason for image attachments", () => {
-    expect(computeAllowedTools()).toContain("image");
+  it("does NOT allow the built-in `pdf`/`image` tools — they cannot read workspace uploads (prod incident 2026-07-14)", () => {
+    // OpenClaw's built-in pdf/image media tools fail with "Local media file not
+    // found" on workspace upload paths. attachment-pipeline routes every PDF and
+    // image through the pinchy-files `pinchy_read` tool instead. Keeping the
+    // built-ins in the allowlist handed weaker models (e.g. kimi-k2.6) a
+    // temptingly-named trap they picked over `pinchy_read`, then reported the
+    // attached file as unreadable even though it was present on disk.
+    const allowed = computeAllowedTools();
+    expect(allowed).not.toContain("pdf");
+    expect(allowed).not.toContain("image");
+    // The intended media reader stays available.
+    expect(allowed).toContain("pinchy_read");
   });
 
   it("allows memory_search/memory_get (bundled memory-core plugin powers agent memory)", () => {
@@ -257,9 +263,12 @@ describe("allow-list drift guard vs OpenClaw built-in tool groups", () => {
     "tts",
   ] as const;
 
-  // The ONLY non-Pinchy tools the allowlist may contain (read-only / attachment
-  // helpers). Anything else from group:media etc. must stay out.
-  const INTENDED_BUILTINS = ["memory_search", "memory_get", "pdf", "image", "session_status"];
+  // The ONLY non-Pinchy tools the allowlist may contain (bundled memory-core +
+  // read-only self-status). Everything in group:media — including the `pdf` and
+  // `image` built-ins — must stay out: chat attachments are read via the
+  // pinchy-files `pinchy_read` tool, not the built-ins (see the tool-registry
+  // comment on INTENDED_BUILTIN_TOOLS and the 2026-07-14 prod incident).
+  const INTENDED_BUILTINS = ["memory_search", "memory_get", "session_status"];
 
   it("excludes every built-in a governed agent must never reach", () => {
     const allowed = new Set(computeAllowedTools());

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -136,18 +136,23 @@ describe("getToolsByCategory", () => {
 });
 
 describe("computeAllowedTools", () => {
-  it("does NOT allow the built-in `pdf`/`image` tools — they cannot read workspace uploads (prod incident 2026-07-14)", () => {
-    // OpenClaw's built-in pdf/image media tools fail with "Local media file not
-    // found" on workspace upload paths. attachment-pipeline routes every PDF and
-    // image through the pinchy-files `pinchy_read` tool instead. Keeping the
-    // built-ins in the allowlist handed weaker models (e.g. kimi-k2.6) a
-    // temptingly-named trap they picked over `pinchy_read`, then reported the
-    // attached file as unreadable even though it was present on disk.
-    const allowed = computeAllowedTools();
-    expect(allowed).not.toContain("pdf");
-    expect(allowed).not.toContain("image");
-    // The intended media reader stays available.
-    expect(allowed).toContain("pinchy_read");
+  // OpenClaw's built-in pdf/image media tools fail with "Local media file not
+  // found" on workspace upload paths. attachment-pipeline routes every PDF and
+  // image through the pinchy-files `pinchy_read` tool instead. Keeping the
+  // built-ins in the allowlist handed weaker models (e.g. kimi-k2.6) a
+  // temptingly-named trap they picked over `pinchy_read`, then reported the
+  // attached file as unreadable even though it was present on disk (prod
+  // incident 2026-07-14).
+  it("does NOT allow the built-in `pdf` tool — it cannot read workspace uploads (prod incident 2026-07-14)", () => {
+    expect(computeAllowedTools()).not.toContain("pdf");
+  });
+
+  it("does NOT allow the built-in `image` tool — same reason as `pdf` (prod incident 2026-07-14)", () => {
+    expect(computeAllowedTools()).not.toContain("image");
+  });
+
+  it("keeps `pinchy_read` — the intended media reader — available", () => {
+    expect(computeAllowedTools()).toContain("pinchy_read");
   });
 
   it("allows memory_search/memory_get (bundled memory-core plugin powers agent memory)", () => {

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -1567,7 +1567,7 @@ describe("ClientRouter", () => {
           role: "user",
           content:
             "Was steht in dieser Datei?\n\n<pinchy:attachments>\n" +
-            "The user attached these files (already saved into your workspace). Read each file with the listed built-in tool, using the exact absolute path:\n" +
+            "The user attached these files (already saved into your workspace). Read each file with the listed tool, using the exact absolute path:\n" +
             "- `/root/.openclaw/workspaces/agent-1/uploads/invoice.pdf` (application/pdf, 240 KB) — analyze with `pinchy_read`\n" +
             "\nIf you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.\n" +
             "</pinchy:attachments>",
@@ -1605,7 +1605,7 @@ describe("ClientRouter", () => {
           role: "user",
           content:
             "<pinchy:attachments>\n" +
-            "The user attached these files (already saved into your workspace). Read each file with the listed built-in tool, using the exact absolute path:\n" +
+            "The user attached these files (already saved into your workspace). Read each file with the listed tool, using the exact absolute path:\n" +
             "- `/root/.openclaw/workspaces/agent-1/uploads/silent-pdf.pdf` (application/pdf, 100 KB) — analyze with `pinchy_read`\n" +
             "\nIf you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.\n" +
             "</pinchy:attachments>",

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -1009,8 +1009,14 @@ export async function regenerateOpenClawConfig() {
   // `existingAllow` on first boot). Without explicit inclusion in
   // plugins.allow they are blocked by the whitelist and the dependent
   // built-in tools fail at runtime.
-  //   - document-extract: PDF text + image extraction backend used by the
-  //     built-in `pdf` tool's extraction fallback mode (pdfjs-dist).
+  //   - document-extract: PDF text + image extraction backend (pdfjs-dist) for
+  //     OpenClaw's built-in `pdf` tool. That built-in is now DENIED by the
+  //     per-agent allowlist — chat attachments are read via the pinchy-files
+  //     `pinchy_read` tool, which bundles its own pdfjs and does NOT depend on
+  //     document-extract (see tool-registry.ts § INTENDED_BUILTIN_TOOLS and the
+  //     2026-07-14 prod incident). This entry is therefore currently inert; it
+  //     is kept until the now-unreachable built-in `pdf` registration
+  //     (`pdfModel` below) is dropped together in a follow-up.
   const REQUIRED_BUNDLED_PLUGINS = ["document-extract"] as const;
 
   const DISABLED_OPENCLAW_PLUGINS = new Set(["acpx", "bonjour", "device-pair", "phone-control"]);

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -240,21 +240,23 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
 //     Pinchy's agent-memory feature (see memory-prompt.ts). They are
 //     plugin-owned, so they must be allowed by NAME — `group:memory` does NOT
 //     match them (verified against OpenClaw 2026.6.8).
-//   - pdf / image: read-only vision/document tools that respect
-//     `tools.fs.workspaceOnly`. They power chat attachments: the upload hint
-//     tells the agent to call them with the workspace path.
 //   - session_status: read-only self-status (the baseline `minimal` profile).
 // Notably ABSENT (hence denied): image_generate / music_generate /
 // video_generate / tts (produce new content — admin-only), the native
 // browser/canvas (group:ui), cron, gateway, message, nodes, subagents,
 // sessions_*, and raw exec/fs/web.
-const INTENDED_BUILTIN_TOOLS = [
-  "memory_search",
-  "memory_get",
-  "pdf",
-  "image",
-  "session_status",
-] as const;
+//
+// Also ABSENT — and this is deliberate, not an oversight: OpenClaw's built-in
+// `pdf` / `image` media tools. Chat attachments (PDFs and images) are read via
+// the pinchy-files `pinchy_read` tool, NOT the built-ins — see toolNameForMime()
+// in server/attachment-pipeline.ts for the rationale (the built-ins 410 when
+// their auto-resolved upstream model retires, and #501). The built-ins also
+// simply do not work here: given a workspace upload path they fail with "Local
+// media file not found", so an agent that reaches for them cannot read the file
+// at all. Worse, keeping them in the allowlist gave weaker models (e.g.
+// kimi-k2.6) a temptingly-named `pdf` tool they picked over `pinchy_read`, then
+// told the user the attachment was unreadable (prod incident 2026-07-14).
+const INTENDED_BUILTIN_TOOLS = ["memory_search", "memory_get", "session_status"] as const;
 
 export function getToolById(id: string): ToolDefinition | undefined {
   return TOOL_REGISTRY.find((t) => t.id === id);

--- a/packages/web/src/server/attachment-pipeline.ts
+++ b/packages/web/src/server/attachment-pipeline.ts
@@ -372,7 +372,7 @@ export function buildAttachmentBlock(refs: ProcessedWorkspaceRef[]): string {
   });
   return [
     ATTACHMENT_BLOCK_OPEN,
-    "The user attached these files (already saved into your workspace). Read each file with the listed built-in tool, using the exact absolute path:",
+    "The user attached these files (already saved into your workspace). Read each file with the listed tool, using the exact absolute path:",
     ...lines,
     "",
     "If you delegate this task to a sub-agent or another tool, pass these exact paths verbatim — do not retype from memory.",


### PR DESCRIPTION
## Problem (prod incident 2026-07-14)

Agent **Piper** (`ollama-cloud/kimi-k2.6`) was sent a PDF ticket and replied it could not read it — *"die Datei scheint noch nicht vollständig im Workspace verfügbar zu sein (wird in der Liste angezeigt, aber beim Zugriff fehlt sie)."*

Debugging on production showed the file was **fully fine**:

- `uploaded_files` row: `status=attached`, 244 491 bytes, `attached_at` matches the message.
- Present and identical in **both** containers (shared `pinchy-workspaces` volume), incl. the openclaw container at the exact path handed to the agent.
- The attachment hint correctly said `— analyze with \`pinchy_read\``.

The openclaw logs told the real story:

```
[tools] pdf   failed: Local media file not found: …/uploads/Epic #2483_… .pdf
[tools] pdf   failed: … (retry)
[tools] pdf   failed: …Epic%20%232483… (retry, url-encoded)
[tools] image failed: Local media file not found: …/uploads/Epic #2483_… .pdf
→ "Leider kann ich das Ticket-PDF aktuell nicht lesen …"
```

The model **ignored the `pinchy_read` hint and called OpenClaw's built-in `pdf`/`image` tools**, which cannot read workspace upload paths and fail with *Local media file not found*. `pinchy_read` was never invoked. (The PDF has a full text layer, so `pinchy_read` would have extracted it locally without even needing the vision path.)

## Root cause

`INTENDED_BUILTIN_TOOLS` in `tool-registry.ts` kept `pdf` and `image` in every agent's `tools.allow`, **contradicting** the design documented in `toolNameForMime()` (`attachment-pipeline.ts`), which routes every PDF/image through `pinchy_read` and deliberately avoids the built-ins (they 410 on model retirement — #501). Keeping the built-ins reachable handed weaker instruction-followers a temptingly-named `pdf` tool that both wins over `pinchy_read` **and** cannot do the job.

## Fix

Remove `pdf`/`image` from `INTENDED_BUILTIN_TOOLS`. Media attachments now have exactly one reader in the allowlist — `pinchy_read` — so the model has no failing detour. Reconciles the two modules that disagreed.

## Tests

- New `computeAllowedTools` test: asserts `pdf`/`image` are excluded and `pinchy_read` stays allowed (TDD — watched it fail first).
- Updated the two contradicting tests that asserted the old behavior (`tool-registry.test.ts`, `openclaw-config.test.ts` "chat-attachment security contract").
- `tool-registry.test.ts` (64) + `openclaw-config.test.ts` (211) + `attachment-pipeline.test.ts` (15) green; eslint + `tsc --noEmit` clean.

## Follow-ups (not in this PR)
- `build.ts` still emits `pdfModel` (now inert — the `pdf` tool it registered is denied by the allowlist). Safe to drop separately. `imageModel` stays — it is still used for image-turn routing (`resolveImageTurnModel`). The bundled `document-extract` plugin (kept in `REQUIRED_BUNDLED_PLUGINS`) only backs that built-in `pdf` tool, so it is now inert too — drop it in the same follow-up (`pinchy_read` bundles its own pdfjs).
- Separate, unrelated bug seen in the same session: the chat title stays "Chat from <date>" instead of deriving from the first message. Different code path; investigated separately.