### PR TITLE
fix(smithers): refresh un-customized souls on upgrade

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -129,9 +129,6 @@ Common host commands from the repository root:
 ```bash
 pnpm test
 pnpm build
-pnpm lint
-pnpm format
-pnpm db:generate
 pnpm test:scripts
 pnpm typecheck:plugins
 pnpm test:plugins
@@ -140,6 +137,9 @@ pnpm test:plugins
 Useful web package commands:
 
 ```bash
+pnpm -C packages/web lint
+pnpm -C packages/web format
+pnpm -C packages/web db:generate
 pnpm -C packages/web test
 pnpm -C packages/web test:db
 pnpm -C packages/web test:e2e

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -105,7 +105,7 @@ You don't need to worry about these — Pinchy handles them on every startup:
 - **Database migrations** — Drizzle ORM tracks which migrations have been applied and only runs new ones. This is idempotent and safe to run repeatedly.
 - **OpenClaw configuration** — Rebuilt from your database state (agents, providers, permissions) every time Pinchy starts. Config format changes between versions are handled transparently.
 - **Plugins** — Copied from the source code into the OpenClaw extensions volume during the Docker build.
-- **Smithers' instructions** — Smithers answers questions about Pinchy by reading the documentation on demand, and we refresh the underlying instructions on startup so a long-running instance keeps pace with new releases. We only replace a `SOUL.md` that still matches one we shipped, so anything you've written in Agent Settings stays exactly as you left it.
+- **Smithers' instructions** — Smithers answers questions about Pinchy by reading the documentation on demand, and we refresh the underlying instructions on startup so a long-running instance keeps pace with new releases. We only replace a `SOUL.md` whose text still matches one we shipped — the moment you change a personality in Agent Settings, it's yours and we leave it alone. The flip side: a `SOUL.md` that matches one of our older versions word for word gets refreshed even if you put it there on purpose, and that applies to any agent, not just Smithers. To keep our text as a starting point, change a line — a single edit is enough to opt out for good.
 
 ## What you might need to check
 

--- a/docs/src/content/docs/guides/upgrading.mdx
+++ b/docs/src/content/docs/guides/upgrading.mdx
@@ -105,6 +105,7 @@ You don't need to worry about these — Pinchy handles them on every startup:
 - **Database migrations** — Drizzle ORM tracks which migrations have been applied and only runs new ones. This is idempotent and safe to run repeatedly.
 - **OpenClaw configuration** — Rebuilt from your database state (agents, providers, permissions) every time Pinchy starts. Config format changes between versions are handled transparently.
 - **Plugins** — Copied from the source code into the OpenClaw extensions volume during the Docker build.
+- **Smithers' instructions** — Smithers answers questions about Pinchy by reading the documentation on demand, and we refresh the underlying instructions on startup so a long-running instance keeps pace with new releases. We only replace a `SOUL.md` that still matches one we shipped, so anything you've written in Agent Settings stays exactly as you left it.
 
 ## What you might need to check
 

--- a/packages/web/src/__tests__/fixtures/smithers-soul-2026-04-09.ts
+++ b/packages/web/src/__tests__/fixtures/smithers-soul-2026-04-09.ts
@@ -1,0 +1,201 @@
+// The Smithers soul as it shipped on 2026-04-09 (commit e53fb7e4) — the last and
+// largest of the hardcoded-platform-knowledge souls, and the one a real
+// pre-2026-04-15 install most likely still has on disk.
+//
+// Copied VERBATIM from that commit's packages/web/src/lib/smithers-soul.ts. Only
+// this header and the export name differ; the template literal is untouched, so
+// the evaluated string is byte-identical to what createSmithersAgent wrote back
+// then. smithers-soul-history.test.ts pins its hash to the matching
+// SHIPPED_SOUL_HASHES entry, so any corruption of this fixture fails loudly
+// rather than silently weakening the migration test into a tautology.
+//
+// lint-staged runs prettier over this path, which is safe: prettier does not
+// reformat template-literal contents, and the file was prettier-clean when it
+// shipped. Do not hand-edit the literal — regenerate it from the commit instead.
+
+export const SOUL_2026_04_09 = `# Smithers
+
+You are Smithers, the personal assistant on the Pinchy platform.
+
+## Personality
+
+You are unfailingly polite, attentive, and eager to help. You take genuine
+satisfaction in being of service — nothing pleases you more than a well-answered
+question.
+
+Your tone is warm but professional — think executive assistant at a top firm.
+You occasionally let characteristic phrases slip in: "Right away!",
+"It would be my pleasure", or "Consider it done". Keep it natural, not forced —
+once every few messages at most.
+
+You are efficient and to the point. When a user asks a question, you answer it
+clearly without unnecessary preamble. You anticipate follow-up questions and
+proactively offer next steps.
+
+If you don't know something, you say so honestly rather than guessing. You'd
+rather disappoint briefly than mislead.
+
+The user's name is available in your context. Use it naturally but don't make a
+fuss about it — and never say "nice to meet you" or act like it's a first
+encounter. Assume you've worked together before.
+
+Always respond in the same language the user writes in.
+
+## Platform Knowledge
+
+You know the Pinchy platform inside out. When users have questions about how
+things work, guide them confidently. Here's what you know:
+
+### Getting Started
+- Pinchy runs as a Docker Compose stack: the web app (port 7777), a PostgreSQL
+  database, and the OpenClaw agent runtime
+- First-time setup happens through a setup wizard: create an admin account,
+  configure an AI provider, and you're ready to go
+- If something goes wrong during setup, error messages include a "Report this
+  issue" link that opens a pre-filled GitHub issue with error details and
+  server diagnostics — users can review everything before submitting
+- If an admin loses access, they can recover it via the setup wizard by setting
+  the PINCHY_ADMIN_EMAIL environment variable to their email address
+- Supported providers: Anthropic (Claude), OpenAI (GPT), Google (Gemini), Ollama (open-source cloud models via ollama.com).
+  Each needs an API key entered in Settings → Providers
+
+### Agents
+- Every user gets a personal "Smithers" agent automatically — that's you!
+- Users can create additional agents via the sidebar: Knowledge Base agents
+  (answer questions from uploaded docs) or Custom agents (full flexibility)
+- Each agent has its own settings: model selection, personality, avatar,
+  and operating instructions (AGENTS.md)
+- Agent settings are accessible via the gear icon next to the agent name
+- Each agent has a unique avatar (auto-generated robot icon) and optional tagline
+- Agents can use personality presets (The Butler, The Professor, The Pilot,
+  The Coach) or a fully customized SOUL.md
+
+### Knowledge Base Agents
+- These agents can only access files you explicitly provide — no internet,
+  no code execution, no file system access
+- Upload documents in the agent settings under "Allowed Paths"
+- Supported formats include plain text, Markdown, and PDF — PDFs are read
+  automatically, no manual conversion needed
+- Great for HR handbooks, product docs, internal wikis
+
+### User Management
+- Admins can invite new users via Settings → Users → Invite
+- Invites are sent as links that new users use to create their account
+- Each invited user gets their own Smithers agent automatically
+
+### Groups
+- Admins can create groups to control which users see which agents
+- Groups are managed in Settings → Groups
+- Each group has a name, description, and a list of members
+- Agents can be set to "All users" or "Restricted" (default)
+- Agent visibility is configured in Agent Settings → Access tab
+- "Restricted" means admins only by default; optionally scoped to specific groups
+- When groups are assigned to a restricted agent, only members of those groups
+  (plus admins) can see and use the agent
+- New agents are "Restricted" by default until explicitly published
+
+### Telegram Channels
+- Each agent can have its own Telegram bot — users message the bot to chat with that agent
+- An admin sets up the first Telegram bot in Settings → Telegram by creating a bot
+  via BotFather and entering the bot token. This connects the bot to Smithers.
+- Additional agents can each get their own bot via Agent Settings → Channels tab
+- Each bot is independent: its own token, its own conversations, its own pairing
+- Smithers' bot cannot be disconnected individually — use "Remove Telegram for
+  everyone" in Settings to remove all Telegram bots at once
+- Users link their Telegram account in Settings → Telegram by scanning a QR code,
+  messaging the bot, and entering the pairing code they receive
+- Linking is done once — after that, the user can message any bot they have
+  permission to access (based on agent visibility and group membership)
+- If a user messages a bot for an agent they don't have access to, they'll
+  receive a pairing prompt instead of an agent response
+- Conversations are unified — the same chat history appears in both the web UI
+  and Telegram, so users can switch between them seamlessly
+
+### Audit Trail
+- Every important action in Pinchy is logged automatically: agent creation,
+  permission changes, user invites, logins, provider configuration, and more
+- Admins can view the full audit log at /audit — it shows who did what, when
+- Each log entry is cryptographically signed (HMAC) to detect tampering
+- Admins can verify the integrity of the entire log with one click
+- The audit log can be exported as CSV for compliance reporting
+- Chat messages are NOT logged in the audit trail — only administrative actions
+- Every event in the audit log — logins, agent changes, settings changes,
+  tool calls — shows a green check or red X, not just tool calls. Admins can
+  filter by status to find anything that failed (e.g. failed logins, denied
+  tools, errored tool calls). If an admin asks why something failed, point
+  them to the detail view of the failure entry — the error message is shown
+  there
+
+### Settings & Restarts
+- When an admin saves settings that affect the agent runtime (provider keys,
+  agent permissions, creating/deleting agents), the runtime restarts briefly
+- During this restart (~5-10 seconds), a full-screen "Applying changes" overlay
+  appears — this is normal and expected
+- Active chats resume automatically once the restart completes
+- Buttons that trigger a restart say "Save & restart" so users know what to expect
+
+### Domain & HTTPS
+- Admins can lock Pinchy to a specific domain in Settings → Security
+- Once locked, access is restricted to that domain over HTTPS only
+- Secure cookies, HSTS, and origin restriction are enabled automatically
+- If HTTPS is not configured yet, the Security tab shows setup instructions
+- A yellow banner appears on all pages until HTTPS is configured
+- If an admin gets locked out (HTTPS goes down), they can run
+  \`docker exec pinchy pnpm domain:reset\` to remove the lock
+
+### Context
+- Each user has their own personal context (Settings → Context) that's applied
+  to their personal assistant (Smithers)
+- Personal context is about you — your role, preferences, and how you work
+- Admins can also set organization context (Settings → Context) that's applied
+  to all shared agents
+- Organization context is about the company — team structure, conventions,
+  and domain knowledge
+
+### Onboarding
+- When you first meet a user, you'll have onboarding instructions that ask you
+  to learn about them through conversation
+- Their name is already available in your system context — use it naturally
+- Gather three key details: role, preferred language, and communication style
+- Be persistent about getting to know the user, but don't block them from doing
+  other things — help first, then steer back
+- After saving their context, let them know they can review and edit it in
+  Settings → Context
+- Once you've saved their context, the onboarding instructions go away and you
+  have their info for all future conversations
+
+### Usage & Costs
+- Pinchy tracks token usage and estimated costs for every agent conversation
+- Admins can view the Usage dashboard at /usage — it shows total tokens,
+  estimated costs, and a daily usage chart
+- Usage can be filtered by time period (7d, 30d, 90d, all) and by agent
+- Enterprise users also get per-user breakdowns and CSV/JSON export
+
+### Enterprise Features
+- Some features (Groups, RBAC, agent access control, per-user usage
+  breakdowns, usage export) require an enterprise license
+- The license key can be entered in Settings → License, or set via the
+  PINCHY_ENTERPRISE_KEY environment variable
+- When set via environment variable, the key is locked and can't be changed in the UI
+- Without a license, Pinchy works as a full-featured platform for individual use
+  and basic team setups
+
+### Common Tasks
+- **Change AI model**: Agent Settings → General tab → Model dropdown
+- **Add a provider**: Settings → Providers → enter API key
+- **Create a new agent**: Click "+" in the sidebar
+- **Edit agent personality**: Agent Settings → Personality tab (choose a preset or edit SOUL.md directly)
+- **Re-roll avatar**: Agent Settings → Personality tab → Re-roll button
+- **Edit agent instructions**: Agent Settings → Instructions tab (define what the agent does)
+- **Add personal context**: Settings → Context tab
+- **Add organization context**: Settings → Context tab (admin only)
+- **Manage groups**: Settings → Groups (admin only)
+- **Set agent access**: Agent Settings → Access tab (admin only)
+- **Set up Telegram**: Settings → Telegram → create bot via BotFather → enter token (admin only)
+- **Connect additional agent to Telegram**: Agent Settings → Channels tab → enter bot token (admin only)
+- **Link Telegram account**: Settings → Telegram → scan QR code → message bot → enter pairing code
+- **Lock domain**: Settings → Security → Lock (must be on HTTPS first)
+- **Remove domain lock**: Settings → Security → Remove domain lock
+- **View audit log**: Go to /audit (admin only) for a complete activity log
+- **View usage stats**: Go to /usage (admin only) for token usage and cost tracking
+`;

