### PR TITLE
fix(memory): make agent memory recall actually work (file fallback + offline embedding index)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -401,6 +401,22 @@ jobs:
             exit 1
           fi
 
+      - name: Verify memory-search embedding wiring (offline, no API key)
+        run: |
+          # Guarantee the full local-embedding chain works in the shipped image:
+          # the llama-cpp provider loads from plugins.allow, the bundled
+          # EmbeddingGemma GGUF is present, boot-staging + registry refresh make
+          # it discoverable, `openclaw memory index` builds the vector index, and
+          # memory_search semantically recalls a stored fact. `--network none`
+          # means a regression that needs a remote model or API key (e.g. a
+          # revert to memory-core's `openai` default) fails LOUD here instead of
+          # silently returning 0 chunks in production. Script + model path are
+          # pinned to build.ts by the memory-embedding-pin-drift unit test.
+          docker run --rm --network none \
+            -v "$PWD/config/verify-memory-search.sh:/verify-memory-search.sh:ro" \
+            --entrypoint bash \
+            ghcr.io/heypinchy/pinchy-openclaw:latest /verify-memory-search.sh
+
       - name: Start production stack
         run: docker compose up -d
         env:

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -77,9 +77,15 @@ RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates
 RUN openclaw plugins install @openclaw/llama-cpp-provider \
     && mkdir -p /opt/llama-cpp-deps \
     && cp -r /root/.openclaw/npm /opt/llama-cpp-deps/npm
+# Download pinned to an immutable commit revision (not the moving `main` ref) and
+# verified against its sha256 — a corrupt or tampered 329 MB blob fails the build
+# LOUD instead of silently shipping in the image. Bump the revision + digest
+# together when updating the model (the memory-embedding-pin-drift unit test
+# enforces that both stay present).
 RUN mkdir -p /opt/embedding-models \
     && curl -fsSL -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
-       https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/main/embeddinggemma-300m-qat-Q8_0.gguf
+       https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/66f974f8cd48cc3b9c41c516b95508e75b4bee64/embeddinggemma-300m-qat-Q8_0.gguf \
+    && echo "6fa0c02a9c302be6f977521d399b4de3a46310a4f2621ee0063747881b673f67  /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf" | sha256sum -c -
 
 # Install pinchy-files plugin dependencies (native modules must be built here).
 # Each bundle's node_modules is copied into /opt/<plugin>-deps so the runtime
@@ -199,11 +205,17 @@ COPY config/start-openclaw.sh /start-openclaw.sh
 # mountpoint-safety invariant is unit-testable — see
 # packages/web/src/__tests__/lib/install-plugin-deps.test.ts.
 COPY config/install-plugin-deps.sh /install-plugin-deps.sh
+# Boot-time staging of the bundled llama.cpp embedding provider, sourced by
+# start-openclaw.sh. Kept as a separate script (same pattern as
+# install-plugin-deps.sh) so the offline smoke test sources the real function and
+# the staging contract is unit-testable — see
+# packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts.
+COPY config/stage-llama-cpp-provider.sh /stage-llama-cpp-provider.sh
 # Device-pairing auto-approver invoked per tick by start-openclaw.sh. Kept as a
 # separate Node module so its requestId-churn convergence is unit-testable
 # (config/__tests__/auto-approve-once.test.mjs) instead of embedded bash.
 COPY config/auto-approve-once.mjs /auto-approve-once.mjs
-RUN chmod +x /start-openclaw.sh /install-plugin-deps.sh
+RUN chmod +x /start-openclaw.sh /install-plugin-deps.sh /stage-llama-cpp-provider.sh
 
 # Bake Pinchy's user-facing docs into the image so Smithers' docs_list /
 # docs_read tools (pinchy-docs plugin) work in every deploy. Previously

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -54,6 +54,33 @@ RUN apt-get update && apt-get install -y --no-install-recommends \
 # literal form unchanged.
 RUN npm install -g openclaw@2026.7.1
 
