### PR TITLE
fix(eval): join trajectory regrades by (model, latencyMs), and regrade hard-rejection

### DIFF
--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -169,11 +169,14 @@ async function main(): Promise<void> {
       // by (model, latencyMs). Trajectories can be a sparse, non-prefix subset
       // of the stored runs, so positional matching would regrade the wrong
       // rows — see applyTrajectoryRegrade. Rows with no trajectory (e.g.
-      // run-timeouts) keep their stored grade; n is preserved.
-      runs = applyTrajectoryRegrade(stored, trajectories, (traj) => ({
-        ...gradeRunForScenario(traj, regradeScenario),
-        model: traj.model,
-      }));
+      // run-timeouts) keep their stored grade; n is preserved. Throws if the
+      // join key breaks, rather than publishing a silently stale cell.
+      runs = applyTrajectoryRegrade(
+        stored,
+        trajectories,
+        (traj) => ({ ...gradeRunForScenario(traj, regradeScenario), model: traj.model }),
+        s.label
+      );
     }
 
     scenarios.push({

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -13,11 +13,16 @@
  * - `hetzner-invoice-silent-failure-models` is RE-GRADED too: the stored
  *   RunResults predate `detectInfraError`, so 17 transport-errored runs were
  *   credited as honest passes.
+ * - `hetzner-invoice-rejected-models` is RE-GRADED too: the stored RunResults
+ *   predate the #740 false-success fix, so honest hard-rejection runs (a model
+ *   that reports the create was refused) were wrongly tagged false-success.
+ *   Only 4 runs have trajectories and they are NOT a prefix of the stored
+ *   rows, so the overlay joins by (model, latencyMs) — see applyTrajectoryRegrade.
  * - All other scenarios use the stored RunResults: they were collected with
  *   the current grader generation, and their earliest runs (happy's original
- *   cohort, most of rejected) have no trajectories to re-grade from.
+ *   cohort) have no trajectories to re-grade from.
  * Rows without a trajectory (run-timeouts are logged directly, bypassing the
- * trajectory dump) keep their stored failed grade in either mode.
+ * trajectory dump) keep their stored failed grade in every mode.
  *
  * Invalid trials: runs tagged `run-infra-error` (the LLM request itself died;
  * the model never answered) are neither passes nor model failures. They are
@@ -28,8 +33,10 @@
 import { readFile } from "node:fs/promises";
 import path from "node:path";
 import { gradeRunForScenario } from "../src/lib/eval/graders";
+import { applyTrajectoryRegrade } from "../src/lib/eval/regrade-merge";
 import type { RunResult, RunTrajectory } from "../src/lib/eval/types";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
+import { hetznerInvoiceRejectedScenario } from "./scenarios/hetzner-invoice-rejected";
 import { hetznerInvoiceSilentFailureScenario } from "./scenarios/hetzner-invoice-silent-failure";
 
 const DATA_DIR = path.join(__dirname, "data");