--- a/packages/web/src/__tests__/lib/boot-inits.test.ts
+++ b/packages/web/src/__tests__/lib/boot-inits.test.ts
@@ -8,6 +8,7 @@ const mocks = vi.hoisted(() => ({
   sanitizeOpenClawConfig: vi.fn().mockReturnValue(false),
   isSetupComplete: vi.fn().mockResolvedValue(true),
   migrateExistingSmithers: vi.fn().mockResolvedValue(undefined),
+  migrateSmithersSoul: vi.fn().mockResolvedValue(undefined),
   regenerateOpenClawConfig: vi.fn().mockResolvedValue(undefined),
   markOpenClawConfigReady: vi.fn(),
 }));
@@ -26,6 +27,9 @@ vi.mock("@/lib/setup", () => ({ isSetupComplete: mocks.isSetupComplete }));
 vi.mock("@/lib/migrate-onboarding", () => ({
   migrateExistingSmithers: mocks.migrateExistingSmithers,
 }));
+vi.mock("@/lib/migrate-smithers-soul", () => ({
+  migrateSmithersSoul: mocks.migrateSmithersSoul,
+}));
 vi.mock("@/lib/openclaw-config-ready", () => ({
   markOpenClawConfigReady: mocks.markOpenClawConfigReady,
 }));
@@ -38,6 +42,7 @@ describe("bootInits", () => {
     mocks.sanitizeOpenClawConfig.mockReturnValue(false);
     mocks.isSetupComplete.mockResolvedValue(true);
     mocks.migrateExistingSmithers.mockResolvedValue(undefined);
+    mocks.migrateSmithersSoul.mockResolvedValue(undefined);
     mocks.regenerateOpenClawConfig.mockResolvedValue(undefined);
   });
 
@@ -52,6 +57,7 @@ describe("bootInits", () => {
     expect(mocks.migrateGatewayTokenToDb).toHaveBeenCalledOnce();
     expect(mocks.sanitizeOpenClawConfig).toHaveBeenCalledOnce();
     expect(mocks.migrateExistingSmithers).toHaveBeenCalledOnce();
+    expect(mocks.migrateSmithersSoul).toHaveBeenCalledOnce();
     expect(mocks.regenerateOpenClawConfig).toHaveBeenCalledOnce();
     expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
   });
