### PR TITLE
fix(uploads): keep the real filename on compressed image attachments

### DIFF
--- a/packages/web/src/__tests__/lib/image-compression.test.ts
+++ b/packages/web/src/__tests__/lib/image-compression.test.ts
@@ -173,6 +173,34 @@ describe("compressImageForChat — compression path", () => {
     expect(result.file.name).toBe("v1.2 mockup.webp");
   });
 
+  it("names the file after the bytes the browser produced, not the format we asked for", async () => {
+    // The library never checks whether the canvas can encode WebP: it calls
+    // toDataURL("image/webp") and reads the MIME back out of whatever data URL
+    // it gets. Where WebP encoding is unsupported (Safari < 14, iOS < 14, some
+    // OffscreenCanvas impls) the canvas silently falls back to PNG, so the
+    // result is PNG bytes. Hardcoding `.webp` there would re-introduce exactly
+    // the name-lies-about-content bug this module was fixed for.
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/png", "x"));
+
+    const result = await compressImageForChat(makeFile(2 * 1024 * 1024, "image/png", "screenshot"));
+
+    expect(result.file.name).toBe("screenshot.png");
+    expect(result.file.type).toBe("image/png");
+  });
+
+  it("carries the original file's lastModified over to the compressed file", async () => {
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/webp", "x"));
+
+    const original = new File([new Uint8Array(2 * 1024 * 1024)], "screenshot.png", {
+      type: "image/png",
+      lastModified: 1_600_000_000_000,
+    });
+    const result = await compressImageForChat(original);
+
+    // Compression re-encodes the pixels; it does not make them a new document.
+    expect(result.file.lastModified).toBe(1_600_000_000_000);
+  });
+
   it("logs a warning when compression fails so production logs surface the fallback", async () => {
     const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
     try {

--- a/packages/web/src/__tests__/lib/image-compression.test.ts
+++ b/packages/web/src/__tests__/lib/image-compression.test.ts
@@ -13,6 +13,32 @@ const makeFile = (bytes: number, mime: string, name = "image"): File => {
   return new File([new Uint8Array(bytes)], `${name}.${mime.split("/")[1]}`, { type: mime });
 };
 
+/**
+ * Mimics what `browser-image-compression@2.0.2` actually returns.
+ *
+ * Its internal `canvasToFile()` never calls `new File(...)` — it constructs a
+ * Blob and monkey-patches `name`/`lastModified` on as plain properties:
+ *
+ *     l = new Blob([h], {type: r}); l.name = i; l.lastModified = o;
+ *
+ * Reading `.name` therefore works, which is why the composer chip showed the
+ * right filename — but `FormData.append()` ignores it and labels any non-File
+ * Blob `"blob"` on the wire. The library's types claim `File`, so this cast
+ * reproduces the same lie TypeScript is told at the real call site.
+ */
+const makeLibraryOutput = (bytes: number, mime: string, name: string): File => {
+  const blob = new Blob([new Uint8Array(bytes)], { type: mime });
+  Object.assign(blob, { name, lastModified: 0 });
+  return blob as File;
+};
+
+/** The filename a multipart body would carry for `file` — "blob" for a bare Blob. */
+const multipartFilename = (file: File): string => {
+  const form = new FormData();
+  form.append("file", file);
+  return (form.get("file") as File).name;
+};
+
 describe("compressImageForChat — skip path", () => {
   beforeEach(() => {
     mockedImageCompression.mockReset();
@@ -41,14 +67,13 @@ describe("compressImageForChat — skip path", () => {
   });
 
   it("does NOT skip small PNGs — they are recompressed because PNG → WebP gains are large", async () => {
-    const compressed = makeFile(50 * 1024, "image/webp", "compressed");
-    mockedImageCompression.mockResolvedValueOnce(compressed);
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(50 * 1024, "image/webp", "x"));
     const smallPng = makeFile(400 * 1024, "image/png");
     const result = await compressImageForChat(smallPng);
     expect(mockedImageCompression).toHaveBeenCalledOnce();
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.file).toBe(compressed);
+      expect(result.file.size).toBe(50 * 1024);
       expect(result.skipped).toBe(false);
     }
   });
@@ -61,8 +86,7 @@ describe("compressImageForChat — compression path", () => {
 
   it("calls browser-image-compression with WebP at the configured target size for a large JPEG", async () => {
     const large = makeFile(5 * 1024 * 1024, "image/jpeg");
-    const compressed = makeFile(800 * 1024, "image/webp", "compressed");
-    mockedImageCompression.mockResolvedValueOnce(compressed);
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(800 * 1024, "image/webp", "x"));
 
     const result = await compressImageForChat(large);
 
@@ -81,7 +105,7 @@ describe("compressImageForChat — compression path", () => {
     );
     expect(result.ok).toBe(true);
     if (result.ok) {
-      expect(result.file).toBe(compressed);
+      expect(result.file.size).toBe(800 * 1024);
       expect(result.skipped).toBe(false);
     }
   });
@@ -101,6 +125,52 @@ describe("compressImageForChat — compression path", () => {
       expect(result.error).toBe(decodeError);
     }
     expect(mockedImageCompression).toHaveBeenCalledOnce();
+  });
+
+  it("returns a real File, not the library's monkey-patched Blob", async () => {
+    // The Blob browser-image-compression hands back carries a readable `.name`,
+    // so asserting on `.name` alone would pass against the broken version. Only
+    // `instanceof File` catches it — and only a real File keeps its name once
+    // FormData encodes it into the multipart body.
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/webp", "x"));
+
+    const result = await compressImageForChat(makeFile(2 * 1024 * 1024, "image/png", "screenshot"));
+
+    expect(result.ok).toBe(true);
+    expect(result.file).toBeInstanceOf(File);
+  });
+
+  it("keeps the original basename on the wire instead of uploading it as 'blob'", async () => {
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/webp", "x"));
+
+    const result = await compressImageForChat(
+      makeFile(2 * 1024 * 1024, "image/png", "quarterly-chart")
+    );
+
+    // What uploadAttachment's `formData.append("file", file)` actually sends —
+    // and what therefore lands in the agent workspace under uploads/.
+    expect(multipartFilename(result.file)).toBe("quarterly-chart.webp");
+  });
+
+  it("renames the extension to .webp because compression converts the bytes to WebP", async () => {
+    // Leaving `screenshot.png` on WebP bytes would put a lying extension in the
+    // agent's workspace. Serving is unaffected (the GET route sniffs magic
+    // bytes), but tools that read the workspace file go by its name.
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/webp", "x"));
+
+    const result = await compressImageForChat(makeFile(2 * 1024 * 1024, "image/png", "screenshot"));
+
+    expect(result.file.name).toBe("screenshot.webp");
+    expect(result.file.type).toBe("image/webp");
+  });
+
+  it("appends .webp rather than clobbering dots inside an extensionless name", async () => {
+    mockedImageCompression.mockResolvedValueOnce(makeLibraryOutput(80 * 1024, "image/webp", "x"));
+
+    const noExt = new File([new Uint8Array(2 * 1024 * 1024)], "v1.2 mockup", { type: "image/png" });
+    const result = await compressImageForChat(noExt);
+
+    expect(result.file.name).toBe("v1.2 mockup.webp");
   });
 
   it("logs a warning when compression fails so production logs surface the fallback", async () => {

--- a/packages/web/src/__tests__/lib/upload-attachment.test.ts
+++ b/packages/web/src/__tests__/lib/upload-attachment.test.ts
@@ -133,6 +133,25 @@ describe("uploadAttachment", () => {
     await promise;
   });
 
+  it("sends the file's own name as the multipart filename, not 'blob'", async () => {
+    const { MockXHRClass, instance: xhr } = createMockXHRClass();
+    vi.stubGlobal("XMLHttpRequest", MockXHRClass);
+
+    const { uploadAttachment } = await import("@/lib/upload-attachment");
+
+    // The server names the workspace file after the multipart filename. FormData
+    // only preserves it for a real File — a Blob with a monkey-patched `.name`
+    // (what browser-image-compression returns) silently becomes "blob" here.
+    const file = new File(["png-bytes"], "screenshot.webp", { type: "image/webp" });
+    const promise = uploadAttachment("agent-abc", "3fa85f64-5717-4562-b3fc-2c963f66afa6", file);
+
+    const formData = xhr.send.mock.calls[0][0] as FormData;
+    expect((formData.get("file") as File).name).toBe("screenshot.webp");
+
+    xhr.simulateLoad();
+    await promise;
+  });
+
   it("calls onProgress with percent values during upload", async () => {
     const { MockXHRClass, instance: xhr } = createMockXHRClass();
     vi.stubGlobal("XMLHttpRequest", MockXHRClass);

--- a/packages/web/src/lib/image-compression.ts
+++ b/packages/web/src/lib/image-compression.ts
@@ -37,7 +37,7 @@ export async function compressImageForChat(file: File): Promise<CompressionResul
       initialQuality: CLIENT_IMAGE_COMPRESSION_QUALITY,
       useWebWorker: true,
     });
-    return { ok: true, file: toNamedFile(compressed, file.name), skipped: false };
+    return { ok: true, file: toNamedFile(compressed, file), skipped: false };
   } catch (err) {
     // Compression can fail on HEIC, corrupt input, OOM, or worker crashes. We
     // hand the original back so the caller can decide between sending anyway
@@ -49,8 +49,15 @@ export async function compressImageForChat(file: File): Promise<CompressionResul
   }
 }
 
-/** Image extensions we replace with `.webp`; anything else is appended to. */
+/** Image extensions we replace with the output's own; anything else is appended to. */
 const IMAGE_EXTENSION = /\.(png|jpe?g|webp|gif|bmp|avif|tiff?|heic|heif)$/i;
+
+/** Every format a canvas can hand back. Compression re-encodes, so the name must follow. */
+const EXTENSION_FOR_TYPE: Record<string, string> = {
+  "image/webp": "webp",
+  "image/png": "png",
+  "image/jpeg": "jpg",
+};
 
 /**
  * Rebuild the compression output as a real `File` named after the original.
@@ -62,13 +69,17 @@ const IMAGE_EXTENSION = /\.(png|jpe?g|webp|gif|bmp|avif|tiff?|heic|heif)$/i;
  * property and labels any non-File Blob `"blob"` on the wire, so every
  * compressed image landed in the agent workspace as `blob`, `blob (1)`, ...
  */
-function toNamedFile(compressed: Blob, originalName: string): File {
-  const base = originalName.replace(IMAGE_EXTENSION, "");
-  // Compression converts to WebP, so the original extension would now lie about
-  // the bytes. Names without an image extension keep their dots and just gain one.
-  return new File([compressed], `${base}.webp`, {
+function toNamedFile(compressed: Blob, original: File): File {
+  const base = original.name.replace(IMAGE_EXTENSION, "");
+  // The extension follows the bytes we actually got, not the format we asked
+  // for: the library requests WebP from the canvas and reads the MIME back out
+  // of the result, so a canvas that can't encode WebP silently yields PNG.
+  // An unknown type means we learned nothing — WebP is what we requested.
+  const extension = EXTENSION_FOR_TYPE[compressed.type] ?? "webp";
+  // Names without an image extension keep their dots and just gain one.
+  return new File([compressed], `${base}.${extension}`, {
     type: compressed.type,
-    lastModified: Date.now(),
+    lastModified: original.lastModified,
   });
 }
 

--- a/packages/web/src/lib/image-compression.ts
+++ b/packages/web/src/lib/image-compression.ts
@@ -37,7 +37,7 @@ export async function compressImageForChat(file: File): Promise<CompressionResul
       initialQuality: CLIENT_IMAGE_COMPRESSION_QUALITY,
       useWebWorker: true,
     });
-    return { ok: true, file: compressed, skipped: false };
+    return { ok: true, file: toNamedFile(compressed, file.name), skipped: false };
   } catch (err) {
     // Compression can fail on HEIC, corrupt input, OOM, or worker crashes. We
     // hand the original back so the caller can decide between sending anyway
@@ -47,6 +47,29 @@ export async function compressImageForChat(file: File): Promise<CompressionResul
     console.warn("[image-compression] compression failed, falling back to original file", err);
     return { ok: false, file, reason: "compression-failed", error: err };
   }
+}
+
+/** Image extensions we replace with `.webp`; anything else is appended to. */
+const IMAGE_EXTENSION = /\.(png|jpe?g|webp|gif|bmp|avif|tiff?|heic|heif)$/i;
+
+/**
+ * Rebuild the compression output as a real `File` named after the original.
+ *
+ * `browser-image-compression` returns a `Blob` with `name`/`lastModified`
+ * monkey-patched on rather than a real `File` (its types claim otherwise, so
+ * TypeScript can't catch this). Reading `.name` works, which is why the
+ * composer chip looked right — but `FormData.append()` ignores the patched
+ * property and labels any non-File Blob `"blob"` on the wire, so every
+ * compressed image landed in the agent workspace as `blob`, `blob (1)`, ...
+ */
+function toNamedFile(compressed: Blob, originalName: string): File {
+  const base = originalName.replace(IMAGE_EXTENSION, "");
+  // Compression converts to WebP, so the original extension would now lie about
+  // the bytes. Names without an image extension keep their dots and just gain one.
+  return new File([compressed], `${base}.webp`, {
+    type: compressed.type,
+    lastModified: Date.now(),
+  });
 }
 
 function shouldSkipCompression(file: File): boolean {


### PR DESCRIPTION
## What does this PR do?

Uploaded and pasted images landed in the agent workspace as `blob`, `blob (1)`, ... instead of their real filename. Verified on the integration stack: `/openclaw-config/workspaces/<agentId>/uploads/` held `blob` and `blob (1)` for pasted PNGs, while `test.pdf` kept its name. The message bubble then rendered `Preview blob` / `alt="Attachment: blob"`, and the agent could not cite the file by any meaningful name.

This is **independent of the paste path** — it hits all three intake routes (file picker, drag & drop, paste).

### Root cause

`browser-image-compression@2.0.2`'s internal `canvasToFile()` never constructs a real `File`. It returns a `Blob` with `name`/`lastModified` monkey-patched on as plain properties:

```js
l = new Blob([h], {type: r}); l.name = i; l.lastModified = o;
```

Reading `result.file.name` still works — which is why the composer upload chip showed the correct filename and the bug was invisible in the UI before send. But `upload-attachment.ts` does `formData.append("file", file)`, and per spec a `Blob` value gets the filename `blob`; the patched `.name` is ignored. The name was lost **only on the wire**. `CompressionResult` is typed `file: File`, so TypeScript could not catch it — the library's return type claims `File` while the runtime value is a `Blob`.

Not affected: `shouldSkipCompression()` returns the original `File` untouched for JPEG/WebP under the skip threshold, so those kept their name. Screenshots are PNG and are always compressed, so they always lost it.

### The fix

`compressImageForChat` now wraps the compression output in a real `File` named after the original.

The extension follows the bytes we actually got back, so normally `screenshot.png` → `screenshot.webp`. It is derived from the output's own MIME rather than from the `fileType: "image/webp"` we requested, because those can differ: the library never checks whether the canvas can encode WebP — it calls `toDataURL("image/webp")` and parses the MIME back out of the resulting data URL. A canvas without WebP encoding (Safari < 14, iOS < 14, some `OffscreenCanvas` impls) silently returns PNG, and hardcoding `.webp` there would re-introduce the very bug this PR fixes. `lastModified` is carried over from the original for the same reason: re-encoding pixels does not make a new document.

Serving is unaffected either way — the uploads `GET` route sniffs magic bytes via `fileTypeFromBuffer` and only falls back to `EXTENSION_TO_MIME` for text files that have none. The reason to rename is the workspace: the file lives there under its name, and a stale extension would lie to the agent reading it. Names without an image extension (`v1.2 mockup`) get the extension appended rather than truncated at the last dot.

### Note for reviewers: the mock was part of the bug

The existing test mock returned a real `File` and so did **not** model the library's actual behavior — that is precisely why this shipped. The mock now mimics the monkey-patched Blob. Without that change, any new test stays green no matter how broken the code is.

The guard is `instanceof File` plus the multipart filename `FormData` actually encodes. **Asserting `.name` alone passes against the broken version**, because the patched property is readable.

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable) — no user-facing behavior documented in `docs/` changes; filenames simply stop being wrong
- [x] All existing tests pass

## Verification

`pnpm test` (8251 tests), `pnpm build`, `pnpm -C packages/web lint` (0 errors) and `format:check` all pass.

Two things to flag honestly:

- **An unexplained flake.** The first full run after adding the `upload-attachment` test reported `1 failed | 8248 passed`. I had truncated the output and could not identify which test it was; it did not recur in **nine** subsequent full runs. `vitest.config.ts` configures no `retry`, so nothing is being masked — this was a genuine flake I could not pin down, not one I re-ran away.
- **`test:db` was not run**, and no end-to-end check against a live stack was done. Several stacks from parallel sessions already occupied the DB ports locally. The diff touches neither schema nor any route, so the DB suite would never execute `image-compression.ts`. The fix is evidenced at unit level including the multipart encoding — exactly where the name was lost.
