### PR TITLE
fix(attachments): normalize upload filenames to NFC (macOS/umlaut names unreadable)

### DIFF
--- a/packages/web/src/__tests__/lib/upload-validation.test.ts
+++ b/packages/web/src/__tests__/lib/upload-validation.test.ts
@@ -46,6 +46,20 @@ describe("sanitizeFilename", () => {
     expect(sanitizeFilename("a..b.pdf")).toBe("a..b.pdf");
   });
 
+  it("normalizes decomposed (NFD) Unicode filenames to NFC so they match the on-disk bytes", () => {
+    // macOS uploads arrive NFD: "ä" is "a" + U+0308 (combining diaeresis). Stored
+    // verbatim on the Linux volume, the file then cannot be read back via the NFC
+    // path that any text round-trip (JSON, the agent's own model) produces — the
+    // read ENOENTs with "no such file or directory". Canonicalize to NFC at this
+    // trust boundary so the stored name matches. (prod incident 2026-07-14)
+    const nfd = "Absch" + "a\u0308" + "tzung.pdf"; // "a" + U+0308 combining diaeresis (NFD)
+    const nfc = "Absch" + "\u00e4" + "tzung.pdf"; // single U+00E4 "\u00e4" codepoint (NFC)
+    expect(nfd).not.toBe(nfc); // sanity: distinct byte sequences
+    const out = sanitizeFilename(nfd);
+    expect(out).toBe(nfc);
+    expect(out.normalize("NFC")).toBe(out); // output is canonical NFC
+  });
+
   it("rejects BiDi override and invisible Unicode control characters", () => {
     expect(() => sanitizeFilename("foo‮.pdf")).toThrow(/invalid/i); // RIGHT-TO-LEFT OVERRIDE
     expect(() => sanitizeFilename("foo​.pdf")).toThrow(/invalid/i); // ZERO-WIDTH SPACE

--- a/packages/web/src/lib/upload-validation.ts
+++ b/packages/web/src/lib/upload-validation.ts
@@ -30,6 +30,17 @@ export function sanitizeFilename(raw: string): string {
   if (typeof raw !== "string") {
     throw new Error("Invalid filename: not a string");
   }
+
+  // Canonicalize to NFC before anything else. macOS uploads a filename in NFD
+  // (decomposed) form — "ä" arrives as "a" + U+0308 combining diaeresis. Stored
+  // verbatim on the Linux workspace volume (which does no Unicode folding), the
+  // file then can't be read back: the attachment path round-trips through JSON
+  // and the agent's own model, both of which emit NFC, so `pinchy_read` is handed
+  // the composed form and readFile ENOENTs with "no such file or directory".
+  // Normalizing here makes the stored name, the DB row, and the path the agent
+  // sees all identical bytes. (prod incident 2026-07-14)
+  raw = raw.normalize("NFC");
+
   if (CONTROL_CHAR_RE.test(raw)) {
     throw new Error("Invalid filename: contains control characters");
   }


### PR DESCRIPTION
## Problem (prod incident 2026-07-14, same session as #724)

After being told to use `pinchy_read`, agent **Piper** still failed on the same PDF — *"no such file or directory"* — and only worked after the user renamed the file to `epic-2483.pdf`. The original name contained `ä`: `Epic #2483_ Abschätzung … Ticket.pdf`.

## Root cause — NFC/NFD filename mismatch

Byte-level evidence from production:

| | `ä` bytes | Form |
|---|---|---|
| Filename **on disk** (openclaw volume) | `61 cc 88` (`a` + U+0308) | **NFD** |
| Path the agent passed to `pinchy_read` (session JSONL) | `c3 a4` (U+00E4) | **NFC** |

macOS hands the browser the filename in **NFD** (decomposed) form. `sanitizeFilename` stored it verbatim, and the Linux workspace volume does no Unicode folding — so the file lives under NFD bytes. But the attachment path round-trips through JSON and the agent's own model, both of which emit **NFC**, so `readFile(<NFC path>)` misses the NFD file → `ENOENT`. A plain-ASCII name (`epic-2483.pdf`) has nothing to decompose, hence the rename worked.

This is independent of #724: even with the built-in `pdf`/`image` tools removed and `pinchy_read` forced, this file would still fail until re-uploaded. Both fixes are needed for the original ticket to be readable.

## Fix

Normalize `raw` to **NFC** at the top of `sanitizeFilename`, so the stored file, the DB row, and the path the agent sees are all identical bytes. Fixes the whole class of macOS-uploaded accented filenames.

## Tests

- New `sanitizeFilename` test: an NFD input (`"Absch" + "ä" + "tzung.pdf"`) must come back as NFC (`"Absch" + "ä" + "tzung.pdf"`) — TDD, watched it fail first.
- `upload-validation.test.ts` (31), `attachment-pipeline.test.ts` + `agent-uploads-route.test.ts` + `uploads-staging.test.ts` (33) green; eslint + `tsc --noEmit` clean.

## Related
- #724 — the tool-selection half of the same "can't read the attachment" symptom (agent used built-in `pdf`/`image` instead of `pinchy_read`).
- Possible defense-in-depth follow-up: have `pinchy_read` fall back to the other normalization form so filenames already stored NFD (pre-this-fix) also resolve.