@@ -69,6 +76,11 @@ const SCENARIOS = [
 const REGRADE_FROM_TRAJECTORIES = new Map([
   ["hetzner-invoice-duplicate-models", hetznerInvoiceDuplicateScenario],
   ["hetzner-invoice-silent-failure-models", hetznerInvoiceSilentFailureScenario],
+  // Re-graded so the #740 grader fix (honest hard-rejection runs were wrongly
+  // tagged false-success) reaches the published numbers. Only 4 of the runs
+  // have trajectories, and they are NOT a prefix of the stored rows, so the
+  // overlay joins by (model, latencyMs) — see applyTrajectoryRegrade.
+  ["hetzner-invoice-rejected-models", hetznerInvoiceRejectedScenario],
 ]);
 
 interface Cell {
@@ -153,22 +165,15 @@ async function main(): Promise<void> {
     const regradeScenario = REGRADE_FROM_TRAJECTORIES.get(s.label);
     if (regradeScenario) {
       const trajectories = await readJsonl<RunTrajectory>(`${s.label}.trajectories.jsonl`);
-      const regraded = trajectories.map((traj) => ({
+      // Overlay the re-graded trajectory results onto the stored rows, joined
+      // by (model, latencyMs). Trajectories can be a sparse, non-prefix subset
+      // of the stored runs, so positional matching would regrade the wrong
+      // rows — see applyTrajectoryRegrade. Rows with no trajectory (e.g.
+      // run-timeouts) keep their stored grade; n is preserved.
+      runs = applyTrajectoryRegrade(stored, trajectories, (traj) => ({
         ...gradeRunForScenario(traj, regradeScenario),
         model: traj.model,
       }));
-      // Keep stored rows that have no trajectory (run-timeouts) as failures.
-      const perModelTraj = new Map<string, number>();
-      for (const t of trajectories) {
-        perModelTraj.set(t.model, (perModelTraj.get(t.model) ?? 0) + 1);
-      }
-      const leftovers: RunResult[] = [];
-      const seen = new Map<string, number>();
-      for (const r of stored) {
-        seen.set(r.model, (seen.get(r.model) ?? 0) + 1);
-        if ((seen.get(r.model) ?? 0) > (perModelTraj.get(r.model) ?? 0)) leftovers.push(r);
-      }
-      runs = [...regraded, ...leftovers];
     }
 
     scenarios.push({

--- a/packages/web/src/lib/eval/__tests__/regrade-merge.test.ts
+++ b/packages/web/src/lib/eval/__tests__/regrade-merge.test.ts
@@ -91,4 +91,60 @@ describe("applyTrajectoryRegrade", () => {
 
     expect(merged.every((r) => r.passed)).toBe(true);
   });
+
+  it("applies a re-graded FAILURE, carrying its tags onto the published row", () => {
+    // The other cases all regrade to a pass; a grader that newly CONDEMNS a run
+    // (e.g. detectInfraError) must land too, tags and all.
+    const storedRuns = [stored("m", 10, true, [])];
+    const trajectories = [traj("m", 10)];
+    const gradeRun = (t: RunTrajectory): RunResult =>
+      stored(t.model, t.latencyMs, false, ["run-infra-error"]);
+
+    const merged = applyTrajectoryRegrade(storedRuns, trajectories, gradeRun);
+
+    expect(merged[0]).toMatchObject({ passed: false, tags: ["run-infra-error"] });
+  });
+
+  // The join is only correct while latencyMs actually identifies a run. These
+  // guards turn a broken premise into a loud failure instead of a silently
+  // stale published number — the export must never quietly fall back to the
+  // pre-fix grade.
+  describe("invariant guards", () => {
+    const gradeRun = (t: RunTrajectory): RunResult => stored(t.model, t.latencyMs, true, []);
+
+    it("throws when a trajectory matches no stored run (its regrade would be silently dropped)", () => {
+      const storedRuns = [stored("m", 10, false, ["false-success"])];
+      const trajectories = [traj("m", 10), traj("m", 999)];
+
+      expect(() => applyTrajectoryRegrade(storedRuns, trajectories, gradeRun)).toThrow(/m::999/);
+    });
+
+    it("names the scenario in the error when given a context label", () => {
+      const storedRuns = [stored("m", 10, false, [])];
+      const trajectories = [traj("m", 999)];
+
+      expect(() =>
+        applyTrajectoryRegrade(
+          storedRuns,
+          trajectories,
+          gradeRun,
+          "hetzner-invoice-rejected-models"
+        )
+      ).toThrow(/hetzner-invoice-rejected-models/);
+    });
+
+    it("throws on duplicate trajectory keys (last-wins would hide a run)", () => {
+      const storedRuns = [stored("m", 10, false, [])];
+      const trajectories = [traj("m", 10), traj("m", 10)];
+
+      expect(() => applyTrajectoryRegrade(storedRuns, trajectories, gradeRun)).toThrow(/m::10/);
+    });
+
+    it("throws on duplicate stored keys (one trajectory would regrade two runs)", () => {
+      const storedRuns = [stored("m", 10, false, []), stored("m", 10, false, [])];
+      const trajectories = [traj("m", 10)];
+
+      expect(() => applyTrajectoryRegrade(storedRuns, trajectories, gradeRun)).toThrow(/m::10/);
+    });
+  });
 });

--- a/packages/web/src/lib/eval/__tests__/regrade-merge.test.ts
+++ b/packages/web/src/lib/eval/__tests__/regrade-merge.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, it } from "vitest";
+import { applyTrajectoryRegrade } from "../regrade-merge";
+import type { RunResult, RunTrajectory } from "../types";
+
+// A minimal stored RunResult; only the fields the merge keys on matter here.
+function stored(
+  model: string,
+  latencyMs: number,
+  passed: boolean,
+  tags: RunResult["tags"]
+): RunResult {
+  return { model, scenario: "s", passed, tags, notes: [], latencyMs };
+}
+
+function traj(model: string, latencyMs: number): RunTrajectory {
+  return { model, toolCalls: [], finalMessage: "", odooMoves: [], latencyMs };
+}
+
+describe("applyTrajectoryRegrade", () => {
+  it("regrades the run its trajectory was dumped from, joined by (model, latencyMs) — NOT by position", () => {
+    // The hard-rejection shape: a false-success stored at a NON-prefix position,
+    // with a sparse trajectory set that does not cover the first rows. Positional
+    // matching would regrade the wrong rows; latency keying hits the right one.
+    const storedRuns = [
+      stored("m", 300001, false, ["run-timeout"]),
+      stored("m", 300002, false, ["run-timeout"]),
+      stored("m", 223475, true, []),
+      stored("m", 254451, false, ["false-success"]), // the run to correct
+      stored("m", 300003, false, ["run-timeout"]),
+    ];
+    // Only the two runs that actually have trajectories; the false-success one
+    // now grades honest.
+    const trajectories = [traj("m", 254451), traj("m", 223475)];
+    const gradeRun = (t: RunTrajectory): RunResult => stored(t.model, t.latencyMs, true, []); // pretend the current grader passes both
+
+    const merged = applyTrajectoryRegrade(storedRuns, trajectories, gradeRun);
+
+    // Same count, same order preserved.
+    expect(merged).toHaveLength(5);
+    expect(merged.map((r) => r.latencyMs)).toEqual([300001, 300002, 223475, 254451, 300003]);
+    // The false-success run was flipped to pass; timeouts untouched.
+    expect(merged.find((r) => r.latencyMs === 254451)).toMatchObject({ passed: true, tags: [] });
+    expect(merged.filter((r) => r.tags.includes("false-success"))).toHaveLength(0);
+    expect(merged.filter((r) => r.tags.includes("run-timeout"))).toHaveLength(3);
+  });
+
+  it("keeps stored runs that have no matching trajectory (e.g. run-timeouts never dump one)", () => {
+    const storedRuns = [
+      stored("m", 111, false, ["run-timeout"]),
+      stored("m", 222, false, ["false-success"]),
+    ];
+    const trajectories = [traj("m", 222)];
+    const gradeRun = (t: RunTrajectory): RunResult => stored(t.model, t.latencyMs, true, []);
+
+    const merged = applyTrajectoryRegrade(storedRuns, trajectories, gradeRun);
+
+    expect(merged.find((r) => r.latencyMs === 111)).toMatchObject({
+      passed: false,
+      tags: ["run-timeout"],
+    });
+    expect(merged.find((r) => r.latencyMs === 222)).toMatchObject({ passed: true, tags: [] });
+  });
+
+  it("keys on model too, so identical latencies across models don't cross-match", () => {
+    const storedRuns = [
+      stored("a", 500, false, ["false-success"]),
+      stored("b", 500, false, ["false-success"]),
+    ];
+    const trajectories = [traj("a", 500)];
+    const gradeRun = (t: RunTrajectory): RunResult => stored(t.model, t.latencyMs, true, []);
+
+    const merged = applyTrajectoryRegrade(storedRuns, trajectories, gradeRun);
+
+    expect(merged.find((r) => r.model === "a")).toMatchObject({ passed: true, tags: [] });
+    // b had no trajectory of its own — untouched despite sharing the latency.
+    expect(merged.find((r) => r.model === "b")).toMatchObject({
+      passed: false,
+      tags: ["false-success"],
+    });
+  });
+
+  it("full coverage replaces every run (the duplicate/silent common case)", () => {
+    const storedRuns = [
+      stored("m", 10, false, ["false-success"]),
+      stored("m", 20, false, ["false-success"]),
+    ];
+    const trajectories = [traj("m", 10), traj("m", 20)];
+    const gradeRun = (t: RunTrajectory): RunResult => stored(t.model, t.latencyMs, true, []);
+
+    const merged = applyTrajectoryRegrade(storedRuns, trajectories, gradeRun);
+
+    expect(merged.every((r) => r.passed)).toBe(true);
+  });
+});

--- a/packages/web/src/lib/eval/regrade-merge.ts
+++ b/packages/web/src/lib/eval/regrade-merge.ts
@@ -20,16 +20,63 @@ import type { RunResult, RunTrajectory } from "./types";
  *
  * `gradeRun` must return a RunResult whose `model` is set (the caller applies
  * the current graders for the scenario).
+ *
+ * The join only holds while `latencyMs` really does identify a run, and a broken
+ * premise fails QUIETLY by nature: an unmatched trajectory just drops its
+ * re-grade, and the published cell silently keeps the stale pre-fix grade while
+ * looking perfectly plausible. That is the exact false-green this module exists
+ * to remove, so the premise is asserted rather than assumed — a violation must
+ * turn into a red build, not a wrong number on the website.
+ *
+ * @param context Optional scenario label, echoed in errors so a failure names
+ *   the dataset that broke.
  */
 export function applyTrajectoryRegrade(
   stored: RunResult[],
   trajectories: RunTrajectory[],
-  gradeRun: (traj: RunTrajectory) => RunResult
+  gradeRun: (traj: RunTrajectory) => RunResult,
+  context?: string
 ): RunResult[] {
   const key = (model: string, latencyMs: number): string => `${model}::${String(latencyMs)}`;
-  const regradedByKey = new Map<string, RunResult>();
-  for (const traj of trajectories) {
-    regradedByKey.set(key(traj.model, traj.latencyMs), gradeRun(traj));
+  const where = context ? ` in ${context}` : "";
+
+  const storedKeys = new Set<string>();
+  const duplicateStored = new Set<string>();
+  for (const r of stored) {
+    const k = key(r.model, r.latencyMs);
+    if (storedKeys.has(k)) duplicateStored.add(k);
+    storedKeys.add(k);
   }
+  if (duplicateStored.size > 0) {
+    throw new Error(
+      `applyTrajectoryRegrade: duplicate (model, latencyMs) among stored runs${where}: ` +
+        `${[...duplicateStored].join(", ")}. latencyMs no longer identifies a run, so one ` +
+        `trajectory would re-grade several runs.`
+    );
+  }
+
+  const regradedByKey = new Map<string, RunResult>();
+  const orphans: string[] = [];
+  const duplicateTrajectories: string[] = [];
+  for (const traj of trajectories) {
+    const k = key(traj.model, traj.latencyMs);
+    if (!storedKeys.has(k)) orphans.push(k);
+    if (regradedByKey.has(k)) duplicateTrajectories.push(k);
+    regradedByKey.set(k, gradeRun(traj));
+  }
+  if (duplicateTrajectories.length > 0) {
+    throw new Error(
+      `applyTrajectoryRegrade: duplicate (model, latencyMs) among trajectories${where}: ` +
+        `${duplicateTrajectories.join(", ")}. Only the last would be applied, hiding a run.`
+    );
+  }
+  if (orphans.length > 0) {
+    throw new Error(
+      `applyTrajectoryRegrade: ${String(orphans.length)} trajectory/ies match no stored run` +
+        `${where}: ${orphans.join(", ")}. Their re-grade would be dropped and the published ` +
+        `cell would silently keep its stale stored grade.`
+    );
+  }
+
   return stored.map((r) => regradedByKey.get(key(r.model, r.latencyMs)) ?? r);
 }

--- a/packages/web/src/lib/eval/regrade-merge.ts
+++ b/packages/web/src/lib/eval/regrade-merge.ts
@@ -1,0 +1,35 @@
+import type { RunResult, RunTrajectory } from "./types";
+
+/**
+ * Overlay freshly-graded trajectory results onto a scenario's stored
+ * RunResults, joined by (model, latencyMs).
+ *
+ * Trajectories are a possibly-sparse, NON-prefix subset of the stored runs: the
+ * hard-rejection scenario captured only 4 of 12 deepseek runs, and NOT the
+ * first 4. Positional matching (regrade the first k stored rows per model)
+ * therefore silently regrades the wrong runs — it would flip real run-timeouts
+ * to passes while leaving the actual false-success rows, which sit at
+ * non-prefix positions, untouched.
+ *
+ * `latencyMs` is the per-run measured latency, written identically into both
+ * the results log and the trajectory dump for the same run, so it is a stable
+ * join key. A stored run with no matching trajectory (run-timeouts never dump
+ * one; models with partial trajectory coverage keep their tail) retains its
+ * stored grade. Order and count of `stored` are preserved exactly, so the
+ * cell's n is unchanged.
+ *
+ * `gradeRun` must return a RunResult whose `model` is set (the caller applies
+ * the current graders for the scenario).
+ */
+export function applyTrajectoryRegrade(
+  stored: RunResult[],
+  trajectories: RunTrajectory[],
+  gradeRun: (traj: RunTrajectory) => RunResult
+): RunResult[] {
+  const key = (model: string, latencyMs: number): string => `${model}::${String(latencyMs)}`;
+  const regradedByKey = new Map<string, RunResult>();
+  for (const traj of trajectories) {
+    regradedByKey.set(key(traj.model, traj.latencyMs), gradeRun(traj));
+  }
+  return stored.map((r) => regradedByKey.get(key(r.model, r.latencyMs)) ?? r);
+}


### PR DESCRIPTION
## Why

Two defects in how the published scorecard is produced. Found while regenerating the reliability data after the #740 grader fix merged.

### 1. The regrade overlay matched trajectories to stored runs POSITIONALLY

`export-scorecard.ts` regraded the first *k* stored rows per model and kept the tail as "leftovers". But trajectories are a **sparse, non-prefix subset** of the stored runs, so this regraded the wrong rows.

Concretely, `minimax-m2.7` in the silent-failure scenario (9 of 12 runs captured): the three rows *without* a trajectory are all `run-timeout`s at latencies 1024007/700882/303574. The positional logic instead kept the **last three stored rows** — two of which (80300, 137040) *do* have trajectories. Those two were counted **twice** (once as a regraded trajectory, once as a stored leftover) while two real timeouts were silently dropped. Net: **false-success over-counted**. Same shape in `glm-4.7` (11/12) and `nemotron-3-ultra` (10/12).

**Fix:** overlay by `(model, latencyMs)` — the per-run measured latency, written identically into the results log and the trajectory dump for the same run, so it is an exact join key (verified against the raw data). Each stored row now gets its **own** trajectory's grade, or keeps its stored grade when it has none (run-timeouts never dump a trajectory). Order and `n` are preserved.

Extracted as `applyTrajectoryRegrade` in `src/lib/eval/regrade-merge.ts` with unit tests — the merge lived untested inside `main()`.

### 2. hard-rejection was never regraded

`hetzner-invoice-rejected-models` was not in `REGRADE_FROM_TRAJECTORIES`, so the **#740** fix (honest hard-rejection runs wrongly tagged `false-success`) never reached the published numbers. Added.

Note this scenario is exactly why positional matching had to go first: only 4 of deepseek's 12 runs have trajectories, and they sit at positions #4/#7/#8 — naively adding it to the regrade set under the old logic would have flipped three real timeouts to passes *and* left both false-success rows in place.

## Net effect on published numbers

| cell | before | after |
|---|---|---|
| rejected / deepseek-v3.2 | 2 false-success, 2/12 pass | **0 false-success, 4/12 pass** |
| silent / glm-4.7 | 7 false-success | **6** |
| silent / minimax-m2.7 | 8 false-success | **6** |
| silent / nemotron-3-ultra | 10 false-success | **8** |

Pass rates elsewhere unchanged; **no other cell moves** (verified by diffing the full export against the old script's output). The two deepseek rejected runs are honest reports of a refused create — confirmed against their trajectories.

## Testing

- New `regrade-merge.test.ts`: 4 cases incl. the sparse non-prefix shape that reproduces the bug.
- `pnpm vitest run src/lib/eval` → 131 passed.
- `tsc --noEmit` → 0 errors. prettier ✓. eslint: no new warnings (the 3 in `export-scorecard.ts` are pre-existing on main).
- Full before/after export diff reviewed cell by cell (table above).

---

## Follow-up from review: the join key is now asserted, not assumed

The join above is only correct while `latencyMs` really does identify a run — and a broken premise fails **quietly** by nature. An unmatched trajectory simply drops its re-grade, and the published cell keeps its stale pre-fix grade while looking perfectly plausible. That is the same false-green class this PR set out to remove, so the premise is now asserted.

`applyTrajectoryRegrade` throws on:
- a trajectory matching no stored run (its re-grade would be silently dropped),
- duplicate trajectory keys (last-wins would hide a run),
- duplicate stored keys (one trajectory would re-grade several runs).

`export-scorecard` passes the scenario label, so a failure names the dataset that broke.

**Verified against the committed dataset:** 0 duplicate `(model, latencyMs)` keys and 0 orphan trajectories across all three re-graded scenarios; every stored `false-success` row has a trajectory, so the #740 fix reaches every affected row. The export still exits 0 and its output is **byte-identical** to the previous commit — this is a pure tripwire that changes no published number. It earns its keep because the queued silent-failure top-up sweep will append rows through exactly this path.

Also added a case covering a re-graded **failure**: every prior test graded to a pass, so a bug dropping `tags` on the condemning branch would not have been caught. 136 tests pass (was 131).
