### PR TITLE
feat(inbox-agent): workflow loader + connection cursor store (#139)

### DIFF
--- a/packages/web/src/__tests__/integration/email-connection-cursors.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-connection-cursors.integration.test.ts
@@ -1,0 +1,68 @@
+// Real-DB integration tests for the Inbox Agent per-connection sync cursor
+// (Brick B). The cursor is a cheap "what's new since last tick" pointer — an
+// opaque provider token (Gmail historyId / Graph deltaLink / timestamp), one
+// per mailbox, shared by every workflow on it (design §4/D2). It is a
+// performance optimization only: the `processed_emails` ledger + reconciliation
+// sweep are the durable correctness layer, so a lost or stale cursor never
+// causes double-processing. The store here is just read + last-write-wins
+// upsert; advancing it "only after durable claim" is the orchestrator's job.
+//
+// Runs against the ephemeral integration Postgres.
+import { describe, it, expect } from "vitest";
+import { eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import { integrationConnections, emailConnectionCursors } from "@/db/schema";
+import { readCursor, advanceCursor } from "@/lib/email-workflows/cursors";
+
+let connCounter = 0;
+async function seedConnection() {
+  const id = `cursor-conn-${connCounter++}`;
+  await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name: "Mailbox", credentials: "enc:placeholder" });
+  return id;
+}
+
+describe("email connection cursor store", () => {
+  it("returns null when a connection has no cursor yet", async () => {
+    const conn = await seedConnection();
+    expect(await readCursor(conn)).toBeNull();
+  });
+
+  it("stores a cursor on first advance and reads it back", async () => {
+    const conn = await seedConnection();
+    await advanceCursor(conn, "historyId:1000");
+    expect(await readCursor(conn)).toBe("historyId:1000");
+  });
+
+  it("overwrites an existing cursor (last write wins) and bumps updatedAt", async () => {
+    const conn = await seedConnection();
+    await advanceCursor(conn, "historyId:1000");
+    // Backdate so a real update is observable regardless of clock resolution;
+    // this also pins the `updatedAt` refresh in the upsert's set clause.
+    const old = new Date("2020-01-01T00:00:00.000Z");
+    await db
+      .update(emailConnectionCursors)
+      .set({ updatedAt: old })
+      .where(eq(emailConnectionCursors.connectionId, conn));
+
+    await advanceCursor(conn, "historyId:2000");
+
+    expect(await readCursor(conn)).toBe("historyId:2000");
+    const [row] = await db
+      .select({ updatedAt: emailConnectionCursors.updatedAt })
+      .from(emailConnectionCursors)
+      .where(eq(emailConnectionCursors.connectionId, conn));
+    expect(row.updatedAt.getTime()).toBeGreaterThan(old.getTime());
+  });
+
+  it("keeps cursors independent per connection", async () => {
+    const connA = await seedConnection();
+    const connB = await seedConnection();
+    await advanceCursor(connA, "cursor-A");
+    await advanceCursor(connB, "cursor-B");
+    expect(await readCursor(connA)).toBe("cursor-A");
+    expect(await readCursor(connB)).toBe("cursor-B");
+  });
+});

