### PR TITLE
fix(composer): restore screenshot paste into the chat box

### DIFF
--- a/packages/web/e2e/integration/upload-and-send.spec.ts
+++ b/packages/web/e2e/integration/upload-and-send.spec.ts
@@ -139,4 +139,73 @@ test.describe("upload and send — happy path", () => {
     const found = await pollAuditForTool(page, { toolName: "pinchy_read", agentId });
     expect(found).toBe(true);
   });
+
+  // The coverage gap that let the paste regression ship: the file-picker path
+  // above was re-wired onto the two-phase upload pipeline in #342 and stayed
+  // green, while paste — a first-class feature since 9fbb91e3c — silently
+  // broke, because no spec ever exercised it. Cmd+V and right-click → Paste
+  // both deliver the same native `paste` event with the bitmap in
+  // `clipboardData.files`, so dispatching that event covers both, against real
+  // Chromium rather than a jsdom approximation of the clipboard.
+  //
+  // Scope: this stops at the ready chip and deliberately does NOT send. Once
+  // `addPendingUpload` has the file, paste and the file picker are the same
+  // code — the upload → send → uploads-URL half is already covered by the
+  // happy path above, and re-asserting it here would buy nothing. It would
+  // also cost: every integration spec shares ONE OpenClaw session, so a second
+  // producer of fake-ollama's generic reply pollutes the specs that assert on
+  // it (agent-chat.spec.ts). The regression lives entirely in whether a paste
+  // reaches the pipeline at all, which is exactly what the chip proves.
+  test("pasted screenshot reaches the upload pipeline", async ({ page }) => {
+    const failedUploadFetches: string[] = [];
+    page.on("response", (response) => {
+      if (response.url().includes("/uploads/") && response.status() === 404) {
+        failedUploadFetches.push(response.url());
+      }
+    });
+
+    await login(page);
+    const agentId = await getSmithersAgentId(page);
+    await page.goto(`/chat/${agentId}`);
+    await expect(page).toHaveURL(`/chat/${agentId}`, { timeout: 10000 });
+    await waitForOpenClawConnected(page);
+
+    const input = page.getByLabel("Message input");
+    await expect(input).toBeVisible({ timeout: 10000 });
+
+    // Paste a real 1x1 PNG. Built in-page rather than read from a fixture
+    // because the bytes must live in a browser-side `File` inside a real
+    // DataTransfer to reach `clipboardData.files` — the shape the OS clipboard
+    // produces for a screenshot. The server content-sniffs uploads, so these
+    // have to be valid PNG magic bytes, not arbitrary filler.
+    await input.focus();
+    await page.evaluate(() => {
+      const PNG_1X1_BASE64 =
+        "iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVR42mNkYPhfDwAChwGA60e6kgAAAABJRU5ErkJggg==";
+      const bytes = Uint8Array.from(atob(PNG_1X1_BASE64), (c) => c.charCodeAt(0));
+      const file = new File([bytes], "screenshot.png", { type: "image/png" });
+      const dt = new DataTransfer();
+      dt.items.add(file);
+      const textarea = document.querySelector<HTMLTextAreaElement>(
+        'textarea[aria-label="Message input"]'
+      );
+      if (!textarea) throw new Error("composer textarea not found");
+      textarea.dispatchEvent(
+        new ClipboardEvent("paste", { clipboardData: dt, bubbles: true, cancelable: true })
+      );
+    });
+
+    // THE REGRESSION: the paste must produce an upload chip that reaches
+    // "ready" (green check = POST /uploads returned 200). Before the fix the
+    // paste was swallowed by assistant-ui's built-in handler — it threw "No
+    // matching adapter found for file" into its own try/catch and no chip ever
+    // appeared.
+    const readyChip = page
+      .locator(".text-green-600")
+      .locator("xpath=ancestor::*[@class and contains(@class,'rounded-lg')]")
+      .first();
+    await expect(readyChip).toBeVisible({ timeout: 20000 });
+
+    expect(failedUploadFetches).toHaveLength(0);
+  });
 });