+# Bundle the external llama.cpp embedding provider (manifest id `llama-cpp`) plus
+# the EmbeddingGemma GGUF it serves. Together they give memory-core a key-less,
+# OFFLINE `local` embedding provider — the backend Pinchy pins in
+# agents.defaults.memorySearch (see build.ts MEMORY_EMBEDDING_MODEL_PATH +
+# REQUIRED_BUNDLED_PLUGINS). Without a working embedding provider, memory_search
+# returns 0 chunks and every recall silently fails; memory-core's default
+# `openai` provider needs a key Pinchy never has, and ollama-cloud/Anthropic
+# expose no embeddings — so a bundled local model is the only option that works
+# on every install.
+#
+# `openclaw plugins install` writes the provider (with its node-llama-cpp native
+# runtime — prebuilt .node/.so for this arch, no compile) into
+# ~/.openclaw/npm/projects/. That dir lives under the `openclaw-config` volume in
+# production, which shadows any image-baked content on upgrade, so we stage the
+# whole npm tree to /opt (non-volume). start-openclaw.sh copies it into
+# ~/.openclaw on boot and refreshes the plugin registry — same pattern as the
+# /opt/*-deps bundles below. ca-certificates + curl live only in this builder
+# stage (the GGUF download); they never reach the runtime image.
+RUN apt-get update && apt-get install -y --no-install-recommends ca-certificates curl \
+    && rm -rf /var/lib/apt/lists/*
+RUN openclaw plugins install @openclaw/llama-cpp-provider \
+    && mkdir -p /opt/llama-cpp-deps \
+    && cp -r /root/.openclaw/npm /opt/llama-cpp-deps/npm
+RUN mkdir -p /opt/embedding-models \
+    && curl -fsSL -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
+       https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/main/embeddinggemma-300m-qat-Q8_0.gguf
+
 # Install pinchy-files plugin dependencies (native modules must be built here).
 # Each bundle's node_modules is copied into /opt/<plugin>-deps so the runtime
 # stage can grab a clean, fully-built tree. The npm download cache stays in this
@@ -140,6 +167,15 @@ COPY --from=builder /opt/pinchy-files-deps /opt/pinchy-files-deps
 COPY --from=builder /opt/pinchy-odoo-deps /opt/pinchy-odoo-deps
 COPY --from=builder /opt/pinchy-web-deps /opt/pinchy-web-deps
 COPY --from=builder /opt/pinchy-email-deps /opt/pinchy-email-deps
+
+# The bundled llama.cpp embedding provider (with its prebuilt node-llama-cpp
+# native binaries) and the EmbeddingGemma GGUF it serves. start-openclaw.sh
+# stages the provider into ~/.openclaw/npm on boot (the config volume shadows an
+# image-baked ~/.openclaw across upgrades) and refreshes the plugin registry;
+# the model is read straight from /opt (never volume-mounted) via
+# MEMORY_EMBEDDING_MODEL_PATH. See the builder stage for why this is bundled.
+COPY --from=builder /opt/llama-cpp-deps /opt/llama-cpp-deps
+COPY --from=builder /opt/embedding-models /opt/embedding-models
 
 # Pre-warm the bundled-plugin runtime-deps cache. Rationale and full
 # behaviour live in config/prewarm-openclaw.sh; in short: boot the

--- a/config/stage-llama-cpp-provider.sh
+++ b/config/stage-llama-cpp-provider.sh
@@ -1,0 +1,41 @@
+#!/bin/bash
+# Stages the bundled llama.cpp embedding provider into the OpenClaw config volume
+# on boot. Extracted from start-openclaw.sh (same pattern as install-plugin-deps.sh)
+# so the staging contract is unit-testable (stage-llama-cpp-provider.test.ts) AND
+# the offline CI smoke test (config/verify-memory-search.sh) exercises the REAL
+# function instead of a re-implemented copy that could drift from production.
+#
+# `openclaw plugins install @openclaw/llama-cpp-provider` runs at image-build time
+# and writes the provider (with its prebuilt node-llama-cpp native runtime) under
+# ~/.openclaw/npm/projects/. That path lives on the `openclaw-config` volume, which
+# shadows the image-baked copy on upgrades — so the built provider is kept in
+# /opt/llama-cpp-deps (non-volume) and copied into ~/.openclaw/npm here if absent,
+# then the persisted plugin registry is refreshed so OpenClaw rediscovers it. This
+# is what gives memory-core its key-less, OFFLINE `local` embedding provider — the
+# backend Pinchy pins in agents.defaults.memorySearch (see MEMORY_EMBEDDING_MODEL_PATH
+# in openclaw-config/build.ts). Without it, memory_search returns 0 chunks and
+# agent recall silently fails. Same volume-shadow-defeating pattern as
+# install_plugin_deps.
+#
+# Paths are env-overridable so the unit test can drive it against temp dirs;
+# production uses the defaults.
+
+LLAMA_CPP_DEPS_ROOT="${LLAMA_CPP_DEPS_ROOT:-/opt/llama-cpp-deps}"
+OPENCLAW_NPM_ROOT="${OPENCLAW_NPM_ROOT:-/root/.openclaw/npm}"
+
+stage_llama_cpp_provider() {
+    [ -d "$LLAMA_CPP_DEPS_ROOT/npm" ] || return 0
+    if ! ls -d "$OPENCLAW_NPM_ROOT"/projects/openclaw-llama-cpp-provider-* >/dev/null 2>&1; then
+        echo "[llama-cpp] staging bundled embedding provider into ${OPENCLAW_NPM_ROOT}"
+        mkdir -p "$OPENCLAW_NPM_ROOT"
+        cp -r "$LLAMA_CPP_DEPS_ROOT"/npm/. "$OPENCLAW_NPM_ROOT"/
+    fi
+    # Idempotent, offline: rescans on-disk source roots (incl. the staged
+    # provider) to rebuild the persisted registry so it loads. A silent failure
+    # here means the provider never loads and recall regresses to 0 chunks — so
+    # warn loudly instead of swallowing it, but stay non-fatal (boot continues;
+    # the file-read fallback in memory-prompt.ts still works).
+    if ! openclaw plugins registry --refresh >/dev/null 2>&1; then
+        echo "[llama-cpp] WARNING: 'openclaw plugins registry --refresh' failed; embedding provider may not load — memory_search could return 0 chunks"
+    fi
+}

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -66,29 +66,14 @@ ensure_secrets_root_owned() {
 # shellcheck source=install-plugin-deps.sh
 source /install-plugin-deps.sh
 
-# Stage the bundled llama.cpp embedding provider into the config volume.
-# `openclaw plugins install @openclaw/llama-cpp-provider` runs at image-build
-# time and places the provider (with its prebuilt node-llama-cpp native runtime)
-# under ~/.openclaw/npm/projects/. That path lives on the `openclaw-config`
-# volume, which shadows the image-baked copy on upgrades — so we keep the built
-# provider in /opt/llama-cpp-deps (non-volume) and copy it into ~/.openclaw/npm
-# here if absent, then refresh the persisted plugin registry so OpenClaw
-# rediscovers it. This is what gives memory-core its key-less, OFFLINE `local`
-# embedding provider — the backend Pinchy pins in agents.defaults.memorySearch
-# (see MEMORY_EMBEDDING_MODEL_PATH in openclaw-config/build.ts). Without it,
-# memory_search returns 0 chunks and agent recall silently fails. Same
-# volume-shadow-defeating pattern as install_plugin_deps above.
-stage_llama_cpp_provider() {
-    [ -d /opt/llama-cpp-deps/npm ] || return 0
-    if ! ls -d /root/.openclaw/npm/projects/openclaw-llama-cpp-provider-* >/dev/null 2>&1; then
-        echo "[llama-cpp] staging bundled embedding provider into ~/.openclaw/npm"
-        mkdir -p /root/.openclaw/npm
-        cp -r /opt/llama-cpp-deps/npm/. /root/.openclaw/npm/
-    fi
-    # Idempotent, offline: rescans on-disk source roots (incl. ~/.openclaw/npm/
-    # projects) to rebuild the persisted registry so the staged provider loads.
-    openclaw plugins registry --refresh >/dev/null 2>&1 || true
-}
+# Boot-time staging of the bundled llama.cpp embedding provider (memory-core's
+# key-less, offline `local` embedding backend). Extracted to its own sourceable
+# script so the offline CI smoke test (config/verify-memory-search.sh) runs the
+# REAL function and the staging contract is unit-testable — see
+# packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts. Defines
+# stage_llama_cpp_provider() into this shell.
+# shellcheck source=stage-llama-cpp-provider.sh
+source /stage-llama-cpp-provider.sh
 
 # Fix plugin ownership — bind-mounted plugin files from the host may have
 # a different UID than root, causing OpenClaw to block them as "suspicious".

--- a/config/start-openclaw.sh
+++ b/config/start-openclaw.sh
@@ -66,6 +66,30 @@ ensure_secrets_root_owned() {
 # shellcheck source=install-plugin-deps.sh
 source /install-plugin-deps.sh
 
+# Stage the bundled llama.cpp embedding provider into the config volume.
+# `openclaw plugins install @openclaw/llama-cpp-provider` runs at image-build
+# time and places the provider (with its prebuilt node-llama-cpp native runtime)
+# under ~/.openclaw/npm/projects/. That path lives on the `openclaw-config`
+# volume, which shadows the image-baked copy on upgrades — so we keep the built
+# provider in /opt/llama-cpp-deps (non-volume) and copy it into ~/.openclaw/npm
+# here if absent, then refresh the persisted plugin registry so OpenClaw
+# rediscovers it. This is what gives memory-core its key-less, OFFLINE `local`
+# embedding provider — the backend Pinchy pins in agents.defaults.memorySearch
+# (see MEMORY_EMBEDDING_MODEL_PATH in openclaw-config/build.ts). Without it,
+# memory_search returns 0 chunks and agent recall silently fails. Same
+# volume-shadow-defeating pattern as install_plugin_deps above.
+stage_llama_cpp_provider() {
+    [ -d /opt/llama-cpp-deps/npm ] || return 0
+    if ! ls -d /root/.openclaw/npm/projects/openclaw-llama-cpp-provider-* >/dev/null 2>&1; then
+        echo "[llama-cpp] staging bundled embedding provider into ~/.openclaw/npm"
+        mkdir -p /root/.openclaw/npm
+        cp -r /opt/llama-cpp-deps/npm/. /root/.openclaw/npm/
+    fi
+    # Idempotent, offline: rescans on-disk source roots (incl. ~/.openclaw/npm/
+    # projects) to rebuild the persisted registry so the staged provider loads.
+    openclaw plugins registry --refresh >/dev/null 2>&1 || true
+}
+
 # Fix plugin ownership — bind-mounted plugin files from the host may have
 # a different UID than root, causing OpenClaw to block them as "suspicious".
 if [ -d /root/.openclaw/extensions ]; then
@@ -239,6 +263,7 @@ mark_bootstrap_when_ready() {
 }
 
 install_plugin_deps
+stage_llama_cpp_provider
 scan_data_directories
 
 # OpenClaw rewrites openclaw.json with root-only permissions on every startup
@@ -336,6 +361,7 @@ while true; do
             echo "OpenClaw Gateway stopped (port 18789 not responding after 10s), restarting..."
             fix_config_permissions
             install_plugin_deps
+            stage_llama_cpp_provider
             scan_data_directories
             ensure_secrets_root_owned
             openclaw gateway --port 18789 &

--- a/config/verify-memory-search.sh
+++ b/config/verify-memory-search.sh
@@ -45,13 +45,11 @@ cat >/root/.openclaw/openclaw.json <<JSON
 JSON
 
 # Stage the bundled provider into the (normally volume-mounted) config dir and
-# refresh the registry — exactly what start-openclaw.sh's stage_llama_cpp_provider
-# does on boot.
-if ! ls -d /root/.openclaw/npm/projects/openclaw-llama-cpp-provider-* >/dev/null 2>&1; then
-  mkdir -p /root/.openclaw/npm
-  cp -r /opt/llama-cpp-deps/npm/. /root/.openclaw/npm/
-fi
-openclaw plugins registry --refresh >/dev/null 2>&1 || true
+# refresh the registry using the REAL boot-path function — sourced from the same
+# helper start-openclaw.sh uses, so this smoke test can't pass against a staging
+# implementation that has drifted from production.
+source /stage-llama-cpp-provider.sh
+stage_llama_cpp_provider
 
 openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
   echo "::error::llama-cpp provider did not load from plugins.allow"

--- a/config/verify-memory-search.sh
+++ b/config/verify-memory-search.sh
@@ -1,0 +1,83 @@
+#!/bin/bash
+# Offline smoke test for the bundled local memory-search embedding provider.
+#
+# Proves the FULL Ebene-1 wiring works with NO network and NO API key, inside
+# the shipped openclaw image:
+#   - the llama-cpp provider loads from `plugins.allow` alone (no per-plugin
+#     entry), after boot-staging + registry refresh (start-openclaw.sh),
+#   - the bundled EmbeddingGemma GGUF is present at MODEL_PATH,
+#   - `openclaw memory index` builds a non-empty vector index for the `local`
+#     provider,
+#   - `memory_search` semantically recalls a stored fact.
+#
+# Run against the built image in CI (docker-smoke job) with `--network none`, so
+# a regression that reaches for a remote model or API key — e.g. a revert to
+# memory-core's `openai` default — fails LOUD here instead of silently
+# returning 0 chunks in production (the exact bug this whole change fixes).
+#
+# MODEL_PATH is kept in lockstep with MEMORY_EMBEDDING_MODEL_PATH in
+# openclaw-config/build.ts and the GGUF download path in Dockerfile.openclaw by
+# the memory-embedding-pin-drift unit test — change all three together.
+set -euo pipefail
+
+MODEL_PATH="/opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf"
+AGENT="memory-smoke-agent"
+WS="/root/.openclaw/workspaces/$AGENT"
+
+test -f "$MODEL_PATH" || {
+  echo "::error::bundled embedding model missing at $MODEL_PATH"
+  exit 1
+}
+
+mkdir -p "$WS/memory"
+printf '# Accounting rules\n' >"$WS/MEMORY.md"
+printf 'Invoices from supplier Helmcraft always post to collective account 3400.\n' \
+  >"$WS/memory/accounts.md"
+
+# Minimal Pinchy-shaped config: llama-cpp enabled via plugins.allow ONLY (no
+# per-plugin entry — mirrors regenerateOpenClawConfig), memory-search pinned to
+# the local provider + bundled model.
+cat >/root/.openclaw/openclaw.json <<JSON
+{"gateway":{"mode":"local","bind":"lan","auth":{"token":"smoke"}},
+ "plugins":{"allow":["memory-core","llama-cpp"],"entries":{}},
+ "agents":{"defaults":{"memorySearch":{"provider":"local","local":{"modelPath":"$MODEL_PATH"}}},
+           "list":[{"id":"$AGENT","name":"Smoke","workspace":"$WS"}]}}
+JSON
+
+# Stage the bundled provider into the (normally volume-mounted) config dir and
+# refresh the registry — exactly what start-openclaw.sh's stage_llama_cpp_provider
+# does on boot.
+if ! ls -d /root/.openclaw/npm/projects/openclaw-llama-cpp-provider-* >/dev/null 2>&1; then
+  mkdir -p /root/.openclaw/npm
+  cp -r /opt/llama-cpp-deps/npm/. /root/.openclaw/npm/
+fi
+openclaw plugins registry --refresh >/dev/null 2>&1 || true
+
+openclaw plugins list 2>&1 | grep -qiE 'llama.?cpp.*enabled' || {
+  echo "::error::llama-cpp provider did not load from plugins.allow"
+  openclaw plugins list 2>&1 | grep -i llama || true
+  exit 1
+}
+
+openclaw memory index --agent "$AGENT"
+
+STATUS="$(openclaw memory status --agent "$AGENT" 2>&1)"
+echo "$STATUS" | grep -qi 'Provider: local' || {
+  echo "::error::memory-search provider is not 'local'"
+  echo "$STATUS"
+  exit 1
+}
+echo "$STATUS" | grep -qiE 'Indexed:[^0-9]*[1-9]' || {
+  echo "::error::embedding index built 0 chunks (provider unavailable?)"
+  echo "$STATUS"
+  exit 1
+}
+
+RESULT="$(openclaw memory search --agent "$AGENT" --query 'Where do Helmcraft invoices post to?' 2>&1)"
+echo "$RESULT" | grep -q '3400' || {
+  echo "::error::memory_search did not recall the stored fact (account 3400)"
+  echo "$RESULT"
+  exit 1
+}
+
+echo "OK: memory-search wiring verified offline — provider=local, index built, semantic recall returned account 3400"

--- a/docs/src/content/docs/explanation/agent-memory.mdx
+++ b/docs/src/content/docs/explanation/agent-memory.mdx
@@ -5,6 +5,8 @@ description: How Pinchy agents remember information and what that means for your
 
 Pinchy agents have a memory system that persists knowledge across conversations. When you talk to an agent, it can remember important information and use it in future conversations — giving better, more contextual responses over time.
 
+Recall runs entirely inside your deployment: agents search their memory with a local embedding model that ships in the image, so no memory content is sent to an external service and search keeps working offline and air-gapped. It's multilingual, so an agent recalls what it stored regardless of the language you wrote it in.
+
 ## Personal vs. shared agent memory
 
 Pinchy has two types of agents, and they handle memory differently:

--- a/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
@@ -43,6 +43,23 @@ describe("memory embedding pin drift guard", () => {
     expect(downloaded).toBe(MEMORY_EMBEDDING_MODEL_PATH);
   });
 
+  it("pins the GGUF download to an immutable commit revision, not a moving ref", () => {
+    // `resolve/main/…` is a moving ref: upstream can replace or rename the file
+    // and the image silently changes (or the build breaks). Everything else in
+    // this repo is pinned (openclaw@<version>, marketplace version) — the model
+    // must be too. HuggingFace serves revision-pinned URLs at resolve/<sha>/.
+    expect(DOCKERFILE_OPENCLAW).not.toMatch(/huggingface\.co\/\S+\/resolve\/main\//);
+    expect(DOCKERFILE_OPENCLAW).toMatch(/huggingface\.co\/\S+\/resolve\/[0-9a-f]{40}\/\S+\.gguf/);
+  });
+
+  it("verifies the downloaded GGUF against a sha256 checksum", () => {
+    // No integrity check means a corrupt or tampered 329 MB download is baked
+    // into the image that ships to every deployment. `sha256sum -c` fails the
+    // build LOUD instead. Pin the expected digest next to the download.
+    expect(DOCKERFILE_OPENCLAW).toMatch(/sha256sum\s+-c/);
+    expect(DOCKERFILE_OPENCLAW).toMatch(/[0-9a-f]{64}\s+\S+\.gguf/);
+  });
+
   it("the CI smoke test checks the same model path", () => {
     const smokePath = VERIFY_SCRIPT.match(/MODEL_PATH="([^"]+\.gguf)"/)?.[1];
     expect(smokePath).toBe(MEMORY_EMBEDDING_MODEL_PATH);

--- a/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
@@ -1,0 +1,50 @@
+/**
+ * Drift guard for the bundled local memory-search embedding model.
+ *
+ * The `local` embedding provider that makes memory_search work offline has its
+ * wiring spread across three files that MUST agree on one thing — the path of
+ * the bundled GGUF model:
+ *
+ *   1. `Dockerfile.openclaw` — `curl -o <path> …embeddinggemma…gguf` bakes the
+ *      model into the image, and `openclaw plugins install …llama-cpp-provider`
+ *      installs the provider that reads it.
+ *   2. `openclaw-config/build.ts` — `MEMORY_EMBEDDING_MODEL_PATH` is written into
+ *      every agent's `memorySearch.local.modelPath`, i.e. the path OpenClaw
+ *      actually loads at runtime.
+ *   3. `config/verify-memory-search.sh` — the offline CI smoke test asserts the
+ *      whole chain against the real image.
+ *
+ * If (1) and (2) drift, memory_search silently loads nothing in production
+ * (0 chunks) while every unit test still passes — the exact silent-failure class
+ * this feature exists to kill. If (3) drifts, the smoke test tests the wrong
+ * file. Structural check so drift trips here at `pnpm test`, not in prod.
+ */
+
+import { describe, it, expect } from "vitest";
+import { readFileSync } from "node:fs";
+import { resolve } from "node:path";
+import { MEMORY_EMBEDDING_MODEL_PATH } from "@/lib/openclaw-config";
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const DOCKERFILE_OPENCLAW = readFileSync(resolve(REPO_ROOT, "Dockerfile.openclaw"), "utf8");
+const VERIFY_SCRIPT = readFileSync(resolve(REPO_ROOT, "config/verify-memory-search.sh"), "utf8");
+
+describe("memory embedding pin drift guard", () => {
+  it("Dockerfile.openclaw installs the external llama-cpp embedding provider", () => {
+    // build.ts pins memorySearch.provider = "local" and adds `llama-cpp` to
+    // plugins.allow; that provider only exists in the image if it's installed.
+    expect(DOCKERFILE_OPENCLAW).toMatch(/openclaw plugins install @openclaw\/llama-cpp-provider/);
+  });
+
+  it("Dockerfile downloads the GGUF to exactly MEMORY_EMBEDDING_MODEL_PATH", () => {
+    // The file Pinchy points memorySearch.local.modelPath at MUST be the file
+    // the image bakes, or memory_search loads nothing while unit tests pass.
+    const downloaded = DOCKERFILE_OPENCLAW.match(/-o\s+(\S+\.gguf)/)?.[1];
+    expect(downloaded).toBe(MEMORY_EMBEDDING_MODEL_PATH);
+  });
+
+  it("the CI smoke test checks the same model path", () => {
+    const smokePath = VERIFY_SCRIPT.match(/MODEL_PATH="([^"]+\.gguf)"/)?.[1];
+    expect(smokePath).toBe(MEMORY_EMBEDDING_MODEL_PATH);
+  });
+});