--- a/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
@@ -1,0 +1,175 @@
+// Real-DB integration tests for the Inbox Agent workflow loader (Brick A). The
+// loader is the missing link between the DB and the already-complete
+// `dispatchEmails`: it reads every *enabled* workflow, fans it out to one unit
+// of work per connection, and resolves the notification recipients per the
+// scope model (design §7) — personal agent → its owner, shared agent → the
+// creator. Its output (`WorkflowForDispatch` + the connection's `sinceTs`) is
+// exactly what the mail lister (Brick C) and the dispatcher consume.
+//
+// The suite runs against the ephemeral integration Postgres; there is no global
+// truncate between tests, and the loader reads ALL enabled workflows, so every
+// assertion is scoped to the workflow ids the test itself seeded.
+import { describe, it, expect } from "vitest";
+
+import { db } from "@/db";
+import {
+  agents,
+  users,
+  emailWorkflows,
+  emailWorkflowConnections,
+  integrationConnections,
+} from "@/db/schema";
+import { loadDispatchableWorkflows } from "@/lib/email-workflows/loader";
+
+let userCounter = 0;
+async function seedUser() {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `loader-${userCounter++}@test.local`, name: "Owner" })
+    .returning();
+  return row;
+}
+
+async function seedAgent(opts: { isPersonal?: boolean; ownerId?: string | null } = {}) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Penny",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: opts.isPersonal ?? false,
+      ownerId: opts.ownerId ?? null,
+    })
+    .returning();
+  return row;
+}
+
+let connCounter = 0;
+async function seedConnection() {
+  const id = `loader-conn-${connCounter++}`;
+  const [row] = await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name: "Mailbox", credentials: "enc:placeholder" })
+    .returning();
+  return row;
+}
+
+async function seedWorkflow(opts: {
+  agentId: string;
+  enabled: boolean;
+  createdBy?: string | null;
+}) {
+  const [row] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId: opts.agentId,
+      name: "File invoices",
+      filter: { hasAttachment: true, attachmentType: "application/pdf" },
+      action: "Draft a supplier bill in Odoo from the attached invoice.",
+      enabled: opts.enabled,
+      createdBy: opts.createdBy ?? null,
+    })
+    .returning();
+  return row;
+}
+
+async function linkConnection(workflowId: string, connectionId: string, sinceTs: Date) {
+  await db.insert(emailWorkflowConnections).values({ workflowId, connectionId, sinceTs });
+}
+
+const onlyWorkflow = (rows: Awaited<ReturnType<typeof loadDispatchableWorkflows>>, id: string) =>
+  rows.filter((r) => r.workflow.id === id);
+
+describe("email workflow loader — loadDispatchableWorkflows", () => {
+  it("loads an enabled personal-agent workflow with the owner as the recipient", async () => {
+    const owner = await seedUser();
+    // A different creator than the owner pins the scope branch: a personal
+    // workflow notifies the OWNER, never the creator (design §7).
+    const creator = await seedUser();
+    const agent = await seedAgent({ isPersonal: true, ownerId: owner.id });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: creator.id });
+    const conn = await seedConnection();
+    const since = new Date("2026-07-01T00:00:00.000Z");
+    await linkConnection(wf.id, conn.id, since);
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toEqual([
+      {
+        workflow: {
+          id: wf.id,
+          agentId: agent.id,
+          connectionId: conn.id,
+          name: "File invoices",
+          filter: { hasAttachment: true, attachmentType: "application/pdf" },
+          action: "Draft a supplier bill in Odoo from the attached invoice.",
+          recipientUserIds: [owner.id],
+        },
+        sinceTs: since,
+      },
+    ]);
+  });
+
+  it("skips disabled workflows — only enabled ones are dispatched", async () => {
+    const owner = await seedUser();
+    const agent = await seedAgent({ isPersonal: true, ownerId: owner.id });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: false, createdBy: owner.id });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(0);
+  });
+
+  it("resolves a shared-agent workflow's recipient to the creator, not an owner", async () => {
+    const creator = await seedUser();
+    // A shared agent has no personal owner; the recipient must come from the
+    // workflow's creator (design §7), never from a stray ownerId.
+    const strayOwner = await seedUser();
+    const agent = await seedAgent({ isPersonal: false, ownerId: strayOwner.id });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: creator.id });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(1);
+    expect(mine[0].workflow.recipientUserIds).toEqual([creator.id]);
+  });
+
+  it("fans out one unit of work per connection, each with its own sinceTs", async () => {
+    const owner = await seedUser();
+    const agent = await seedAgent({ isPersonal: true, ownerId: owner.id });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: owner.id });
+    const connA = await seedConnection();
+    const connB = await seedConnection();
+    const sinceA = new Date("2026-06-01T00:00:00.000Z");
+    const sinceB = new Date("2026-06-15T00:00:00.000Z");
+    await linkConnection(wf.id, connA.id, sinceA);
+    await linkConnection(wf.id, connB.id, sinceB);
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(2);
+    expect(new Map(mine.map((r) => [r.workflow.connectionId, r.sinceTs]))).toEqual(
+      new Map([
+        [connA.id, sinceA],
+        [connB.id, sinceB],
+      ])
+    );
+  });
+
+  it("drops a workflow with no resolvable recipient — it would be undeliverable", async () => {
+    // Shared agent, no creator recorded: dispatchEmails would reject an empty
+    // recipient set, so the loader must not emit it at all.
+    const agent = await seedAgent({ isPersonal: false, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: null });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
@@ -19,6 +19,7 @@ import {
   emailWorkflowConnections,
   integrationConnections,
 } from "@/db/schema";
+import type { EmailWorkflowStatus } from "@/db/enums";
 import { loadDispatchableWorkflows } from "@/lib/email-workflows/loader";
 
 let userCounter = 0;
@@ -58,6 +59,7 @@ async function seedWorkflow(opts: {
   agentId: string;
   enabled: boolean;
   createdBy?: string | null;
+  status?: EmailWorkflowStatus;
 }) {
   const [row] = await db
     .insert(emailWorkflows)
@@ -68,6 +70,7 @@ async function seedWorkflow(opts: {
       action: "Draft a supplier bill in Odoo from the attached invoice.",
       enabled: opts.enabled,
       createdBy: opts.createdBy ?? null,
+      ...(opts.status ? { status: opts.status } : {}),
     })
     .returning();
   return row;
@@ -171,5 +174,44 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
     const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
 
     expect(mine).toHaveLength(0);
+  });
+
+  it("drops a personal-agent workflow whose agent has no owner — no fallback to the creator", async () => {
+    // Symmetric to the shared/no-creator drop: a PERSONAL workflow resolves to
+    // the agent owner and must NOT silently fall back to createdBy when the
+    // owner is missing. A present creator here would be wrongly picked up by a
+    // "recipient = owner ?? createdBy" mutation — so seed one to pin the branch.
+    const creator = await seedUser();
+    const agent = await seedAgent({ isPersonal: true, ownerId: null });
+    const wf = await seedWorkflow({ agentId: agent.id, enabled: true, createdBy: creator.id });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(0);
+  });
+
+  it("dispatches an enabled workflow even when its status is 'error' — status is a health signal, not a dispatch gate", async () => {
+    // `enabled` is the sole dispatch gate; `status` (pending|active|error) is an
+    // observability field the dispatcher WRITES, never a gate it reads. Gating
+    // on status would let one bad run wedge an enabled workflow off forever
+    // (nothing resets it to active), breaking the at-least-once resilience the
+    // ledger + sweep are built on. Pin that an errored-but-enabled workflow is
+    // still loaded.
+    const owner = await seedUser();
+    const agent = await seedAgent({ isPersonal: true, ownerId: owner.id });
+    const wf = await seedWorkflow({
+      agentId: agent.id,
+      enabled: true,
+      createdBy: owner.id,
+      status: "error",
+    });
+    const conn = await seedConnection();
+    await linkConnection(wf.id, conn.id, new Date());
+
+    const mine = onlyWorkflow(await loadDispatchableWorkflows(), wf.id);
+
+    expect(mine).toHaveLength(1);
   });
 });

