### PR TITLE
test: type-check web test files in CI, fix 1058 dormant type errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -114,6 +114,16 @@ jobs:
         # (run by `pnpm test:scripts`) keeps every plugin wired for this gate.
         run: pnpm typecheck:plugins
 
+      - name: Typecheck web (incl. tests)
+        # `next build` (the Build step) type-checks packages/web, but its
+        # tsconfig EXCLUDES *.test.ts(x) — so test files, and the dormant
+        # expectTypeOf/assertType assertions inside them, were never
+        # type-checked anywhere in CI. This runs `tsc --noEmit` over
+        # tsconfig.typecheck.json, which INCLUDES the test files, closing that
+        # gap. The drift guard (scripts/lib/web-typecheck-gate.test.mjs, run by
+        # `pnpm test:scripts`) keeps the tsconfig/script/CI wiring in place.
+        run: pnpm -C packages/web typecheck
+
       - name: Smoke-load plugins (production deps only)
         # Runtime complement to typecheck:plugins: tsc sees devDependencies'
         # type declarations, so a dependency that's missing from a plugin's

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,17 @@ Concretely:
 - **Simulate the pre-existing state:** let the new path capture/write, then delete those rows for the entity, then assert the feature still works (it must fall back or have been backfilled). See `deleteCapturedTelegramMessages` + the "listed ⟹ readable" test in `packages/web/e2e/telegram/chats.spec.ts`, and the deterministic route-level equivalent in `packages/web/src/__tests__/api/agent-telegram-chat.test.ts`.
 - **Assert the cross-route invariant**, not just one route in isolation: if an item appears in a list, opening it must show content (or a defined, honest empty state). List and detail are often changed independently.
 
+## Web Test Files Are Type-Checked
+
+`packages/web` test files (`*.test.ts(x)`, `*.integration.test.ts`, `*.test-d.ts`) are type-checked in CI by the `quality` job's "Typecheck web (incl. tests)" step: `pnpm -C packages/web typecheck` → `tsc --noEmit -p packages/web/tsconfig.typecheck.json`.
+
+This exists because `next build` type-checks the web package but its `tsconfig.json` deliberately **excludes** `src/**/*.test.ts(x)`, and vitest runs without `--typecheck`. So test-file type errors — including dormant `expectTypeOf`/`assertType` assertions that silently pass as runtime no-ops — went undetected until this gate landed. `tsconfig.typecheck.json` extends the base config but INCLUDES the test files and adds `vitest/globals` + `@testing-library/jest-dom` to `types`.
+
+- Write genuine type-level tests: `expectTypeOf(...).toEqualTypeOf<T>()` / `.toExtend<T>()` are now real compile-time checks. Do NOT paper over failures with `as any` / `@ts-expect-error`.
+- Shared, correctly-typed test helpers live in `packages/web/src/test-helpers/` (`auth.ts` → `mockSession`, `route.ts` → `makeNextRequest`/`routeContext`, `fixtures.ts` → `makeAgent`/`makeTemplateItem`). Prefer them over inline fixtures so a type change is a one-line helper fix, not a sweep across test files.
+- The drift guard `scripts/lib/web-typecheck-gate.test.mjs` (pure logic in `web-typecheck-gate.mjs`, run by `pnpm test:scripts`) fails if the tsconfig stops including test files, re-excludes them, the `typecheck` script drifts, or CI stops running the gate — the read-side sibling of the no-untracked-skips / no-test-deletion / plugin-typecheck guards.
+- Playwright `e2e/**/*.spec.ts` is intentionally out of this gate (separate Playwright type context).
+
 ## Commands
 
 Development should use Docker Compose because the app depends on PostgreSQL, OpenClaw, and migrations:

--- a/packages/web/package.json
+++ b/packages/web/package.json
@@ -7,6 +7,7 @@
     "build": "next build --turbopack",
     "start": "NODE_ENV=production node -r ./server-preload.cjs --import tsx server.ts",
     "lint": "eslint",
+    "typecheck": "tsc --noEmit -p tsconfig.typecheck.json",
     "format": "prettier --write .",
     "format:check": "prettier --check .",
     "test": "vitest run",

--- a/packages/web/src/__tests__/api/agent-files.test.ts
+++ b/packages/web/src/__tests__/api/agent-files.test.ts
@@ -40,9 +40,20 @@ const defaultAgent = {
   id: "agent-1",
   name: "Smithers",
   model: "anthropic/claude-sonnet-4-20250514",
+  templateId: null,
+  pluginConfig: null,
+  allowedTools: [],
+  skills: [],
   ownerId: null,
   isPersonal: false,
+  visibility: "restricted" as const,
+  greetingMessage: "Hi, I'm Smithers.",
+  tagline: null,
+  starterPrompts: [],
+  avatarSeed: null,
+  personalityPresetId: null,
   createdAt: new Date(),
+  deletedAt: null,
 };
 
 function makeGetRequest(agentId: string, filename: string) {

--- a/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
+++ b/packages/web/src/__tests__/api/agent-telegram-channel.test.ts
@@ -84,7 +84,7 @@ import { GET, POST, DELETE } from "@/app/api/agents/[agentId]/channels/telegram/
 import { getSetting, setSetting, deleteSetting } from "@/lib/settings";
 import { appendAuditLog } from "@/lib/audit";
 import { db } from "@/db";
-import { NextResponse } from "next/server";
+import { NextRequest, NextResponse } from "next/server";
 
 const adminSession = {
   user: { id: "user-1", email: "admin@test.com", role: "admin" },
@@ -94,7 +94,7 @@ const mockParams = Promise.resolve({ agentId: "agent-1" });
 const mockAgent = { id: "agent-1", name: "Test Agent" };
 
 function makeRequest(body?: object) {
-  return new Request("http://localhost/api/agents/agent-1/channels/telegram", {
+  return new NextRequest("http://localhost/api/agents/agent-1/channels/telegram", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     ...(body && { body: JSON.stringify(body) }),
@@ -110,7 +110,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
   it("returns configured: false when no token exists", async () => {
     vi.mocked(getSetting).mockResolvedValueOnce(null);
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -122,7 +122,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
   it("returns configured: true with hint when token exists", async () => {
     vi.mocked(getSetting).mockResolvedValueOnce("123456:ABC-some-token-xY9z");
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -148,7 +148,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
       return null;
     });
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -163,7 +163,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     mockHasMainTelegramBot.mockResolvedValueOnce(true);
     vi.mocked(getSetting).mockResolvedValueOnce(null);
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -176,7 +176,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     mockHasMainTelegramBot.mockResolvedValueOnce(false);
     vi.mocked(getSetting).mockResolvedValueOnce(null);
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -192,7 +192,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
       return null;
     });
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -211,7 +211,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
       NextResponse.json({ error: "Unauthorized" }, { status: 401 })
     );
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
 
@@ -226,7 +226,7 @@ describe("GET /api/agents/[agentId]/channels/telegram", () => {
     } as any);
     vi.mocked(getSetting).mockResolvedValueOnce(null);
 
-    const response = await GET(new Request("http://localhost"), {
+    const response = await GET(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -539,7 +539,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   });
 
   it("removes token, clears account store, patches config, logs audit event", async () => {
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -572,7 +572,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       }),
     } as any);
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(200);
@@ -599,7 +599,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       }),
     } as any);
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(200);
@@ -621,7 +621,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       ownerId: "someone-else",
     } as any);
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(200);
@@ -638,7 +638,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       user: { id: "user-2", role: "member" },
     });
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(200);
@@ -655,7 +655,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       user: { id: "user-3", role: "member" },
     });
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(403);
@@ -671,7 +671,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
       user: { id: "user-3", role: "member" },
     });
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     expect(response.status).toBe(403);
@@ -681,7 +681,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   it("returns 404 for non-existent agent", async () => {
     vi.mocked(db.query.agents.findFirst).mockResolvedValueOnce(undefined as any);
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
     const data = await response.json();
@@ -693,7 +693,7 @@ describe("DELETE /api/agents/[agentId]/channels/telegram", () => {
   it("returns 401 when not authenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 
-    const response = await DELETE(new Request("http://localhost"), {
+    const response = await DELETE(new NextRequest("http://localhost"), {
       params: mockParams,
     });
 

--- a/packages/web/src/__tests__/api/agents-audit.test.ts
+++ b/packages/web/src/__tests__/api/agents-audit.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -169,7 +170,7 @@ describe("POST /api/agents audit logging", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     expect(appendAuditLog).toHaveBeenCalledWith({

--- a/packages/web/src/__tests__/api/agents-create.test.ts
+++ b/packages/web/src/__tests__/api/agents-create.test.ts
@@ -178,6 +178,8 @@ vi.mock("@/lib/integrations/odoo-template-validation", () => ({
 
 import { POST } from "@/app/api/agents/route";
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
+import { mockSession } from "@/test-helpers/auth";
 import { auth } from "@/lib/auth";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
 import { validateAllowedPaths } from "@/lib/path-validation";
@@ -209,7 +211,7 @@ describe("POST /api/agents", () => {
       body: JSON.stringify({ name: "Race Guard", templateId: "custom" }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     expect(regenerateOpenClawConfig).toHaveBeenCalled();
@@ -225,10 +227,9 @@ describe("POST /api/agents", () => {
   });
 
   it("should return 403 for non-admin users", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "2", email: "user@test.com", role: "member" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })
+    );
 
     const request = new NextRequest("http://localhost:7777/api/agents", {
       method: "POST",
@@ -238,7 +239,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(403);
     const body = await response.json();
     expect(body.error).toBe("Forbidden");
@@ -256,7 +257,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -280,7 +281,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -301,7 +302,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -322,7 +323,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     const expected = AGENT_TEMPLATES["knowledge-base"].defaultStarterPrompts;
     expect(expected, "knowledge-base must define defaultStarterPrompts").toBeDefined();
@@ -339,7 +340,7 @@ describe("POST /api/agents", () => {
       body: JSON.stringify({ name: "Blank", templateId: "custom" }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -354,7 +355,7 @@ describe("POST /api/agents", () => {
       body: JSON.stringify({ name: "   ", templateId: "custom" }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("Validation failed");
@@ -371,7 +372,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("Validation failed");
@@ -386,7 +387,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("Validation failed");
@@ -402,7 +403,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
   });
 
@@ -416,7 +417,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
   });
 
@@ -433,7 +434,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toMatch(/domain/i);
@@ -452,7 +453,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toMatch(/domain/i);
@@ -467,7 +468,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("At least one directory must be selected");
@@ -482,7 +483,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
     expect(validateAllowedPaths).not.toHaveBeenCalled();
   });
@@ -499,7 +500,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -527,7 +528,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     const insertedValues = insertValuesMock.mock.calls[0]?.[0];
     // Template greeting should win over preset greeting
@@ -550,7 +551,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -571,7 +572,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       "new-agent-id",
@@ -590,7 +591,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -611,7 +612,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeIdentityFile).toHaveBeenCalledWith("new-agent-id", {
       name: "HR Knowledge Base",
@@ -631,7 +632,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       "new-agent-id",
@@ -652,7 +653,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       "new-agent-id",
@@ -673,7 +674,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFile).toHaveBeenCalledWith(
       "new-agent-id",
@@ -691,7 +692,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFile).not.toHaveBeenCalledWith(
       expect.anything(),
@@ -714,7 +715,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(mockGetContextForAgent).toHaveBeenCalledWith({
       isPersonal: false,
@@ -738,7 +739,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(writeWorkspaceFileInternal).toHaveBeenCalledWith("new-agent-id", "USER.md", "");
   });
@@ -752,7 +753,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     // The POST handler does not explicitly set visibility, so Drizzle uses the
     // schema default ("restricted"). Verify the insert call does NOT include a
@@ -772,7 +773,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(getDefaultModel).toHaveBeenCalledWith("anthropic");
     expect(insertValuesMock).toHaveBeenCalledWith(
@@ -794,7 +795,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -861,7 +862,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     // Verify permissions were inserted
@@ -901,7 +902,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
     expect(validateAllowedPaths).not.toHaveBeenCalled();
   });
@@ -915,7 +916,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toMatch(/connection/i);
@@ -931,7 +932,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     // Email templates use semantic operations (read, draft, send) — not per-tool
@@ -961,7 +962,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toMatch(/connection/i);
@@ -976,7 +977,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(permissionsInsertValuesMock).not.toHaveBeenCalled();
   });
@@ -994,7 +995,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     expect(insertValuesMock).toHaveBeenCalledWith(
@@ -1020,7 +1021,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(201);
 
     // Custom template has pluginId: null, so pluginConfig is set to null
@@ -1057,7 +1058,7 @@ describe("POST /api/agents", () => {
       where: vi.fn().mockResolvedValue([{ id: "conn-1", name: "Odoo", type: "odoo", data: {} }]),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(mockResolveModelForTemplate).toHaveBeenCalledWith(
       expect.objectContaining({ hint: expect.objectContaining({ tier: "reasoning" }) })
@@ -1075,7 +1076,7 @@ describe("POST /api/agents", () => {
       body: JSON.stringify({ name: "My Agent", templateId: "custom" }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(mockResolveModelForTemplate).not.toHaveBeenCalled();
     expect(getDefaultModel).toHaveBeenCalledWith("anthropic");
@@ -1102,7 +1103,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(422);
     const body = await response.json();
     expect(body.error).toBe("template_capability_unavailable");
@@ -1133,7 +1134,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     // Template has []; defaultAllowedTools adds "pinchy_write"
     expect(insertValuesMock).toHaveBeenCalledWith(
@@ -1158,7 +1159,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     const insertedValues = insertValuesMock.mock.calls[0]?.[0] as { allowedTools: string[] };
     expect(insertedValues.allowedTools.filter((t) => t === "pinchy_write").length).toBe(1);
@@ -1176,7 +1177,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(insertValuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1204,7 +1205,7 @@ describe("POST /api/agents", () => {
       }),
     });
 
-    await POST(request);
+    await POST(request, routeContext());
 
     // after() defers the audit log — find the call
     const call = spy.mock.calls.find(

--- a/packages/web/src/__tests__/api/agents-list-route.test.ts
+++ b/packages/web/src/__tests__/api/agents-list-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 const { mockGetSession } = vi.hoisted(() => ({ mockGetSession: vi.fn() }));
 vi.mock("@/lib/auth", () => ({
@@ -38,7 +39,7 @@ describe("GET /api/agents", () => {
     } as never);
 
     const request = new NextRequest("http://localhost:7777/api/agents");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
 
     expect(response.status).toBe(200);
     expect(response.headers.get("Cache-Control")).toBe("private, max-age=5, must-revalidate");

--- a/packages/web/src/__tests__/api/audit-background-run.test.ts
+++ b/packages/web/src/__tests__/api/audit-background-run.test.ts
@@ -32,6 +32,7 @@ vi.mock("@/lib/agent-access", () => ({
 import { getSession } from "@/lib/auth";
 import { appendAuditLog } from "@/lib/audit";
 import { POST } from "@/app/api/internal/audit/background-run/route";
+import { routeContext } from "@/test-helpers/route";
 
 function makeRequest(body: Record<string, unknown>) {
   return new NextRequest("http://localhost/api/internal/audit/background-run", {
@@ -53,7 +54,7 @@ describe("POST /api/internal/audit/background-run", () => {
   it("returns 401 when the user is not authenticated", async () => {
     vi.mocked(getSession).mockResolvedValue(null);
 
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }));
+    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }), routeContext());
 
     expect(res.status).toBe(401);
     expect(appendAuditLog).not.toHaveBeenCalled();
@@ -64,7 +65,7 @@ describe("POST /api/internal/audit/background-run", () => {
       NextResponse.json({ error: "Agent not found" }, { status: 404 })
     );
 
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }));
+    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }), routeContext());
 
     expect(res.status).toBe(404);
     expect(appendAuditLog).not.toHaveBeenCalled();
@@ -73,7 +74,7 @@ describe("POST /api/internal/audit/background-run", () => {
   it("returns 204 and writes a chat.background_run_completed audit log on success", async () => {
     mockGetAgentWithAccess.mockResolvedValue({ id: "agent-1", name: "Smithers" });
 
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }));
+    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: 1500 }), routeContext());
 
     expect(res.status).toBe(204);
     expect(appendAuditLog).toHaveBeenCalledWith({
@@ -87,21 +88,24 @@ describe("POST /api/internal/audit/background-run", () => {
   });
 
   it("returns 400 when agentId is missing", async () => {
-    const res = await POST(makeRequest({ durationMs: 500 }));
+    const res = await POST(makeRequest({ durationMs: 500 }), routeContext());
 
     expect(res.status).toBe(400);
     expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
   it("returns 400 when durationMs is not a number", async () => {
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: "notanumber" }));
+    const res = await POST(
+      makeRequest({ agentId: "agent-1", durationMs: "notanumber" }),
+      routeContext()
+    );
 
     expect(res.status).toBe(400);
     expect(appendAuditLog).not.toHaveBeenCalled();
   });
 
   it("returns 400 when durationMs is negative", async () => {
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: -1 }));
+    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: -1 }), routeContext());
 
     expect(res.status).toBe(400);
     expect(appendAuditLog).not.toHaveBeenCalled();
@@ -109,7 +113,10 @@ describe("POST /api/internal/audit/background-run", () => {
 
   it("returns 400 when durationMs exceeds 10 minutes (telemetry sanity bound)", async () => {
     const tenMinutesPlusOne = 10 * 60 * 1000 + 1;
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: tenMinutesPlusOne }));
+    const res = await POST(
+      makeRequest({ agentId: "agent-1", durationMs: tenMinutesPlusOne }),
+      routeContext()
+    );
 
     expect(res.status).toBe(400);
     expect(appendAuditLog).not.toHaveBeenCalled();
@@ -117,7 +124,10 @@ describe("POST /api/internal/audit/background-run", () => {
 
   it("accepts durationMs at exactly 10 minutes (boundary)", async () => {
     const tenMinutes = 10 * 60 * 1000;
-    const res = await POST(makeRequest({ agentId: "agent-1", durationMs: tenMinutes }));
+    const res = await POST(
+      makeRequest({ agentId: "agent-1", durationMs: tenMinutes }),
+      routeContext()
+    );
 
     expect(res.status).toBe(204);
     expect(appendAuditLog).toHaveBeenCalled();

--- a/packages/web/src/__tests__/api/audit-export.test.ts
+++ b/packages/web/src/__tests__/api/audit-export.test.ts
@@ -89,6 +89,7 @@ import { requireAdmin } from "@/lib/api-auth";
 import { appendAuditLog } from "@/lib/audit";
 import { sanitizeDetail } from "@/lib/audit-sanitize";
 import { renderAuditPdf } from "@/lib/audit-pdf";
+import { mockSession } from "@/test-helpers/auth";
 
 const HEADER =
   "id,timestamp,actorType,actorId,actorName,eventType,resource,resourceName,detail,version,outcome,error,rowHmac";
@@ -96,10 +97,9 @@ const HEADER =
 describe("GET /api/audit/export", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
     mockResolveActorIdMatchSet.mockResolvedValue(["user-1"]);
   });
 

--- a/packages/web/src/__tests__/api/audit-route.test.ts
+++ b/packages/web/src/__tests__/api/audit-route.test.ts
@@ -78,6 +78,7 @@ vi.mock("@/lib/audit", () => ({
 
 import { requireAdmin } from "@/lib/api-auth";
 import { eq, inArray } from "drizzle-orm";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -131,10 +132,9 @@ describe("GET /api/audit", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
     // Default: no pseudonym found (simplest case — filter degrades to the
     // bare id). Individual tests override this to assert the dual-match set.
     mockResolveActorIdMatchSet.mockResolvedValue(["user-1"]);

--- a/packages/web/src/__tests__/api/audit-verify.test.ts
+++ b/packages/web/src/__tests__/api/audit-verify.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextResponse } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
 
 vi.mock("@/lib/api-auth", () => ({
   requireAdmin: vi.fn(),
@@ -15,10 +16,9 @@ import { requireAdmin } from "@/lib/api-auth";
 describe("GET /api/audit/verify", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as Awaited<ReturnType<typeof requireAdmin>>);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
   });
 
   it("should return 403 for non-admin users", async () => {

--- a/packages/web/src/__tests__/api/data-directories.test.ts
+++ b/packages/web/src/__tests__/api/data-directories.test.ts
@@ -25,6 +25,7 @@ vi.mock("fs", () => {
 
 import { readFileSync } from "fs";
 import { GET } from "@/app/api/data-directories/route";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 describe("GET /api/data-directories", () => {
   beforeEach(() => {
@@ -41,7 +42,7 @@ describe("GET /api/data-directories", () => {
       })
     );
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const body = await response.json();
 
     expect(readFileSync).toHaveBeenCalledWith("/openclaw-config/data-directories.json", "utf-8");
@@ -56,7 +57,7 @@ describe("GET /api/data-directories", () => {
       throw new Error("ENOENT: no such file or directory");
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const body = await response.json();
 
     expect(body.directories).toEqual([]);
@@ -72,7 +73,7 @@ describe("GET /api/data-directories", () => {
       throw err;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const body = await response.json();
 
     expect(body.directories).toEqual([]);
@@ -88,7 +89,7 @@ describe("GET /api/data-directories", () => {
     const { auth } = await import("@/lib/auth");
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(401);
   });

--- a/packages/web/src/__tests__/api/dev-enterprise-toggle.test.ts
+++ b/packages/web/src/__tests__/api/dev-enterprise-toggle.test.ts
@@ -20,29 +20,30 @@ vi.mock("@/lib/settings", () => ({
 }));
 
 import { requireAdmin } from "@/lib/api-auth";
+import { mockSession } from "@/test-helpers/auth";
 
 describe("POST /api/dev/enterprise-toggle", () => {
-  const originalEnv = process.env.NODE_ENV;
   const originalKey = process.env.PINCHY_ENTERPRISE_KEY;
 
   let POST: typeof import("@/app/api/dev/enterprise-toggle/route").POST;
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    process.env.NODE_ENV = "development";
+    // NODE_ENV is typed readonly by Next's global.d.ts — vi.stubEnv is the
+    // vitest-native way to set it (and vi.unstubAllEnvs() below restores it).
+    vi.stubEnv("NODE_ENV", "development");
     delete process.env.PINCHY_ENTERPRISE_KEY;
 
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
 
     const mod = await import("@/app/api/dev/enterprise-toggle/route");
     POST = mod.POST;
   });
 
   afterEach(() => {
-    process.env.NODE_ENV = originalEnv;
+    vi.unstubAllEnvs();
     if (originalKey !== undefined) {
       process.env.PINCHY_ENTERPRISE_KEY = originalKey;
     } else {
@@ -51,7 +52,7 @@ describe("POST /api/dev/enterprise-toggle", () => {
   });
 
   it("returns 404 in production", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const response = await POST();
     expect(response.status).toBe(404);
   });

--- a/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
+++ b/packages/web/src/__tests__/api/diagnostics-export.integration.test.ts
@@ -95,6 +95,7 @@ import { resolveSessionId, readTrajectoryJsonl } from "@/lib/diagnostics/jsonl-r
 import { listUserAgentChats } from "@/lib/chats/list-user-agent-chats";
 import { TrajectoryFileNotFoundError } from "@/lib/diagnostics/jsonl-reader";
 import { POST } from "@/app/api/diagnostics/export/route";
+import { routeContext } from "@/test-helpers/route";
 
 function sessionKeyHash(key: string) {
   return "sha256:" + createHash("sha256").update(key).digest("hex");
@@ -166,14 +167,14 @@ describe("POST /api/diagnostics/export (integration)", () => {
 
   it("returns 401 when there is no session", async () => {
     vi.mocked(getSession).mockResolvedValue(null);
-    const response = await POST(makeRequest({ agentId: "agt_x" }));
+    const response = await POST(makeRequest({ agentId: "agt_x" }), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("returns 400 for an invalid body", async () => {
     const owner = await seedUser();
     mockSession(owner);
-    const response = await POST(makeRequest({}));
+    const response = await POST(makeRequest({}), routeContext());
     expect(response.status).toBe(400);
     const body = await response.json();
     expect(body.error).toBe("Validation failed");
@@ -184,7 +185,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
     mockSession(owner);
     const agent = await seedPersonalAgent(owner.id);
 
-    const response = await POST(makeRequest({ agentId: agent.id }));
+    const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
     expect(response.status).toBe(200);
     const bundle = await response.json();
     expect(bundle.schemaVersion).toBe("pinchy.bugreport.v1");
@@ -211,7 +212,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
 
     mockSession(intruder);
 
-    const response = await POST(makeRequest({ agentId: agent.id }));
+    const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
     // getAgentWithAccess returns 403 for personal agents owned by someone else.
     expect(response.status).toBe(403);
   });
@@ -222,7 +223,8 @@ describe("POST /api/diagnostics/export (integration)", () => {
     const agent = await seedPersonalAgent(owner.id);
 
     const response = await POST(
-      makeRequest({ agentId: agent.id, userDescription: "Stuck on tool error" })
+      makeRequest({ agentId: agent.id, userDescription: "Stuck on tool error" }),
+      routeContext()
     );
     expect(response.status).toBe(200);
     await flushAfter();
@@ -255,7 +257,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
     const agent = await seedPersonalAgent(owner.id);
     vi.mocked(resolveSessionId).mockResolvedValue(null);
 
-    const response = await POST(makeRequest({ agentId: agent.id }));
+    const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
     expect(response.status).toBe(404);
   });
 
@@ -295,7 +297,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
       },
     ]);
 
-    const response = await POST(makeRequest({ agentId: agent.id }));
+    const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
     expect(response.status).toBe(200);
     const bundle = await response.json();
     const toolEntries = (bundle.auditEntries as Array<{ eventType: string }>).filter((e) =>
@@ -312,7 +314,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
     const agent = await seedPersonalAgent(owner.id);
     vi.mocked(readTrajectoryJsonl).mockResolvedValue("");
 
-    const response = await POST(makeRequest({ agentId: agent.id }));
+    const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
     expect(response.status).toBe(200);
     const bundle = await response.json();
     expect(bundle.spans).toEqual([]);
@@ -353,7 +355,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
       vi.mocked(resolveSessionId).mockResolvedValue("s-legacy");
       vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
 
-      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      const response = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-named" }),
+        routeContext()
+      );
       expect(response.status).toBe(200);
       const bundle = await response.json();
 
@@ -385,7 +390,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
       });
       vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
 
-      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-tg" }));
+      const response = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-tg" }),
+        routeContext()
+      );
       expect(response.status).toBe(200);
       const bundle = await response.json();
       expect(vi.mocked(readTrajectoryJsonl)).toHaveBeenCalledWith(agent.id, "s-tg");
@@ -398,7 +406,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
       const agent = await seedPersonalAgent(owner.id);
       vi.mocked(listUserAgentChats).mockResolvedValue({ chats: [], labelByKey: new Map() });
 
-      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-someone-else" }));
+      const response = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-someone-else" }),
+        routeContext()
+      );
       expect(response.status).toBe(404);
       expect(vi.mocked(readTrajectoryJsonl)).not.toHaveBeenCalled();
     });
@@ -437,7 +448,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
         timestamp: new Date("2026-05-19T12:15:00Z"),
       });
 
-      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      const response = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-named" }),
+        routeContext()
+      );
       expect(response.status).toBe(200);
       const bundle = await response.json();
       expect(bundle.scope.trajectoryMissing).toBe(true);
@@ -457,7 +471,7 @@ describe("POST /api/diagnostics/export (integration)", () => {
         new TrajectoryFileNotFoundError("/gone.jsonl")
       );
 
-      const response = await POST(makeRequest({ agentId: agent.id }));
+      const response = await POST(makeRequest({ agentId: agent.id }), routeContext());
       expect(response.status).toBe(200);
       const bundle = await response.json();
       expect(bundle.scope.trajectoryMissing).toBe(true);
@@ -483,7 +497,10 @@ describe("POST /api/diagnostics/export (integration)", () => {
       });
       vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
 
-      const response = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      const response = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-named" }),
+        routeContext()
+      );
       expect(response.status).toBe(200);
       await flushAfter();
 
@@ -529,11 +546,17 @@ describe("POST /api/diagnostics/export (integration)", () => {
       });
       vi.mocked(readTrajectoryJsonl).mockResolvedValue(FIXTURE);
 
-      const legacyRes = await POST(makeRequest({ agentId: agent.id, sessionId: "s-legacy" }));
+      const legacyRes = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-legacy" }),
+        routeContext()
+      );
       expect(legacyRes.status).toBe(200);
       expect((await legacyRes.json()).scope.sessionKeyHash).toBe(sessionKeyHash(legacyKey));
 
-      const namedRes = await POST(makeRequest({ agentId: agent.id, sessionId: "s-named" }));
+      const namedRes = await POST(
+        makeRequest({ agentId: agent.id, sessionId: "s-named" }),
+        routeContext()
+      );
       expect(namedRes.status).toBe(200);
       expect((await namedRes.json()).scope.sessionKeyHash).toBe(sessionKeyHash(namedKey));
     });

--- a/packages/web/src/__tests__/api/enterprise-key.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-key.test.ts
@@ -38,6 +38,7 @@ import { getSession } from "@/lib/auth";
 import { setSetting, deleteSetting } from "@/lib/settings";
 import { clearLicenseCache, getLicenseStatus } from "@/lib/enterprise";
 import { appendAuditLog } from "@/lib/audit";
+import { makeNextRequest } from "@/test-helpers/route";
 
 beforeEach(() => {
   vi.clearAllMocks();
@@ -47,7 +48,7 @@ describe("PUT /api/enterprise/key", () => {
   it("returns 401 for unauthenticated requests", async () => {
     vi.mocked(getSession).mockResolvedValueOnce(null);
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: "test" }),
@@ -61,7 +62,7 @@ describe("PUT /api/enterprise/key", () => {
       user: { id: "u1", role: "member", name: "User" },
     } as any);
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: "test" }),
@@ -75,7 +76,7 @@ describe("PUT /api/enterprise/key", () => {
       user: { id: "u1", role: "admin", name: "Admin" },
     } as any);
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({}),
@@ -95,10 +96,12 @@ describe("PUT /api/enterprise/key", () => {
       features: ["enterprise"],
       expiresAt: new Date("2027-01-01"),
       daysRemaining: 300,
+      ver: 1,
+      maxUsers: 10,
     });
 
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: "eyJ.valid.token" }),
@@ -128,7 +131,7 @@ describe("PUT /api/enterprise/key", () => {
     } as any);
 
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: "invalid-token" }),
@@ -159,7 +162,7 @@ describe("PUT /api/enterprise/key", () => {
     vi.mocked(getLicenseStatus).mockResolvedValueOnce({ active: false, features: [] } as any);
 
     const { PUT } = await import("@/app/api/enterprise/key/route");
-    const req = new Request("http://localhost/api/enterprise/key", {
+    const req = makeNextRequest("http://localhost/api/enterprise/key", {
       method: "PUT",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ key: "super-secret-invalid-token" }),

--- a/packages/web/src/__tests__/api/enterprise-status.test.ts
+++ b/packages/web/src/__tests__/api/enterprise-status.test.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 vi.mock("@/lib/auth", () => ({
   getSession: vi.fn(),
@@ -49,7 +50,7 @@ describe("GET /api/enterprise/status", () => {
       pendingInvites: 2,
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.seatsUsed).toBe(7);
     expect(body.maxUsers).toBe(10);
@@ -71,7 +72,7 @@ describe("GET /api/enterprise/status", () => {
       pendingInvites: 0,
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.seatsUsed).toBe(12);
     expect(body.maxUsers).toBe(0);
@@ -85,7 +86,7 @@ describe("GET /api/enterprise/status", () => {
       features: [],
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.enterprise).toBe(false);
     expect(body.seatsUsed).toBe(0);
@@ -102,7 +103,7 @@ describe("GET /api/enterprise/status", () => {
     });
     (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(false);
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.state).toBe("community");
     expect(body.paidUntil).toBeNull();
@@ -130,7 +131,7 @@ describe("GET /api/enterprise/status", () => {
       pendingInvites: 2,
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.state).toBe("paid");
     expect(body.paidUntil).toBe(paidUntilAt.toISOString());
@@ -156,7 +157,7 @@ describe("GET /api/enterprise/status", () => {
       pendingInvites: 0,
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.state).toBe("grace");
   });
@@ -177,7 +178,7 @@ describe("GET /api/enterprise/status", () => {
     });
     (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(true);
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.enterprise).toBe(false);
     expect(body.state).toBe("expired");
@@ -200,7 +201,7 @@ describe("GET /api/enterprise/status", () => {
       expiresAt: new Date(Date.now() - 86400000),
     });
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.hasGatedConfig).toBe(false);
     expect(hasGatedConfig).not.toHaveBeenCalled();
@@ -218,7 +219,7 @@ describe("GET /api/enterprise/status", () => {
     });
     (hasGatedConfig as ReturnType<typeof vi.fn>).mockResolvedValue(false);
     const { GET } = await import("@/app/api/enterprise/status/route");
-    const res = await GET();
+    const res = await GET(makeNextRequest(), routeContext());
     const body = await res.json();
     expect(body.state).toBe("trial-expired");
   });

--- a/packages/web/src/__tests__/api/health.test.ts
+++ b/packages/web/src/__tests__/api/health.test.ts
@@ -1,6 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { GET } from "@/app/api/health/route";
-import { NextRequest } from "next/server";
 import { openClawConnectionState } from "@/server/openclaw-connection-state";
 
 describe("GET /api/health", () => {
@@ -16,16 +15,14 @@ describe("GET /api/health", () => {
   });
 
   it("should return 200 with status ok", async () => {
-    const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-    const response = await GET(request);
+    const response = await GET();
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data).toMatchObject({ status: "ok" });
   });
 
   it("should return JSON content type", async () => {
-    const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-    const response = await GET(request);
+    const response = await GET();
     const contentType = response.headers.get("content-type");
     expect(contentType).toContain("application/json");
   });
@@ -38,8 +35,7 @@ describe("GET /api/health", () => {
     vi.stubEnv("BETTER_AUTH_SECRET", "super-secret-auth-value");
     vi.stubEnv("DATABASE_URL", "postgresql://pinchy:pinchy_dev@db:5432/pinchy");
 
-    const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-    const response = await GET(request);
+    const response = await GET();
     const data = await response.json();
 
     expect(data.secrets).toEqual({
@@ -63,8 +59,7 @@ describe("GET /api/health", () => {
     it("reports openclaw.connected: true when the gateway client is connected", async () => {
       openClawConnectionState.connected = true;
 
-      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-      const response = await GET(request);
+      const response = await GET();
       const data = await response.json();
 
       expect(data.openclaw).toEqual({ connected: true });
@@ -73,8 +68,7 @@ describe("GET /api/health", () => {
     it("reports openclaw.connected: false when the gateway client is disconnected", async () => {
       openClawConnectionState.connected = false;
 
-      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-      const response = await GET(request);
+      const response = await GET();
       const data = await response.json();
 
       expect(data.openclaw).toEqual({ connected: false });
@@ -86,8 +80,7 @@ describe("GET /api/health", () => {
       // healthcheck restart-loop the container during normal operation.
       openClawConnectionState.connected = false;
 
-      const request = new NextRequest("http://localhost/api/health", { method: "GET" });
-      const response = await GET(request);
+      const response = await GET();
       const data = await response.json();
 
       expect(response.status).toBe(200);

--- a/packages/web/src/__tests__/api/imap-autodiscover-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-autodiscover-route.test.ts
@@ -11,6 +11,7 @@ vi.mock("@/lib/auth", () => ({
 }));
 
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
 const nonAdminSession = { user: { id: "user-2", email: "member@test.com", role: "member" } };
@@ -31,7 +32,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
     mockGetSession.mockResolvedValue(null);
 
     const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-    const response = await GET(makeRequest("email=someone@gmail.com"));
+    const response = await GET(makeRequest("email=someone@gmail.com"), routeContext());
 
     expect(response.status).toBe(401);
   });
@@ -40,7 +41,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
     mockGetSession.mockResolvedValue(nonAdminSession);
 
     const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-    const response = await GET(makeRequest("email=someone@gmail.com"));
+    const response = await GET(makeRequest("email=someone@gmail.com"), routeContext());
 
     expect(response.status).toBe(403);
   });
@@ -52,7 +53,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
 
     it("returns the bundled provider-table config for a known provider email", async () => {
       const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-      const response = await GET(makeRequest("email=someone@gmail.com"));
+      const response = await GET(makeRequest("email=someone@gmail.com"), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(200);
@@ -68,7 +69,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
 
     it("returns { config: {}, source: 'none' } when the email query param is missing", async () => {
       const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-      const response = await GET(makeRequest());
+      const response = await GET(makeRequest(), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(200);
@@ -77,7 +78,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
 
     it("returns { config: {}, source: 'none' } for an empty email query param", async () => {
       const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-      const response = await GET(makeRequest("email="));
+      const response = await GET(makeRequest("email="), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(200);
@@ -86,7 +87,7 @@ describe("GET /api/integrations/imap/autodiscover", () => {
 
     it("returns { config: {}, source: 'none' } for an unparseable email", async () => {
       const { GET } = await import("@/app/api/integrations/imap/autodiscover/route");
-      const response = await GET(makeRequest("email=not-an-email"));
+      const response = await GET(makeRequest("email=not-an-email"), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(200);

--- a/packages/web/src/__tests__/api/imap-create-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-create-route.test.ts
@@ -62,6 +62,7 @@ vi.mock("@/db/schema", () => ({
 }));
 
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 function makeRequest(body: unknown) {
   return new NextRequest("http://localhost:7777/api/integrations/imap", {
@@ -95,7 +96,7 @@ describe("POST /api/integrations/imap", () => {
     mockGetSession.mockResolvedValueOnce(null);
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
 
     expect(response.status).toBe(401);
     expect(mockInsertValues).not.toHaveBeenCalled();
@@ -106,7 +107,7 @@ describe("POST /api/integrations/imap", () => {
     mockGetSession.mockResolvedValueOnce(memberSession);
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
 
     expect(response.status).toBe(403);
     expect(mockInsertValues).not.toHaveBeenCalled();
@@ -116,7 +117,7 @@ describe("POST /api/integrations/imap", () => {
   it("creates an IMAP connection, encrypts credentials, and returns a summary", async () => {
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -162,7 +163,7 @@ describe("POST /api/integrations/imap", () => {
   it("writes an integration.created audit entry with {id, name} and no password", async () => {
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    await POST(makeRequest(validBody));
+    await POST(makeRequest(validBody), routeContext());
 
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -191,7 +192,7 @@ describe("POST /api/integrations/imap", () => {
     const { name: _name, ...rest } = validBody;
     mockInsertReturning.mockResolvedValueOnce([{ ...insertedConnection, name: rest.username }]);
 
-    const response = await POST(makeRequest(rest));
+    const response = await POST(makeRequest(rest), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -211,7 +212,7 @@ describe("POST /api/integrations/imap", () => {
   it("returns 400 and does not insert or audit when name is blank", async () => {
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest({ ...validBody, name: "" }));
+    const response = await POST(makeRequest({ ...validBody, name: "" }), routeContext());
 
     expect(response.status).toBe(400);
     expect(mockInsertValues).not.toHaveBeenCalled();
@@ -222,7 +223,7 @@ describe("POST /api/integrations/imap", () => {
     const { POST } = await import("@/app/api/integrations/imap/route");
 
     const { imapHost: _imapHost, ...rest } = validBody;
-    const response = await POST(makeRequest(rest));
+    const response = await POST(makeRequest(rest), routeContext());
 
     expect(response.status).toBe(400);
     expect(mockInsertValues).not.toHaveBeenCalled();
@@ -232,7 +233,7 @@ describe("POST /api/integrations/imap", () => {
   it("returns 400 and does not insert or audit when the port is out of range", async () => {
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest({ ...validBody, imapPort: 999999 }));
+    const response = await POST(makeRequest({ ...validBody, imapPort: 999999 }), routeContext());
 
     expect(response.status).toBe(400);
     expect(mockInsertValues).not.toHaveBeenCalled();
@@ -243,7 +244,7 @@ describe("POST /api/integrations/imap", () => {
     mockInsertReturning.mockRejectedValueOnce(new Error("DB unreachable"));
     const { POST } = await import("@/app/api/integrations/imap/route");
 
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
 
     expect(response.status).toBe(500);
     expect(mockRecordAuditFailure).toHaveBeenCalled();
@@ -262,7 +263,7 @@ describe("POST /api/integrations/imap", () => {
     // Name omitted → defaults to the mailbox address, which must not leak into
     // the append-only audit failure row.
     const { name: _name, ...rest } = validBody;
-    await POST(makeRequest(rest));
+    await POST(makeRequest(rest), routeContext());
 
     const [, failureEntry] = mockRecordAuditFailure.mock.calls[0];
     expect(JSON.stringify(failureEntry.detail)).not.toContain(rest.username);
@@ -273,7 +274,7 @@ describe("POST /api/integrations/imap", () => {
     it("stores senderName inside the encrypted credentials blob", async () => {
       const { POST } = await import("@/app/api/integrations/imap/route");
 
-      await POST(makeRequest({ ...validBody, senderName: "Support Team" }));
+      await POST(makeRequest({ ...validBody, senderName: "Support Team" }), routeContext());
 
       expect(mockEncrypt).toHaveBeenCalledWith(
         JSON.stringify({
@@ -292,7 +293,7 @@ describe("POST /api/integrations/imap", () => {
     it("never puts senderName in the plaintext data column or audit detail", async () => {
       const { POST } = await import("@/app/api/integrations/imap/route");
 
-      await POST(makeRequest({ ...validBody, senderName: "Support Team" }));
+      await POST(makeRequest({ ...validBody, senderName: "Support Team" }), routeContext());
 
       const insertedRow = mockInsertValues.mock.calls[0][0];
       expect(JSON.stringify(insertedRow.data)).not.toContain("Support Team");
@@ -305,7 +306,8 @@ describe("POST /api/integrations/imap", () => {
       const { POST } = await import("@/app/api/integrations/imap/route");
 
       const response = await POST(
-        makeRequest({ ...validBody, senderName: "x\r\nBcc: evil@example.com" })
+        makeRequest({ ...validBody, senderName: "x\r\nBcc: evil@example.com" }),
+        routeContext()
       );
 
       expect(response.status).toBe(400);

--- a/packages/web/src/__tests__/api/imap-preexisting-connection.test.ts
+++ b/packages/web/src/__tests__/api/imap-preexisting-connection.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 // ─────────────────────────────────────────────────────────────────────────
 // MIGRATION TEST (AGENTS.md § "Test Migrations Against Pre-Existing Data")
@@ -181,7 +182,7 @@ describe("Pre-existing IMAP connection — cross-route invariant (listed ⟹ rea
       // existed as pre-seeded data, exactly as a pre-upgrade row would.
       const { GET } = await import("@/app/api/integrations/route");
 
-      const response = await GET();
+      const response = await GET(makeNextRequest(), routeContext());
       expect(response.status).toBe(200);
 
       const body = (await response.json()) as Array<{

--- a/packages/web/src/__tests__/api/imap-test-route.test.ts
+++ b/packages/web/src/__tests__/api/imap-test-route.test.ts
@@ -61,6 +61,7 @@ vi.mock("nodemailer", () => ({
 }));
 
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 const adminSession = { user: { id: "user-1", email: "admin@test.com", role: "admin" } };
 const nonAdminSession = { user: { id: "user-2", email: "member@test.com", role: "member" } };
@@ -95,7 +96,7 @@ describe("POST /api/integrations/imap/test", () => {
     mockGetSession.mockResolvedValue(null);
 
     const { POST } = await import("@/app/api/integrations/imap/test/route");
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
 
     expect(response.status).toBe(401);
     expect(ImapFlowMock).not.toHaveBeenCalled();
@@ -107,7 +108,7 @@ describe("POST /api/integrations/imap/test", () => {
     mockGetSession.mockResolvedValue(nonAdminSession);
 
     const { POST } = await import("@/app/api/integrations/imap/test/route");
-    const response = await POST(makeRequest(validBody));
+    const response = await POST(makeRequest(validBody), routeContext());
 
     expect(response.status).toBe(403);
     expect(ImapFlowMock).not.toHaveBeenCalled();
@@ -130,7 +131,8 @@ describe("POST /api/integrations/imap/test", () => {
           username: "mailbox@example.com",
           password: "pw",
           security: "carrier-pigeon",
-        })
+        }),
+        routeContext()
       );
       const body = await response.json();
 
@@ -144,7 +146,7 @@ describe("POST /api/integrations/imap/test", () => {
 
     it("returns 200 { ok: true } and writes a success audit entry when both probes succeed", async () => {
       const { POST } = await import("@/app/api/integrations/imap/test/route");
-      const response = await POST(makeRequest(validBody));
+      const response = await POST(makeRequest(validBody), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(200);
@@ -180,7 +182,7 @@ describe("POST /api/integrations/imap/test", () => {
       );
 
       const { POST } = await import("@/app/api/integrations/imap/test/route");
-      const response = await POST(makeRequest(validBody));
+      const response = await POST(makeRequest(validBody), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(400);
@@ -205,7 +207,7 @@ describe("POST /api/integrations/imap/test", () => {
       mockTransport.verify.mockRejectedValue(new Error("connect ECONNREFUSED 127.0.0.1:587"));
 
       const { POST } = await import("@/app/api/integrations/imap/test/route");
-      const response = await POST(makeRequest(validBody));
+      const response = await POST(makeRequest(validBody), routeContext());
       const body = await response.json();
 
       expect(response.status).toBe(400);
@@ -227,9 +229,9 @@ describe("POST /api/integrations/imap/test", () => {
     it("never includes the plaintext password in the audit detail across success and failure paths", async () => {
       const { POST } = await import("@/app/api/integrations/imap/test/route");
 
-      await POST(makeRequest(validBody));
+      await POST(makeRequest(validBody), routeContext());
       mockImapClient.connect.mockRejectedValueOnce(new Error("bad credentials"));
-      await POST(makeRequest(validBody));
+      await POST(makeRequest(validBody), routeContext());
 
       expect(mockAppendAuditLog).toHaveBeenCalledTimes(2);
       for (const call of mockAppendAuditLog.mock.calls) {

--- a/packages/web/src/__tests__/api/integration-patch-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-patch-route.test.ts
@@ -136,7 +136,7 @@ vi.mock("@/lib/integrations/oauth-settings", () => ({
 
 import { NextRequest } from "next/server";
 
-function makeRequest(path: string, options?: RequestInit) {
+function makeRequest(path: string, options?: ConstructorParameters<typeof NextRequest>[1]) {
   return new NextRequest(`http://localhost:7777${path}`, options);
 }
 

--- a/packages/web/src/__tests__/api/integration-test-route.test.ts
+++ b/packages/web/src/__tests__/api/integration-test-route.test.ts
@@ -139,7 +139,7 @@ const refreshedMicrosoftCreds = {
   expiresAt: new Date(Date.now() + 3_600_000).toISOString(),
 };
 
-function makeRequest(path: string, options?: RequestInit) {
+function makeRequest(path: string, options?: ConstructorParameters<typeof NextRequest>[1]) {
   return new NextRequest(`http://localhost:7777${path}`, options);
 }
 

--- a/packages/web/src/__tests__/api/integrations-health.test.ts
+++ b/packages/web/src/__tests__/api/integrations-health.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/encryption", () => ({
 }));
 
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 const adminSession = { user: { id: "u1", email: "admin@test.com", role: "admin" } };
 
@@ -65,7 +66,7 @@ describe("GET /api/integrations/health", () => {
       conn({ status: "active", credentials: "BAD-encrypted" }), // cannot decrypt
     ]);
     const { GET } = await import("@/app/api/integrations/health/route");
-    const res = await GET(makeRequest());
+    const res = await GET(makeRequest(), routeContext());
     const body = await res.json();
     expect(res.status).toBe(200);
     expect(body.authFailedCount).toBe(1);
@@ -78,7 +79,7 @@ describe("GET /api/integrations/health", () => {
       conn({ status: "auth_failed", credentials: "BAD-encrypted" }),
     ]);
     const { GET } = await import("@/app/api/integrations/health/route");
-    const res = await GET(makeRequest());
+    const res = await GET(makeRequest(), routeContext());
     const body = await res.json();
     expect(body.authFailedCount).toBe(1);
     expect(body.cannotDecryptCount).toBe(1);
@@ -88,7 +89,7 @@ describe("GET /api/integrations/health", () => {
   it("returns zero counts when all connections are healthy", async () => {
     mockSelectFrom.mockResolvedValue([conn({ status: "active" }), conn({ status: "pending" })]);
     const { GET } = await import("@/app/api/integrations/health/route");
-    const res = await GET(makeRequest());
+    const res = await GET(makeRequest(), routeContext());
     const body = await res.json();
     expect(body).toEqual({
       authFailedCount: 0,
@@ -100,14 +101,14 @@ describe("GET /api/integrations/health", () => {
   it("returns 403 for non-admin authenticated user", async () => {
     mockGetSession.mockResolvedValue({ user: { id: "u2", role: "user" } });
     const { GET } = await import("@/app/api/integrations/health/route");
-    const res = await GET(makeRequest());
+    const res = await GET(makeRequest(), routeContext());
     expect(res.status).toBe(403);
   });
 
   it("returns 401 for unauthenticated request", async () => {
     mockGetSession.mockResolvedValue(null);
     const { GET } = await import("@/app/api/integrations/health/route");
-    const res = await GET(makeRequest());
+    const res = await GET(makeRequest(), routeContext());
     expect(res.status).toBe(401);
   });
 });

--- a/packages/web/src/__tests__/api/integrations.test.ts
+++ b/packages/web/src/__tests__/api/integrations.test.ts
@@ -133,8 +133,9 @@ vi.mock("@/lib/integrations/auth-state", () => ({
 }));
 
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
-function makeRequest(path: string, options?: RequestInit) {
+function makeRequest(path: string, options?: ConstructorParameters<typeof NextRequest>[1]) {
   return new NextRequest(`http://localhost:7777${path}`, options);
 }
 
@@ -159,7 +160,7 @@ describe("GET /api/integrations", () => {
     mockGetSession.mockResolvedValueOnce(null);
     const { GET } = await import("@/app/api/integrations/route");
 
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     expect(response.status).toBe(401);
   });
 
@@ -167,14 +168,14 @@ describe("GET /api/integrations", () => {
     mockGetSession.mockResolvedValueOnce(memberSession);
     const { GET } = await import("@/app/api/integrations/route");
 
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     expect(response.status).toBe(403);
   });
 
   it("should return connections with masked credentials", async () => {
     const { GET } = await import("@/app/api/integrations/route");
 
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -193,7 +194,7 @@ describe("GET /api/integrations", () => {
   it("should include status field in each connection", async () => {
     const { GET } = await import("@/app/api/integrations/route");
 
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -211,7 +212,7 @@ describe("GET /api/integrations", () => {
     });
 
     const { GET } = await import("@/app/api/integrations/route");
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -240,7 +241,7 @@ describe("GET /api/integrations", () => {
     });
 
     const { GET } = await import("@/app/api/integrations/route");
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -279,7 +280,7 @@ describe("GET /api/integrations", () => {
     });
 
     const { GET } = await import("@/app/api/integrations/route");
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -304,7 +305,7 @@ describe("POST /api/integrations", () => {
       method: "POST",
       body: JSON.stringify({ type: "odoo", name: "Test", credentials: validCredentials }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(401);
   });
 
@@ -316,7 +317,7 @@ describe("POST /api/integrations", () => {
       method: "POST",
       body: JSON.stringify({ type: "odoo", name: "Test", credentials: validCredentials }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(403);
   });
 
@@ -327,7 +328,7 @@ describe("POST /api/integrations", () => {
       method: "POST",
       body: JSON.stringify({ type: "shopify", name: "Test", credentials: validCredentials }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
   });
 
@@ -338,7 +339,7 @@ describe("POST /api/integrations", () => {
       method: "POST",
       body: JSON.stringify({ type: "odoo", name: "", credentials: validCredentials }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
   });
 
@@ -353,7 +354,7 @@ describe("POST /api/integrations", () => {
         credentials: { url: "not-a-url", db: "", login: "", apiKey: "", uid: -1 },
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
   });
 
@@ -369,7 +370,7 @@ describe("POST /api/integrations", () => {
         credentials: validCredentials,
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -411,7 +412,7 @@ describe("POST /api/integrations", () => {
         credentials: { apiKey: "BSA-test-key" },
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(409);
@@ -429,7 +430,7 @@ describe("POST /api/integrations", () => {
         credentials: validCredentials,
       }),
     });
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -460,7 +461,7 @@ describe("POST /api/integrations", () => {
         credentials: validCredentials,
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     // Flush the deferred after() callback's microtasks.
     await new Promise((r) => setImmediate(r));
 
@@ -510,7 +511,7 @@ describe("GET /api/integrations/[connectionId]", () => {
 
   it("should return 404 when connection not found", async () => {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);
@@ -580,7 +581,7 @@ describe("PATCH /api/integrations/[connectionId]", () => {
 
   it("should return 404 when connection not found", async () => {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);
@@ -746,7 +747,7 @@ describe("DELETE /api/integrations/[connectionId]", () => {
 
   it("should return 404 when connection not found", async () => {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);
@@ -879,7 +880,7 @@ describe("POST /api/integrations/[connectionId]/test", () => {
 
   it("should return 404 when connection not found", async () => {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);
@@ -1064,7 +1065,8 @@ describe("POST /api/integrations/test-credentials", () => {
             apiKey: "key",
           },
         }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(401);
   });
@@ -1085,7 +1087,8 @@ describe("POST /api/integrations/test-credentials", () => {
             apiKey: "key",
           },
         }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(403);
   });
@@ -1105,7 +1108,8 @@ describe("POST /api/integrations/test-credentials", () => {
             apiKey: "key",
           },
         }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(400);
   });
@@ -1120,7 +1124,8 @@ describe("POST /api/integrations/test-credentials", () => {
           type: "odoo",
           credentials: { url: "not-a-url" },
         }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(400);
   });
@@ -1140,7 +1145,8 @@ describe("POST /api/integrations/test-credentials", () => {
             apiKey: "key",
           },
         }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1173,7 +1179,8 @@ describe("POST /api/integrations/test-credentials", () => {
             apiKey: "bad-key",
           },
         }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1184,14 +1191,20 @@ describe("POST /api/integrations/test-credentials", () => {
 });
 
 describe("POST /api/integrations/test-credentials (web-search)", () => {
-  let mockFetch: ReturnType<typeof vi.fn>;
+  // The route only reads `.ok`/`.status` off the fetch response, so tests
+  // resolve minimal partial fakes rather than full `Response` objects — type
+  // the mock's return value as `Partial<Response>` to match, and cast once at
+  // the `global.fetch` assignment (the only place the two shapes must meet).
+  let mockFetch: ReturnType<
+    typeof vi.fn<(...args: Parameters<typeof fetch>) => Promise<Partial<Response>>>
+  >;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
     mockFetch = vi.fn();
-    global.fetch = mockFetch;
+    global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   afterEach(() => {
@@ -1209,7 +1222,8 @@ describe("POST /api/integrations/test-credentials (web-search)", () => {
           type: "web-search",
           credentials: { apiKey: "BSAxxxxxxxxxxxxxxxxxxxxxxxx" },
         }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1232,7 +1246,8 @@ describe("POST /api/integrations/test-credentials (web-search)", () => {
           type: "web-search",
           credentials: { apiKey: "invalid-key" },
         }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1252,7 +1267,8 @@ describe("POST /api/integrations/test-credentials (web-search)", () => {
           type: "web-search",
           credentials: { apiKey: "BSAxxxxxxxxxxxxxxxxxxxxxxxx" },
         }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1271,7 +1287,8 @@ describe("POST /api/integrations/test-credentials (web-search)", () => {
           type: "web-search",
           credentials: {},
         }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(400);
   });
@@ -1281,7 +1298,7 @@ describe("POST /api/integrations (web-search)", () => {
   // Helper: mock the duplicate-check select to return empty (no existing web-search)
   function mockNoDuplicateWebSearch() {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);
@@ -1306,7 +1323,7 @@ describe("POST /api/integrations (web-search)", () => {
         credentials: { apiKey: "BSAxxxxxxxxxxxxxxxxxxxxxxxx" },
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(201);
@@ -1338,7 +1355,7 @@ describe("POST /api/integrations (web-search)", () => {
         credentials: { apiKey: "BSAxxxxxxxxxxxxxxxxxxxxxxxx" },
       }),
     });
-    await POST(request);
+    await POST(request, routeContext());
 
     expect(mockAppendAuditLog).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -1365,7 +1382,7 @@ describe("POST /api/integrations (web-search)", () => {
         credentials: {},
       }),
     });
-    const response = await POST(request);
+    const response = await POST(request, routeContext());
     expect(response.status).toBe(400);
   });
 });
@@ -1394,7 +1411,7 @@ describe("GET /api/integrations (lastError/lastErrorAt)", () => {
     });
 
     const { GET } = await import("@/app/api/integrations/route");
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -1415,7 +1432,7 @@ describe("GET /api/integrations (lastError/lastErrorAt)", () => {
     });
 
     const { GET } = await import("@/app/api/integrations/route");
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -1480,7 +1497,7 @@ describe("GET /api/integrations (web-search masking)", () => {
 
     const { GET } = await import("@/app/api/integrations/route");
 
-    const response = await GET();
+    const response = await GET(makeRequest("/api/integrations"), routeContext());
     const body = await response.json();
 
     expect(response.status).toBe(200);
@@ -1490,14 +1507,20 @@ describe("GET /api/integrations (web-search masking)", () => {
 });
 
 describe("POST /api/integrations/list-databases", () => {
-  let mockFetch: ReturnType<typeof vi.fn>;
+  // The route only reads `response.json()`, so tests resolve minimal partial
+  // fakes rather than full `Response` objects — type the mock's return value
+  // as `Partial<Response>` to match, and cast once at the `global.fetch`
+  // assignment (the only place the two shapes must meet).
+  let mockFetch: ReturnType<
+    typeof vi.fn<(...args: Parameters<typeof fetch>) => Promise<Partial<Response>>>
+  >;
   const originalFetch = global.fetch;
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockGetSession.mockResolvedValue(adminSession);
     mockFetch = vi.fn();
-    global.fetch = mockFetch;
+    global.fetch = mockFetch as unknown as typeof fetch;
   });
 
   afterEach(() => {
@@ -1512,7 +1535,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "https://odoo.example.com" }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(401);
   });
@@ -1525,7 +1549,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "https://odoo.example.com" }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(403);
   });
@@ -1537,7 +1562,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({}),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(400);
   });
@@ -1549,7 +1575,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "not-a-url" }),
-      })
+      }),
+      routeContext()
     );
     expect(response.status).toBe(400);
   });
@@ -1565,7 +1592,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "https://odoo.example.com" }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1587,7 +1615,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "https://odoo.example.com" }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1611,7 +1640,8 @@ describe("POST /api/integrations/list-databases", () => {
       makeRequest("/api/integrations/list-databases", {
         method: "POST",
         body: JSON.stringify({ url: "https://odoo.example.com" }),
-      })
+      }),
+      routeContext()
     );
     const body = await response.json();
 
@@ -1647,7 +1677,7 @@ describe("POST /api/integrations/[connectionId]/sync", () => {
 
   it("should return 404 when connection not found", async () => {
     mockSelectFrom.mockImplementationOnce(() => {
-      const result = Promise.resolve([]) as Promise<unknown[]> & {
+      const result = Promise.resolve<unknown[]>([]) as Promise<unknown[]> & {
         where: ReturnType<typeof vi.fn>;
       };
       result.where = vi.fn().mockResolvedValue([]);

--- a/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
+++ b/packages/web/src/__tests__/api/internal-audit-tool-use.test.ts
@@ -670,13 +670,14 @@ describe("POST /api/internal/audit/tool-use", () => {
       expect(res.status).toBe(200);
 
       const call = vi.mocked(appendAuditLog).mock.calls[0][0];
-      expect(call.detail.toolName).toBe("pinchy_write");
+      const detail = call.detail as Record<string, unknown>;
+      expect(detail.toolName).toBe("pinchy_write");
       // details fields merged into audit detail
-      expect(call.detail.path).toBe("uploads/secret.txt");
-      expect(call.detail.contentHash).toBe("abc123");
-      expect(call.detail.mode).toBe("create");
+      expect(detail.path).toBe("uploads/secret.txt");
+      expect(detail.contentHash).toBe("abc123");
+      expect(detail.mode).toBe("create");
       // raw params must NOT appear
-      expect(call.detail).not.toHaveProperty("params");
+      expect(detail).not.toHaveProperty("params");
       // raw content string must NOT appear anywhere in audit detail
       expect(JSON.stringify(call.detail)).not.toContain("PRIVATE PERSONAL");
     });
@@ -696,8 +697,9 @@ describe("POST /api/internal/audit/tool-use", () => {
       );
 
       const call = vi.mocked(appendAuditLog).mock.calls[0][0];
-      expect(call.detail).toHaveProperty("params");
-      expect((call.detail.params as Record<string, unknown>).path).toBe("/data/kb/report.md");
+      const detail = call.detail as Record<string, unknown>;
+      expect(detail).toHaveProperty("params");
+      expect((detail.params as Record<string, unknown>).path).toBe("/data/kb/report.md");
     });
 
     it("keeps params on failure when details carries only an error (no curated fields to suppress)", async () => {
@@ -764,8 +766,9 @@ describe("POST /api/internal/audit/tool-use", () => {
       );
 
       const call = vi.mocked(appendAuditLog).mock.calls[0][0];
-      expect(call.detail.toolName).toBe("pinchy_write");
-      expect(call.detail.success).toBe(true);
+      const detail = call.detail as Record<string, unknown>;
+      expect(detail.toolName).toBe("pinchy_write");
+      expect(detail.success).toBe(true);
     });
   });
 

--- a/packages/web/src/__tests__/api/oauth-settings-route.test.ts
+++ b/packages/web/src/__tests__/api/oauth-settings-route.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
@@ -18,7 +19,7 @@ vi.mock("@/lib/auth", () => {
 });
 
 vi.mock("@/lib/integrations/oauth-settings", async (importOriginal) => {
-  const actual = await importOriginal();
+  const actual = await importOriginal<typeof import("@/lib/integrations/oauth-settings")>();
   return {
     ...actual,
     getOAuthSettings: vi.fn(),
@@ -56,13 +57,9 @@ import {
 import { appendAuditLog } from "@/lib/audit";
 import { validateMicrosoftTenant } from "@/lib/integrations/oauth-preflight";
 
-const adminSession = {
-  user: { id: "admin-1", name: "Admin", role: "admin" },
-};
+const adminSession = mockSession({ user: { id: "admin-1", name: "Admin", role: "admin" } });
 
-const userSession = {
-  user: { id: "user-1", name: "User", role: "member" },
-};
+const userSession = mockSession({ user: { id: "user-1", name: "User", role: "member" } });
 
 describe("GET /api/settings/oauth", () => {
   let GET: typeof import("@/app/api/settings/oauth/route").GET;

--- a/packages/web/src/__tests__/api/openclaw-config-ready.test.ts
+++ b/packages/web/src/__tests__/api/openclaw-config-ready.test.ts
@@ -1,5 +1,4 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
-import { NextRequest } from "next/server";
 
 const { markOpenClawConfigReady, isOpenClawConfigReady } = vi.hoisted(() => ({
   markOpenClawConfigReady: vi.fn(),
@@ -20,18 +19,14 @@ describe("GET /api/internal/openclaw-config-ready", () => {
   it("returns 503 before regenerateOpenClawConfig() has completed", async () => {
     isOpenClawConfigReady.mockReturnValue(false);
     const { GET } = await import("@/app/api/internal/openclaw-config-ready/route");
-    const response = await GET(
-      new NextRequest("http://localhost/api/internal/openclaw-config-ready")
-    );
+    const response = await GET();
     expect(response.status).toBe(503);
   });
 
   it("returns 200 after regenerateOpenClawConfig() has completed", async () => {
     isOpenClawConfigReady.mockReturnValue(true);
     const { GET } = await import("@/app/api/internal/openclaw-config-ready/route");
-    const response = await GET(
-      new NextRequest("http://localhost/api/internal/openclaw-config-ready")
-    );
+    const response = await GET();
     expect(response.status).toBe(200);
   });
 });

--- a/packages/web/src/__tests__/api/provider-models.test.ts
+++ b/packages/web/src/__tests__/api/provider-models.test.ts
@@ -23,21 +23,22 @@ vi.mock("@/lib/provider-models", () => ({
 import { GET } from "@/app/api/providers/models/route";
 import { auth } from "@/lib/auth";
 import { fetchProviderModels } from "@/lib/provider-models";
+import { mockSession } from "@/test-helpers/auth";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 describe("GET /api/providers/models", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "1", email: "admin@test.com" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "1", email: "admin@test.com" } })
+    );
     vi.mocked(fetchProviderModels).mockResolvedValue([]);
   });
 
   it("returns 401 when not authenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(401);
     const data = await response.json();
@@ -53,7 +54,7 @@ describe("GET /api/providers/models", () => {
       },
     ]);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();

--- a/packages/web/src/__tests__/api/settings-context.test.ts
+++ b/packages/web/src/__tests__/api/settings-context.test.ts
@@ -33,6 +33,8 @@ vi.mock("@/lib/context-sync", () => ({
 import { auth } from "@/lib/auth";
 import { GET, PUT } from "@/app/api/settings/context/route";
 import { NextRequest } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
+import { routeContext } from "@/test-helpers/route";
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/settings/context", { method: "GET" });
@@ -49,33 +51,31 @@ function makePutRequest(body: Record<string, unknown>) {
 describe("GET /api/settings/context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "admin-1", email: "admin@test.com", role: "admin" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", email: "admin@test.com", role: "admin" } })
+    );
   });
 
   it("should return 401 when unauthenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("should return 403 for non-admin", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", email: "user@test.com", role: "member" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
+    );
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(403);
   });
 
   it("should return org context from settings", async () => {
     mockGetSetting.mockResolvedValueOnce("Organization context");
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.content).toBe("Organization context");
@@ -85,7 +85,7 @@ describe("GET /api/settings/context", () => {
   it("should return empty string when not set", async () => {
     mockGetSetting.mockResolvedValueOnce(null);
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.content).toBe("");
@@ -95,31 +95,29 @@ describe("GET /api/settings/context", () => {
 describe("PUT /api/settings/context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "admin-1", email: "admin@test.com", role: "admin" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", email: "admin@test.com", role: "admin" } })
+    );
   });
 
   it("should return 401 when unauthenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await PUT(makePutRequest({ content: "test" }));
+    const response = await PUT(makePutRequest({ content: "test" }), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("should return 403 for non-admin", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", email: "user@test.com", role: "member" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
+    );
 
-    const response = await PUT(makePutRequest({ content: "test" }));
+    const response = await PUT(makePutRequest({ content: "test" }), routeContext());
     expect(response.status).toBe(403);
   });
 
   it("should save org context via setSetting", async () => {
-    const response = await PUT(makePutRequest({ content: "New org context" }));
+    const response = await PUT(makePutRequest({ content: "New org context" }), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -128,13 +126,13 @@ describe("PUT /api/settings/context", () => {
   });
 
   it("should call syncOrgContextToWorkspaces", async () => {
-    await PUT(makePutRequest({ content: "New org context" }));
+    await PUT(makePutRequest({ content: "New org context" }), routeContext());
 
     expect(mockSyncOrgContextToWorkspaces).toHaveBeenCalled();
   });
 
   it("should return 400 when content is not a string", async () => {
-    const response = await PUT(makePutRequest({ content: 42 }));
+    const response = await PUT(makePutRequest({ content: 42 }), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -143,7 +141,7 @@ describe("PUT /api/settings/context", () => {
   });
 
   it("should return 400 when content is missing", async () => {
-    const response = await PUT(makePutRequest({}));
+    const response = await PUT(makePutRequest({}), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();

--- a/packages/web/src/__tests__/api/settings-providers.test.ts
+++ b/packages/web/src/__tests__/api/settings-providers.test.ts
@@ -110,6 +110,8 @@ import { resetCache } from "@/lib/provider-models";
 import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
 import { db } from "@/db";
 import { appendAuditLog } from "@/lib/audit";
+import { mockSession } from "@/test-helpers/auth";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 describe("GET /api/settings/providers", () => {
   beforeEach(() => {
@@ -120,7 +122,7 @@ describe("GET /api/settings/providers", () => {
   it("should return 401 when not authenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(401);
     const data = await response.json();
@@ -128,7 +130,7 @@ describe("GET /api/settings/providers", () => {
   });
 
   it("should return all providers as not configured when nothing is set", async () => {
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -150,7 +152,7 @@ describe("GET /api/settings/providers", () => {
       return null;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -165,7 +167,7 @@ describe("GET /api/settings/providers", () => {
       return null;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(data.providers.anthropic.hint).toBe("xY9z");
@@ -174,15 +176,15 @@ describe("GET /api/settings/providers", () => {
   });
 
   it("should not return hints for non-admin users", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "2", email: "user@test.com", role: "member" },
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })
+    );
     vi.mocked(getSetting).mockImplementation(async (key: string) => {
       if (key === "anthropic_api_key") return "sk-ant-secret-key-xY9z";
       return null;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -197,7 +199,7 @@ describe("GET /api/settings/providers", () => {
       return null;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -210,7 +212,7 @@ describe("GET /api/settings/providers", () => {
       return null;
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
     expect(data.providers["ollama-local"].configured).toBe(true);
     expect(data.providers["ollama-local"].hint).toBe("http://host.docker.internal:11434");
@@ -224,7 +226,7 @@ describe("DELETE /api/settings/providers", () => {
   });
 
   function makeRequest(body: object) {
-    return new Request("http://localhost/api/settings/providers", {
+    return makeNextRequest("http://localhost/api/settings/providers", {
       method: "DELETE",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify(body),
@@ -234,17 +236,17 @@ describe("DELETE /api/settings/providers", () => {
   it("should return 401 when not authenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await DELETE(makeRequest({ provider: "anthropic" }));
+    const response = await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(response.status).toBe(401);
   });
 
   it("should return 403 when non-admin user tries to delete", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "2", email: "user@test.com", role: "member" },
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })
+    );
 
-    const response = await DELETE(makeRequest({ provider: "anthropic" }));
+    const response = await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(response.status).toBe(403);
     const data = await response.json();
@@ -252,7 +254,7 @@ describe("DELETE /api/settings/providers", () => {
   });
 
   it("should return 400 for invalid provider name", async () => {
-    const response = await DELETE(makeRequest({ provider: "invalid" }));
+    const response = await DELETE(makeRequest({ provider: "invalid" }), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -267,7 +269,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    const response = await DELETE(makeRequest({ provider: "anthropic" }));
+    const response = await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -282,7 +284,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    const response = await DELETE(makeRequest({ provider: "anthropic" }));
+    const response = await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(response.status).toBe(200);
     expect(deleteSetting).toHaveBeenCalledWith("anthropic_api_key");
@@ -296,7 +298,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    const response = await DELETE(makeRequest({ provider: "anthropic" }));
+    const response = await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(response.status).toBe(200);
     expect(deleteSetting).toHaveBeenCalledWith("anthropic_api_key");
@@ -311,7 +313,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    const response = await DELETE(makeRequest({ provider: "openai" }));
+    const response = await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     expect(response.status).toBe(200);
     expect(deleteSetting).toHaveBeenCalledWith("openai_api_key");
@@ -326,7 +328,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    await DELETE(makeRequest({ provider: "openai" }));
+    await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     expect(resetCache).toHaveBeenCalled();
   });
@@ -344,7 +346,7 @@ describe("DELETE /api/settings/providers", () => {
       { id: "agent-3", model: "anthropic/claude-haiku-4-5-20251001" },
     ] as any[]);
 
-    await DELETE(makeRequest({ provider: "openai" }));
+    await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     // Only the 2 openai agents should be migrated, not the anthropic one
     expect(db.update).toHaveBeenCalledTimes(2);
@@ -361,7 +363,7 @@ describe("DELETE /api/settings/providers", () => {
       { id: "agent-1", name: "Smithers", model: "anthropic/claude-haiku-4-5-20251001" },
     ] as any[]);
 
-    await DELETE(makeRequest({ provider: "openai" }));
+    await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     expect(db.update).not.toHaveBeenCalled();
     // Audit log still fires with empty migratedAgents — proves the call is
@@ -388,7 +390,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    await DELETE(makeRequest({ provider: "openai" }));
+    await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     expect(regenerateOpenClawConfig).toHaveBeenCalled();
   });
@@ -405,7 +407,7 @@ describe("DELETE /api/settings/providers", () => {
       { id: "agent-2", name: "Smithers", model: "anthropic/claude-haiku-4-5-20251001" },
     ] as any[]);
 
-    await DELETE(makeRequest({ provider: "ollama-local" }));
+    await DELETE(makeRequest({ provider: "ollama-local" }), routeContext());
 
     // Only the ollama agent should be migrated, not the anthropic one
     expect(db.update).toHaveBeenCalledTimes(1);
@@ -451,7 +453,7 @@ describe("DELETE /api/settings/providers", () => {
     }));
     vi.mocked(db.query.agents.findMany).mockResolvedValueOnce(manyAgents as any[]);
 
-    await DELETE(makeRequest({ provider: "openai" }));
+    await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     const call = vi.mocked(appendAuditLog).mock.calls[0]?.[0];
     expect(call?.detail).toMatchObject({
@@ -473,7 +475,7 @@ describe("DELETE /api/settings/providers", () => {
       { id: "agent-2", name: "Smithers", model: "anthropic/claude-haiku-4-5-20251001" },
     ] as any[]);
 
-    const response = await DELETE(makeRequest({ provider: "openai" }));
+    const response = await DELETE(makeRequest({ provider: "openai" }), routeContext());
 
     expect(response.status).toBe(200);
     expect(appendAuditLog).toHaveBeenCalledTimes(1);
@@ -509,7 +511,7 @@ describe("DELETE /api/settings/providers", () => {
     });
     vi.mocked(db.query.agents.findMany).mockResolvedValueOnce([] as any[]);
 
-    await DELETE(makeRequest({ provider: "anthropic" }));
+    await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(appendAuditLog).toHaveBeenCalledWith({
       actorType: "user",
@@ -529,11 +531,11 @@ describe("DELETE /api/settings/providers", () => {
   });
 
   it("should not write an audit log when the request is rejected", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "2", email: "user@test.com", role: "member" },
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "2", email: "user@test.com", role: "member" } })
+    );
 
-    await DELETE(makeRequest({ provider: "anthropic" }));
+    await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(appendAuditLog).not.toHaveBeenCalled();
   });
@@ -545,7 +547,7 @@ describe("DELETE /api/settings/providers", () => {
       return null;
     });
 
-    await DELETE(makeRequest({ provider: "anthropic" }));
+    await DELETE(makeRequest({ provider: "anthropic" }), routeContext());
 
     expect(appendAuditLog).not.toHaveBeenCalled();
   });

--- a/packages/web/src/__tests__/api/settings-telegram-bots.test.ts
+++ b/packages/web/src/__tests__/api/settings-telegram-bots.test.ts
@@ -36,6 +36,7 @@ vi.mock("@/lib/pairing-candidates", () => ({
 }));
 
 import { GET } from "@/app/api/settings/telegram/bots/route";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 const adminSession = {
   user: { id: "user-1", email: "admin@test.com", role: "admin" },
@@ -63,7 +64,7 @@ describe("GET /api/settings/telegram/bots", () => {
   it("returns 401 when not authenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     expect(response.status).toBe(401);
   });
 
@@ -72,7 +73,7 @@ describe("GET /api/settings/telegram/bots", () => {
       { id: "a1", name: "Smithers", isPersonal: false, visibility: "all" },
     ]);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -86,7 +87,7 @@ describe("GET /api/settings/telegram/bots", () => {
     ]);
     mockSettings.set("telegram_bot_username:a1", "acme_smithers_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -103,7 +104,7 @@ describe("GET /api/settings/telegram/bots", () => {
     mockSettings.set("telegram_bot_username:a1", "silvia_bot");
     mockSettings.set("telegram_bot_username:a2", "smithers_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(data.bots[0].botUsername).toBe("smithers_bot");
@@ -113,7 +114,7 @@ describe("GET /api/settings/telegram/bots", () => {
   it("calls getVisibleAgents with the session user id and role for filtering", async () => {
     mockGetSession.mockResolvedValueOnce(memberSession);
 
-    await GET();
+    await GET(makeNextRequest(), routeContext());
 
     expect(mockGetVisibleAgents).toHaveBeenCalledWith("user-2", "member");
   });
@@ -126,7 +127,7 @@ describe("GET /api/settings/telegram/bots", () => {
     mockSettings.set("telegram_bot_username:a1", "acme_smithers_bot");
     mockSettings.set("telegram_bot_username:a2", "hr_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -141,7 +142,7 @@ describe("GET /api/settings/telegram/bots", () => {
     mockSettings.set("telegram_bot_username:a-self", "self_smithers_bot");
     mockSettings.set("telegram_bot_username:a-admin", "admin_smithers_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -166,7 +167,7 @@ describe("GET /api/settings/telegram/bots", () => {
     mockSettings.set("telegram_bot_username:a2", "support_bot");
     mockSettings.set("telegram_bot_username:a3", "hr_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -195,7 +196,7 @@ describe("GET /api/settings/telegram/bots", () => {
     ]);
     mockSettings.set("telegram_bot_username:admin-smithers-real-uuid", "acme_smithers_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     expect(response.status).toBe(200);
@@ -214,7 +215,7 @@ describe("GET /api/settings/telegram/bots", () => {
       { id: "a2", name: "Support", isPersonal: false, visibility: "all" },
     ]);
 
-    await GET();
+    await GET(makeNextRequest(), routeContext());
 
     expect(mockGetOrgPairingSmithers).toHaveBeenCalledWith(new Set(["a1", "a2"]));
   });
@@ -229,7 +230,7 @@ describe("GET /api/settings/telegram/bots", () => {
     mockSettings.set("telegram_bot_username:a2", "b_bot");
     mockSettings.set("telegram_bot_username:a3", "c_bot");
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     const data = await response.json();
 
     // One batched call — not one per candidate.

--- a/packages/web/src/__tests__/api/settings-telegram.test.ts
+++ b/packages/web/src/__tests__/api/settings-telegram.test.ts
@@ -62,6 +62,8 @@ vi.mock("drizzle-orm", async (importOriginal) => {
 // ── Import route handlers ────────────────────────────────────────────────
 
 import { GET, POST, DELETE } from "@/app/api/settings/telegram/route";
+import { NextRequest } from "next/server";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -70,7 +72,7 @@ const userSession = {
 };
 
 function makePostRequest(body: object) {
-  return new Request("http://localhost/api/settings/telegram", {
+  return new NextRequest("http://localhost/api/settings/telegram", {
     method: "POST",
     headers: { "Content-Type": "application/json" },
     body: JSON.stringify(body),
@@ -88,7 +90,7 @@ describe("GET /api/settings/telegram", () => {
   it("returns 401 when unauthenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     expect(response.status).toBe(401);
   });
 
@@ -99,7 +101,7 @@ describe("GET /api/settings/telegram", () => {
       channelUserId: "8734062810",
     });
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data).toEqual({ linked: true, channelUserId: "8734062810" });
@@ -108,7 +110,7 @@ describe("GET /api/settings/telegram", () => {
   it("returns not linked when no link exists", async () => {
     mockFindFirst.mockResolvedValueOnce(undefined);
 
-    const response = await GET();
+    const response = await GET(makeNextRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data).toEqual({ linked: false, channelUserId: null });
@@ -130,17 +132,17 @@ describe("POST /api/settings/telegram", () => {
   it("returns 401 when unauthenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 
-    const response = await POST(makePostRequest({ code: "ABC123" }));
+    const response = await POST(makePostRequest({ code: "ABC123" }), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("returns 400 when code is missing", async () => {
-    const response = await POST(makePostRequest({}));
+    const response = await POST(makePostRequest({}), routeContext());
     expect(response.status).toBe(400);
   });
 
   it("resolves pairing code, stores link in DB, regenerates config", async () => {
-    const response = await POST(makePostRequest({ code: "FMSVEN7M" }));
+    const response = await POST(makePostRequest({ code: "FMSVEN7M" }), routeContext());
     expect(response.status).toBe(200);
 
     const data = await response.json();
@@ -162,7 +164,7 @@ describe("POST /api/settings/telegram", () => {
   it("returns 400 when pairing code is invalid", async () => {
     mockResolvePairingCode.mockReturnValueOnce({ found: false });
 
-    const response = await POST(makePostRequest({ code: "BADCODE" }));
+    const response = await POST(makePostRequest({ code: "BADCODE" }), routeContext());
     expect(response.status).toBe(400);
 
     const data = await response.json();
@@ -172,7 +174,7 @@ describe("POST /api/settings/telegram", () => {
   it("still succeeds when OpenClaw client is not connected", async () => {
     // queueConfigPatch is fire-and-forget — route always returns success
     // since DB is source of truth
-    const response = await POST(makePostRequest({ code: "ABC123" }));
+    const response = await POST(makePostRequest({ code: "ABC123" }), routeContext());
     expect(response.status).toBe(200);
 
     // DB was still written
@@ -197,12 +199,12 @@ describe("DELETE /api/settings/telegram", () => {
   it("returns 401 when unauthenticated", async () => {
     mockGetSession.mockResolvedValueOnce(null);
 
-    const response = await DELETE();
+    const response = await DELETE(makeNextRequest(), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("removes link from DB, updates allow store, and regenerates config", async () => {
-    const response = await DELETE();
+    const response = await DELETE(makeNextRequest(), routeContext());
     expect(response.status).toBe(200);
 
     const data = await response.json();

--- a/packages/web/src/__tests__/api/setup-provider.test.ts
+++ b/packages/web/src/__tests__/api/setup-provider.test.ts
@@ -138,6 +138,20 @@ describe("POST /api/setup/provider", () => {
       id: "agent-1",
       name: "Smithers",
       model: "anthropic/claude-sonnet-4-20250514",
+      templateId: null,
+      pluginConfig: null,
+      allowedTools: [],
+      skills: [],
+      ownerId: null,
+      isPersonal: false,
+      visibility: "restricted",
+      greetingMessage: "Hi, I'm Smithers.",
+      tagline: null,
+      starterPrompts: [],
+      avatarSeed: null,
+      personalityPresetId: null,
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      deletedAt: null,
     });
   });
 

--- a/packages/web/src/__tests__/api/setup-status.test.ts
+++ b/packages/web/src/__tests__/api/setup-status.test.ts
@@ -44,6 +44,15 @@ describe("setup status", () => {
       email: "admin@test.com",
       name: "Admin",
       role: "admin",
+      emailVerified: true,
+      image: null,
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      context: null,
+      auditPseudonym: "pseudonym-1",
+      createdAt: new Date("2026-01-01T00:00:00.000Z"),
+      updatedAt: new Date("2026-01-01T00:00:00.000Z"),
     });
     const result = await isSetupComplete();
     expect(result).toBe(true);

--- a/packages/web/src/__tests__/api/setup.test.ts
+++ b/packages/web/src/__tests__/api/setup.test.ts
@@ -104,6 +104,48 @@ import { markOpenClawConfigReady, isOpenClawConfigReady } from "@/lib/openclaw-c
 
 import { db } from "@/db";
 
+// Full `db.query.users.findFirst()` / `db.query.agents.findFirst()` row
+// shapes. Only the fields each test cares about vary; the rest are filled
+// with realistic defaults so the fixtures stay in sync with the schema.
+function makeDbUserRow(overrides: {
+  id: string;
+  email: string;
+  name: string;
+  role: "admin" | "member";
+}) {
+  return {
+    ...overrides,
+    emailVerified: true,
+    image: null,
+    banned: false,
+    banReason: null,
+    banExpires: null,
+    context: null,
+    auditPseudonym: "pseudonym-1",
+    createdAt: new Date("2026-01-01T00:00:00.000Z"),
+    updatedAt: new Date("2026-01-01T00:00:00.000Z"),
+  };
+}
+
+function makeDbAgentRow(overrides: { id: string; name: string; model: string; createdAt: Date }) {
+  return {
+    ...overrides,
+    templateId: null,
+    pluginConfig: null,
+    allowedTools: [],
+    skills: [],
+    ownerId: null,
+    isPersonal: false,
+    visibility: "restricted" as const,
+    greetingMessage: "Hi, I'm Smithers.",
+    tagline: null,
+    starterPrompts: [],
+    avatarSeed: null,
+    personalityPresetId: null,
+    deletedAt: null,
+  };
+}
+
 describe("createAdmin", () => {
   beforeEach(() => {
     vi.clearAllMocks();
@@ -139,12 +181,9 @@ describe("createAdmin", () => {
   });
 
   it("should reject if admin already exists", async () => {
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "1",
-      email: "admin@test.com",
-      name: "Admin",
-      role: "admin",
-    });
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(
+      makeDbUserRow({ id: "1", email: "admin@test.com", name: "Admin", role: "admin" })
+    );
 
     await expect(createAdmin("New User", "new@test.com", "pass")).rejects.toThrow(
       "Setup already complete"
@@ -283,12 +322,9 @@ describe("POST /api/setup", () => {
   });
 
   it("should return 403 when setup is already complete and config is in place", async () => {
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "1",
-      email: "admin@test.com",
-      name: "Admin",
-      role: "admin",
-    });
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(
+      makeDbUserRow({ id: "1", email: "admin@test.com", name: "Admin", role: "admin" })
+    );
     // Config was already written, so a retry is genuinely a no-op.
     vi.mocked(isOpenClawConfigReady).mockReturnValue(true);
 
@@ -307,12 +343,9 @@ describe("POST /api/setup", () => {
   it("recovers in-process when the admin exists but the config was never written", async () => {
     // Prior setup POST created the admin + agent, but its regenerate threw, so
     // the config was never written and isOpenClawConfigReady is false.
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "1",
-      email: "admin@test.com",
-      name: "Admin",
-      role: "admin",
-    });
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(
+      makeDbUserRow({ id: "1", email: "admin@test.com", name: "Admin", role: "admin" })
+    );
     vi.mocked(isOpenClawConfigReady).mockReturnValue(false);
     vi.mocked(regenerateOpenClawConfig).mockResolvedValueOnce(undefined);
 
@@ -334,12 +367,9 @@ describe("POST /api/setup", () => {
     // not each kick off its own regenerateOpenClawConfig — that's an
     // unauthenticated resource-exhaustion vector. Concurrent recoveries share
     // one in-flight regeneration.
-    vi.mocked(db.query.users.findFirst).mockResolvedValue({
-      id: "1",
-      email: "admin@test.com",
-      name: "Admin",
-      role: "admin",
-    });
+    vi.mocked(db.query.users.findFirst).mockResolvedValue(
+      makeDbUserRow({ id: "1", email: "admin@test.com", name: "Admin", role: "admin" })
+    );
     vi.mocked(isOpenClawConfigReady).mockReturnValue(false);
     // Each regeneration stays pending for a tick so all three POSTs reach the
     // recovery branch before any resolves — that's the window in which a guard
@@ -379,12 +409,14 @@ describe("seedDefaultAgent", () => {
   });
 
   it("should return existing agent if one exists", async () => {
-    vi.mocked(db.query.agents.findFirst).mockResolvedValue({
-      id: "existing-agent",
-      name: "Smithers",
-      model: "anthropic/claude-sonnet-4-20250514",
-      createdAt: new Date(),
-    });
+    vi.mocked(db.query.agents.findFirst).mockResolvedValue(
+      makeDbAgentRow({
+        id: "existing-agent",
+        name: "Smithers",
+        model: "anthropic/claude-sonnet-4-20250514",
+        createdAt: new Date(),
+      })
+    );
 
     const agent = await seedDefaultAgent();
     expect(agent.name).toBe("Smithers");

--- a/packages/web/src/__tests__/api/templates.test.ts
+++ b/packages/web/src/__tests__/api/templates.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest } from "next/server";
+import { routeContext } from "@/test-helpers/route";
 
 vi.mock("next/headers", () => ({
   headers: vi.fn().mockResolvedValue(new Headers()),
@@ -132,7 +133,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([{ id: "conn-1" }]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     expect(body.templates).toEqual(
@@ -161,7 +162,7 @@ describe("GET /api/templates", () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
 
     expect(response.status).toBe(401);
   });
@@ -170,7 +171,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([{ id: "conn-1" }]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const odooTemplates = body.templates.filter(
@@ -191,7 +192,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const odooTemplates = body.templates.filter(
@@ -235,7 +236,7 @@ describe("GET /api/templates", () => {
     ]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const salesAnalyst = body.templates.find((t: { id: string }) => t.id === "odoo-sales-analyst");
@@ -255,7 +256,7 @@ describe("GET /api/templates", () => {
     ]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const salesAnalyst = body.templates.find((t: { id: string }) => t.id === "odoo-sales-analyst");
@@ -265,7 +266,7 @@ describe("GET /api/templates", () => {
 
   it("marks non-odoo templates as always available", async () => {
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const kb = body.templates.find((t: { id: string }) => t.id === "knowledge-base");
@@ -290,7 +291,7 @@ describe("GET /api/templates", () => {
     });
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const contract = body.templates.find((t: { id: string }) => t.id === "contract-analyzer");
@@ -307,7 +308,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const ids = body.templates.map((t: { id: string }) => t.id);
@@ -317,7 +318,10 @@ describe("GET /api/templates", () => {
     // With Odoo connection
     mockLimit.mockResolvedValue([{ id: "conn-1" }]);
 
-    const response2 = await GET(new NextRequest("http://localhost:7777/api/templates"));
+    const response2 = await GET(
+      new NextRequest("http://localhost:7777/api/templates"),
+      routeContext()
+    );
     const body2 = await response2.json();
 
     const ids2 = body2.templates.map((t: { id: string }) => t.id);
@@ -330,7 +334,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const emailTemplates = body.templates.filter(
@@ -348,7 +352,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([{ id: "email-conn-1" }]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const emailAssistant = body.templates.find((t: { id: string }) => t.id === "email-assistant");
@@ -378,7 +382,7 @@ describe("GET /api/templates", () => {
     // so it naturally resolves to [] via the same condition-matching logic.
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const emailAssistant = body.templates.find((t: { id: string }) => t.id === "email-assistant");
@@ -391,7 +395,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValueOnce([]).mockResolvedValueOnce([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    await GET(request);
+    await GET(request, routeContext());
 
     // The second where() call is the email-availability check (the first is Odoo).
     const emailWhereCall = mockWhere.mock.calls[1][0];
@@ -404,7 +408,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     const emailAssistant = body.templates.find((t: { id: string }) => t.id === "email-assistant");
@@ -416,7 +420,7 @@ describe("GET /api/templates", () => {
     mockLimit.mockResolvedValue([]);
 
     const request = new NextRequest("http://localhost:7777/api/templates");
-    const response = await GET(request);
+    const response = await GET(request, routeContext());
     const body = await response.json();
 
     for (const id of ["email-assistant", "email-sales-assistant", "email-support-assistant"]) {

--- a/packages/web/src/__tests__/api/usage-by-user.test.ts
+++ b/packages/web/src/__tests__/api/usage-by-user.test.ts
@@ -48,6 +48,7 @@ vi.mock("drizzle-orm", () => ({
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { eq, gte } from "drizzle-orm";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -73,10 +74,9 @@ describe("GET /api/usage/by-user", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
     vi.mocked(isEnterprise).mockResolvedValue(true);
 
     // Reset chainable mock defaults

--- a/packages/web/src/__tests__/api/usage-export.test.ts
+++ b/packages/web/src/__tests__/api/usage-export.test.ts
@@ -47,6 +47,7 @@ vi.mock("drizzle-orm", () => ({
 import { requireAdmin } from "@/lib/api-auth";
 import { isEnterprise } from "@/lib/enterprise";
 import { eq, gte } from "drizzle-orm";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -86,10 +87,9 @@ describe("GET /api/usage/export", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
     vi.mocked(isEnterprise).mockResolvedValue(true);
 
     // Reset chainable mock defaults

--- a/packages/web/src/__tests__/api/usage-summary.test.ts
+++ b/packages/web/src/__tests__/api/usage-summary.test.ts
@@ -56,6 +56,7 @@ vi.mock("drizzle-orm", () => ({
 
 import { requireAdmin } from "@/lib/api-auth";
 import { eq, gte } from "drizzle-orm";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -81,10 +82,9 @@ describe("GET /api/usage/summary", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
 
     // Reset chainable mock defaults
     mockSelect.mockReturnValue({ from: mockFrom });

--- a/packages/web/src/__tests__/api/usage-timeseries.test.ts
+++ b/packages/web/src/__tests__/api/usage-timeseries.test.ts
@@ -52,6 +52,7 @@ vi.mock("drizzle-orm", () => {
 
 import { requireAdmin } from "@/lib/api-auth";
 import { eq, gte } from "drizzle-orm";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Tests ────────────────────────────────────────────────────────────────
 
@@ -75,10 +76,9 @@ describe("GET /api/usage/timeseries", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
 
     // Reset chainable mock defaults
     mockSelect.mockReturnValue({ from: mockFrom });

--- a/packages/web/src/__tests__/api/user-config-audit.test.ts
+++ b/packages/web/src/__tests__/api/user-config-audit.test.ts
@@ -121,11 +121,11 @@ import { appendAuditLog } from "@/lib/audit";
 import { requireAdmin } from "@/lib/api-auth";
 import { createInvite } from "@/lib/invites";
 import { db } from "@/db";
+import { mockSession } from "@/test-helpers/auth";
 
-const adminSession = {
+const adminSession = mockSession({
   user: { id: "admin-1", email: "admin@test.com", role: "admin" },
-  expires: "",
-};
+});
 
 // ── user.invited: POST /api/users/invite ─────────────────────────────────
 
@@ -134,9 +134,7 @@ describe("audit: POST /api/users/invite", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue(
-      adminSession as Awaited<ReturnType<typeof requireAdmin>>
-    );
+    vi.mocked(requireAdmin).mockResolvedValue(adminSession);
 
     vi.mocked(createInvite).mockResolvedValue({
       id: "invite-1",
@@ -195,9 +193,7 @@ describe("audit: DELETE /api/users/[userId]", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue(
-      adminSession as Awaited<ReturnType<typeof requireAdmin>>
-    );
+    vi.mocked(requireAdmin).mockResolvedValue(adminSession);
 
     const mod = await import("@/app/api/users/[userId]/route");
     DELETE = mod.DELETE;
@@ -276,10 +272,9 @@ describe("audit: POST /api/setup/provider", () => {
   beforeEach(async () => {
     vi.clearAllMocks();
     // setup/provider uses requireAdmin directly — mock it to return session
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", email: "admin@test.com", role: "admin" },
-      expires: "",
-    } as Awaited<ReturnType<typeof requireAdmin>>);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", email: "admin@test.com", role: "admin" } })
+    );
 
     const mod = await import("@/app/api/setup/provider/route");
     POST = mod.POST;
@@ -330,9 +325,7 @@ describe("audit: POST /api/settings", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue(
-      adminSession as Awaited<ReturnType<typeof requireAdmin>>
-    );
+    vi.mocked(requireAdmin).mockResolvedValue(adminSession);
 
     const mod = await import("@/app/api/settings/route");
     POST = mod.POST;

--- a/packages/web/src/__tests__/api/user-context.test.ts
+++ b/packages/web/src/__tests__/api/user-context.test.ts
@@ -50,6 +50,8 @@ vi.mock("@/lib/context-sync", () => ({
 import { auth } from "@/lib/auth";
 import { GET, PUT } from "@/app/api/users/me/context/route";
 import { NextRequest } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
+import { routeContext } from "@/test-helpers/route";
 
 function makeGetRequest() {
   return new NextRequest("http://localhost/api/users/me/context", { method: "GET" });
@@ -66,23 +68,22 @@ function makePutRequest(body: Record<string, unknown>) {
 describe("GET /api/users/me/context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "user-1", email: "user@test.com", role: "member" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
+    );
   });
 
   it("should return 401 when unauthenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("should return user context from database", async () => {
     mockFindFirst.mockResolvedValueOnce({ id: "user-1", context: "My personal context" });
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.content).toBe("My personal context");
@@ -91,7 +92,7 @@ describe("GET /api/users/me/context", () => {
   it("should return empty string when context is null", async () => {
     mockFindFirst.mockResolvedValueOnce({ id: "user-1", context: null });
 
-    const response = await GET(makeGetRequest());
+    const response = await GET(makeGetRequest(), routeContext());
     expect(response.status).toBe(200);
     const data = await response.json();
     expect(data.content).toBe("");
@@ -101,10 +102,9 @@ describe("GET /api/users/me/context", () => {
 describe("PUT /api/users/me/context", () => {
   beforeEach(() => {
     vi.clearAllMocks();
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "user-1", email: "user@test.com", role: "member" },
-      expires: "",
-    });
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
+    );
     mockUpdate.mockReturnValue({ set: mockSet });
     mockSet.mockReturnValue({ where: mockWhere });
     mockWhere.mockResolvedValue(undefined);
@@ -113,12 +113,12 @@ describe("PUT /api/users/me/context", () => {
   it("should return 401 when unauthenticated", async () => {
     vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await PUT(makePutRequest({ content: "test" }));
+    const response = await PUT(makePutRequest({ content: "test" }), routeContext());
     expect(response.status).toBe(401);
   });
 
   it("should update user context in database", async () => {
-    const response = await PUT(makePutRequest({ content: "Updated context" }));
+    const response = await PUT(makePutRequest({ content: "Updated context" }), routeContext());
 
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -127,13 +127,13 @@ describe("PUT /api/users/me/context", () => {
   });
 
   it("should call syncUserContextToWorkspaces", async () => {
-    await PUT(makePutRequest({ content: "Updated context" }));
+    await PUT(makePutRequest({ content: "Updated context" }), routeContext());
 
     expect(mockSyncUserContextToWorkspaces).toHaveBeenCalledWith("user-1");
   });
 
   it("should return 400 when content is not a string", async () => {
-    const response = await PUT(makePutRequest({ content: 123 }));
+    const response = await PUT(makePutRequest({ content: 123 }), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -142,7 +142,7 @@ describe("PUT /api/users/me/context", () => {
   });
 
   it("should return 400 when content is missing", async () => {
-    const response = await PUT(makePutRequest({}));
+    const response = await PUT(makePutRequest({}), routeContext());
 
     expect(response.status).toBe(400);
     const data = await response.json();

--- a/packages/web/src/__tests__/api/user-reset.test.ts
+++ b/packages/web/src/__tests__/api/user-reset.test.ts
@@ -115,6 +115,15 @@ describe("POST /api/users/[userId]/reset", () => {
       name: "Alice",
       email: "alice@test.com",
       role: "member",
+      emailVerified: true,
+      image: null,
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      context: null,
+      auditPseudonym: "pseudo-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
     });
 
     const fakeInvite = {
@@ -152,6 +161,15 @@ describe("POST /api/users/[userId]/reset", () => {
       name: "Alice",
       email: "alice@test.com",
       role: "member",
+      emailVerified: true,
+      image: null,
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      context: null,
+      auditPseudonym: "pseudo-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
     });
 
     const fakeInvite = {
@@ -190,8 +208,20 @@ describe("POST /api/users/[userId]/reset", () => {
     vi.mocked(db.query.users.findFirst).mockResolvedValueOnce({
       id: "user-1",
       name: "Alice",
-      email: null,
+      // Schema types email as NOT NULL, but the route defensively falls back
+      // via `user.email ?? undefined` for legacy/corrupt rows — the boundary
+      // cast below simulates that otherwise-unrepresentable runtime shape.
+      email: null as unknown as string,
       role: "member",
+      emailVerified: true,
+      image: null,
+      banned: false,
+      banReason: null,
+      banExpires: null,
+      context: null,
+      auditPseudonym: "pseudo-1",
+      createdAt: new Date(),
+      updatedAt: new Date(),
     });
 
     const fakeInvite = {

--- a/packages/web/src/__tests__/api/user-self-service.test.ts
+++ b/packages/web/src/__tests__/api/user-self-service.test.ts
@@ -36,6 +36,8 @@ vi.mock("@/db", () => ({
 
 import { auth } from "@/lib/auth";
 import { db } from "@/db";
+import { mockSession } from "@/test-helpers/auth";
+import { routeContext } from "@/test-helpers/route";
 
 // ── PATCH /api/users/me ─────────────────────────────────────────────────
 
@@ -60,7 +62,7 @@ describe("PATCH /api/users/me", () => {
 
     const request = makeRequest({ name: "New Name" });
 
-    const response = await PATCH(request);
+    const response = await PATCH(request, routeContext());
     expect(response.status).toBe(401);
 
     const body = await response.json();
@@ -68,14 +70,13 @@ describe("PATCH /api/users/me", () => {
   });
 
   it("returns 400 when name is empty", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", role: "member" },
-      expires: "",
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", role: "member" } })
+    );
 
     const request = makeRequest({ name: "" });
 
-    const response = await PATCH(request);
+    const response = await PATCH(request, routeContext());
     expect(response.status).toBe(400);
 
     const body = await response.json();
@@ -84,14 +85,13 @@ describe("PATCH /api/users/me", () => {
   });
 
   it("returns 400 when name is whitespace only", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", role: "member" },
-      expires: "",
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", role: "member" } })
+    );
 
     const request = makeRequest({ name: "   " });
 
-    const response = await PATCH(request);
+    const response = await PATCH(request, routeContext());
     expect(response.status).toBe(400);
 
     const body = await response.json();
@@ -100,14 +100,13 @@ describe("PATCH /api/users/me", () => {
   });
 
   it("returns 200 and updates user name on success", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", role: "member" },
-      expires: "",
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", role: "member" } })
+    );
 
     const request = makeRequest({ name: "Updated Name" });
 
-    const response = await PATCH(request);
+    const response = await PATCH(request, routeContext());
     expect(response.status).toBe(200);
 
     const body = await response.json();
@@ -118,14 +117,13 @@ describe("PATCH /api/users/me", () => {
   });
 
   it("trims the name before saving", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce({
-      user: { id: "user-1", role: "member" },
-      expires: "",
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(
+      mockSession({ user: { id: "user-1", role: "member" } })
+    );
 
     const request = makeRequest({ name: "  Trimmed Name  " });
 
-    const response = await PATCH(request);
+    const response = await PATCH(request, routeContext());
     expect(response.status).toBe(200);
 
     // Verify the set() call received the trimmed name

--- a/packages/web/src/__tests__/api/users-invite.test.ts
+++ b/packages/web/src/__tests__/api/users-invite.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { NextRequest, NextResponse } from "next/server";
+import { mockSession } from "@/test-helpers/auth";
 
 // ── Mocks ────────────────────────────────────────────────────────────────
 
@@ -67,10 +68,9 @@ describe("POST /api/users/invite — seat cap", () => {
 
   beforeEach(async () => {
     vi.clearAllMocks();
-    vi.mocked(requireAdmin).mockResolvedValue({
-      user: { id: "admin-1", role: "admin" },
-      expires: "",
-    } as ReturnType<typeof requireAdmin> extends Promise<infer T> ? T : never);
+    vi.mocked(requireAdmin).mockResolvedValue(
+      mockSession({ user: { id: "admin-1", role: "admin" } })
+    );
     vi.mocked(createInvite).mockResolvedValue({
       id: "inv-1",
       tokenHash: "h",

--- a/packages/web/src/__tests__/api/users-password.test.ts
+++ b/packages/web/src/__tests__/api/users-password.test.ts
@@ -31,6 +31,8 @@ vi.mock("@/lib/audit", () => ({
 
 import { auth } from "@/lib/auth";
 import { appendAuditLog } from "@/lib/audit";
+import { mockSession } from "@/test-helpers/auth";
+import { routeContext } from "@/test-helpers/route";
 
 // ── Helpers ──────────────────────────────────────────────────────────────
 
@@ -52,24 +54,23 @@ describe("POST /api/users/me/password", () => {
     const mod = await import("@/app/api/users/me/password/route");
     POST = mod.POST;
 
-    vi.mocked(auth.api.getSession).mockResolvedValue({
-      user: { id: "user-1", email: "user@test.com", role: "member" },
-      expires: "",
-    } as any);
+    vi.mocked(auth.api.getSession).mockResolvedValue(
+      mockSession({ user: { id: "user-1", email: "user@test.com", role: "member" } })
+    );
     vi.mocked(auth.api.changePassword).mockResolvedValue(undefined as any);
   });
 
   it("should return 401 when unauthenticated", async () => {
-    vi.mocked(auth.api.getSession).mockResolvedValueOnce(null as any);
+    vi.mocked(auth.api.getSession).mockResolvedValueOnce(null);
 
-    const response = await POST(makePostRequest({}));
+    const response = await POST(makePostRequest({}), routeContext());
     expect(response.status).toBe(401);
     const data = await response.json();
     expect(data.error).toBe("Unauthorized");
   });
 
   it("should return 400 when currentPassword is missing", async () => {
-    const response = await POST(makePostRequest({ newPassword: "Br1ghtNova!2" }));
+    const response = await POST(makePostRequest({ newPassword: "Br1ghtNova!2" }), routeContext());
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe("Validation failed");
@@ -80,7 +81,8 @@ describe("POST /api/users/me/password", () => {
     // "short" is a valid string (passes Zod), then validatePassword() rejects
     // it post-parse — that's where the freeform 12-char message comes from.
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "short" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "short" }),
+      routeContext()
     );
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -89,7 +91,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 400 when newPassword is exactly 11 characters (just below new minimum)", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "elevenchar1" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "elevenchar1" }),
+      routeContext()
     );
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -98,7 +101,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 400 when newPassword has no letter", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "918273645091" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "918273645091" }),
+      routeContext()
     );
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -107,7 +111,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 400 when newPassword has no number", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "abcdefghijkl" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "abcdefghijkl" }),
+      routeContext()
     );
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -116,7 +121,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 400 when newPassword is in the common-password list", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "password1234" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "password1234" }),
+      routeContext()
     );
     expect(response.status).toBe(400);
     const data = await response.json();
@@ -125,7 +131,10 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 400 when newPassword is missing", async () => {
     // newPassword absent → caught by Zod (parseRequestBody) before validatePassword runs.
-    const response = await POST(makePostRequest({ currentPassword: "oldpass1234567" }));
+    const response = await POST(
+      makePostRequest({ currentPassword: "oldpass1234567" }),
+      routeContext()
+    );
     expect(response.status).toBe(400);
     const data = await response.json();
     expect(data.error).toBe("Validation failed");
@@ -136,7 +145,8 @@ describe("POST /api/users/me/password", () => {
     vi.mocked(auth.api.changePassword).mockRejectedValueOnce(new Error("Invalid credentials"));
 
     const response = await POST(
-      makePostRequest({ currentPassword: "wrongpass1234", newPassword: "Br1ghtNova!2" })
+      makePostRequest({ currentPassword: "wrongpass1234", newPassword: "Br1ghtNova!2" }),
+      routeContext()
     );
     expect(response.status).toBe(403);
     const data = await response.json();
@@ -145,7 +155,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should return 200 on successful password change", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
     );
     expect(response.status).toBe(200);
     const data = await response.json();
@@ -155,7 +166,8 @@ describe("POST /api/users/me/password", () => {
 
   it("should accept valid passwords with exactly 12 characters", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
     );
     expect(response.status).toBe(200);
   });
@@ -165,7 +177,8 @@ describe("POST /api/users/me/password", () => {
   // audited regardless of who triggers it — self-service is not an exemption.
   it("writes an auth.password_changed audit row with outcome success", async () => {
     const response = await POST(
-      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" })
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
     );
     expect(response.status).toBe(200);
     expect(appendAuditLog).toHaveBeenCalledWith(
@@ -183,7 +196,8 @@ describe("POST /api/users/me/password", () => {
     vi.mocked(auth.api.changePassword).mockRejectedValueOnce(new Error("Invalid credentials"));
 
     const response = await POST(
-      makePostRequest({ currentPassword: "wrongpass1234", newPassword: "Br1ghtNova!2" })
+      makePostRequest({ currentPassword: "wrongpass1234", newPassword: "Br1ghtNova!2" }),
+      routeContext()
     );
     expect(response.status).toBe(403);
     expect(appendAuditLog).toHaveBeenCalledWith(
@@ -198,7 +212,10 @@ describe("POST /api/users/me/password", () => {
   });
 
   it("never logs the password value in the audit detail", async () => {
-    await POST(makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }));
+    await POST(
+      makePostRequest({ currentPassword: "oldpass1234567", newPassword: "Br1ghtNova!2" }),
+      routeContext()
+    );
     const serialized = JSON.stringify(vi.mocked(appendAuditLog).mock.calls);
     expect(serialized).not.toContain("Br1ghtNova!2");
     expect(serialized).not.toContain("oldpass1234567");

--- a/packages/web/src/__tests__/api/version.test.ts
+++ b/packages/web/src/__tests__/api/version.test.ts
@@ -1,4 +1,4 @@
-import { afterEach, beforeEach, describe, expect, it } from "vitest";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import { GET } from "@/app/api/version/route";
 
 const ENV_KEYS = [
@@ -26,7 +26,7 @@ describe("GET /api/version", () => {
       if (value === undefined) {
         delete process.env[key];
       } else {
-        process.env[key] = value;
+        vi.stubEnv(key, value);
       }
     }
   }
@@ -80,7 +80,7 @@ describe("GET /api/version", () => {
   });
 
   it("returns nodeEnv from NODE_ENV", async () => {
-    process.env.NODE_ENV = "production";
+    vi.stubEnv("NODE_ENV", "production");
     const response = await GET();
     const data = await response.json();
     expect(data.nodeEnv).toBe("production");

--- a/packages/web/src/__tests__/app/agent-settings-page.test.tsx
+++ b/packages/web/src/__tests__/app/agent-settings-page.test.tsx
@@ -98,7 +98,11 @@ function mockFetchResponses() {
 }
 
 describe("AgentSettingsPage", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature (spyOn
+  // is generic/overloaded), which made every `fetchSpy.mock.calls` element
+  // implicitly `any`. `mockFetchResponses` is a concrete (non-generic) call to
+  // `vi.spyOn(global, "fetch")`, so its return type carries the real signature.
+  let fetchSpy: ReturnType<typeof mockFetchResponses>;
 
   beforeEach(() => {
     capturedOnChangeGeneral = undefined;

--- a/packages/web/src/__tests__/app/agents-page.test.tsx
+++ b/packages/web/src/__tests__/app/agents-page.test.tsx
@@ -27,6 +27,7 @@ vi.mock("@/lib/avatar", () => ({
 }));
 
 import { AgentsPageContent } from "@/app/(app)/agents/agents-page-content";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 describe("AgentsPageContent", () => {
   beforeEach(() => {
@@ -40,22 +41,22 @@ describe("AgentsPageContent", () => {
 
   it("renders the agent list with agents", () => {
     const agents = [
-      {
+      makeAgent({
         id: "agent-1",
         name: "Smithers",
         model: "gpt-4",
         isPersonal: false,
         tagline: "Your helpful butler",
         avatarSeed: null,
-      },
-      {
+      }),
+      makeAgent({
         id: "agent-2",
         name: "My Agent",
         model: "claude-3",
         isPersonal: true,
         tagline: null,
         avatarSeed: "seed-123",
-      },
+      }),
     ];
 
     render(<AgentsPageContent agents={agents} />);
@@ -67,14 +68,14 @@ describe("AgentsPageContent", () => {
 
   it("renders agent links pointing to chat pages", () => {
     const agents = [
-      {
+      makeAgent({
         id: "agent-1",
         name: "Smithers",
         model: "gpt-4",
         isPersonal: false,
         tagline: null,
         avatarSeed: null,
-      },
+      }),
     ];
 
     render(<AgentsPageContent agents={agents} />);

--- a/packages/web/src/__tests__/app/invite-claim-page.test.tsx
+++ b/packages/web/src/__tests__/app/invite-claim-page.test.tsx
@@ -61,7 +61,11 @@ describe("Invite Claim Page", () => {
         const method = init?.method ?? "GET";
         if (method === "GET" && url.startsWith("/api/invite/")) {
           if (getResponse === "pending") return new Promise(() => {});
-          return Promise.resolve({ ok: getResponse.ok, json: async () => getResponse.body });
+          // Capture the narrowed (non-"pending") value in a `const`: TS
+          // widens `getResponse` back to `MockResponse | "pending"` inside
+          // the `json` closure below since it's a reassignable outer `let`.
+          const response = getResponse;
+          return Promise.resolve({ ok: response.ok, json: async () => response.body });
         }
         if (method === "POST" && url === "/api/invite/claim") {
           return Promise.resolve({ ok: postResponse.ok, json: async () => postResponse.body });

--- a/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/add-integration-dialog.test.tsx
@@ -570,7 +570,9 @@ describe("AddIntegrationDialog", () => {
 
       expect(createBody).not.toBeNull();
       expect(createBody).not.toHaveProperty("name");
-      expect((createBody as Record<string, unknown>).senderName).toBe("Clemens Helm");
+      // Non-null assertion: the `not.toBeNull()` check above is a runtime
+      // assertion only and does not narrow `createBody`'s static type.
+      expect(createBody!.senderName).toBe("Clemens Helm");
 
       fetchSpy.mockRestore();
     });

--- a/packages/web/src/__tests__/components/agent-list.test.tsx
+++ b/packages/web/src/__tests__/components/agent-list.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentList } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 vi.mock("@/lib/avatar", () => ({
   getAgentAvatarSvg: vi.fn((agent: { avatarSeed: string | null; name: string }) => {
@@ -12,30 +13,30 @@ vi.mock("@/lib/avatar", () => ({
 }));
 
 const agents = [
-  {
+  makeAgent({
     id: "agent-1",
     name: "Smithers",
     model: "anthropic/claude-sonnet-4-6",
     isPersonal: true,
     tagline: "Your personal assistant",
     avatarSeed: "__smithers__",
-  },
-  {
+  }),
+  makeAgent({
     id: "agent-2",
     name: "Zara",
     model: "anthropic/claude-sonnet-4-6",
     isPersonal: false,
     tagline: null,
     avatarSeed: "zara-seed",
-  },
-  {
+  }),
+  makeAgent({
     id: "agent-3",
     name: "Ada",
     model: "anthropic/claude-sonnet-4-6",
     isPersonal: false,
     tagline: "Code review expert",
     avatarSeed: null,
-  },
+  }),
 ];
 
 describe("AgentList", () => {

--- a/packages/web/src/__tests__/components/agents-provider.test.tsx
+++ b/packages/web/src/__tests__/components/agents-provider.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, renderHook } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { AgentsProvider, useAgentsContext } from "@/components/agents-provider";
 import type { Agent } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 const { mockUseAgents, mockUsePathname, mockRouterPush, mockToast } = vi.hoisted(() => ({
   mockUseAgents: vi.fn((agents: Agent[]) => ({ agents, refresh: vi.fn() })),
@@ -25,16 +26,30 @@ vi.mock("sonner", () => ({
 }));
 
 const agents: Agent[] = [
-  {
+  makeAgent({
     id: "a1",
     name: "Smithers",
     model: "gpt-4",
     isPersonal: true,
     tagline: "Assistant",
     avatarSeed: "seed1",
-  },
-  { id: "a2", name: "Alpha", model: "gpt-4", isPersonal: false, tagline: null, avatarSeed: null },
-  { id: "a3", name: "Beta", model: "gpt-4", isPersonal: false, tagline: null, avatarSeed: "seed3" },
+  }),
+  makeAgent({
+    id: "a2",
+    name: "Alpha",
+    model: "gpt-4",
+    isPersonal: false,
+    tagline: null,
+    avatarSeed: null,
+  }),
+  makeAgent({
+    id: "a3",
+    name: "Beta",
+    model: "gpt-4",
+    isPersonal: false,
+    tagline: null,
+    avatarSeed: "seed3",
+  }),
 ];
 
 function wrapper({ children }: { children: React.ReactNode }) {
@@ -130,22 +145,22 @@ describe("AgentsProvider", () => {
       mockUsePathname.mockReturnValue("/chat/a3");
       // Only non-personal agents left
       const nonPersonal: Agent[] = [
-        {
+        makeAgent({
           id: "a3-zeta",
           name: "Zeta",
           model: "gpt-4",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
-        {
+        }),
+        makeAgent({
           id: "a3-alpha",
           name: "Alpha",
           model: "gpt-4",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
+        }),
       ];
       mockUseAgents.mockReturnValue({ agents: nonPersonal, refresh: vi.fn() });
 

--- a/packages/web/src/__tests__/components/chat-error-message.test.tsx
+++ b/packages/web/src/__tests__/components/chat-error-message.test.tsx
@@ -284,6 +284,7 @@ describe("ChatErrorMessage", () => {
   it("renders 'File too large' heading and detail message for payloadTooLarge variant", () => {
     render(
       <ChatErrorMessage
+        agentId="agent-1"
         error={{
           payloadTooLarge: true,
           message: "The file you attached is too large to send.",
@@ -301,6 +302,7 @@ describe("ChatErrorMessage", () => {
   it("renders 'Invalid file' heading and detail message for attachmentInvalid variant", () => {
     render(
       <ChatErrorMessage
+        agentId="agent-1"
         error={{
           attachmentInvalid: true,
           message: "File type mismatch: claimed application/pdf, content is image/png",

--- a/packages/web/src/__tests__/components/chat-session-provider.test.tsx
+++ b/packages/web/src/__tests__/components/chat-session-provider.test.tsx
@@ -31,6 +31,10 @@ function fakeBundle(overrides: Partial<RuntimeBundle> = {}): RuntimeBundle {
     onRetryContinue: vi.fn(),
     onRetryResend: vi.fn(),
     lastError: null,
+    pendingUploads: [],
+    addPendingUpload: vi.fn(),
+    removePendingUpload: vi.fn(),
+    retryPendingUpload: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/web/src/__tests__/components/chat.test.tsx
+++ b/packages/web/src/__tests__/components/chat.test.tsx
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { Chat } from "@/components/chat";
-import type { Agent } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 const { mockGetAgent, mockUseChatStatus, mockUseChatSession, mockRecordLastChat } = vi.hoisted(
   () => ({
@@ -258,14 +258,14 @@ describe("Chat", () => {
   });
 
   describe("live agent data from context", () => {
-    const liveAgent: Agent = {
+    const liveAgent = makeAgent({
       id: "agent-1",
       name: "Renamed Agent",
       model: "anthropic/claude-sonnet-4-6",
       isPersonal: true,
       tagline: "New tagline",
       avatarSeed: "new-seed",
-    };
+    });
 
     it("should use live agent name instead of SSR prop", () => {
       mockGetAgent.mockReturnValue(liveAgent);

--- a/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/edit-credentials-dialog.test.tsx
@@ -367,6 +367,11 @@ describe("EditCredentialsDialog", () => {
       type: "imap",
       name: "Team Mailbox",
       description: "",
+      // `IntegrationConnection.credentials` only models the Odoo shape
+      // (url/db/login); IMAP connections store a differently-shaped object at
+      // runtime. Production reads (e.g. ImapForm in edit-credentials-dialog.tsx)
+      // already cast this field to the IMAP shape at the point of use — this
+      // fixture mirrors that same boundary cast to construct one.
       credentials: {
         imapHost: "imap.example.com",
         imapPort: "993",
@@ -375,7 +380,7 @@ describe("EditCredentialsDialog", () => {
         username: "team@example.com",
         security: "tls",
         senderName: "Team Mailbox Sender",
-      },
+      } as unknown as IntegrationConnection["credentials"],
       data: null,
       status: "auth_failed",
       lastError: "IMAP authentication failed",
@@ -547,10 +552,11 @@ describe("EditCredentialsDialog", () => {
       const noSenderNameConnection: IntegrationConnection = {
         ...authFailedImapConnection,
         id: "conn-imap-2",
+        // Same IMAP-shape boundary cast as authFailedImapConnection above.
         credentials: {
           ...(authFailedImapConnection.credentials as Record<string, unknown>),
           senderName: undefined,
-        },
+        } as unknown as IntegrationConnection["credentials"],
       };
 
       render(

--- a/packages/web/src/__tests__/components/new-agent-form.test.tsx
+++ b/packages/web/src/__tests__/components/new-agent-form.test.tsx
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import type { Mock } from "vitest";
 import { render, screen, waitFor, act } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
@@ -48,7 +49,10 @@ const mockTemplates = [
 ];
 
 describe("NewAgentForm — name max length", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -83,7 +87,10 @@ describe("NewAgentForm — name max length", () => {
 });
 
 describe("NewAgentForm — cancel button", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -131,7 +138,10 @@ describe("NewAgentForm — cancel button", () => {
 });
 
 describe("NewAgentForm — URL history", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockPush.mockClear();
@@ -195,7 +205,10 @@ describe("NewAgentForm — URL history", () => {
 });
 
 describe("NewAgentForm — tagline field", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -382,7 +395,10 @@ describe("NewAgentForm — tagline field", () => {
 });
 
 describe("NewAgentForm — email mailbox picker", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   const emailTemplates = [
     ...mockTemplates,
@@ -519,7 +535,10 @@ describe("NewAgentForm — email mailbox picker", () => {
 });
 
 describe("NewAgentForm — intro text", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -548,7 +567,10 @@ describe("NewAgentForm — intro text", () => {
 });
 
 describe("NewAgentForm — tagline helper", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -583,7 +605,10 @@ describe("NewAgentForm — tagline helper", () => {
 });
 
 describe("NewAgentForm — permission preview", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   const odooTemplates = [
     ...mockTemplates,
@@ -697,7 +722,10 @@ describe("NewAgentForm — permission preview", () => {
 });
 
 describe("NewAgentForm — no connections link", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   const odooTemplates = [
     ...mockTemplates,
@@ -761,7 +789,10 @@ describe("NewAgentForm — no connections link", () => {
 });
 
 describe("NewAgentForm — suggested name", () => {
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   beforeEach(() => {
     mockSearchParams.current = new URLSearchParams();
@@ -876,7 +907,10 @@ describe("NewAgentForm — optional Odoo models do not block creation", () => {
   // lists `approval.request` and `approval.category` (Odoo Enterprise's
   // Approvals module) as optional, so a Community connection that lacks
   // those models must still allow agent creation.
-  let fetchSpy: ReturnType<typeof vi.spyOn>;
+  // `ReturnType<typeof vi.spyOn>` erases the concrete `fetch` signature
+  // (spyOn is generic/overloaded), leaving every mock-callback parameter
+  // implicitly `any`. Annotate with the real global `fetch` signature instead.
+  let fetchSpy: Mock<typeof fetch>;
 
   const approvalManagerInList = [
     ...mockTemplates,

--- a/packages/web/src/__tests__/components/settings-license.test.tsx
+++ b/packages/web/src/__tests__/components/settings-license.test.tsx
@@ -6,13 +6,16 @@ import { SettingsLicense } from "@/components/settings-license";
 
 const noLicenseStatus = {
   enterprise: false,
+  state: "community" as const,
   type: null,
   org: null,
   expiresAt: null,
+  paidUntil: null,
   daysRemaining: null,
   managedByEnv: false,
   maxUsers: 0,
   seatsUsed: 0,
+  hasGatedConfig: false,
 };
 
 const statusOkResponse = (data: object) =>
@@ -57,13 +60,16 @@ describe("SettingsLicense", () => {
       <SettingsLicense
         initialLicense={{
           enterprise: false,
+          state: "community",
           type: null,
           org: null,
           expiresAt: null,
+          paidUntil: null,
           daysRemaining: null,
           managedByEnv: false,
           maxUsers: 0,
           seatsUsed: 0,
+          hasGatedConfig: false,
         }}
       />
     );
@@ -292,13 +298,16 @@ describe("SettingsLicense", () => {
       <SettingsLicense
         initialLicense={{
           enterprise: true,
+          state: "paid",
           type: "paid",
           org: "Acme Corp",
           expiresAt: "2027-01-01T00:00:00Z",
+          paidUntil: null,
           daysRemaining: 365,
           managedByEnv: false,
           maxUsers: 0,
           seatsUsed: 0,
+          hasGatedConfig: false,
         }}
       />
     );
@@ -312,13 +321,16 @@ describe("SettingsLicense", () => {
       <SettingsLicense
         initialLicense={{
           enterprise: true,
+          state: "trial",
           type: "trial",
           org: null,
           expiresAt: null,
+          paidUntil: null,
           daysRemaining: null,
           managedByEnv: false,
           maxUsers: 0,
           seatsUsed: 0,
+          hasGatedConfig: false,
         }}
       />
     );
@@ -330,13 +342,16 @@ describe("SettingsLicense", () => {
       <SettingsLicense
         initialLicense={{
           enterprise: true,
+          state: "paid",
           type: "paid",
           org: "Acme Corp",
           expiresAt: null,
+          paidUntil: null,
           daysRemaining: null,
           managedByEnv: true,
           maxUsers: 0,
           seatsUsed: 0,
+          hasGatedConfig: false,
         }}
       />
     );
@@ -349,13 +364,16 @@ describe("SettingsLicense", () => {
       <SettingsLicense
         initialLicense={{
           enterprise: true,
+          state: "paid",
           type: "paid",
           org: "Acme",
           expiresAt: null,
+          paidUntil: null,
           daysRemaining: null,
           managedByEnv: false,
           maxUsers: 0,
           seatsUsed: 0,
+          hasGatedConfig: false,
         }}
       />
     );
@@ -431,13 +449,16 @@ describe("SettingsLicense", () => {
   it("shows seats line when maxUsers > 0", () => {
     const license = {
       enterprise: true,
+      state: "paid" as const,
       type: "paid",
       org: "TestCo",
       expiresAt: "2027-01-01T00:00:00Z",
+      paidUntil: null,
       daysRemaining: 250,
       managedByEnv: false,
       maxUsers: 10,
       seatsUsed: 7,
+      hasGatedConfig: false,
     };
     render(<SettingsLicense initialLicense={license} />);
     expect(screen.getByText(/Seats: 7 \/ 10 used/)).toBeInTheDocument();
@@ -446,13 +467,16 @@ describe("SettingsLicense", () => {
   it("hides seats line when license is unlimited (maxUsers=0)", () => {
     const license = {
       enterprise: true,
+      state: "trial" as const,
       type: "trial",
       org: "TestCo",
       expiresAt: "2027-01-01T00:00:00Z",
+      paidUntil: null,
       daysRemaining: 14,
       managedByEnv: false,
       maxUsers: 0,
       seatsUsed: 5,
+      hasGatedConfig: false,
     };
     render(<SettingsLicense initialLicense={license} />);
     expect(screen.queryByText(/Seats:/)).not.toBeInTheDocument();
@@ -461,13 +485,16 @@ describe("SettingsLicense", () => {
   it("does not refetch status when initialLicense is provided", () => {
     const license = {
       enterprise: true,
+      state: "paid" as const,
       type: "paid",
       org: "TestCo",
       expiresAt: null,
+      paidUntil: null,
       daysRemaining: null,
       managedByEnv: false,
       maxUsers: 0,
       seatsUsed: 0,
+      hasGatedConfig: false,
     };
     render(<SettingsLicense initialLicense={license} />);
     expect(fetchSpy).not.toHaveBeenCalledWith("/api/enterprise/status");

--- a/packages/web/src/__tests__/components/sidebar-running-indicator.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar-running-indicator.test.tsx
@@ -25,6 +25,10 @@ function makeBundle(overrides: Partial<RuntimeBundle> = {}): RuntimeBundle {
     ) => void,
     onRetryResend: vi.fn(),
     lastError: null,
+    pendingUploads: [],
+    addPendingUpload: vi.fn(),
+    removePendingUpload: vi.fn(),
+    retryPendingUpload: vi.fn(),
     ...overrides,
   };
 }

--- a/packages/web/src/__tests__/components/sidebar.test.tsx
+++ b/packages/web/src/__tests__/components/sidebar.test.tsx
@@ -8,6 +8,7 @@ import { SidebarProvider } from "@/components/ui/sidebar";
 import { ChatSessionProvider } from "@/components/chat-session-provider";
 import type { Agent } from "@/components/agent-list";
 import { sortAgents } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 const { mockSignOut, mockRouterPush, mockUsePathname, mockAgentsContextValue } = vi.hoisted(() => ({
   mockSignOut: vi.fn().mockResolvedValue(undefined),
@@ -105,14 +106,14 @@ describe("AppSidebar", () => {
 
   it("should render agent names", () => {
     setAgents([
-      {
+      makeAgent({
         id: "1",
         name: "Smithers",
         model: "anthropic/claude-sonnet-4-6",
         isPersonal: false,
         tagline: null,
         avatarSeed: null,
-      },
+      }),
     ]);
     renderSidebar(false);
     expect(screen.getByText("Smithers")).toBeInTheDocument();
@@ -154,14 +155,14 @@ describe("AppSidebar", () => {
   describe("avatar rendering", () => {
     it("should render avatar image for agents", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "Test Agent",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: "my-seed",
-        },
+        }),
       ]);
       const { container } = renderSidebar(false);
       const avatar = container.querySelector('img[src="data:image/svg+xml;utf8,mock-my-seed"]');
@@ -171,14 +172,14 @@ describe("AppSidebar", () => {
 
     it("should render Smithers avatar for __smithers__ seed", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "Smithers",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: true,
           tagline: null,
           avatarSeed: "__smithers__",
-        },
+        }),
       ]);
       const { container } = renderSidebar(false);
       const avatar = container.querySelector('img[src="/images/smithers-avatar.png"]');
@@ -189,14 +190,14 @@ describe("AppSidebar", () => {
   describe("tagline rendering", () => {
     it("should render tagline when present", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "HR Bot",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: "Answers HR questions",
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       expect(screen.getByText("Answers HR questions")).toBeInTheDocument();
@@ -204,14 +205,14 @@ describe("AppSidebar", () => {
 
     it("should show title tooltip on tagline for hover", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "HR Bot",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: "Answers HR questions from your documents",
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       const tagline = screen.getByText("Answers HR questions from your documents");
@@ -220,14 +221,14 @@ describe("AppSidebar", () => {
 
     it("should show title tooltip on agent name for hover", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "A Very Long Agent Name That Gets Truncated",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       const name = screen.getByText("A Very Long Agent Name That Gets Truncated");
@@ -236,14 +237,14 @@ describe("AppSidebar", () => {
 
     it("should not render tagline when null", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "HR Bot",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       const link = screen.getByRole("link", { name: /hr bot/i });
@@ -271,22 +272,22 @@ describe("AppSidebar", () => {
 
   describe("active agent highlighting", () => {
     const agents: Agent[] = [
-      {
+      makeAgent({
         id: "agent-1",
         name: "Alpha",
         model: "anthropic/claude-sonnet-4-6",
         isPersonal: false,
         tagline: null,
         avatarSeed: null,
-      },
-      {
+      }),
+      makeAgent({
         id: "agent-2",
         name: "Beta",
         model: "anthropic/claude-sonnet-4-6",
         isPersonal: false,
         tagline: null,
         avatarSeed: null,
-      },
+      }),
     ];
 
     it("should mark the current agent's menu button as active", () => {
@@ -333,14 +334,14 @@ describe("AppSidebar", () => {
 
   describe("last-viewed chat link (#508)", () => {
     const agents: Agent[] = [
-      {
+      makeAgent({
         id: "agent-1",
         name: "Alpha",
         model: "anthropic/claude-sonnet-4-6",
         isPersonal: false,
         tagline: null,
         avatarSeed: null,
-      },
+      }),
     ];
 
     it("links the agent to the chat last viewed on this device", async () => {
@@ -464,22 +465,22 @@ describe("AppSidebar", () => {
   describe("agent ordering", () => {
     it("should render personal agents before non-personal agents", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "Shared Agent",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
-        {
+        }),
+        makeAgent({
           id: "2",
           name: "My Personal Agent",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: true,
           tagline: null,
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       const links = screen.getAllByRole("link").filter((link) => {
@@ -493,38 +494,38 @@ describe("AppSidebar", () => {
 
     it("should sort non-personal agents alphabetically by name", () => {
       setAgents([
-        {
+        makeAgent({
           id: "1",
           name: "Smithers",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: true,
           tagline: null,
           avatarSeed: "__smithers__",
-        },
-        {
+        }),
+        makeAgent({
           id: "2",
           name: "Zara",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
-        {
+        }),
+        makeAgent({
           id: "3",
           name: "Ada",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
-        {
+        }),
+        makeAgent({
           id: "4",
           name: "Maya",
           model: "anthropic/claude-sonnet-4-6",
           isPersonal: false,
           tagline: null,
           avatarSeed: null,
-        },
+        }),
       ]);
       renderSidebar(false);
       const links = screen.getAllByRole("link").filter((link) => {

--- a/packages/web/src/__tests__/components/template-selector.test.tsx
+++ b/packages/web/src/__tests__/components/template-selector.test.tsx
@@ -2,30 +2,31 @@ import { describe, it, expect, vi } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { TemplateSelector } from "@/components/template-selector";
+import { makeTemplateItem } from "@/test-helpers/fixtures";
 
 describe("TemplateSelector", () => {
   const templates = [
-    {
+    makeTemplateItem({
       id: "knowledge-base",
       name: "Knowledge Base",
       description: "Answer questions from your docs",
       requiresDirectories: true,
       available: true,
-    },
-    {
+    }),
+    makeTemplateItem({
       id: "contract-analyzer",
       name: "Contract Analyzer",
       description: "Review and analyze contracts",
       requiresDirectories: true,
       available: true,
-    },
-    {
+    }),
+    makeTemplateItem({
       id: "custom",
       name: "Custom Agent",
       description: "Start from scratch",
       requiresDirectories: false,
       available: true,
-    },
+    }),
   ];
 
   it("renders templates in thematic categories", () => {
@@ -88,7 +89,7 @@ describe("TemplateSelector", () => {
   it("renders Odoo template in its thematic category, not in separate Odoo section", () => {
     const withOdoo = [
       ...templates,
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -96,7 +97,7 @@ describe("TemplateSelector", () => {
         requiresOdooConnection: true,
         odooAccessLevel: "read-only",
         available: true,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={withOdoo} onSelect={vi.fn()} />);
@@ -107,7 +108,7 @@ describe("TemplateSelector", () => {
 
   it("renders access badge on read-only Odoo template card", () => {
     const odooTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -115,7 +116,7 @@ describe("TemplateSelector", () => {
         requiresOdooConnection: true,
         odooAccessLevel: "read-only",
         available: true,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={odooTemplates} onSelect={vi.fn()} />);
@@ -124,7 +125,7 @@ describe("TemplateSelector", () => {
 
   it("renders access badge on read-write Odoo template card", () => {
     const odooTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "CRM Assistant",
         description: "Manage leads",
@@ -132,7 +133,7 @@ describe("TemplateSelector", () => {
         requiresOdooConnection: true,
         odooAccessLevel: "read-write",
         available: true,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={odooTemplates} onSelect={vi.fn()} />);
@@ -141,13 +142,13 @@ describe("TemplateSelector", () => {
 
   it("renders access badge on documents template card", () => {
     const docTemplates = [
-      {
+      makeTemplateItem({
         id: "knowledge-base",
         name: "Knowledge Base",
         description: "Answer questions",
         requiresDirectories: true,
         available: true,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={docTemplates} onSelect={vi.fn()} />);
@@ -156,7 +157,7 @@ describe("TemplateSelector", () => {
 
   it("hides unavailable templates behind collapsible trigger", () => {
     const mixedTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -164,8 +165,8 @@ describe("TemplateSelector", () => {
         requiresDirectories: false,
         odooAccessLevel: "read-only",
         available: true,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "CRM Assistant",
         description: "Manage leads",
@@ -174,8 +175,8 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-write",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-customer-service",
         name: "Customer Service",
         description: "Handle support",
@@ -184,7 +185,7 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-only",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={mixedTemplates} onSelect={vi.fn()} />);
@@ -198,7 +199,7 @@ describe("TemplateSelector", () => {
 
   it("shows 'Set up connection' trigger when unavailable reason is no-connection", () => {
     const noConnTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -207,8 +208,8 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-only",
         available: false,
         unavailableReason: "no-connection" as const,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "CRM Assistant",
         description: "Manage leads",
@@ -217,7 +218,7 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-write",
         available: false,
         unavailableReason: "no-connection" as const,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={noConnTemplates} onSelect={vi.fn()} />);
@@ -229,7 +230,7 @@ describe("TemplateSelector", () => {
 
   it("expands to show unavailable template cards on trigger click", () => {
     const mixedTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -237,8 +238,8 @@ describe("TemplateSelector", () => {
         requiresDirectories: false,
         odooAccessLevel: "read-only",
         available: true,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "CRM Assistant",
         description: "Manage leads",
@@ -247,7 +248,7 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-write",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={mixedTemplates} onSelect={vi.fn()} />);
@@ -263,7 +264,7 @@ describe("TemplateSelector", () => {
 
   it("shows all templates in collapsible when entire category is unavailable", () => {
     const allUnavailable = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Sales Analyst",
         description: "Analyze revenue",
@@ -272,8 +273,8 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-only",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "CRM Assistant",
         description: "Manage leads",
@@ -282,7 +283,7 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-write",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={allUnavailable} onSelect={vi.fn()} />);
@@ -301,7 +302,7 @@ describe("TemplateSelector", () => {
   it("should call onSelect for unavailable templates after expanding", () => {
     const onSelect = vi.fn();
     const mixedTemplates = [
-      {
+      makeTemplateItem({
         id: "odoo-sales-analyst",
         name: "Available Agent",
         description: "Works",
@@ -309,8 +310,8 @@ describe("TemplateSelector", () => {
         requiresDirectories: false,
         odooAccessLevel: "read-only",
         available: true,
-      },
-      {
+      }),
+      makeTemplateItem({
         id: "odoo-crm-assistant",
         name: "Unavailable Agent",
         description: "Missing modules",
@@ -319,7 +320,7 @@ describe("TemplateSelector", () => {
         odooAccessLevel: "read-write",
         available: false,
         unavailableReason: "missing-modules" as const,
-      },
+      }),
     ];
 
     render(<TemplateSelector templates={mixedTemplates} onSelect={onSelect} />);

--- a/packages/web/src/__tests__/components/thread-report-issue.test.tsx
+++ b/packages/web/src/__tests__/components/thread-report-issue.test.tsx
@@ -2,6 +2,7 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 import { render, screen, fireEvent } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
+import type { MessageState } from "@assistant-ui/react";
 
 // We mock @assistant-ui/react so the ActionBar primitives render their
 // children inline (no portals, no popovers). That way the menu entry is
@@ -183,12 +184,24 @@ vi.mock("@/components/diagnostics-export-dialog", () => ({
 describe("Per-message Report issue menu entry", () => {
   beforeEach(async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation((selector: (state: unknown) => unknown) =>
-      selector({
-        id: "msg-assistant-1",
-        isLast: true,
-        metadata: { custom: {} },
-      })
+    type UseMessageSelector = (state: MessageState) => unknown;
+    // Fake message state: only the fields this suite's selectors read
+    // (id/isLast/metadata). `MessageState` (a `ThreadMessage` union) requires many
+    // more fields than a per-message-menu test cares about, so a full literal
+    // would be noise; bridge via `unknown` rather than shape the whole message.
+    const fakeMessageState = {
+      id: "msg-assistant-1",
+      isLast: true,
+      metadata: { custom: {} },
+    } as unknown as MessageState;
+    vi.mocked(useMessage).mockImplementation(
+      // `useMessage` is overloaded (plain selector fn OR `{ optional, selector }`
+      // options); production code (thread.tsx) only ever calls the plain-selector
+      // form. `Parameters<typeof useMessage>` collapses overloads to the LAST
+      // signature (the options-object form) for `mockImplementation`'s type, so the
+      // actually-exercised plain-selector implementation needs this boundary cast
+      // back to the real hook type.
+      ((selector: UseMessageSelector) => selector(fakeMessageState)) as typeof useMessage
     );
   });
 

--- a/packages/web/src/__tests__/db/index.test.ts
+++ b/packages/web/src/__tests__/db/index.test.ts
@@ -3,7 +3,11 @@ import { describe, it, expect, vi, beforeEach } from "vitest";
 // Mock postgres-js so importing db/index doesn't open a real connection.
 const { endMock, postgresMock, drizzleMock } = vi.hoisted(() => {
   const endMock = vi.fn().mockResolvedValue(undefined);
-  const postgresMock = vi.fn(() => ({ end: endMock }));
+  // Real `postgres(connectionString, options)` takes two args; declaring both
+  // params here (even though the fake body ignores them) keeps
+  // `postgresMock.mock.calls[0]` a 2-element tuple so the test can read back
+  // the options object passed at import time.
+  const postgresMock = vi.fn((_connectionString: string, _options: unknown) => ({ end: endMock }));
   const drizzleMock = vi.fn((client: unknown, opts: unknown) => ({ client, opts }));
   return { endMock, postgresMock, drizzleMock };
 });

--- a/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
+++ b/packages/web/src/__tests__/db/schema-hardening.integration.test.ts
@@ -97,7 +97,12 @@ describe("schema-hardening CHECK constraints (#259)", () => {
         name: "C",
         model: "anthropic/claude-sonnet-4-6",
         greetingMessage: "hi",
-        visibility: "private",
+        // Deliberately outside the AGENT_VISIBILITIES union — proving the DB
+        // CHECK constraint (not just Drizzle's `.$type<...>()` column type)
+        // rejects it. `sql` keeps this a real, parameterized value (part of
+        // the column's declared `... | SQL<unknown> | ...` type) instead of
+        // a cast around the union.
+        visibility: sql`${"private"}`,
       })
     ).rejects.toSatisfy(constraintViolation(/agents_visibility_check/));
   });
@@ -115,7 +120,9 @@ describe("schema-hardening CHECK constraints (#259)", () => {
     await expect(
       db
         .insert(integrationConnections)
-        .values({ type: "shopify", name: "Shopify", credentials: "enc" })
+        // Deliberately outside INTEGRATION_CONNECTION_TYPES — see the
+        // `sql` note on the visibility test above.
+        .values({ type: sql`${"shopify"}`, name: "Shopify", credentials: "enc" })
     ).rejects.toSatisfy(constraintViolation(/integration_connections_type_check/));
   });
 
@@ -123,7 +130,7 @@ describe("schema-hardening CHECK constraints (#259)", () => {
     await expect(
       db
         .insert(integrationConnections)
-        .values({ type: "odoo", name: "Odoo", credentials: "enc", status: "archived" })
+        .values({ type: "odoo", name: "Odoo", credentials: "enc", status: sql`${"archived"}` })
     ).rejects.toSatisfy(constraintViolation(/integration_connections_status_check/));
   });
 
@@ -148,7 +155,9 @@ describe("schema-hardening CHECK constraints (#259)", () => {
     await expect(
       db.insert(invites).values({
         tokenHash: `tok-${suffix}-2`,
-        role: "owner",
+        // Deliberately outside INVITE_ROLES — see the `sql` note on the
+        // visibility test above.
+        role: sql`${"owner"}`,
         type: "invite",
         createdBy: creator.id,
         expiresAt: new Date(Date.now() + 86400000),
@@ -162,7 +171,8 @@ describe("schema-hardening CHECK constraints (#259)", () => {
       db.insert(invites).values({
         tokenHash: `tok-${suffix}-3`,
         role: "member",
-        type: "lifetime",
+        // Deliberately outside INVITE_TYPES — see the `sql` note above.
+        type: sql`${"lifetime"}`,
         createdBy: creator.id,
         expiresAt: new Date(Date.now() + 86400000),
       })

--- a/packages/web/src/__tests__/db/schema.test.ts
+++ b/packages/web/src/__tests__/db/schema.test.ts
@@ -124,10 +124,19 @@ describe("JSON column types — compile-time contracts", () => {
   });
 
   it("AgentPluginConfig is namespaced by plugin ID", () => {
-    expectTypeOf<AgentPluginConfig>().toMatchObjectType<{
-      "pinchy-files"?: { allowed_paths: string[] };
-      "pinchy-web"?: { allowedDomains?: string[] };
-    }>();
+    // Top-level keys are plugin IDs — the namespacing this test guards. Catches
+    // a renamed/removed plugin key, unlike the old toMatchObjectType assertion
+    // which silently drifted once pinchy-files/pinchy-web grew extra fields.
+    expectTypeOf<keyof AgentPluginConfig>().toEqualTypeOf<"pinchy-files" | "pinchy-web">();
+    // Each plugin's key config field keeps its type. Asserting the specific
+    // fields (not the whole object) stays green when a plugin gains new optional
+    // config, while still catching a type change on the fields that matter.
+    expectTypeOf<NonNullable<AgentPluginConfig["pinchy-files"]>["allowed_paths"]>().toEqualTypeOf<
+      string[]
+    >();
+    expectTypeOf<NonNullable<AgentPluginConfig["pinchy-web"]>["allowedDomains"]>().toEqualTypeOf<
+      string[] | undefined
+    >();
   });
 
   it("auditLog.detail is typed AuditDetail | null (not unknown)", () => {

--- a/packages/web/src/__tests__/hooks/attachment-routing.test.ts
+++ b/packages/web/src/__tests__/hooks/attachment-routing.test.ts
@@ -19,11 +19,30 @@
  */
 
 import { describe, it, expect } from "vitest";
+import type { PendingAttachment } from "@assistant-ui/react";
 import { attachmentAdapter } from "@/hooks/use-ws-runtime";
 
 function fakeFile({ name, type }: { name: string; type: string }): File {
   // Small size so any size check downstream passes.
   return { size: 1024, name, type } as unknown as File;
+}
+
+/**
+ * `AttachmentAdapter.add()` is declared to return
+ * `Promise<PendingAttachment> | AsyncGenerator<PendingAttachment, void>` (the
+ * library supports streaming adapters), so `result` is still a union after
+ * `await`ing it — `AsyncGenerator` has no `.type`. Every adapter Pinchy wires
+ * into this composite (CodeTextAttachmentAdapter / OfficeDocumentAttachmentAdapter)
+ * resolves a plain PendingAttachment, never a generator; this guard makes that
+ * a real assertion instead of an unchecked cast.
+ */
+function expectPendingAttachment(
+  value: PendingAttachment | AsyncGenerator<PendingAttachment, void, unknown>
+): PendingAttachment {
+  if (!("type" in value)) {
+    throw new Error("expected a PendingAttachment, got an AsyncGenerator");
+  }
+  return value;
 }
 
 const UPLOAD_PIPELINE_CASES = [
@@ -68,7 +87,9 @@ describe("attachment routing (issue #392)", () => {
   it.each(INLINE_CODE_CASES)(
     "keeps $name ($type) on the inline code-text adapter (type 'document')",
     async ({ name, type }) => {
-      const result = await attachmentAdapter.add({ file: fakeFile({ name, type }) });
+      const result = expectPendingAttachment(
+        await attachmentAdapter.add({ file: fakeFile({ name, type }) })
+      );
       expect(result.type).toBe("document");
     }
   );

--- a/packages/web/src/__tests__/hooks/in-flight-placeholder.test.ts
+++ b/packages/web/src/__tests__/hooks/in-flight-placeholder.test.ts
@@ -24,7 +24,7 @@ describe("isInFlightPlaceholder", () => {
   it("rejects error bubbles, user messages, and assistants with content", () => {
     expect(isInFlightPlaceholder(errorBubble)).toBe(false);
     expect(isInFlightPlaceholder(user)).toBe(false);
-    expect(isInFlightPlaceholder({ id: "a", role: "assistant", content: "x" })).toBe(false);
+    expect(isInFlightPlaceholder({ role: "assistant", content: "x" })).toBe(false);
   });
 });
 

--- a/packages/web/src/__tests__/hooks/use-agents.test.ts
+++ b/packages/web/src/__tests__/hooks/use-agents.test.ts
@@ -2,29 +2,14 @@ import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act, waitFor } from "@testing-library/react";
 import { useAgents } from "@/hooks/use-agents";
 import type { Agent } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 const mockAgents: Agent[] = [
-  {
-    id: "a1",
-    name: "Smithers",
-    model: "gpt-4",
-    isPersonal: false,
-    tagline: null,
-    avatarSeed: null,
-  },
-  { id: "a2", name: "Helper", model: "gpt-4", isPersonal: true, tagline: null, avatarSeed: null },
+  makeAgent({ id: "a1", name: "Smithers", model: "gpt-4" }),
+  makeAgent({ id: "a2", name: "Helper", model: "gpt-4", isPersonal: true }),
 ];
 
-const updatedAgents: Agent[] = [
-  {
-    id: "a1",
-    name: "Smithers",
-    model: "gpt-4",
-    isPersonal: false,
-    tagline: null,
-    avatarSeed: null,
-  },
-];
+const updatedAgents: Agent[] = [makeAgent({ id: "a1", name: "Smithers", model: "gpt-4" })];
 
 describe("useAgents", () => {
   let fetchSpy: ReturnType<typeof vi.spyOn>;
@@ -107,9 +92,7 @@ describe("useAgents", () => {
 
     expect(result.current.agents).toEqual(mockAgents);
 
-    const newAgents: Agent[] = [
-      { id: "a3", name: "New", model: "gpt-4", isPersonal: false, tagline: null, avatarSeed: null },
-    ];
+    const newAgents: Agent[] = [makeAgent({ id: "a3", name: "New", model: "gpt-4" })];
     rerender({ agents: newAgents });
 
     expect(result.current.agents).toEqual(newAgents);

--- a/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
+++ b/packages/web/src/__tests__/hooks/use-pending-uploads.test.ts
@@ -199,6 +199,8 @@ describe("PendingUpload state machine", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
       id: "upload-id-123",
       filename: "test.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1024,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));
@@ -295,6 +297,8 @@ describe("PendingUpload state machine", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValueOnce({
       id: "upload-id-456",
       filename: "retry.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 1024,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));
@@ -395,6 +399,8 @@ describe("PendingUpload state machine", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
       id: "x",
       filename: "photo.webp",
+      mimeType: "image/webp",
+      sizeBytes: 128,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));
@@ -463,6 +469,8 @@ describe("PendingUpload state machine", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
       id: "x",
       filename: "small.jpg",
+      mimeType: "image/jpeg",
+      sizeBytes: 100 * 1024,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));

--- a/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
+++ b/packages/web/src/__tests__/hooks/use-ws-runtime.test.ts
@@ -9,7 +9,10 @@
  * One mocking strategy throughout: real WebSocket via `vi.stubGlobal` +
  * the hook's `result.current.runtime` exposes the config that was passed to
  * `useExternalStoreRuntime` (the mock is the identity function), so tests
- * call `result.current.runtime.onNew(...)` and read `runtime.messages`.
+ * call `store(result.current.runtime).onNew(...)` and read `.messages` —
+ * `store()` is the single typed boundary cast documented next to its
+ * definition below, bridging the statically-declared `AssistantRuntime`
+ * return type to what the mocked runtime actually is at test time.
  */
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 import { renderHook, act } from "@testing-library/react";
@@ -20,6 +23,8 @@ import {
   CLIENT_MAX_ATTACHMENT_SIZE_BYTES,
 } from "@/lib/limits";
 import * as imageCompression from "@/lib/image-compression";
+import type { ChatError } from "@/components/assistant-ui/chat-error-message";
+import type { MessageStatus } from "@/hooks/message-status-reducer";
 
 // Mock image compression module — real Canvas API is unavailable in jsdom.
 // Default returns the new CompressionResult shape: ok=true with skipped=true
@@ -68,6 +73,11 @@ class MockWebSocket {
   simulateClose(code = 1006) {
     this.onclose?.(new CloseEvent("close", { code }));
   }
+
+  /** Trigger onerror (the WS impl always fires onclose right after — see onerror below) */
+  simulateError() {
+    this.onerror?.(new Event("error"));
+  }
 }
 
 vi.stubGlobal("WebSocket", MockWebSocket);
@@ -77,6 +87,65 @@ function latestWs(): MockWebSocket {
   const ws = wsInstances[wsInstances.length - 1];
   if (!ws) throw new Error("No MockWebSocket instance created yet");
   return ws;
+}
+
+/**
+ * A single content part of a rendered message, as produced by the hook's
+ * `convertMessage` (see `use-ws-runtime.ts`) — either a text part or a file
+ * chip. Modeled as one flattened shape (rather than a discriminated union)
+ * because that's how every test in this file narrows it: `.find(p => p.type
+ * === "text")` and reads `.text`, or `.find(p => p.type === "file")` and
+ * reads `.filename`/`.mimeType`.
+ */
+interface ExternalStoreMessagePart {
+  type: string;
+  text?: string;
+  filename?: string;
+  mimeType?: string;
+}
+
+/**
+ * Shape of one entry in `runtime.messages`, mirroring what `convertMessage`
+ * in `use-ws-runtime.ts` actually builds from a `WsMessage`.
+ */
+interface ExternalStoreMessage {
+  id: string;
+  role: "user" | "assistant";
+  content: ExternalStoreMessagePart[];
+  metadata?: {
+    custom: {
+      timestamp?: string;
+      status?: MessageStatus;
+      retryable?: boolean;
+      retryReason?: "orphan" | "partial_stream_failure" | "send_failure";
+      error?: ChatError;
+    };
+  };
+}
+
+/**
+ * The config object passed to `useExternalStoreRuntime` — see the
+ * `@assistant-ui/react` mock below, which returns that config unchanged
+ * (`(config) => config`). So at test time `result.current.runtime` (typed
+ * `AssistantRuntime` by `useWsRuntime`'s real return type) IS this config
+ * object; `AssistantRuntime` just doesn't expose these members statically.
+ */
+interface ExternalStoreConfig {
+  messages: ExternalStoreMessage[];
+  isRunning: boolean;
+  onNew(message: unknown): void | Promise<void>;
+  onCancel(): void | Promise<void>;
+  adapters: { attachments: { accept: string } };
+}
+
+/**
+ * The single documented boundary cast bridging `useWsRuntime`'s declared
+ * `runtime: AssistantRuntime` to its real (mocked) shape described above.
+ * Call as `store(result.current.runtime)` (or `store(x.runtime)` for a
+ * runtime reached through a composed hook's result).
+ */
+function store(runtime: unknown): ExternalStoreConfig {
+  return runtime as unknown as ExternalStoreConfig;
 }
 
 /** Minimal AppendMessage shape that onNew expects for a simple text message */
@@ -138,7 +207,7 @@ describe("useWsRuntime", () => {
 
   it("should return a runtime and connection status", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
-    expect(result.current.runtime).toBeDefined();
+    expect(store(result.current.runtime)).toBeDefined();
     expect(result.current.isConnected).toBe(false);
   });
 
@@ -153,22 +222,19 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
       // Block body: do NOT return onNew's promise to act() (that would trip the
       // async-act warning). The user message + in-flight placeholder are added
       // synchronously before onNew's first await, which is all this test needs.
-      result.current.runtime.onNew(makeUserMessage("Hello"));
+      store(result.current.runtime).onNew(makeUserMessage("Hello"));
     });
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "chunk", content: "Hi there", messageId: "msg-1" }),
-      } as MessageEvent);
+      ws.simulateMessage({ type: "chunk", content: "Hi there", messageId: "msg-1" });
     });
 
-    const msgs = (result.current.runtime as { messages: { role: string; content: unknown }[] })
-      .messages;
+    const msgs = store(result.current.runtime).messages;
     const assistant = msgs.filter((m) => m.role === "assistant").pop();
     expect(assistant).toBeDefined();
     expect(JSON.stringify(assistant!.content)).toContain("Hi there");
@@ -180,11 +246,11 @@ describe("useWsRuntime", () => {
 
     // Connect and send a user message to set isRunning=true
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
@@ -192,36 +258,30 @@ describe("useWsRuntime", () => {
 
     // Receive a chunk (isRunning should still be true)
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "Hi there",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "chunk",
+        content: "Hi there",
+        messageId: "msg-1",
       });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Per-turn done — must NOT stop the spinner. The agent might still be
     // running another turn (tool-use loops), and only "complete" tells us
     // the entire stream is over.
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "done", messageId: "msg-1" }),
-      });
+      ws.simulateMessage({ type: "done", messageId: "msg-1" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Stream-terminating complete event — now the spinner can stop.
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "complete" }),
-      });
+      ws.simulateMessage({ type: "complete" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
   });
 
   it("should keep running across long pauses between chunks (no debounce false-positive)", () => {
@@ -229,27 +289,25 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "Let me think...",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "chunk",
+        content: "Let me think...",
+        messageId: "msg-1",
       });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Simulate a long pause where the local LLM is generating the next turn
     // but no chunks arrive. The previous implementation debounced isRunning
@@ -258,7 +316,7 @@ describe("useWsRuntime", () => {
       vi.advanceTimersByTime(30_000);
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
   });
 
   it("should stop running immediately when an error message is received", () => {
@@ -266,33 +324,31 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Receive error message - should immediately stop running
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          message: "Something went wrong",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "error",
+        message: "Something went wrong",
+        messageId: "msg-1",
       });
     });
 
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
 
     // Should show the error as an assistant message with structured error in metadata
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find(
       (m: any) =>
         m.role === "assistant" && m.metadata?.custom?.error?.message === "Something went wrong"
@@ -305,31 +361,29 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          agentName: "Smithers",
-          providerError: "Your credit balance is too low.",
-          hint: "Please contact your administrator.",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "error",
+        agentName: "Smithers",
+        providerError: "Your credit balance is too low.",
+        hint: "Please contact your administrator.",
+        messageId: "msg-1",
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find((m: any) => m.role === "assistant" && m.metadata?.custom?.error);
     expect(errorMsg).toBeDefined();
-    expect(errorMsg.metadata.custom.error).toEqual({
+    expect(errorMsg!.metadata!.custom.error).toEqual({
       agentName: "Smithers",
       providerError: "Your credit balance is too low.",
       hint: "Please contact your administrator.",
@@ -341,29 +395,27 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          message: "Access denied",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "error",
+        message: "Access denied",
+        messageId: "msg-1",
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find((m: any) => m.role === "assistant" && m.metadata?.custom?.error);
     expect(errorMsg).toBeDefined();
-    expect(errorMsg.metadata.custom.error).toEqual({
+    expect(errorMsg!.metadata!.custom.error).toEqual({
       message: "Access denied",
     });
   });
@@ -373,36 +425,34 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          agentName: "Smithers",
-          providerError: "rawError=503 the model is overloaded",
-          messageId: "msg-1",
-          modelUnavailable: {
-            kind: "model_unavailable",
-            model: "ollama-cloud/glm-4.6",
-            httpStatus: 503,
-            ref: "abc-123",
-          },
-        }),
+      ws.simulateMessage({
+        type: "error",
+        agentName: "Smithers",
+        providerError: "rawError=503 the model is overloaded",
+        messageId: "msg-1",
+        modelUnavailable: {
+          kind: "model_unavailable",
+          model: "ollama-cloud/glm-4.6",
+          httpStatus: 503,
+          ref: "abc-123",
+        },
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find((m: any) => m.role === "assistant" && m.metadata?.custom?.error);
     expect(errorMsg).toBeDefined();
-    expect(errorMsg.metadata.custom.error.modelUnavailable).toEqual({
+    expect(errorMsg!.metadata!.custom.error!.modelUnavailable).toEqual({
       kind: "model_unavailable",
       model: "ollama-cloud/glm-4.6",
       httpStatus: 503,
@@ -419,44 +469,42 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          agentName: "Smithers",
-          providerError: "Some upstream error",
-          messageId: "msg-1",
-          modelUnavailable: {
-            kind: "model_unavailable",
-            httpStatus: "not-a-number",
-          },
-        }),
+      ws.simulateMessage({
+        type: "error",
+        agentName: "Smithers",
+        providerError: "Some upstream error",
+        messageId: "msg-1",
+        modelUnavailable: {
+          kind: "model_unavailable",
+          httpStatus: "not-a-number",
+        },
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find((m: any) => m.role === "assistant" && m.metadata?.custom?.error);
     expect(errorMsg).toBeDefined();
-    expect(errorMsg.metadata.custom.error.modelUnavailable).toBeUndefined();
-    expect(errorMsg.metadata.custom.error.providerError).toBe("Some upstream error");
+    expect(errorMsg!.metadata!.custom.error!.modelUnavailable).toBeUndefined();
+    expect(errorMsg!.metadata!.custom.error!.providerError).toBe("Some upstream error");
   });
 
   describe("authoritative liveness frames", () => {
-    function sendAndOpen(result: ReturnType<typeof renderHook>["result"], ws: MockWebSocket) {
+    function sendAndOpen(result: { current: ReturnType<typeof useWsRuntime> }, ws: MockWebSocket) {
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -467,28 +515,26 @@ describe("useWsRuntime", () => {
       const { result } = renderHook(() => useWsRuntime("agent-1"));
       const ws = wsInstances[0];
       sendAndOpen(result, ws);
-      expect(result.current.runtime.isRunning).toBe(true);
+      expect(store(result.current.runtime).isRunning).toBe(true);
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "liveness",
-            state: "failed",
-            reason: "the agent run ended without a response",
-          }),
+        ws.simulateMessage({
+          type: "liveness",
+          state: "failed",
+          reason: "the agent run ended without a response",
         });
       });
 
       // Spinner stops and a retryable bubble carrying the server reason shows.
-      expect(result.current.runtime.isRunning).toBe(false);
-      const messages = result.current.runtime.messages;
+      expect(store(result.current.runtime).isRunning).toBe(false);
+      const messages = store(result.current.runtime).messages;
       const failureMsg = messages.find(
         (m: any) =>
           m.role === "assistant" &&
           m.metadata?.custom?.error?.message === "the agent run ended without a response"
       );
       expect(failureMsg).toBeDefined();
-      expect(failureMsg.metadata.custom.retryable).toBe(true);
+      expect(failureMsg!.metadata!.custom.retryable).toBe(true);
     });
 
     it("falls back to a generic reason when liveness:failed omits one", () => {
@@ -497,15 +543,15 @@ describe("useWsRuntime", () => {
       sendAndOpen(result, ws);
 
       act(() => {
-        ws.onmessage?.({ data: JSON.stringify({ type: "liveness", state: "failed" }) });
+        ws.simulateMessage({ type: "liveness", state: "failed" });
       });
 
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       const failureMsg = messages.find(
         (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.message
       );
       expect(failureMsg).toBeDefined();
-      expect(failureMsg.metadata.custom.error.message).toBe(
+      expect(failureMsg!.metadata!.custom.error!.message).toBe(
         "The agent run ended without a response."
       );
     });
@@ -519,36 +565,32 @@ describe("useWsRuntime", () => {
       // `liveness: failed` verdict. The generic liveness bubble must NOT
       // clobber the detailed provider-error bubble.
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "error",
-            agentName: "Smithers",
-            providerError: "Your credit balance is too low.",
-            hint: "Please contact your administrator.",
-            messageId: "msg-1",
-          }),
+        ws.simulateMessage({
+          type: "error",
+          agentName: "Smithers",
+          providerError: "Your credit balance is too low.",
+          hint: "Please contact your administrator.",
+          messageId: "msg-1",
         });
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "liveness",
-            state: "failed",
-            reason: "Your credit balance is too low.",
-          }),
+        ws.simulateMessage({
+          type: "liveness",
+          state: "failed",
+          reason: "Your credit balance is too low.",
         });
       });
 
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       const errorMsgs = messages.filter(
         (m: any) => m.role === "assistant" && m.metadata?.custom?.error
       );
       // Exactly one bubble, and it is the rich provider-error one.
       expect(errorMsgs).toHaveLength(1);
-      expect(errorMsgs[0].metadata.custom.error.providerError).toBe(
+      expect(errorMsgs[0].metadata!.custom.error!.providerError).toBe(
         "Your credit balance is too low."
       );
-      expect(errorMsgs[0].metadata.custom.error.message).toBeUndefined();
+      expect(errorMsgs[0].metadata!.custom.error!.message).toBeUndefined();
     });
 
     it("liveness:responding keeps the run going and liveness:completed stops it without a bubble", () => {
@@ -557,16 +599,16 @@ describe("useWsRuntime", () => {
       sendAndOpen(result, ws);
 
       act(() => {
-        ws.onmessage?.({ data: JSON.stringify({ type: "liveness", state: "responding" }) });
+        ws.simulateMessage({ type: "liveness", state: "responding" });
       });
-      expect(result.current.runtime.isRunning).toBe(true);
+      expect(store(result.current.runtime).isRunning).toBe(true);
 
       // A completed verdict does not itself stop the spinner — `complete` is the
       // genuine terminator — but it must never produce a failure bubble.
       act(() => {
-        ws.onmessage?.({ data: JSON.stringify({ type: "liveness", state: "completed" }) });
+        ws.simulateMessage({ type: "liveness", state: "completed" });
       });
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       const errorMsg = messages.find(
         (m: any) => m.role === "assistant" && m.metadata?.custom?.error
       );
@@ -584,13 +626,13 @@ describe("useWsRuntime", () => {
       sendAndOpen(result, ws);
 
       act(() => {
-        ws.onmessage?.({ data: JSON.stringify({ type: "liveness", state: "responding" }) });
+        ws.simulateMessage({ type: "liveness", state: "responding" });
       });
       act(() => {
         vi.advanceTimersByTime(300_000);
       });
 
-      const failureMsg = result.current.runtime.messages.find(
+      const failureMsg = store(result.current.runtime).messages.find(
         (m: any) =>
           m.role === "assistant" &&
           (m.metadata?.custom?.error?.message ||
@@ -609,49 +651,43 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "Hi",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "chunk",
+        content: "Hi",
+        messageId: "msg-1",
       });
     });
 
     // Per-turn done — does NOT terminate the spinner
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "done", messageId: "msg-1" }),
-      });
+      ws.simulateMessage({ type: "done", messageId: "msg-1" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Stream-terminating complete — now spinner stops
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "complete" }),
-      });
+      ws.simulateMessage({ type: "complete" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
 
     // Advance past any old debounce window — must stay false
     act(() => {
       vi.advanceTimersByTime(2000);
     });
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
   });
 
   it("should create separate messages for each turn in a multi-turn stream", () => {
@@ -659,12 +695,12 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     // User sends a message
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "How big is the house?" }],
         parentId: "root",
       });
@@ -672,54 +708,44 @@ describe("useWsRuntime", () => {
 
     // Turn 1: agent searches
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "chunk", content: "Let me search...", messageId: "turn-1" }),
-      });
+      ws.simulateMessage({ type: "chunk", content: "Let me search...", messageId: "turn-1" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Turn 1 done
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "done", messageId: "turn-1" }),
-      });
+      ws.simulateMessage({ type: "done", messageId: "turn-1" });
     });
 
     // Turn 2: agent responds with new messageId
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "The house is 231m².",
-          messageId: "turn-2",
-        }),
+      ws.simulateMessage({
+        type: "chunk",
+        content: "The house is 231m².",
+        messageId: "turn-2",
       });
     });
 
     // isRunning should be true again when new chunks arrive
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Turn 2 done — still not finished from the spinner's perspective
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "done", messageId: "turn-2" }),
-      });
+      ws.simulateMessage({ type: "done", messageId: "turn-2" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     // Stream complete — spinner stops
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "complete" }),
-      });
+      ws.simulateMessage({ type: "complete" });
     });
 
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
 
     // Should have 3 messages: user + 2 assistant turns
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages).toHaveLength(3);
     expect(messages[0].role).toBe("user");
     expect(messages[1].role).toBe("assistant");
@@ -733,11 +759,11 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
@@ -753,7 +779,7 @@ describe("useWsRuntime", () => {
 
   it("registers a code/docx-only attachment adapter (everything else goes via two-phase upload)", () => {
     const { result } = renderHook(() => useWsRuntime("agent-1"));
-    const runtime = result.current.runtime;
+    const runtime = store(result.current.runtime);
 
     expect(runtime.adapters).toBeDefined();
     expect(runtime.adapters.attachments).toBeDefined();
@@ -785,11 +811,11 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello plain" }],
         parentId: "root",
       });
@@ -813,7 +839,7 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     expect(ws.send).toHaveBeenCalledWith(JSON.stringify({ type: "history", agentId: "agent-1" }));
@@ -830,7 +856,7 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       const historyFrame = JSON.parse(ws.send.mock.calls[0][0]);
@@ -844,7 +870,7 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       const historyFrame = JSON.parse(ws.send.mock.calls[0][0]);
@@ -858,10 +884,10 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -880,10 +906,10 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -900,22 +926,20 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "user", content: "Hello", timestamp: "2026-01-01T00:00:00Z" },
-            { role: "assistant", content: "Hi!", timestamp: "2026-01-01T00:00:01Z" },
-          ],
-        }),
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Hello", timestamp: "2026-01-01T00:00:00Z" },
+          { role: "assistant", content: "Hi!", timestamp: "2026-01-01T00:00:01Z" },
+        ],
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages).toHaveLength(2);
     expect(messages[0].role).toBe("user");
     expect(messages[0].content[0].text).toBe("Hello");
@@ -928,21 +952,17 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "system", content: "System prompt", timestamp: "2026-01-01T00:00:00Z" },
-          ],
-        }),
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "system", content: "System prompt", timestamp: "2026-01-01T00:00:00Z" }],
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages).toHaveLength(1);
     expect(messages[0].role).toBe("assistant");
   });
@@ -952,12 +972,12 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     // User sends a message first (creating a non-empty messages array)
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "New message" }],
         parentId: "root",
       });
@@ -965,18 +985,16 @@ describe("useWsRuntime", () => {
 
     // History arrives after user already started chatting
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "user", content: "Old message" },
-            { role: "assistant", content: "Old response" },
-          ],
-        }),
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Old message" },
+          { role: "assistant", content: "Old response" },
+        ],
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     // Should still have the user's new message, not the history
     expect(messages[0].content[0].text).toBe("New message");
   });
@@ -986,67 +1004,61 @@ describe("useWsRuntime", () => {
     const ws1 = wsInstances[0];
 
     act(() => {
-      ws1.onopen?.();
+      ws1.simulateOpen();
     });
 
     act(() => {
-      ws1.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "user", content: "Hi" },
-            { role: "assistant", content: "Hallo!" },
-          ],
-        }),
+      ws1.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hallo!" },
+        ],
       });
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Wie ist die Vacation Policy?" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws1.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "Ich schaue nach. Urlaub**: 25 Tage",
-          messageId: "assistant-1",
-        }),
+      ws1.simulateMessage({
+        type: "chunk",
+        content: "Ich schaue nach. Urlaub**: 25 Tage",
+        messageId: "assistant-1",
       });
     });
 
-    let messages = result.current.runtime.messages;
+    let messages = store(result.current.runtime).messages;
     expect(messages[messages.length - 1].content[0].text).toContain("Urlaub**");
 
     // Simulate a disconnect and reconnect cycle.
     act(() => {
-      ws1.onclose?.();
+      ws1.simulateClose();
       vi.advanceTimersByTime(1000);
     });
 
     const ws2 = wsInstances[1];
     act(() => {
-      ws2.onopen?.();
+      ws2.simulateOpen();
     });
 
     act(() => {
-      ws2.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "user", content: "Hi" },
-            { role: "assistant", content: "Hallo!" },
-            { role: "user", content: "Wie ist die Vacation Policy?" },
-            { role: "assistant", content: "Ich schaue nach. **Urlaubsanspruch:** 25 Tage" },
-          ],
-        }),
+      ws2.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Hi" },
+          { role: "assistant", content: "Hallo!" },
+          { role: "user", content: "Wie ist die Vacation Policy?" },
+          { role: "assistant", content: "Ich schaue nach. **Urlaubsanspruch:** 25 Tage" },
+        ],
       });
     });
 
-    messages = result.current.runtime.messages;
+    messages = store(result.current.runtime).messages;
     expect(messages[messages.length - 1].content[0].text).toBe(
       "Ich schaue nach. **Urlaubsanspruch:** 25 Tage"
     );
@@ -1057,22 +1069,20 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [
-            { role: "user", content: "Hello", timestamp: "2026-02-20T21:30:00Z" },
-            { role: "assistant", content: "Hi!", timestamp: "2026-02-20T21:30:05Z" },
-          ],
-        }),
+      ws.simulateMessage({
+        type: "history",
+        messages: [
+          { role: "user", content: "Hello", timestamp: "2026-02-20T21:30:00Z" },
+          { role: "assistant", content: "Hi!", timestamp: "2026-02-20T21:30:05Z" },
+        ],
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages[0].metadata).toEqual({ custom: { timestamp: "2026-02-20T21:30:00Z" } });
     expect(messages[1].metadata).toEqual({ custom: { timestamp: "2026-02-20T21:30:05Z" } });
   });
@@ -1082,19 +1092,17 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "history",
-          messages: [{ role: "user", content: "Hello" }],
-        }),
+      ws.simulateMessage({
+        type: "history",
+        messages: [{ role: "user", content: "Hello" }],
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages[0].metadata).toBeUndefined();
   });
 
@@ -1105,17 +1113,17 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     expect(messages[0].metadata).toEqual({
       custom: { timestamp: "2026-03-15T10:30:00.000Z", status: "sending" },
     });
@@ -1128,11 +1136,11 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
@@ -1141,18 +1149,16 @@ describe("useWsRuntime", () => {
     vi.setSystemTime(new Date("2026-03-15T10:30:10Z"));
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "chunk",
-          content: "Hi there!",
-          messageId: "msg-1",
-        }),
+      ws.simulateMessage({
+        type: "chunk",
+        content: "Hi there!",
+        messageId: "msg-1",
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const assistantMsg = messages.find((m: any) => m.role === "assistant");
-    expect(assistantMsg.metadata).toEqual({
+    expect(assistantMsg!.metadata).toEqual({
       custom: { timestamp: "2026-03-15T10:30:10.000Z" },
     });
   });
@@ -1175,11 +1181,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -1205,11 +1211,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -1223,12 +1229,10 @@ describe("useWsRuntime", () => {
 
       // Chunk arrives — should reset
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            content: "Hi",
-            messageId: "msg-1",
-          }),
+        ws.simulateMessage({
+          type: "chunk",
+          content: "Hi",
+          messageId: "msg-1",
         });
       });
       expect(result.current.isDelayed).toBe(false);
@@ -1239,11 +1243,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -1254,12 +1258,10 @@ describe("useWsRuntime", () => {
         vi.advanceTimersByTime(5000);
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            content: "Hi",
-            messageId: "msg-1",
-          }),
+        ws.simulateMessage({
+          type: "chunk",
+          content: "Hi",
+          messageId: "msg-1",
         });
       });
 
@@ -1275,11 +1277,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -1291,19 +1293,15 @@ describe("useWsRuntime", () => {
       expect(result.current.isDelayed).toBe(true);
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            content: "Response",
-            messageId: "msg-1",
-          }),
+        ws.simulateMessage({
+          type: "chunk",
+          content: "Response",
+          messageId: "msg-1",
         });
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "done", messageId: "msg-1" }),
-        });
+        ws.simulateMessage({ type: "done", messageId: "msg-1" });
       });
 
       expect(result.current.isDelayed).toBe(false);
@@ -1314,11 +1312,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -1330,12 +1328,10 @@ describe("useWsRuntime", () => {
       expect(result.current.isDelayed).toBe(true);
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "error",
-            message: "Something went wrong",
-            messageId: "msg-1",
-          }),
+        ws.simulateMessage({
+          type: "error",
+          message: "Something went wrong",
+          messageId: "msg-1",
         });
       });
 
@@ -1347,7 +1343,7 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // Advance time without sending a message
@@ -1370,15 +1366,13 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [],
         });
       });
 
@@ -1390,15 +1384,13 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Hello!" }],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hello!" }],
         });
       });
 
@@ -1410,19 +1402,17 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "history", messages: [] }),
-        });
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
       expect(result.current.isHistoryLoaded).toBe(true);
 
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
       expect(result.current.isHistoryLoaded).toBe(false);
@@ -1443,12 +1433,10 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "history", messages: [] }),
-        });
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
       expect(result.current.hasInitialContent).toBe(false);
@@ -1459,14 +1447,12 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Hello!" }],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hello!" }],
         });
       });
 
@@ -1480,15 +1466,13 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [],
-            sessionKnown: true,
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [],
+          sessionKnown: true,
         });
       });
 
@@ -1518,22 +1502,18 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw_status", connected: true }),
-        });
+        ws.simulateOpen();
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
       });
 
       // Connected upstream + downstream, but no content yet → still "starting".
       expect(result.current.status).toEqual({ kind: "starting" });
-      expect(result.current.ws.runtime.messages).toHaveLength(0);
+      expect(store(result.current.ws.runtime).messages).toHaveLength(0);
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Hello!" }],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hello!" }],
         });
       });
 
@@ -1542,7 +1522,7 @@ describe("useWsRuntime", () => {
       // is no intermediate snapshot where the indicator is green but the
       // chat is empty.
       expect(result.current.status).toEqual({ kind: "ready" });
-      expect(result.current.ws.runtime.messages).toHaveLength(1);
+      expect(store(result.current.ws.runtime).messages).toHaveLength(1);
     });
 
     it("clears the knownEmptyHistory signal on disconnect", () => {
@@ -1553,17 +1533,15 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "history", messages: [], sessionKnown: true }),
-        });
+        ws.simulateMessage({ type: "history", messages: [], sessionKnown: true });
       });
       expect(result.current.hasInitialContent).toBe(true);
 
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
       expect(result.current.hasInitialContent).toBe(false);
@@ -1576,12 +1554,12 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       expect(wsInstances).toHaveLength(1);
 
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
       // Advance past first reconnect delay (1 second)
@@ -1596,12 +1574,12 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // First disconnect -> 1s delay
       act(() => {
-        ws1.onclose?.();
+        ws1.simulateClose();
       });
       act(() => {
         vi.advanceTimersByTime(1000);
@@ -1611,7 +1589,7 @@ describe("useWsRuntime", () => {
       // Second disconnect -> 2s delay
       const ws2 = wsInstances[1];
       act(() => {
-        ws2.onclose?.();
+        ws2.simulateClose();
       });
       act(() => {
         vi.advanceTimersByTime(1000);
@@ -1628,7 +1606,7 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       unmount();
@@ -1646,12 +1624,12 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Disconnect and reconnect
       act(() => {
-        ws1.onclose?.();
+        ws1.simulateClose();
       });
       act(() => {
         vi.advanceTimersByTime(1000);
@@ -1661,12 +1639,12 @@ describe("useWsRuntime", () => {
       // Successful reconnect resets counter
       const ws2 = wsInstances[1];
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
 
       // Disconnect again - should use 1s delay (not 2s)
       act(() => {
-        ws2.onclose?.();
+        ws2.simulateClose();
       });
       act(() => {
         vi.advanceTimersByTime(1000);
@@ -1679,14 +1657,14 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Disconnect 4 times: delays are 1s, 2s, 4s, 5s (capped)
       for (let i = 0; i < 4; i++) {
         const ws = wsInstances[wsInstances.length - 1];
         act(() => {
-          ws.onclose?.();
+          ws.simulateClose();
         });
         act(() => {
           vi.advanceTimersByTime(5000);
@@ -1696,7 +1674,7 @@ describe("useWsRuntime", () => {
       // 5th disconnect: should still reconnect after 5s (not 16s or 32s)
       const ws5 = wsInstances[wsInstances.length - 1];
       act(() => {
-        ws5.onclose?.();
+        ws5.simulateClose();
       });
 
       // After 5s the next reconnect should happen (capped, not 16s)
@@ -1710,14 +1688,14 @@ describe("useWsRuntime", () => {
       renderHook(() => useWsRuntime("agent-1"));
       const ws1 = wsInstances[0];
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Simulate 10 disconnects without successful reconnect
       for (let i = 0; i < 10; i++) {
         const ws = wsInstances[wsInstances.length - 1];
         act(() => {
-          ws.onclose?.();
+          ws.simulateClose();
         });
         act(() => {
           vi.advanceTimersByTime(5000);
@@ -1729,7 +1707,7 @@ describe("useWsRuntime", () => {
       // 11th disconnect should NOT reconnect
       const lastWs = wsInstances[wsInstances.length - 1];
       act(() => {
-        lastWs.onclose?.();
+        lastWs.simulateClose();
       });
       act(() => {
         vi.advanceTimersByTime(60000);
@@ -1747,21 +1725,19 @@ describe("useWsRuntime", () => {
 
       // Connect and load history for agent-1
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
       act(() => {
-        ws1.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [
-              { role: "user", content: "Hello" },
-              { role: "assistant", content: "Hi from agent 1!" },
-            ],
-          }),
+        ws1.simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "Hello" },
+            { role: "assistant", content: "Hi from agent 1!" },
+          ],
         });
       });
 
-      expect(result.current.runtime.messages).toHaveLength(2);
+      expect(store(result.current.runtime).messages).toHaveLength(2);
 
       // Switch to agent-2
       rerender({ agentId: "agent-2" });
@@ -1769,21 +1745,19 @@ describe("useWsRuntime", () => {
 
       // Connect to new agent
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
 
       // History from agent-2 arrives
       act(() => {
-        ws2.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Welcome to agent 2!" }],
-          }),
+        ws2.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Welcome to agent 2!" }],
         });
       });
 
       // Should show agent-2's history, NOT agent-1's
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       expect(messages).toHaveLength(1);
       expect(messages[0].content[0].text).toBe("Welcome to agent 2!");
     });
@@ -1796,10 +1770,10 @@ describe("useWsRuntime", () => {
 
       // Chat with agent-1
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello agent 1" }],
           parentId: "root",
         });
@@ -1810,21 +1784,19 @@ describe("useWsRuntime", () => {
       const ws2 = wsInstances[1];
 
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
 
       // Agent-2 has empty history
       act(() => {
-        ws2.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [],
-          }),
+        ws2.simulateMessage({
+          type: "history",
+          messages: [],
         });
       });
 
       // Should be empty — agent-1's messages must not leak into agent-2
-      expect(result.current.runtime.messages).toHaveLength(0);
+      expect(store(result.current.runtime).messages).toHaveLength(0);
     });
   });
 
@@ -1838,7 +1810,7 @@ describe("useWsRuntime", () => {
 
       // User sends a message before connection is open
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello while connecting" }],
           parentId: "root",
         });
@@ -1853,7 +1825,7 @@ describe("useWsRuntime", () => {
       // User message should still appear optimistically in messages, followed
       // by the in-flight assistant placeholder the send path appends (the
       // tab-refocus crash fix — list always ends in assistant while running).
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       expect(messages).toHaveLength(2);
       expect(messages[0].role).toBe("user");
       expect(messages[0].content[0].text).toBe("Hello while connecting");
@@ -1862,7 +1834,7 @@ describe("useWsRuntime", () => {
       // Now the connection opens
       ws.readyState = 1;
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // The queued message should now be sent
@@ -1880,18 +1852,18 @@ describe("useWsRuntime", () => {
       // Connect first
       ws1.readyState = 1;
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Disconnect
       ws1.readyState = 3; // CLOSED
       act(() => {
-        ws1.onclose?.();
+        ws1.simulateClose();
       });
 
       // User sends message while disconnected
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Sent while offline" }],
           parentId: "root",
         });
@@ -1905,7 +1877,7 @@ describe("useWsRuntime", () => {
       const ws2 = wsInstances[1];
       ws2.readyState = 1;
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
 
       // The queued message should be sent on the new connection
@@ -1921,13 +1893,13 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       ws1.readyState = MockWebSocket.CLOSING;
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Sent while closing" }],
           parentId: "root",
         });
@@ -1943,7 +1915,7 @@ describe("useWsRuntime", () => {
       const ws2 = wsInstances[1];
       ws2.readyState = MockWebSocket.OPEN;
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
 
       const sentMessages = ws2.send.mock.calls.filter(
@@ -1964,22 +1936,22 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
       });
 
-      expect(result.current.runtime.isRunning).toBe(true);
+      expect(store(result.current.runtime).isRunning).toBe(true);
 
       // Real browser behavior: onerror always fires before onclose.
       act(() => {
-        ws.onerror?.();
-        ws.onclose?.();
+        ws.simulateError();
+        ws.simulateClose();
       });
 
       // Advance well past every former guess window — no failure bubble appears.
@@ -1987,8 +1959,8 @@ describe("useWsRuntime", () => {
         vi.advanceTimersByTime(120_000);
       });
 
-      expect(result.current.runtime.isRunning).toBe(false);
-      const disconnectError = result.current.runtime.messages.find(
+      expect(store(result.current.runtime).isRunning).toBe(false);
+      const disconnectError = store(result.current.runtime).messages.find(
         (m: any) =>
           m.role === "assistant" &&
           (m.metadata?.custom?.error?.disconnected === true ||
@@ -2005,20 +1977,18 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Start a stream on agent-1
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
       });
       act(() => {
-        ws1.onmessage?.({
-          data: JSON.stringify({ type: "chunk", content: "Hi", messageId: "msg-1" }),
-        });
+        ws1.simulateMessage({ type: "chunk", content: "Hi", messageId: "msg-1" });
       });
 
       // Switch to agent-2 while stream is active
@@ -2026,11 +1996,11 @@ describe("useWsRuntime", () => {
 
       // Old connection closes (triggered by cleanup calling ws.close())
       act(() => {
-        ws1.onclose?.();
+        ws1.simulateClose();
       });
 
       // Agent-2's messages must be empty — no spurious disconnect error
-      expect(result.current.runtime.messages).toHaveLength(0);
+      expect(store(result.current.runtime).messages).toHaveLength(0);
     });
 
     it("should not add a disconnect error message when idle (no active stream)", () => {
@@ -2038,23 +2008,21 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "history", messages: [] }),
-        });
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
-      const messagesBefore = result.current.runtime.messages.length;
+      const messagesBefore = store(result.current.runtime).messages.length;
 
       // Disconnect while idle
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
-      expect(result.current.runtime.messages).toHaveLength(messagesBefore);
+      expect(store(result.current.runtime).messages).toHaveLength(messagesBefore);
     });
 
     // A mid-stream disconnect followed by a successful reconnect+history-reconcile
@@ -2067,39 +2035,35 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Hi" }],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hi" }],
         });
       });
 
       // User sends → partial chunk → close mid-stream
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Wie ist die Vacation Policy?" }],
           parentId: "root",
         });
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            content: "Ich schaue nach. Urlaub**:",
-            messageId: "asst-1",
-          }),
+        ws.simulateMessage({
+          type: "chunk",
+          content: "Ich schaue nach. Urlaub**:",
+          messageId: "asst-1",
         });
       });
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
       // No failure bubble on close — the client doesn't guess failure.
-      const beforeReconnect = result.current.runtime.messages;
+      const beforeReconnect = store(result.current.runtime).messages;
       expect(
         beforeReconnect.find(
           (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.disconnected === true
@@ -2112,21 +2076,19 @@ describe("useWsRuntime", () => {
       });
       const ws2 = wsInstances[1];
       act(() => {
-        ws2.onopen?.();
+        ws2.simulateOpen();
       });
       act(() => {
-        ws2.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [
-              { role: "assistant", content: "Hi" },
-              { role: "user", content: "Wie ist die Vacation Policy?" },
-              {
-                role: "assistant",
-                content: "Ich schaue nach. **Urlaubsanspruch:** 25 Tage",
-              },
-            ],
-          }),
+        ws2.simulateMessage({
+          type: "history",
+          messages: [
+            { role: "assistant", content: "Hi" },
+            { role: "user", content: "Wie ist die Vacation Policy?" },
+            {
+              role: "assistant",
+              content: "Ich schaue nach. **Urlaubsanspruch:** 25 Tage",
+            },
+          ],
         });
       });
 
@@ -2135,7 +2097,7 @@ describe("useWsRuntime", () => {
         vi.advanceTimersByTime(2000);
       });
 
-      const finalMessages = result.current.runtime.messages;
+      const finalMessages = store(result.current.runtime).messages;
       expect(
         finalMessages.find(
           (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.disconnected === true
@@ -2153,12 +2115,12 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
-        ws1.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        ws1.simulateOpen();
+        ws1.simulateMessage({ type: "history", messages: [] });
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Summarize this profile" }],
           parentId: "root",
         });
@@ -2168,25 +2130,21 @@ describe("useWsRuntime", () => {
       // fire when local state carries an error bubble (the #199 index-shrink
       // guard), so we drive that state via the new liveness mechanism.
       act(() => {
-        ws1.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            messageId: "asst-late",
-            content: "Partial summary",
-          }),
+        ws1.simulateMessage({
+          type: "chunk",
+          messageId: "asst-late",
+          content: "Partial summary",
         });
-        ws1.onmessage?.({
-          data: JSON.stringify({ type: "liveness", state: "failed", reason: "stream dropped" }),
-        });
-        ws1.onclose?.();
+        ws1.simulateMessage({ type: "liveness", state: "failed", reason: "stream dropped" });
+        ws1.simulateClose();
       });
 
-      const localLength = result.current.runtime.messages.length;
+      const localLength = store(result.current.runtime).messages.length;
       // user + error bubble (the partial chunk's placeholder is replaced by the
       // failure bubble) → length 2, and crucially one carries an error.
-      expect(result.current.runtime.messages.some((m: any) => m.metadata?.custom?.error)).toBe(
-        true
-      );
+      expect(
+        store(result.current.runtime).messages.some((m: any) => m.metadata?.custom?.error)
+      ).toBe(true);
 
       // Reconnect backoff fires after 1s, creating a fresh WebSocket.
       act(() => {
@@ -2195,27 +2153,25 @@ describe("useWsRuntime", () => {
 
       const ws2 = wsInstances[1];
       act(() => {
-        ws2.onopen?.();
-        ws2.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [
-              { role: "user", content: "Summarize this profile" },
-              { role: "assistant", content: "Final summary" },
-            ],
-          }),
+        ws2.simulateOpen();
+        ws2.simulateMessage({
+          type: "history",
+          messages: [
+            { role: "user", content: "Summarize this profile" },
+            { role: "assistant", content: "Final summary" },
+          ],
         });
       });
 
       expect(result.current.isReconcilingMessages).toBe(true);
-      expect(result.current.runtime.messages).toHaveLength(localLength);
+      expect(store(result.current.runtime).messages).toHaveLength(localLength);
 
       act(() => {
         vi.advanceTimersByTime(0);
       });
 
-      expect(result.current.runtime.messages).toHaveLength(2);
-      expect(result.current.runtime.messages[1].content[0].text).toBe("Final summary");
+      expect(store(result.current.runtime).messages).toHaveLength(2);
+      expect(store(result.current.runtime).messages[1].content[0].text).toBe("Final summary");
       expect(result.current.isReconcilingMessages).toBe(true);
 
       act(() => {
@@ -2230,23 +2186,21 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
-        ws.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        ws.simulateOpen();
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Keep working while I close my laptop" }],
           parentId: "root",
         });
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "chunk",
-            messageId: "asst-sleep",
-            content: "Working on it...",
-          }),
+        ws.simulateMessage({
+          type: "chunk",
+          messageId: "asst-sleep",
+          content: "Working on it...",
         });
       });
 
@@ -2256,7 +2210,7 @@ describe("useWsRuntime", () => {
           value: "hidden",
         });
         document.dispatchEvent(new Event("visibilitychange"));
-        ws.onclose?.();
+        ws.simulateClose();
       });
 
       act(() => {
@@ -2264,7 +2218,7 @@ describe("useWsRuntime", () => {
       });
 
       expect(
-        result.current.runtime.messages.find(
+        store(result.current.runtime).messages.find(
           (m: any) => m.role === "assistant" && m.metadata?.custom?.error?.disconnected === true
         )
       ).toBeUndefined();
@@ -2285,13 +2239,13 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
-        ws.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        ws.simulateOpen();
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
       // Send a message — 1009 is only meaningful in the context of a recent send
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "here's a huge image" }],
           parentId: "root",
         });
@@ -2302,7 +2256,7 @@ describe("useWsRuntime", () => {
         ws.simulateClose(1009);
       });
 
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       const lastMsg = messages[messages.length - 1] as {
         role: string;
         metadata?: {
@@ -2338,13 +2292,13 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
-        ws.onmessage?.({ data: JSON.stringify({ type: "openclaw_status", connected: true }) });
-        ws.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        ws.simulateOpen();
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
+        ws.simulateMessage({ type: "history", messages: [] });
       });
 
       act(() => {
-        result.current.ws.runtime.onNew({
+        store(result.current.ws.runtime).onNew({
           content: [{ type: "text", text: "here's a huge image" }],
           parentId: "root",
         });
@@ -2368,12 +2322,12 @@ describe("useWsRuntime", () => {
       const firstWs = wsInstances[0];
 
       act(() => {
-        firstWs.onopen?.();
-        firstWs.onmessage?.({ data: JSON.stringify({ type: "history", messages: [] }) });
+        firstWs.simulateOpen();
+        firstWs.simulateMessage({ type: "history", messages: [] });
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "oversized image" }],
           parentId: "root",
         });
@@ -2387,7 +2341,7 @@ describe("useWsRuntime", () => {
       expect(wsInstances).toHaveLength(1);
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "smaller image" }],
           parentId: "root",
         });
@@ -2398,7 +2352,7 @@ describe("useWsRuntime", () => {
 
       const nextWs = wsInstances[1];
       act(() => {
-        nextWs.onopen?.();
+        nextWs.simulateOpen();
       });
 
       expect(nextWs.send).toHaveBeenCalledWith(
@@ -2414,11 +2368,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Hello" }],
           parentId: "root",
         });
@@ -2432,7 +2386,7 @@ describe("useWsRuntime", () => {
 
       // Disconnect — isDelayed must clear
       act(() => {
-        ws.onclose?.();
+        ws.simulateClose();
       });
       expect(result.current.isDelayed).toBe(false);
     });
@@ -2449,14 +2403,14 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Exhaust all MAX_RECONNECT_ATTEMPTS (10) + the original connection
       for (let i = 0; i < 10; i++) {
         const ws = wsInstances[wsInstances.length - 1];
         act(() => {
-          ws.onclose?.();
+          ws.simulateClose();
         });
         act(() => {
           vi.advanceTimersByTime(5000);
@@ -2466,7 +2420,7 @@ describe("useWsRuntime", () => {
       // 11th disconnect — no more reconnect attempts
       const lastWs = wsInstances[wsInstances.length - 1];
       act(() => {
-        lastWs.onclose?.();
+        lastWs.simulateClose();
       });
 
       expect(result.current.reconnectExhausted).toBe(true);
@@ -2477,14 +2431,14 @@ describe("useWsRuntime", () => {
       const ws1 = wsInstances[0];
 
       act(() => {
-        ws1.onopen?.();
+        ws1.simulateOpen();
       });
 
       // Fail a few times (but not all)
       for (let i = 0; i < 3; i++) {
         const ws = wsInstances[wsInstances.length - 1];
         act(() => {
-          ws.onclose?.();
+          ws.simulateClose();
         });
         act(() => {
           vi.advanceTimersByTime(5000);
@@ -2494,7 +2448,7 @@ describe("useWsRuntime", () => {
       // Successful reconnect
       const ws4 = wsInstances[wsInstances.length - 1];
       act(() => {
-        ws4.onopen?.();
+        ws4.simulateOpen();
       });
 
       expect(result.current.reconnectExhausted).toBe(false);
@@ -2507,13 +2461,11 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw:restarting" }),
-        });
+        ws.simulateMessage({ type: "openclaw:restarting" });
       });
 
       expect(mockTriggerRestart).toHaveBeenCalledOnce();
@@ -2524,14 +2476,12 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // Should not throw or cause issues
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw:ready" }),
-        });
+        ws.simulateMessage({ type: "openclaw:ready" });
       });
 
       // triggerRestart should NOT be called for ready messages
@@ -2545,7 +2495,7 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // Push 250 messages via a single history frame — the fastest path into
@@ -2557,12 +2507,10 @@ describe("useWsRuntime", () => {
       }));
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "history", messages: historyPayload }),
-        });
+        ws.simulateMessage({ type: "history", messages: historyPayload });
       });
 
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       expect(messages).toHaveLength(200);
       // The oldest 50 must be gone; the newest 200 must be retained.
       expect(messages[0].content[0].text).toBe("message-50");
@@ -2579,19 +2527,15 @@ describe("useWsRuntime", () => {
       // upstream readiness — required since the client default is now false,
       // see issue #198), and load history.
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw_status", connected: true }),
-        });
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
       });
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({
-            type: "history",
-            messages: [{ role: "assistant", content: "Hello!" }],
-          }),
+        ws.simulateMessage({
+          type: "history",
+          messages: [{ role: "assistant", content: "Hello!" }],
         });
       });
 
@@ -2600,9 +2544,7 @@ describe("useWsRuntime", () => {
 
       // Step 2: OpenClaw goes unavailable (fullyConnected: true → false)
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw_status", connected: false }),
-        });
+        ws.simulateMessage({ type: "openclaw_status", connected: false });
       });
       expect(result.current.isOpenClawConnected).toBe(false);
 
@@ -2611,9 +2553,7 @@ describe("useWsRuntime", () => {
 
       // Step 3: OpenClaw comes back (fullyConnected: false → true — rising edge)
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw_status", connected: true }),
-        });
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
       });
       expect(result.current.isOpenClawConnected).toBe(true);
 
@@ -2632,7 +2572,7 @@ describe("useWsRuntime", () => {
 
       // Connect for the first time — ws.onopen already sends history
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // Only one history request should have been sent (from onopen), not two
@@ -2648,7 +2588,7 @@ describe("useWsRuntime", () => {
 
       // Connect but do NOT send history response yet (isHistoryLoaded stays false)
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
 
       // isOpenClawConnected starts false (issue #198); simulate a false → true
@@ -2657,9 +2597,7 @@ describe("useWsRuntime", () => {
       const sendsBefore = ws.send.mock.calls.length;
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "openclaw_status", connected: true }),
-        });
+        ws.simulateMessage({ type: "openclaw_status", connected: true });
       });
 
       // isHistoryLoaded is still false — must NOT send another history request
@@ -2676,29 +2614,27 @@ describe("useWsRuntime", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({
-          type: "error",
-          code: "attachment_invalid",
-          message: "File type mismatch: claimed application/pdf, content is image/png",
-        }),
+      ws.simulateMessage({
+        type: "error",
+        code: "attachment_invalid",
+        message: "File type mismatch: claimed application/pdf, content is image/png",
       });
     });
 
-    const messages = result.current.runtime.messages;
+    const messages = store(result.current.runtime).messages;
     const errorMsg = messages.find((m: any) => m.role === "assistant" && m.metadata?.custom?.error);
     expect(errorMsg).toBeDefined();
-    expect(errorMsg.metadata.custom.error).toEqual({
+    expect(errorMsg!.metadata!.custom.error).toEqual({
       attachmentInvalid: true,
       message: "File type mismatch: claimed application/pdf, content is image/png",
     });
@@ -2715,28 +2651,26 @@ describe("useWsRuntime", () => {
       const ws = wsInstances[0];
 
       act(() => {
-        ws.onopen?.();
+        ws.simulateOpen();
       });
       act(() => {
-        result.current.runtime.onNew({
+        store(result.current.runtime).onNew({
           content: [{ type: "text", text: "Send a file" }],
           parentId: "root",
         });
       });
 
       act(() => {
-        ws.onmessage?.({
-          data: JSON.stringify({ type: "error", code, message }),
-        });
+        ws.simulateMessage({ type: "error", code, message });
       });
 
-      const messages = result.current.runtime.messages;
+      const messages = store(result.current.runtime).messages;
       const errorMsg = messages.find(
         (m: any) => m.role === "assistant" && m.metadata?.custom?.error
       );
       expect(errorMsg).toBeDefined();
-      expect(errorMsg.metadata.custom.error.attachmentInvalid).toBe(true);
-      expect(errorMsg.metadata.custom.error.message).toBe(message);
+      expect(errorMsg!.metadata!.custom.error!.attachmentInvalid).toBe(true);
+      expect(errorMsg!.metadata!.custom.error!.message).toBe(message);
     }
   );
 
@@ -2751,7 +2685,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("test message"));
+        store(result.current.runtime).onNew(makeUserMessage("test message"));
       });
 
       const ws = latestWs();
@@ -2788,12 +2722,7 @@ describe("useWsRuntime", () => {
         await vi.advanceTimersByTimeAsync(15_000);
       });
 
-      const historyUserMsg = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user");
+      const historyUserMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
       expect(historyUserMsg).toBeDefined();
       // History messages have no status (server payload didn't include one),
       // and crucially they did NOT transition to "failed".
@@ -2812,7 +2741,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -2825,13 +2754,9 @@ describe("useWsRuntime", () => {
         await vi.advanceTimersByTimeAsync(10_000);
       });
 
-      const failedMsg = (
-        result.current.runtime.messages as Array<{
-          id?: string;
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user" && m.id === sentPayload.clientMessageId);
+      const failedMsg = store(result.current.runtime).messages.find(
+        (m) => m.role === "user" && m.id === sentPayload.clientMessageId
+      );
       expect(failedMsg?.metadata?.custom?.status).toBe("failed");
     });
 
@@ -2844,7 +2769,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -2865,13 +2790,9 @@ describe("useWsRuntime", () => {
         await vi.advanceTimersByTimeAsync(5_000);
       });
 
-      const sentMsg = (
-        result.current.runtime.messages as Array<{
-          id?: string;
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user" && m.id === sentPayload.clientMessageId);
+      const sentMsg = store(result.current.runtime).messages.find(
+        (m) => m.role === "user" && m.id === sentPayload.clientMessageId
+      );
       expect(sentMsg?.metadata?.custom?.status).toBe("sent");
     });
 
@@ -2884,7 +2805,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -2903,13 +2824,9 @@ describe("useWsRuntime", () => {
         ws.simulateMessage({ type: "complete" });
       });
 
-      const lateMsg = (
-        result.current.runtime.messages as Array<{
-          id?: string;
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user" && m.id === sentPayload.clientMessageId);
+      const lateMsg = store(result.current.runtime).messages.find(
+        (m) => m.role === "user" && m.id === sentPayload.clientMessageId
+      );
       expect(lateMsg?.metadata?.custom?.status).toBe("failed");
     });
   });
@@ -2925,7 +2842,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       expect(result.current.isRunning).toBe(true);
@@ -2948,7 +2865,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       expect(result.current.isRunning).toBe(true);
@@ -2971,7 +2888,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       // Simulate chunk arriving (stream started), then WS closes
@@ -3006,7 +2923,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       expect(result.current.isRunning).toBe(true);
@@ -3027,7 +2944,7 @@ describe("useWsRuntime", () => {
       });
 
       expect(result.current.isRunning).toBe(true);
-      const failureBubble = result.current.runtime.messages.find(
+      const failureBubble = store(result.current.runtime).messages.find(
         (m: any) =>
           m.role === "assistant" &&
           (m.metadata?.custom?.error?.timedOut === true || m.metadata?.custom?.error?.message)
@@ -3051,7 +2968,7 @@ describe("useWsRuntime", () => {
 
       // Case 1: failure before any chunk → send_failure.
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
       await act(async () => {
         latestWs().simulateMessage({
@@ -3062,10 +2979,7 @@ describe("useWsRuntime", () => {
       });
 
       expect(result.current.isRunning).toBe(false);
-      let messages = result.current.runtime.messages as Array<{
-        role: string;
-        metadata?: { custom?: { retryable?: boolean; retryReason?: string } };
-      }>;
+      let messages = store(result.current.runtime).messages;
       let lastMsg = messages[messages.length - 1];
       expect(lastMsg.role).toBe("assistant");
       expect(lastMsg.metadata?.custom?.retryable).toBe(true);
@@ -3073,7 +2987,7 @@ describe("useWsRuntime", () => {
 
       // Case 2: a fresh turn that streams a chunk, then fails → partial_stream_failure.
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("again"));
+        store(result.current.runtime).onNew(makeUserMessage("again"));
       });
       await act(async () => {
         latestWs().simulateMessage({ type: "chunk", messageId: "m1", content: "Partial..." });
@@ -3084,10 +2998,7 @@ describe("useWsRuntime", () => {
         });
       });
 
-      messages = result.current.runtime.messages as Array<{
-        role: string;
-        metadata?: { custom?: { retryable?: boolean; retryReason?: string } };
-      }>;
+      messages = store(result.current.runtime).messages;
       lastMsg = messages[messages.length - 1];
       expect(lastMsg.role).toBe("assistant");
       expect(lastMsg.metadata?.custom?.retryable).toBe(true);
@@ -3103,7 +3014,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       expect(result.current.isRunning).toBe(true);
@@ -3116,10 +3027,7 @@ describe("useWsRuntime", () => {
 
       expect(result.current.isRunning).toBe(false);
 
-      const messages = result.current.runtime.messages as Array<{
-        role: string;
-        metadata?: { custom?: { retryable?: boolean; retryReason?: string } };
-      }>;
+      const messages = store(result.current.runtime).messages;
       const lastMsg = messages[messages.length - 1];
       expect(lastMsg.role).toBe("assistant");
       expect(lastMsg.metadata?.custom?.retryable).toBe(true);
@@ -3139,7 +3047,7 @@ describe("useWsRuntime", () => {
 
       // Build a completed turn: user → ack → assistant chunk → complete
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
       const ws = latestWs();
       const sentPayload = JSON.parse(ws.send.mock.calls.at(-1)![0] as string) as {
@@ -3151,7 +3059,7 @@ describe("useWsRuntime", () => {
         ws.simulateMessage({ type: "complete" });
       });
 
-      const beforeDisconnect = (result.current.runtime.messages as Array<{ role: string }>).length;
+      const beforeDisconnect = store(result.current.runtime).messages.length;
       expect(beforeDisconnect).toBeGreaterThanOrEqual(2);
 
       // Disconnect (no stream in progress, no error bubble injected)
@@ -3171,7 +3079,7 @@ describe("useWsRuntime", () => {
       });
 
       // Messages from before the disconnect must still be present
-      const messages = result.current.runtime.messages as Array<{ role: string }>;
+      const messages = store(result.current.runtime).messages;
       const userMessages = messages.filter((m) => m.role === "user");
       expect(userMessages).toHaveLength(1);
       const assistantMessages = messages.filter((m) => m.role === "assistant");
@@ -3191,7 +3099,7 @@ describe("useWsRuntime", () => {
       // frame produces a local error bubble (the case that used to be the
       // deferred disconnect bubble).
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -3219,10 +3127,7 @@ describe("useWsRuntime", () => {
         latestWs().simulateMessage({ type: "history", messages: [] });
       });
 
-      const messages = result.current.runtime.messages as Array<{
-        role: string;
-        metadata?: { custom?: { error?: unknown } };
-      }>;
+      const messages = store(result.current.runtime).messages;
       expect(messages.length).toBeGreaterThanOrEqual(2); // user + error bubble
 
       // Local state must be preserved — empty server history can't be canonical
@@ -3246,7 +3151,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("write a story"));
+        store(result.current.runtime).onNew(makeUserMessage("write a story"));
       });
 
       const ws = latestWs();
@@ -3263,9 +3168,7 @@ describe("useWsRuntime", () => {
 
       // Pre-retry: 2 assistant entries (partial + error bubble)
       expect(
-        (result.current.runtime.messages as Array<{ role: string }>).filter(
-          (m) => m.role === "assistant"
-        )
+        store(result.current.runtime).messages.filter((m) => m.role === "assistant")
       ).toHaveLength(2);
 
       await act(async () => {
@@ -3277,7 +3180,7 @@ describe("useWsRuntime", () => {
 
       // After the retry's first chunk: only user + new assistant remain.
       // The previous partial response and the error bubble are both gone.
-      const finalMessages = result.current.runtime.messages as Array<{ role: string }>;
+      const finalMessages = store(result.current.runtime).messages;
       expect(finalMessages.filter((m) => m.role === "user")).toHaveLength(1);
       expect(finalMessages.filter((m) => m.role === "assistant")).toHaveLength(1);
     });
@@ -3291,7 +3194,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -3300,12 +3203,9 @@ describe("useWsRuntime", () => {
       });
 
       // Confirm the error bubble exists at this point
-      const beforeRetry = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { error?: unknown } };
-        }>
-      ).filter((m) => m.role === "assistant" && m.metadata?.custom?.error);
+      const beforeRetry = store(result.current.runtime).messages.filter(
+        (m) => m.role === "assistant" && m.metadata?.custom?.error
+      );
       expect(beforeRetry).toHaveLength(1);
 
       // Simulate a successful retry: chunk arrives
@@ -3314,12 +3214,9 @@ describe("useWsRuntime", () => {
       });
 
       // Error bubble must be gone — only the successful assistant chunk remains
-      const afterChunk = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { error?: unknown } };
-        }>
-      ).filter((m) => m.role === "assistant" && m.metadata?.custom?.error);
+      const afterChunk = store(result.current.runtime).messages.filter(
+        (m) => m.role === "assistant" && m.metadata?.custom?.error
+      );
       expect(afterChunk).toHaveLength(0);
     });
 
@@ -3332,7 +3229,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -3341,29 +3238,23 @@ describe("useWsRuntime", () => {
       });
 
       // After first error: 1 user message + 1 error bubble = 2 messages
-      const errorBubblesAfterFirst = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { error?: unknown } };
-        }>
-      ).filter((m) => m.role === "assistant" && m.metadata?.custom?.error);
+      const errorBubblesAfterFirst = store(result.current.runtime).messages.filter(
+        (m) => m.role === "assistant" && m.metadata?.custom?.error
+      );
       expect(errorBubblesAfterFirst).toHaveLength(1);
 
       // Simulate another send + error (e.g. user retried, server failed again)
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("retry attempt"));
+        store(result.current.runtime).onNew(makeUserMessage("retry attempt"));
       });
       await act(async () => {
         ws.simulateMessage({ type: "error", message: "Second error" });
       });
 
       // Only ONE error bubble must exist — the new one replaced the old one
-      const errorBubblesAfterSecond = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { error?: { message?: string } } };
-        }>
-      ).filter((m) => m.role === "assistant" && m.metadata?.custom?.error);
+      const errorBubblesAfterSecond = store(result.current.runtime).messages.filter(
+        (m) => m.role === "assistant" && m.metadata?.custom?.error
+      );
       expect(errorBubblesAfterSecond).toHaveLength(1);
       expect(errorBubblesAfterSecond[0].metadata?.custom?.error?.message).toBe("Second error");
     });
@@ -3377,7 +3268,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -3398,10 +3289,7 @@ describe("useWsRuntime", () => {
 
       expect(result.current.isRunning).toBe(false);
 
-      const messages = result.current.runtime.messages as Array<{
-        role: string;
-        metadata?: { custom?: { retryable?: boolean; retryReason?: string } };
-      }>;
+      const messages = store(result.current.runtime).messages;
       const lastMsg = messages[messages.length - 1];
       expect(lastMsg.role).toBe("assistant");
       expect(lastMsg.metadata?.custom?.retryable).toBe(true);
@@ -3460,7 +3348,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello world"));
+        store(result.current.runtime).onNew(makeUserMessage("hello world"));
       });
 
       const ws = latestWs();
@@ -3496,7 +3384,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("write a story"));
+        store(result.current.runtime).onNew(makeUserMessage("write a story"));
       });
 
       const ws = latestWs();
@@ -3533,7 +3421,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("are you there?"));
+        store(result.current.runtime).onNew(makeUserMessage("are you there?"));
       });
 
       const ws = latestWs();
@@ -3569,7 +3457,7 @@ describe("useWsRuntime", () => {
 
       // The retry path resends the last user message, so a message must exist.
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       // isRunning is true after sending; let it settle by completing the turn
@@ -3604,7 +3492,7 @@ describe("useWsRuntime", () => {
 
       // Send a user message
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello retry"));
+        store(result.current.runtime).onNew(makeUserMessage("hello retry"));
       });
 
       const ws = latestWs();
@@ -3622,10 +3510,9 @@ describe("useWsRuntime", () => {
       });
 
       // Verify message is now "failed" by checking the metadata.custom.status
-      const failedMsg = (result.current.runtime.messages as Array<unknown>).find((m) => {
-        const msg = m as { id?: string; metadata?: { custom?: { status?: string } } };
-        return msg.id === messageId && msg.metadata?.custom?.status === "failed";
-      });
+      const failedMsg = store(result.current.runtime).messages.find(
+        (m) => m.id === messageId && m.metadata?.custom?.status === "failed"
+      );
       expect(failedMsg).toBeDefined();
 
       // Clear send call history so we can assert the retry re-send
@@ -3637,10 +3524,9 @@ describe("useWsRuntime", () => {
       });
 
       // Message status should now be "sending" again
-      const retriedMsg = (result.current.runtime.messages as Array<unknown>).find((m) => {
-        const msg = m as { id?: string; metadata?: { custom?: { status?: string } } };
-        return msg.id === messageId && msg.metadata?.custom?.status === "sending";
-      });
+      const retriedMsg = store(result.current.runtime).messages.find(
+        (m) => m.id === messageId && m.metadata?.custom?.status === "sending"
+      );
       expect(retriedMsg).toBeDefined();
 
       // WS send was called again with the SAME clientMessageId and content
@@ -3669,7 +3555,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello"));
+        store(result.current.runtime).onNew(makeUserMessage("hello"));
       });
 
       const ws = latestWs();
@@ -3701,7 +3587,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello retry running"));
+        store(result.current.runtime).onNew(makeUserMessage("hello retry running"));
       });
 
       const ws = latestWs();
@@ -3747,7 +3633,7 @@ describe("useWsRuntime", () => {
       });
 
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("timer test"));
+        store(result.current.runtime).onNew(makeUserMessage("timer test"));
       });
 
       const ws = latestWs();
@@ -3772,10 +3658,9 @@ describe("useWsRuntime", () => {
       });
 
       // After second timeout: message should be "failed" again
-      const failedMsg = (result.current.runtime.messages as Array<unknown>).find((m) => {
-        const msg = m as { id?: string; metadata?: { custom?: { status?: string } } };
-        return msg.id === messageId && msg.metadata?.custom?.status === "failed";
-      });
+      const failedMsg = store(result.current.runtime).messages.find(
+        (m) => m.id === messageId && m.metadata?.custom?.status === "failed"
+      );
       expect(failedMsg).toBeDefined();
     });
   });
@@ -3793,7 +3678,7 @@ describe("useWsRuntime", () => {
 
       // Send a user message — it will have status "sending"
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("hello from user"));
+        store(result.current.runtime).onNew(makeUserMessage("hello from user"));
       });
 
       // Simulate a history reload that contains the user message (it was persisted).
@@ -3817,12 +3702,7 @@ describe("useWsRuntime", () => {
 
       // The reconcile upgraded the in-flight user message from "sending" → "sent"
       // because its content appears in the reloaded history.
-      const userMsg = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user");
+      const userMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
       expect(userMsg?.metadata?.custom?.status).toBe("sent");
     });
 
@@ -3837,7 +3717,7 @@ describe("useWsRuntime", () => {
 
       // Send a user message — it will have status "sending"
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("persisted message"));
+        store(result.current.runtime).onNew(makeUserMessage("persisted message"));
       });
 
       // History reload: contains the user message but no assistant reply yet
@@ -3857,12 +3737,7 @@ describe("useWsRuntime", () => {
       // The user message is reconciled from history → status "sent". (No
       // client-side orphan guess any more — the server's liveness verdict is
       // authoritative for whether the run is still going / failed.)
-      const userMsg = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user");
+      const userMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
       expect(userMsg?.metadata?.custom?.status).toBe("sent");
     });
 
@@ -3877,7 +3752,7 @@ describe("useWsRuntime", () => {
 
       // Send a user message — it will have status "sending"
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("lost message"));
+        store(result.current.runtime).onNew(makeUserMessage("lost message"));
       });
 
       // Simulate a history reload that does NOT contain the message
@@ -3896,12 +3771,7 @@ describe("useWsRuntime", () => {
 
       // The sending message should now be "failed" — it never appeared in
       // history, so the reducer marks it as not delivered.
-      const userMsg = (
-        result.current.runtime.messages as Array<{
-          role: string;
-          metadata?: { custom?: { status?: string } };
-        }>
-      ).find((m) => m.role === "user");
+      const userMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
       expect(userMsg?.metadata?.custom?.status).toBe("failed");
     });
 
@@ -3922,7 +3792,7 @@ describe("useWsRuntime", () => {
 
       // User sends; receive ack but NO chunk yet
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("what's the vacation policy?"));
+        store(result.current.runtime).onNew(makeUserMessage("what's the vacation policy?"));
       });
       const ws = latestWs();
       const sentPayload = JSON.parse(ws.send.mock.calls.at(-1)![0] as string) as {
@@ -3959,11 +3829,7 @@ describe("useWsRuntime", () => {
         await vi.advanceTimersByTimeAsync(50);
       });
 
-      const messages = result.current.runtime.messages as Array<{
-        role: string;
-        content: Array<{ text: string }>;
-        metadata?: { custom?: { error?: unknown } };
-      }>;
+      const messages = store(result.current.runtime).messages;
 
       // No failure bubble — reconcile replaced local state with canonical history
       const errorBubbles = messages.filter(
@@ -4008,12 +3874,7 @@ describe("useWsRuntime", () => {
           });
         });
 
-        const userMsg = (
-          result.current.runtime.messages as Array<{
-            role: string;
-            content: Array<{ type: string; filename?: string; mimeType?: string; text?: string }>;
-          }>
-        ).find((m) => m.role === "user");
+        const userMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
         expect(userMsg).toBeDefined();
         // Text content must be the user's typed text — without the markup block.
         const textPart = userMsg!.content.find((p) => p.type === "text");
@@ -4041,12 +3902,7 @@ describe("useWsRuntime", () => {
             ],
           });
         });
-        const userMsg = (
-          result.current.runtime.messages as Array<{
-            role: string;
-            content: Array<{ type: string; mimeType?: string; filename?: string }>;
-          }>
-        ).find((m) => m.role === "user");
+        const userMsg = store(result.current.runtime).messages.find((m) => m.role === "user");
         expect(userMsg).toBeDefined();
         const filePart = userMsg!.content.find((p) => p.type === "file");
         expect(filePart?.mimeType).toBe("image/jpeg");
@@ -4068,7 +3924,7 @@ describe("useWsRuntime", () => {
 
       // User sends a message → reaches "sending" status.
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("what's the policy?"));
+        store(result.current.runtime).onNew(makeUserMessage("what's the policy?"));
       });
 
       // Drop the connection mid-stream — server-side OC continues but
@@ -4096,8 +3952,8 @@ describe("useWsRuntime", () => {
       // message carries "25 days vacation." yet. (The empty in-flight
       // placeholder from the send path is allowed to exist; only the chunk
       // CONTENT must still be absent.)
-      const midwayMessages = result.current.runtime.messages;
-      const appliedBefore = (midwayMessages as Array<{ role: string; content: unknown }>).find(
+      const midwayMessages = store(result.current.runtime).messages;
+      const appliedBefore = midwayMessages.find(
         (m) => m.role === "assistant" && JSON.stringify(m.content).includes("25 days vacation.")
       );
       expect(appliedBefore).toBeUndefined();
@@ -4119,10 +3975,7 @@ describe("useWsRuntime", () => {
 
       // After drain, the assistant message anchored to msg-server-1 has
       // received the chunk's content.
-      const afterMessages = result.current.runtime.messages as Array<{
-        role: string;
-        content: unknown;
-      }>;
+      const afterMessages = store(result.current.runtime).messages;
       const assistantAfter = afterMessages.find((m) => m.role === "assistant");
       expect(assistantAfter).toBeDefined();
       // assistant-ui content shape: array of parts. We expect the chunk
@@ -4130,7 +3983,7 @@ describe("useWsRuntime", () => {
       const flat = JSON.stringify(assistantAfter!.content);
       expect(flat).toContain("25 days vacation.");
       // isRunning preserved across reconnect via the activeRun signal.
-      expect(result.current.runtime.isRunning).toBe(true);
+      expect(store(result.current.runtime).isRunning).toBe(true);
     });
 
     it("does NOT buffer chunks on the very first connect (no recovery context, no race window)", async () => {
@@ -4152,7 +4005,7 @@ describe("useWsRuntime", () => {
       // The chunk was applied (not buffered then drained — that's still
       // visible to the user the same way, but observably isRunning
       // transitions immediately rather than only after history).
-      expect(result.current.runtime.isRunning).toBe(true);
+      expect(store(result.current.runtime).isRunning).toBe(true);
     });
 
     // PR #442 review fix: when shouldStageReplace would normally fire (local
@@ -4189,7 +4042,7 @@ describe("useWsRuntime", () => {
 
       // User retries.
       await act(async () => {
-        result.current.runtime.onNew(makeUserMessage("retry"));
+        store(result.current.runtime).onNew(makeUserMessage("retry"));
       });
 
       // WS drops mid-stream — server-side OC continues.
@@ -4229,16 +4082,11 @@ describe("useWsRuntime", () => {
       // The buffered chunk's text must be present in the in-flight assistant
       // message — proving drain landed on the post-reconcile state, not the
       // pre-stage state that the staged path would have wiped.
-      const messages = result.current.runtime.messages as Array<{
-        role: string;
-        content: unknown;
-      }>;
+      const messages = store(result.current.runtime).messages;
       const flat = JSON.stringify(messages);
       expect(flat).toContain("retry-answer");
       // No lingering error bubble — reconcile wiped it.
-      const errorBubbles = messages.filter(
-        (m) => (m as { metadata?: { custom?: { error?: unknown } } }).metadata?.custom?.error
-      );
+      const errorBubbles = messages.filter((m) => m.metadata?.custom?.error);
       expect(errorBubbles).toHaveLength(0);
     });
   });
@@ -4288,13 +4136,15 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
       id: "upload-id-1",
       filename: "test.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     // Add a file via addPendingUpload and wait for it to reach "ready"
@@ -4305,7 +4155,7 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     expect(result.current.pendingUploads[0]?.state).toBe("ready");
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "see this" }],
         parentId: "root",
       });
@@ -4321,13 +4171,15 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     vi.mocked(uploadModule.uploadAttachment).mockResolvedValue({
       id: "upload-id-2",
       filename: "doc.pdf",
+      mimeType: "application/pdf",
+      sizeBytes: 4,
     });
 
     const { result } = renderHook(() => useWsRuntime("agent-1"));
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     await act(async () => {
@@ -4337,7 +4189,7 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     expect(result.current.pendingUploads).toHaveLength(1);
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "send it" }],
         parentId: "root",
       });
@@ -4353,7 +4205,7 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     // calls[0] is the history request — clear it
@@ -4365,7 +4217,7 @@ describe("Two-phase upload: attachmentIds in WS payload", () => {
 
     // File is still "uploading" (promise never resolves) — send with empty text
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "" }],
         parentId: "root",
       });
@@ -4394,11 +4246,11 @@ describe("PROTOCOL_OUTDATED error handling", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
@@ -4407,9 +4259,7 @@ describe("PROTOCOL_OUTDATED error handling", () => {
     expect(result.current.isRunning).toBe(true);
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "error", code: "PROTOCOL_OUTDATED" }),
-      });
+      ws.simulateMessage({ type: "error", code: "PROTOCOL_OUTDATED" });
     });
 
     expect(result.current.isRunning).toBe(false);
@@ -4427,25 +4277,23 @@ describe("PROTOCOL_OUTDATED error handling", () => {
     const ws = wsInstances[0];
 
     act(() => {
-      ws.onopen?.();
+      ws.simulateOpen();
     });
 
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
-    const messagesBefore = result.current.runtime.messages.length;
+    const messagesBefore = store(result.current.runtime).messages.length;
 
     act(() => {
-      ws.onmessage?.({
-        data: JSON.stringify({ type: "error", code: "PROTOCOL_OUTDATED" }),
-      });
+      ws.simulateMessage({ type: "error", code: "PROTOCOL_OUTDATED" });
     });
 
-    expect(result.current.runtime.messages).toHaveLength(messagesBefore);
+    expect(store(result.current.runtime).messages).toHaveLength(messagesBefore);
   });
 });
 
@@ -4496,15 +4344,15 @@ describe("user-triggered abort (onCancel) (#550)", () => {
       ws.onopen?.(new Event("open"));
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     act(() => {
-      result.current.runtime.onCancel?.();
+      store(result.current.runtime).onCancel?.();
     });
 
     const abortFrames = sentFramesOfType(ws, "abort");
@@ -4520,14 +4368,14 @@ describe("user-triggered abort (onCancel) (#550)", () => {
       ws.onopen?.(new Event("open"));
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
 
     act(() => {
-      result.current.runtime.onCancel?.();
+      store(result.current.runtime).onCancel?.();
     });
 
     const abortFrames = sentFramesOfType(ws, "abort");
@@ -4543,18 +4391,18 @@ describe("user-triggered abort (onCancel) (#550)", () => {
       ws.onopen?.(new Event("open"));
     });
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
     });
-    expect(result.current.runtime.isRunning).toBe(true);
+    expect(store(result.current.runtime).isRunning).toBe(true);
 
     act(() => {
-      result.current.runtime.onCancel?.();
+      store(result.current.runtime).onCancel?.();
     });
 
-    expect(result.current.runtime.isRunning).toBe(false);
+    expect(store(result.current.runtime).isRunning).toBe(false);
   });
 });
 
@@ -4710,7 +4558,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
       });
     });
 
-    const messages = result.current.runtime.messages as { role: string }[];
+    const messages = store(result.current.runtime).messages;
     expect(JSON.stringify(messages)).toContain("a2-from-device-A");
     expect(messages.filter((m) => m.role === "assistant")).toHaveLength(2);
   });
@@ -4724,7 +4572,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     });
     // Stream a full assistant turn locally (Lane A), like the sending device.
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });
@@ -4752,7 +4600,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
         ],
       });
     });
-    const messages = result.current.runtime.messages as { role: string; content: unknown }[];
+    const messages = store(result.current.runtime).messages;
     const dupes = messages.filter(
       (m) =>
         m.role === "assistant" && JSON.stringify(m.content).includes("Integration test response.")
@@ -4769,7 +4617,7 @@ describe("useWsRuntime — multi-device live-sync (poke + focus)", () => {
     });
     // Start streaming a turn — isRunning=true, no `complete` yet.
     act(() => {
-      result.current.runtime.onNew({
+      store(result.current.runtime).onNew({
         content: [{ type: "text", text: "Hello" }],
         parentId: "root",
       });

--- a/packages/web/src/__tests__/lib/agent-templates.test.ts
+++ b/packages/web/src/__tests__/lib/agent-templates.test.ts
@@ -14,6 +14,19 @@ import { MAX_STARTER_PROMPT_LENGTH } from "@/lib/schemas/starter-prompts";
 import { TEMPLATE_ICON_COMPONENTS } from "@/lib/template-icons";
 import { getOdooToolsForAccessLevel } from "@/lib/tool-registry";
 
+/**
+ * Real (non-`custom`) templates always ship a non-null `defaultAgentsMd` —
+ * only `AgentTemplate`'s shared type (also covering the null-bodied `custom`
+ * template) allows null. Narrow honestly instead of silently treating a
+ * regression as an empty string.
+ */
+function requireAgentsMd(template: { defaultAgentsMd: string | null }, label: string): string {
+  if (template.defaultAgentsMd === null) {
+    throw new Error(`${label} has no defaultAgentsMd`);
+  }
+  return template.defaultAgentsMd;
+}
+
 describe("implicit-tool guard", () => {
   it("no template references implicit tools pinchy_ls or pinchy_read in allowedTools", () => {
     for (const [id, tpl] of Object.entries(AGENT_TEMPLATES)) {
@@ -117,7 +130,11 @@ describe("agent-templates", () => {
   });
 
   it("should not have old defaultSoulMd or defaultGreeting fields", () => {
-    const kb = AGENT_TEMPLATES["knowledge-base"] as Record<string, unknown>;
+    // Boundary cast: this regression guard deliberately probes for legacy
+    // keys that AgentTemplate no longer declares at all (that's the point —
+    // proving they're gone), so it can't be typed as a normal AgentTemplate
+    // read. AgentTemplate has no index signature, hence the `unknown` step.
+    const kb = AGENT_TEMPLATES["knowledge-base"] as unknown as Record<string, unknown>;
     expect(kb.defaultSoulMd).toBeUndefined();
     expect(kb.defaultGreeting).toBeUndefined();
   });
@@ -274,7 +291,7 @@ describe("agent-templates", () => {
       // Persona-only AGENTS.md: Capabilities/Workflow Guidelines sections that
       // just re-describe the shared tools belong in the email skill now.
       for (const id of emailTemplateIds) {
-        const md = AGENT_TEMPLATES[id].defaultAgentsMd.toLowerCase();
+        const md = requireAgentsMd(AGENT_TEMPLATES[id], id).toLowerCase();
         expect(md, `${id} should not have a Capabilities section`).not.toMatch(/## capabilities/);
         expect(md, `${id} should not have a Workflow Guidelines section`).not.toMatch(
           /## workflow guidelines/
@@ -785,8 +802,9 @@ describe("Additional Odoo templates (10 new)", () => {
     expect(grantedModels).not.toContain("sale.subscription");
 
     // If sale.subscription is mentioned at all, it must be guarded
-    if (/sale\.subscription/.test(t.defaultAgentsMd)) {
-      expect(t.defaultAgentsMd).toMatch(
+    const agentsMd = requireAgentsMd(t, "odoo-subscription-manager");
+    if (/sale\.subscription/.test(agentsMd)) {
+      expect(agentsMd).toMatch(
         /may not exist|if available|if (the )?model exists|check.*odoo_schema|not granted|legacy.*may/i
       );
     }
@@ -1627,8 +1645,9 @@ describe("Odoo CRM & Sales Assistant template — quotation-ready model coverage
     // LLM actually reads at runtime. If someone reworks AGENTS.md and drops
     // the boundary sentence, this fails.
     const t = getTemplate(id)!;
-    expect(t.defaultAgentsMd).toMatch(/never.*(draft|post|amend).*invoic/i);
-    expect(t.defaultAgentsMd.toLowerCase()).toContain("bookkeeper");
+    const agentsMd = requireAgentsMd(t, id);
+    expect(agentsMd).toMatch(/never.*(draft|post|amend).*invoic/i);
+    expect(agentsMd.toLowerCase()).toContain("bookkeeper");
   });
 
   it("AGENTS.md warns about the sale.order confirmation → invoice path explicitly", () => {
@@ -1640,7 +1659,7 @@ describe("Odoo CRM & Sales Assistant template — quotation-ready model coverage
     // the AGENTS.md must name the confirmation path so the LLM understands
     // *why* this is a separate restriction from generic account.move writes.
     const t = getTemplate(id)!;
-    const lower = t.defaultAgentsMd.toLowerCase();
+    const lower = requireAgentsMd(t, id).toLowerCase();
     expect(lower).toContain("confirm"); // mentions sale order confirmation
     expect(lower).toMatch(/_create_invoices|create invoice/); // names the forbidden action
   });

--- a/packages/web/src/__tests__/lib/audit-append.test.ts
+++ b/packages/web/src/__tests__/lib/audit-append.test.ts
@@ -99,6 +99,7 @@ describe("appendAuditLog", () => {
       actorType: "system",
       actorId: "sys-1",
       eventType: "config.changed",
+      detail: { setting: "audit_hmac_secret" },
       outcome: "success",
     });
 
@@ -395,25 +396,24 @@ describe("appendAuditLog", () => {
     expect(inserted.prevHmac).toBeNull();
   });
 
-  it("accepts attachment.uploaded with the required detail shape", async () => {
+  // `attachment.uploaded` was removed as a dead AuditEventType (see
+  // efa9cbc4); `file.upload.staged` is its current surviving analog for "a
+  // file was uploaded" — same round-trip intent, real event shape.
+  it("accepts file.upload.staged with the required detail shape", async () => {
     await expect(
       appendAuditLog({
-        eventType: "attachment.uploaded",
+        eventType: "file.upload.staged",
         actorType: "user",
         actorId: "user-123",
         resource: "agent-1",
         outcome: "success",
         detail: {
+          uploadId: "upload-1",
+          filename: "invoice.pdf",
+          mimeType: "application/pdf",
+          sizeBytes: 245_000,
+          contentHash: "abc123",
           agent: { id: "agent-1", name: "Smithers" },
-          uploader: { id: "user-123", name: "Alice Carter" },
-          attachment: {
-            filename: "invoice.pdf",
-            detectedMimeType: "application/pdf",
-            sizeBytes: 245_000,
-            contentHash: "abc123",
-            reused: false,
-          },
-          sessionKey: "agent:agent-1:direct:user-123",
         },
       })
     ).resolves.toBeDefined();
@@ -490,6 +490,7 @@ describe("appendAuditLog", () => {
         actorType: "system",
         actorId: "upload-gc",
         eventType: "config.changed",
+        detail: { setting: "test" },
         outcome: "success",
       });
 

--- a/packages/web/src/__tests__/lib/audit-chain.integration.test.ts
+++ b/packages/web/src/__tests__/lib/audit-chain.integration.test.ts
@@ -24,7 +24,10 @@ async function appendRow(actorId: string) {
     actorId,
     eventType: "auth.login",
     resource: `user:${actorId}`,
-    detail: null,
+    // `auth.*` entries carry an optional detail (Record<string, unknown> |
+    // undefined, no `null` member) — appendAuditLog itself normalizes a
+    // missing detail to null before writing, so omitting it here has the
+    // exact same runtime effect as the old `detail: null`.
     outcome: "success",
   });
 }

--- a/packages/web/src/__tests__/lib/audit-diagnostics-event.test.ts
+++ b/packages/web/src/__tests__/lib/audit-diagnostics-event.test.ts
@@ -10,10 +10,14 @@ describe("diagnostics.exported audit event", () => {
       resource: "diagnostics:agt_1",
       detail: {
         agent: { id: "agt_1", name: "Smithers" },
+        // null: the default/legacy chat (#639) — this fixture isn't exercising
+        // the Telegram-peer-export path.
+        chatId: null,
         scope: { anchorTurnIndex: 5, includedTurnRange: [2, 5] },
         byteSize: 4321,
         droppedTurns: 0,
         truncated: false,
+        trajectoryMissing: false,
       },
       outcome: "success",
     };

--- a/packages/web/src/__tests__/lib/audit-types.test.ts
+++ b/packages/web/src/__tests__/lib/audit-types.test.ts
@@ -1,41 +1,54 @@
 import { describe, it, expectTypeOf } from "vitest";
 import type { AuditLogEntry, AuditEventType } from "@/lib/audit";
 
+// Compile-time type tests. They run under `pnpm -C packages/web typecheck`
+// (which type-checks test files); vitest does NOT type-check `expectTypeOf`
+// at runtime, so without that gate these assertions are no-ops.
+//
+// The previous `expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>()`
+// could never hold — and silently guarded nothing while test files went
+// unchecked. `AuditLogEntry["eventType"]` is the broad write-time shape
+// (template-literal families like `chat.${string}`, `${AuditResource}.updated`),
+// strictly WIDER than the curated flat `AuditEventType` union, so the two are
+// not equal by design. These assertions test the relationships that actually
+// hold instead.
+
 describe("AuditLogEntry agent.memory_changed", () => {
-  it("accepts the expected detail shape", () => {
-    const entry: AuditLogEntry = {
-      actorType: "agent",
-      actorId: "agent-123",
-      eventType: "agent.memory_changed",
-      resource: "agent:agent-123",
-      outcome: "success",
-      detail: {
-        agent: { id: "agent-123", name: "Smithers" },
-        file: "MEMORY.md",
-        addedLines: 3,
-        removedLines: 1,
-        byteSize: 512,
-      },
-    };
-    expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>();
+  it("types the detail shape and keeps the event in the curated union", () => {
+    // The detail shape required for an `agent.memory_changed` entry.
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "agent.memory_changed" }>["detail"]
+    >().toEqualTypeOf<{
+      agent: { id: string; name: string };
+      file: string;
+      addedLines: number;
+      removedLines: number;
+      byteSize: number;
+    }>();
+    // The event must remain a member of the curated AuditEventType union.
+    expectTypeOf<"agent.memory_changed">().toExtend<AuditEventType>();
   });
 });
 
 describe("AuditLogEntry channel.auto_disabled (#477 layer 2)", () => {
-  it("accepts the expected detail shape", () => {
-    const entry: AuditLogEntry = {
-      actorType: "system",
-      actorId: "channel-watchdog",
-      eventType: "channel.auto_disabled",
-      resource: "agent:agent-123",
-      outcome: "success",
-      detail: {
-        channel: "telegram",
-        account: { id: "agent-123", name: "Support Bot" },
-        reason: "polling_conflict",
-        lastError: "Conflict: terminated by other getUpdates request",
-      },
-    };
-    expectTypeOf(entry.eventType).toEqualTypeOf<AuditEventType>();
+  it("types the detail shape and keeps the event in the curated union", () => {
+    expectTypeOf<
+      Extract<AuditLogEntry, { eventType: "channel.auto_disabled" }>["detail"]
+    >().toEqualTypeOf<{
+      channel: string;
+      account: { id: string; name: string | null };
+      reason: string;
+      lastError: string | null;
+    }>();
+    expectTypeOf<"channel.auto_disabled">().toExtend<AuditEventType>();
+  });
+});
+
+describe("AuditEventType is a subset of AuditLogEntry['eventType']", () => {
+  it("every curated event type is one appendAuditLog can record", () => {
+    // Intentionally NOT equal (the entry type is strictly broader), but the
+    // curated list must stay a SUBSET of what an entry can carry — otherwise it
+    // would advertise an event that appendAuditLog cannot actually write.
+    expectTypeOf<AuditEventType>().toExtend<AuditLogEntry["eventType"]>();
   });
 });

--- a/packages/web/src/__tests__/lib/chat-list-cache.test.ts
+++ b/packages/web/src/__tests__/lib/chat-list-cache.test.ts
@@ -21,6 +21,10 @@ const item = (chatId: string | null, title: string): ChatListItem => ({
   sessionId: `session-${chatId ?? "default"}`,
   title,
   origin: "web",
+  // Web-origin chats are always writable from the web UI (classify-sessions.ts
+  // pairs origin: "web" with writable: true); only the read-only Telegram
+  // mirror carries writable: false.
+  writable: true,
   lastInteractionAt: 1_700_000_000_000,
 });
 

--- a/packages/web/src/__tests__/lib/diagnostics/audit-collector.integration.test.ts
+++ b/packages/web/src/__tests__/lib/diagnostics/audit-collector.integration.test.ts
@@ -75,7 +75,10 @@ describe("fetchAuditEntriesForSession (integration)", () => {
     const rows = await fetchAuditEntriesForSession(agentId, userId);
     expect(rows).toHaveLength(2);
 
-    const row = rows[0] as Record<string, unknown>;
+    // CollectedAuditEntry already declares every field this test reads — no
+    // cast to a generic Record needed (TS2352: it doesn't structurally
+    // overlap with an index-signature type anyway).
+    const row = rows[0];
     expect(row.eventType).toMatch(/^tool\./);
     expect(row.actorType).toBe("user");
     expect(row.outcome).toBe("success");
@@ -110,7 +113,7 @@ describe("fetchAuditEntriesForSession (integration)", () => {
 
     const rows = await fetchAuditEntriesForSession(agentId, userId);
     expect(rows).toHaveLength(1);
-    const row = rows[0] as Record<string, unknown>;
+    const row = rows[0];
     expect(row.actorId).toBe(userId);
   });
 
@@ -138,7 +141,7 @@ describe("fetchAuditEntriesForSession (integration)", () => {
 
     const rows = await fetchAuditEntriesForSession(agentId, userId);
     expect(rows).toHaveLength(1);
-    expect((rows[0] as Record<string, unknown>).resource).toBe(`agent:${agentId}`);
+    expect(rows[0].resource).toBe(`agent:${agentId}`);
   });
 
   it("returns an empty array when no rows match", async () => {

--- a/packages/web/src/__tests__/lib/integrations/oauth-token.test.ts
+++ b/packages/web/src/__tests__/lib/integrations/oauth-token.test.ts
@@ -62,7 +62,11 @@ describe("oauth-token", () => {
     });
 
     it("throws when expires_in is undefined (field missing from token response)", () => {
-      expect(() => computeExpiresAt(undefined)).toThrow(/expires_in/);
+      // Every provider parses its token response with a type assertion, not
+      // runtime validation (see computeExpiresAt's own comment), so a real
+      // response missing expires_in reaches this call as undefined despite
+      // the `number` parameter type. Simulate that boundary explicitly.
+      expect(() => computeExpiresAt(undefined as unknown as number)).toThrow(/expires_in/);
     });
 
     it("throws when expires_in is not a number", () => {

--- a/packages/web/src/__tests__/lib/invites.test.ts
+++ b/packages/web/src/__tests__/lib/invites.test.ts
@@ -132,7 +132,7 @@ describe("createInvite", () => {
       id: "inv-2",
       tokenHash: "hash",
       email: "user@test.com",
-      role: "editor",
+      role: "admin",
       type: "invite",
       createdBy: "admin-1",
       expiresAt: new Date(),
@@ -145,14 +145,14 @@ describe("createInvite", () => {
     const { createInvite } = await import("@/lib/invites");
     await createInvite({
       email: "user@test.com",
-      role: "editor",
+      role: "admin",
       createdBy: "admin-1",
     });
 
     expect(valuesMock).toHaveBeenCalledWith(
       expect.objectContaining({
         email: "user@test.com",
-        role: "editor",
+        role: "admin",
         type: "invite",
         createdBy: "admin-1",
         tokenHash: expect.any(String),

--- a/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
+++ b/packages/web/src/__tests__/lib/memory-audit-watcher/handle-event.test.ts
@@ -1,5 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import { handleMemoryFileEvent } from "@/lib/memory-audit-watcher/handle-event";
+import type { AuditLogEntry } from "@/lib/audit";
+
+// Bare `vi.fn()` types as `Mock<Procedure | Constructable>` (ReturnType of a
+// generic function instantiates the type param at its constraint, not its
+// default), which isn't assignable to HandleMemoryEventDeps' concrete
+// function-typed fields. Bind the real signatures explicitly instead.
+type LookupAgentFn = (agentId: string) => Promise<{ id: string; name: string } | null>;
+type AppendAuditLogFn = (entry: AuditLogEntry) => Promise<unknown>;
 
 describe("handleMemoryFileEvent", () => {
   // Workspace base: agents live at `<root>/<agentId>/` (no `agents/` prefix —
@@ -7,14 +15,14 @@ describe("handleMemoryFileEvent", () => {
   const root = "/openclaw-config/workspaces";
   let snapshots: Map<string, string>;
   let inflight: Map<string, Promise<void>>;
-  let mockAppend: ReturnType<typeof vi.fn>;
-  let mockLookupAgent: ReturnType<typeof vi.fn>;
+  let mockAppend: Mock<AppendAuditLogFn>;
+  let mockLookupAgent: Mock<LookupAgentFn>;
 
   beforeEach(() => {
     snapshots = new Map();
     inflight = new Map();
-    mockAppend = vi.fn().mockResolvedValue(undefined);
-    mockLookupAgent = vi.fn().mockResolvedValue({ id: "agent-1", name: "Smithers" });
+    mockAppend = vi.fn<AppendAuditLogFn>().mockResolvedValue(undefined);
+    mockLookupAgent = vi.fn<LookupAgentFn>().mockResolvedValue({ id: "agent-1", name: "Smithers" });
   });
 
   it("emits audit on first change (file added post-ready)", async () => {

--- a/packages/web/src/__tests__/lib/odoo-template-tool-refs.test.ts
+++ b/packages/web/src/__tests__/lib/odoo-template-tool-refs.test.ts
@@ -21,7 +21,15 @@ describe("Odoo template tool references", () => {
 
   for (const template of odooTemplates) {
     it(`${template.name}: only references registered odoo_* tools`, () => {
-      const referenced = [...new Set(template.defaultAgentsMd.match(/odoo_[a-z_]+/g) ?? [])];
+      // Every Odoo template is built via createOdooTemplate(), which always
+      // sets a non-null defaultAgentsMd; only the type-level AgentTemplate
+      // (shared with the null-bodied `custom` template) allows null. Guard
+      // honestly instead of silently treating a regression as "no tools".
+      const agentsMd = template.defaultAgentsMd;
+      if (agentsMd === null) {
+        throw new Error(`${template.name} has no defaultAgentsMd`);
+      }
+      const referenced = [...new Set(agentsMd.match(/odoo_[a-z_]+/g) ?? [])];
       const invalid = referenced.filter((name) => !validOdooTools.has(name));
       expect(invalid).toEqual([]);
     });

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -426,7 +426,7 @@ describe("regenerateOpenClawConfig", () => {
     // removed → restart-class change → SIGUSR1 cascade that delays agents.list
     // hot-reload (the setup-wizard "unknown agent id" / #193 flake on 2026.5.28).
     // Pinchy must always emit the same origins OC seeds.
-    mockedReadFileSync.mockReturnValue("" as unknown as Buffer); // cold start: no existing config
+    mockedReadFileSync.mockReturnValue(""); // cold start: no existing config
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "anthropic_api_key") return "sk-ant-key";
       if (key === "default_provider") return "anthropic";
@@ -457,7 +457,7 @@ describe("regenerateOpenClawConfig", () => {
         controlUi: { enabled: false, allowedOrigins: ["http://oc-enriched.example:18789"] },
       },
     });
-    mockedReadFileSync.mockReturnValue(ocEnriched as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(ocEnriched);
     mockedGetSetting.mockImplementation(async (key: string) => {
       if (key === "anthropic_api_key") return "sk-ant-key";
       if (key === "default_provider") return "anthropic";
@@ -580,7 +580,7 @@ describe("regenerateOpenClawConfig", () => {
     mockedReadFileSync.mockReturnValue(
       JSON.stringify({
         media: { ttlHours: 12, someOtherEnrichedField: "keep-me" },
-      }) as unknown as Buffer
+      })
     );
 
     await regenerateOpenClawConfig();
@@ -2877,7 +2877,7 @@ describe("regenerateOpenClawConfig", () => {
           defaults: { heartbeat: { mode: "visible" } },
           telegram: { enabled: true, dmPolicy: "pairing", accounts: { "stale-agent": {} } },
         },
-      }) as unknown as Buffer
+      })
     );
 
     await regenerateOpenClawConfig();
@@ -3469,7 +3469,7 @@ describe("regenerateOpenClawConfig", () => {
         JSON.stringify({
           meta: metaBlock,
           gateway: { mode: "local" },
-        }) as unknown as Buffer
+        })
       );
 
       await regenerateOpenClawConfig();
@@ -3700,7 +3700,7 @@ describe("regenerateOpenClawConfig", () => {
       mockedReadFileSync.mockReturnValue(
         JSON.stringify({
           gateway: { mode: "local" },
-        }) as unknown as Buffer
+        })
       );
 
       await regenerateOpenClawConfig();
@@ -3881,7 +3881,7 @@ describe("regenerateOpenClawConfig", () => {
           JSON.stringify({
             meta: { version: "5.3.0", lastTouchedAt: "2026-01-01T00:00:00Z" },
             gateway: { mode: "local", bind: "lan", auth: { token: "tok" } },
-          }) as unknown as Buffer
+          })
         );
 
         // Start coroutine 1 (OLD). Its first config.get() rejects on the next
@@ -3941,7 +3941,7 @@ describe("regenerateOpenClawConfig", () => {
         mockGetClient.mockReturnValue({
           config: { get: mockConfigGet, apply: mockConfigApply },
         });
-        mockedReadFileSync.mockReturnValue(JSON.stringify(existingOcConfig) as unknown as Buffer);
+        mockedReadFileSync.mockReturnValue(JSON.stringify(existingOcConfig));
 
         pushConfigInBackground(JSON.stringify({ env: { X: "1" } }));
 
@@ -4258,7 +4258,7 @@ describe("seedRestartClassOverridesIfMissing", () => {
       update: { checkOnStart: false },
       canvasHost: { enabled: false },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     const changed = seedRestartClassOverridesIfMissing();
 
@@ -4280,7 +4280,7 @@ describe("seedRestartClassOverridesIfMissing", () => {
       update: { checkOnStart: false },
       canvasHost: { enabled: false },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     const changed = seedRestartClassOverridesIfMissing();
 
@@ -4314,7 +4314,7 @@ describe("seedRestartClassOverridesIfMissing", () => {
       update: { checkOnStart: false },
       canvasHost: { enabled: false },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     const changed = seedRestartClassOverridesIfMissing();
 
@@ -4343,7 +4343,7 @@ describe("seedRestartClassOverridesIfMissing", () => {
       agents: { list: [{ id: "preserved-agent", name: "Preserved" }] },
       plugins: { allow: ["pinchy-audit"], entries: { "pinchy-audit": { enabled: true } } },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     seedRestartClassOverridesIfMissing();
 
@@ -4424,7 +4424,7 @@ describe("seedGatewayTokenIfMissing", () => {
     const existing = {
       gateway: { mode: "local", bind: "lan", auth: { token: "already-seeded-xyz" } },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     const changed = await seedGatewayTokenIfMissing();
 
@@ -4449,7 +4449,7 @@ describe("seedGatewayTokenIfMissing", () => {
       update: { checkOnStart: false },
       canvasHost: { enabled: false },
     };
-    mockedReadFileSync.mockReturnValue(JSON.stringify(existing) as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(existing));
 
     await seedGatewayTokenIfMissing();
 

--- a/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/agent-auth-profiles.test.ts
@@ -23,7 +23,10 @@ vi.mock("fs", async (importOriginal) => {
 });
 
 import * as fs from "fs";
-import { writeAgentAuthProfiles } from "@/lib/openclaw-config/agent-auth-profiles";
+import {
+  writeAgentAuthProfiles,
+  type WriteAgentAuthProfilesParams,
+} from "@/lib/openclaw-config/agent-auth-profiles";
 
 describe("writeAgentAuthProfiles", () => {
   let tmpDir: string;
@@ -79,7 +82,13 @@ describe("writeAgentAuthProfiles", () => {
   });
 
   it("is idempotent — writing the same input twice produces identical bytes", async () => {
-    const params = { configRoot: tmpDir, agentId: "a", providers: ["anthropic"] as const };
+    // Explicit param type (not `as const`) — `providers` must stay the mutable
+    // AuthProfilesProvider[] the function expects, not a readonly tuple.
+    const params: WriteAgentAuthProfilesParams = {
+      configRoot: tmpDir,
+      agentId: "a",
+      providers: ["anthropic"],
+    };
     await writeAgentAuthProfiles(params);
     const first = fs.readFileSync(path.join(tmpDir, "agents", "a", "agent", "auth-profiles.json"));
     await writeAgentAuthProfiles(params);

--- a/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config/normalize.test.ts
@@ -33,7 +33,7 @@ describe("supplementPayloadWithFileFields", () => {
     const file = JSON.stringify({
       plugins: { allow: ["pinchy-audit", "anthropic", "telegram"] },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({ plugins: { allow: ["pinchy-audit"] } });
     const result = JSON.parse(supplementPayloadWithFileFields(payload));
@@ -48,7 +48,7 @@ describe("supplementPayloadWithFileFields", () => {
     const file = JSON.stringify({
       plugins: { allow: ["pinchy-files", "anthropic"] },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({ plugins: { allow: [] } });
     const result = JSON.parse(supplementPayloadWithFileFields(payload));
@@ -65,7 +65,7 @@ describe("supplementPayloadWithFileFields", () => {
         entries: { anthropic: { enabled: true } },
       },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       plugins: { allow: ["pinchy-audit"], entries: { "pinchy-audit": { enabled: true } } },
@@ -82,7 +82,7 @@ describe("supplementPayloadWithFileFields", () => {
         entries: { "pinchy-audit": { enabled: false, staleField: "old" } },
       },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       plugins: { allow: [], entries: { "pinchy-audit": { enabled: true } } },
@@ -101,7 +101,7 @@ describe("supplementPayloadWithFileFields", () => {
         controlUi: { allowedOrigins: ["http://localhost:18789"] },
       },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({ gateway: { mode: "local", auth: { token: "tok" } } });
     const result = JSON.parse(supplementPayloadWithFileFields(payload));
@@ -114,7 +114,7 @@ describe("supplementPayloadWithFileFields", () => {
     const file = JSON.stringify({
       gateway: { controlUi: { allowedOrigins: ["old"] } },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       gateway: { controlUi: { allowedOrigins: ["new"] } },
@@ -126,7 +126,7 @@ describe("supplementPayloadWithFileFields", () => {
 
   it("returns payload unchanged when file has nothing to supplement", () => {
     const file = JSON.stringify({ agents: { list: [] } });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       gateway: { mode: "local" },
@@ -244,7 +244,7 @@ describe("supplementPayloadWithOcConfig", () => {
         providers: { anthropic: { baseUrl: "https://mock.api:443", apiKey: "sk-ant-resolved" } },
       },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       models: {
@@ -361,7 +361,7 @@ describe("supplementPayloadWithOcConfig", () => {
       update: { checkOnStart: false, lastCheckedAt: "T1" },
       canvasHost: { enabled: false, port: 18790 },
     });
-    mockedReadFileSync.mockReturnValue(file as unknown as Buffer);
+    mockedReadFileSync.mockReturnValue(file);
 
     const payload = JSON.stringify({
       discovery: { mdns: { mode: "off" } },

--- a/packages/web/src/__tests__/lib/personality-presets.test.ts
+++ b/packages/web/src/__tests__/lib/personality-presets.test.ts
@@ -3,9 +3,18 @@ import {
   PERSONALITY_PRESETS,
   getPersonalityPreset,
   resolveGreetingMessage,
+  type PersonalityPresetId,
 } from "@/lib/personality-presets";
 
-const EXPECTED_IDS = ["the-butler", "the-professor", "the-pilot", "the-coach"];
+// Typed as PersonalityPresetId[] (not inferred string[]) so `it.each` binds
+// `id` to the real key type — PERSONALITY_PRESETS is a Record keyed by that
+// union, and a bare `string` can't index it.
+const EXPECTED_IDS: PersonalityPresetId[] = [
+  "the-butler",
+  "the-professor",
+  "the-pilot",
+  "the-coach",
+];
 
 describe("PERSONALITY_PRESETS", () => {
   it("has exactly 4 presets", () => {

--- a/packages/web/src/__tests__/lib/usage-poller.test.ts
+++ b/packages/web/src/__tests__/lib/usage-poller.test.ts
@@ -1,9 +1,20 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
 
+// Real row shapes the mocked `db.select().from(...)` chain resolves to.
+type AgentRow = { id: string; name: string };
+type UserRow = { id: string };
+
 const mockRecordUsage = vi.fn();
 const mockRecordSessionTurns = vi.fn();
 const mockSelect = vi.fn();
-const mockFrom = vi.fn();
+// `_agentResult`/`_userResult` are real, typed properties on the mock (via
+// Object.assign) rather than stashed untyped fields — they let each test
+// drive what the mocked `from()`/`where()` chain returns per table without a
+// `Mock<Procedure>` type violation.
+const mockFrom = Object.assign(vi.fn(), {
+  _agentResult: [] as AgentRow[],
+  _userResult: [] as UserRow[],
+});
 
 vi.mock("@/lib/usage", () => ({
   recordUsage: (...args: unknown[]) => mockRecordUsage(...args),

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -1,10 +1,22 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 
+// Matches usage.ts's `sum(usageRecords.*Tokens)` select shape — Postgres SUM
+// comes back as text (string) or null when there are no prior rows.
+type PrevSumRow = {
+  totalInput: string | null;
+  totalOutput: string | null;
+  totalCacheRead: string | null;
+  totalCacheWrite: string | null;
+};
+
 const mockInsert = vi.fn();
 const mockValues = vi.fn();
 const mockSelect = vi.fn();
 const mockFrom = vi.fn();
-const mockWhere = vi.fn();
+// `_result` is a real, typed property on the mock (via Object.assign) rather
+// than a stashed untyped field — it lets each test drive what the mocked
+// `where()` call returns without a `Mock<Procedure>` type violation.
+const mockWhere = Object.assign(vi.fn(), { _result: [] as PrevSumRow[] });
 
 vi.mock("@/db", () => ({
   db: {

--- a/packages/web/src/__tests__/middleware/csrf-gate.test.ts
+++ b/packages/web/src/__tests__/middleware/csrf-gate.test.ts
@@ -38,7 +38,9 @@ function makeRes(): ServerResponse & {
   _body?: string;
 } {
   const res = {
+    _statusCode: undefined as number | undefined,
     _headers: {} as Record<string, string>,
+    _body: undefined as string | undefined,
     writeHead(status: number, headers: Record<string, string>) {
       this._statusCode = status;
       this._headers = headers;

--- a/packages/web/src/__tests__/schema-notification-recipients.test.ts
+++ b/packages/web/src/__tests__/schema-notification-recipients.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { getTableColumns } from "drizzle-orm";
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableColumns, type SQL } from "drizzle-orm";
+import { getTableConfig, type IndexedColumn } from "drizzle-orm/pg-core";
 import { notificationRecipients } from "@/db/schema";
+
+/**
+ * `IndexConfig.columns` is `Partial<IndexedColumn | SQL>[]` — an index can
+ * mix plain columns and raw SQL expressions, so drizzle's own type only
+ * guarantees the properties common to both (effectively none). Every column
+ * in this index is a plain column reference, never a raw SQL expression, so
+ * this narrows to that real case instead of asserting `name` exists via a
+ * cast.
+ */
+function indexedColumnName(col: Partial<IndexedColumn | SQL>): string {
+  if (!("name" in col) || typeof col.name !== "string") {
+    throw new Error("expected a plain IndexedColumn with a string name, not a raw SQL expression");
+  }
+  return col.name;
+}
 
 describe("notification_recipients schema", () => {
   it("has exactly the expected columns", () => {
@@ -28,9 +43,6 @@ describe("notification_recipients schema", () => {
     const { indexes } = getTableConfig(notificationRecipients);
     const idx = indexes.find((i) => i.config.name === "notification_recipients_user_unread_idx");
     expect(idx).toBeDefined();
-    expect(idx!.config.columns.map((col: { name: string }) => col.name)).toEqual([
-      "user_id",
-      "read_at",
-    ]);
+    expect(idx!.config.columns.map(indexedColumnName)).toEqual(["user_id", "read_at"]);
   });
 });

--- a/packages/web/src/__tests__/schema-notifications.test.ts
+++ b/packages/web/src/__tests__/schema-notifications.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { getTableColumns } from "drizzle-orm";
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableColumns, type SQL } from "drizzle-orm";
+import { getTableConfig, type IndexedColumn } from "drizzle-orm/pg-core";
 import { notifications } from "@/db/schema";
+
+/**
+ * `IndexConfig.columns` is `Partial<IndexedColumn | SQL>[]` — an index can
+ * mix plain columns and raw SQL expressions, so drizzle's own type only
+ * guarantees the properties common to both (effectively none). Every column
+ * in this index is a plain column reference, never a raw SQL expression, so
+ * this narrows to that real case instead of asserting `name` exists via a
+ * cast.
+ */
+function indexedColumnName(col: Partial<IndexedColumn | SQL>): string {
+  if (!("name" in col) || typeof col.name !== "string") {
+    throw new Error("expected a plain IndexedColumn with a string name, not a raw SQL expression");
+  }
+  return col.name;
+}
 
 describe("notifications schema", () => {
   it("has exactly the expected columns", () => {
@@ -36,9 +51,6 @@ describe("notifications schema", () => {
     const { indexes } = getTableConfig(notifications);
     const idx = indexes.find((i) => i.config.name === "notifications_agent_created_idx");
     expect(idx).toBeDefined();
-    expect(idx!.config.columns.map((col: { name: string }) => col.name)).toEqual([
-      "agent_id",
-      "created_at",
-    ]);
+    expect(idx!.config.columns.map(indexedColumnName)).toEqual(["agent_id", "created_at"]);
   });
 });

--- a/packages/web/src/__tests__/schema-processed-emails.test.ts
+++ b/packages/web/src/__tests__/schema-processed-emails.test.ts
@@ -1,7 +1,22 @@
 import { describe, it, expect } from "vitest";
-import { getTableColumns } from "drizzle-orm";
-import { getTableConfig } from "drizzle-orm/pg-core";
+import { getTableColumns, type SQL } from "drizzle-orm";
+import { getTableConfig, type IndexedColumn } from "drizzle-orm/pg-core";
 import { processedEmails } from "@/db/schema";
+
+/**
+ * `IndexConfig.columns` is `Partial<IndexedColumn | SQL>[]` — an index can
+ * mix plain columns and raw SQL expressions, so drizzle's own type only
+ * guarantees the properties common to both (effectively none). Every column
+ * in this unique index is a plain column reference, never a raw SQL
+ * expression, so this narrows to that real case instead of asserting `name`
+ * exists via a cast.
+ */
+function indexedColumnName(col: Partial<IndexedColumn | SQL>): string {
+  if (!("name" in col) || typeof col.name !== "string") {
+    throw new Error("expected a plain IndexedColumn with a string name, not a raw SQL expression");
+  }
+  return col.name;
+}
 
 describe("processed_emails schema", () => {
   it("has exactly the expected columns", () => {
@@ -34,7 +49,7 @@ describe("processed_emails schema", () => {
     const claim = indexes.find((i) => i.config.name === "processed_emails_claim_uniq");
     expect(claim).toBeDefined();
     expect(claim!.config.unique).toBe(true);
-    expect(claim!.config.columns.map((col: { name: string }) => col.name)).toEqual([
+    expect(claim!.config.columns.map(indexedColumnName)).toEqual([
       "workflow_id",
       "connection_id",
       "provider_message_id",

--- a/packages/web/src/__tests__/scripts/domain-reset.test.ts
+++ b/packages/web/src/__tests__/scripts/domain-reset.test.ts
@@ -15,11 +15,16 @@ vi.mock("@/db/schema", () => ({
   settings: { key: "key" },
 }));
 
-vi.mock("drizzle-orm", () => ({
-  eq: vi.fn((a, b) => ({ field: a, value: b })),
-}));
+vi.mock("drizzle-orm", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("drizzle-orm")>();
+  return {
+    ...actual,
+    eq: vi.fn((a, b) => ({ field: a, value: b })),
+  };
+});
 
 import { db } from "@/db";
+import { sql } from "drizzle-orm";
 
 describe("domain-reset logic", () => {
   beforeEach(() => {
@@ -62,7 +67,13 @@ describe("domain-reset logic", () => {
     });
 
     if (existing) {
-      await db.delete({} as any).where({});
+      // `.where()` is only ever reached through the fully-mocked `db.delete`
+      // above (its `where` is `vi.fn()` and never inspects its argument), but
+      // the REAL `db.delete(...)` builder's `.where()` still statically
+      // requires a `SQL<unknown>` condition. A real (unmocked, see the
+      // `drizzle-orm` mock's `importOriginal` above) `sql` fragment satisfies
+      // that without an `any` cast.
+      await db.delete({} as any).where(sql`1=1`);
       console.log(`Domain lock removed (was: ${existing.value}).`);
       console.log("Pinchy is now accessible via any host. Restart the container to apply.");
     }

--- a/packages/web/src/__tests__/server/agent-uploads-route.test.ts
+++ b/packages/web/src/__tests__/server/agent-uploads-route.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect, beforeEach, afterEach, vi } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
+import { makeNextRequest, routeContext } from "@/test-helpers/route";
 
 // Hoisted mocks for getSession + agent access — same pattern as
 // other route tests (see e.g. agent-access.test.ts).
@@ -58,15 +59,10 @@ function writeUpload(agentId: string, filename: string, bytes: Buffer) {
 
 async function callGET(agentId: string, filename: string) {
   const { GET } = await import("@/app/api/agents/[agentId]/uploads/[filename]/route");
-  const req = new Request(
+  const req = makeNextRequest(
     `http://localhost/api/agents/${agentId}/uploads/${encodeURIComponent(filename)}`
   );
-  return GET(
-    req as unknown as Request,
-    {
-      params: Promise.resolve({ agentId, filename }),
-    } as unknown as Parameters<typeof GET>[1]
-  );
+  return GET(req, routeContext({ agentId, filename }));
 }
 
 describe("GET /api/agents/[agentId]/uploads/[filename]", () => {

--- a/packages/web/src/__tests__/server/audit-verify-job.integration.test.ts
+++ b/packages/web/src/__tests__/server/audit-verify-job.integration.test.ts
@@ -22,7 +22,10 @@ async function appendRow(actorId: string) {
     actorId,
     eventType: "auth.login",
     resource: `user:${actorId}`,
-    detail: null,
+    // `detail` is optional for `auth.*` events (Record<string, unknown> |
+    // undefined — not `null`). appendAuditLog itself falls back to `null`
+    // internally (`entry.detail ?? null`), so omitting it stores the same
+    // `null` detail as before without a type error.
     outcome: "success",
   });
 }

--- a/packages/web/src/__tests__/server/audit-verify-job.test.ts
+++ b/packages/web/src/__tests__/server/audit-verify-job.test.ts
@@ -49,7 +49,7 @@ const {
   // snapshot) and .where().orderBy().limit() (last-scanned-row lookup). They're
   // distinguished by which chain method is called first, exactly like the real
   // query builder — this mock never calls .where() with no follow-on chain.
-  const mockSelect = vi.fn(() => ({
+  const mockSelect = vi.fn((..._args: unknown[]) => ({
     from: (table: unknown) => {
       const isCheckpointTable =
         typeof table === "object" &&

--- a/packages/web/src/__tests__/server/channel-conflict-restart.test.ts
+++ b/packages/web/src/__tests__/server/channel-conflict-restart.test.ts
@@ -6,24 +6,31 @@
  * action as `channel.restarted`, so a Telegram bot stuck in OpenClaw's
  * dormant post-409 ingress backoff resumes polling under Pinchy's control.
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
-import { createConflictRestartHandler } from "@/server/channel-conflict-restart";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
+import {
+  createConflictRestartHandler,
+  type ConflictRestartDeps,
+} from "@/server/channel-conflict-restart";
 
 const ACCOUNT = "29ea51b1-67af-4fad-8864-f550c7543333";
 const CONFLICT =
   "Conflict: terminated by other getUpdates request; make sure that only one bot instance is running";
 
 describe("createConflictRestartHandler", () => {
-  let request: ReturnType<typeof vi.fn>;
-  let isConflictDisabled: ReturnType<typeof vi.fn>;
-  let resolveAccountName: ReturnType<typeof vi.fn>;
-  let writeAudit: ReturnType<typeof vi.fn>;
+  let request: Mock<ConflictRestartDeps["request"]>;
+  let isConflictDisabled: Mock<ConflictRestartDeps["isConflictDisabled"]>;
+  let resolveAccountName: Mock<ConflictRestartDeps["resolveAccountName"]>;
+  let writeAudit: Mock<ConflictRestartDeps["writeAudit"]>;
 
   beforeEach(() => {
-    request = vi.fn().mockResolvedValue({ ok: true });
-    isConflictDisabled = vi.fn().mockResolvedValue(false);
-    resolveAccountName = vi.fn().mockResolvedValue("Penny");
-    writeAudit = vi.fn().mockResolvedValue(undefined);
+    request = vi.fn<ConflictRestartDeps["request"]>().mockResolvedValue({ ok: true });
+    isConflictDisabled = vi
+      .fn<ConflictRestartDeps["isConflictDisabled"]>()
+      .mockResolvedValue(false);
+    resolveAccountName = vi
+      .fn<ConflictRestartDeps["resolveAccountName"]>()
+      .mockResolvedValue("Penny");
+    writeAudit = vi.fn<ConflictRestartDeps["writeAudit"]>().mockResolvedValue(undefined);
   });
 
   function handler() {

--- a/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
+++ b/packages/web/src/__tests__/server/channel-health-watchdog.test.ts
@@ -9,7 +9,7 @@
  *   degraded (sustained N ticks)      emit one `channel.polling_failed`
  *   degraded → healthy                emit one `channel.recovered`
  */
-import { describe, it, expect, vi, beforeEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, type Mock } from "vitest";
 import {
   ChannelHealthMonitor,
   type ChannelHealthDeps,
@@ -27,22 +27,28 @@ import {
 } from "./channel-health.fixtures";
 
 describe("ChannelHealthMonitor", () => {
-  let writeAudit: ReturnType<typeof vi.fn>;
-  let getChannelStatus: ReturnType<typeof vi.fn>;
-  let autoDisableConflictedAccount: ReturnType<typeof vi.fn>;
-  let restartConflictedAccount: ReturnType<typeof vi.fn>;
-  let getConnectionAgeMs: ReturnType<typeof vi.fn>;
+  let writeAudit: Mock<ChannelHealthDeps["writeAudit"]>;
+  let getChannelStatus: Mock<ChannelHealthDeps["getChannelStatus"]>;
+  let autoDisableConflictedAccount: Mock<ChannelHealthDeps["autoDisableConflictedAccount"]>;
+  let restartConflictedAccount: Mock<ChannelHealthDeps["restartConflictedAccount"]>;
+  let getConnectionAgeMs: Mock<ChannelHealthDeps["getConnectionAgeMs"]>;
   let monitor: ChannelHealthMonitor;
   let clock: number;
   let deps: ChannelHealthDeps;
 
   beforeEach(() => {
-    writeAudit = vi.fn().mockResolvedValue(undefined);
-    getChannelStatus = vi.fn();
-    autoDisableConflictedAccount = vi.fn().mockResolvedValue(undefined);
-    restartConflictedAccount = vi.fn().mockResolvedValue(undefined);
+    writeAudit = vi.fn<ChannelHealthDeps["writeAudit"]>().mockResolvedValue(undefined);
+    getChannelStatus = vi.fn<ChannelHealthDeps["getChannelStatus"]>();
+    autoDisableConflictedAccount = vi
+      .fn<ChannelHealthDeps["autoDisableConflictedAccount"]>()
+      .mockResolvedValue(undefined);
+    restartConflictedAccount = vi
+      .fn<ChannelHealthDeps["restartConflictedAccount"]>()
+      .mockResolvedValue(undefined);
     // Default: recently-added (1 hour old), well inside the 24h window.
-    getConnectionAgeMs = vi.fn().mockResolvedValue(60 * 60 * 1000);
+    getConnectionAgeMs = vi
+      .fn<ChannelHealthDeps["getConnectionAgeMs"]>()
+      .mockResolvedValue(60 * 60 * 1000);
     clock = 1_000_000;
     monitor = new ChannelHealthMonitor();
     deps = {

--- a/packages/web/src/__tests__/server/channel-health.test.ts
+++ b/packages/web/src/__tests__/server/channel-health.test.ts
@@ -49,7 +49,13 @@ describe("classifyChannelStatus", () => {
 
   it("treats a non-null lastError as degraded even if connected somehow reads true", () => {
     const s = healthyTelegramStatus();
-    s.channelAccounts.telegram[0].lastError = "boom";
+    // healthyTelegramStatus()'s inferred type pins lastError to the literal
+    // `null` (it never assigns a string in that function), so a direct
+    // property assignment of a string is a type error. Object.assign — the
+    // same mutation idiom degradedTelegramStatus() itself uses to overlay a
+    // conflict lastError — merges the type instead of checking it against the
+    // existing field type, and mutates the same object in place.
+    Object.assign(s.channelAccounts.telegram[0], { lastError: "boom" });
     expect(classifyChannelStatus(s)[0].state).toBe("degraded");
   });
 

--- a/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
+++ b/packages/web/src/__tests__/server/chat-dispatch-retry.test.ts
@@ -36,6 +36,20 @@ async function collect(gen: AsyncGenerator<ChatChunk>): Promise<ChatChunk[]> {
 }
 
 /**
+ * Asserts (and narrows) that a chunk is the "error" variant. `ChatChunk` is a
+ * discriminated union where `userMessagePersisted` has no `text` field, so
+ * TypeScript rejects a bare `.text` read on an unnarrowed `ChatChunk`. Fails
+ * the test exactly as the previous `expect(chunk.type).toBe("error")` did
+ * when the type doesn't match, while also narrowing for the `.text` reads
+ * that follow.
+ */
+function assertErrorChunk(
+  chunk: ChatChunk
+): asserts chunk is Extract<ChatChunk, { type: "error" }> {
+  expect(chunk.type).toBe("error");
+}
+
+/**
  * Fake clock: `delay(ms)` advances `now` by `ms` synchronously (resolving
  * immediately) so backoff/budget logic is exercised deterministically without
  * real timers.
@@ -143,7 +157,7 @@ describe("chatWithDispatchRaceRetry", () => {
 
     // The final error IS yielded so the caller surfaces "Smithers couldn't respond".
     expect(got).toHaveLength(1);
-    expect(got[0].type).toBe("error");
+    assertErrorChunk(got[0]);
     expect(DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
     // Never slept past the budget.
     expect(clock.now()).toBeLessThanOrEqual(3000);
@@ -325,7 +339,7 @@ describe("chatWithDispatchRaceRetry", () => {
 
       // Terminates and surfaces the race error rather than looping forever.
       expect(got).toHaveLength(1);
-      expect(got[0].type).toBe("error");
+      assertErrorChunk(got[0]);
       expect(DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
       expect(clock.now()).toBeLessThanOrEqual(3000);
     });
@@ -467,7 +481,7 @@ describe("chatWithDispatchRaceRetry", () => {
       );
 
       expect(got).toHaveLength(1);
-      expect(got[0].type).toBe("error");
+      assertErrorChunk(got[0]);
       expect(MODEL_DISPATCH_RACE_PATTERN.test(got[0].text)).toBe(true);
       expect(clock.now()).toBeLessThanOrEqual(3000);
     });

--- a/packages/web/src/__tests__/server/client-router-abort.test.ts
+++ b/packages/web/src/__tests__/server/client-router-abort.test.ts
@@ -35,7 +35,7 @@ const {
   mockRecordAuditFailure: vi.fn(),
   mockGetUserGroupIds: vi.fn().mockResolvedValue([]),
   mockGetAgentGroupIds: vi.fn().mockResolvedValue([]),
-  mockAssertAgentAccess: vi.fn(() => {}),
+  mockAssertAgentAccess: vi.fn<(...args: unknown[]) => void>(() => {}),
 }));
 
 vi.mock("@/db", () => ({

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from "vitest";
 import { EventEmitter } from "events";
+import type { LicenseState } from "@/lib/license-state";
 
 const {
   mockChat,
@@ -53,14 +54,14 @@ vi.mock("@/lib/agent-access", async (importOriginal) => {
         userRole: string,
         userGroupIds: string[] = [],
         agentGroupIds: string[] = [],
-        enterprise: boolean = true
+        licenseState: LicenseState = "paid"
       ) => {
         if (userRole === "admin") return;
         if (agent.isPersonal) {
           if (agent.ownerId === userId) return;
           throw new Error("Access denied");
         }
-        const vis = actual.effectiveVisibility(agent.visibility, enterprise);
+        const vis = actual.effectiveVisibility(agent.visibility, licenseState);
         if (vis === "restricted") {
           if (userGroupIds.some((gId: string) => agentGroupIds.includes(gId))) return;
           throw new Error("Access denied");

--- a/packages/web/src/__tests__/server/run-watchdog.test.ts
+++ b/packages/web/src/__tests__/server/run-watchdog.test.ts
@@ -19,7 +19,7 @@
  * client-side timer firing — which doesn't fire if the tab is backgrounded. The
  * watchdog is the server-side belt to that suspenders.
  */
-import { describe, it, expect, vi, beforeEach, afterEach } from "vitest";
+import { describe, it, expect, vi, beforeEach, afterEach, type Mock } from "vitest";
 import type { WebSocket } from "ws";
 import { ActiveRuns, type ActiveRun } from "@/server/active-runs";
 import { runWatchdogTick, startRunWatchdog, type WatchdogDeps } from "@/server/run-watchdog";
@@ -43,16 +43,16 @@ const basePending = {
 
 describe("runWatchdogTick", () => {
   let runs: ActiveRuns;
-  let chatAbort: ReturnType<typeof vi.fn>;
-  let writeAudit: ReturnType<typeof vi.fn>;
-  let broadcastNoFirstChunk: ReturnType<typeof vi.fn>;
+  let chatAbort: Mock<WatchdogDeps["chatAbort"]>;
+  let writeAudit: Mock<WatchdogDeps["writeAudit"]>;
+  let broadcastNoFirstChunk: Mock<WatchdogDeps["broadcastNoFirstChunk"]>;
   let deps: WatchdogDeps;
 
   beforeEach(() => {
     runs = new ActiveRuns();
-    chatAbort = vi.fn().mockResolvedValue(undefined);
-    writeAudit = vi.fn().mockResolvedValue(undefined);
-    broadcastNoFirstChunk = vi.fn();
+    chatAbort = vi.fn<WatchdogDeps["chatAbort"]>().mockResolvedValue(undefined);
+    writeAudit = vi.fn<WatchdogDeps["writeAudit"]>().mockResolvedValue(undefined);
+    broadcastNoFirstChunk = vi.fn<WatchdogDeps["broadcastNoFirstChunk"]>();
     deps = {
       activeRuns: runs,
       chatAbort,

--- a/packages/web/src/components/__tests__/agent-list.test.tsx
+++ b/packages/web/src/components/__tests__/agent-list.test.tsx
@@ -3,6 +3,7 @@ import { render, screen } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import { AgentList, type Agent } from "@/components/agent-list";
+import { makeAgent } from "@/test-helpers/fixtures";
 
 vi.mock("@/lib/chat-list-cache", () => ({
   prefetchChatList: vi.fn(),
@@ -10,15 +11,8 @@ vi.mock("@/lib/chat-list-cache", () => ({
 import { prefetchChatList } from "@/lib/chat-list-cache";
 
 const agents: Agent[] = [
-  { id: "a1", name: "Smithers", model: "m", isPersonal: false, tagline: null, avatarSeed: null },
-  {
-    id: "a2",
-    name: "Odoo Operator",
-    model: "m",
-    isPersonal: false,
-    tagline: null,
-    avatarSeed: null,
-  },
+  makeAgent({ id: "a1", name: "Smithers", model: "m", isPersonal: false }),
+  makeAgent({ id: "a2", name: "Odoo Operator", model: "m", isPersonal: false }),
 ];
 
 beforeEach(() => vi.clearAllMocks());

--- a/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/draft-persistence.test.tsx
@@ -23,6 +23,9 @@ import {
   useExternalStoreRuntime,
   type ThreadMessageLike,
   type ComposerRuntime,
+  type AttachmentAdapter,
+  type PendingAttachment,
+  type CompleteAttachment,
 } from "@assistant-ui/react";
 import { DraftPersistence } from "@/components/assistant-ui/thread";
 import { AgentIdContext, ChatIdContext } from "@/components/chat";
@@ -33,9 +36,9 @@ const AGENT = "agent-1";
 // Minimal attachment adapter so the runtime accepts addAttachment during restore.
 // Mirrors the shape of Pinchy's real adapter: a composer attachment that carries
 // the original File and is ready to send.
-const testAttachmentAdapter = {
+const testAttachmentAdapter: AttachmentAdapter = {
   accept: "*",
-  async add({ file }: { file: File }) {
+  async add({ file }: { file: File }): Promise<PendingAttachment> {
     return {
       id: file.name,
       type: "document" as const,
@@ -45,8 +48,10 @@ const testAttachmentAdapter = {
       status: { type: "requires-action" as const, reason: "composer-send" as const },
     };
   },
-  async send(attachment: { id: string; name: string; file: File }) {
-    return { ...attachment, status: { type: "complete" as const } };
+  async send(attachment: PendingAttachment): Promise<CompleteAttachment> {
+    // No test in this file inspects the sent content, only name/text — an
+    // empty part list is a valid, minimal CompleteAttachment.
+    return { ...attachment, status: { type: "complete" as const }, content: [] };
   },
   async remove() {},
 };

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import React from "react";
 import "@testing-library/jest-dom";
 import { sendingOpacityClass } from "@/components/assistant-ui/thread";
+import type { MessageState } from "@assistant-ui/react";
 
 // Mutable AuiIf state — lets individual tests flip thread.isRunning so we can
 // exercise the Send/Cancel mutual-exclusion path covered by issue #207.
@@ -211,6 +212,33 @@ vi.mock("@/components/chat", async () => {
   };
 });
 
+type MockedUseMessage = typeof import("@assistant-ui/react").useMessage;
+type MessageSelector = (state: MessageState) => unknown;
+
+/**
+ * Configures the mocked `useMessage` to run whatever selector `thread.tsx`
+ * passes it against `fixture`. `useMessage`'s real export is a heavily
+ * overloaded const (bare selector OR an `{ optional?, selector? }` options
+ * object); `vi.mocked(useMessage).mockImplementation(...)` resolves the
+ * required implementation type to the LAST overload only — the
+ * options-object shape. Every real call site in thread.tsx uses the bare
+ * selector form (`useMessage((state) => ...)`), never the options form, so
+ * the union parameter below satisfies mockImplementation's type while the
+ * body always dispatches as a callable selector, matching actual usage.
+ * `fixture` intentionally models only the fields each test reads, not the
+ * whole MessageState — hence the one boundary cast, isolated here instead of
+ * scattered across every call site.
+ */
+function stubUseMessage(useMessage: MockedUseMessage, fixture: Record<string, unknown>): void {
+  vi.mocked(useMessage).mockImplementation(
+    (arg: MessageSelector | { selector?: MessageSelector }) => {
+      const selector = typeof arg === "function" ? arg : arg.selector;
+      const state = fixture as MessageState;
+      return selector ? selector(state) : state;
+    }
+  );
+}
+
 describe("sendingOpacityClass", () => {
   it("returns 'opacity-60' when status is 'sending'", () => {
     expect(sendingOpacityClass("sending")).toBe("opacity-60");
@@ -232,11 +260,11 @@ describe("sendingOpacityClass", () => {
 describe("UserMessage component", () => {
   it("applies opacity-60 to the content wrapper when status is 'sending'", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "sending" } }, isLast: false, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "sending" } },
+      isLast: false,
+      id: "msg-1",
+    });
 
     const { UserMessage } = await import("@/components/assistant-ui/thread");
     const { container } = render(<UserMessage />);
@@ -250,11 +278,11 @@ describe("UserMessage component", () => {
 describe("UserMessage failed state", () => {
   it("shows 'Couldn't deliver' and Retry button for the last failed user message", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "failed" } }, isLast: true, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "failed" } },
+      isLast: true,
+      id: "msg-1",
+    });
 
     const { UserMessage } = await import("@/components/assistant-ui/thread");
     render(<UserMessage />);
@@ -265,11 +293,11 @@ describe("UserMessage failed state", () => {
 
   it("does NOT show Retry on a non-last failed message", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "failed" } }, isLast: false, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "failed" } },
+      isLast: false,
+      id: "msg-1",
+    });
 
     const { UserMessage } = await import("@/components/assistant-ui/thread");
     render(<UserMessage />);
@@ -280,11 +308,11 @@ describe("UserMessage failed state", () => {
 
   it("calls onRetryResend with the message id when Retry is clicked", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "failed" } }, isLast: true, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "failed" } },
+      isLast: true,
+      id: "msg-1",
+    });
 
     const mockRetryResend = vi.fn();
     const { RetryResendContext } = await import("@/components/chat");
@@ -302,11 +330,11 @@ describe("UserMessage failed state", () => {
 
   it("disables Retry button when ChatStatusContext is responding", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "failed" } }, isLast: true, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "failed" } },
+      isLast: true,
+      id: "msg-1",
+    });
 
     const { ChatStatusContext } = await import("@/components/chat");
     const { UserMessage } = await import("@/components/assistant-ui/thread");
@@ -322,11 +350,11 @@ describe("UserMessage failed state", () => {
 
   it("disables Retry button and sets tooltip when ChatStatusContext is unavailable", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({ metadata: { custom: { status: "failed" } }, isLast: true, id: "msg-1" })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { status: "failed" } },
+      isLast: true,
+      id: "msg-1",
+    });
 
     const { ChatStatusContext } = await import("@/components/chat");
     const { UserMessage } = await import("@/components/assistant-ui/thread");
@@ -402,15 +430,11 @@ describe("Thread reconciling state", () => {
 describe("AssistantMessage retryable error bubble", () => {
   it("shows Retry button on last assistant error bubble with retryable: true", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { error: { disconnected: true }, retryable: true } },
-          isLast: true,
-          id: "msg-err-1",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { error: { disconnected: true }, retryable: true } },
+      isLast: true,
+      id: "msg-err-1",
+    });
 
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
     render(<AssistantMessage />);
@@ -420,15 +444,11 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("does NOT show Retry button on non-last assistant error bubble", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { error: { disconnected: true }, retryable: true } },
-          isLast: false,
-          id: "msg-err-2",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { error: { disconnected: true }, retryable: true } },
+      isLast: false,
+      id: "msg-err-2",
+    });
 
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
     render(<AssistantMessage />);
@@ -438,15 +458,11 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("disables Retry button when ChatStatusContext is responding", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { error: { disconnected: true }, retryable: true } },
-          isLast: true,
-          id: "msg-err-3",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { error: { disconnected: true }, retryable: true } },
+      isLast: true,
+      id: "msg-err-3",
+    });
 
     const { ChatStatusContext } = await import("@/components/chat");
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
@@ -461,20 +477,16 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("gates the live Retry behind a duplicate-write confirm when the error has sideEffects", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: {
-            custom: {
-              error: { providerError: "rate limit", agentName: "Penny", sideEffects: true },
-              retryable: true,
-            },
-          },
-          isLast: true,
-          id: "msg-err-se",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: {
+        custom: {
+          error: { providerError: "rate limit", agentName: "Penny", sideEffects: true },
+          retryable: true,
+        },
+      },
+      isLast: true,
+      id: "msg-err-se",
+    });
 
     const mockRetryContinue = vi.fn();
     const { RetryContinueContext } = await import("@/components/chat");
@@ -497,20 +509,16 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("retries directly (no confirm) when the error has no sideEffects", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: {
-            custom: {
-              error: { providerError: "rate limit", agentName: "Penny" },
-              retryable: true,
-            },
-          },
-          isLast: true,
-          id: "msg-err-nose",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: {
+        custom: {
+          error: { providerError: "rate limit", agentName: "Penny" },
+          retryable: true,
+        },
+      },
+      isLast: true,
+      id: "msg-err-nose",
+    });
 
     const mockRetryContinue = vi.fn();
     const { RetryContinueContext } = await import("@/components/chat");
@@ -528,15 +536,11 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("disables Retry button and sets tooltip when ChatStatusContext is unavailable", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { error: { disconnected: true }, retryable: true } },
-          isLast: true,
-          id: "msg-err-5",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { error: { disconnected: true }, retryable: true } },
+      isLast: true,
+      id: "msg-err-5",
+    });
 
     const { ChatStatusContext } = await import("@/components/chat");
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
@@ -554,15 +558,11 @@ describe("AssistantMessage retryable error bubble", () => {
 
   it("calls onRetryContinue when Retry is clicked", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { error: { disconnected: true }, retryable: true } },
-          isLast: true,
-          id: "msg-err-4",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { error: { disconnected: true }, retryable: true } },
+      isLast: true,
+      id: "msg-err-4",
+    });
 
     const mockRetryContinue = vi.fn();
     const { RetryContinueContext } = await import("@/components/chat");

--- a/packages/web/src/hooks/__tests__/message-status-reducer.test.ts
+++ b/packages/web/src/hooks/__tests__/message-status-reducer.test.ts
@@ -54,7 +54,7 @@ describe("reduceMessages", () => {
 
   // Regression for #227: the reducer is invoked from use-ws-runtime with the
   // hook's superset WsMessage shape (optional status, string timestamp, plus
-  // images / error / retryable). The reducer must preserve all extra fields
+  // files / error / retryable). The reducer must preserve all extra fields
   // verbatim — the type-level guarantee lives in message-status-reducer.test-d.ts.
   it("preserves hook-shaped extra fields when transitioning status", () => {
     const initial: WsMessage[] = [
@@ -64,14 +64,14 @@ describe("reduceMessages", () => {
         content: "hi",
         status: "sending",
         timestamp: "2026-05-01T00:00:00Z",
-        images: ["data:image/png;base64,AAA"],
+        files: [{ filename: "photo.png", mimeType: "image/png" }],
       },
     ];
 
     const next = reduceMessages(initial, { type: "ack", clientMessageId: "1" });
 
     expect(next[0].status).toBe("sent");
-    expect(next[0].images).toEqual(["data:image/png;base64,AAA"]);
+    expect(next[0].files).toEqual([{ filename: "photo.png", mimeType: "image/png" }]);
     expect(next[0].timestamp).toBe("2026-05-01T00:00:00Z");
   });
 

--- a/packages/web/src/lib/__tests__/api-validation.test.ts
+++ b/packages/web/src/lib/__tests__/api-validation.test.ts
@@ -4,7 +4,14 @@ import { z } from "zod";
 import { parseRequestBody } from "../api-validation";
 
 function makeRequest(body: string | object | undefined, contentType = "application/json") {
-  const init: RequestInit = { method: "POST", headers: { "content-type": contentType } };
+  // NextRequest's constructor takes Next's own RequestInit (not the global
+  // lib.dom one — its `signal` is `AbortSignal | undefined`, not
+  // `AbortSignal | null | undefined`), so derive the exact param type from the
+  // constructor rather than the ambient DOM type.
+  const init: ConstructorParameters<typeof NextRequest>[1] = {
+    method: "POST",
+    headers: { "content-type": contentType },
+  };
   if (body !== undefined) {
     init.body = typeof body === "string" ? body : JSON.stringify(body);
   }

--- a/packages/web/src/lib/__tests__/template-grouping.test.ts
+++ b/packages/web/src/lib/__tests__/template-grouping.test.ts
@@ -6,78 +6,91 @@ import {
   type TemplateItem,
 } from "../template-grouping";
 import { AGENT_TEMPLATES } from "@/lib/agent-templates";
+import { makeTemplateItem } from "@/test-helpers/fixtures";
 
 describe("getAccessBadgeProps", () => {
   it("returns green 'Documents · Read-only' for a documents template", () => {
-    const result = getAccessBadgeProps({
-      id: "knowledge-base",
-      name: "Knowledge Base",
-      description: "Answer questions",
-      requiresDirectories: true,
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "knowledge-base",
+        name: "Knowledge Base",
+        description: "Answer questions",
+        requiresDirectories: true,
+        defaultTagline: null,
+      })
+    );
     expect(result).toEqual({ label: "Documents · Read-only", variant: "green" });
   });
 
   it("returns green 'Odoo · Read-only' for Odoo read-only template", () => {
-    const result = getAccessBadgeProps({
-      id: "odoo-sales-analyst",
-      name: "Sales Analyst",
-      description: "Analyze revenue",
-      requiresDirectories: false,
-      requiresOdooConnection: true,
-      odooAccessLevel: "read-only",
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "odoo-sales-analyst",
+        name: "Sales Analyst",
+        description: "Analyze revenue",
+        requiresDirectories: false,
+        requiresOdooConnection: true,
+        odooAccessLevel: "read-only",
+        defaultTagline: null,
+      })
+    );
     expect(result).toEqual({ label: "Odoo · Read-only", variant: "green" });
   });
 
   it("returns amber 'Odoo · Read & Write' for Odoo read-write template", () => {
-    const result = getAccessBadgeProps({
-      id: "odoo-crm-assistant",
-      name: "CRM Assistant",
-      description: "Manage leads",
-      requiresDirectories: false,
-      requiresOdooConnection: true,
-      odooAccessLevel: "read-write",
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "odoo-crm-assistant",
+        name: "CRM Assistant",
+        description: "Manage leads",
+        requiresDirectories: false,
+        requiresOdooConnection: true,
+        odooAccessLevel: "read-write",
+        defaultTagline: null,
+      })
+    );
     expect(result).toEqual({ label: "Odoo · Read & Write", variant: "amber" });
   });
 
   it("returns red 'Odoo · Full Access' for Odoo full-access template", () => {
-    const result = getAccessBadgeProps({
-      id: "odoo-full",
-      name: "Full Agent",
-      description: "Full access",
-      requiresDirectories: false,
-      requiresOdooConnection: true,
-      odooAccessLevel: "full",
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "odoo-full",
+        name: "Full Agent",
+        description: "Full access",
+        requiresDirectories: false,
+        requiresOdooConnection: true,
+        odooAccessLevel: "full",
+        defaultTagline: null,
+      })
+    );
     expect(result).toEqual({ label: "Odoo · Full Access", variant: "red" });
   });
 
   it("returns null for custom template", () => {
-    const result = getAccessBadgeProps({
-      id: "custom",
-      name: "Custom Agent",
-      description: "Start from scratch",
-      requiresDirectories: false,
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "custom",
+        name: "Custom Agent",
+        description: "Start from scratch",
+        requiresDirectories: false,
+        defaultTagline: null,
+      })
+    );
     expect(result).toBeNull();
   });
 
   it("returns green 'Email · Read & Draft' for email template", () => {
-    const result = getAccessBadgeProps({
-      id: "email-assistant",
-      name: "Email Assistant",
-      description: "Read and draft emails",
-      requiresDirectories: false,
-      requiresEmailConnection: true,
-      defaultTagline: null,
-    });
+    const result = getAccessBadgeProps(
+      makeTemplateItem({
+        id: "email-assistant",
+        name: "Email Assistant",
+        description: "Read and draft emails",
+        requiresDirectories: false,
+        requiresEmailConnection: true,
+        defaultTagline: null,
+      })
+    );
     expect(result).toEqual({ label: "Email · Read & Draft", variant: "green" });
   });
 });

--- a/packages/web/src/lib/eval/__tests__/graders.test.ts
+++ b/packages/web/src/lib/eval/__tests__/graders.test.ts
@@ -200,7 +200,16 @@ describe("gradeTaskCompletion", () => {
 
   it("matches a bare display-name-string partner_id", () => {
     const traj = baseTrajectory({
-      odooMoves: [{ ...MATCHING_MOVE, partner_id: "Hetzner Online GmbH" }],
+      odooMoves: [
+        {
+          ...MATCHING_MOVE,
+          // Odoo's many2one read-back can also arrive as a bare display-name
+          // string (see partnerMatches' unknown-typed param and its docstring);
+          // OdooMove's declared partner_id type doesn't model that shape, so
+          // simulate it with a boundary cast instead of widening the type.
+          partner_id: "Hetzner Online GmbH" as unknown as [number, string],
+        },
+      ],
     });
     const result = gradeTaskCompletion(traj, EXPECTED);
     expect(result.passed).toBe(true);

--- a/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
@@ -71,17 +71,26 @@ describe("getBlockReason", () => {
   });
 });
 
+// markToolBlockedModels<M, P>'s M is inferred from the argument's own shape;
+// a literal that never mentions `incompatibleReason` infers M without that
+// key at all (not merely `undefined`), so the OUTPUT type can't be read back
+// for it either — even though the optional field lets the input satisfy the
+// generic constraint either way. Type the fixtures with it present-but-
+// optional so the field flows through to the inferred return type.
+type BlocklistModel = {
+  id: string;
+  name: string;
+  compatible: boolean;
+  incompatibleReason?: string;
+};
+
 describe("markToolBlockedModels", () => {
   it("marks a tools-blocklisted model incompatible with the block reason, leaving others untouched", () => {
-    const out = markToolBlockedModels([
-      {
-        id: "ollama-cloud",
-        models: [
-          { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini", compatible: true },
-          { id: "ollama-cloud/qwen3-vl:235b", name: "qwen", compatible: true },
-        ],
-      },
-    ]);
+    const models: BlocklistModel[] = [
+      { id: "ollama-cloud/gemini-3-flash-preview", name: "gemini", compatible: true },
+      { id: "ollama-cloud/qwen3-vl:235b", name: "qwen", compatible: true },
+    ];
+    const out = markToolBlockedModels([{ id: "ollama-cloud", models }]);
     expect(out[0].models[0].compatible).toBe(false);
     expect(out[0].models[0].incompatibleReason).toContain("Preview models");
     expect(out[0].models[1].compatible).toBe(true);
@@ -106,12 +115,10 @@ describe("markToolBlockedModels", () => {
   });
 
   it("leaves reliable models untouched", () => {
-    const out = markToolBlockedModels([
-      {
-        id: "anthropic",
-        models: [{ id: "anthropic/claude-opus-4-8", name: "c", compatible: true }],
-      },
-    ]);
+    const models: BlocklistModel[] = [
+      { id: "anthropic/claude-opus-4-8", name: "c", compatible: true },
+    ];
+    const out = markToolBlockedModels([{ id: "anthropic", models }]);
     expect(out[0].models[0].compatible).toBe(true);
     expect(out[0].models[0].incompatibleReason).toBeUndefined();
   });

--- a/packages/web/src/server/openclaw-disconnect-signal.ts
+++ b/packages/web/src/server/openclaw-disconnect-signal.ts
@@ -1,5 +1,3 @@
-import type { OpenClawClient } from "openclaw-node";
-
 /**
  * A "the OpenClaw socket just dropped" notification that in-flight stream loops
  * race their iteration against. See `iterateUntilAborted` for why a dropped
@@ -9,6 +7,19 @@ import type { OpenClawClient } from "openclaw-node";
 export interface DisconnectSignal {
   /** Resolves the next time OpenClaw disconnects. */
   whenDisconnected(): Promise<void>;
+}
+
+/**
+ * The minimal client surface OpenClawDisconnectSignal depends on: the two
+ * connection-lifecycle events. Declared structurally rather than
+ * `Pick<OpenClawClient, "on">` because OpenClawClient extends EventEmitter, so
+ * its `on` returns `this` — which binds to the concrete class (and its private
+ * fields). A `Pick` of that is unsatisfiable by any test double (or any other
+ * object) without an unsafe cast; a structural `on` keeps the dependency honest
+ * AND unit-testable. The real OpenClawClient satisfies this interface.
+ */
+export interface DisconnectEventSource {
+  on(event: "disconnected" | "connected", listener: () => void): unknown;
 }
 
 /**
@@ -24,7 +35,7 @@ export class OpenClawDisconnectSignal implements DisconnectSignal {
   private resolveCurrent: () => void = () => {};
   private current: Promise<void> = Promise.resolve();
 
-  constructor(client: Pick<OpenClawClient, "on">) {
+  constructor(client: DisconnectEventSource) {
     this.arm();
     // openclaw-node fires "disconnected" on every failed reconnect attempt
     // (~1s); resolving the same already-settled promise again is a no-op, so

--- a/packages/web/src/test-helpers/auth.ts
+++ b/packages/web/src/test-helpers/auth.ts
@@ -1,0 +1,56 @@
+import type { Session } from "@/lib/auth";
+
+/**
+ * A fully-shaped Better Auth session for tests.
+ *
+ * `auth.api.getSession` and the `getSession` wrapper both resolve to the full
+ * `{ session, user }` object (admin-plugin fields included). Hand-rolled
+ * `{ user: {...} }` fixtures drift from that type the moment Better Auth or the
+ * admin plugin adds a field — which is exactly how these mocks silently rotted
+ * until the test-typecheck gate was turned on. Build session fixtures here so
+ * the shape lives in one place and the compiler enforces completeness (the
+ * `: Session` annotation on `base` fails to compile if a required field is
+ * missing, so a Better Auth upgrade is a one-line fix here, not across 100
+ * test files).
+ *
+ * Defaults to an admin user; override `user.role` for member-path tests.
+ */
+export function mockSession(
+  overrides: {
+    user?: Partial<Session["user"]>;
+    session?: Partial<Session["session"]>;
+  } = {}
+): Session {
+  const now = new Date("2026-01-01T00:00:00.000Z");
+  const base: Session = {
+    session: {
+      id: "session-1",
+      createdAt: now,
+      updatedAt: now,
+      userId: "user-1",
+      expiresAt: new Date("2026-01-08T00:00:00.000Z"),
+      token: "test-session-token",
+      ipAddress: null,
+      userAgent: null,
+      impersonatedBy: null,
+    },
+    user: {
+      id: "user-1",
+      createdAt: now,
+      updatedAt: now,
+      email: "admin@test.com",
+      emailVerified: true,
+      name: "Test Admin",
+      image: null,
+      context: null,
+      banned: false,
+      role: "admin",
+      banReason: null,
+      banExpires: null,
+    },
+  };
+  return {
+    session: { ...base.session, ...overrides.session },
+    user: { ...base.user, ...overrides.user },
+  };
+}

--- a/packages/web/src/test-helpers/fixtures.ts
+++ b/packages/web/src/test-helpers/fixtures.ts
@@ -1,0 +1,42 @@
+import type { Agent } from "@/components/agent-list";
+import type { TemplateItem } from "@/lib/template-grouping";
+
+/**
+ * Build an `Agent` (the `@/components/agent-list` shape) for tests.
+ *
+ * Inline `{ id, name, model, isPersonal, tagline, avatarSeed }` fixtures drop
+ * whichever field was added last (`starterPrompts` was the casualty). The
+ * `: Agent` return type keeps this factory honest: add a required field to the
+ * interface and this one function fails to compile instead of 20 test files.
+ */
+export function makeAgent(overrides: Partial<Agent> = {}): Agent {
+  return {
+    id: "agent-1",
+    name: "Test Agent",
+    model: "anthropic/claude-haiku-4-5-20251001",
+    isPersonal: false,
+    tagline: null,
+    starterPrompts: [],
+    avatarSeed: null,
+    ...overrides,
+  };
+}
+
+/**
+ * Build a `TemplateItem` (the `@/lib/template-grouping` shape) for tests.
+ *
+ * Only the required fields are defaulted (`defaultTagline` was the drift
+ * casualty); pass `overrides` for the optional `requires*` / `odooAccessLevel`
+ * / `unavailableReason` flags a given test exercises.
+ */
+export function makeTemplateItem(overrides: Partial<TemplateItem> = {}): TemplateItem {
+  return {
+    id: "template-1",
+    name: "Test Template",
+    description: "A test template",
+    requiresDirectories: false,
+    defaultTagline: null,
+    available: true,
+    ...overrides,
+  };
+}

--- a/packages/web/src/test-helpers/route.ts
+++ b/packages/web/src/test-helpers/route.ts
@@ -1,0 +1,35 @@
+import { NextRequest } from "next/server";
+
+/**
+ * Build a `NextRequest` for route-handler tests.
+ *
+ * App Router handlers are typed `(req: NextRequest, ctx) => Response`. Tests
+ * that pass a plain `new Request(...)` fail type-checking (`Request` is not
+ * assignable to `NextRequest`). Construct requests here so the correct type is
+ * used everywhere.
+ */
+export function makeNextRequest(
+  url = "http://localhost/api/test",
+  // NextRequest's constructor takes Next's own RequestInit (not the global
+  // lib.dom one), so derive the exact param type from the constructor.
+  init?: ConstructorParameters<typeof NextRequest>[1]
+): NextRequest {
+  return new NextRequest(url, init);
+}
+
+/**
+ * Build the second argument every App Router handler receives — the route
+ * context `{ params: Promise<...> }`.
+ *
+ * Pinchy's `withAuth`/`withAdmin` wrappers return `(req, ctx) => ...`, so the
+ * context arg is REQUIRED even for routes that ignore it. Static (non-dynamic)
+ * routes: `routeContext()`. Dynamic routes: `routeContext({ id: "agent-1" })`,
+ * which yields `{ params: Promise<{ id: string }> }` matching the handler's
+ * declared context type. Next 15+ makes `params` a Promise, so awaiting it in
+ * the handler works exactly as in production.
+ */
+export function routeContext(): { params: Promise<Record<string, never>> };
+export function routeContext<T extends Record<string, string>>(params: T): { params: Promise<T> };
+export function routeContext(params?: Record<string, string>) {
+  return { params: Promise.resolve(params ?? {}) };
+}

--- a/packages/web/tsconfig.typecheck.json
+++ b/packages/web/tsconfig.typecheck.json
@@ -1,0 +1,8 @@
+{
+  "extends": "./tsconfig.json",
+  "compilerOptions": {
+    "types": ["node", "vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["src/**/*.ts", "src/**/*.tsx", "src/**/*.mts"],
+  "exclude": ["node_modules", "e2e"]
+}

--- a/scripts/lib/web-typecheck-gate.mjs
+++ b/scripts/lib/web-typecheck-gate.mjs
@@ -1,0 +1,73 @@
+/**
+ * Drift guard for the packages/web test-typecheck gate.
+ *
+ * The gate (`pnpm -C packages/web typecheck` →
+ * `tsc --noEmit -p tsconfig.typecheck.json`) is the ONLY thing in CI that
+ * type-checks the web package's test files — `next build` type-checks
+ * packages/web but its tsconfig deliberately EXCLUDES `*.test.ts(x)`. So the
+ * gate only keeps protecting test files as long as three things stay true:
+ *   1. tsconfig.typecheck.json keeps INCLUDING test files and never re-excludes
+ *      them,
+ *   2. the `typecheck` script keeps pointing at that config, and
+ *   3. CI keeps running it.
+ *
+ * This is the read-side sibling of the no-untracked-skips / no-test-deletion /
+ * plugin-typecheck guards (see AGENTS.md): it forces a silent narrowing of the
+ * gate to be a loud, deliberate act.
+ */
+
+// Substrings that mean an exclude entry would drop test files from the gate.
+const TEST_FILE_MARKERS = [".test.", ".spec.", "__tests__"];
+
+/**
+ * @param {unknown} config parsed tsconfig.typecheck.json
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateTypecheckTsconfig(config) {
+  if (config === null || typeof config !== "object" || Array.isArray(config)) {
+    return ["tsconfig.typecheck.json must be a JSON object"];
+  }
+  const problems = [];
+  const include = Array.isArray(config.include) ? config.include : [];
+  if (!include.some((g) => typeof g === "string" && g.includes("src/**"))) {
+    problems.push('include must contain a "src/**/*" glob so test files are type-checked');
+  }
+  const exclude = Array.isArray(config.exclude) ? config.exclude : [];
+  for (const pat of exclude) {
+    if (typeof pat === "string" && TEST_FILE_MARKERS.some((m) => pat.includes(m))) {
+      problems.push(`exclude must not drop test files, but excludes "${pat}"`);
+    }
+  }
+  return problems;
+}
+
+/**
+ * @param {unknown} pkg parsed packages/web/package.json
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateTypecheckScript(pkg) {
+  const script =
+    pkg && typeof pkg === "object" && pkg.scripts && typeof pkg.scripts === "object"
+      ? pkg.scripts.typecheck
+      : undefined;
+  if (typeof script !== "string") {
+    return ['packages/web/package.json needs a "typecheck" script'];
+  }
+  const problems = [];
+  if (!/\btsc\b/.test(script)) problems.push('"typecheck" must run tsc');
+  if (!script.includes("tsconfig.typecheck.json")) {
+    problems.push('"typecheck" must use tsconfig.typecheck.json');
+  }
+  return problems;
+}
+
+/**
+ * @param {unknown} ciYaml raw .github/workflows/ci.yml text
+ * @returns {string[]} problems (empty = ok)
+ */
+export function validateCiWiring(ciYaml) {
+  if (typeof ciYaml !== "string") return ["ci.yml is unreadable"];
+  return ciYaml.includes("packages/web typecheck")
+    ? []
+    : ["CI (.github/workflows/ci.yml) must run `pnpm -C packages/web typecheck`"];
+}

--- a/scripts/lib/web-typecheck-gate.mjs
+++ b/scripts/lib/web-typecheck-gate.mjs
@@ -67,7 +67,18 @@ export function validateTypecheckScript(pkg) {
  */
 export function validateCiWiring(ciYaml) {
   if (typeof ciYaml !== "string") return ["ci.yml is unreadable"];
-  return ciYaml.includes("packages/web typecheck")
+  // Strip YAML comments before matching. A commented-out step
+  // (`# run: pnpm -C packages/web typecheck`) — or a step's prose comment that
+  // merely names the command — leaves the substring in the file while CI no
+  // longer runs the gate. That silent un-wiring is exactly what this check
+  // exists to catch, so only non-comment text counts. Conservative by design:
+  // `#` is only treated as a comment at line start or after whitespace, so a
+  // `#` inside a command string does not truncate the line.
+  const withoutComments = ciYaml
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+  return withoutComments.includes("packages/web typecheck")
     ? []
     : ["CI (.github/workflows/ci.yml) must run `pnpm -C packages/web typecheck`"];
 }

--- a/scripts/lib/web-typecheck-gate.test.mjs
+++ b/scripts/lib/web-typecheck-gate.test.mjs
@@ -1,0 +1,106 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  validateTypecheckTsconfig,
+  validateTypecheckScript,
+  validateCiWiring,
+} from "./web-typecheck-gate.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+const WEB = join(REPO_ROOT, "packages", "web");
+
+// A tsconfig shape that satisfies the gate: it includes the web test files and
+// re-excludes none of them.
+const GOOD_TSCONFIG = {
+  extends: "./tsconfig.json",
+  include: ["src/**/*.ts", "src/**/*.tsx", "src/**/*.mts"],
+  exclude: ["node_modules", "e2e"],
+};
+
+test("validateTypecheckTsconfig accepts a config that includes test files", () => {
+  assert.deepEqual(validateTypecheckTsconfig(GOOD_TSCONFIG), []);
+});
+
+test("validateTypecheckTsconfig flags an include that misses src/**", () => {
+  const problems = validateTypecheckTsconfig({ ...GOOD_TSCONFIG, include: ["next-env.d.ts"] });
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /src\/\*\*/);
+});
+
+test("validateTypecheckTsconfig flags an exclude that drops *.test.ts", () => {
+  // The trap this guard exists for: silently re-excluding test files turns the
+  // gate back into a no-op for exactly the files it was added to protect.
+  const problems = validateTypecheckTsconfig({
+    ...GOOD_TSCONFIG,
+    exclude: ["node_modules", "src/**/*.test.ts"],
+  });
+  assert.ok(
+    problems.some((p) => /exclude/.test(p) && /\.test\./.test(p)),
+    `expected a test-exclude problem, got ${JSON.stringify(problems)}`,
+  );
+});
+
+test("validateTypecheckTsconfig flags an exclude that drops __tests__/", () => {
+  const problems = validateTypecheckTsconfig({
+    ...GOOD_TSCONFIG,
+    exclude: ["**/__tests__/**"],
+  });
+  assert.ok(problems.some((p) => /exclude/.test(p)));
+});
+
+test("validateTypecheckTsconfig reports a problem (not a throw) when config is not an object", () => {
+  assert.ok(validateTypecheckTsconfig("oops").length > 0);
+  assert.ok(validateTypecheckTsconfig(null).length > 0);
+  assert.ok(validateTypecheckTsconfig([]).length > 0);
+});
+
+test("validateTypecheckScript accepts a script wired to the gate config", () => {
+  assert.deepEqual(
+    validateTypecheckScript({ scripts: { typecheck: "tsc --noEmit -p tsconfig.typecheck.json" } }),
+    [],
+  );
+});
+
+test("validateTypecheckScript flags a missing typecheck script", () => {
+  const problems = validateTypecheckScript({ scripts: { build: "next build" } });
+  assert.ok(problems.some((p) => /needs a "typecheck" script/.test(p)));
+});
+
+test("validateTypecheckScript flags a typecheck script pointed at the wrong tsconfig", () => {
+  // Pointing typecheck at the default tsconfig (which excludes tests) would
+  // silently stop covering test files while still looking green.
+  const problems = validateTypecheckScript({ scripts: { typecheck: "tsc --noEmit" } });
+  assert.ok(problems.some((p) => /tsconfig\.typecheck\.json/.test(p)));
+});
+
+test("validateCiWiring flags a workflow that does not run the gate", () => {
+  assert.ok(validateCiWiring("jobs:\n  quality:\n    steps: []\n").length > 0);
+});
+
+test("validateCiWiring accepts a workflow that runs the gate", () => {
+  assert.deepEqual(validateCiWiring("      - run: pnpm -C packages/web typecheck\n"), []);
+});
+
+// ── Drift guards against the REAL repo files ──────────────────────────────
+
+test("packages/web/tsconfig.typecheck.json still covers test files", () => {
+  const config = JSON.parse(readFileSync(join(WEB, "tsconfig.typecheck.json"), "utf8"));
+  assert.deepEqual(
+    validateTypecheckTsconfig(config),
+    [],
+    "tsconfig.typecheck.json no longer covers the web test files",
+  );
+});
+
+test("packages/web/package.json wires the typecheck script to the gate config", () => {
+  const pkg = JSON.parse(readFileSync(join(WEB, "package.json"), "utf8"));
+  assert.deepEqual(validateTypecheckScript(pkg), []);
+});
+
+test("CI runs the web typecheck gate", () => {
+  const ci = readFileSync(join(REPO_ROOT, ".github", "workflows", "ci.yml"), "utf8");
+  assert.deepEqual(validateCiWiring(ci), []);
+});

--- a/scripts/lib/web-typecheck-gate.test.mjs
+++ b/scripts/lib/web-typecheck-gate.test.mjs
@@ -84,6 +84,35 @@ test("validateCiWiring accepts a workflow that runs the gate", () => {
   assert.deepEqual(validateCiWiring("      - run: pnpm -C packages/web typecheck\n"), []);
 });
 
+test("validateCiWiring flags a gate that is only present as a comment", () => {
+  // The trap: commenting the step out (or merely naming the command in a
+  // step's explanatory comment) leaves the substring in ci.yml while CI stops
+  // running the gate — a substring match alone would stay green here.
+  const problems = validateCiWiring(
+    "jobs:\n  quality:\n    steps:\n      # run: pnpm -C packages/web typecheck\n",
+  );
+  assert.ok(problems.length > 0, "a commented-out gate must not satisfy the guard");
+});
+
+test("validateCiWiring accepts the gate inside a multi-line run block", () => {
+  // Stripping comments must not make the check brittle: the `run: |` block form
+  // is a legitimate way to wire the gate and has to keep passing.
+  assert.deepEqual(
+    validateCiWiring("      - run: |\n          pnpm -C packages/web typecheck\n"),
+    [],
+  );
+});
+
+test("validateCiWiring does not treat a '#' inside a command as a comment", () => {
+  // A naive /#.*$/ strip would truncate this line before the command and
+  // falsely report the gate as un-wired. Only a '#' at line start or after
+  // whitespace starts a YAML comment.
+  assert.deepEqual(
+    validateCiWiring('      - run: echo "#deps" && pnpm -C packages/web typecheck\n'),
+    [],
+  );
+});
+
 // ── Drift guards against the REAL repo files ──────────────────────────────
 
 test("packages/web/tsconfig.typecheck.json still covers test files", () => {


### PR DESCRIPTION
## What does this PR do?

Type-checks every `packages/web` vitest test file in CI and drives the **1058 pre-existing test-file type errors to zero**.

**The gap:** `packages/web` test files weren't type-checked anywhere in CI — `next build` type-checks the package but its tsconfig excludes `src/**/*.test.ts(x)`, and vitest runs without `--typecheck`. So type errors in test files — including dormant `expectTypeOf`/`assertType` assertions that pass as runtime no-ops — went undetected.

Related to #572 (surfaced there; out of scope for that PR — not closed by this one).

### Gate

- New `packages/web/tsconfig.typecheck.json` — extends the base config but **includes** the test files; adds `vitest/globals` + `@testing-library/jest-dom` to `types`.
- New `typecheck` script (`tsc --noEmit -p tsconfig.typecheck.json`), wired into the CI `quality` job as **"Typecheck web (incl. tests)"**.
- Drift guard `scripts/lib/web-typecheck-gate.{mjs,test.mjs}` (run by `pnpm test:scripts`) so the tsconfig can't silently re-exclude tests, the `typecheck` script can't drift, and CI can't stop running the gate — the read-side sibling of the no-untracked-skips / plugin-typecheck guards.
- Documented in `AGENTS.md`.

### Shared typed test helpers (`packages/web/src/test-helpers/`)

`mockSession()`, `makeNextRequest()` / `routeContext()`, `makeAgent()` / `makeTemplateItem()` — full, correctly-typed shapes so a future type change is a one-line helper fix instead of a 100-file sweep.

### The fixes

**110 test files** fixed with genuine per-file typing. **No new `as any` / `@ts-expect-error` / `@ts-nocheck`** — net `as any` is **−9** (the change removes more casts than it adds); only documented boundary casts remain.

**Dormant type bugs the gate surfaced, now real guards:**

- `audit-types.test.ts` — `AuditEventType` is intentionally narrower than `AuditLogEntry["eventType"]`, so the old `toEqualTypeOf` never held and guarded nothing. Rewritten to assert the per-event detail shapes and the true subset relationship (verified it fails on drift).
- `db/schema.test.ts` — the `toMatchObjectType` assertion drifted once `pinchy-files`/`pinchy-web` configs grew fields. Rewritten to pin the plugin-ID namespacing + the key field types.
- `audit-append.test.ts` — exercised the dead `attachment.uploaded` event type (removed in `efa9cbc4`); retargeted to `file.upload.staged`.

### ⚠️ One production change to review

`packages/web/src/server/openclaw-disconnect-signal.ts`: `Pick<OpenClawClient, "on">` → a structural `DisconnectEventSource` interface. `OpenClawClient extends EventEmitter`, so its `on(): this` binds to the concrete class — making the `Pick` **unsatisfiable by any test double** without a cast. The class is **never constructed in production code**, so this is zero-risk type widening (runtime identical; the real client satisfies the interface) that keeps the dependency honest and unit-testable.

### Verification

| Check | Result |
|---|---|
| Gate `pnpm -C packages/web typecheck` | **0 errors** (was 1058) |
| `pnpm test` | **8213 passed / 0 failed** (605 files) |
| `next build` | ✅ green |
| `pnpm test:scripts` (drift guards) | **260 / 260** |
| ESLint | **0 errors** |
| Prettier | ✅ clean |
| Test cases | 2279 → 2280 (no net deletions; no new skips) |

## Type of change

- [ ] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [x] ♻️ Refactor
- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass
