### PR TITLE
feat(inbox-agent): reclaim stuck ledger rows for reconciliation (#139)

### DIFF
--- a/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
@@ -13,7 +13,11 @@ import {
   processedEmails,
   integrationConnections,
 } from "@/db/schema";
-import { claimEmail, finalizeEmail } from "@/lib/email-workflows/ledger";
+import {
+  claimEmail,
+  finalizeEmail,
+  resetStuckProcessingEmails,
+} from "@/lib/email-workflows/ledger";
 
 async function getProcessed(key: {
   workflowId: string;
@@ -184,6 +188,100 @@ describe("email ledger — finalizeEmail", () => {
     const row = await getProcessed(key);
     expect(row.status).toBe("done");
     expect(row.outcome).toEqual({ note: "first" });
+  });
+});
+
+describe("email ledger — resetStuckProcessingEmails (reconciliation)", () => {
+  // Backdate a claim's `claimedAt` so it looks like it has been stuck in
+  // `processing` for `ageMs`. A row is stuck when its run deferred (a transient
+  // not-ready gap, #717's RunDeferredError) or the dispatch crashed after the
+  // claim but before finalize — it never reached a terminal status.
+  async function backdateClaim(
+    key: { workflowId: string; connectionId: string; providerMessageId: string },
+    ageMs: number
+  ) {
+    await db
+      .update(processedEmails)
+      .set({ claimedAt: new Date(Date.now() - ageMs) })
+      .where(
+        and(
+          eq(processedEmails.workflowId, key.workflowId),
+          eq(processedEmails.connectionId, key.connectionId),
+          eq(processedEmails.providerMessageId, key.providerMessageId)
+        )
+      );
+  }
+
+  const GRACE_MS = 10 * 60_000; // 10 min — comfortably past the 5-min run timeout.
+
+  it("deletes a processing row stuck past the grace window and returns its key", async () => {
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "stuck-1" };
+
+    await claimEmail(key);
+    await backdateClaim(key, GRACE_MS + 60_000); // stuck 11 min → past grace
+
+    const reset = await resetStuckProcessingEmails(GRACE_MS);
+
+    // The caller (reconciliation sweep) needs the claim tuple to audit the
+    // reset and re-list the email — return it, don't just report a count.
+    expect(reset).toEqual([
+      { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "stuck-1" },
+    ]);
+    // Deleted, not merely flagged: the unique claim key must be free again so
+    // onConflictDoNothing can re-claim on the next sweep (delete-and-reclaim).
+    expect(await getProcessed(key)).toBeUndefined();
+  });
+
+  it("leaves a freshly-claimed processing row untouched (a live run must not be reset)", async () => {
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "live-1" };
+
+    await claimEmail(key); // claimedAt = now, well inside the grace window
+
+    const reset = await resetStuckProcessingEmails(GRACE_MS);
+
+    expect(reset).toHaveLength(0);
+    expect(await getProcessed(key)).toBeDefined();
+  });
+
+  it("never touches terminal rows, however old — only processing is reset", async () => {
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const done = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "done-old" };
+    const failed = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "failed-old" };
+
+    await claimEmail(done);
+    await finalizeEmail({ ...done, status: "done", outcome: { note: "kept" } });
+    await claimEmail(failed);
+    await finalizeEmail({ ...failed, status: "failed" });
+    // Backdate both far past the grace window — age alone must not reset them.
+    await backdateClaim(done, GRACE_MS * 100);
+    await backdateClaim(failed, GRACE_MS * 100);
+
+    const reset = await resetStuckProcessingEmails(GRACE_MS);
+
+    expect(reset).toHaveLength(0);
+    expect((await getProcessed(done)).status).toBe("done");
+    expect((await getProcessed(failed)).status).toBe("failed");
+  });
+
+  it("makes a reset email re-claimable — the sweep can re-run it end to end", async () => {
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "retry-1" };
+
+    // Claim, get stuck (deferred not-ready run), then the sweep resets it.
+    await claimEmail(key);
+    await backdateClaim(key, GRACE_MS + 60_000);
+    await resetStuckProcessingEmails(GRACE_MS);
+
+    // The whole point of delete-and-reclaim: a fresh claim now WINS (returns a
+    // new id) instead of being rejected as already-claimed. This is what turns
+    // #717's transient deferral into an actual retry.
+    expect(await claimEmail(key)).toEqual(expect.any(String));
   });
 });
 

--- a/packages/web/src/lib/email-workflows/ledger.ts
+++ b/packages/web/src/lib/email-workflows/ledger.ts
@@ -1,4 +1,4 @@
-import { and, eq } from "drizzle-orm";
+import { and, eq, lt } from "drizzle-orm";
 import { db } from "@/db";
 import { processedEmails } from "@/db/schema";
 import type { ProcessedEmailOutcome } from "@/lib/email-workflows/types";
@@ -86,4 +86,45 @@ export async function finalizeEmail(input: FinalizeInput): Promise<void> {
       `finalizeEmail: no processing ledger row for (${input.workflowId}, ${input.connectionId}, ${input.providerMessageId}) — already finalized or never claimed?`
     );
   }