--- a/packages/web/src/lib/email-workflows/cursors.ts
+++ b/packages/web/src/lib/email-workflows/cursors.ts
@@ -1,0 +1,39 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { emailConnectionCursors } from "@/db/schema";
+
+/**
+ * Per-connection sync cursor (design §4/D2): an opaque provider token — Gmail
+ * `historyId`, Graph `deltaLink`, or a timestamp — marking "what's new since the
+ * last tick" for one mailbox, shared by every workflow on it.
+ *
+ * The cursor is a **performance optimization, not correctness**: it lets a poll
+ * ask the provider only for recent mail instead of re-listing everything. The
+ * `processed_emails` ledger + reconciliation sweep are the durable truth, so a
+ * lost, stale, or expired cursor (Gmail 404 / Graph 410) never causes
+ * double-processing — the sweep re-lists and the ledger dedups the resync.
+ *
+ * This module is just read + last-write-wins upsert. The load-bearing ordering
+ * ("advance only AFTER claims are durable", design §8) lives in the orchestrator
+ * that calls these, not here.
+ */
+
+/** The connection's current cursor, or null if it has never been advanced. */
+export async function readCursor(connectionId: string): Promise<string | null> {
+  const [row] = await db
+    .select({ cursor: emailConnectionCursors.cursor })
+    .from(emailConnectionCursors)
+    .where(eq(emailConnectionCursors.connectionId, connectionId));
+  return row?.cursor ?? null;
+}
+
+/** Upsert the connection's cursor to `cursor` (last write wins). */
+export async function advanceCursor(connectionId: string, cursor: string): Promise<void> {
+  await db
+    .insert(emailConnectionCursors)
+    .values({ connectionId, cursor })
+    .onConflictDoUpdate({
+      target: emailConnectionCursors.connectionId,
+      set: { cursor, updatedAt: new Date() },
+    });
+}

--- a/packages/web/src/lib/email-workflows/cursors.ts
+++ b/packages/web/src/lib/email-workflows/cursors.ts
@@ -1,4 +1,4 @@
-import { eq } from "drizzle-orm";
+import { eq, sql } from "drizzle-orm";
 import { db } from "@/db";
 import { emailConnectionCursors } from "@/db/schema";
 
@@ -34,6 +34,9 @@ export async function advanceCursor(connectionId: string, cursor: string): Promi
     .values({ connectionId, cursor })
     .onConflictDoUpdate({
       target: emailConnectionCursors.connectionId,
-      set: { cursor, updatedAt: new Date() },
+      // `now()` (DB clock) matches the column's insert-path default, so both
+      // paths stamp `updatedAt` from the same clock rather than mixing the
+      // app's `new Date()` with the server's default.
+      set: { cursor, updatedAt: sql`now()` },
     });
 }

