### PR TITLE
fix(chat): reserve action-bar height so messages don't resize

### DIFF
--- a/packages/web/e2e/19-message-hover-layout-shift.spec.ts
+++ b/packages/web/e2e/19-message-hover-layout-shift.spec.ts
@@ -1,0 +1,197 @@
+// packages/web/e2e/19-message-hover-layout-shift.spec.ts
+//
+// Real-browser regression guard for the message layout shift: assistant messages
+// changed height by 8px depending on whether their action bar was mounted, so
+// messages jumped whenever the bar appeared or disappeared.
+//
+// Root cause: assistant-ui UNMOUNTS the action bar rather than hiding it with
+// CSS (`ActionBarRoot` returns null), and `autohide="not-last"` means the bar is
+// mounted IN FLOW (`normal`, position: static) on the last message but absent on
+// every other one. The footer row therefore measured 24px (button height, size-6)
+// on the last message and only 16px (timestamp line-height, text-xs) elsewhere.
+// Every isLast handover — a new reply arriving, a run finishing (hideWhenRunning)
+// — resized a message by 8px and shifted the view. The fix reserves the bar's
+// height on every footer row (min-h-6 in thread.tsx), making all messages equal.
+//
+// Measured in Chromium before the fix: non-last message 68px / footer 16px,
+// last message 76px / footer 24px.
+//
+// This spec is authoritative and jsdom cannot replace it: the bug IS layout, and
+// jsdom has no layout engine — every element there reports height 0. The unit
+// test in thread.test.tsx can only assert the class is present, which stays green
+// if TooltipIconButton's size-6 ever grows. Only a real browser measures the
+// actual shift.
+//
+// The WebSocket is fully mocked client-side so the conversation is deterministic
+// and no OpenClaw stack is needed (same technique as 04-chat-reconnect.spec.ts
+// and 18-tab-refocus-shrink.spec.ts).
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig } from "./helpers";
+
+// Timestamps matter: MessageTimestamp only renders when metadata.custom.timestamp
+// is set, and its text-xs line-height is exactly the 16px the bar-less rows had.
+// The two assistant replies are the same length so their content wraps identically
+// and any height difference can only come from the footer.
+const HISTORY_MESSAGES = [
+  { role: "user", content: "layout turn one", timestamp: "2026-07-15T09:39:00.000Z" },
+  { role: "assistant", content: "reply alpha", timestamp: "2026-07-15T09:39:01.000Z" },
+  { role: "user", content: "layout turn two", timestamp: "2026-07-15T09:39:02.000Z" },
+  { role: "assistant", content: "reply bravo", timestamp: "2026-07-15T09:39:03.000Z" },
+];
+
+const mockHistorySocket = (historyMessages: typeof HISTORY_MESSAGES) => {
+  type ClientMessage = { type?: string };
+  const RealWebSocket = window.WebSocket;
+
+  class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    CONNECTING = 0;
+    OPEN = 1;
+    CLOSING = 2;
+    CLOSED = 3;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readyState = 1;
+    binaryType = "blob";
+    constructor(url: string) {
+      if (url.includes("/_next/")) {
+        return new RealWebSocket(url) as unknown as MockWebSocket;
+      }
+      queueMicrotask(() => this.onopen?.());
+    }
+    addEventListener() {}
+    removeEventListener() {}
+    send(raw: string) {
+      const message = JSON.parse(raw) as ClientMessage;
+      if (message.type === "history") {
+        setTimeout(() => {
+          this.onmessage?.({
+            data: JSON.stringify({ type: "history", messages: historyMessages }),
+          });
+        }, 0);
+      }
+    }
+    close() {
+      this.readyState = 3;
+      this.onclose?.();
+    }
+  }
+
+  Object.defineProperty(window, "WebSocket", {
+    configurable: true,
+    writable: true,
+    value: MockWebSocket,
+  });
+};
+
+test.describe("message action-bar layout shift", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const setupResponse = await request.post("/api/setup", {
+      data: { name: "Test Admin", email: "admin@test.local", password: "test-password-123" },
+    });
+    expect([201, 403]).toContain(setupResponse.status());
+
+    await seedProviderConfig();
+    await page.addInitScript(mockHistorySocket, HISTORY_MESSAGES);
+
+    // Sign in via the auth API rather than the login form — the form's onSubmit
+    // races hydration on a cold server's first compile (see the same note in
+    // 18-tab-refocus-shrink.spec.ts).
+    const signIn = await page.request.post("/api/auth/sign-in/email", {
+      data: { email: "admin@test.local", password: "test-password-123" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(signIn.ok()).toBeTruthy();
+    const agents = (await (await page.request.get("/api/agents")).json()) as { id: string }[];
+    expect(agents.length).toBeGreaterThan(0);
+    await page.goto(`/chat/${agents[0]!.id}`);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+    await expect(page.locator('[data-role="assistant"]')).toHaveCount(2, { timeout: 15000 });
+  });
+
+  // THE regression test for the fix. assistant-ui mounts the bar in flow on the
+  // last message only, so without a reserved height the last message is 8px
+  // taller than the rest — and every message shrinks by 8px the moment it stops
+  // being last (i.e. whenever the next reply arrives).
+  test("a message must not change height when it stops being the last one", async ({ page }) => {
+    const assistantMessages = page.locator('[data-role="assistant"]');
+    const nonLast = assistantMessages.first();
+    const last = assistantMessages.nth(1);
+
+    // The bar is mounted in flow on the last message and absent on the other —
+    // that asymmetry is exactly what the reserved height has to absorb. Assert it
+    // so this test fails loudly if assistant-ui ever changes the autohide model,
+    // rather than passing for the wrong reason.
+    await expect(last.locator(".aui-assistant-action-bar-root")).toBeVisible();
+    await expect(nonLast.locator(".aui-assistant-action-bar-root")).toHaveCount(0);
+
+    const footerHeight = (locator: typeof nonLast) =>
+      locator
+        .locator(".aui-assistant-message-footer")
+        .boundingBox()
+        .then((box) => box!.height);
+
+    expect(
+      await footerHeight(nonLast),
+      "footer row of a non-last message must already reserve the action bar's height"
+    ).toBe(await footerHeight(last));
+
+    const nonLastBox = (await nonLast.boundingBox())!;
+    const lastBox = (await last.boundingBox())!;
+    expect(
+      Math.abs(nonLastBox.height - lastBox.height),
+      `messages differ in height (${nonLastBox.height}px vs ${lastBox.height}px), so the view jumps when the last-message bar mounts or unmounts`
+    ).toBeLessThan(1);
+  });
+
+  // Guards the floating mechanism itself: a hovered non-last message gets the bar
+  // back as an absolutely-positioned overlay (data-floating → data-floating:absolute).
+  // If those utilities ever stop applying, the bar lands in flow and hovering
+  // starts pushing the conversation around — the symptom originally reported.
+  test("hovering a non-last message must not move the messages below it", async ({ page }) => {
+    const assistantMessages = page.locator('[data-role="assistant"]');
+    const hoverTarget = assistantMessages.first();
+    const messageBelow = page.getByText("layout turn two");
+
+    // Measure the GAP between the two, not their viewport coordinates: hover()
+    // scrolls the target into view inside the scrollable thread viewport, which
+    // moves absolute positions by a pixel or two for reasons unrelated to layout.
+    // The gap is scroll-invariant and is what actually grows when the bar lands
+    // in flow.
+    const gap = async () => {
+      const target = (await hoverTarget.boundingBox())!;
+      const below = (await messageBelow.boundingBox())!;
+      return below.y - target.y;
+    };
+
+    const heightBefore = (await hoverTarget.boundingBox())!.height;
+    const gapBefore = await gap();
+
+    await hoverTarget.hover();
+
+    // Wait for the bar to actually mount — otherwise a green result would only
+    // prove the hover never registered. The Copy button carries an sr-only
+    // "Copy" label (TooltipIconButton), a stable user-facing handle.
+    const actionBar = hoverTarget.locator(".aui-assistant-action-bar-root");
+    await expect(hoverTarget.getByRole("button", { name: "Copy" })).toBeVisible({ timeout: 5000 });
+    await expect(actionBar).toHaveAttribute("data-floating", "true");
+    await expect(actionBar).toHaveCSS("position", "absolute");
+
+    const heightAfter = (await hoverTarget.boundingBox())!.height;
+    const gapAfter = await gap();
+
+    expect(
+      Math.abs(heightAfter - heightBefore),
+      `message grew on hover: ${heightBefore}px → ${heightAfter}px`
+    ).toBeLessThan(1);
+    expect(
+      Math.abs(gapAfter - gapBefore),
+      `messages below jumped on hover: gap ${gapBefore}px → ${gapAfter}px`
+    ).toBeLessThan(1);
+  });
+});

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -119,10 +119,11 @@ vi.mock("@assistant-ui/react", () => ({
     Message: () => null,
   },
   ActionBarPrimitive: {
+    // NOTE: the real Root returns null while the bar is hidden and only renders
+    // in flow on the last message. This mock always renders it, so no jsdom test
+    // can observe the mount/unmount layout shift — see e2e/19-message-hover-layout-shift.
     Root: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
-      <div data-testid="assistant-action-bar" {...props}>
-        {children}
-      </div>
+      <div {...props}>{children}</div>
     ),
     Copy: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
     ExportMarkdown: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
@@ -825,12 +826,18 @@ describe("Composer no longer gates attachments client-side", () => {
   });
 });
 
