### PR TITLE
fix(pinchy-files): NFC/NFD filename fallback so already-stored macOS uploads read

### DIFF
--- a/packages/plugins/pinchy-files/index.test.ts
+++ b/packages/plugins/pinchy-files/index.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment node
 import { describe, it, expect, vi, beforeEach, afterEach, afterAll } from "vitest";
-import { readFileSync as realReadFileSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, existsSync } from "fs";
+import { readFileSync as realReadFileSync, mkdtempSync, rmSync, mkdirSync, writeFileSync, symlinkSync, existsSync, readdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
 import Database from "better-sqlite3";
@@ -1063,5 +1063,92 @@ describe("pinchy_write tool", () => {
     expect(result.details.path).not.toMatch(/^\//);
 
     expect(realReadFileSync(filePath, "utf-8")).toBe("new content");
+  });
+});
+
+// ── pinchy_write: NFC/NFD normalization fallback ─────────────────────────────
+// A file already on disk in a different Unicode normalization form than the path
+// the model emits (an NFD macOS upload vs the NFC request) is the same file — see
+// resolveOnDiskPath. Its decision logic is unit-tested with an injectable `exists`
+// in unicode-path.test.ts; these tests exercise the real pinchy_write wiring
+// end-to-end against the filesystem, so overwrite=false reports the collision and
+// overwrite=true reuses the existing file instead of writing an NFC duplicate.
+//
+// This can only reproduce on a normalization-sensitive filesystem (Linux/ext4,
+// where CI runs). macOS/APFS folds NFC and NFD onto the same file, so the mismatch
+// physically cannot occur and the block is gated off there — an OS-feature gate
+// (allowed by AGENTS.md), not a suppression: a real-tempfile test would pass even
+// without the fix and prove nothing, which is why resolveOnDiskPath is injectable.
+function fsFoldsUnicode(): boolean {
+  const probeDir = mkdtempSync(join(tmpdir(), "pinchy-fold-probe-"));
+  try {
+    const nfd = join(probeDir, "probe-a\u0308"); // "a" + U+0308 (decomposed)
+    const nfc = join(probeDir, "probe-\u00e4"); // U+00E4 (composed)
+    writeFileSync(nfd, "");
+    return existsSync(nfc); // true => the FS folded the NFC lookup onto the NFD file
+  } finally {
+    rmSync(probeDir, { recursive: true, force: true });
+  }
+}
+
+describe.skipIf(fsFoldsUnicode())("pinchy_write NFC/NFD fallback (normalization-sensitive FS only)", () => {
+  let tmpDir: string;
+
+  // Explicit escapes so the source file's own encoding can't fold the two forms.
+  const NFD_NAME = "Absch" + "a\u0308" + "tzung.pdf"; // "a" + U+0308 (decomposed)
+  const NFC_NAME = "Absch" + "\u00e4" + "tzung.pdf"; // U+00E4 (composed)
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    tmpDir = mkdtempSync(join(tmpdir(), "pinchy-write-nfc-nfd-"));
+  });
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true });
+  });
+
+  async function makeWriteTool() {
+    const api = createMockApi({
+      "agent-1": { allowed_paths: [tmpDir], write_paths: [tmpDir] },
+    });
+    const { default: plugin } = await import("./index");
+    plugin.register!(api as any);
+    const factory = mockRegisterTool.mock.calls.find(
+      (call: any[]) => call[1]?.name === "pinchy_write"
+    )?.[0];
+    return factory({ agentId: "agent-1" });
+  }
+
+  it("reports the collision instead of creating an NFC duplicate (overwrite=false)", async () => {
+    writeFileSync(join(tmpDir, NFD_NAME), "original-nfd");
+    const tool = await makeWriteTool();
+
+    const result = await tool.execute("call-1", {
+      path: join(tmpDir, NFC_NAME), // NFC request; the file on disk is NFD
+      content: "would-be-duplicate",
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/already exists/i);
+    // No second file: the NFC write must not have landed beside the NFD original.
+    expect(readdirSync(tmpDir)).toHaveLength(1);
+    expect(realReadFileSync(join(tmpDir, NFD_NAME), "utf-8")).toBe("original-nfd");
+  });
+
+  it("overwrites the existing NFD file rather than duplicating it (overwrite=true)", async () => {
+    writeFileSync(join(tmpDir, NFD_NAME), "original-nfd");
+    const tool = await makeWriteTool();
+
+    const result = await tool.execute("call-1", {
+      path: join(tmpDir, NFC_NAME),
+      content: "updated",
+      overwrite: true,
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(result.details.mode).toBe("overwrite");
+    // Still exactly one file, and it's the original NFD file with new content.
+    expect(readdirSync(tmpDir)).toHaveLength(1);
+    expect(realReadFileSync(join(tmpDir, NFD_NAME), "utf-8")).toBe("updated");
   });
 });

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -1,4 +1,4 @@
-import { readdirSync, statSync, realpathSync } from "fs";
+import { readdirSync, statSync, realpathSync, existsSync } from "fs";
 import { readFile, open, writeFile } from "fs/promises";
 import { createHash } from "crypto";
 import { join, extname, basename } from "path";
@@ -14,6 +14,24 @@ import { resolveAgentInfo } from "./resolve-agent-info";
 
 interface PluginToolContext {
   agentId?: string;
+}
+
+// Resolve a caller-supplied path to the Unicode form that actually exists on
+// disk. Linux filesystems don't fold Unicode, so a path the agent's model
+// produced in NFC ("ä" = U+00E4) will not match a file stored in NFD ("a" +
+// U+0308) — the case for anything uploaded from macOS before the sanitizeFilename
+// NFC fix landed. Try the path as given, then its NFC and NFD forms, returning
+// the first that exists; fall back to the original so the caller's realpathSync
+// still throws its normal ENOENT when the file is genuinely absent. `exists` is
+// injectable because the dev host (macOS/APFS) folds normalization and would mask
+// the mismatch that only reproduces on the Linux container filesystem.
+export function resolveOnDiskPath(requestedPath: string, exists: (p: string) => boolean = existsSync): string {
+  if (exists(requestedPath)) return requestedPath;
+  for (const form of ["NFC", "NFD"] as const) {
+    const variant = requestedPath.normalize(form);
+    if (variant !== requestedPath && exists(variant)) return variant;
+  }
+  return requestedPath;
 }
 
 // Strips the workspace/writePath prefix from an absolute path for audit logging.
@@ -271,7 +289,10 @@ const plugin = {
           ) {
             try {
               const requestedPath = params.path as string;
-              const realPath = realpathSync(requestedPath);
+              // Fall back to the other Unicode normalization form when the exact
+              // bytes don't exist — an NFC path from the model vs an NFD file on
+              // the Linux volume (macOS upload). See resolveOnDiskPath.
+              const realPath = realpathSync(resolveOnDiskPath(requestedPath));
               validateAccess({ allowed_paths: paths }, realPath);
 
               const entries = readdirSync(realPath);
@@ -336,7 +357,10 @@ const plugin = {
           ) {
             try {
               const requestedPath = params.path as string;
-              const realPath = realpathSync(requestedPath);
+              // Fall back to the other Unicode normalization form when the exact
+              // bytes don't exist — an NFC path from the model vs an NFD file on
+              // the Linux volume (macOS upload). See resolveOnDiskPath.
+              const realPath = realpathSync(resolveOnDiskPath(requestedPath));
               validateAccess({ allowed_paths: paths }, realPath);
 
               const lowerPath = realPath.toLowerCase();

--- a/packages/plugins/pinchy-files/index.ts
+++ b/packages/plugins/pinchy-files/index.ts
@@ -25,6 +25,12 @@ interface PluginToolContext {
 // still throws its normal ENOENT when the file is genuinely absent. `exists` is
 // injectable because the dev host (macOS/APFS) folds normalization and would mask
 // the mismatch that only reproduces on the Linux container filesystem.
+//
+// Only uniform, whole-string normalization forms are tried: a mixed-form path
+// (e.g. an NFC directory segment with an NFD filename) matches neither the NFC
+// nor the NFD normalization of the whole string and won't resolve — it just
+// falls back to the original (safe). That case doesn't arise here because every
+// segment comes from the same macOS upload written in one normalization form.
 export function resolveOnDiskPath(requestedPath: string, exists: (p: string) => boolean = existsSync): string {
   if (exists(requestedPath)) return requestedPath;
   for (const form of ["NFC", "NFD"] as const) {
@@ -546,11 +552,22 @@ const plugin = {
                 "write"
               );
 
+              // A file already stored in the other Unicode normalization form (an
+              // NFD upload from macOS vs the NFC path the model emits) is the same
+              // file. Without this, overwrite=true would create an NFC duplicate
+              // beside the NFD original, and overwrite=false would silently create
+              // a duplicate instead of reporting the collision. resolveOnDiskPath
+              // returns the form that exists on disk, or `resolved` unchanged when
+              // creating a genuinely new file. Like the read side, this only bites
+              // on a normalization-sensitive FS (Linux); macOS/APFS folds the forms.
+              const onDisk = resolveOnDiskPath(resolved);
+
               // Defense in depth: the read tools realpath before validating, so
               // a symlink inside an allowed dir pointing outside it is caught.
               // The lexical check above can't see that, so reject any write
               // whose real (symlink-resolved) target escapes the write roots.
-              assertNoSymlinkEscape(requestedPath, writePaths);
+              // Check the form we actually write to.
+              assertNoSymlinkEscape(onDisk, writePaths);
 
               const buffer = Buffer.from(content, "utf-8");
               if (buffer.byteLength > MAX_FILE_SIZE) {
@@ -564,17 +581,17 @@ const plugin = {
 
               if (overwrite) {
                 try {
-                  const existing = await readFile(resolved);
+                  const existing = await readFile(onDisk);
                   previousContentHash = createHash("sha256").update(existing).digest("hex");
                   mode = "overwrite";
                 } catch (err) {
                   if ((err as NodeJS.ErrnoException).code !== "ENOENT") throw err;
                   mode = "create";
                 }
-                await writeFile(resolved, buffer);
+                await writeFile(onDisk, buffer);
               } else {
                 try {
-                  const fh = await open(resolved, "wx");
+                  const fh = await open(onDisk, "wx");
                   try {
                     await fh.writeFile(buffer);
                   } finally {
@@ -594,7 +611,7 @@ const plugin = {
                       // Set details so the audit endpoint suppresses raw params
                       // (which include the full content blob — PII protection).
                       details: {
-                        path: relativizeWritePath(resolved, writePaths),
+                        path: relativizeWritePath(onDisk, writePaths),
                         mode: "create",
                         overwrite: false,
                         error: "File already exists",
@@ -615,7 +632,7 @@ const plugin = {
                   },
                 ],
                 details: {
-                  path: relativizeWritePath(resolved, writePaths),
+                  path: relativizeWritePath(onDisk, writePaths),
                   mode,
                   sizeBytes: buffer.byteLength,
                   contentHash,

--- a/packages/plugins/pinchy-files/unicode-path.test.ts
+++ b/packages/plugins/pinchy-files/unicode-path.test.ts
@@ -1,0 +1,32 @@
+import { describe, it, expect } from "vitest";
+import { resolveOnDiskPath } from "./index";
+
+// The `ä` in these paths is built from explicit escapes so the source file's own
+// encoding can't collapse the two forms into one.
+const NFD = "/ws/uploads/Absch" + "a\u0308" + "tzung.pdf"; // "a" + U+0308 (decomposed)
+const NFC = "/ws/uploads/Absch" + "\u00e4" + "tzung.pdf"; //  U+00E4       (composed)
+
+describe("resolveOnDiskPath (NFC/NFD filename fallback)", () => {
+  it("resolves an NFC request path to the NFD file that exists on disk (Linux-style FS)", () => {
+    // Linux filesystems don't fold Unicode: only the exact NFD bytes exist.
+    // The agent's model handed us the composed (NFC) form.
+    expect(NFC).not.toBe(NFD); // sanity: genuinely different byte sequences
+    const exists = (p: string) => p === NFD;
+    expect(resolveOnDiskPath(NFC, exists)).toBe(NFD);
+  });
+
+  it("resolves an NFD request path to an NFC file when only the composed form exists", () => {
+    const exists = (p: string) => p === NFC;
+    expect(resolveOnDiskPath(NFD, exists)).toBe(NFC);
+  });
+
+  it("returns the path unchanged when it already exists as given", () => {
+    const p = "/ws/uploads/plain-ascii.pdf";
+    expect(resolveOnDiskPath(p, () => true)).toBe(p);
+  });
+
+  it("returns the original path when no normalization form exists (caller then ENOENTs normally)", () => {
+    const p = "/ws/uploads/missing.pdf";
+    expect(resolveOnDiskPath(p, () => false)).toBe(p);
+  });
+});


### PR DESCRIPTION
## Why

Defense-in-depth companion to #729. #729 normalizes **new** uploads to NFC at `sanitizeFilename`, but files **already** on the Linux workspace volume in NFD form stay unreadable: `pinchy_read` gets the NFC path the agent's model emits, `realpathSync` misses the NFD file, and it `ENOENT`s with *"no such file or directory"*. Confirmed on prod 2026-07-14 (disk `…61 cc 88…` NFD vs model path `…c3 a4…` NFC).

## Fix

`resolveOnDiskPath()` tries the requested path as given, then its NFC and NFD forms, returning the first that exists (falls back to the original so a genuinely-missing file still ENOENTs normally). Wired into both `pinchy_read` and `pinchy_ls` before `realpathSync`. This resolves both files already stored NFD **and** any future normalization round-trip mismatch — so the original ticket PDF becomes readable without re-uploading.

## Testing note (why `exists` is injected)

The mismatch only reproduces on a **normalization-sensitive** filesystem (Linux/ext4). The dev host (macOS/APFS) folds NFC/NFD, so a real-tempfile test would pass even without the fix. `resolveOnDiskPath` therefore takes an injectable `exists` predicate; the test drives it with a Linux-style predicate (only the exact NFD bytes exist) to assert the NFC→NFD fallback deterministically.

- New `unicode-path.test.ts` (4 cases), TDD — watched them fail first.
- Full `pinchy-files` suite (178) green; `tsc --noEmit` clean.

## Related
- #729 — NFC normalization at upload (prevents new NFD files).
- #724 — routes attachments through `pinchy_read` (drops the built-in `pdf`/`image` trap).

Together, #724 + #729 + this make the original `Epic #2483 … Abschätzung … .pdf` readable end-to-end.