+}
+
+/** The claim tuple of a reset row, enough for the sweep to re-list and audit it. */
+export interface StuckClaimKey {
+  workflowId: string;
+  connectionId: string;
+  providerMessageId: string;
+}
+
+/**
+ * Un-stick claims that never reached a terminal status. A row is stuck in
+ * `processing` when its run deferred (a transient not-ready gap — #717's
+ * {@link RunDeferredError}) or the dispatch crashed after the claim but before
+ * finalize. Left alone, such a row is a permanent gap: the ledger's unique claim
+ * key blocks any re-claim, so the email is never retried.
+ *
+ * The fix is **delete-and-reclaim**: DELETE processing rows older than
+ * `graceMs`, freeing the claim key so the reconciliation sweep's re-list re-runs
+ * the email through the normal `claimEmail` path (design §8, "stuck `processing`
+ * past timeout reset by reconciliation"). We delete rather than flip status
+ * because `onConflictDoNothing` re-claims only when the key row is absent; a
+ * never-finalized claim carries no recorded outcome, so nothing is lost.
+ *
+ * `graceMs` MUST exceed the run timeout so a legitimately in-flight run is never
+ * reset out from under itself — at-least-once still permits a duplicate run on a
+ * genuinely-slow row, caught by the action layer's real-world dedup (design D4).
+ * Terminal rows (`done`/`no_action`/`failed`) are never touched, however old.
+ *
+ * Returns the deleted rows' claim tuples so the caller can re-list them and
+ * write one audit row per reset (with a shared `sweepId`).
+ */
+export async function resetStuckProcessingEmails(graceMs: number): Promise<StuckClaimKey[]> {
+  const cutoff = new Date(Date.now() - graceMs);
+  return db
+    .delete(processedEmails)
+    .where(and(eq(processedEmails.status, "processing"), lt(processedEmails.claimedAt, cutoff)))
+    .returning({
+      workflowId: processedEmails.workflowId,
+      connectionId: processedEmails.connectionId,
+      providerMessageId: processedEmails.providerMessageId,
+    });
 }


### PR DESCRIPTION
## What

Adds the reconciliation sweep's pure-DB core to the Inbox-Agent ledger:
`resetStuckProcessingEmails(graceMs)` un-sticks claims that never reached a
terminal status.

A row gets stuck in `processing` when:
- its run **deferred** on a transient not-ready gap — #717's `RunDeferredError`
  (the agent hadn't landed in the OpenClaw runtime yet), or
- the dispatch **crashed** after the claim but before `finalizeEmail`.

Left alone, such a row is a permanent gap: the ledger's unique claim key blocks
any re-claim, so the email is **never retried** — the silent-loss hole #717
opened by deliberately leaving these rows `processing`.

## How — delete-and-reclaim

`DELETE` `processing` rows whose `claimedAt` is older than `graceMs`, freeing the
claim key so the sweep's re-list re-runs the email through the normal `claimEmail`
path (design §8, "stuck `processing` past timeout reset by reconciliation").

- **Delete, not flip status:** `onConflictDoNothing` re-claims only when the key
  row is absent. A never-finalized claim carries no recorded outcome, so nothing
  is lost by deleting it.
- **`graceMs` must exceed the run timeout** so a legitimately in-flight run is
  never reset out from under itself. At-least-once still permits a duplicate run
  on a genuinely-slow row, caught by the action layer's real-world dedup (D4).
- **Terminal rows** (`done`/`no_action`/`failed`) are never touched, however old.
- Returns the deleted claim tuples so the future caller can re-list them and
  write one audit row per reset (shared `sweepId`).

This is the sweep's **foundation primitive** — same brick cadence as
`claimEmail`/`finalizeEmail`. The re-list + re-dispatch orchestration (and its
audited caller) lands with the discovery route, which both the normal poll and
the sweep share; a full provider-re-listing sweep can't land cleanly before that
shared discovery layer exists.

## Tests (TDD, real Postgres)

4 integration tests in `email-ledger.integration.test.ts`:
- resets a stuck row and returns its claim key (row is gone, not just flagged);
- leaves a fresh/live `processing` row untouched (a live run must not be reset);
- never touches terminal rows, however old;
- proves the reset email is **re-claimable end to end** — the retry #717 needs.

Both guards (`status = processing`, `claimedAt < cutoff`) were mutation-verified:
neutralizing each reddens exactly its pinning test.

## Gates
- `pnpm -C packages/web test` — 8205 passed | 15 skipped
- `pnpm test:db` (ephemeral throwaway Postgres, not the shared stack) — 210 passed
- `pnpm -C packages/web lint` — clean · `format:check` — clean · `pnpm build` — ✓ compiled

## Scope notes
- Purely additive: one new export + one `lt` import. No schema/migration change
  (uses the existing `processed_emails_status_idx`).
- No new state-changing route, so no audit call here — the primitive is caller-
  audited, exactly like `claimEmail`/`finalizeEmail`.