### PR TITLE
fix(chat): stop trusting a non-throwing chat.abort as a real abort (#550)

### DIFF
--- a/packages/web/src/__tests__/server/client-router-abort.test.ts
+++ b/packages/web/src/__tests__/server/client-router-abort.test.ts
@@ -304,6 +304,29 @@ describe("ClientRouter user-triggered abort (#550)", () => {
     expect(mockAppendAuditLog.mock.calls[0]![0].outcome).toBe("failure");
   });
 
+  /**
+   * A stop click with nothing in flight is a safe no-op the method
+   * deliberately does NOT audit — an unbounded "aborted nothing" write is
+   * noise a buggy or hostile client could spam (see handleAbort's docstring).
+   * A live gateway answers such a call `{ ok: true, aborted: false }`, so the
+   * aborted-nothing branch must key its warning on there having BEEN a run to
+   * abort — otherwise the exact log-spam vector the no-audit rule guards
+   * against reopens one level down, at the log.
+   */
+  it("does not warn about 'aborted nothing' when a stop click finds no run in flight", async () => {
+    const warn = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const ws = createMockWs();
+    // No run registered.
+    mockChatAbort.mockResolvedValueOnce({ ok: true, aborted: false, runIds: [] });
+    const router = makeRouter();
+
+    await router.handleMessage(ws, { type: "abort", agentId: "agent-1" });
+
+    expect(mockAppendAuditLog).not.toHaveBeenCalled();
+    expect(warn).not.toHaveBeenCalled();
+    warn.mockRestore();
+  });
+
   it("audits outcome=success when the gateway confirms it aborted the run", async () => {
     const ws = createMockWs();
     registerActiveRun(activeRuns, ws, "run-xyz");

--- a/packages/web/src/__tests__/server/client-router-abort.test.ts
+++ b/packages/web/src/__tests__/server/client-router-abort.test.ts
@@ -201,6 +201,60 @@ describe("ClientRouter user-triggered abort (#550)", () => {
     expect(mockAppendAuditLog).not.toHaveBeenCalled();
   });
 
+  /**
+   * A run is registered at DISPATCH time (`registerPending`) with a PROVISIONAL
+   * runId — Pinchy's per-turn messageId, which OpenClaw has never seen. It is
+   * reconciled to the real runId by `markFirstChunk`, on the first chunk that
+   * carries one.
+   *
+   * Passing that provisional id to `chatAbort` is worse than passing nothing:
+   * the gateway is told to abort a run it cannot find and aborts NOTHING, while
+   * the composer's stop button clears client-side. The user sees a stopped
+   * chat and the reply streams on — the exact openclaw#42172 failure this
+   * feature was rolled back for once already. Omitting the runId instead makes
+   * the gateway abort the session's current run, which is precisely what the
+   * user asked for.
+   *
+   * `handleHistory` already gates on `firstChunkAt !== null` for `livenessRunId`
+   * ("a pending run has no meaningful runId yet"); abort must use the same gate.
+   */
+  function registerPendingRun(activeRuns: ActiveRuns, ws: WebSocket, messageId = "msg-1") {
+    activeRuns.registerPending({
+      runId: messageId,
+      sessionKey: SESSION_KEY,
+      agentId: "agent-1",
+      userId: "user-1",
+      agentName: "Smithers",
+      currentMessageId: messageId,
+      submittedAt: 1000,
+      ws,
+    });
+  }
+
+  it("aborts a still-pending run by sessionKey alone — never with the provisional runId", async () => {
+    const ws = createMockWs();
+    registerPendingRun(activeRuns, ws, "msg-1");
+    const router = makeRouter();
+
+    await router.handleMessage(ws, { type: "abort", agentId: "agent-1" });
+
+    expect(mockChatAbort).toHaveBeenCalledWith(SESSION_KEY, undefined);
+  });
+
+  it("does not attribute a pending abort to the provisional runId in the audit trail", async () => {
+    // There IS a run to attribute, so the row is written — but claiming the
+    // messageId as the aborted runId would make the trail point at a run that
+    // never existed on the gateway.
+    const ws = createMockWs();
+    registerPendingRun(activeRuns, ws, "msg-1");
+    const router = makeRouter();
+
+    await router.handleMessage(ws, { type: "abort", agentId: "agent-1" });
+
+    expect(mockAppendAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditLog.mock.calls[0]![0].detail.runId).toBeNull();
+  });
+
   it("targets the per-chat session key when a chatId is supplied (#508)", async () => {
     const ws = createMockWs();
     const router = makeRouter();
@@ -220,6 +274,45 @@ describe("ClientRouter user-triggered abort (#550)", () => {
 
     expect(mockAppendAuditLog).toHaveBeenCalledTimes(1);
     expect(mockAppendAuditLog.mock.calls[0]![0].outcome).toBe("failure");
+  });
+
+  /**
+   * `chat.abort` answers `{ ok, aborted, runIds }` — verified against a live
+   * gateway (OpenClaw 2026.7.1): aborting a session with nothing in flight
+   * returns `{ ok: true, aborted: false, runIds: [] }`.
+   *
+   * `ok: true` only means the RPC was understood; `aborted: false` means the
+   * gateway stopped NOTHING. That is precisely the openclaw#42172 failure this
+   * feature was rolled back for once: the reply keeps streaming while the
+   * composer clears. Treating a non-throwing call as success made that state
+   * indistinguishable from a real abort in the trail — the button lied and the
+   * audit agreed with it.
+   *
+   * A gateway that reports no payload at all (older builds) is NOT reported as
+   * a failure: we cannot tell, and inventing a failure would be as dishonest as
+   * inventing a success.
+   */
+  it("audits outcome=failure when the gateway reports it aborted nothing", async () => {
+    const ws = createMockWs();
+    registerActiveRun(activeRuns, ws, "run-xyz");
+    mockChatAbort.mockResolvedValueOnce({ ok: true, aborted: false, runIds: [] });
+    const router = makeRouter();
+
+    await router.handleMessage(ws, { type: "abort", agentId: "agent-1" });
+
+    expect(mockAppendAuditLog).toHaveBeenCalledTimes(1);
+    expect(mockAppendAuditLog.mock.calls[0]![0].outcome).toBe("failure");
+  });
+
+  it("audits outcome=success when the gateway confirms it aborted the run", async () => {
+    const ws = createMockWs();
+    registerActiveRun(activeRuns, ws, "run-xyz");
+    mockChatAbort.mockResolvedValueOnce({ ok: true, aborted: true, runIds: ["run-xyz"] });
+    const router = makeRouter();
+
+    await router.handleMessage(ws, { type: "abort", agentId: "agent-1" });
+
+    expect(mockAppendAuditLog.mock.calls[0]![0].outcome).toBe("success");
   });
 
   it("does not abort or audit when the user lacks access to the agent", async () => {

--- a/packages/web/src/__tests__/server/run-watchdog.test.ts
+++ b/packages/web/src/__tests__/server/run-watchdog.test.ts
@@ -120,8 +120,16 @@ describe("runWatchdogTick", () => {
       // No PII in detail.
       expect(JSON.stringify(audit.detail)).not.toContain("@");
 
+      // A pending run's runId is PROVISIONAL — Pinchy's per-turn messageId,
+      // which the gateway has never seen (scanForUnstartedRuns only returns
+      // firstChunkAt===null runs). Handing it to chatAbort names a run the
+      // gateway cannot find, so it aborts NOTHING while we tear the entry down
+      // and tell the user to retry. Omitting it aborts the session's current
+      // run instead — the same gate handleAbort uses (#550). The forensic audit
+      // row above keeps the provisional id (it identifies the Pinchy-side run
+      // that never started); only the abort RPC must not claim it.
       expect(chatAbort).toHaveBeenCalledTimes(1);
-      expect(chatAbort).toHaveBeenCalledWith(basePending.sessionKey, "provisional-1");
+      expect(chatAbort).toHaveBeenCalledWith(basePending.sessionKey, undefined);
 
       // Retryable broadcast.
       expect(broadcastNoFirstChunk).toHaveBeenCalledTimes(1);

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -251,7 +251,11 @@ export class ClientRouter {
       // indistinguishable from a working one in the trail.
       // A gateway that reports no payload (older builds) stays `success`: we
       // cannot tell, and a made-up failure is as dishonest as a made-up success.
-      if (res?.aborted === false) {
+      // Gated on `run`: a stop click with nothing in flight answers
+      // `aborted: false` too, and this method deliberately neither audits nor
+      // logs that (see the docstring) — warning here would reopen exactly the
+      // "aborted nothing" spam vector a buggy or hostile client could exploit.
+      if (run && res?.aborted === false) {
         outcome = "failure";
         console.warn(
           `[client-router] gateway reported no run aborted for ${sessionKey} (runId=${runId ?? "none"})`

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -231,10 +231,32 @@ export class ClientRouter {
   ): Promise<void> {
     const sessionKey = this.computeSessionKey(agent.id, chatId);
     const run = this.activeRuns.get(sessionKey);
+    // A PENDING run's runId is provisional — Pinchy's per-turn messageId, which
+    // the gateway has never seen (`registerPending`; reconciled to the real one
+    // by `markFirstChunk`). Handing it to `chatAbort` would name a run the
+    // gateway cannot find, so it would abort NOTHING while the stop button
+    // clears client-side: the reply streams on and the UI lies. Omitting it
+    // aborts the session's current run instead — what the user actually asked
+    // for. Same gate as `livenessRunId` in `handleHistory`.
+    const runId = run && run.firstChunkAt !== null ? run.runId : undefined;
 
     let outcome: "success" | "failure" = "success";
     try {
-      await this.openclawClient.chatAbort(sessionKey, run?.runId);
+      const res = await this.openclawClient.chatAbort(sessionKey, runId);
+      // The gateway answers `{ ok, aborted, runIds }`. `ok: true` only means it
+      // understood the call — `aborted: false` means it stopped NOTHING, which
+      // is the openclaw#42172 failure mode (the reply streams on while the
+      // composer clears). A non-throwing call is therefore NOT proof of an
+      // abort, and recording one as success made a lying stop button
+      // indistinguishable from a working one in the trail.
+      // A gateway that reports no payload (older builds) stays `success`: we
+      // cannot tell, and a made-up failure is as dishonest as a made-up success.
+      if (res?.aborted === false) {
+        outcome = "failure";
+        console.warn(
+          `[client-router] gateway reported no run aborted for ${sessionKey} (runId=${runId ?? "none"})`
+        );
+      }
     } catch (err) {
       outcome = "failure";
       console.warn(
@@ -253,7 +275,9 @@ export class ClientRouter {
       detail: {
         agent: { id: agent.id, name: agent.name },
         sessionKey,
-        runId: run.runId,
+        // Null while pending: the trail must not point at a runId the gateway
+        // never issued.
+        runId: runId ?? null,
         reason: "user_request",
       },
       outcome,

--- a/packages/web/src/server/run-watchdog.ts
+++ b/packages/web/src/server/run-watchdog.ts
@@ -57,7 +57,7 @@ export interface WatchdogDeps {
    * Abort the OpenClaw-side run. Implementations should swallow internal
    * errors and resolve (or throw — the watchdog catches and continues).
    */
-  chatAbort: (sessionKey: string, runId: string) => Promise<void>;
+  chatAbort: (sessionKey: string, runId?: string) => Promise<void>;
   /**
    * Write the terminal audit row. The watchdog awaits this BEFORE the
    * broadcast and registry-delete so a forwarding error can't lose the
@@ -140,7 +140,13 @@ export async function runWatchdogTick(deps: WatchdogDeps): Promise<void> {
     // began streaming (OpenClaw now owns liveness for started runs).
     if (deps.activeRuns.get(run.sessionKey) !== run || run.firstChunkAt !== null) continue;
     try {
-      await deps.chatAbort(run.sessionKey, run.runId);
+      // A pending run's `runId` is PROVISIONAL — Pinchy's per-turn messageId,
+      // which the gateway has never seen (scanForUnstartedRuns only returns
+      // firstChunkAt===null runs, reconciled to the real id by markFirstChunk).
+      // Passing it names a run the gateway cannot find, so it aborts NOTHING.
+      // Omit it to abort the session's current run instead — same gate as the
+      // user-triggered abort in client-router (#550).
+      await deps.chatAbort(run.sessionKey, undefined);
     } catch (err) {
       console.warn(
         `[run-watchdog] chatAbort (no_first_chunk) failed for ${run.sessionKey} (run ${run.runId}):`,


### PR DESCRIPTION
Found while investigating the `19-chat-stop-button` integration failure on **main** (run 29395485884, 07:14 today) — the same failure that reddens #750's CI. It is **not** my PR, and it is **not** a flake.

## The test is doing its job

The CI trace is unambiguous. Stop was clicked **0.9 s** into a 4.5 s stream — 3.6 s of headroom — and:

| Message | Appears | Text |
|---|---|---|
| `e0e5d522` (streamed) | 891 ms after Enter | stays at **"one"** |
| `e9fa6963` (new) | **5027 ms** after Enter | full "one two … ten" |

The client-side abort worked (the streamed bubble stops at "one"). But ~5 s after Enter — the full stream duration — the *complete* reply reappears as a **second** message: OpenClaw's run never stopped, finished generating, and persisted the reply into session history, which Pinchy then reconciled. `.last()` sees it, "ten" is there, red.

So the spec caught exactly the openclaw#42172 regression it was written as an empirical gate for. Narrowing `.last()` to the streamed bubble would turn it green while hiding that — the assertion is correct as written.

## Two defects, both of which make a lying abort look like a working one

**1. A pending run's runId is provisional.** `registerPending` stores Pinchy's per-turn `messageId`; only `markFirstChunk` reconciles it to the real runId. `handleAbort` passed it straight to `chatAbort`, naming a run the gateway cannot find — so it aborts **nothing**, while the composer clears. Omitting the runId aborts the session's current run instead. `handleHistory` already gates `livenessRunId` on `firstChunkAt !== null` ("a pending run has no meaningful runId yet"); abort now uses the same gate. **No abort test used `registerPending`** — every one used the legacy `register()`, where `firstChunkAt` is already set. That is how it shipped.

**2. We threw away the gateway's answer.** Probed against a live gateway (OpenClaw 2026.7.1):

```
$ openclaw gateway call chat.abort --params '{"sessionKey":"agent:nonexistent:direct:probe"}'
{ "ok": true, "aborted": false, "runIds": [] }
```

`ok: true` only means the RPC was understood. `aborted: false` means it stopped **nothing** — the literal signature of openclaw#42172. We discarded the payload and audited every non-throwing call `outcome: "success"`, making a broken stop button indistinguishable from a working one in the trail. A gateway reporting no payload (older builds) stays `success`: we cannot tell, and a made-up failure is as dishonest as a made-up success.

This also gives the E2E's step-6 `outcome === "success"` assertion teeth for the first time — outcome was previously success unconditionally.

## What this does NOT claim

**I cannot claim this fixes the CI failure.** The abort succeeded in **7/7** local runs (one full suite + 6× spec 19) — `stopReason=aborted` in the OpenClaw log every time. The failing CI runs took 17 s against 11.6 s locally; that host hits a window this one doesn't.

What fix 2 does buy: the next occurrence reports itself as `outcome: failure` + a warning in the audit trail, instead of looking like a flaky E2E.

**Open, unproven:** both chat integration failures on main today (02:50, 06:52) postdate yesterday's OpenClaw bump 2026.6.11 → 2026.7.1 (13:23); the preceding 40 runs held one unrelated failure. Correlation only. If `chat.abort` regressed in 7.1 that belongs upstream as an issue, not worked around here.

## Tests

TDD; each test watched failing first.

- *aborts a still-pending run by sessionKey alone* — RED: `chatAbort` received `"msg-1"`, the messageId.
- *does not attribute a pending abort to the provisional runId in the audit trail* — RED: `expected 'msg-1' to be null`.
- *audits outcome=failure when the gateway reports it aborted nothing* — RED: `expected 'success' to be 'failure'`.
- *audits outcome=success when the gateway confirms it aborted the run* — green from the start, deliberately: it pins the fix from overreaching.

## Gates

`pnpm test` (8269 ✓) · `pnpm build` · `lint` (0 errors) · `format:check` · integration spec 19 ✓ **against the real gateway** on a rebuilt image — the working path still reports `aborted: true`, so a real abort still audits success.