### PR TITLE
feat(inbox-agent): reconciliation sweep orchestrator (#139)

### DIFF
--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -267,6 +267,37 @@ describe("reconciliation sweep — listing window", () => {
     ).toBe(true);
   });
 
+  it("still warns when a saturated page also holds a poison message", async () => {
+    // Saturation is a property of what `search` RETURNS, not of what survives
+    // hydration. The lister drops a message it cannot hydrate (bad date, a read
+    // that 404s), so a saturated window with one poison mail hands back
+    // LIMIT-1 usable emails. If the warning gated on the hydrated count it would
+    // fall silent on exactly the pass that is BOTH truncated AND lossy — the
+    // worst case, hidden by a single outlier. The signal must come from the
+    // candidate count.
+    const { connection } = await seedDispatchableWorkflow();
+    const saturated = Array.from({ length: SWEEP_LIST_LIMIT }, (_, i) =>
+      message({ id: `bulk-${i}` })
+    );
+    // Poison exactly one: an unparseable date makes the lister's normalize throw,
+    // so it is isolated and dropped — LIMIT candidates, LIMIT-1 hydrated.
+    saturated[0] = message({ id: "bulk-poison", date: "not-a-date" });
+    const { createPort } = portFor(connection.id, saturated);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let warned: string[] = [];
+    try {
+      await runReconciliationSweep({ createPort, runAgent: doneRun });
+      warned = warn.mock.calls.map((call) => String(call[0]));
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(
+      warned.some((msg) => msg.includes("listing limit") && msg.includes(connection.id)),
+      `a saturated listing must warn even when one message failed to hydrate; warnings seen: ${JSON.stringify(warned)}`
+    ).toBe(true);
+  });
+
   it("narrows the provider query to the filter's folder", async () => {
     // The filter re-checks the folder anyway, so this is purely about not
     // hydrating (read()) mail the filter is guaranteed to drop.

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -1,0 +1,502 @@
+// Real-DB integration tests for the Inbox Agent reconciliation sweep (Brick D) —
+// the orchestrator that finally wires the finished bricks into one runnable pass:
+// loader (A) → mail lister (C) → dispatcher (§6 filter/claim/run/notify/finalize).
+//
+// The sweep is the *correctness* path of design §4: it re-lists the last N days
+// straight from each connection and dispatches whatever the ledger has not seen,
+// so a lost/expired cursor can never lose an email. (The cheap cursor-driven poll
+// is the event-trigger's job and needs OpenClaw 2026.7.1 — a later brick. The
+// lister only speaks `sinceDays`, never a cursor, for exactly that reason.)
+//
+// The mailbox port and the agent run are injected, mirroring how `dispatchEmails`
+// injects `RunAgent`: the production port is built from decrypted connection
+// credentials and is out of this brick's scope.
+//
+// The suite runs against the ephemeral integration Postgres with no truncate
+// between tests, and the sweep deliberately loads EVERY enabled workflow — so
+// each test scopes its assertions to the rows it seeded itself, and its fake port
+// hands back an empty mailbox for any connection it does not own.
+import { describe, it, expect } from "vitest";
+import { and, eq } from "drizzle-orm";
+
+import { db } from "@/db";
+import {
+  agents,
+  auditLog,
+  users,
+  emailWorkflows,
+  emailWorkflowConnections,
+  integrationConnections,
+  processedEmails,
+} from "@/db/schema";
+import { claimEmail, finalizeEmail } from "@/lib/email-workflows/ledger";
+import { runReconciliationSweep } from "@/lib/email-workflows/sweep";
+import type { EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
+import type { RunAgent } from "@/lib/email-workflows/dispatch";
+
+let userCounter = 0;
+async function seedUser() {
+  const [row] = await db
+    .insert(users)
+    .values({ email: `sweep-${userCounter++}@test.local`, name: "Owner" })
+    .returning();
+  return row;
+}
+
+async function seedAgent(ownerId: string) {
+  const [row] = await db
+    .insert(agents)
+    .values({
+      name: "Penny",
+      model: "ollama-cloud/gemini-3-flash",
+      greetingMessage: "Hi",
+      isPersonal: true,
+      ownerId,
+    })
+    .returning();
+  return row;
+}
+
+let connCounter = 0;
+async function seedConnection() {
+  const id = `sweep-conn-${connCounter++}`;
+  const [row] = await db
+    .insert(integrationConnections)
+    .values({ id, type: "imap", name: "Mailbox", credentials: "enc:placeholder" })
+    .returning();
+  return row;
+}
+
+/**
+ * One enabled personal-agent workflow on one fresh connection — the shape the
+ * loader emits and the sweep consumes. `sinceTs` defaults to the epoch so the
+ * watermark imposes no constraint unless a test opts in.
+ */
+async function seedDispatchableWorkflow(
+  opts: { sinceTs?: Date; sweepWindowDays?: number; folder?: string } = {}
+) {
+  const owner = await seedUser();
+  const agent = await seedAgent(owner.id);
+  const [wf] = await db
+    .insert(emailWorkflows)
+    .values({
+      agentId: agent.id,
+      name: "File invoices",
+      filter: {
+        hasAttachment: true,
+        attachmentType: "application/pdf",
+        ...(opts.folder ? { folder: opts.folder } : {}),
+      },
+      action: "Draft a supplier bill in Odoo from the attached invoice.",
+      enabled: true,
+      createdBy: owner.id,
+      ...(opts.sweepWindowDays ? { sweepWindowDays: opts.sweepWindowDays } : {}),
+    })
+    .returning();
+  const conn = await seedConnection();
+  await db.insert(emailWorkflowConnections).values({
+    workflowId: wf.id,
+    connectionId: conn.id,
+    sinceTs: opts.sinceTs ?? new Date(0),
+  });
+  return { owner, agent, workflow: wf, connection: conn };
+}
+
+function message(overrides: Partial<EmailReadResult> = {}): EmailReadResult {
+  return {
+    id: "msg-1",
+    from: "Vendor <vendor@supplier.com>",
+    to: "ap@acme.com",
+    cc: "",
+    subject: "Invoice 4711",
+    date: "2026-07-14T09:00:00.000Z",
+    folder: "INBOX",
+    attachments: [{ mimeType: "application/pdf", filename: "invoice.pdf" }],
+    ...overrides,
+  };
+}
+
+/**
+ * A fake mailbox for exactly one connection. Every other connection (workflows
+ * other tests seeded, which the global sweep also picks up) gets an empty
+ * mailbox, so tests never dispatch each other's mail.
+ */
+function portFor(connectionId: string, messages: EmailReadResult[]) {
+  const searchCalls: { sinceDays?: number; folder?: string; limit?: number }[] = [];
+  const createPort = async (id: string): Promise<EmailPort> => ({
+    search: async (opts) => {
+      if (id !== connectionId) return [];
+      searchCalls.push(opts);
+      return messages.map((m) => ({ id: m.id }));
+    },
+    read: async (msgId) => messages.find((m) => m.id === msgId)!,
+  });
+  return { createPort, searchCalls };
+}
+
+const doneRun: RunAgent = async () => ({
+  status: "done",
+  outcome: { odooModel: "account.move", odooId: 7 },
+  runId: "run-x",
+  title: "1 invoice filed",
+  content: "Drafted a supplier bill in Odoo.",
+});
+
+async function ledgerRow(workflowId: string, providerMessageId: string) {
+  const [row] = await db
+    .select()
+    .from(processedEmails)
+    .where(
+      and(
+        eq(processedEmails.workflowId, workflowId),
+        eq(processedEmails.providerMessageId, providerMessageId)
+      )
+    );
+  return row;
+}
+
+describe("reconciliation sweep — loader → lister → dispatcher", () => {
+  it("lists a connection's mail and dispatches a matching email into a finalized ledger row", async () => {
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const { createPort } = portFor(connection.id, [message()]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent });
+
+    // The email travelled the whole chain: listed from the port, normalized by
+    // the lister, past the filter, claimed, run, finalized.
+    expect(ran).toEqual(["msg-1"]);
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("done");
+    expect(row.connectionId).toBe(connection.id);
+    expect(row.outcome).toEqual({ odooModel: "account.move", odooId: 7 });
+  });
+});
+
+describe("reconciliation sweep — sinceTs watermark", () => {
+  it("never processes mail older than the workflow's sinceTs, even inside the sweep window", async () => {
+    // The failure mode from design §8, "New workflow on old mailbox": the sweep
+    // re-lists the last N days wholesale, so a workflow attached to a mailbox
+    // today would retroactively act on two weeks of history — a flood of drafts
+    // nobody asked for. `sinceTs` is the per-(workflow × connection) watermark
+    // that bounds it, and NOTHING downstream enforces it: the lister only speaks
+    // `sinceDays`, and neither `matchesFilter` nor `dispatchEmails` looks at
+    // `receivedAt`. The sweep owns this gate.
+    const { workflow, connection } = await seedDispatchableWorkflow({
+      sinceTs: new Date("2026-07-10T00:00:00.000Z"),
+    });
+    const { createPort } = portFor(connection.id, [
+      message({ id: "old", date: "2026-07-09T23:59:59.000Z" }),
+      message({ id: "new", date: "2026-07-10T00:00:01.000Z" }),
+    ]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent });
+
+    expect(ran).toEqual(["new"]);
+    // Below the watermark is not "skipped for now" — it must never be claimed,
+    // or the ledger would record an email the workflow was never meant to see.
+    expect(await ledgerRow(workflow.id, "old")).toBeUndefined();
+    expect((await ledgerRow(workflow.id, "new")).status).toBe("done");
+  });
+});
+
+describe("reconciliation sweep — listing window", () => {
+  it("bounds the re-list by the workflow's own sweepWindowDays", async () => {
+    // `sweepWindowDays` is the workflow's configured N (design §5, default 14).
+    // It has to reach the provider query itself: the window is what keeps the
+    // sweep's N+1 hydration bounded, and design §8 accepts "email older than N"
+    // as a documented limitation only because N is honestly the *listing* bound.
+    // Hardcoding a default here would silently ignore the column.
+    const { connection } = await seedDispatchableWorkflow({ sweepWindowDays: 3 });
+    const { createPort, searchCalls } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(searchCalls).toHaveLength(1);
+    expect(searchCalls[0].sinceDays).toBe(3);
+  });
+
+  it("narrows the provider query to the filter's folder", async () => {
+    // The filter re-checks the folder anyway, so this is purely about not
+    // hydrating (read()) mail the filter is guaranteed to drop.
+    const { connection } = await seedDispatchableWorkflow({ folder: "Invoices" });
+    const { createPort, searchCalls } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(searchCalls[0].folder).toBe("Invoices");
+  });
+});
+
+describe("reconciliation sweep — stuck claims", () => {
+  const GRACE_MS = 10 * 60_000;
+
+  /** Age a claim past the grace period, as if its run died `ms` ago. */
+  async function backdateClaim(ledgerId: string, ms: number) {
+    await db
+      .update(processedEmails)
+      .set({ claimedAt: new Date(Date.now() - ms) })
+      .where(eq(processedEmails.id, ledgerId));
+  }
+
+  it("resets a stuck claim and re-processes the email within the same sweep", async () => {
+    // A run that crashed (or deferred) after claiming leaves a `processing` row
+    // forever: the ledger's unique claim key blocks any re-claim, so the email is
+    // never retried — a permanent, silent gap. The sweep closes it by
+    // delete-and-reclaim (#735) BEFORE it lists, so the freed email is re-listed
+    // and re-dispatched in this same pass rather than one cadence later.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const stuckId = await claimEmail({
+      workflowId: workflow.id,
+      connectionId: connection.id,
+      providerMessageId: "msg-1",
+    });
+    await backdateClaim(stuckId!, GRACE_MS + 60_000);
+
+    const { createPort } = portFor(connection.id, [message()]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent, graceMs: GRACE_MS });
+
+    expect(ran).toEqual(["msg-1"]);
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.status).toBe("done");
+    // Delete-and-reclaim, not resurrect: the stuck row is gone and this is a
+    // genuinely fresh claim — the identity `finalizeEmail` is pinned to (#735).
+    expect(row.id).not.toBe(stuckId);
+  });
+
+  it("leaves a still-in-grace claim alone — a slow run is not a stuck run", async () => {
+    // The mirror image, and the reason `graceMs` must exceed the run timeout: a
+    // legitimately in-flight run must never be reset out from under itself. If
+    // the sweep reset on age alone, every long run would be duplicated.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const inFlightId = await claimEmail({
+      workflowId: workflow.id,
+      connectionId: connection.id,
+      providerMessageId: "msg-1",
+    });
+
+    const { createPort } = portFor(connection.id, [message()]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent, graceMs: GRACE_MS });
+
+    // Re-listed, but the surviving claim rejects the re-claim: no second run.
+    expect(ran).toEqual([]);
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.id).toBe(inFlightId);
+    expect(row.status).toBe("processing");
+  });
+
+  it("never touches a terminal row, however old", async () => {
+    // Only `processing` is stuck-able. Resetting an old `done` row would delete a
+    // recorded outcome and re-run an email that was already handled.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const ledgerId = await claimEmail({
+      workflowId: workflow.id,
+      connectionId: connection.id,
+      providerMessageId: "msg-1",
+    });
+    await finalizeEmail({ id: ledgerId!, status: "done", outcome: { note: "already filed" } });
+    await backdateClaim(ledgerId!, GRACE_MS * 100);
+
+    const { createPort } = portFor(connection.id, [message()]);
+    const ran: string[] = [];
+    const runAgent: RunAgent = async (ctx) => {
+      ran.push(ctx.email.providerMessageId);
+      return doneRun(ctx);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent, graceMs: GRACE_MS });
+
+    expect(ran).toEqual([]);
+    const row = await ledgerRow(workflow.id, "msg-1");
+    expect(row.id).toBe(ledgerId);
+    expect(row.outcome).toEqual({ note: "already filed" });
+  });
+});
+
+async function workflowStatus(workflowId: string) {
+  const [row] = await db
+    .select({ status: emailWorkflows.status })
+    .from(emailWorkflows)
+    .where(eq(emailWorkflows.id, workflowId));
+  return row.status;
+}
+
+describe("reconciliation sweep — workflow health status", () => {
+  it("marks a workflow active once a pass completes", async () => {
+    // `status` is the health signal the loader deliberately does NOT gate on —
+    // it is written here and read by the Automations UI. A workflow is seeded
+    // `pending`; the first clean pass is what proves it actually works.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    expect(await workflowStatus(workflow.id)).toBe("pending");
+    const { createPort } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("active");
+  });
+
+  it("marks a workflow error when its mailbox is unreachable, and recovers it on the next clean pass", async () => {
+    // A broken connection (revoked token, wrong host) is the workflow-level
+    // failure the user must see in the UI — it is invisible in the ledger,
+    // because nothing was ever listed, let alone claimed.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const failingPort = async (): Promise<EmailPort> => ({
+      search: async () => {
+        throw new Error("IMAP auth failed");
+      },
+      read: async () => {
+        throw new Error("IMAP auth failed");
+      },
+    });
+
+    await runReconciliationSweep({ createPort: failingPort, runAgent: doneRun });
+    expect(await workflowStatus(workflow.id)).toBe("error");
+
+    // Recovery must be automatic: `error` is a health signal, not a latch. If it
+    // stuck, a workflow would need manual intervention after any blip — and the
+    // loader (by design) will not gate on it, so it would silently keep running
+    // while permanently displaying `error`.
+    const { createPort } = portFor(connection.id, [message()]);
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("active");
+  });
+
+  it("reports error when only ONE of a workflow's mailboxes is broken", async () => {
+    // A workflow fans out to one unit of work per connection (D9), but `status`
+    // is a single per-workflow column. If each unit wrote it directly, a
+    // half-broken workflow's status would depend on which connection the loader
+    // happened to return last — green on a coin flip, hiding a mailbox that is
+    // silently processing nothing. Any broken connection must surface.
+    // The broken connection is attached FIRST and the healthy one second, so the
+    // healthy unit is the last to run. A naive "write the status inside the loop"
+    // would end on `active` and bury the breakage — this ordering is what makes
+    // the test load-bearing rather than accidentally green.
+    const { workflow, connection: broken } = await seedDispatchableWorkflow();
+    const good = await seedConnection();
+    await db
+      .insert(emailWorkflowConnections)
+      .values({ workflowId: workflow.id, connectionId: good.id, sinceTs: new Date(0) });
+
+    const { createPort: goodPort } = portFor(good.id, [message()]);
+    const createPort = async (id: string): Promise<EmailPort> => {
+      if (id === broken.id) throw new Error("connection credentials missing");
+      return goodPort(id);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(await workflowStatus(workflow.id)).toBe("error");
+    // The healthy mailbox still delivered — degraded, not dead.
+    expect((await ledgerRow(workflow.id, "msg-1")).status).toBe("done");
+  });
+
+  it("isolates a broken workflow — the rest of the sweep still runs", async () => {
+    // One unreachable mailbox must never stall every other workflow's mail.
+    const broken = await seedDispatchableWorkflow();
+    const healthy = await seedDispatchableWorkflow();
+    const { createPort: healthyPort } = portFor(healthy.connection.id, [message()]);
+    const createPort = async (id: string): Promise<EmailPort> => {
+      if (id === broken.connection.id) throw new Error("connection credentials missing");
+      return healthyPort(id);
+    };
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(await workflowStatus(broken.workflow.id)).toBe("error");
+    expect(await workflowStatus(healthy.workflow.id)).toBe("active");
+    expect((await ledgerRow(healthy.workflow.id, "msg-1")).status).toBe("done");
+  });
+});
+
+describe("reconciliation sweep — audit", () => {
+  const GRACE_MS = 10 * 60_000;
+
+  async function claimResetRows(workflowId: string) {
+    const rows = await db
+      .select()
+      .from(auditLog)
+      .where(eq(auditLog.eventType, "inbox.claim_reset"));
+    return rows.filter(
+      (r) => (r.detail as { workflow?: { id?: string } })?.workflow?.id === workflowId
+    );
+  }
+
+  it("writes one audit row per reset claim, correlated by a shared sweepId", async () => {
+    // Delete-and-reclaim destroys a ledger row — the one place the sweep loses
+    // state. That must be attributable: an analyst has to be able to answer "why
+    // was this email processed twice?" from the trail alone. `sweepId` is what
+    // turns N scattered rows back into one drill-down query for a single run.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    for (const id of ["msg-1", "msg-2"]) {
+      const stuck = await claimEmail({
+        workflowId: workflow.id,
+        connectionId: connection.id,
+        providerMessageId: id,
+      });
+      await db
+        .update(processedEmails)
+        .set({ claimedAt: new Date(Date.now() - GRACE_MS - 60_000) })
+        .where(eq(processedEmails.id, stuck!));
+    }
+
+    const { createPort } = portFor(connection.id, [
+      message({ id: "msg-1" }),
+      message({ id: "msg-2" }),
+    ]);
+    await runReconciliationSweep({ createPort, runAgent: doneRun, graceMs: GRACE_MS });
+
+    const rows = await claimResetRows(workflow.id);
+    expect(rows).toHaveLength(2);
+    expect(rows.every((r) => r.outcome === "success")).toBe(true);
+    expect(rows.every((r) => r.actorType === "system")).toBe(true);
+
+    // One sweep ⟹ one correlation id across every row it emitted.
+    const sweepIds = new Set(rows.map((r) => (r.detail as { sweepId: string }).sweepId));
+    expect(sweepIds.size).toBe(1);
+
+    // The workflow name is snapshotted beside the id: the row must stay readable
+    // after the workflow is renamed or deleted.
+    expect(rows.map((r) => r.detail)).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          workflow: { id: workflow.id, name: "File invoices" },
+          connectionId: connection.id,
+          providerMessageId: "msg-1",
+        }),
+        expect.objectContaining({ providerMessageId: "msg-2" }),
+      ])
+    );
+  });
+
+  it("writes no reset audit rows when nothing was stuck", async () => {
+    // The trail must stay signal: a routine no-op sweep is not an event.
+    const { workflow, connection } = await seedDispatchableWorkflow();
+    const { createPort } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun, graceMs: GRACE_MS });
+
+    expect(await claimResetRows(workflow.id)).toHaveLength(0);
+  });
+});

