### PR TITLE
test(chat): compare footer heights with sub-pixel tolerance, not bit-exactly

### DIFF
--- a/packages/web/e2e/19-message-hover-layout-shift.spec.ts
+++ b/packages/web/e2e/19-message-hover-layout-shift.spec.ts
@@ -136,10 +136,19 @@ test.describe("message action-bar layout shift", () => {
         .boundingBox()
         .then((box) => box!.height);
 
+    // Sub-pixel tolerance, not bit-exact equality: the reserved height comes
+    // from `min-h-6` (24px) while the last message's footer is sized by the
+    // action bar it actually contains. Two different layout computations that
+    // agree only to within float noise — CI has produced both 23.999984 and
+    // 24.000015 against an expected 24, i.e. it drifts in BOTH directions, so
+    // this is rounding, not a height difference. The regression being guarded
+    // is the 8px action-bar row, which a sub-pixel tolerance still catches by
+    // three orders of magnitude. Same tolerance as the message-height
+    // assertion below, which had it right from the start.
     expect(
-      await footerHeight(nonLast),
+      Math.abs((await footerHeight(nonLast)) - (await footerHeight(last))),
       "footer row of a non-last message must already reserve the action bar's height"
-    ).toBe(await footerHeight(last));
+    ).toBeLessThan(1);
 
     const nonLastBox = (await nonLast.boundingBox())!;
     const lastBox = (await last.boundingBox())!;


### PR DESCRIPTION
**main is red on this test right now**, and has been since it landed. Fixing it unblocks every open PR's `E2E Tests` job (it is what reddened #752).

## Why it never passed

`19-message-hover-layout-shift` landed in `4126ae668` — whose CI run was **cancelled**. `6f899065d` was the first commit to actually execute the spec, and it failed immediately. So the spec has never been green in CI; it presumably passed on the author's machine.

## The defect

The footer assertion demanded **bit-exact** equality between two independently measured `boundingBox()` floats:

```ts
expect(await footerHeight(nonLast)).toBe(await footerHeight(last));
```

Those two heights are computed two different ways. The non-last footer reserves its height with `min-h-6` (24px, `thread.tsx:588`); the last message's footer is sized by the action bar it actually contains. They agree only to within float noise, and the evidence is that it drifts in **both directions** around 24:

| Where | Received | Expected |
|---|---|---|
| main (`6f899065d`) | `24.000015258789062` | `24` |
| branch (#752) | `23.999984741210938` | `24` |

±1.5e-5 px in both directions is rounding, not a height difference.

## The fix

Compare with the same sub-pixel tolerance the message-height assertion **right below it** already used — that one had it right from the start; only the footer line demanded bit-exactness.

**This does not weaken the guard.** The regression being watched is the 8px action-bar row, three orders of magnitude above the tolerance. Verified by mutation rather than argument — dropping `min-h-6` from `thread.tsx` reddens exactly this assertion:

```
Error: footer row of a non-last message must already reserve the action bar's height
expect(received).toBeLessThan(expected)
Expected: < 1
Received:   8
```

## Gates

Spec run locally against a throwaway Postgres: 2 passed. Mutation → red on the intended assertion → restore → 2 passed again.