-// The action bar mounts on hover (assistant-ui unmounts it while hidden), so the
-// footer row must already reserve the bar's height. Otherwise the row grows from
-// the timestamp's line-height to the button height and every message below it
-// jumps down on hover.
+// assistant-ui unmounts the action bar rather than hiding it, and mounts it in
+// flow on the LAST message only (autohide="not-last"). The footer row therefore
+// has to reserve the bar's height, or a message is 8px taller while it is last
+// and shrinks as soon as the next reply arrives.
+//
+// This is a cheap smoke test for the class being present — it cannot prove the
+// heights match, because jsdom has no layout engine (every element here reports
+// height 0) and it would stay green if TooltipIconButton's size-6 grew. The real
+// guard is e2e/19-message-hover-layout-shift.spec.ts, which measures both
+// messages in Chromium.
 describe("AssistantMessage footer height", () => {
-  it("reserves the action bar's height so hovering does not shift messages", async () => {
+  it("keeps the min-h-6 row that reserves the action bar's height", async () => {
     const { useMessage } = await import("@assistant-ui/react");
     vi.mocked(useMessage).mockImplementation(
       // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -848,7 +855,7 @@ describe("AssistantMessage footer height", () => {
     const footer = container.querySelector(".aui-assistant-message-footer")!;
     expect(footer).toBeTruthy();
 
-    // size-6 (1.5rem) is the TooltipIconButton height used by the action bar.
+    // min-h-6 mirrors TooltipIconButton's size-6 (1.5rem).
     expect(footer.className).toContain("min-h-6");
   });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -112,6 +112,29 @@ vi.mock("@assistant-ui/react", () => ({
     });
     return show ? <>{children}</> : null;
   },
+  ErrorPrimitive: {
+    Root: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
+      <div {...props}>{children}</div>
+    ),
+    Message: () => null,
+  },
+  ActionBarPrimitive: {
+    Root: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
+      <div data-testid="assistant-action-bar" {...props}>
+        {children}
+      </div>
+    ),
+    Copy: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    ExportMarkdown: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+  },
+  ActionBarMorePrimitive: {
+    Root: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Trigger: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Content: ({ children }: { children?: React.ReactNode }) => <>{children}</>,
+    Item: ({ children, ...props }: { children?: React.ReactNode; [key: string]: unknown }) => (
+      <div {...props}>{children}</div>
+    ),
+  },
   useMessage: vi.fn(),
   useComposerRuntime: vi.fn(() => null),
   useMessagePartFile: vi.fn(() => ({
@@ -188,6 +211,10 @@ vi.mock("@/components/assistant-ui/attachment", () => ({
   ComposerAddAttachment: () => null,
 }));
 
+vi.mock("@/components/diagnostics-export-dialog", () => ({
+  DiagnosticsExportDialog: () => null,
+}));
+
 vi.mock("@/components/assistant-ui/chat-error-message", () => ({
   ChatErrorMessage: ({ actionSlot }: { actionSlot?: React.ReactNode }) => (
     <div data-testid="chat-error-message">{actionSlot}</div>
@@ -199,6 +226,7 @@ vi.mock("@/components/chat", async () => {
   return {
     AgentAvatarContext: React.createContext<string | null>(null),
     AgentIdContext: React.createContext<string | null>(null),
+    AgentNameContext: React.createContext<string | null>(null),
     ChatIdContext: React.createContext<string | null>(null),
     AgentModelContext: React.createContext<string | null>(null),
     RetryResendContext: React.createContext<(messageId: string) => void>(() => {}),
@@ -794,5 +822,33 @@ describe("Composer no longer gates attachments client-side", () => {
     );
 
     expect(screen.queryByRole("region", { name: /can't be sent/i })).not.toBeInTheDocument();
+  });
+});
+
+// The action bar mounts on hover (assistant-ui unmounts it while hidden), so the
+// footer row must already reserve the bar's height. Otherwise the row grows from
+// the timestamp's line-height to the button height and every message below it
+// jumps down on hover.
+describe("AssistantMessage footer height", () => {
+  it("reserves the action bar's height so hovering does not shift messages", async () => {
+    const { useMessage } = await import("@assistant-ui/react");
+    vi.mocked(useMessage).mockImplementation(
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      (selector: (state: any) => unknown) =>
+        selector({
+          metadata: { custom: { timestamp: "2026-07-15T09:39:00.000Z" } },
+          isLast: false,
+          id: "msg-footer-1",
+        })
+    );
+
+    const { AssistantMessage } = await import("@/components/assistant-ui/thread");
+    const { container } = render(<AssistantMessage />);
+
+    const footer = container.querySelector(".aui-assistant-message-footer")!;
+    expect(footer).toBeTruthy();
+
+    // size-6 (1.5rem) is the TooltipIconButton height used by the action bar.
+    expect(footer.className).toContain("min-h-6");
   });
 });

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -577,7 +577,10 @@ const AssistantFooter: FC = () => {
   if (isError) return null;
 
   return (
-    <div className="aui-assistant-message-footer mt-1 ml-2 flex items-center gap-2">
+    // min-h-6 reserves the action bar's height (size-6 buttons). The bar only
+    // mounts on hover, so without it the row would collapse to the timestamp's
+    // line-height and every message below would jump down on hover.
+    <div className="aui-assistant-message-footer mt-1 ml-2 flex min-h-6 items-center gap-2">
       <MessageTimestamp />
       <AssistantActionBar />
     </div>

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -577,9 +577,12 @@ const AssistantFooter: FC = () => {
   if (isError) return null;
 
   return (
-    // min-h-6 reserves the action bar's height (size-6 buttons). The bar only
-    // mounts on hover, so without it the row would collapse to the timestamp's
-    // line-height and every message below would jump down on hover.
+    // min-h-6 reserves the height of the action bar's size-6 buttons. assistant-ui
+    // mounts the bar in flow on the LAST message only (autohide="not-last"), and
+    // unmounts it entirely elsewhere, so without a reserved height a message is
+    // 8px taller while it is last and shrinks the moment the next reply arrives.
+    // Keep in sync with TooltipIconButton's size-6; e2e/19-message-hover-layout-shift
+    // measures this in a real browser.
     <div className="aui-assistant-message-footer mt-1 ml-2 flex min-h-6 items-center gap-2">
       <MessageTimestamp />
       <AssistantActionBar />

--- a/packages/web/src/components/assistant-ui/tooltip-icon-button.tsx
+++ b/packages/web/src/components/assistant-ui/tooltip-icon-button.tsx
@@ -27,6 +27,9 @@ export function TooltipIconButton({
           variant="ghost"
           size="icon"
           {...rest}
+          // size-6 is mirrored by min-h-6 on the assistant message footer
+          // (thread.tsx), which reserves this height so messages don't resize
+          // when their action bar mounts. Change both together.
           className={cn("aui-button-icon size-6 p-1", className)}
           ref={ref}
         >


### PR DESCRIPTION
## What does this PR do?

Fixes an 8px layout shift in the chat: an assistant message changed height depending on whether its action bar was mounted, so the conversation jumped.

**Cause:** assistant-ui *unmounts* the action bar rather than hiding it (`ActionBarRoot` returns `null`), and `autohide="not-last"` mounts it **in flow** (`position: static`) on the **last** message only. So the footer row measured 24px (button height, `size-6`) on the last message and 16px (timestamp line-height, `text-xs`) everywhere else. Every `isLast` handover — a new reply arriving, a run finishing via `hideWhenRunning` — resized a message by 8px.

**Fix:** one class — `min-h-6` on `.aui-assistant-message-footer` — reserves the bar's height, so every message is the same height whether the bar is mounted, floating, or absent.

## Correction to the original diagnosis

This PR was first written as a *hover* fix. Writing a real-browser test disproved that, and the finding is worth recording:

**Hovering never shifted anything.** A hovered non-last message gets `data-floating="true"` → `position: absolute`, i.e. the bar is an overlay and displaces nothing. The `data-floating:*` utilities work correctly. Pinchy uses `useExternalStoreRuntime` with a flat message list, so `branchCount` is always 1 and a hovered non-last message is *always* floating — the inline (`normal`) mode only ever applies to the last message, which is what the reported screenshots show (inline icons, no card border).

Measured in Chromium before the fix:

| Message | action bar | footer | height |
| --- | --- | --- | --- |
| non-last, not hovered | unmounted | 16px | 68px |
| non-last, hovered | `absolute`, floating | 16px | **68px** (no shift) |
| last | `static`, in flow | 24px | **76px** |

So `min-h-6` is the right fix — its *rationale* was wrong, not its effect. It equalises all messages at 76px.

## Verification

`e2e/19-message-hover-layout-shift.spec.ts` measures this in real Chromium (jsdom has no layout engine — every element there reports height 0, which is why the unit test can only smoke-check the class):

- **`a message must not change height when it stops being the last one`** — the actual regression test. Red without `min-h-6` (footer 16px vs 24px), green with it.
- **`hovering a non-last message must not move the messages below it`** — guards the floating mechanism. Green before and after; it would turn red if the `data-floating` utilities ever stopped applying, which is what would make hovering shift the conversation.

The spec mocks the WebSocket client-side (same technique as `04-chat-reconnect` / `18-tab-refocus-shrink`), so it needs no OpenClaw stack and runs in the existing `e2e` job.

Also documents the `min-h-6` ↔ `size-6` coupling at both ends (`thread.tsx` and `tooltip-icon-button.tsx`), since nothing else enforces it.

## Note for the reviewer

Messages without a `metadata.custom.timestamp` (it's optional — `use-ws-runtime.ts:115`) now get a 24px footer that renders empty, where it previously collapsed to 0px. That's deliberate: those messages show the bar when they're last, so without the reserved height they'd jump by the full 24px instead of 8px.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable) — n/a, no user-facing behavior change
- [x] All existing tests pass