--- a/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-sweep.integration.test.ts
@@ -16,7 +16,7 @@
 // between tests, and the sweep deliberately loads EVERY enabled workflow — so
 // each test scopes its assertions to the rows it seeded itself, and its fake port
 // hands back an empty mailbox for any connection it does not own.
-import { describe, it, expect } from "vitest";
+import { describe, it, expect, vi } from "vitest";
 import { and, eq } from "drizzle-orm";
 
 import { db } from "@/db";
@@ -30,7 +30,7 @@ import {
   processedEmails,
 } from "@/db/schema";
 import { claimEmail, finalizeEmail } from "@/lib/email-workflows/ledger";
-import { runReconciliationSweep } from "@/lib/email-workflows/sweep";
+import { runReconciliationSweep, SWEEP_LIST_LIMIT } from "@/lib/email-workflows/sweep";
 import type { EmailPort, EmailReadResult } from "@/lib/email-workflows/lister";
 import type { RunAgent } from "@/lib/email-workflows/dispatch";
 
@@ -223,6 +223,48 @@ describe("reconciliation sweep — listing window", () => {
 
     expect(searchCalls).toHaveLength(1);
     expect(searchCalls[0].sinceDays).toBe(3);
+  });
+
+  it("bounds how much mail one pass hydrates", async () => {
+    // The lister hydrates EVERY candidate with a sequential read() — an N+1 whose
+    // N is whatever the mailbox happens to hold in the window. `sweepWindowDays`
+    // bounds the window in time, not in volume: a busy mailbox can hold thousands
+    // of messages in 14 days, and the sweep would read them all, every cadence,
+    // before the filter drops almost all of them.
+    const { connection } = await seedDispatchableWorkflow();
+    const { createPort, searchCalls } = portFor(connection.id, [message()]);
+
+    await runReconciliationSweep({ createPort, runAgent: doneRun });
+
+    expect(searchCalls[0].limit).toBe(SWEEP_LIST_LIMIT);
+  });
+
+  it("warns loudly when a pass fills its listing limit instead of truncating in silence", async () => {
+    // The limit is a safety valve, and it has a real cost: `search` cannot filter
+    // by the ledger, so the mail beyond the limit is not merely "deferred to the
+    // next pass" — if the provider keeps returning the same saturated page, the
+    // overflow is never dispatched at all. That risk is acceptable only while it
+    // is VISIBLE, so saturation has to say so. Silent truncation in the component
+    // whose entire job is "never lose an email" is the worst possible failure.
+    const { connection } = await seedDispatchableWorkflow();
+    const saturated = Array.from({ length: SWEEP_LIST_LIMIT }, (_, i) =>
+      message({ id: `bulk-${i}` })
+    );
+    const { createPort } = portFor(connection.id, saturated);
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    let warned: string[] = [];
+    try {
+      await runReconciliationSweep({ createPort, runAgent: doneRun });
+      // Read the calls BEFORE restoring: mockRestore() also clears mock.calls.
+      warned = warn.mock.calls.map((call) => String(call[0]));
+    } finally {
+      warn.mockRestore();
+    }
+
+    expect(
+      warned.some((msg) => msg.includes("listing limit") && msg.includes(connection.id)),
+      `a saturated listing must name the connection that overflowed; warnings seen: ${JSON.stringify(warned)}`
+    ).toBe(true);
   });
 
   it("narrows the provider query to the filter's folder", async () => {

--- a/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
+++ b/packages/web/src/__tests__/integration/email-workflow-loader.integration.test.ts
@@ -109,6 +109,10 @@ describe("email workflow loader — loadDispatchableWorkflows", () => {
           recipientUserIds: [owner.id],
         },
         sinceTs: since,
+        // The sweep's listing window (design §5 default). Carried per workflow
+        // so the reconciliation sweep can bound its re-list without re-reading
+        // the row.
+        sweepWindowDays: 14,
       },
     ]);
   });