--- a/packages/web/src/__tests__/lib/memory-prompt.test.ts
+++ b/packages/web/src/__tests__/lib/memory-prompt.test.ts
@@ -41,4 +41,31 @@ describe("buildMemoryPromptBlock", () => {
     expect(buildMemoryPromptBlock([])).toBeNull();
     expect(buildMemoryPromptBlock(["pinchy_read"])).toBeNull();
   });
+
+  it("steers every write-capable agent to read its memory files with pinchy_read", () => {
+    // memory_search rides on an embedding index that can be unavailable (prod:
+    // default `openai` provider, no key → 0 chunks → the tool returns disabled).
+    // Without a fallback the agent confabulates ("memory index unavailable, tell
+    // me again"). A write-capable agent ALWAYS has pinchy_read/pinchy_ls with its
+    // MEMORY.md + memory/ dir in allowed_paths (computeAllowedTools emits them for
+    // every agent; build.ts grants the memory paths on write — verified in prod:
+    // Penny's tools.allow + allowed_paths), so reading the files is a recall path
+    // that always works. It must be told to use it.
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!).toContain("pinchy_read");
+  });
+
+  it("tells the agent to list memory/ with pinchy_ls to find topic notes", () => {
+    // Topic notes (e.g. memory/helmcraft_odoo.md) aren't guessable by name;
+    // the agent needs to list the directory to discover them.
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!).toContain("pinchy_ls");
+  });
+
+  it("frames memory_search as possibly unavailable so failure triggers the file fallback", () => {
+    // The behavioural fix for the reported symptom: a memory_search that returns
+    // 'unavailable' must route the agent to its files, not to a fabricated excuse.
+    const block = buildMemoryPromptBlock(["pinchy_write"]);
+    expect(block!.toLowerCase()).toContain("unavailable");
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -182,6 +182,7 @@ import {
   updateTelegramChannelConfig,
   DEFAULT_DOCS_PUBLIC_BASE_URL,
   DOCS_PUBLIC_BASE_URL_SETTING_KEY,
+  MEMORY_EMBEDDING_MODEL_PATH,
 } from "@/lib/openclaw-config";
 import { pushConfigInBackground, _resetPushGeneration } from "@/lib/openclaw-config/write";
 import { getPendingConfigPushCount, _resetConfigPushState } from "@/lib/openclaw-config/push-state";
@@ -1351,6 +1352,38 @@ describe("regenerateOpenClawConfig", () => {
     expect(resolveFlushPlan({ cfg: withoutFlag })).not.toBeNull();
   });
 
+  it("pins memory-search to the bundled local embedding provider (no API key, offline)", async () => {
+    // memory_search / memory_get ride on memory-core's embedding index.
+    // memory-core defaults to the `openai` embedding provider, for which Pinchy
+    // provisions no key (only ollama-cloud) — so in production every index sync
+    // failed ("No API key found for provider openai"), leaving 0 chunks and a
+    // disabled tool. ollama-cloud and Anthropic offer NO embeddings, so the only
+    // provider that works for every deployment is the bundled local GGUF
+    // (llama-cpp provider + EmbeddingGemma). Pin it in agents.defaults so recall
+    // works offline, with no key, on every install.
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.agents.defaults.memorySearch.provider).toBe("local");
+    expect(config.agents.defaults.memorySearch.local.modelPath).toMatch(/\.gguf$/);
+  });
+
+  it("includes the OpenClaw `llama-cpp` embedding provider in plugins.allow", async () => {
+    // The `local` memorySearch provider is registered by the external llama-cpp
+    // provider plugin (manifest id `llama-cpp`). Without it in plugins.allow the
+    // provider never loads and memory_search resolves to nothing.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
+        plugins: { allow: ["browser", "memory-core"] },
+      })
+    );
+    await regenerateOpenClawConfig();
+
+    const config = JSON.parse(mockedWriteFileSync.mock.calls[0][1] as string);
+    expect(config.plugins.allow).toContain("llama-cpp");
+  });
+
   it("should handle empty agents list", async () => {
     mockedDb.select.mockReturnValue({
       from: mockFrom(),
@@ -1374,10 +1407,15 @@ describe("regenerateOpenClawConfig", () => {
 
     // No env block when no provider keys are configured
     expect(config.env).toBeUndefined();
-    // No provider-derived defaults (no model). The memory-flush disable is
-    // provider-independent and always present (see dedicated test above).
+    // No provider-derived defaults (no model). The memory-flush disable and the
+    // local memory-search embedding provider are provider-independent and always
+    // present (see dedicated tests above).
     expect(config.agents.defaults).toEqual({
       compaction: { memoryFlush: { enabled: false } },
+      memorySearch: {
+        provider: "local",
+        local: { modelPath: MEMORY_EMBEDDING_MODEL_PATH },
+      },
     });
   });
 
@@ -6291,13 +6329,15 @@ describe("restart-state integration", () => {
 
     // Order must match the existing file exactly. Anything else - even with
     // identical contents - triggers a full gateway restart.
-    // pinchy-files is now always emitted (workspace inject); document-extract is required bundled.
+    // pinchy-files is now always emitted (workspace inject); document-extract and
+    // llama-cpp are required bundled plugins appended at the tail.
     expect(config.plugins.allow).toEqual([
       "pinchy-audit",
       "telegram",
       "pinchy-files",
       "pinchy-transcript",
       "document-extract",
+      "llama-cpp",
     ]);
   });
 
@@ -6732,7 +6772,8 @@ describe("restart-state integration", () => {
       const written = JSON.parse(write[1] as string);
       // Same set, same order. Without the fix, telegram migrates to position 0
       // and the pinchy-* entries get re-shuffled by entries-insertion order.
-      // pinchy-files is always emitted (workspace inject); document-extract is required bundled.
+      // pinchy-files is always emitted (workspace inject); document-extract and
+      // llama-cpp are required bundled plugins appended at the tail.
       expect(written.plugins.allow).toEqual([
         "pinchy-audit",
         "pinchy-context",
@@ -6741,6 +6782,7 @@ describe("restart-state integration", () => {
         "pinchy-files",
         "pinchy-transcript",
         "document-extract",
+        "llama-cpp",
       ]);
     }
     // Acceptable alternative: byte-equal early return (no write).

--- a/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
+++ b/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect, beforeEach, afterEach } from "vitest";
 import { execFileSync } from "node:child_process";
-import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { mkdtempSync, mkdirSync, existsSync, rmSync, writeFileSync, chmodSync } from "node:fs";
 import { tmpdir } from "node:os";
-import { join, resolve } from "node:path";
+import { join, resolve, delimiter } from "node:path";
 
 // config/stage-llama-cpp-provider.sh is start-openclaw.sh's boot-time staging
 // step for the bundled llama.cpp embedding provider, extracted into a sourceable
@@ -18,6 +18,12 @@ import { join, resolve } from "node:path";
 // that shadows image-baked content on upgrade. On boot the function copies it
 // into ~/.openclaw/npm if the provider isn't already there, then refreshes the
 // registry. Paths are env-overridable so this test can drive it against temp dirs.
+//
+// The function shells out to `openclaw plugins registry --refresh`. We stub that
+// binary on PATH so the refresh is deterministic and instant in EVERY
+// environment: the real CLI may be absent, or present-and-slow, on a CI runner —
+// exactly the non-determinism that timed this test out in CI. The stub's exit
+// code also lets us exercise the warn-on-failure branch directly.
 
 const REPO_ROOT = resolve(__dirname, "../../../../..");
 const SCRIPT = resolve(REPO_ROOT, "config/stage-llama-cpp-provider.sh");
@@ -25,11 +31,25 @@ const SCRIPT = resolve(REPO_ROOT, "config/stage-llama-cpp-provider.sh");
 let root: string;
 let depsRoot: string;
 let npmRoot: string;
+let binDir: string;
+
+// Install a stub `openclaw` on PATH whose `plugins registry --refresh` returns
+// the given exit code (0 = refresh succeeds, non-zero = refresh fails).
+function stubOpenclaw(exitCode: number): void {
+  const bin = join(binDir, "openclaw");
+  writeFileSync(bin, `#!/bin/bash\nexit ${exitCode}\n`);
+  chmodSync(bin, 0o755);
+}
 
 function runStage(): string {
   return execFileSync("bash", ["-c", `source '${SCRIPT}'; stage_llama_cpp_provider`], {
-    env: { ...process.env, LLAMA_CPP_DEPS_ROOT: depsRoot, OPENCLAW_NPM_ROOT: npmRoot },
-    stdio: "pipe",
+    env: {
+      ...process.env,
+      PATH: `${binDir}${delimiter}${process.env.PATH ?? ""}`,
+      LLAMA_CPP_DEPS_ROOT: depsRoot,
+      OPENCLAW_NPM_ROOT: npmRoot,
+    },
+    stdio: ["ignore", "pipe", "pipe"],
     encoding: "utf8",
   });
 }
@@ -38,6 +58,9 @@ beforeEach(() => {
   root = mkdtempSync(join(tmpdir(), "stage-llama-cpp-"));
   depsRoot = join(root, "opt", "llama-cpp-deps");
   npmRoot = join(root, "home", ".openclaw", "npm");
+  binDir = join(root, "bin");
+  mkdirSync(binDir, { recursive: true });
+  stubOpenclaw(0); // registry refresh succeeds by default
 });
 
 afterEach(() => {
@@ -74,5 +97,23 @@ describe("stage_llama_cpp_provider", () => {
     // No depsRoot/npm — e.g. a build that didn't bundle the provider.
     expect(() => runStage()).not.toThrow();
     expect(existsSync(join(npmRoot, "projects"))).toBe(false);
+  });
+
+  it("warns but stays non-fatal when the registry refresh fails", () => {
+    // A silent refresh failure means the provider never loads and recall
+    // regresses to 0 chunks — so the function must WARN (not swallow with
+    // `|| true`) yet keep booting (the file-read fallback still works).
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+    stubOpenclaw(1); // registry refresh fails
+
+    let output = "";
+    expect(() => {
+      output = runStage();
+    }).not.toThrow(); // non-fatal: boot continues
+    expect(output).toMatch(/WARNING/);
+    // Staging still happened despite the refresh failure.
+    expect(existsSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"))).toBe(true);
   });
 });

--- a/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
+++ b/packages/web/src/__tests__/lib/stage-llama-cpp-provider.test.ts
@@ -1,0 +1,78 @@
+import { describe, it, expect, beforeEach, afterEach } from "vitest";
+import { execFileSync } from "node:child_process";
+import { mkdtempSync, mkdirSync, existsSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join, resolve } from "node:path";
+
+// config/stage-llama-cpp-provider.sh is start-openclaw.sh's boot-time staging
+// step for the bundled llama.cpp embedding provider, extracted into a sourceable
+// helper (same pattern as config/install-plugin-deps.sh) for two reasons:
+//   1. The staging contract becomes unit-testable here.
+//   2. The offline CI smoke test (config/verify-memory-search.sh) SOURCES this
+//      same file and calls the real function, instead of re-implementing the
+//      copy inline — so a drift between the smoke test and the production boot
+//      path can't hide.
+//
+// Contract: the built provider lives in /opt/llama-cpp-deps/npm (non-volume,
+// baked into the image) because ~/.openclaw/npm is on the openclaw-config volume
+// that shadows image-baked content on upgrade. On boot the function copies it
+// into ~/.openclaw/npm if the provider isn't already there, then refreshes the
+// registry. Paths are env-overridable so this test can drive it against temp dirs.
+
+const REPO_ROOT = resolve(__dirname, "../../../../..");
+const SCRIPT = resolve(REPO_ROOT, "config/stage-llama-cpp-provider.sh");
+
+let root: string;
+let depsRoot: string;
+let npmRoot: string;
+
+function runStage(): string {
+  return execFileSync("bash", ["-c", `source '${SCRIPT}'; stage_llama_cpp_provider`], {
+    env: { ...process.env, LLAMA_CPP_DEPS_ROOT: depsRoot, OPENCLAW_NPM_ROOT: npmRoot },
+    stdio: "pipe",
+    encoding: "utf8",
+  });
+}
+
+beforeEach(() => {
+  root = mkdtempSync(join(tmpdir(), "stage-llama-cpp-"));
+  depsRoot = join(root, "opt", "llama-cpp-deps");
+  npmRoot = join(root, "home", ".openclaw", "npm");
+});
+
+afterEach(() => {
+  rmSync(root, { recursive: true, force: true });
+});
+
+describe("stage_llama_cpp_provider", () => {
+  it("copies the bundled provider into the config-volume npm dir when absent", () => {
+    // Simulate the image-baked provider tree under /opt.
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+
+    runStage();
+
+    // Provider is now discoverable under ~/.openclaw/npm (where OpenClaw scans).
+    expect(existsSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"))).toBe(true);
+  });
+
+  it("is idempotent — does not error when the provider is already staged", () => {
+    mkdirSync(join(depsRoot, "npm", "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+    // Provider already present in the config volume from a previous boot.
+    mkdirSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"), {
+      recursive: true,
+    });
+
+    expect(() => runStage()).not.toThrow();
+    expect(existsSync(join(npmRoot, "projects", "openclaw-llama-cpp-provider-abc123"))).toBe(true);
+  });
+
+  it("is a safe no-op when the /opt bundle is missing (nothing to stage)", () => {
+    // No depsRoot/npm — e.g. a build that didn't bundle the provider.
+    expect(() => runStage()).not.toThrow();
+    expect(existsSync(join(npmRoot, "projects"))).toBe(false);
+  });
+});

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -155,6 +155,19 @@ describe("computeAllowedTools", () => {
     expect(computeAllowedTools()).toContain("pinchy_read");
   });
 
+  it("keeps `pinchy_read` AND `pinchy_ls` available — the memory-prompt recall fallback promises both", () => {
+    // buildMemoryPromptBlock (memory-prompt.ts) unconditionally steers every
+    // write-capable agent to recall its memory by reading files with pinchy_read
+    // and discovering topic notes with pinchy_ls. That promise is only safe
+    // because computeAllowedTools() — the OUTER OpenClaw allowlist emitted for
+    // EVERY agent — always lists both. If either is ever trimmed here, the prompt
+    // would tell agents to use a tool they no longer have, silently breaking the
+    // fallback (finding #3, PR #736 review). This guards that coupling.
+    const allowed = computeAllowedTools();
+    expect(allowed).toContain("pinchy_read");
+    expect(allowed).toContain("pinchy_ls");
+  });
+
   it("allows memory_search/memory_get (bundled memory-core plugin powers agent memory)", () => {
     const allowed = computeAllowedTools();
     expect(allowed).toContain("memory_search");

--- a/packages/web/src/lib/memory-prompt.ts
+++ b/packages/web/src/lib/memory-prompt.ts
@@ -13,6 +13,19 @@
  * persist memory (group:fs is denied; pinchy_write is the only writer — see
  * build.ts). Telling such an agent it has memory would reproduce the
  * hallucination this whole change fixes (#368), just from the other side.
+ *
+ * Recall fallback: `memory_search` / `memory_get` ride on OpenClaw's memory-core
+ * embedding index, which is unavailable whenever no embedding provider is
+ * configured (production: the default `openai` provider has no key → 0 indexed
+ * chunks → the tool returns `disabled`). When that happened the agent used to
+ * confabulate ("the memory index changed, tell me again"). So we steer it to the
+ * ALWAYS-working path: reading its own memory files with `pinchy_read`, using
+ * `pinchy_ls` to discover topic notes. This is safe to promise unconditionally
+ * here because a write-capable agent ALWAYS has those tools with its `MEMORY.md`
+ * + `memory/` dir in `allowed_paths` — `computeAllowedTools()` emits pinchy_read
+ * / pinchy_ls for every agent and build.ts grants the memory paths whenever
+ * pinchy_write is granted (the per-agent `allowedTools` DB column is Pinchy's UI
+ * grant model, NOT the emitted OpenClaw allowlist, so it must not gate this).
  */
 export function buildMemoryPromptBlock(allowedTools: string[]): string | null {
   if (!allowedTools.includes("pinchy_write")) return null;
@@ -20,13 +33,21 @@ export function buildMemoryPromptBlock(allowedTools: string[]): string | null {
   return [
     "## Memory",
     "You have persistent memory that survives across conversations:",
-    "- **Long-term** — `MEMORY.md` holds curated, durable knowledge worth keeping.",
+    "- **Long-term** — `MEMORY.md` holds curated, durable knowledge worth " +
+      "keeping. Keep it as an index that points to your topic notes.",
     "- **Daily notes** — append raw observations to `memory/YYYY-MM-DD.md`.",
     "",
-    "Write to these with your `pinchy_write` tool. Your memory is indexed " +
-      "automatically — recall it later with `memory_search` and `memory_get`. " +
-      "When the user asks you to remember something, actually write it; don't " +
-      "just say you will.",
+    "Write to these with your `pinchy_write` tool. When the user asks you to " +
+      "remember something, actually write it; don't just say you will.",
+    "",
+    "To recall what you stored, read your memory files with `pinchy_read` — " +
+      "`MEMORY.md` and the notes under `memory/`. Use `pinchy_ls` on `memory/` " +
+      "to find topic notes when you don't know the filename. Your memory is also " +
+      "indexed for faster `memory_search` / `memory_get`, but that index may be " +
+      "unavailable; if a search returns nothing or reports it is unavailable, " +
+      "fall back to reading the files. If you still can't find it, say you " +
+      'checked — never invent a reason like "the index changed" and never ask ' +
+      "the user to repeat something you already saved.",
     "",
     "Your identity and instructions (`SOUL.md`, `AGENTS.md`) are " +
       "platform-managed and not writable — don't try to change who you are by " +

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -71,6 +71,17 @@ export const DOCS_PUBLIC_BASE_URL_SETTING_KEY = "docs_public_base_url";
 export const DEFAULT_DOCS_PUBLIC_BASE_URL = "https://docs.heypinchy.com";
 
 /**
+ * Absolute path (inside the OpenClaw container) to the bundled EmbeddingGemma
+ * GGUF used by memory-core's `local` embedding provider. Baked into the openclaw
+ * image at build time so memory search works offline with no API key — see
+ * Dockerfile.openclaw. Overridable via `MEMORY_EMBEDDING_MODEL_PATH` for
+ * air-gapped forks that ship a different local model.
+ */
+export const MEMORY_EMBEDDING_MODEL_PATH =
+  process.env.MEMORY_EMBEDDING_MODEL_PATH?.trim() ||
+  "/opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf";
+
+/**
  * Rewrites the user-supplied Ollama URL so OpenClaw's `isLocalBaseUrl` check
  * passes. Container-host aliases (see `DOCKER_HOST_ALIASES`) get normalized to
  * `ollama.local` — which clears the check via the rock-stable `.local` rule and
@@ -367,6 +378,25 @@ export async function regenerateOpenClawConfig() {
     // byte-identical → zero changed paths → no reload at all. The field is also
     // schema-valid (OpenClaw's zod schema declares memoryFlush.enabled as boolean).
     compaction: { memoryFlush: { enabled: false } },
+    // Pin memory-core's embedding provider to the bundled local GGUF model
+    // (the llama-cpp provider + EmbeddingGemma-300m, baked into the openclaw
+    // image — see Dockerfile.openclaw and REQUIRED_BUNDLED_PLUGINS below).
+    // memory-core defaults to the `openai` embedding provider, for which Pinchy
+    // provisions no key (only ollama-cloud) — so in production every index sync
+    // failed ("No API key found for provider openai"), leaving 0 chunks and a
+    // `disabled` memory_search. ollama-cloud and Anthropic expose NO embedding
+    // models, so a local, key-less, offline model is the only provider that
+    // works for every Pinchy deployment. EmbeddingGemma is multilingual (100+
+    // languages, #1 MTEB-multilingual <500M), which matters for non-English
+    // memory. Switching the provider changes the index identity; memory-core
+    // rebuilds the index automatically on next sync. Set in agents.defaults
+    // (deep-merged, preserving OpenClaw-enriched siblings — same reload-safe
+    // pattern as compaction above); memory-core reads it from
+    // agents.*.memorySearch.
+    memorySearch: {
+      provider: "local",
+      local: { modelPath: MEMORY_EMBEDDING_MODEL_PATH },
+    },
   };
   const defaultProvider = (await getSetting("default_provider")) as ProviderName | null;
   if (defaultProvider && PROVIDERS[defaultProvider]) {
@@ -1017,7 +1047,13 @@ export async function regenerateOpenClawConfig() {
   //     2026-07-14 prod incident). This entry is therefore currently inert; it
   //     is kept until the now-unreachable built-in `pdf` registration
   //     (`pdfModel` below) is dropped together in a follow-up.
-  const REQUIRED_BUNDLED_PLUGINS = ["document-extract"] as const;
+  //   - llama-cpp: the external llama.cpp provider plugin (manifest id
+  //     `llama-cpp`) that registers memory-core's `local` embedding provider —
+  //     the key-less, offline GGUF backend we pin in agents.defaults.memorySearch
+  //     above. Installed + bundled in Dockerfile.openclaw; without it in
+  //     plugins.allow the `local` provider never loads and memory_search resolves
+  //     to nothing (the same silent-recall failure, one layer down).
+  const REQUIRED_BUNDLED_PLUGINS = ["document-extract", "llama-cpp"] as const;
 
   const DISABLED_OPENCLAW_PLUGINS = new Set(["acpx", "bonjour", "device-pair", "phone-control"]);
   const isWanted = (p: string) =>

--- a/packages/web/src/lib/openclaw-config/index.ts
+++ b/packages/web/src/lib/openclaw-config/index.ts
@@ -13,6 +13,7 @@ export {
   regenerateOpenClawConfig,
   DEFAULT_DOCS_PUBLIC_BASE_URL,
   DOCS_PUBLIC_BASE_URL_SETTING_KEY,
+  MEMORY_EMBEDDING_MODEL_PATH,
 } from "./build";
 export {
   sanitizeOpenClawConfig,


### PR DESCRIPTION
Fixes agent memory **recall** in production, in two layers.

## The bug

Agents write memory fine (`pinchy_write` → `MEMORY.md` + `memory/`), but could not read it back in a new session — so a rule a user asked an agent to remember (e.g. which collective account certain invoices post to) got applied wrong again next time. Two independent causes, both verified on prod via SSH:

1. **Semantic search was dead.** `memory_search` rides on memory-core's embedding index, which defaults to the `openai` embedding provider. Pinchy provisions no OpenAI key (only `ollama-cloud`), so every index sync failed — `[memory] sync failed: No API key found for provider "openai"` — leaving `0 chunks` and a `disabled` tool. Neither ollama-cloud nor Anthropic expose embedding models at all.
2. **No fallback.** The `## Memory` prompt promised recall only via `memory_search`, so when it returned "unavailable" the agent **confabulated** ("the memory index changed, tell me again") instead of reading its files.

## Ebene 0 — file-read recall fallback (commit 1, prompt only)

Steer write-capable agents to the always-working path: read `MEMORY.md` + `memory/` with `pinchy_read`, list with `pinchy_ls`, treat `memory_search` as an optional accelerator that may be unavailable, and never invent an excuse. Safe to promise unconditionally — a write-capable agent always has `pinchy_read`/`pinchy_ls` with its memory dir in `allowed_paths` (the emitted `tools.allow` is `computeAllowedTools()`; the per-agent DB column is a UI grant model, not the runtime allowlist — verified in prod).

## Ebene 1 — bundle a local, offline embedding provider (commit 2)

Make semantic `memory_search` actually work for every deployment by bundling a key-less local model:

- **build.ts:** pin `agents.defaults.memorySearch` to provider `local` + the bundled EmbeddingGemma GGUF, and add the external `llama-cpp` provider plugin to `plugins.allow`.
- **Dockerfile.openclaw:** install `@openclaw/llama-cpp-provider` (prebuilt node-llama-cpp — no compile) and download the 329 MB EmbeddingGemma GGUF in the builder; stage both to `/opt` (non-volume).
- **start-openclaw.sh:** stage the provider into `~/.openclaw/npm` on boot and refresh the plugin registry (the config volume shadows an image-baked `~/.openclaw` on upgrades — same pattern as `install_plugin_deps`).

EmbeddingGemma is multilingual (100+ languages, #1 MTEB-multilingual <500M), which matters for non-English memory.

## Verification

- Unit: `memory-prompt` 9/9, `openclaw-config` 213/213 (+ new provider/allow tests), 460 green across touched areas. Prettier/ESLint clean.
- **End-to-end in the real `Dockerfile.openclaw` image with `docker run --network none`:** boot-staging runs, `llama-cpp` loads from `plugins.allow` alone, `openclaw memory index` builds the vector index (768-dim), and a **German paraphrased query semantically recalls the stored answer** — no network, no API key.

## Type of change

- [x] 🐛 Bug fix
- [x] ✨ New feature (bundled offline embedding provider)

## Checklist

- [x] Follows project style; tests added; existing tests pass
- [x] Docs updated (`agent-memory.mdx`: recall runs on a local, multilingual, offline model)

## Reviewer notes

- Ebene 0's behaviour is LLM-dependent (prompt contract is unit-tested; following it is observable after redeploy). Ebene 1's embedding chain is deterministically verified in the real image, offline.
- Image grows ~0.4 GB (329 MB GGUF + prebuilt native libs). node-llama-cpp uses prebuilts on glibc — no toolchain in the runtime stage.
- Follow-up (not in this PR): per-provider embedding selection (use OpenAI/Gemini/Voyage embeddings when a user configures them, else this local default) + reindex-on-change.