### PR TITLE
fix(auth): stop reporting rate-limited and failed sign-ins as a wrong password

### DIFF
--- a/packages/web/src/__tests__/app/login-page.test.tsx
+++ b/packages/web/src/__tests__/app/login-page.test.tsx
@@ -203,4 +203,65 @@ describe("Login Page", () => {
       expect(screen.getByText("Invalid email or password")).toBeInTheDocument();
     });
   });
+
+  // Better Auth answers a rate-limited sign-in with 429 and a real server
+  // failure with 5xx. Reporting either as "Invalid email or password" tells the
+  // user their (correct) password is wrong and hides the actual cause: with the
+  // production limit of 5 attempts/60s (see getAuthRateLimitConfig), a few
+  // typos lock the account out, every retry re-arms the window, and the user is
+  // told the whole time that their password is bad. Distinguish by status.
+  async function submitLogin(user: ReturnType<typeof userEvent.setup>) {
+    await user.type(screen.getByLabelText(/email/i), "user@example.com");
+    await user.type(screen.getByLabelText("Password"), "correct-password-123");
+    await user.click(screen.getByRole("button", { name: /sign in/i }));
+  }
+
+  it("reports rate limiting as such, not as a wrong password", async () => {
+    const user = userEvent.setup();
+    mockSignInEmail.mockResolvedValue({
+      error: { status: 429, statusText: "Too Many Requests", message: "Too many requests." },
+    });
+
+    render(<LoginPage />);
+    await submitLogin(user);
+
+    await waitFor(() => {
+      expect(screen.getByText(/too many sign-in attempts/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
+  });
+
+  it("reports a server error as such, not as a wrong password", async () => {
+    const user = userEvent.setup();
+    mockSignInEmail.mockResolvedValue({
+      error: { status: 500, statusText: "Internal Server Error", message: "boom" },
+    });
+
+    render(<LoginPage />);
+    await submitLogin(user);
+
+    await waitFor(() => {
+      expect(screen.getByText(/login failed\. please try again/i)).toBeInTheDocument();
+    });
+    expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
+  });
+
+  it("still reports genuinely invalid credentials as a wrong password", async () => {
+    const user = userEvent.setup();
+    mockSignInEmail.mockResolvedValue({
+      error: {
+        status: 401,
+        statusText: "UNAUTHORIZED",
+        message: "Invalid email or password",
+        code: "INVALID_EMAIL_OR_PASSWORD",
+      },
+    });
+
+    render(<LoginPage />);
+    await submitLogin(user);
+
+    await waitFor(() => {
+      expect(screen.getByText("Invalid email or password")).toBeInTheDocument();
+    });
+  });
 });

--- a/packages/web/src/__tests__/app/login-page.test.tsx
+++ b/packages/web/src/__tests__/app/login-page.test.tsx
@@ -3,6 +3,7 @@ import { render, screen, waitFor } from "@testing-library/react";
 import userEvent from "@testing-library/user-event";
 import "@testing-library/jest-dom";
 import LoginPage from "@/app/login/page";
+import { SIGN_IN_RATE_LIMIT_WINDOW_SECONDS } from "@/lib/auth-rate-limit";
 
 const mockSignInEmail = vi.fn();
 
@@ -189,8 +190,18 @@ describe("Login Page", () => {
 
   it("should display error when signIn returns an error", async () => {
     const user = userEvent.setup();
+    // The real shape Better Auth sends for a rejected credential: 401 with
+    // INVALID_EMAIL_OR_PASSWORD (better-auth's sign-in route throws
+    // UNAUTHORIZED for an unknown user, a missing account and a bad password
+    // alike). `status` is required on a BetterFetchError, so a status-less
+    // fixture would test a response the client can never produce.
     mockSignInEmail.mockResolvedValue({
-      error: { message: "Invalid credentials" },
+      error: {
+        status: 401,
+        statusText: "UNAUTHORIZED",
+        message: "Invalid email or password",
+        code: "INVALID_EMAIL_OR_PASSWORD",
+      },
     });
 
     render(<LoginPage />);
@@ -204,64 +215,127 @@ describe("Login Page", () => {
     });
   });
 
-  // Better Auth answers a rate-limited sign-in with 429 and a real server
-  // failure with 5xx. Reporting either as "Invalid email or password" tells the
-  // user their (correct) password is wrong and hides the actual cause: with the
-  // production limit of 5 attempts/60s (see getAuthRateLimitConfig), a few
-  // typos lock the account out, every retry re-arms the window, and the user is
-  // told the whole time that their password is bad. Distinguish by status.
-  async function submitLogin(user: ReturnType<typeof userEvent.setup>) {
-    await user.type(screen.getByLabelText(/email/i), "user@example.com");
-    await user.type(screen.getByLabelText("Password"), "correct-password-123");
-    await user.click(screen.getByRole("button", { name: /sign in/i }));
-  }
+  // Only a 401 means the credentials were wrong. Reporting any other failure as
+  // "Invalid email or password" sends the user hunting for a password that was
+  // right all along, and hides the one fact that would actually help them.
+  describe("sign-in failures are reported by cause, not all as a wrong password", () => {
+    async function submitLogin(user: ReturnType<typeof userEvent.setup>) {
+      await user.type(screen.getByLabelText(/email/i), "user@example.com");
+      await user.type(screen.getByLabelText("Password"), "correct-password-123");
+      await user.click(screen.getByRole("button", { name: /sign in/i }));
+    }
 
-  it("reports rate limiting as such, not as a wrong password", async () => {
-    const user = userEvent.setup();
-    mockSignInEmail.mockResolvedValue({
-      error: { status: 429, statusText: "Too Many Requests", message: "Too many requests." },
+    // With the production limit of 5 attempts/60s (see getAuthRateLimitConfig),
+    // a few typos lock the account out and every retry re-arms the window — so
+    // a user who hammers the button stays locked out while the page insists
+    // their (correct) password is bad.
+    it("reports rate limiting as such, not as a wrong password", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({
+        error: { status: 429, statusText: "Too Many Requests", message: "Too many requests." },
+      });
+
+      render(<LoginPage />);
+      await submitLogin(user);
+
+      await waitFor(() => {
+        expect(screen.getByText(/too many sign-in attempts/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
     });
 
-    render(<LoginPage />);
-    await submitLogin(user);
+    // The wait we promise must be the wait the server actually enforces, so the
+    // message is pinned to the same constant getAuthRateLimitConfig uses.
+    it("tells the user to wait as long as the server actually throttles them", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({
+        error: { status: 429, statusText: "Too Many Requests", message: "Too many requests." },
+      });
 
-    await waitFor(() => {
-      expect(screen.getByText(/too many sign-in attempts/i)).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
-  });
+      render(<LoginPage />);
+      await submitLogin(user);
 
-  it("reports a server error as such, not as a wrong password", async () => {
-    const user = userEvent.setup();
-    mockSignInEmail.mockResolvedValue({
-      error: { status: 500, statusText: "Internal Server Error", message: "boom" },
-    });
-
-    render(<LoginPage />);
-    await submitLogin(user);
-
-    await waitFor(() => {
-      expect(screen.getByText(/login failed\. please try again/i)).toBeInTheDocument();
-    });
-    expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
-  });
-
-  it("still reports genuinely invalid credentials as a wrong password", async () => {
-    const user = userEvent.setup();
-    mockSignInEmail.mockResolvedValue({
-      error: {
-        status: 401,
-        statusText: "UNAUTHORIZED",
-        message: "Invalid email or password",
-        code: "INVALID_EMAIL_OR_PASSWORD",
-      },
+      await waitFor(() => {
+        expect(screen.getByText(/too many sign-in attempts/i)).toHaveTextContent(
+          `${SIGN_IN_RATE_LIMIT_WINDOW_SECONDS} seconds`
+        );
+      });
     });
 
-    render(<LoginPage />);
-    await submitLogin(user);
+    // 403 is only reachable *after* the password verified: better-auth rejects a
+    // bad credential with 401, and reaches FORBIDDEN only for a banned user (the
+    // admin plugin's session.create.before hook — which is how Pinchy deactivates
+    // an account) or an unverified email. Telling that user their password is
+    // wrong is the exact dead end this whole describe block exists to prevent.
+    it("reports a deactivated account as such, not as a wrong password", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({
+        error: {
+          status: 403,
+          statusText: "FORBIDDEN",
+          message: "You have been banned from this application.",
+          code: "BANNED_USER",
+        },
+      });
 
-    await waitFor(() => {
-      expect(screen.getByText("Invalid email or password")).toBeInTheDocument();
+      render(<LoginPage />);
+      await submitLogin(user);
+
+      await waitFor(() => {
+        expect(screen.getByText(/contact your administrator/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
+    });
+
+    it("reports a server error as such, not as a wrong password", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({
+        error: { status: 500, statusText: "Internal Server Error", message: "boom" },
+      });
+
+      render(<LoginPage />);
+      await submitLogin(user);
+
+      await waitFor(() => {
+        expect(screen.getByText(/login failed\. please try again/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
+    });
+
+    // No BetterFetchError is status-less, but an unrecognized failure must not
+    // be guessed into a password accusation either.
+    it("falls back to a generic failure when the error has no status", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({ error: { message: "something unexpected" } });
+
+      render(<LoginPage />);
+      await submitLogin(user);
+
+      await waitFor(() => {
+        expect(screen.getByText(/login failed\. please try again/i)).toBeInTheDocument();
+      });
+      expect(screen.queryByText("Invalid email or password")).not.toBeInTheDocument();
+    });
+
+    // The error text is the entire point of this page's failure path — a screen
+    // reader user has to hear it change, not just sighted users see it.
+    it("announces the error to screen readers", async () => {
+      const user = userEvent.setup();
+      mockSignInEmail.mockResolvedValue({
+        error: {
+          status: 401,
+          statusText: "UNAUTHORIZED",
+          message: "Invalid email or password",
+          code: "INVALID_EMAIL_OR_PASSWORD",
+        },
+      });
+
+      render(<LoginPage />);
+      await submitLogin(user);
+
+      await waitFor(() => {
+        expect(screen.getByRole("alert")).toHaveTextContent("Invalid email or password");
+      });
     });
   });
 });

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -27,6 +27,30 @@ const loginSchema = z.object({
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
+/**
+ * Turns a Better Auth sign-in failure into the message the user sees.
+ *
+ * Only a credential rejection may be reported as a wrong password. Better Auth
+ * answers a throttled sign-in with 429 (see `getAuthRateLimitConfig`: 5
+ * attempts / 60s, active whenever NODE_ENV=production) and a broken backend
+ * with 5xx. Reporting those as "Invalid email or password" sends the user
+ * hunting for a password that was right all along — and because every retry
+ * re-arms the rate-limit window, hammering the button keeps them locked out
+ * while the page insists their credentials are bad.
+ *
+ * A failure without a status is treated as a credential rejection: that is
+ * Better Auth's own default shape for a rejected sign-in.
+ */
+function loginErrorMessage(status: number | undefined): string {
+  if (status === 429) {
+    return "Too many sign-in attempts. Please wait a minute and try again.";
+  }
+  if (status === undefined || status === 401 || status === 403) {
+    return "Invalid email or password";
+  }
+  return "Login failed. Please try again.";
+}
+
 export default function LoginPage() {
   // useSearchParams() opts the render into a Suspense boundary (Next.js
   // requires one so the rest of the page can still be statically
@@ -61,7 +85,7 @@ function LoginForm() {
       });
 
       if (error) {
-        setError("Invalid email or password");
+        setError(loginErrorMessage(error.status));
       } else {
         const returnTo = searchParams.get("returnTo");
         router.push(isSafeReturnTo(returnTo) ? returnTo : "/");

--- a/packages/web/src/app/login/page.tsx
+++ b/packages/web/src/app/login/page.tsx
@@ -7,6 +7,7 @@ import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { z } from "zod";
 import { isSafeReturnTo } from "@/lib/return-to";
+import { SIGN_IN_RATE_LIMIT_WINDOW_SECONDS } from "@/lib/auth-rate-limit";
 import { Button } from "@/components/ui/button";
 import { PasswordInput } from "@/components/password-input";
 import { Input } from "@/components/ui/input";
@@ -27,28 +28,40 @@ const loginSchema = z.object({
 
 type LoginFormValues = z.infer<typeof loginSchema>;
 
+/** Shown when we can't tell the user anything more specific than "it failed". */
+const GENERIC_LOGIN_ERROR = "Login failed. Please try again.";
+
 /**
  * Turns a Better Auth sign-in failure into the message the user sees.
  *
- * Only a credential rejection may be reported as a wrong password. Better Auth
- * answers a throttled sign-in with 429 (see `getAuthRateLimitConfig`: 5
- * attempts / 60s, active whenever NODE_ENV=production) and a broken backend
- * with 5xx. Reporting those as "Invalid email or password" sends the user
- * hunting for a password that was right all along — and because every retry
- * re-arms the rate-limit window, hammering the button keeps them locked out
- * while the page insists their credentials are bad.
+ * Only a 401 may be reported as a wrong password. Better Auth answers every
+ * credential rejection with 401/INVALID_EMAIL_OR_PASSWORD — unknown user,
+ * missing account and bad password alike. Reporting anything else that way
+ * sends the user hunting for a password that was right all along.
  *
- * A failure without a status is treated as a credential rejection: that is
- * Better Auth's own default shape for a rejected sign-in.
+ * 429 is a throttled sign-in (see `getAuthRateLimitConfig`: 5 attempts per
+ * window, active whenever NODE_ENV=production). Because every retry re-arms the
+ * window, hammering the button keeps the user locked out while the page insists
+ * their credentials are bad.
+ *
+ * 403 is never a wrong password — it is only reachable *after* the password
+ * verified. It means the account is banned (the admin plugin's
+ * `session.create.before` hook, which is how Pinchy deactivates a user) or its
+ * email is unverified. Naming the password there hides the only fact that would
+ * help, and the user cannot fix it alone. Saying so leaks nothing: whoever sees
+ * a 403 has already proven the correct password.
  */
 function loginErrorMessage(status: number | undefined): string {
   if (status === 429) {
-    return "Too many sign-in attempts. Please wait a minute and try again.";
+    return `Too many sign-in attempts. Please wait ${SIGN_IN_RATE_LIMIT_WINDOW_SECONDS} seconds and try again.`;
   }
-  if (status === undefined || status === 401 || status === 403) {
+  if (status === 401) {
     return "Invalid email or password";
   }
-  return "Login failed. Please try again.";
+  if (status === 403) {
+    return "This account can't sign in. Please contact your administrator.";
+  }
+  return GENERIC_LOGIN_ERROR;
 }
 
 export default function LoginPage() {
@@ -91,7 +104,7 @@ function LoginForm() {
         router.push(isSafeReturnTo(returnTo) ? returnTo : "/");
       }
     } catch {
-      setError("Login failed. Please try again.");
+      setError(GENERIC_LOGIN_ERROR);
     } finally {
       setLoading(false);
     }
@@ -116,7 +129,14 @@ function LoginForm() {
                 noValidate
                 className="space-y-6"
               >
-                {error && <p className="text-destructive">{error}</p>}
+                {/* role="alert" so the failure reaches screen-reader users too:
+                    the message appears without a navigation or focus change,
+                    which is otherwise silent. */}
+                {error && (
+                  <p role="alert" className="text-destructive">
+                    {error}
+                  </p>
+                )}
 
                 <FormField
                   control={form.control}

--- a/packages/web/src/lib/auth-rate-limit.ts
+++ b/packages/web/src/lib/auth-rate-limit.ts
@@ -1,0 +1,11 @@
+/**
+ * How long Better Auth throttles a client after too many sign-in attempts.
+ *
+ * This lives in its own module because both sides of the login flow need it:
+ * `getAuthRateLimitConfig()` in `@/lib/auth` enforces the window, and the login
+ * page tells the user how long to wait. `@/lib/auth` cannot be imported from a
+ * client component — it pulls in the Drizzle adapter, bcrypt and the database —
+ * so the one value they must agree on lives here instead of being typed out
+ * twice and drifting apart.
+ */
+export const SIGN_IN_RATE_LIMIT_WINDOW_SECONDS = 60;

--- a/packages/web/src/lib/auth.ts
+++ b/packages/web/src/lib/auth.ts
@@ -7,6 +7,7 @@ import bcrypt from "bcryptjs";
 import { db } from "@/db";
 import * as schema from "@/db/schema";
 import { appendAuditLog, redactEmail } from "@/lib/audit";
+import { SIGN_IN_RATE_LIMIT_WINDOW_SECONDS } from "@/lib/auth-rate-limit";
 import { getCachedDomain } from "@/lib/domain";
 import { shouldUseSecureCookies } from "@/lib/secure-cookies";
 import { PASSWORD_MIN_LENGTH } from "@/lib/validate-password";
@@ -122,8 +123,10 @@ export function getAuthRateLimitConfig(): BetterAuthRateLimitOptions {
     // covers any future sub-path (OAuth, magic-link, passkey) we add.
     customRules: {
       // Pre-auth — brute-force / credential-stuffing protection
-      "/sign-in/email": { window: 60, max: 5 }, // was 3/10s = 18/min
-      "/sign-in/*": { window: 60, max: 5 },
+      // The window is shared with the login page, which tells the user how long
+      // to wait — see @/lib/auth-rate-limit.
+      "/sign-in/email": { window: SIGN_IN_RATE_LIMIT_WINDOW_SECONDS, max: 5 }, // was 3/10s = 18/min
+      "/sign-in/*": { window: SIGN_IN_RATE_LIMIT_WINDOW_SECONDS, max: 5 },
       "/sign-up/email": { window: 300, max: 3 },
       "/sign-up/*": { window: 300, max: 3 },
       // Reset flow — also a spam-DOS vector against user inboxes


### PR DESCRIPTION
## What I investigated

The report was that login is broken on current `main`, possibly a hydration issue or fallout from a Next.js update. I could not reproduce a total login failure, and the evidence rules both suspicions out:

- **Hydration is fine.** On `/login` the form hydrates cleanly in dev *and* in a production build (`__reactFiber`/`__reactProps` present, `onSubmit` attached, no hydration warning, no page error). A submit dispatches `POST /api/auth/sign-in/email` — no native form submit.
- **Next.js is not implicated.** Only patch bumps landed (16.2.9 → 16.2.10).
- **Login works** in the dev-server E2E layer, against a real production build (fresh instance, fully set-up instance, and the `returnTo` deep-link flow), and in CI.

## The real defect

`LoginPage` mapped **every** Better Auth failure to `"Invalid email or password"`:

```ts
const { error } = await authClient.signIn.email({ ... });
if (error) setError("Invalid email or password");
```

That is what "login is broken" feels like from the outside — the page blames a password that is right, and the actual cause never surfaces. Two of these are reachable in production today:

**Rate limiting (429).** Production enables the throttle (`getAuthRateLimitConfig` — 5 attempts / 60s), so a few typos lock the account out, and from then on the *correct* password is rejected with the claim that it is wrong. Every retry re-arms the window, so a user who keeps trying stays locked out while the page keeps blaming their password. Reproduced against a production build:

```
attempt 1-5: 200 OK
attempt 6:   429 Too Many Requests   -> UI: "Invalid email or password"   <- correct password
```

**A deactivated account (403).** `better-auth` rejects a bad credential with 401/`INVALID_EMAIL_OR_PASSWORD` in every case — unknown user, missing account, bad password alike (`api/routes/sign-in.mjs`). It only reaches FORBIDDEN *after* the password verified: a banned user (the admin plugin's `session.create.before` hook — which is exactly how Pinchy deactivates an account in `/api/users/[userId]`) or an unverified email. So a deactivated employee typing their correct password was sent hunting for a fault that isn't theirs.

Naming the cause leaks nothing: whoever sees a 403 has already proven the correct password, so there is no enumeration surface.

## The fix

Map by status. Only a 401 may be reported as a wrong password; 429 says how long to wait; 403 points at the administrator; anything else is an honest generic failure.

The status-less special case is gone. Its comment claimed to mirror "Better Auth's own default shape for a rejected sign-in", which is wrong — `status` is required on a `BetterFetchError`, and a rejection is a 401. The old test's status-less fixture was mocking a response the client cannot produce.

Two things fall out of it:

- The error is now `role="alert"`. This page's failure path is carried entirely by that one line of text, and it appears with no navigation or focus change — silent to a screen reader until now.
- The 429 text names the window from a constant shared with `getAuthRateLimitConfig` instead of hardcoding "a minute", so the wait we promise stays the wait the server enforces.

## Verification

| Scenario | User now sees |
|---|---|
| Rate-limited + **correct** password | "Too many sign-in attempts. Please wait 60 seconds and try again." |
| Deactivated account + correct password | "This account can't sign in. Please contact your administrator." |
| Wrong password | "Invalid email or password" |
| Correct password | signed in, lands on `/chat/…` |

The 429 and 401 rows were driven end-to-end against a production build. The 403 row is covered at the unit layer and derived from reading `better-auth@1.6.23`'s sign-in route and admin plugin — I did not stand up a stack and ban a live user to observe it. Worth knowing: if that status were ever something other than 403, the message degrades to the generic failure, not back to a password accusation.

Gates: full web suite 8279 passed · typecheck (incl. tests) clean · `test:scripts` clean · lint 0 errors · prettier clean · `next build` green. `test:db` not run locally — the diff has no DB surface (`auth.ts` only swaps the literal `60` for a constant equal to `60`); CI covers it.