--- a/packages/web/src/lib/email-workflows/loader.ts
+++ b/packages/web/src/lib/email-workflows/loader.ts
@@ -22,13 +22,20 @@ export interface DispatchableWorkflow {
  * builds the `WorkflowForDispatch` values the dispatcher consumes but nobody
  * else produces. Both the normal poll and the reconciliation sweep start here.
  *
- * Only `enabled` workflows are scanned (the partial index
- * `email_workflows_enabled_idx` exists for exactly this query). Recipients
- * follow the scope model (design §7): a **personal** agent's workflow notifies
- * its owner; a **shared** agent's workflow notifies its creator. A workflow
- * whose recipient can't be resolved (e.g. a shared workflow with no recorded
- * creator) is dropped rather than emitted — `dispatchEmails` rejects an empty
- * recipient set, so an undeliverable unit of work must never reach it.
+ * `enabled` is the **sole** dispatch gate (the partial index
+ * `email_workflows_enabled_idx` exists for exactly this query). `status`
+ * (`pending | active | error`) is deliberately NOT filtered: it is a health
+ * signal the dispatcher *writes*, not a gate it *reads*. Gating on it would let
+ * one failed run wedge an `enabled` workflow off forever (nothing resets it to
+ * `active`), and would strand freshly-created `pending` workflows — both break
+ * the at-least-once resilience the ledger + reconciliation sweep are built on.
+ *
+ * Recipients follow the scope model (design §7): a **personal** agent's workflow
+ * notifies its owner; a **shared** agent's workflow notifies its creator. A
+ * workflow whose recipient can't be resolved (e.g. a shared workflow with no
+ * recorded creator, or a personal agent with no owner) is dropped rather than
+ * emitted — `dispatchEmails` rejects an empty recipient set, so an
+ * undeliverable unit of work must never reach it.
  */
 export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[]> {
   const rows = await db

--- a/packages/web/src/lib/email-workflows/loader.ts
+++ b/packages/web/src/lib/email-workflows/loader.ts
@@ -1,0 +1,84 @@
+import { eq } from "drizzle-orm";
+import { db } from "@/db";
+import { agents, emailWorkflows, emailWorkflowConnections } from "@/db/schema";
+import type { WorkflowForDispatch } from "@/lib/email-workflows/dispatch";
+
+/**
+ * One (workflow × connection) unit of work, ready to hand downstream: the
+ * dispatcher's {@link WorkflowForDispatch} plus the connection's watermark. The
+ * mail lister (Brick C) lists only mail newer than `sinceTs` (design §6); the
+ * dispatcher then runs each listed email through filter → claim → run → notify.
+ */
+export interface DispatchableWorkflow {
+  workflow: WorkflowForDispatch;
+  /** email_workflow_connections.since_ts — the per-connection listing floor. */
+  sinceTs: Date;
+}
+
+/**
+ * Load every *enabled* email workflow, fanned out to one unit of work per
+ * attached connection with its notification recipients resolved. This is the
+ * missing link between the DB and the already-complete `dispatchEmails`: it
+ * builds the `WorkflowForDispatch` values the dispatcher consumes but nobody
+ * else produces. Both the normal poll and the reconciliation sweep start here.
+ *
+ * Only `enabled` workflows are scanned (the partial index
+ * `email_workflows_enabled_idx` exists for exactly this query). Recipients
+ * follow the scope model (design §7): a **personal** agent's workflow notifies
+ * its owner; a **shared** agent's workflow notifies its creator. A workflow
+ * whose recipient can't be resolved (e.g. a shared workflow with no recorded
+ * creator) is dropped rather than emitted — `dispatchEmails` rejects an empty
+ * recipient set, so an undeliverable unit of work must never reach it.
+ */
+export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[]> {
+  const rows = await db
+    .select({
+      workflowId: emailWorkflows.id,
+      agentId: emailWorkflows.agentId,
+      name: emailWorkflows.name,
+      filter: emailWorkflows.filter,
+      action: emailWorkflows.action,
+      createdBy: emailWorkflows.createdBy,
+      isPersonal: agents.isPersonal,
+      ownerId: agents.ownerId,
+      connectionId: emailWorkflowConnections.connectionId,
+      sinceTs: emailWorkflowConnections.sinceTs,
+    })
+    .from(emailWorkflows)
+    .innerJoin(agents, eq(agents.id, emailWorkflows.agentId))
+    .innerJoin(emailWorkflowConnections, eq(emailWorkflowConnections.workflowId, emailWorkflows.id))
+    .where(eq(emailWorkflows.enabled, true));
+
+  const result: DispatchableWorkflow[] = [];
+  for (const row of rows) {
+    const recipientUserIds = resolveRecipients(row);
+    if (recipientUserIds.length === 0) continue;
+    result.push({
+      workflow: {
+        id: row.workflowId,
+        agentId: row.agentId,
+        connectionId: row.connectionId,
+        name: row.name,
+        filter: row.filter,
+        action: row.action,
+        recipientUserIds,
+      },
+      sinceTs: row.sinceTs,
+    });
+  }
+  return result;
+}
+
+/**
+ * Scope model (design §7): a personal agent's workflow notifies its owner; a
+ * shared agent's workflow notifies its creator. Returns `[]` when no recipient
+ * can be resolved, which the caller drops.
+ */
+function resolveRecipients(row: {
+  isPersonal: boolean;
+  ownerId: string | null;
+  createdBy: string | null;
+}): string[] {
+  const recipient = row.isPersonal ? row.ownerId : row.createdBy;
+  return recipient ? [recipient] : [];
+}


### PR DESCRIPTION
## What

Two **pure-DB primitives** of the Inbox-Agent orchestration layer — the DB seam between the schema and the already-complete `dispatchEmails` (from #717/#734). The dispatch **core** is done (filter → claim → run → notify → finalize, plus `resetStuckProcessingEmails` for the sweep); these are the two read/write helpers the poll and the sweep call into.

Bundled because both are tiny, same-natured (pure-DB, integration-tested, no OpenClaw). The I/O-seam mail-lister and the orchestrator that wires everything are deliberately **separate** follow-up PRs.

## Brick A — `loadDispatchableWorkflows()`

Scans every **enabled** email workflow (partial index `email_workflows_enabled_idx`), joins agent + attached connections, and returns one **unit of work per (workflow × connection)**:

```ts
interface DispatchableWorkflow {
  workflow: WorkflowForDispatch; // id, agentId, connectionId, name, filter, action, recipientUserIds
  sinceTs: Date;                 // the connection's watermark — the mail lister's listing floor
}
```

**Recipient resolution — scope model (design §7):** personal agent's workflow → its **owner**; shared agent's workflow → its **creator**. A workflow whose recipient can't be resolved is **dropped, not emitted** — `dispatchEmails` rejects an empty recipient set, so an undeliverable unit must never reach it.

## Brick B — `readCursor` / `advanceCursor`

The per-connection sync cursor over `email_connection_cursors` (design §4/D2): an opaque provider token (Gmail `historyId` / Graph `deltaLink` / timestamp), one per mailbox, shared by every workflow on it. Read before a poll lists mail, advanced after.

**Performance optimization, not correctness:** the `processed_emails` ledger + reconciliation sweep are the durable truth, so a lost/stale/expired cursor (Gmail 404 / Graph 410) never double-processes — the sweep re-lists, the ledger dedups. The store is just read + last-write-wins upsert; the load-bearing "advance only after claims are durable" ordering (§8) lives in the orchestrator, not here.

## Tests (TDD, real Postgres)

**Loader** (5): enabled personal-agent workflow → owner (owner ≠ creator, so the branch is actually pinned); skips disabled; shared-agent → creator not owner; fans out per connection with own `sinceTs`; drops no-recipient workflow.
**Cursor** (4): null on missing; store + read back; last-write-wins overwrite + `updatedAt` bump; per-connection isolation.

All loader assertions are scoped to the ids the test seeded (loader reads all enabled workflows; no global truncate). Every guard — `enabled` filter, personal→owner, shared→creator, upsert-overwrite, null-on-missing — was **mutation-verified**: neutralizing each reddens exactly its pinning test.

## Gates
- `pnpm -C packages/web test` — 8212 passed | 15 skipped
- `pnpm test:db` (ephemeral throwaway Postgres, not the shared stack) — 219 passed
- `pnpm -C packages/web lint` / `format:check` — clean · `pnpm build` — ✓ compiled

## Scope notes
- Purely additive: two new modules + two new test files. No schema/migration change (reads/writes existing tables + index).
- No state-changing route, so no audit call here — read-only loader + a cursor bookmark.
- **Next bricks** (each its own PR from fresh main): Mail-Lister (connection → `DispatchableEmail[]` via `pinchy-email` tools, an OpenClaw-I/O seam), then the Orchestrator wiring loader + cursor + lister + `dispatchEmails` (normal poll) and the audited sweep variant with a shared `sweepId`.