@@ -61,6 +67,9 @@ describe("bootInits", () => {
     mocks.migrateExistingSmithers.mockImplementation(async () => {
       callOrder.push("migrateExistingSmithers");
     });
+    mocks.migrateSmithersSoul.mockImplementation(async () => {
+      callOrder.push("migrateSmithersSoul");
+    });
     mocks.regenerateOpenClawConfig.mockImplementation(async () => {
       callOrder.push("regenerateOpenClawConfig");
     });
@@ -68,7 +77,26 @@ describe("bootInits", () => {
     const { bootInits } = await import("@/lib/boot-inits");
     await bootInits();
 
-    expect(callOrder).toEqual(["migrateExistingSmithers", "regenerateOpenClawConfig"]);
+    expect(callOrder).toEqual([
+      "migrateExistingSmithers",
+      "migrateSmithersSoul",
+      "regenerateOpenClawConfig",
+    ]);
+  });
+
+  it("still regenerates the config when the soul migration throws", async () => {
+    // SOUL.md drift is cosmetic next to a stale openclaw.json. The soul
+    // migration gets its own try/catch precisely so a broken workspace volume
+    // cannot cost the instance its config regeneration — and with it a working
+    // OpenClaw. Without the nested catch, `result` here would be false.
+    mocks.migrateSmithersSoul.mockRejectedValue(new Error("workspace volume gone"));
+
+    const { bootInits } = await import("@/lib/boot-inits");
+    const result = await bootInits();
+
+    expect(result).toBe(true);
+    expect(mocks.regenerateOpenClawConfig).toHaveBeenCalledOnce();
+    expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
   });
 
   it("calls regenerateOpenClawConfig exactly once", async () => {
@@ -89,6 +117,7 @@ describe("bootInits", () => {
 
     expect(result).toBe(false);
     expect(mocks.migrateExistingSmithers).not.toHaveBeenCalled();
+    expect(mocks.migrateSmithersSoul).not.toHaveBeenCalled();
     expect(mocks.regenerateOpenClawConfig).not.toHaveBeenCalled();
     expect(mocks.markOpenClawConfigReady).toHaveBeenCalledOnce();
   });

--- a/packages/web/src/__tests__/lib/migrate-smithers-soul.test.ts
+++ b/packages/web/src/__tests__/lib/migrate-smithers-soul.test.ts
@@ -83,6 +83,42 @@ describe("migrateSmithersSoul", () => {
     expect(written).toContain("You do NOT know Pinchy's features from memory");
   });
 
+  // ── The accepted limit of the hash selector, pinned so it stays a decision
+  //    rather than a surprise. The migration matches OUR TEXT, wherever it
+  //    sits — it asks nothing about the agent row. Both cases below are
+  //    therefore upgrades, not skips, and docs/guides/upgrading.mdx is worded
+  //    to match ("we only replace a SOUL.md that still matches one we
+  //    shipped") rather than promising that everything typed in Agent Settings
+  //    survives. Change this behavior only with the collision guard in
+  //    smithers-soul-history.test.ts in view.
+  it("upgrades an unrelated agent whose SOUL.md was copied from Smithers", async () => {
+    // Someone builds a second assistant and pastes Smithers' soul in as a
+    // starting point, unchanged. The bytes are ours, so the sweep takes it.
+    findManyMock.mockResolvedValue([agentRow("copycat-1", "Research Buddy")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).toHaveBeenCalledWith("copycat-1", "SOUL.md", SMITHERS_SOUL_MD);
+    // findMany is mocked, so the assertion above would stay green if someone
+    // narrowed the query to `where: eq(agents.isPersonal, true)` — the sweep
+    // would simply never see this agent in production. Pin the absence of a
+    // row filter here, where the reason for it is written down.
+    expect(findManyMock.mock.calls[0][0]).not.toHaveProperty("where");
+  });
+
+  it("upgrades a soul the user deliberately pasted back from an older release", async () => {
+    // The user preferred the old behavior and restored the file by hand. A
+    // byte match cannot distinguish that from a file we wrote ourselves, so
+    // they get upgraded anyway. Documented, not fixable by hashing alone.
+    findManyMock.mockResolvedValue([agentRow("smithers-1")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).toHaveBeenCalledOnce();
+  });
+
   it("never touches a soul the user has customized", async () => {
     findManyMock.mockResolvedValue([agentRow("custom-1")]);
     readWorkspaceFileMock.mockReturnValue(SMITHERS_SOUL_MD + "\n\nAlways answer in haiku.\n");
@@ -215,6 +251,11 @@ describe("migrateSmithersSoul", () => {
   });
 
   it("keeps the sweep going when one agent's SOUL.md is unreadable", async () => {
+    // Guards the catch, not a reachable production path: the real
+    // readWorkspaceFile swallows fs errors and returns "" (covered by the
+    // missing-SOUL.md test above), so nothing but its agentId assertion can
+    // throw. This pins the loop's structure — one bad agent must not strand
+    // the rest — against a future readWorkspaceFile that propagates EIO.
     findManyMock.mockResolvedValue([agentRow("broken-1"), agentRow("smithers-2")]);
     readWorkspaceFileMock.mockImplementationOnce(() => {
       throw new Error("EIO");

--- a/packages/web/src/__tests__/lib/migrate-smithers-soul.test.ts
+++ b/packages/web/src/__tests__/lib/migrate-smithers-soul.test.ts
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+// ── Mock @/db ────────────────────────────────────────────────────────────────
+const findManyMock = vi.fn().mockResolvedValue([]);
+vi.mock("@/db", () => ({
+  db: {
+    query: {
+      agents: {
+        findMany: (...args: unknown[]) => findManyMock(...args),
+      },
+    },
+  },
+}));
+
+// ── Mock @/lib/workspace ─────────────────────────────────────────────────────
+const readWorkspaceFileMock = vi.fn();
+const writeWorkspaceFileMock = vi.fn();
+vi.mock("@/lib/workspace", () => ({
+  readWorkspaceFile: (...args: unknown[]) => readWorkspaceFileMock(...args),
+  writeWorkspaceFile: (...args: unknown[]) => writeWorkspaceFileMock(...args),
+}));
+
+// ── Mock @/lib/audit + @/lib/audit-deferred ──────────────────────────────────
+const appendAuditLogMock = vi.fn().mockResolvedValue({ id: 1, rowHmac: "x" });
+vi.mock("@/lib/audit", () => ({
+  appendAuditLog: (...args: unknown[]) => appendAuditLogMock(...args),
+}));
+const recordAuditFailureMock = vi.fn();
+vi.mock("@/lib/audit-deferred", () => ({
+  recordAuditFailure: (...args: unknown[]) => recordAuditFailureMock(...args),
+}));
+
+// NOT mocked, deliberately: @/lib/smithers-soul and @/lib/smithers-soul-history.
+// The whole point of this suite is that a REAL historical soul upgrades to the
+// REAL current one. Stubbing either constant would turn the migration test into
+// a tautology that passes no matter what the hash list says.
+import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+import { CURRENT_SOUL_HASH, hashSoul } from "@/lib/smithers-soul-history";
+import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
+import { SOUL_2026_04_09 } from "../fixtures/smithers-soul-2026-04-09";
+
+const agentRow = (id: string, name = "Smithers") => ({ id, name });
+
+async function runMigration() {
+  const { migrateSmithersSoul } = await import("@/lib/migrate-smithers-soul");
+  return migrateSmithersSoul();
+}
+
+describe("migrateSmithersSoul", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    findManyMock.mockResolvedValue([]);
+    appendAuditLogMock.mockResolvedValue({ id: 1, rowHmac: "x" });
+  });
+
+  // ── The pre-existing-data test AGENTS.md § "Test Migrations Against
+  //    Pre-Existing Data" mandates. Every other test here starts from a clean
+  //    slate where the current soul was written on the first write, which proves
+  //    nothing about the state an UPGRADE produces: old data, new code.
+  it("upgrades a real pre-2026-04-15 soul that predates the docs-driven rewrite", async () => {
+    findManyMock.mockResolvedValue([agentRow("smithers-1")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).toHaveBeenCalledWith("smithers-1", "SOUL.md", SMITHERS_SOUL_MD);
+  });
+
+  it("leaves the stale soul's hardcoded platform knowledge behind entirely", async () => {
+    // The bug in one assertion: the old soul claims to know the platform from
+    // memory, which is what makes a pre-April Smithers state stale facts with
+    // confidence. After the migration that claim must be gone, replaced by the
+    // docs_list/docs_read procedure.
+    findManyMock.mockResolvedValue([agentRow("smithers-1")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+    expect(SOUL_2026_04_09).toContain("You know the Pinchy platform inside out");
+
+    await runMigration();
+
+    const written = writeWorkspaceFileMock.mock.calls[0][2] as string;
+    expect(written).not.toContain("You know the Pinchy platform inside out");
+    expect(written).toContain("docs_list");
+    expect(written).toContain("You do NOT know Pinchy's features from memory");
+  });
+
+  it("never touches a soul the user has customized", async () => {
+    findManyMock.mockResolvedValue([agentRow("custom-1")]);
+    readWorkspaceFileMock.mockReturnValue(SMITHERS_SOUL_MD + "\n\nAlways answer in haiku.\n");
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).not.toHaveBeenCalled();
+    expect(appendAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it.each(Object.entries(PERSONALITY_PRESETS))(
+    "never touches an agent created from the %s preset",
+    async (id, preset) => {
+      // The REAL preset soul, not a stand-in string: preset souls are the one
+      // other set Pinchy ships, and `the-butler`'s already shares paragraphs
+      // with Smithers'. An invented string would only re-test the "customized"
+      // case above and prove nothing about the actual collision risk.
+      //
+      // This is the behavioral half. The structural half — "no preset may ever
+      // hash into SHIPPED_SOUL_HASHES" — is guarded in
+      // smithers-soul-history.test.ts, which fails loudly and names the preset.
+      findManyMock.mockResolvedValue([agentRow(`preset-${id}`, preset.name)]);
+      readWorkspaceFileMock.mockReturnValue(preset.soulMd);
+
+      await runMigration();
+
+      expect(writeWorkspaceFileMock).not.toHaveBeenCalled();
+      expect(appendAuditLogMock).not.toHaveBeenCalled();
+    }
+  );
+
+  it("is a no-op when the soul is already current", async () => {
+    findManyMock.mockResolvedValue([agentRow("smithers-1")]);
+    readWorkspaceFileMock.mockReturnValue(SMITHERS_SOUL_MD);
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).not.toHaveBeenCalled();
+    expect(appendAuditLogMock).not.toHaveBeenCalled();
+  });
+
+  it("skips an agent with no SOUL.md on disk", async () => {
+    // readWorkspaceFile returns "" for a missing file rather than throwing. No
+    // file means no hash means no proof of provenance, so there is nothing to
+    // upgrade — and we must not conjure a Smithers soul into an unrelated agent.
+    findManyMock.mockResolvedValue([agentRow("no-soul-1")]);
+    readWorkspaceFileMock.mockReturnValue("");
+
+    await runMigration();
+
+    expect(writeWorkspaceFileMock).not.toHaveBeenCalled();
+  });
+
+  it("handles an install with no agents", async () => {
+    findManyMock.mockResolvedValue([]);
+
+    await expect(runMigration()).resolves.not.toThrow();
+
+    expect(writeWorkspaceFileMock).not.toHaveBeenCalled();
+  });
+
+  // ── Audit ──────────────────────────────────────────────────────────────────
+  it("writes an agent.updated row recording the hash change, not the prompt", async () => {
+    findManyMock.mockResolvedValue([agentRow("smithers-1", "Smithers")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await runMigration();
+
+    expect(appendAuditLogMock).toHaveBeenCalledTimes(1);
+    const entry = appendAuditLogMock.mock.calls[0][0];
+    expect(entry).toMatchObject({
+      actorType: "system",
+      actorId: "system",
+      eventType: "agent.updated",
+      resource: "agent:smithers-1",
+      outcome: "success",
+    });
+    expect(entry.detail.changes["SOUL.md"]).toEqual({
+      from: hashSoul(SOUL_2026_04_09),
+      to: CURRENT_SOUL_HASH,
+    });
+    expect(entry.detail.agent).toEqual({ id: "smithers-1", name: "Smithers" });
+    expect(entry.detail.sweepId).toMatch(/^[0-9a-f-]{36}$/);
+
+    // The prompt itself must never enter the audit trail — same rule the
+    // diagnostics collector follows for instructionsHash.
+    const serialized = JSON.stringify(entry);
+    expect(serialized).not.toContain("You know the Pinchy platform inside out");
+    expect(serialized).not.toContain("## Personality");
+  });
+
+  it("shares one sweepId across every agent upgraded in the same run", async () => {
+    findManyMock.mockResolvedValue([agentRow("smithers-1"), agentRow("smithers-2")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await runMigration();
+
+    expect(appendAuditLogMock).toHaveBeenCalledTimes(2);
+    const [a, b] = appendAuditLogMock.mock.calls.map((c) => c[0].detail.sweepId);
+    expect(a).toBe(b);
+  });
+
+  it("keeps the sweep going when one agent's audit write fails", async () => {
+    // The soul is already on disk by the time the audit runs — a non-rollbackable
+    // side effect, so the failure is recorded rather than thrown (AGENTS.md's
+    // non-request-context pattern).
+    findManyMock.mockResolvedValue([agentRow("smithers-1"), agentRow("smithers-2")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+    appendAuditLogMock.mockRejectedValueOnce(new Error("audit down"));
+
+    await expect(runMigration()).resolves.not.toThrow();
+
+    expect(recordAuditFailureMock).toHaveBeenCalledTimes(1);
+    expect(writeWorkspaceFileMock).toHaveBeenCalledTimes(2);
+  });
+
+  it("keeps the sweep going when one agent's workspace is unwritable", async () => {
+    findManyMock.mockResolvedValue([agentRow("broken-1"), agentRow("smithers-2")]);
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+    writeWorkspaceFileMock.mockImplementationOnce(() => {
+      throw new Error("EACCES");
+    });
+
+    await expect(runMigration()).resolves.not.toThrow();
+
+    expect(writeWorkspaceFileMock).toHaveBeenCalledTimes(2);
+    // No audit row for the agent whose soul never changed.
+    expect(appendAuditLogMock).toHaveBeenCalledTimes(1);
+    expect(appendAuditLogMock.mock.calls[0][0].resource).toBe("agent:smithers-2");
+  });
+
+  it("keeps the sweep going when one agent's SOUL.md is unreadable", async () => {
+    findManyMock.mockResolvedValue([agentRow("broken-1"), agentRow("smithers-2")]);
+    readWorkspaceFileMock.mockImplementationOnce(() => {
+      throw new Error("EIO");
+    });
+    readWorkspaceFileMock.mockReturnValue(SOUL_2026_04_09);
+
+    await expect(runMigration()).resolves.not.toThrow();
+
+    expect(writeWorkspaceFileMock).toHaveBeenCalledTimes(1);
+    expect(writeWorkspaceFileMock).toHaveBeenCalledWith("smithers-2", "SOUL.md", SMITHERS_SOUL_MD);
+  });
+});

--- a/packages/web/src/__tests__/lib/smithers-soul-history.test.ts
+++ b/packages/web/src/__tests__/lib/smithers-soul-history.test.ts
@@ -1,0 +1,172 @@
+import { describe, it, expect, afterEach } from "vitest";
+import { mkdtempSync, rmSync } from "node:fs";
+import { tmpdir } from "node:os";
+import { join } from "node:path";
+import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+import {
+  CURRENT_SOUL_HASH,
+  SHIPPED_SOUL_HASHES,
+  hashSoul,
+  isPristineShippedSoul,
+} from "@/lib/smithers-soul-history";
+import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
+import { PERSONALITY_PRESETS } from "@/lib/personality-presets";
+import { SOUL_2026_04_09 } from "../fixtures/smithers-soul-2026-04-09";
+
+describe("SHIPPED_SOUL_HASHES drift guard", () => {
+  // THE guard. migrateSmithersSoul() only upgrades a SOUL.md whose hash is in
+  // this list, so a soul that ships without its hash appended is invisible to
+  // the migration forever: users who install that build get a file the next
+  // migration cannot prove the provenance of, and it is skipped as "customized"
+  // for the rest of time. Appending is not bookkeeping, it is the contract.
+  it("pins the last entry to the soul this build ships", () => {
+    const actual = hashSoul(SMITHERS_SOUL_MD);
+    expect(
+      SHIPPED_SOUL_HASHES.at(-1),
+      `SMITHERS_SOUL_MD changed. Append this hash as the LAST entry of ` +
+        `SHIPPED_SOUL_HASHES in lib/smithers-soul-history.ts:\n\n  "${actual}",\n`
+    ).toBe(actual);
+  });
+
+  it("exposes the current hash as CURRENT_SOUL_HASH", () => {
+    expect(CURRENT_SOUL_HASH).toBe(hashSoul(SMITHERS_SOUL_MD));
+  });
+
+  it("has no duplicate entries", () => {
+    // A duplicate means the generator counted one soul twice; harmless at
+    // runtime but a sign the list was hand-edited rather than appended to.
+    expect(new Set(SHIPPED_SOUL_HASHES).size).toBe(SHIPPED_SOUL_HASHES.length);
+  });
+
+  it("stores every entry in the sha256:hex shape the diagnostics collector uses", () => {
+    for (const h of SHIPPED_SOUL_HASHES) {
+      expect(h).toMatch(/^sha256:[a-f0-9]{64}$/);
+    }
+  });
+
+  it("covers the whole shipped history, oldest first", () => {
+    // 25 distinct souls between 2026-02-20 (fef013ef) and 2026-05-19 (806cbed1).
+    // The count is asserted so that a rebase or bad merge dropping entries is
+    // loud rather than silently shrinking the migration's reach.
+    expect(SHIPPED_SOUL_HASHES.length).toBeGreaterThanOrEqual(25);
+    // The first soul ever shipped — the one that opened with "You know the
+    // Pinchy platform inside out".
+    expect(SHIPPED_SOUL_HASHES[0]).toBe(
+      "sha256:91fc60b2f9c0b2b5ad2dc774e69fd76e6628477aa3850ae73f1584f03019b766"
+    );
+  });
+});
+
+describe("isPristineShippedSoul", () => {
+  it("recognizes the current soul", () => {
+    expect(isPristineShippedSoul(SMITHERS_SOUL_MD)).toBe(true);
+  });
+
+  it("recognizes a real historical soul", () => {
+    // The actual 2026-04-09 soul (e53fb7e4), byte-identical to what shipped —
+    // not just its hash. This is the call the migration makes on a pre-April
+    // install, so it is worth making it for real.
+    expect(isPristineShippedSoul(SOUL_2026_04_09)).toBe(true);
+  });
+
+  it("covers the 2026-04-15 soul that live installs still carry", () => {
+    // Verified by hash on staging and demo (2026-07-15): the Smithers on both
+    // still runs e73a13f5's soul. No fixture for it — the hash IS what the
+    // migration matches on, so pinning the hash is the whole assertion.
+    expect(SHIPPED_SOUL_HASHES).toContain(
+      "sha256:fac4cbf250a79bce3730438372bfbc331b42544338eac2387ed64a599e4066db"
+    );
+  });
+
+  it("rejects a customized soul", () => {
+    expect(isPristineShippedSoul(SMITHERS_SOUL_MD + "\nBe extra polite.\n")).toBe(false);
+  });
+
+  it("rejects a soul that differs by a single trailing newline", () => {
+    // Documents the deliberate no-normalization choice: raw bytes only. A user
+    // whose editor added a newline is treated as customized and skipped, which
+    // is the safe direction — we never clobber an edit, we only miss a case.
+    expect(isPristineShippedSoul(SMITHERS_SOUL_MD + "\n")).toBe(false);
+  });
+
+  it("rejects empty content", () => {
+    expect(isPristineShippedSoul("")).toBe(false);
+  });
+});
+
+describe("collision safety against the other souls Pinchy ships", () => {
+  // migrateSmithersSoul() asks nothing about the agent row — it matches OUR
+  // TEXT by hash, wherever it sits. That is only safe while no other soul
+  // Pinchy ships can hash into SHIPPED_SOUL_HASHES.
+  //
+  // Personality presets are the one other shipped set, and the two are closer
+  // than they look: `the-butler`'s soulMd already shares whole paragraphs with
+  // Smithers' ("You are unfailingly polite, attentive, and eager to help..."),
+  // and createSmithersAgent stamps `personalityPresetId: "the-butler"` onto
+  // Smithers itself. They are maintained in different files and drift
+  // independently.
+  //
+  // So the realistic break is mundane, not exotic: someone adds a preset by
+  // starting from SMITHERS_SOUL_MD as a template, or edits one until it
+  // converges. From the next boot on, every agent using that preset silently
+  // has its SOUL.md replaced with Smithers' — with an audit row claiming a
+  // "Pinchy-shipped soul upgraded". Nothing else in the suite would notice.
+  it("never collides with a personality preset's soul", () => {
+    for (const [id, preset] of Object.entries(PERSONALITY_PRESETS)) {
+      expect(
+        isPristineShippedSoul(preset.soulMd),
+        `Preset "${id}" hashes into SHIPPED_SOUL_HASHES, so migrateSmithersSoul() ` +
+          `would overwrite the SOUL.md of every agent using it on the next boot. ` +
+          `Do not derive a preset from SMITHERS_SOUL_MD — give it its own text.`
+      ).toBe(false);
+    }
+  });
+});
+
+describe("hash integrity across a real workspace round trip", () => {
+  // migrateSmithersSoul's unit tests mock @/lib/workspace, so nothing else here
+  // proves the load-bearing assumption of the whole design: that the bytes
+  // writeWorkspaceFile puts on disk are the bytes readWorkspaceFile hands back,
+  // unchanged. If either ever gained normalization — a trailing-newline fixer,
+  // a CRLF pass — every shipped hash would stop matching and the migration
+  // would silently classify every soul as customized and upgrade nothing, for
+  // good. That failure is invisible: no error, no test failure, just a sweep
+  // that quietly does nothing. Hence a real filesystem here.
+  let base: string | undefined;
+  const previousBase = process.env.WORKSPACE_BASE_PATH;
+
+  afterEach(() => {
+    if (base) rmSync(base, { recursive: true, force: true });
+    base = undefined;
+    if (previousBase === undefined) delete process.env.WORKSPACE_BASE_PATH;
+    else process.env.WORKSPACE_BASE_PATH = previousBase;
+  });
+
+  const roundTrip = (content: string): string => {
+    base = mkdtempSync(join(tmpdir(), "pinchy-soul-"));
+    process.env.WORKSPACE_BASE_PATH = base;
+    writeWorkspaceFile("agent-1", "SOUL.md", content);
+    return readWorkspaceFile("agent-1", "SOUL.md");
+  };
+
+  it("preserves the current soul byte-for-byte", () => {
+    const read = roundTrip(SMITHERS_SOUL_MD);
+
+    expect(read).toBe(SMITHERS_SOUL_MD);
+    expect(hashSoul(read)).toBe(CURRENT_SOUL_HASH);
+  });
+
+  it("preserves a historical soul, non-ASCII and all", () => {
+    // The souls carry em-dashes and typographic quotes. A round trip through a
+    // wrong encoding would mangle exactly those and nothing else.
+    expect(SOUL_2026_04_09).toMatch(/[—’]/);
+
+    const read = roundTrip(SOUL_2026_04_09);
+
+    expect(read).toBe(SOUL_2026_04_09);
+    expect(isPristineShippedSoul(read)).toBe(true);
+    expect(hashSoul(read)).toBe(
+      "sha256:e56305f854afb99d5156a7529ad5cba6717a9fc68b15f29c02beaf6df5bb7950"
+    );
+  });
+});

--- a/packages/web/src/lib/boot-inits.ts
+++ b/packages/web/src/lib/boot-inits.ts
@@ -10,6 +10,7 @@ import {
 } from "@/lib/openclaw-config";
 import { isSetupComplete } from "@/lib/setup";
 import { migrateExistingSmithers } from "@/lib/migrate-onboarding";
+import { migrateSmithersSoul } from "@/lib/migrate-smithers-soul";
 import { markOpenClawConfigReady } from "@/lib/openclaw-config-ready";
 import { seedBuiltinModels } from "@/lib/model-capabilities/seed";
 import { loadModelCapabilityCache } from "@/lib/model-capabilities/cache";
@@ -140,6 +141,19 @@ export async function bootInits(): Promise<boolean> {
   try {
     if (await isSetupComplete()) {
       await migrateExistingSmithers();
+
+      // Bring un-customized Smithers souls up to the soul this build ships.
+      // Own try/catch: SOUL.md drift must never cost the instance its config
+      // regeneration below. Idempotent — one file read per agent once current.
+      try {
+        await migrateSmithersSoul();
+      } catch (err) {
+        console.error(
+          "[pinchy] Failed to migrate Smithers souls:",
+          err instanceof Error ? err.message : err
+        );
+      }
+
       await regenerateOpenClawConfig();
       console.log("[pinchy] OpenClaw config regenerated from DB state");
       setupWasComplete = true;

--- a/packages/web/src/lib/migrate-smithers-soul.ts
+++ b/packages/web/src/lib/migrate-smithers-soul.ts
@@ -20,11 +20,27 @@ import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
  * The hash is the selector, deliberately — see the provenance note in
  * lib/smithers-soul-history.ts for why row data (`isPersonal`, `name`,
  * `avatarSeed`) cannot be trusted for this, and why a byte match is proof that
- * the file came from createSmithersAgent and was never edited.
+ * the CONTENT is text Pinchy shipped.
+ *
+ * That proof is about the bytes, not the user's intent, and the sweep asks
+ * nothing about the agent row. So two files get upgraded that a stricter
+ * reading might spare: an older shipped soul someone pasted back deliberately,
+ * and an unrelated agent whose SOUL.md was copied from Smithers. Both are
+ * pinned in migrate-smithers-soul.test.ts and both are accepted — the
+ * alternative is a selector that cannot answer the only question that makes an
+ * overwrite safe.
  *
  * Runs on every boot from bootInits(), behind the isSetupComplete() gate.
  * Idempotent: once a soul is current it hashes to CURRENT_SOUL_HASH and is
  * skipped, so steady-state cost is one file read per agent.
+ *
+ * Single-writer assumption: two instances booting against the same volume both
+ * sweep. The write is idempotent and the second finds CURRENT_SOUL_HASH, but a
+ * true race (both reading the stale soul before either writes) yields two
+ * audit rows with different sweepIds for one upgrade. Harmless, and out of
+ * reach of the compose deployment this ships for — if Pinchy ever runs
+ * replicas, this needs the audit chain's advisory lock around the whole sweep,
+ * not per row.
  *
  * Boot budget: everything here happens BEFORE markOpenClawConfigReady(), and
  * compose gives the healthcheck 5s + 30×2s = 65s before Pinchy is declared
@@ -53,8 +69,13 @@ export async function migrateSmithersSoul(): Promise<void> {
     try {
       current = readWorkspaceFile(agent.id, "SOUL.md");
     } catch (err) {
-      // One unreadable workspace must not strand the remaining agents on a
-      // stale soul.
+      // Belt and braces: readWorkspaceFile swallows every fs error itself and
+      // returns "" (handled below), so the only throw that reaches here is its
+      // agentId/filename assertion — unreachable with a UUID and a literal.
+      // Kept so a future readWorkspaceFile that does propagate EIO cannot
+      // strand the remaining agents on a stale soul. Do not read this as a
+      // tested EIO path; the matching test mocks a throw the real dependency
+      // does not currently produce.
       console.error(
         `[pinchy] Could not read SOUL.md for agent ${agent.id}:`,
         err instanceof Error ? err.message : err

--- a/packages/web/src/lib/migrate-smithers-soul.ts
+++ b/packages/web/src/lib/migrate-smithers-soul.ts
@@ -1,0 +1,116 @@
+import { randomUUID } from "node:crypto";
+
+import { db } from "@/db";
+import { appendAuditLog, type AuditLogEntry } from "@/lib/audit";
+import { recordAuditFailure } from "@/lib/audit-deferred";
+import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+import { CURRENT_SOUL_HASH, hashSoul, isPristineShippedSoul } from "@/lib/smithers-soul-history";
+import { readWorkspaceFile, writeWorkspaceFile } from "@/lib/workspace";
+
+/**
+ * Bring every un-customized Smithers SOUL.md up to the soul this build ships.
+ *
+ * `createSmithersAgent` writes SOUL.md once, at creation, and until this
+ * migration nothing ever rewrote it — so an instance installed before
+ * 2026-04-15 still ran a soul that claimed to know the platform from memory and
+ * then recited facts that have since gone stale. The docs-driven rewrite and
+ * every docs page written since simply never reached those installs: the
+ * pinchy-docs plugin was there, but the soul never told Smithers to use it.
+ *
+ * The hash is the selector, deliberately — see the provenance note in
+ * lib/smithers-soul-history.ts for why row data (`isPersonal`, `name`,
+ * `avatarSeed`) cannot be trusted for this, and why a byte match is proof that
+ * the file came from createSmithersAgent and was never edited.
+ *
+ * Runs on every boot from bootInits(), behind the isSetupComplete() gate.
+ * Idempotent: once a soul is current it hashes to CURRENT_SOUL_HASH and is
+ * skipped, so steady-state cost is one file read per agent.
+ *
+ * Boot budget: everything here happens BEFORE markOpenClawConfigReady(), and
+ * compose gives the healthcheck 5s + 30×2s = 65s before Pinchy is declared
+ * unhealthy — at which point OpenClaw (depends_on: service_healthy) never
+ * starts at all. Steady state is far inside that: the skip path never awaits,
+ * so it is N sync reads and hashes. The cost lands on the ONE boot that
+ * actually upgrades, which writes an audit row per Smithers sequentially, each
+ * taking the audit chain's advisory lock. That is one row per user, so an
+ * instance with thousands of users spends seconds, not milliseconds, here. If
+ * that budget ever gets tight, batch the audit writes rather than dropping
+ * them — a silent upgrade is worse than a slow one.
+ */
+export async function migrateSmithersSoul(): Promise<void> {
+  // No `where` filter: which agents are Smithers is decided by the soul's hash,
+  // not by the row.
+  const allAgents = await db.query.agents.findMany({
+    columns: { id: true, name: true },
+  });
+
+  // Correlates every row this sweep emits, so one drill-down query reconstructs
+  // the full upgrade (AGENTS.md's batched-maintenance convention).
+  const sweepId = randomUUID();
+
+  for (const agent of allAgents) {
+    let current: string;
+    try {
+      current = readWorkspaceFile(agent.id, "SOUL.md");
+    } catch (err) {
+      // One unreadable workspace must not strand the remaining agents on a
+      // stale soul.
+      console.error(
+        `[pinchy] Could not read SOUL.md for agent ${agent.id}:`,
+        err instanceof Error ? err.message : err
+      );
+      continue;
+    }
+
+    // readWorkspaceFile returns "" for a missing file. Either way there is no
+    // hash, so no provenance, so nothing we may safely overwrite — and we must
+    // not conjure a Smithers soul into an unrelated agent.
+    if (!current) continue;
+
+    const previousHash = hashSoul(current);
+    if (previousHash === CURRENT_SOUL_HASH) continue;
+
+    // Anything we did not ship is the user's own text. Leave it alone. Raw
+    // bytes, no normalization: someone whose editor touched the whitespace is
+    // treated as customized and skipped, which is the safe way to be wrong —
+    // we never clobber an edit, we only miss a case.
+    if (!isPristineShippedSoul(current)) continue;
+
+    try {
+      writeWorkspaceFile(agent.id, "SOUL.md", SMITHERS_SOUL_MD);
+    } catch (err) {
+      // Nothing changed, so there is nothing for the audit trail to record —
+      // console.error is how every other bootInits step surfaces failure.
+      console.error(
+        `[pinchy] Could not upgrade SOUL.md for agent ${agent.id}:`,
+        err instanceof Error ? err.message : err
+      );
+      continue;
+    }
+
+    const entry: AuditLogEntry = {
+      actorType: "system",
+      actorId: "system",
+      eventType: "agent.updated",
+      resource: `agent:${agent.id}`,
+      detail: {
+        // Hashes only. The prompt never enters the audit trail, matching the
+        // diagnostics collector's instructionsHash rule.
+        changes: { "SOUL.md": { from: previousHash, to: CURRENT_SOUL_HASH } },
+        agent: { id: agent.id, name: agent.name },
+        sweepId,
+        reason: "Pinchy-shipped soul upgraded to the version this build ships",
+      },
+      outcome: "success",
+    };
+
+    // The soul is already on disk — a side effect we cannot roll back — so a
+    // failed audit write is recorded, not thrown (AGENTS.md's non-request
+    // context pattern).
+    try {
+      await appendAuditLog(entry);
+    } catch (err) {
+      recordAuditFailure(err, entry);
+    }
+  }
+}

--- a/packages/web/src/lib/smithers-soul-history.ts
+++ b/packages/web/src/lib/smithers-soul-history.ts
@@ -132,7 +132,13 @@ export const CURRENT_SOUL_HASH = hashSoul(SMITHERS_SOUL_MD);
 
 /**
  * True when `content` byte-matches a soul Pinchy shipped at some point — i.e.
- * it came from `createSmithersAgent` and the user has never edited it.
+ * the CONTENT is text we wrote, and nothing else can produce those bytes by
+ * accident.
+ *
+ * Note what this does NOT say: it is no proof that the user never touched the
+ * file. Someone who pastes an older shipped soul back byte-for-byte matches
+ * too. That is the accepted limit of the design — see the provenance note at
+ * the top of this file.
  *
  * The current soul counts as shipped. Callers that want "stale and pristine"
  * must check `hash !== CURRENT_SOUL_HASH` themselves.

--- a/packages/web/src/lib/smithers-soul-history.ts
+++ b/packages/web/src/lib/smithers-soul-history.ts
@@ -1,0 +1,142 @@
+import { createHash } from "node:crypto";
+
+import { SMITHERS_SOUL_MD } from "@/lib/smithers-soul";
+
+// =============================================================================
+// Provenance record for Smithers' SOUL.md — READ THIS before editing
+// smithers-soul.ts.
+// =============================================================================
+//
+// `createSmithersAgent` writes SMITHERS_SOUL_MD to the agent's workspace exactly
+// once, at creation time. Nothing ever rewrote it, so changing the constant had
+// no effect on any Smithers that already existed: an instance installed before
+// 2026-04-15 still ran a soul that opened with "You know the Pinchy platform
+// inside out" and then listed platform facts that have since gone stale (the
+// provider list predates ollama-local; Telegram, email and Odoo did not exist).
+// The docs-driven rewrite never reached those instances.
+//
+// `migrateSmithersSoul()` fixes that on boot, and this list is what makes it
+// safe. SOUL.md is user-editable (Agent Settings → SOUL.md), so the migration
+// may only touch files the user has NOT customized. A hash match against this
+// list proves the CONTENT is text Pinchy shipped — nothing else can produce
+// those bytes by accident.
+//
+// Note the exact claim. It is about the content, not the user's intent: it
+// does NOT prove nobody ever touched the file. Someone who pastes an older
+// shipped soul back byte-for-byte — out of git, a backup, or a preference for
+// the old behavior — matches too, and gets upgraded. That is the accepted
+// limit of the design, and docs/guides/upgrading.mdx states the rule the way
+// the code actually behaves ("we only replace a SOUL.md that still matches one
+// we shipped"), not as a promise about edits.
+//
+// Within that limit the hash is still the only workable selector, and no
+// database column can replace it. `isPersonal` / `ownerId` can tell you an
+// agent IS Smithers; nothing in the row tells you whether its SOUL.md is still
+// the one we wrote. Only the bytes do. (`name` and `avatarSeed` are
+// user-changeable on top of that, so they would be poor identifiers even for
+// the weaker question.) So the migration does not identify Smithers at all —
+// it identifies OUR TEXT, wherever it sits.
+//
+// Over-inclusion within this list is safe by construction. A hash here that
+// never actually shipped can only ever match a file that byte-equals it — in
+// which case it did ship. So the list errs toward completeness.
+//
+// The real boundary is the OTHER souls Pinchy ships. `the-butler`'s preset soul
+// already shares whole paragraphs with Smithers' and drifts in a different
+// file, so a preset derived from SMITHERS_SOUL_MD would land in this list and
+// get every agent using it silently overwritten. smithers-soul-history.test.ts
+// guards that; it is the one collision this design cannot tolerate.
+//
+// APPEND-ONLY. Editing SMITHERS_SOUL_MD without appending its new hash breaks
+// smithers-soul-history.test.ts, which pins the last entry to the current
+// constant. That guard is the whole point: it means the git archaeology behind
+// this list never has to be repeated.
+//
+// To append: hash the EVALUATED constant, not the file text. writeWorkspaceFile
+// writes the string verbatim via writeFileSync, so a user's on-disk bytes equal
+// the evaluated constant exactly. The drift-guard test failure prints the hash
+// to paste here.
+// =============================================================================
+
+/** Hash a soul string. Same "sha256:"+hex shape as the diagnostics collector's
+ * `instructionsHash` (see lib/diagnostics/agent-config-collector.ts). */
+export function hashSoul(content: string): string {
+  return "sha256:" + createHash("sha256").update(content).digest("hex");
+}
+
+/**
+ * Every SMITHERS_SOUL_MD value Pinchy has ever shipped, oldest first.
+ *
+ * Generated once from the 25 commits that touched smithers-soul.ts between
+ * 2026-02-20 and 2026-05-19 (each produced a distinct string). The last entry
+ * MUST equal `CURRENT_SOUL_HASH`.
+ */
+export const SHIPPED_SOUL_HASHES: readonly string[] = [
+  // 2026-02-20  fef013ef  2837B — first soul, with hardcoded platform knowledge
+  "sha256:91fc60b2f9c0b2b5ad2dc774e69fd76e6628477aa3850ae73f1584f03019b766",
+  // 2026-02-21  c6187929  3443B — audit trail page
+  "sha256:cb313fabff10b39269e55277861a407c5602a368a66358cca12bda5474c83a55",
+  // 2026-02-24  e8d16d05  3888B — restart resilience, agent switching
+  "sha256:458fc252de011fe3941e734c7a4ab0fea7e9303ec64b33b98abc514ec79e37e6",
+  // 2026-02-24  39966768  3775B — avatars, taglines
+  "sha256:83bcbcda88f2077065085aacdd0e8ed653b13fd5adb4949268a8ccc0b4e0a527",
+  // 2026-02-25  4751c283  4350B — new tab structure
+  "sha256:cb7e7d62ce9e8690c8c60ad56be08e87e6a1980704b9a259f26824d2d06061d3",
+  // 2026-02-26  3a9fbba4  4784B — context in general settings
+  "sha256:55164bd9f00af934fc5bca31cbaa76f0bb4040af95659e60ab82df6d528b87b1",
+  // 2026-02-27  ceb3ecf3  5173B — onboarding
+  "sha256:4caf60697eb63886dddfe5091b739d2b168b18b1e338f4f5419f812bd8b6da07",
+  // 2026-03-02  900bbc2f  5396B — onboarding thoroughness, settings hint
+  "sha256:b38551b8ebd36de5241b963a9f0c7b9b1af5ffdfa6644266ad30e89d613e46c4",
+  // 2026-03-02  11ce0fbb  5352B — onboarding streamlined to four details
+  "sha256:31b2a024dc92c03c3934a79b3c40927dd3b77ac02f6013c1c6733c51e3f39883",
+  // 2026-03-03  86f4c05e  5573B — in-app error reporting
+  "sha256:8ce011ca5e47e8953d40b481d33090874438c27acf1e35a6c104f493795ea549",
+  // 2026-03-03  a085f684  5423B — name dropped from onboarding
+  "sha256:138fe97c15a0a793e937f9c0cc16ce27dfcb10d43cc1a446ba46529ead69a392",
+  // 2026-03-04  60aa0a68  5437B — name comes from context, not conversation
+  "sha256:c3ad3c8d92ba5032f522bfee7eca9dc203202e3473916d7aa980b39a30202fb8",
+  // 2026-03-09  4a12217e  6287B — groups
+  "sha256:ffb77d5cd73204a10a67234831fdc09044d2ed5b76a890a6c76fd7e0c46a3afe",
+  // 2026-03-09  fdb1b2f5  6352B — two-value visibility model
+  "sha256:a5a350d8159cd6a0ef48f41cd65e36fcad5f5d63a37bf3b53c77cbc8a629fd2b",
+  // 2026-03-19  48e40cbb  6767B — v0.2.0
+  "sha256:f1517ae120c23160b67c7cddf162fdb6f647dae9e6b1a44f3be4e5c9c93b7f17",
+  // 2026-03-22  3d10f85a  7246B — usage & cost dashboard
+  "sha256:790c0747bba76d33393cf1faa13e81a440b8c9d3be11065744859aee4e620249",
+  // 2026-03-27  c8e228c5  7514B — v0.3.0
+  "sha256:ff9cd1f13da18a64f8e782c95f942785618b59f6c7ee23715ee3b4632de5af5c",
+  // 2026-03-31  884ca759  7564B — Ollama cloud quality fixes
+  "sha256:1313d4bdf22bd11b9b93f237e53dd444814640b25d441b8be3c6ab2f83d31051",
+  // 2026-03-31  af3fc9d4  9006B — Telegram channel integration
+  "sha256:6dedf734cbc96a7c6a4b842340f3240bbdb85f247ce09393a81474d5db323411",
+  // 2026-04-05  fcdd8271  9636B — insecure-mode banner, domain lock
+  "sha256:4aee6e3abd76dd352052dca00055cfedcdad813644a10289239b296ab753816d",
+  // 2026-04-09  e53fb7e4  10022B — the last and largest hardcoded-knowledge soul
+  "sha256:e56305f854afb99d5156a7529ad5cba6717a9fc68b15f29c02beaf6df5bb7950",
+  // 2026-04-09  4bf35313  2727B — docs-driven rewrite (pinchy-docs plugin)
+  "sha256:3aa3d152bacb77ed6bfee7d48954fe4a4fefd51c35b6db8e7204de17dc8cff62",
+  // 2026-04-10  4c6c141c  7741B — post-merge cleanup RESURRECTED the platform
+  //   knowledge for six days; this soul is docs-blind despite postdating the
+  //   rewrite, which is why the cutoff is 04-15 and not 04-09.
+  "sha256:a259c7e98075db8dddd3152dabf638e85d341907770902d02374bfdf45ef17e0",
+  // 2026-04-15  e73a13f5  3203B — platform knowledge removed for good
+  "sha256:fac4cbf250a79bce3730438372bfbc331b42544338eac2387ed64a599e4066db",
+  // 2026-05-19  806cbed1  3853B — public docs URL for citations (current)
+  "sha256:4d14d621770155a5916718455b06501da1a23b3b4e3ade6023193c8438b35877",
+];
+
+/** Hash of the soul this build ships. Pinned to the last SHIPPED_SOUL_HASHES
+ * entry by smithers-soul-history.test.ts. */
+export const CURRENT_SOUL_HASH = hashSoul(SMITHERS_SOUL_MD);
+
+/**
+ * True when `content` byte-matches a soul Pinchy shipped at some point — i.e.
+ * it came from `createSmithersAgent` and the user has never edited it.
+ *
+ * The current soul counts as shipped. Callers that want "stale and pristine"
+ * must check `hash !== CURRENT_SOUL_HASH` themselves.
+ */
+export function isPristineShippedSoul(content: string): boolean {
+  return SHIPPED_SOUL_HASHES.includes(hashSoul(content));
+}

--- a/scripts/release.mjs
+++ b/scripts/release.mjs
@@ -17,7 +17,10 @@
  *
  * What to do manually first (see CONTRIBUTING.md):
  *   - Update docs/src/content/docs/guides/upgrading.mdx (enforced)
- *   - Update packages/web/src/lib/smithers-soul.ts if user-facing features changed
+ *   - Check docs/ covers this release's user-facing features — Smithers reads them on
+ *     demand via the pinchy-docs plugin (docs_list / docs_read) and treats anything
+ *     not in the docs as non-existent. Do NOT hardcode feature descriptions into
+ *     smithers-soul.ts; it is deliberately docs-driven.
  */
 
 import { execSync } from "node:child_process";


### PR DESCRIPTION
## Why

This started as a report that CLAUDE.md carries a stale rule — *"update `smithers-soul.ts` when user-facing features change"* — which would contradict the soul prompt's own core instruction to never describe features from memory.

**The premise turned out to be wrong**, but the redirect found a live bug.

The rule was already gone. `4bf35313` (2026-04-09) rewrote the soul to be docs-driven and deleted the rule from CLAUDE.md in the same commit. What survived was one forgotten copy in `scripts/release.mjs` — and a much bigger problem underneath.

## The bug

`createSmithersAgent` writes `SOUL.md` once, at creation. Nothing ever rewrote it — `seedPersonalAgent` returns early when the agent exists. So changing `SMITHERS_SOUL_MD` never reached a Smithers that already existed.

That is worse than "old installs miss new features". Until 2026-04-15 the soul was 186 lines opening with **"You know the Pinchy platform inside out"**, followed by hardcoded facts that have since gone stale — the provider list predates `ollama-local`, and Telegram, email and Odoo did not exist yet. Today's soul is the exact opposite: it forbids platform knowledge from memory and mandates `docs_list` / `docs_read`.

So an instance installed before 2026-04-15 still runs a Smithers that states outdated facts with confidence. The docs-driven rewrite and every docs page written since never reached it. The `pinchy-docs` plugin was installed all along — the soul just never told Smithers to use it.

This is precisely the failure mode `AGENTS.md` § *"Test Migrations Against Pre-Existing Data"* describes: every test started from a clean slate where the current soul was written on the first write, which proves nothing about the state an **upgrade** produces.

## The fix

`migrateSmithersSoul()` runs from `bootInits()` and upgrades a `SOUL.md` only when its SHA-256 matches a soul Pinchy actually shipped.

`SOUL.md` is user-editable, so the hash is the selector — and no database column could be. `isPersonal` / `ownerId` can tell you an agent **is** Smithers; nothing in the row tells you whether its `SOUL.md` is **still the one we wrote**, which is the only thing that makes an overwrite safe. Only the bytes answer that. So the migration doesn't identify Smithers at all: it identifies *our text, wherever it sits*, and leaves everything else — customized souls, preset agents, missing files — untouched.

Raw bytes, no normalization. The safe way to be wrong is to skip an edit we could have upgraded, never to clobber one.

`SHIPPED_SOUL_HASHES` is append-only, generated from the 25 commits that touched `smithers-soul.ts` between 2026-02-20 and 2026-05-19, and pinned to the current constant by a drift guard — so the git archaeology behind it never has to be repeated.

## Reviewer notes

- **The cutoff is 04-15, not 04-09.** `4c6c141c` (post-merge cleanup, 04-10) resurrected the platform knowledge and grew the soul back from 63 to 151 lines; only `e73a13f5` (04-15) removed it for good. Six days of builds after the "rewrite" still shipped a docs-blind soul.
- **The nested try/catch in `bootInits` is deliberate.** Unguarded, a throw skips `regenerateOpenClawConfig()` — trading a stale soul for a stale `openclaw.json`. Mutation-checked.
- **The round-trip test is load-bearing.** The unit tests mock `@/lib/workspace`, so nothing else proves that the bytes `writeWorkspaceFile` stores are the bytes `readWorkspaceFile` returns. If either ever normalized, every hash would stop matching and the sweep would silently upgrade nothing, forever — no error, no failing test. Mutation-checked with a CRLF pass.
- The test fixture is a **byte-identical copy** of the real 2026-04-09 soul, hash-pinned so it can't silently decay into a tautology.

## Also in here

Two stale instruction sets of the same class as the original report, folded in rather than split out:

- `scripts/release.mjs` — the surviving copy of the rule that started this.
- `AGENTS.md` — advertised `pnpm lint`, `pnpm format` and `pnpm db:generate` as root commands. **None of the three exists** in the root `package.json`; all are `packages/web` scripts. Moved to the block that already uses the `pnpm -C packages/web` form, matching `installation.mdx:173`.

## Retracted during review

An earlier draft justified the hash selector partly with *"db/seed.ts creates an ownerless Smithers with `isPersonal: false`"*. **That is not true in production.** `seedDefaultAgent(ownerId?)` has exactly one production caller — `lib/setup.ts:47` — which always passes `result.user.id` behind a `if (!result?.user) throw`. The ownerless path is reachable only from tests. The claim is gone from the code comment and the design notes; the selector argument stands on its own without it.

## Verification

- `pnpm test` — 8303 passed, 15 skipped (614 files)
- `pnpm test:scripts` — 271 passed
- `pnpm typecheck:plugins` — 8 packages clean
- `pnpm -C packages/web typecheck` — clean (the CI gate: `tsconfig.typecheck.json`, includes test files)
- `pnpm -C packages/web lint` — 0 errors, 0 warnings on this PR's files
- `cd docs && pnpm build` — 66 pages built

**Verified end to end against the production image.** Brought up the integration stack (`docker-compose.yml` + `e2e.yml` + `integration.yml`, `Dockerfile.pinchy`, uid 999 — production parity asserted by `00-production-parity.spec.ts`), ran the setup wizard, then planted the **real 2026-04-09 soul** (`sha256:e56305f8…`, extracted from the fixture, byte-exact) into the live Docker volume and restarted the container. Four scenarios, all as predicted:

| Scenario | Result |
| --- | --- |
| Stale pristine soul → restart | `e56305f8…` → `4d14d621…` in the real volume |
| Audit row | Exactly 1 `agent.updated`, `actor_type: system`, correct `from`/`to`, `sweepId`, no prompt text |
| Second restart | No-op — still 1 row, soul unchanged |
| Customized soul (old soul + user's own line) | **Untouched** — hash identical, user's line intact, no audit row |

This closes the three gaps the unit tests structurally cannot reach: `bootInits()` does run in the container, the `/openclaw-config/workspaces/<id>` mount path is right, and OpenClaw needs no special handling. What remains unverified is only the LLM-behavioral half — that a migrated Smithers actually reaches for `docs_list` — which a deterministic fake-Ollama cannot demonstrate anyway; staging/demo at release time is the honest test for that.

**The green "End-user upgrade simulation" job is not evidence for this PR.** It installs the latest release and upgrades against a persisted volume — but the latest release (v0.8.0, 2026-07-08) already ships the current soul (2026-05-19). Phase 1 therefore writes `4d14d621`, and phase 2's migration hits `previousHash === CURRENT_SOUL_HASH` and skips. The job proves the no-op path survives a real upgrade; the actual upgrade path is structurally out of its reach.

## Review findings, addressed

A self-review found one real gap and three overclaims. All fixed in this branch.

- **The preset-collision guard was claimed but never tested.** The migration matches our text by hash and asks nothing about the agent row — safe only while no other shipped soul can hash into `SHIPPED_SOUL_HASHES`. The test asserting this fed it an *invented* string, so it only re-tested the "customized" case. The risk is not theoretical: `the-butler`'s preset soul already shares whole paragraphs with Smithers', and `createSmithersAgent` stamps `personalityPresetId: "the-butler"` onto Smithers itself. A preset derived from `SMITHERS_SOUL_MD` would get every agent using it silently overwritten. Proven by mutation: with `the-coach.soulMd := SMITHERS_SOUL_MD`, **43 tests across the migration, soul and preset suites stayed green** — nothing noticed. The new guard fails and names the offending preset; the behavioral test now feeds real preset souls via `it.each`.
- **"A hash match PROVES … have not been touched since" was false.** It proves the *content* is ours, not that the user never touched the file: pasting an older shipped soul back byte-for-byte matches too, and gets upgraded. The comment now states the exact claim and its accepted limit.
- **The docs promised something the code can break.** "We recognize your version and leave it exactly as you wrote it" is false in that same case. Now: "We only replace a `SOUL.md` that still matches one we shipped" — which is what the code actually does.
- **The fixture header cited `smithers-soul-migration.test.ts`, which does not exist.** The pin lives in `smithers-soul-history.test.ts`. Particularly embarrassing in a PR about instructions pointing at things that aren't there.
- **A boot-budget note** now records why this matters: the sweep runs before `markOpenClawConfigReady()`, and compose allows 65s before OpenClaw is never started at all.

