### PR TITLE
fix(inbox-agent): pin finalizeEmail to the claim row id (#735)

### DIFF
--- a/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
@@ -124,9 +124,9 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    await claimEmail(key);
+    const id = await claimEmail(key);
     await finalizeEmail({
-      ...key,
+      id: id!,
       status: "done",
       outcome: { odooModel: "account.move", odooId: 42 },
       runId: "run-1",
@@ -144,8 +144,8 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    await claimEmail(key);
-    await finalizeEmail({ ...key, status: "done" });
+    const id = await claimEmail(key);
+    await finalizeEmail({ id: id!, status: "done" });
 
     // Simulate the reconciliation sweep finding the same provider message again
     // after a cursor loss: the ledger — not the cursor — is the source of truth,
@@ -154,18 +154,10 @@ describe("email ledger — finalizeEmail", () => {
   });
 
   it("throws when finalizing an email that was never claimed", async () => {
-    const agent = await seedAgent();
-    const wf = await seedWorkflow(agent.id);
-
     // finalize-before-claim is always a bug: surface it loudly rather than
     // silently updating zero rows and leaving the (nonexistent) row unmarked.
     await expect(
-      finalizeEmail({
-        workflowId: wf.id,
-        connectionId: "conn-1",
-        providerMessageId: "never-claimed",
-        status: "done",
-      })
+      finalizeEmail({ id: "00000000-0000-0000-0000-000000000000", status: "done" })
     ).rejects.toThrow(/no processing ledger row/);
   });
 
@@ -174,13 +166,13 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    await claimEmail(key);
-    await finalizeEmail({ ...key, status: "done", outcome: { note: "first" } });
+    const id = await claimEmail(key);
+    await finalizeEmail({ id: id!, status: "done", outcome: { note: "first" } });
 
     // finalize only ever transitions processing → terminal. A duplicate finalize
     // (e.g. a buggy retry) must NOT silently overwrite the recorded outcome —
     // the WHERE clause no longer matches, so zero rows update and we throw.
-    await expect(finalizeEmail({ ...key, status: "failed" })).rejects.toThrow(
+    await expect(finalizeEmail({ id: id!, status: "failed" })).rejects.toThrow(
       /no processing ledger row/
     );
 
@@ -253,10 +245,10 @@ describe("email ledger — resetStuckProcessingEmails (reconciliation)", () => {
     const done = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "done-old" };
     const failed = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "failed-old" };
 
-    await claimEmail(done);
-    await finalizeEmail({ ...done, status: "done", outcome: { note: "kept" } });
-    await claimEmail(failed);
-    await finalizeEmail({ ...failed, status: "failed" });
+    const doneId = await claimEmail(done);
+    await finalizeEmail({ id: doneId!, status: "done", outcome: { note: "kept" } });
+    const failedId = await claimEmail(failed);
+    await finalizeEmail({ id: failedId!, status: "failed" });
     // Backdate both far past the grace window — age alone must not reset them.
     await backdateClaim(done, GRACE_MS * 100);
     await backdateClaim(failed, GRACE_MS * 100);
@@ -282,6 +274,36 @@ describe("email ledger — resetStuckProcessingEmails (reconciliation)", () => {
     // new id) instead of being rejected as already-claimed. This is what turns
     // #717's transient deferral into an actual retry.
     expect(await claimEmail(key)).toEqual(expect.any(String));
+  });
+
+  it("a late finalize from a superseded claim must not terminalize the fresh re-claim (#735)", async () => {
+    const agent = await seedAgent();
+    const wf = await seedWorkflow(agent.id);
+    const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "supersede-1" };
+
+    // Run A claims the email → row R1, then hangs (genuinely slow, not dead).
+    const r1 = await claimEmail(key);
+    await backdateClaim(key, GRACE_MS + 60_000);
+    // The sweep deletes the stuck R1 and re-lists; a fresh run re-claims → row R2.
+    await resetStuckProcessingEmails(GRACE_MS);
+    const r2 = await claimEmail(key);
+    expect(r2).toEqual(expect.any(String));
+    expect(r2).not.toBe(r1); // genuinely a different claim, same email
+
+    // Run A finally wakes and finalizes ITS claim (R1). R1 is gone, so finalize
+    // must hit zero rows and throw loudly — it must NOT graft Run A's stale
+    // outcome onto R2, which belongs to the fresh run and is still processing.
+    // This holds only because finalize is pinned to the claim's row id: the
+    // claim *tuple* is reusable and still matches R2.
+    await expect(
+      finalizeEmail({ id: r1!, status: "done", outcome: { note: "stale-run-A" } })
+    ).rejects.toThrow(/no processing ledger row/);
+
+    // R2 survives untouched: still processing, no stale outcome grafted on.
+    const row = await getProcessed(key);
+    expect(row.id).toBe(r2);
+    expect(row.status).toBe("processing");
+    expect(row.outcome).toBeNull();
   });
 });
 
@@ -336,8 +358,8 @@ describe("email ledger — durability across connection deletion", () => {
     const conn = await seedConnection("conn-survives");
     const key = { workflowId: wf.id, connectionId: conn.id, providerMessageId: "msg-1" };
 
-    await claimEmail(key);
-    await finalizeEmail({ ...key, status: "done" });
+    const id = await claimEmail(key);
+    await finalizeEmail({ id: id!, status: "done" });
 
     // processed_emails.connectionId is intentionally FK-less: the ledger is a
     // historical record of what was already handled. Deleting the connection

--- a/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-ledger.integration.test.ts
@@ -17,7 +17,23 @@ import {
   claimEmail,
   finalizeEmail,
   resetStuckProcessingEmails,
+  type ClaimInput,
 } from "@/lib/email-workflows/ledger";
+
+/**
+ * claimEmail + assert this caller won, narrowing the id to a plain string.
+ * Every test that finalizes needs the *winning* row id; a lost claim there is a
+ * broken fixture, and failing on it here beats a confusing `no processing
+ * ledger row` throw further down. Tests that assert claim semantics themselves
+ * (a rejected re-claim, a race) call claimEmail directly.
+ */
+async function claimOrFail(key: ClaimInput): Promise<string> {
+  const id = await claimEmail(key);
+  if (id === null) {
+    throw new Error(`test fixture: claim unexpectedly lost for ${key.providerMessageId}`);
+  }
+  return id;
+}
 
 async function getProcessed(key: {
   workflowId: string;
@@ -124,9 +140,9 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    const id = await claimEmail(key);
+    const id = await claimOrFail(key);
     await finalizeEmail({
-      id: id!,
+      id,
       status: "done",
       outcome: { odooModel: "account.move", odooId: 42 },
       runId: "run-1",
@@ -144,8 +160,8 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    const id = await claimEmail(key);
-    await finalizeEmail({ id: id!, status: "done" });
+    const id = await claimOrFail(key);
+    await finalizeEmail({ id, status: "done" });
 
     // Simulate the reconciliation sweep finding the same provider message again
     // after a cursor loss: the ledger — not the cursor — is the source of truth,
@@ -166,13 +182,13 @@ describe("email ledger — finalizeEmail", () => {
     const wf = await seedWorkflow(agent.id);
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "msg-1" };
 
-    const id = await claimEmail(key);
-    await finalizeEmail({ id: id!, status: "done", outcome: { note: "first" } });
+    const id = await claimOrFail(key);
+    await finalizeEmail({ id, status: "done", outcome: { note: "first" } });
 
     // finalize only ever transitions processing → terminal. A duplicate finalize
     // (e.g. a buggy retry) must NOT silently overwrite the recorded outcome —
     // the WHERE clause no longer matches, so zero rows update and we throw.
-    await expect(finalizeEmail({ id: id!, status: "failed" })).rejects.toThrow(
+    await expect(finalizeEmail({ id, status: "failed" })).rejects.toThrow(
       /no processing ledger row/
     );
 
@@ -245,10 +261,10 @@ describe("email ledger — resetStuckProcessingEmails (reconciliation)", () => {
     const done = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "done-old" };
     const failed = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "failed-old" };
 
-    const doneId = await claimEmail(done);
-    await finalizeEmail({ id: doneId!, status: "done", outcome: { note: "kept" } });
-    const failedId = await claimEmail(failed);
-    await finalizeEmail({ id: failedId!, status: "failed" });
+    const doneId = await claimOrFail(done);
+    await finalizeEmail({ id: doneId, status: "done", outcome: { note: "kept" } });
+    const failedId = await claimOrFail(failed);
+    await finalizeEmail({ id: failedId, status: "failed" });
     // Backdate both far past the grace window — age alone must not reset them.
     await backdateClaim(done, GRACE_MS * 100);
     await backdateClaim(failed, GRACE_MS * 100);
@@ -282,28 +298,37 @@ describe("email ledger — resetStuckProcessingEmails (reconciliation)", () => {
     const key = { workflowId: wf.id, connectionId: "conn-1", providerMessageId: "supersede-1" };
 
     // Run A claims the email → row R1, then hangs (genuinely slow, not dead).
-    const r1 = await claimEmail(key);
+    const r1 = await claimOrFail(key);
     await backdateClaim(key, GRACE_MS + 60_000);
-    // The sweep deletes the stuck R1 and re-lists; a fresh run re-claims → row R2.
+    // The sweep deletes the stuck R1 and re-lists; a fresh run (B) re-claims → R2.
     await resetStuckProcessingEmails(GRACE_MS);
-    const r2 = await claimEmail(key);
-    expect(r2).toEqual(expect.any(String));
+    const r2 = await claimOrFail(key);
     expect(r2).not.toBe(r1); // genuinely a different claim, same email
 
     // Run A finally wakes and finalizes ITS claim (R1). R1 is gone, so finalize
     // must hit zero rows and throw loudly — it must NOT graft Run A's stale
-    // outcome onto R2, which belongs to the fresh run and is still processing.
+    // outcome onto R2, which belongs to Run B and is still processing.
     // This holds only because finalize is pinned to the claim's row id: the
     // claim *tuple* is reusable and still matches R2.
     await expect(
-      finalizeEmail({ id: r1!, status: "done", outcome: { note: "stale-run-A" } })
+      finalizeEmail({ id: r1, status: "done", outcome: { note: "stale-run-A" } })
     ).rejects.toThrow(/no processing ledger row/);
 
     // R2 survives untouched: still processing, no stale outcome grafted on.
-    const row = await getProcessed(key);
-    expect(row.id).toBe(r2);
-    expect(row.status).toBe("processing");
-    expect(row.outcome).toBeNull();
+    const survived = await getProcessed(key);
+    expect(survived.id).toBe(r2);
+    expect(survived.status).toBe("processing");
+    expect(survived.outcome).toBeNull();
+
+    // The other half of the contract: rejecting the superseded run must not cost
+    // Run B its own finalize. Pinning to the row id has to block only the stale
+    // claim, not every finalize that follows a reset — otherwise the sweep's
+    // re-run could never reach a terminal status and the email would be stuck
+    // in `processing` forever, reset and re-claimed on every sweep.
+    await finalizeEmail({ id: r2, status: "done", outcome: { note: "run-B" } });
+    const finalized = await getProcessed(key);
+    expect(finalized.status).toBe("done");
+    expect(finalized.outcome).toEqual({ note: "run-B" });
   });
 });
 
@@ -358,8 +383,8 @@ describe("email ledger — durability across connection deletion", () => {
     const conn = await seedConnection("conn-survives");
     const key = { workflowId: wf.id, connectionId: conn.id, providerMessageId: "msg-1" };
 
-    const id = await claimEmail(key);
-    await finalizeEmail({ id: id!, status: "done" });
+    const id = await claimOrFail(key);
+    await finalizeEmail({ id, status: "done" });
 
     // processed_emails.connectionId is intentionally FK-less: the ledger is a
     // historical record of what was already handled. Deleting the connection

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -176,7 +176,7 @@ export async function dispatchEmails(params: {
           recipientUserIds: workflow.recipientUserIds,
         });
         await finalizeEmail({
-          ...claimKey,
+          id: ledgerId,
           status: result.status,
           outcome: result.outcome,
           runId: result.runId,
@@ -193,7 +193,7 @@ export async function dispatchEmails(params: {
           sourceId: ledgerId,
           recipientUserIds: workflow.recipientUserIds,
         });
-        await finalizeEmail({ ...claimKey, status: "failed" });
+        await finalizeEmail({ id: ledgerId, status: "failed" });
         summary.failed++;
       }
     } catch (err) {

--- a/packages/web/src/lib/email-workflows/dispatch.ts
+++ b/packages/web/src/lib/email-workflows/dispatch.ts
@@ -77,9 +77,9 @@ export interface DispatchSummary {
   succeeded: number;
   failed: number;
   /**
-   * Claimed emails whose delivery (notify) or finalize threw. Their ledger row
-   * is intentionally left `processing` for the reconciliation sweep to retry —
-   * see the ordering note below. Distinct from `failed`, which is a *run* that
+   * Claimed emails whose delivery (notify) or finalize threw. We intentionally
+   * do not finalize them, leaving the retry to the reconciliation sweep — see
+   * the ordering note below. Distinct from `failed`, which is a *run* that
    * threw but was itself delivered and finalized as `failed`.
    */
   deferred: number;
@@ -198,11 +198,18 @@ export async function dispatchEmails(params: {
       }
     } catch (err) {
       // A deferral (RunDeferredError), or delivery/finalize threw after the
-      // claim. Leave the row `processing` for the reconciliation sweep; never
-      // abort the batch.
+      // claim. Either way we do not finalize, so the reconciliation sweep owns
+      // the retry; never abort the batch.
+      //
+      // Usually that means our own row is simply left `processing` for the
+      // sweep to pick up. The one exception is a *superseded* claim (#735): a
+      // previous sweep already deleted our row and someone else re-claimed the
+      // email, so finalize threw. Retry ownership has passed to that run — the
+      // row now in `processing` is theirs, and this branch correctly does
+      // nothing to it.
       summary.deferred++;
       console.error(
-        `dispatchEmails: deferred email ${email.providerMessageId} (workflow ${workflow.id}) after claim — left processing for the reconciliation sweep`,
+        `dispatchEmails: deferred email ${email.providerMessageId} (workflow ${workflow.id}) after claim — not finalized, the reconciliation sweep owns the retry`,
         err
       );
     }

--- a/packages/web/src/lib/email-workflows/ledger.ts
+++ b/packages/web/src/lib/email-workflows/ledger.ts
@@ -45,9 +45,8 @@ export async function claimEmail(input: ClaimInput): Promise<string | null> {
 export type FinalizeStatus = "done" | "no_action" | "failed";
 
 export interface FinalizeInput {
-  workflowId: string;
-  connectionId: string;
-  providerMessageId: string;
+  /** The claim's ledger row id, exactly as returned by {@link claimEmail}. */
+  id: string;
   status: FinalizeStatus;
   outcome?: ProcessedEmailOutcome;
   runId?: string;
@@ -56,12 +55,20 @@ export interface FinalizeInput {
 /**
  * Mark a claimed email's ledger row with its terminal status and outcome. Called
  * by the isolated agent run when it finishes (draft created / nothing to do /
- * failed). Keyed by the same claim tuple as {@link claimEmail}.
+ * failed). Pinned to the claim's **row id** — the id {@link claimEmail} handed
+ * the winning caller — not the reusable claim tuple.
  *
- * finalize only ever transitions `processing` → terminal: the WHERE clause pins
- * `status = 'processing'`, so a zero-row update means either finalize-before-claim
- * or a duplicate finalize of an already-terminal row. Both are bugs, and both must
- * NOT silently overwrite a recorded outcome — we surface them loudly instead.
+ * The row id (not the tuple) is load-bearing because the reconciliation sweep
+ * uses delete-and-reclaim (#735): a stuck row is DELETEd and its claim tuple is
+ * re-claimed as a *fresh* row. Matching finalize on the tuple would let a slow,
+ * superseded run terminalize that fresh claim with its stale outcome. Matching
+ * on the id instead means a superseded run's finalize hits zero rows and takes
+ * the loud-throw path below, leaving the live claim untouched.
+ *
+ * finalize only ever transitions `processing` → terminal: the WHERE clause also
+ * pins `status = 'processing'`, so a zero-row update means finalize-before-claim,
+ * a duplicate finalize of an already-terminal row, or a superseded claim. All are
+ * bugs and none may silently overwrite a recorded outcome — we throw instead.
  */
 export async function finalizeEmail(input: FinalizeInput): Promise<void> {
   const rows = await db
@@ -72,18 +79,11 @@ export async function finalizeEmail(input: FinalizeInput): Promise<void> {
       runId: input.runId ?? null,
       finalizedAt: new Date(),
     })
-    .where(
-      and(
-        eq(processedEmails.workflowId, input.workflowId),
-        eq(processedEmails.connectionId, input.connectionId),
-        eq(processedEmails.providerMessageId, input.providerMessageId),
-        eq(processedEmails.status, "processing")
-      )
-    )
+    .where(and(eq(processedEmails.id, input.id), eq(processedEmails.status, "processing")))
     .returning({ id: processedEmails.id });
   if (rows.length === 0) {
     throw new Error(
-      `finalizeEmail: no processing ledger row for (${input.workflowId}, ${input.connectionId}, ${input.providerMessageId}) — already finalized or never claimed?`
+      `finalizeEmail: no processing ledger row ${input.id} — already finalized, never claimed, or superseded by a reconciliation reset?`
     );
   }
 }


### PR DESCRIPTION
Closes #735.

## The hazard

`finalizeEmail` located its ledger row by the claim tuple `(workflowId, connectionId, providerMessageId)` + `status = 'processing'`. That tuple is **reusable**: the reconciliation sweep's delete-and-reclaim (`resetStuckProcessingEmails`) DELETEs a stuck row, freeing the tuple so the email is re-listed and re-claimed as a *fresh* row.

That opens a cross-contamination edge:

1. Run A claims email X → row **R1** (`processing`).
2. Run A hangs; R1 sits stuck past `graceMs`.
3. Sweep DELETEs R1, re-lists X, re-claims → row **R2** (`processing`).
4. Run A — merely slow, not dead — finally calls `finalizeEmail` for X.
5. The tuple still matches **R2**, so Run A terminalizes a claim it no longer owns, grafting its stale outcome onto Run B's row.

`graceMs > run-timeout` makes this unlikely, but the guarantee rested entirely on that timeout relationship rather than on identity.

## The fix

Pin the terminal transition to the claim's **row id** — the id `claimEmail` already returns and the dispatcher already holds as `ledgerId`:

```ts
.where(and(eq(processedEmails.id, input.id), eq(processedEmails.status, "processing")))
```

A superseded run's finalize now matches zero rows and takes the **existing** loud-throw path, leaving the live claim untouched.

`FinalizeInput` drops the tuple for `{ id, status, outcome?, runId? }` — the tuple was only ever meaningful for the claim itself, and every caller has the id from `claimEmail`. `status = 'processing'` stays: it is what still makes finalize-before-claim and duplicate-finalize throw.

## Verification

Test-first. The new hazard test was written against the **pre-fix** code with the pre-fix tuple call and observed failing for the exact right reason — the late finalize resolved instead of throwing, i.e. it had clobbered R2.

Both WHERE predicates mutation-verified individually:

| Mutation | Result |
|---|---|
| drop `eq(id, input.id)` | hazard test reds (+ a dispatch deferral test) |
| drop `eq(status, "processing")` | exactly the terminal-guard test reds |

Gates: integration **222/222** (was 221 + the new hazard test) · unit **8231 passed** · prettier clean · eslint 0 errors · `pnpm build` ✓.

Existing finalize behavior is preserved — the finalize-before-claim and duplicate-finalize loud-throw tests still assert the same thing, migrated to the id API. The dispatch integration tests pass **unchanged**, which is what confirms the end-to-end wiring.

## Why now

Must land before the audited sweep caller (Brick D orchestrator) goes live — that's the caller that actually exercises re-list + re-dispatch on a shared discovery route.

---

## Review follow-up (2nd commit)

Review of this PR found the hazard test proved only the **forbidden** half of the contract — that a superseded run's finalize is rejected. It never proved the **permitted** half: that the run owning the fresh re-claim can still finalize it. An over-blocking fix — one rejecting *every* finalize after a reset — would have passed the test, and that is exactly the path Brick D's sweep takes in production. The email would sit in `processing` forever, reset and re-claimed on every sweep, with a green suite.

Closed, and mutation-verified: making finalize's WHERE never match reds the test at exactly Run B's finalize, while the pre-existing assertions stayed green.

Also in that commit:

- **`claimOrFail` helper** replaces the `id!` non-null assertions. A lost claim now fails as a named fixture error rather than a confusing `no processing ledger row` throw further down. Mutation-verified with a sweep that skips its delete.
- **Corrected the deferred log line + `DispatchSummary` doc.** Both claimed the row is "left processing" — wrong for a superseded claim, where our row is gone and the `processing` row belongs to another run. Retry ownership is what actually holds across both cases, so they say that now.

Gates re-run after the follow-up: integration **222/222** · unit **8231 passed** · prettier clean · eslint 0 errors · `pnpm build` ✓.
