### PR TITLE
fix(email): preserve umlaut/international attachment filenames (NFC)

### DIFF
--- a/docs/src/content/docs/guides/connect-email.mdx
+++ b/docs/src/content/docs/guides/connect-email.mdx
@@ -39,7 +39,7 @@ An agent with read access can also download an email's attachments into its own 
 A few operational details worth knowing:
 
 - **Size cap**: attachments over 25 MB are rejected — the same cap `odoo_attach_file` uses, so anything the agent downloads here is always small enough to hand off downstream.
-- **Filename sanitization**: the sender picks the attachment's original filename, so Pinchy sanitizes it before saving (stripping path separators and unsafe characters) rather than trusting it outright.
+- **Filename sanitization**: the sender picks the attachment's original filename, so Pinchy sanitizes it before saving — stripping path separators and unsafe characters — rather than trusting it outright. International characters are kept intact (an `Abschätzung.pdf` stays `Abschätzung.pdf`) and normalized to a consistent Unicode form, so the agent can read the file back reliably afterward.
 - **Collision handling**: if a file with that name already exists in the agent's workspace, Pinchy appends `-1`, `-2`, and so on rather than overwriting anything.
 - **Use the returned filename**: because sanitization or a collision suffix can change the name, always use the filename the tool actually returns — not the original attachment name — for any hand-off to another tool, such as `odoo_attach_file`.
 

--- a/packages/plugins/pinchy-email/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-email/__tests__/tools.test.ts
@@ -1519,6 +1519,67 @@ describe("email_get_attachment", () => {
     expect(payload.filename).toMatch(/^attachment-.+\.pdf$/);
   });
 