--- a/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
@@ -44,7 +44,7 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const emails = await listDispatchableEmails(port, { sinceDays: 14 });
+    const { emails } = await listDispatchableEmails(port, { sinceDays: 14 });
 
     expect(emails).toEqual([
       {
@@ -75,7 +75,9 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const [email] = await listDispatchableEmails(port, {});
+    const {
+      emails: [email],
+    } = await listDispatchableEmails(port, {});
 
     expect(email.to).toEqual(["shared@acme.test"]);
   });
@@ -95,7 +97,9 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const [email] = await listDispatchableEmails(port, {});
+    const {
+      emails: [email],
+    } = await listDispatchableEmails(port, {});
 
     expect(email.to).toEqual([]);
     expect(email.attachments).toEqual([]);
@@ -138,7 +142,9 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const [email] = await listDispatchableEmails(port, {});
+    const {
+      emails: [email],
+    } = await listDispatchableEmails(port, {});
 
     expect(email.to).toEqual(["john@acme.test", "jane@acme.test"]);
   });
@@ -158,7 +164,9 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const [email] = await listDispatchableEmails(port, {});
+    const {
+      emails: [email],
+    } = await listDispatchableEmails(port, {});
 
     expect(email.to).toEqual(["a@acme.test", "b@acme.test"]);
   });