--- a/packages/web/src/components/assistant-ui/__tests__/pinchy-composer-input.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/pinchy-composer-input.test.tsx
@@ -1,0 +1,150 @@
+// Regression guard for the clipboard-paste attachment path.
+//
+// Bug history: pasting a screenshot into the composer (Cmd+V or right-click →
+// Paste) silently did nothing. `9fbb91e3c` shipped paste as a first-class
+// feature ("add chat attachments (images, text files, clipboard paste)") on the
+// back of `SimpleImageAttachmentAdapter`. `f50c72eb6` (PR #342) migrated
+// attachments to the two-phase upload pipeline and dropped that adapter,
+// because its base64 `image_url` frames are rejected server-side with
+// PROTOCOL_OUTDATED. That commit re-wired the file picker
+// (PinchyAttachmentButton) and drag & drop (PinchyDropZone) onto
+// `addPendingUpload` — but not paste.
+//
+// Root cause: assistant-ui's `ComposerPrimitive.Input` has a built-in paste
+// handler (`addAttachmentOnPaste`, default TRUE) that calls
+// `composer.addAttachment(file)`. That lands in `CompositeAttachmentAdapter`,
+// which after #342 holds only the code-text and .docx adapters. No adapter
+// accepts `image/png`, so `add()` throws "No matching adapter found for file".
+// The throw is swallowed by handlePaste's own try/catch and downgraded to a
+// console.error — and since it calls `e.preventDefault()` first, the paste
+// vanishes with no user-visible feedback.
+//
+// Why this test renders the REAL primitive (no assistant-ui mock, same reason
+// as composer-ime-composition.test.tsx): the entire bug lives in the seam
+// between our wiring and the dependency's built-in paste behavior. A mocked
+// `ComposerPrimitive.Input` is a bare <textarea> with no built-in handler, so
+// the double-handling this file pins could never regress there. Pinning it
+// against the real dependency means a version bump that changes the
+// `addAttachmentOnPaste` contract fails HERE.
+
+import { describe, it, expect, vi } from "vitest";
+import { render, screen, fireEvent } from "@testing-library/react";
+import "@testing-library/jest-dom";
+import type { FC } from "react";
+import {
+  AssistantRuntimeProvider,
+  useExternalStoreRuntime,
+  type ThreadMessageLike,
+} from "@assistant-ui/react";
+import { AddPendingUploadContext } from "@/components/chat";
+import { PinchyComposerInput } from "@/components/assistant-ui/pinchy-composer-input";
+
+// A permissive attachment adapter standing in for the real adapter chain. It
+// accepts everything, so if the built-in paste handler were still live it would
+// dispatch here — letting `add` double as the probe for "paste leaked into the
+// adapter chain". Its presence is also what makes the thread report
+// `capabilities.attachments === true`, the precondition the built-in handler
+// checks before doing anything at all.
+function makeSpyAdapter() {
+  return {
+    accept: "*",
+    add: vi.fn(async ({ file }: { file: File }) => ({
+      id: file.name,
+      type: "image" as const,
+      name: file.name,
+      contentType: file.type,
+      file,
+      status: { type: "requires-action" as const, reason: "composer-send" as const },
+    })),
+    send: vi.fn(),
+    remove: vi.fn(),
+  };
+}
+
+const Harness: FC<{
+  addPendingUpload: (file: File) => void;
+  adapter: ReturnType<typeof makeSpyAdapter>;
+}> = ({ addPendingUpload, adapter }) => {
+  const runtime = useExternalStoreRuntime({
+    messages: [] as ThreadMessageLike[],
+    isRunning: false,
+    convertMessage: (m: ThreadMessageLike) => m,
+    onNew: async () => {},
+    adapters: { attachments: adapter },
+  });
+  return (
+    <AssistantRuntimeProvider runtime={runtime}>
+      <AddPendingUploadContext.Provider value={addPendingUpload}>
+        <PinchyComposerInput aria-label="Message input" />
+      </AddPendingUploadContext.Provider>
+    </AssistantRuntimeProvider>
+  );
+};
+
+function renderComposer() {
+  const addPendingUpload = vi.fn();
+  const adapter = makeSpyAdapter();
+  render(<Harness addPendingUpload={addPendingUpload} adapter={adapter} />);
+  return {
+    addPendingUpload,
+    adapter,
+    textarea: screen.getByRole("textbox") as HTMLTextAreaElement,
+  };
+}
+
+// Model a clipboard payload the way a browser delivers one. A screenshot paste
+// carries the bitmap in `files`; a plain-text paste carries none.
+function firePaste(textarea: HTMLTextAreaElement, files: File[]) {
+  return fireEvent.paste(textarea, {
+    clipboardData: { files, items: files.map((f) => ({ kind: "file", type: f.type })) },
+  });
+}
+
+describe("PinchyComposerInput clipboard paste", () => {
+  it("routes a pasted screenshot into the two-phase upload pipeline", () => {
+    const { addPendingUpload, textarea } = renderComposer();
+    const screenshot = new File(["png-bytes"], "screenshot.png", { type: "image/png" });
+
+    firePaste(textarea, [screenshot]);
+
+    // THE REGRESSION: this was 0 calls — the paste was swallowed by the
+    // dependency's built-in handler and lost in a console.error.
+    expect(addPendingUpload).toHaveBeenCalledTimes(1);
+    expect(addPendingUpload).toHaveBeenCalledWith(screenshot);
+  });
+
+  it("does NOT route pasted files through the assistant-ui adapter chain", () => {
+    const { adapter, textarea } = renderComposer();
+
+    firePaste(textarea, [new File(["png-bytes"], "screenshot.png", { type: "image/png" })]);
+
+    // The adapter chain is the path that emits base64 `image_url` frames the
+    // server rejects with PROTOCOL_OUTDATED. Paste must bypass it entirely —
+    // otherwise an attachment gets added twice (once per path) for any MIME the
+    // chain happens to accept.
+    expect(adapter.add).not.toHaveBeenCalled();
+  });
+
+  it("attaches every file of a multi-file paste", () => {
+    const { addPendingUpload, textarea } = renderComposer();
+    const png = new File(["a"], "shot.png", { type: "image/png" });
+    const pdf = new File(["b"], "doc.pdf", { type: "application/pdf" });
+
+    firePaste(textarea, [png, pdf]);
+
+    expect(addPendingUpload).toHaveBeenCalledTimes(2);
+    expect(addPendingUpload).toHaveBeenNthCalledWith(1, png);
+    expect(addPendingUpload).toHaveBeenNthCalledWith(2, pdf);
+  });
+
+  it("leaves a plain-text paste to the browser", () => {
+    const { addPendingUpload, textarea } = renderComposer();
+
+    // `fireEvent` returns false once a handler called preventDefault. Text must
+    // keep its default behavior, or pasting into the message box stops working.
+    const notPrevented = firePaste(textarea, []);
+
+    expect(addPendingUpload).not.toHaveBeenCalled();
+    expect(notPrevented).toBe(true);
+  });
+});