+  it("preserves umlaut/accented filenames instead of stripping them to underscores", async () => {
+    const data = Buffer.from("pdf-bytes-here");
+    mockGetAttachment.mockResolvedValue({
+      filename: "Abschätzung.pdf", // NFC (composed ä = U+00E4)
+      mimeType: "application/pdf",
+      data,
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_get_attachment", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockWriteFile).toHaveBeenCalledWith(
+      "/root/.openclaw/workspaces/agent-1/uploads/Abschätzung.pdf",
+      data,
+      { flag: "wx" },
+    );
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.filename).toBe("Abschätzung.pdf");
+  });
+
+  it("normalizes an NFD attachment filename to NFC so the stored bytes match the web upload path", async () => {
+    // macOS mail clients emit decomposed (NFD) filenames: "a" + U+0308.
+    // The web upload path stores NFC (see upload-validation.ts), and
+    // pinchy-files resolves both — but writing NFC here keeps the on-disk
+    // bytes consistent at the source instead of leaning on the read-side
+    // fallback.
+    const nfd = "Absch" + "a\u0308" + "tzung.pdf"; // a + combining diaeresis (NFD)
+    const nfc = "Absch" + "\u00e4" + "tzung.pdf"; // composed ä (NFC)
+    const data = Buffer.from("x");
+    mockGetAttachment.mockResolvedValue({
+      filename: nfd,
+      mimeType: "application/pdf",
+      data,
+    });
+
+    const tools = createApi();
+    const tool = findTool(tools, "email_get_attachment", agentId)!;
+
+    const result = await tool.execute("call-1", {
+      messageId: "msg-1",
+      attachmentId: "att-1",
+    });
+
+    expect(result.isError).toBeFalsy();
+    const [writtenPath] = mockWriteFile.mock.calls[0] as [string, Buffer];
+    expect(writtenPath).toBe(
+      `/root/.openclaw/workspaces/agent-1/uploads/${nfc}`,
+    );
+
+    const payload = JSON.parse(result.content[0].text);
+    expect(payload.filename).toBe(nfc);
+    expect(payload.filename.normalize("NFC")).toBe(payload.filename);
+  });
+
   it("falls back to a .bin extension for an unrecognized mime type with an empty filename", async () => {
     mockGetAttachment.mockResolvedValue({
       filename: "   ",

--- a/packages/plugins/pinchy-email/index.ts
+++ b/packages/plugins/pinchy-email/index.ts
@@ -55,9 +55,23 @@ function humanReadableSize(bytes: number): string {
 }
 
 /**
- * Strip anything that isn't a conservative safe-filename character, then
- * strip leading dots (hidden files / traversal remnants like ".."). Shared
- * by both sanitizeAttachmentFilename call sites below — the cleaned
+ * Normalize to NFC, replace anything that isn't a safe-filename character
+ * with "_", then strip leading dots (hidden files / traversal remnants like
+ * "..").
+ *
+ * The allowlist keeps Unicode letters/marks/numbers (\p{L}\p{M}\p{N}) so real
+ * names survive — "Abschätzung.pdf" stays "Abschätzung.pdf" instead of being
+ * mangled to "Absch_tzung.pdf". Everything dangerous is still replaced: path
+ * separators ("/", "\"), C0/DEL control and BiDi/zero-width formatting
+ * characters, quotes and backticks are all outside \p{L}\p{M}\p{N}._- and
+ * become "_".
+ *
+ * NFC normalization mirrors the web upload path (upload-validation.ts): macOS
+ * mail clients emit decomposed (NFD) filenames, so composing here keeps the
+ * on-disk bytes consistent with what pinchy_read/pinchy_write expect instead
+ * of leaning on the read-side NFC/NFD fallback.
+ *
+ * Shared by both sanitizeAttachmentFilename call sites below — the cleaned
  * filename and the attachmentId-derived fallback stem — so the two paths
  * can never drift apart. Keep this leading-dot strip if you touch it: the
  * defense-in-depth path check in email_get_attachment's execute() relies on
@@ -65,7 +79,10 @@ function humanReadableSize(bytes: number): string {
  * attachment-<id> fallback instead of ever reaching the write.
  */
 function sanitizeNameToken(value: string): string {
-  return value.replace(/[^a-zA-Z0-9._-]/g, "_").replace(/^\.+/, "");
+  return value
+    .normalize("NFC")
+    .replace(/[^\p{L}\p{M}\p{N}._-]/gu, "_")
+    .replace(/^\.+/, "");
 }
 
 /**


### PR DESCRIPTION
## Why

The email attachment sanitizer stored sender-chosen filenames with an **ASCII-only allowlist**, replacing every non-ASCII character with `_`. `Abschätzung.pdf` from an inbox landed on disk as `Absch_tzung.pdf` — a mangled name the agent then hands to `odoo_attach_file` and friends.

This is the email-ingestion sibling of the web-upload fix ([#729](https://github.com/heypinchy/pinchy/pull/729)) and the read-side fallback ([#732](https://github.com/heypinchy/pinchy/pull/732)). Both of those covered chat uploads and `pinchy_read`/`pinchy_write`; email attachments went through their own sanitizer, which still stripped umlauts.

## What

`sanitizeNameToken` now:

1. **Normalizes to NFC first.** macOS mail clients emit decomposed (NFD) filenames (`a` + combining diaeresis). Composing at the source keeps the on-disk bytes consistent with what `pinchy_read`/`pinchy_write` expect, matching the web upload path — instead of relying on the read-side NFC/NFD fallback.
2. **Uses a Unicode-aware allowlist** (`\p{L}\p{M}\p{N}._-`) so real international names survive: `Abschätzung.pdf` stays `Abschätzung.pdf`.

### Security invariants unchanged

Everything dangerous still falls outside the allowlist and is replaced with `_`:

- path separators `/` and `\`
- C0/DEL control + BiDi/zero-width formatting characters
- quotes and backticks

The leading-dot strip that routes literal `.`/`..` into the `attachment-<id>` fallback is retained. NFC composition can only combine base+combining characters into precomposed letters — it can never introduce a separator, control char, or dot. The existing path-traversal (POSIX + Windows) and empty-filename fallback tests stay green.

## Tests (TDD)

Two new cases in `tools.test.ts`:

- an NFC umlaut name is preserved on write (not underscored)
- an NFD name is normalized to NFC on write (`payload.filename.normalize("NFC") === payload.filename`)

Both were red before the change, green after. Full plugin suite: **88/88** in `tools.test.ts`, 339 across the package (the one unrelated `config-schema.test.ts` failure in local runs is a cross-package module-resolution artifact of an isolated mount, not this change).

## Docs

`connect-email.mdx` now states that international characters are kept intact and normalized to a consistent Unicode form.