@@ -178,7 +186,9 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const [email] = await listDispatchableEmails(port, {});
+    const {
+      emails: [email],
+    } = await listDispatchableEmails(port, {});
 
     expect(email.from).toBe("bad@y.test");
   });
@@ -220,11 +230,14 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     ]);
 
-    const emails = await listDispatchableEmails(port, {});
+    const { emails, candidateCount } = await listDispatchableEmails(port, {});
 
     // The poison message is dropped — never a half-normalized email with an
     // Invalid Date, which would only throw later inside the run adapter.
     expect(emails.map((e) => e.providerMessageId)).toEqual(["id-good-before", "id-good-after"]);
+    // …but the dropped candidate still counts: `candidateCount` reflects what
+    // `search` returned, so the sweep can see a page was full even after a drop.
+    expect(candidateCount).toBe(3);
   });
 
   it("skips a message whose hydration fails, not just one that fails to normalize", async () => {
@@ -249,7 +262,7 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     };
 
-    const emails = await listDispatchableEmails(port, {});
+    const { emails } = await listDispatchableEmails(port, {});
 
     expect(emails.map((e) => e.providerMessageId)).toEqual(["id-ok"]);
   });
@@ -307,7 +320,7 @@ describe("mail lister — listDispatchableEmails", () => {
       },
     };
 