--- a/packages/web/src/components/assistant-ui/__tests__/pinchy-composer-input.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/pinchy-composer-input.test.tsx
@@ -113,6 +113,21 @@ describe("PinchyComposerInput clipboard paste", () => {
     expect(addPendingUpload).toHaveBeenCalledWith(screenshot);
   });
 
+  it("suppresses the default so a file paste does not also dump text", () => {
+    const { textarea } = renderComposer();
+
+    // A screenshot copied from a web page carries a text/html flavor next to
+    // the bitmap; a file copied from the file manager carries its filename as
+    // text. Without preventDefault the browser writes that flavor into the
+    // message box alongside the attachment. `fireEvent` returns false once a
+    // handler prevented the default.
+    const prevented = firePaste(textarea, [
+      new File(["png-bytes"], "screenshot.png", { type: "image/png" }),
+    ]);
+
+    expect(prevented).toBe(false);
+  });
+
   it("does NOT route pasted files through the assistant-ui adapter chain", () => {
     const { adapter, textarea } = renderComposer();
 

--- a/packages/web/src/components/assistant-ui/pinchy-composer-input.tsx
+++ b/packages/web/src/components/assistant-ui/pinchy-composer-input.tsx
@@ -4,6 +4,12 @@ import { type ComponentProps, type FC, useContext } from "react";
 import { ComposerPrimitive } from "@assistant-ui/react";
 import { AddPendingUploadContext } from "@/components/chat";
 
+// `ComposerPrimitive.Input`'s props are a discriminated union (`submitMode`
+// XOR the deprecated `submitOnEnter`). A plain `Omit` is not distributive: it
+// collapses that union into one object where both keys may be set at once,
+// which then matches neither branch. Mapping over the union preserves it.
+type DistributiveOmit<T, K extends PropertyKey> = T extends unknown ? Omit<T, K> : never;
+
 /**
  * Composer textarea that routes pasted files (screenshots via Cmd+V or
  * right-click → Paste, files copied from the file manager) into the two-phase
@@ -15,12 +21,13 @@ import { AddPendingUploadContext } from "@/components/chat";
  * carries an image adapter — pasting a screenshot threw "No matching adapter
  * found for file" into its own try/catch and dropped the paste silently. Left
  * enabled it would also double-attach any MIME the chain still accepts, once
- * per path.
+ * per path. It is `Omit`ted from the props rather than merely overridden, so
+ * re-enabling the broken built-in is a compile error instead of a prop this
+ * component silently ignores.
  */
-export const PinchyComposerInput: FC<ComponentProps<typeof ComposerPrimitive.Input>> = ({
-  onPaste,
-  ...props
-}) => {
+export const PinchyComposerInput: FC<
+  DistributiveOmit<ComponentProps<typeof ComposerPrimitive.Input>, "addAttachmentOnPaste">
+> = ({ onPaste, ...props }) => {
   const addPendingUpload = useContext(AddPendingUploadContext);
 
   return (

--- a/packages/web/src/components/assistant-ui/pinchy-composer-input.tsx
+++ b/packages/web/src/components/assistant-ui/pinchy-composer-input.tsx
@@ -1,0 +1,48 @@
+"use client";
+
+import { type ComponentProps, type FC, useContext } from "react";
+import { ComposerPrimitive } from "@assistant-ui/react";
+import { AddPendingUploadContext } from "@/components/chat";
+
+/**
+ * Composer textarea that routes pasted files (screenshots via Cmd+V or
+ * right-click → Paste, files copied from the file manager) into the two-phase
+ * upload pipeline (`addPendingUpload`). The sibling of PinchyAttachmentButton
+ * (picked files) and PinchyDropZone (dropped files) for the third intake path.
+ *
+ * `addAttachmentOnPaste={false}` is load-bearing: assistant-ui's built-in paste
+ * handler routes files through `CompositeAttachmentAdapter`, which no longer
+ * carries an image adapter — pasting a screenshot threw "No matching adapter
+ * found for file" into its own try/catch and dropped the paste silently. Left
+ * enabled it would also double-attach any MIME the chain still accepts, once
+ * per path.
+ */
+export const PinchyComposerInput: FC<ComponentProps<typeof ComposerPrimitive.Input>> = ({
+  onPaste,
+  ...props
+}) => {
+  const addPendingUpload = useContext(AddPendingUploadContext);
+
+  return (
+    <ComposerPrimitive.Input
+      {...props}
+      addAttachmentOnPaste={false}
+      onPaste={(e) => {
+        onPaste?.(e);
+        if (e.defaultPrevented) return;
+
+        const files = Array.from(e.clipboardData?.files ?? []);
+        // No files means an ordinary text paste — leave it to the browser.
+        if (files.length === 0) return;
+
+        // Suppress the default so a file paste that also carries a text
+        // flavor (the filename, or the source page's HTML) does not dump that
+        // text into the message box alongside the attachment.
+        e.preventDefault();
+        for (const file of files) {
+          addPendingUpload(file);
+        }
+      }}
+    />
+  );
+};

--- a/packages/web/src/components/assistant-ui/thread.tsx
+++ b/packages/web/src/components/assistant-ui/thread.tsx
@@ -1,6 +1,7 @@
 import { UserMessageAttachments, ComposerAttachments } from "@/components/assistant-ui/attachment";
 import { PinchyAttachmentButton } from "@/components/assistant-ui/pinchy-attachment-button";
 import { PinchyDropZone } from "@/components/assistant-ui/pinchy-drop-zone";
+import { PinchyComposerInput } from "@/components/assistant-ui/pinchy-composer-input";
 import {
   useSlashCommandMenu,
   SlashCommandMenuList,
@@ -483,7 +484,7 @@ export const Composer: FC = () => {
       <PinchyDropZone className="aui-composer-attachment-dropzone flex w-full flex-col rounded-2xl border border-input bg-background px-1 pt-2 outline-none transition-shadow has-[textarea:focus-visible]:border-ring has-[textarea:focus-visible]:ring-2 has-[textarea:focus-visible]:ring-ring/20">
         <PendingUploadChips />
         <ComposerAttachments />
-        <ComposerPrimitive.Input
+        <PinchyComposerInput
           placeholder="Send a message, or type / for commands"
           className="aui-composer-input mb-0.5 md:mb-1 max-h-32 min-h-10 md:min-h-14 w-full resize-none bg-transparent px-4 pt-2 pb-1 md:pb-3 text-sm outline-none placeholder:text-muted-foreground focus-visible:ring-0"
           rows={1}

--- a/packages/web/src/hooks/use-ws-runtime.ts
+++ b/packages/web/src/hooks/use-ws-runtime.ts
@@ -1854,9 +1854,10 @@ export function useWsRuntime(
 
   // Fire-and-forget: the upload's outcome is driven entirely through the
   // `pendingUploads` state machine (uploading → ready / failed). Callers
-  // (PinchyAttachmentButton, PinchyDropZone) iterate over picked files and
-  // never await — so the public signature is `void`, not `Promise<void>`.
-  // All async work lives inside the IIFE below.
+  // (PinchyAttachmentButton for picked files, PinchyDropZone for dropped,
+  // PinchyComposerInput for pasted, ShareIntake for the /share hand-off)
+  // iterate over their files and never await — so the public signature is
+  // `void`, not `Promise<void>`. All async work lives inside the IIFE below.
   const addPendingUpload = useCallback(
     (file: File): void => {
       // Refuse the 11th-and-beyond attachment client-side. Server-side


### PR DESCRIPTION
## What does this PR do?

Restores pasting a screenshot into the chat composer (Cmd+V and right-click → Paste). Both silently did nothing.

**Root cause.** assistant-ui's `ComposerPrimitive.Input` has a built-in paste handler (`addAttachmentOnPaste`, default `true`) that routes clipboard files through `composer.addAttachment()` → `CompositeAttachmentAdapter`.

`9fbb91e3c` shipped paste as a first-class feature ("add chat attachments (images, text files, **clipboard paste**)") on the back of `SimpleImageAttachmentAdapter`. `f50c72eb6` (PR #342) migrated attachments to the two-phase upload pipeline and removed that adapter, since its base64 `image_url` frames are rejected server-side with `PROTOCOL_OUTDATED`. That commit's own message lists the re-wiring:

> composer wiring: PinchyAttachmentButton + PinchyDropZone route picked / dropped files through addPendingUpload

**picked** and **dropped** were migrated. **pasted** was not. With no adapter accepting `image/png`, `add()` throws `No matching adapter found for file` — straight into `handlePaste`'s own `try/catch`, which downgrades it to a `console.error`. Since it calls `e.preventDefault()` first, the paste vanishes with no user-visible feedback. The file picker and drag & drop kept working, which is why this stayed invisible.

**The fix.** `PinchyComposerInput` is the third sibling of that intake trio: it disables the broken built-in and routes `clipboardData.files` through `addPendingUpload`, exactly as the picker and drop zone do. `addAttachmentOnPaste={false}` is load-bearing — left enabled it would also double-attach any MIME the adapter chain still accepts, once per path. A plain text paste keeps its default browser behavior.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [ ] 📝 Documentation
- [ ] ♻️ Refactor
- [ ] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Notes for the reviewer

**Why this shipped unnoticed: paste had zero coverage.** The picker and drop paths have E2E tests and stayed green while the third sibling silently died. Both new tests were verified **red before the fix**, not just green after:

- **Unit** (`pinchy-composer-input.test.tsx`) renders the *real* assistant-ui primitive against a real runtime — deliberately no mock, same rationale as `composer-ime-composition.test.tsx`. A mocked `Input` is a bare `<textarea>` with no built-in handler, so the double-handling this pins could never regress there. Red output named the mechanism directly: the spy adapter's `add` **was** called.
- **Integration E2E** (`upload-and-send.spec.ts`) dispatches a real `paste` event with a `DataTransfer` in Chromium against the production image. Red without the fix (no upload chip appears — the reported symptom, reproduced); green with it.

**E2E scope is deliberate.** It stops at the ready chip and does not send. Past `addPendingUpload`, paste and the file picker are literally the same code, and the upload → send → uploads-URL half is already covered by the happy path above it. Asserting fake-ollama's generic reply would also pollute the single OpenClaw session every integration spec shares — that pollution broke the neighbouring `pinchy_read` test in an earlier draft of this branch.

**Docs:** no update needed. `guides/file-uploads.mdx` never enumerates the intake methods (picker/drop/paste), so this restores intended-but-undocumented behavior rather than changing documented behavior.

**Found in passing, deliberately NOT in this PR:** every *compressed* image is stored server-side as `blob` instead of its real filename — verified on the integration stack (`uploads/` held `blob` and `blob (1)` for pasted PNGs, while `test.pdf` kept its name). `browser-image-compression@2.0.2` returns a `Blob` with `name` monkey-patched on rather than a real `File`, so `formData.append("file", file)` sends `filename="blob"`; the composer chip reads `.name` fine, which hides it until send. It predates this branch and affects all three intake paths equally, so it belongs in its own PR.

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

Gates run locally: `pnpm test` (8239 passed), `pnpm build`, `pnpm lint` (0 errors), `pnpm format:check`, plus the full `upload-and-send.spec.ts` integration suite (3/3).

---

### Review follow-ups (`134556ad7`)

Three findings from review, all fixed:

1. **The `preventDefault()` on a file paste was documented as load-bearing but unasserted** — only the inverse (a plain text paste keeps its default) was covered. Removing the call left the suite green: the same class of gap that let the original regression ship. Now pinned by a fifth unit test, verified red before green.
2. **`addAttachmentOnPaste` is now `Omit`ted from the public props** rather than merely overridden, so re-enabling the broken built-in is a compile error instead of a silently ignored prop. This needs a *distributive* Omit: the primitive's props are a discriminated union (`submitMode` XOR the deprecated `submitOnEnter`), and a plain `Omit` collapses that union into one object where both keys may be set at once — matching neither branch, which `tsc` rejects outright. Probed both directions: passing the prop is now an error, and the union survives.
3. **`addPendingUpload`'s caller enumeration** listed only the picker and drop zone; paste and `ShareIntake` (already missing before this branch) are callers too.

Gates re-run green: `pnpm test` (8240 passed, +1), `pnpm build`, `pnpm lint` (0 errors), `pnpm format:check`.
