### PR TITLE
fix(test): repair the two type errors that leave main's typecheck red

### DIFF
--- a/packages/web/src/__tests__/security/credential-forms-post-method.test.ts
+++ b/packages/web/src/__tests__/security/credential-forms-post-method.test.ts
@@ -46,8 +46,10 @@ import path from "node:path";
 const webSrcDir = path.resolve(__dirname, "../..");
 
 // Matches a full opening <form ...> tag, allowing attributes/newlines
-// between "<form" and the closing ">".
-const FORM_OPEN_TAG_RE = /<form\b[^>]*>/gs;
+// between "<form" and the closing ">". No /s: it only ever affects ".", which
+// this pattern doesn't use, and [^>] spans newlines on its own. The flag was
+// inert, and it needs target >= ES2018 (tsconfig targets ES2017).
+const FORM_OPEN_TAG_RE = /<form\b[^>]*>/g;
 
 const EXCLUDED_DIR_NAMES = new Set(["__tests__", "node_modules"]);
 

--- a/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
+++ b/packages/web/src/components/assistant-ui/__tests__/thread.test.tsx
@@ -839,15 +839,11 @@ describe("Composer no longer gates attachments client-side", () => {
 describe("AssistantMessage footer height", () => {
   it("keeps the min-h-6 row that reserves the action bar's height", async () => {
     const { useMessage } = await import("@assistant-ui/react");
-    vi.mocked(useMessage).mockImplementation(
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any
-      (selector: (state: any) => unknown) =>
-        selector({
-          metadata: { custom: { timestamp: "2026-07-15T09:39:00.000Z" } },
-          isLast: false,
-          id: "msg-footer-1",
-        })
-    );
+    stubUseMessage(useMessage, {
+      metadata: { custom: { timestamp: "2026-07-15T09:39:00.000Z" } },
+      isLast: false,
+      id: "msg-footer-1",
+    });
 
     const { AssistantMessage } = await import("@/components/assistant-ui/thread");
     const { container } = render(<AssistantMessage />);


### PR DESCRIPTION
main is **red** at `0e2b199a4`, so every open PR's CI fails on a fault of its own — I hit it on an unrelated eval PR and traced it back here.

`ec338bcaa` wired up the `Typecheck web (incl. tests)` gate and fixed 1058 dormant type errors in the same pass. Two more arrived from PRs that merged between that commit's green run and its merge, so the gate went red the moment it landed. Nothing was wrong with the gate — it is doing exactly its job.

## The two errors

**`credential-forms-post-method.test.ts:50`** — `/<form\b[^>]*>/gs` needs `target >= ES2018`; the tsconfig targets ES2017.

The `/s` flag was **inert**: it only ever affects `.`, and this pattern has none — `[^>]` already spans newlines by itself. So I dropped the flag instead of bumping the whole app's compile target for a no-op. Verified equivalent on attribute, multi-line, and bare `<form>` inputs.

Since this file is the `method="post"` drift guard, the risk worth naming is a *vacuously green* guard. It has its own anti-vacuity tests — `should find production .tsx files to scan`, `should find at least one <form> in production source` — and they pass, still enumerating the real files (`login/page.tsx`, `invite/[token]/page.tsx`, `add-integration-dialog.tsx`).

**`thread.test.tsx:844`** — the footer-height test hand-rolled a `vi.mocked(useMessage).mockImplementation` typed as a bare selector, but `vi.mocked` resolves `useMessage`'s overloads to the **last** one (the `{ optional?, selector? }` options object).

`stubUseMessage()` already exists three tests above for precisely this reason, and its docblock spells out the trap. Used it rather than adding another cast.

## Verification

- `pnpm -C packages/web typecheck` — green (was 2 errors).
- The two touched test files: 52 passed.
- No production code touched; both changes are test-local and behavior-preserving.