-    const emails = await listDispatchableEmails(port, {
+    const { emails, candidateCount } = await listDispatchableEmails(port, {
       sinceDays: 14,
       folder: "INBOX",
       limit: 50,
@@ -315,5 +328,7 @@ describe("mail lister — listDispatchableEmails", () => {
 
     expect(seen).toEqual([{ sinceDays: 14, folder: "INBOX", limit: 50 }]);
     expect(emails.map((e) => e.providerMessageId)).toEqual(["a", "b"]);
+    // Every candidate hydrated, so the count matches the returned batch.
+    expect(candidateCount).toBe(2);
   });
 });

--- a/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
+++ b/packages/web/src/__tests__/lib/email-workflows/lister.test.ts
@@ -183,6 +183,95 @@ describe("mail lister — listDispatchableEmails", () => {
     expect(email.from).toBe("bad@y.test");
   });
 
+  it("skips a single unusable message and still returns the rest of the mailbox", async () => {
+    // Poison-message isolation. One malformed message must not cost a mailbox its
+    // whole pass: `normalize` throws on a bad date, and the sweep's unit-level
+    // catch is per (workflow × connection) — so without isolation here, one
+    // corrupt mail silently stops every OTHER mail on that connection from ever
+    // being dispatched, and parks the workflow in `error` until a human deletes
+    // it from the mailbox by hand.
+    const port = fakePort([
+      {
+        id: "id-good-before",
+        from: "a@x.test",
+        to: "",
+        cc: "",
+        subject: "A",
+        date: "2026-07-10T00:00:00.000Z",
+        attachments: [],
+      },
+      {
+        id: "id-poison",
+        from: "bad@x.test",
+        to: "",
+        cc: "",
+        subject: "corrupt",
+        date: "not-a-date",
+        attachments: [],
+      },
+      {
+        id: "id-good-after",
+        from: "b@x.test",
+        to: "",
+        cc: "",
+        subject: "B",
+        date: "2026-07-11T00:00:00.000Z",
+        attachments: [],
+      },
+    ]);
+
+    const emails = await listDispatchableEmails(port, {});
+
+    // The poison message is dropped — never a half-normalized email with an
+    // Invalid Date, which would only throw later inside the run adapter.
+    expect(emails.map((e) => e.providerMessageId)).toEqual(["id-good-before", "id-good-after"]);
+  });
+
+  it("skips a message whose hydration fails, not just one that fails to normalize", async () => {
+    // A provider that 404s or errors on a single message (deleted mid-sweep,
+    // server-side corruption) is the same class of failure as a bad date: it is
+    // about ONE message, so it must cost exactly that message.
+    const port: EmailPort = {
+      async search() {
+        return [{ id: "id-gone" }, { id: "id-ok" }];
+      },
+      async read(id) {
+        if (id === "id-gone") throw new Error("404 message not found");
+        return {
+          id: "id-ok",
+          from: "b@x.test",
+          to: "",
+          cc: "",
+          subject: "B",
+          date: "2026-07-11T00:00:00.000Z",
+          attachments: [],
+        };
+      },
+    };
+
+    const emails = await listDispatchableEmails(port, {});
+
+    expect(emails.map((e) => e.providerMessageId)).toEqual(["id-ok"]);
+  });
+
+  it("throws when EVERY candidate fails — a dead mailbox is not a poison message", async () => {
+    // The isolation above must not swallow a broken *mailbox*. Credentials that
+    // expire between `search` and `read` fail every hydration; reporting that as
+    // an empty inbox would turn a loud `error` status into "nothing new today"
+    // and silently stop the workflow. Per-message isolation is for the outlier —
+    // when there IS no good message, the failure is the mailbox's.
+    const port: EmailPort = {
+      async search() {
+        return [{ id: "a" }, { id: "b" }];
+      },
+      async read() {
+        throw new Error("401 credentials expired");
+      },
+    };
+
+    await expect(listDispatchableEmails(port, {})).rejects.toThrow(/401 credentials expired/);
+  });
+
   it("forwards the listing window (sinceDays/folder/limit) to the port and hydrates every candidate in order", async () => {
     // The sweep passes its window down; the lister must forward it verbatim and
     // return one hydrated DispatchableEmail per candidate, preserving order.

--- a/packages/web/src/lib/audit.ts
+++ b/packages/web/src/lib/audit.ts
@@ -89,7 +89,8 @@ export type AuditEventType =
   | "file.upload.expired"
   | "retrieval.query"
   | "knowledge.source_viewed"
-  | "knowledge.reindex";
+  | "knowledge.reindex"
+  | "inbox.claim_reset";
 
 interface HmacFieldsV1 {
   timestamp: Date;
@@ -614,6 +615,23 @@ export type AuditLogEntry =
         skipped: number;
         removed: number;
         reason?: string;
+      };
+    })
+  | (AuditLogBase & {
+      eventType: "inbox.claim_reset";
+      detail: {
+        // The reconciliation sweep freed a stuck `processing` claim by deleting
+        // its ledger row (delete-and-reclaim, #735), so the email is listed and
+        // processed again. This is the sweep's only destructive act and the only
+        // way an email is processed twice — it has to be attributable.
+        //
+        // No PII: the claim tuple is opaque provider/DB ids, never an address.
+        workflow: EntityRef;
+        connectionId: string;
+        /** Provider immutable id (Graph id / Gmail message id). */
+        providerMessageId: string;
+        /** Correlates every row emitted by a single sweep run. */
+        sweepId: string;
       };
     });
 

--- a/packages/web/src/lib/email-workflows/lister.ts
+++ b/packages/web/src/lib/email-workflows/lister.ts
@@ -42,6 +42,21 @@ export interface EmailPort {
   read(id: string): Promise<EmailReadResult>;
 }
 
+/**
+ * The lister's output. `emails` is the hydrated, usable batch; `candidateCount`
+ * is how many candidates `search` returned *before* hydration dropped any.
+ *
+ * The two differ by the poison messages the lister isolates, and that gap is
+ * exactly why the sweep's saturation check must read `candidateCount`, not
+ * `emails.length`: a full page with a single unusable message hands back
+ * `limit - 1` emails, so gating truncation on the hydrated count would fall
+ * silent on the worst pass — one that is both truncated AND lossy.
+ */
+export interface EmailListResult {
+  emails: DispatchableEmail[];
+  candidateCount: number;
+}
+
 /** Extract the bare, lower-cased address from `Display Name <addr>` or a raw `addr`. */
 function normalizeAddress(raw: string): string {
   const angle = raw.lastIndexOf("<");
@@ -104,7 +119,7 @@ function normalizeAddressList(raw: string): string[] {
 export async function listDispatchableEmails(
   port: EmailPort,
   opts: { sinceDays?: number; folder?: string; limit?: number }
-): Promise<DispatchableEmail[]> {
+): Promise<EmailListResult> {
   // `search` is the mailbox-level probe: if it throws, nothing was listed and the
   // failure is the connection's, so it propagates to the sweep's unit-level catch
   // and surfaces as the workflow's `error` status.
@@ -131,7 +146,9 @@ export async function listDispatchableEmails(
   if (failures.length > 0 && emails.length === 0) {
     throw failures[0];
   }
-  return emails;
+  // `candidateCount` is the pre-hydration count on purpose: the sweep reads it to
+  // detect a truncated page, and a dropped poison message must not mask a full one.
+  return { emails, candidateCount: candidates.length };
 }
 
 function normalize(msg: EmailReadResult): DispatchableEmail {

--- a/packages/web/src/lib/email-workflows/lister.ts
+++ b/packages/web/src/lib/email-workflows/lister.ts
@@ -105,11 +105,31 @@ export async function listDispatchableEmails(
   port: EmailPort,
   opts: { sinceDays?: number; folder?: string; limit?: number }
 ): Promise<DispatchableEmail[]> {
+  // `search` is the mailbox-level probe: if it throws, nothing was listed and the
+  // failure is the connection's, so it propagates to the sweep's unit-level catch
+  // and surfaces as the workflow's `error` status.
   const candidates = await port.search(opts);
   const emails: DispatchableEmail[] = [];
+  const failures: unknown[] = [];
   for (const candidate of candidates) {
-    const msg = await port.read(candidate.id);
-    emails.push(normalize(msg));
+    // Isolate per message: one unusable mail (unparseable date, a read that 404s
+    // on a message deleted mid-sweep) must cost exactly that mail, not the whole
+    // mailbox's pass. Without this, a single corrupt message stops every other
+    // message on the connection from ever being dispatched — indefinitely, since
+    // the sweep re-lists the same window every cadence.
+    try {
+      emails.push(normalize(await port.read(candidate.id)));
+    } catch (err) {
+      failures.push(err);
+      console.warn(`mail lister: skipping unusable message ${candidate.id}`, err);
+    }
+  }
+  // But isolation must not swallow a dead mailbox. Credentials expiring between
+  // `search` and `read` fail EVERY hydration; reported as an empty inbox that
+  // would read as "nothing new" and silently retire the workflow while its status
+  // stayed `active`. No usable message at all is a mailbox failure, not an outlier.
+  if (failures.length > 0 && emails.length === 0) {
+    throw failures[0];
   }
   return emails;
 }

--- a/packages/web/src/lib/email-workflows/loader.ts
+++ b/packages/web/src/lib/email-workflows/loader.ts
@@ -13,6 +13,8 @@ export interface DispatchableWorkflow {
   workflow: WorkflowForDispatch;
   /** email_workflow_connections.since_ts — the per-connection listing floor. */
   sinceTs: Date;
+  /** email_workflows.sweep_window_days — how far back the sweep re-lists (design §5). */
+  sweepWindowDays: number;
 }
 
 /**
@@ -45,6 +47,7 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[
       name: emailWorkflows.name,
       filter: emailWorkflows.filter,
       action: emailWorkflows.action,
+      sweepWindowDays: emailWorkflows.sweepWindowDays,
       createdBy: emailWorkflows.createdBy,
       isPersonal: agents.isPersonal,
       ownerId: agents.ownerId,
@@ -71,6 +74,7 @@ export async function loadDispatchableWorkflows(): Promise<DispatchableWorkflow[
         recipientUserIds,
       },
       sinceTs: row.sinceTs,
+      sweepWindowDays: row.sweepWindowDays,
     });
   }
   return result;

--- a/packages/web/src/lib/email-workflows/run-adapter.ts
+++ b/packages/web/src/lib/email-workflows/run-adapter.ts
@@ -47,7 +47,12 @@ export interface OpenClawRunAgentDeps {
   timeoutMs?: number;
 }
 
-const DEFAULT_TIMEOUT_MS = 5 * 60_000;
+/**
+ * Watchdog for a single inbox run. Exported because the reconciliation sweep's
+ * stuck-claim grace period is derived from it: the grace MUST exceed the run
+ * timeout, so the two must not drift apart (see `DEFAULT_STUCK_GRACE_MS`).
+ */
+export const DEFAULT_RUN_TIMEOUT_MS = 5 * 60_000;
 
 const REPORT_CONTRACT = `You are executing an automated inbox workflow run. No human reads this conversation or can answer questions — decide and act using your tools.
 End your reply with exactly one fenced \`\`\`json code block of this shape:
@@ -55,7 +60,7 @@ End your reply with exactly one fenced \`\`\`json code block of this shape:
 Use "status": "no_action" when the email needs nothing done. "outcome" is optional — include it when you created or changed a record. The JSON block must be the last thing in your reply.`;
 
 export function createOpenClawRunAgent(deps: OpenClawRunAgentDeps): RunAgent {
-  const timeoutMs = deps.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const timeoutMs = deps.timeoutMs ?? DEFAULT_RUN_TIMEOUT_MS;
 
   return async ({ workflow, email, ledgerId }) => {
     const model = await deps.loadAgentModel(workflow.agentId);

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -76,7 +76,7 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
       const port = await deps.createPort(unit.workflow.connectionId);
       // `folder` only narrows the provider query — the filter re-checks it
       // anyway, so this saves hydrating mail that is guaranteed to be dropped.
-      const emails = await listDispatchableEmails(port, {
+      const { emails, candidateCount } = await listDispatchableEmails(port, {
         sinceDays: unit.sweepWindowDays,
         folder: unit.workflow.filter.folder,
         limit: SWEEP_LIST_LIMIT,
@@ -85,7 +85,12 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
       // to hydrate, so this pass saw a truncated mailbox. Say so: the overflow is
       // not merely deferred (see SWEEP_LIST_LIMIT), and a component whose whole
       // job is "never lose an email" must not truncate in silence.
-      if (emails.length >= SWEEP_LIST_LIMIT) {
+      //
+      // Read the CANDIDATE count, not `emails.length`: the lister drops messages
+      // it cannot hydrate, so a full page with one poison mail yields LIMIT-1
+      // emails — and gating on the hydrated count would fall silent on exactly
+      // the pass that is both truncated and lossy.
+      if (candidateCount >= SWEEP_LIST_LIMIT) {
         console.warn(
           `reconciliation sweep: hit the listing limit of ${SWEEP_LIST_LIMIT} for workflow ${unit.workflow.id} on connection ${unit.workflow.connectionId} — mail beyond it was not seen this pass`
         );

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -1,0 +1,144 @@
+import { eq, inArray } from "drizzle-orm";
+
+import { db } from "@/db";
+import { emailWorkflows } from "@/db/schema";
+import type { EmailWorkflowStatus } from "@/db/enums";
+import { appendAuditLog } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
+import { dispatchEmails } from "@/lib/email-workflows/dispatch";
+import { resetStuckProcessingEmails } from "@/lib/email-workflows/ledger";
+import type { StuckClaimKey } from "@/lib/email-workflows/ledger";
+import { listDispatchableEmails } from "@/lib/email-workflows/lister";
+import { loadDispatchableWorkflows } from "@/lib/email-workflows/loader";
+import { DEFAULT_RUN_TIMEOUT_MS } from "@/lib/email-workflows/run-adapter";
+import type { EmailPort } from "@/lib/email-workflows/lister";
+import type { RunAgent } from "@/lib/email-workflows/dispatch";
+
+/**
+ * How long a `processing` claim may sit before the sweep treats it as stuck.
+ *
+ * This MUST exceed the run timeout, or the sweep would reset live runs out from
+ * under themselves and duplicate every slow one. Derived from the run timeout
+ * rather than hardcoded so the two cannot drift apart; the 3× headroom covers
+ * the notify + finalize tail that follows the run itself.
+ */
+export const DEFAULT_STUCK_GRACE_MS = 3 * DEFAULT_RUN_TIMEOUT_MS;
+
+export interface SweepDeps {
+  /** Builds a mailbox port for one connection, from its decrypted credentials. */
+  createPort: (connectionId: string) => Promise<EmailPort>;
+  runAgent: RunAgent;
+  /** Overrides {@link DEFAULT_STUCK_GRACE_MS}; must exceed the run timeout. */
+  graceMs?: number;
+}
+
+/**
+ * The reconciliation sweep (design §4/§8): re-list each connection's recent mail
+ * and dispatch whatever the ledger has not seen. This is the correctness path —
+ * the cursor is only an optimization, so a lost or expired cursor costs a resync,
+ * never an email.
+ */
+export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
+  // Free stuck claims BEFORE listing, so an email whose run died is re-listed and
+  // retried in this same pass rather than one cadence later. Delete-and-reclaim:
+  // the row goes away, the normal claim path re-creates it (#735).
+  const reset = await resetStuckProcessingEmails(deps.graceMs ?? DEFAULT_STUCK_GRACE_MS);
+  await auditClaimResets(reset, crypto.randomUUID());
+
+  const units = await loadDispatchableWorkflows();
+
+  // `status` is per workflow, but a unit of work is per (workflow × connection)
+  // (D9). Collect each unit's health first and write the column once, so a
+  // half-broken workflow reports `error` deterministically instead of taking
+  // whichever connection the loader happened to return last.
+  const failedWorkflowIds = new Set<string>();
+  const seenWorkflowIds = new Set<string>();
+
+  for (const unit of units) {
+    seenWorkflowIds.add(unit.workflow.id);
+    try {
+      const port = await deps.createPort(unit.workflow.connectionId);
+      // `folder` only narrows the provider query — the filter re-checks it
+      // anyway, so this saves hydrating mail that is guaranteed to be dropped.
+      const emails = await listDispatchableEmails(port, {
+        sinceDays: unit.sweepWindowDays,
+        folder: unit.workflow.filter.folder,
+      });
+      // The sweep re-lists a whole window, so it is the only place the per-
+      // (workflow × connection) watermark can be enforced: the lister speaks
+      // `sinceDays` and nothing downstream reads `receivedAt`. Without this gate
+      // a workflow attached to an old mailbox would retroactively act on the
+      // entire window (design §8, "New workflow on old mailbox"). Below the
+      // watermark is dropped before the claim, never claimed-and-skipped.
+      const fresh = emails.filter((email) => email.receivedAt >= unit.sinceTs);
+      await dispatchEmails({ workflow: unit.workflow, emails: fresh, runAgent: deps.runAgent });
+    } catch (err) {
+      // A unit-level failure is a broken *mailbox* (credentials, unreachable
+      // host) — invisible in the ledger, because nothing was ever listed. It
+      // surfaces as the workflow's health status. One bad mailbox must never
+      // stall the rest of the sweep.
+      failedWorkflowIds.add(unit.workflow.id);
+      console.error(
+        `reconciliation sweep: workflow ${unit.workflow.id} failed on connection ${unit.workflow.connectionId}`,
+        err
+      );
+    }
+  }
+
+  for (const workflowId of seenWorkflowIds) {
+    // Not a latch: a clean pass clears a previous `error`, otherwise any blip
+    // would need manual intervention — and the loader deliberately does not gate
+    // on `status`, so the workflow would keep running while displaying `error`.
+    await setWorkflowStatus(workflowId, failedWorkflowIds.has(workflowId) ? "error" : "active");
+  }
+}
+
+async function setWorkflowStatus(workflowId: string, status: EmailWorkflowStatus): Promise<void> {
+  await db.update(emailWorkflows).set({ status }).where(eq(emailWorkflows.id, workflowId));
+}
+
+/**
+ * One audit row per freed claim, all sharing `sweepId` so a single sweep is one
+ * drill-down query. Deleting a ledger row is the sweep's only destructive act,
+ * and the only way an email gets processed twice — the trail has to explain it.
+ *
+ * The workflow *name* is snapshotted beside the id (AGENTS.md): the row must
+ * still read sensibly after a rename or a delete, when the id resolves to
+ * nothing. Deleting a workflow cascades its ledger rows away, so an unresolvable
+ * name here is near-impossible (a delete racing this query) — the fallback keeps
+ * the trail honest rather than dropping the row.
+ */
+async function auditClaimResets(reset: StuckClaimKey[], sweepId: string): Promise<void> {
+  if (reset.length === 0) return;
+
+  const names = new Map(
+    (
+      await db
+        .select({ id: emailWorkflows.id, name: emailWorkflows.name })
+        .from(emailWorkflows)
+        .where(inArray(emailWorkflows.id, [...new Set(reset.map((r) => r.workflowId))]))
+    ).map((row) => [row.id, row.name])
+  );
+
+  for (const claim of reset) {
+    const entry = {
+      eventType: "inbox.claim_reset" as const,
+      actorType: "system" as const,
+      actorId: "inbox-sweep",
+      outcome: "success" as const,
+      detail: {
+        workflow: { id: claim.workflowId, name: names.get(claim.workflowId) ?? "(deleted)" },
+        connectionId: claim.connectionId,
+        providerMessageId: claim.providerMessageId,
+        sweepId,
+      },
+    };
+    // Never fire-and-forget, and never let an audit outage abort the sweep: the
+    // reset already happened, so the write is recorded for retry instead.
+    try {
+      await appendAuditLog(entry);
+    } catch (auditErr) {
+      recordAuditFailure(auditErr, entry);
+    }
+  }
+}

--- a/packages/web/src/lib/email-workflows/sweep.ts
+++ b/packages/web/src/lib/email-workflows/sweep.ts
@@ -24,6 +24,22 @@ import type { RunAgent } from "@/lib/email-workflows/dispatch";
  */
 export const DEFAULT_STUCK_GRACE_MS = 3 * DEFAULT_RUN_TIMEOUT_MS;
 
+/**
+ * How many messages one (workflow × connection) pass may hydrate.
+ *
+ * `sweepWindowDays` bounds the re-list in *time*, not in volume — a busy mailbox
+ * holds thousands of messages in 14 days, and the lister hydrates every candidate
+ * with a sequential `read()` before the filter drops nearly all of them. This is
+ * the volume bound that keeps one noisy mailbox from stalling the whole cadence.
+ *
+ * It is a safety valve, not a page size: `search` cannot filter by the ledger, so
+ * mail beyond the limit is NOT reliably "picked up next pass" — a mailbox that
+ * stays saturated may never surface its overflow at all. That is why saturation
+ * warns (see below) instead of truncating quietly. The value is deliberately far
+ * above a realistic filtered window.
+ */
+export const SWEEP_LIST_LIMIT = 200;
+
 export interface SweepDeps {
   /** Builds a mailbox port for one connection, from its decrypted credentials. */
   createPort: (connectionId: string) => Promise<EmailPort>;
@@ -63,7 +79,17 @@ export async function runReconciliationSweep(deps: SweepDeps): Promise<void> {
       const emails = await listDispatchableEmails(port, {
         sinceDays: unit.sweepWindowDays,
         folder: unit.workflow.filter.folder,
+        limit: SWEEP_LIST_LIMIT,
       });
+      // A full page means the window held at least as much mail as we are willing
+      // to hydrate, so this pass saw a truncated mailbox. Say so: the overflow is
+      // not merely deferred (see SWEEP_LIST_LIMIT), and a component whose whole
+      // job is "never lose an email" must not truncate in silence.
+      if (emails.length >= SWEEP_LIST_LIMIT) {
+        console.warn(
+          `reconciliation sweep: hit the listing limit of ${SWEEP_LIST_LIMIT} for workflow ${unit.workflow.id} on connection ${unit.workflow.connectionId} — mail beyond it was not seen this pass`
+        );
+      }
       // The sweep re-lists a whole window, so it is the only place the per-
       // (workflow × connection) watermark can be enforced: the lister speaks
       // `sinceDays` and nothing downstream reads `receivedAt`. Without this gate


### PR DESCRIPTION
Brick D of the Inbox Agent (#139). Wires the finished bricks into the first runnable pass: **loader (A) → mail lister (C) → dispatcher** (§6 filter → claim → run → notify → finalize).

## Why the sweep, not the cursor poll

The lister speaks `sinceDays`, never a cursor — the cursor lives in the event-trigger's `trigger.state` and needs OpenClaw 2026.7.1 (a later brick). Design §4 makes the sweep the correctness path regardless: the cursor is only an optimization, so a lost or expired cursor costs a resync, never an email. `advanceCursor` stays unused until the trigger lands.

## Two gaps that had no home before this

**The `sinceTs` watermark.** The loader emits it, but nothing downstream reads `receivedAt` — not the lister, not `matchesFilter`, not `dispatchEmails`. Since the sweep re-lists a whole window, a workflow attached to an old mailbox would have retroactively acted on two weeks of history (design §8, *"New workflow on old mailbox"*). The sweep drops below-watermark mail **before** the claim, so the ledger never records an email the workflow was not meant to see.

**`status`.** `pending|active|error` existed in the schema, and the loader deliberately does not gate on it — but nothing ever wrote it. It is now written once per workflow after aggregating every unit, so a half-broken workflow (one of two mailboxes down) reports `error` deterministically instead of taking whichever connection the loader happened to return last. It is not a latch: a clean pass clears it, because the loader will keep dispatching regardless and a stuck `error` would be a lie.

## Stuck claims + audit

Stuck claims are freed **before** listing, so an email whose run died is retried in the same pass rather than one cadence later. Each freed claim emits an `inbox.claim_reset` audit row (new event type) sharing one `sweepId`: delete-and-reclaim (#735) is the sweep's only destructive act and the only way an email gets processed twice, so it has to be attributable from the trail alone. Detail carries the claim tuple plus a `{ id, name }` workflow snapshot; the tuple is opaque provider/DB ids, so no PII.

`DEFAULT_STUCK_GRACE_MS` is derived from the now-exported `DEFAULT_RUN_TIMEOUT_MS` rather than hardcoded — the grace MUST exceed the run timeout or the sweep would reset live runs out from under themselves, and the two must not silently drift apart.

## Tests

TDD throughout; every test watched failing first. The guard tests are **mutation-verified** — each of these reddens exactly one test and nothing else:

| Mutation | Test that catches it |
|---|---|
| Write `status` per unit instead of aggregating | *reports error when only ONE mailbox is broken* |
| Fresh `sweepId` per audit row | *correlated by a shared sweepId* |
| Ignore `graceMs` (reset everything) | *leaves a still-in-grace claim alone* |
| Drop the ledger's `status='processing'` guard | *never touches a terminal row* |

The multi-connection test attaches the **broken** connection first and the healthy one second on purpose: with the naive per-unit write it would have ended on `active` and passed by accident.

## Scope / follow-ups

- The mailbox port and the agent run are **injected**, mirroring how `dispatchEmails` injects `RunAgent`. This settles the open contract question: raw headers stay, parsing stays in the hardened lister (one parser, already tested).
- The **production `EmailPort`** (from decrypted connection credentials) and the **route/cron trigger** that calls the sweep are separate slices.
- `createPort` is called per (workflow × connection), so two workflows on one mailbox build it twice. Left deliberate: a cache saves little and adds a failure mode, and no behavior needs it.
- No docs in this PR — the sweep is not user-reachable yet. Docs (§13) land with the Automations UI.

## Gates

`pnpm test` (8244 ✓) · `pnpm -C packages/web test:db` (235 ✓) · `pnpm build` · `lint` (0 errors) · `format:check` — all green locally.