### PR TITLE
fix(pinchy-web): dispatch web_fetch through undici's own fetch

### DIFF
--- a/packages/plugins/pinchy-web/web-fetch-dispatcher.test.ts
+++ b/packages/plugins/pinchy-web/web-fetch-dispatcher.test.ts
@@ -1,0 +1,88 @@
+// @vitest-environment node
+//
+// Drives the real dispatcher against a real HTTP server: no mocked fetch, no
+// mocked DNS. Separate from web-fetch.test.ts on purpose — that suite mocks
+// fetch wholesale, so it can only assert an Agent was attached, never that
+// undici accepts one. A pairing of Agent and fetch drawn from two different
+// undici copies fails every dispatch while that suite stays green, so this file
+// is the only thing standing between such a mismatch and production.
+import { describe, it, expect, beforeAll, afterAll } from "vitest";
+import http from "node:http";
+import type { AddressInfo } from "node:net";
+import { buildPinnedAgent, httpFetch } from "./web-fetch.js";
+
+describe("pinned dispatcher is compatible with the fetch webFetch dispatches through", () => {
+  let server: http.Server;
+  let port: number;
+
+  beforeAll(async () => {
+    server = http.createServer((req, res) => {
+      if (req.url === "/redirect") {
+        res.writeHead(302, { location: "/" });
+        res.end();
+        return;
+      }
+      res.writeHead(200, { "content-type": "text/html" });
+      res.end("<html><body><p>pinned ok</p></body></html>");
+    });
+    await new Promise<void>((resolve) => server.listen(0, "127.0.0.1", resolve));
+    port = (server.address() as AddressInfo).port;
+  });
+
+  afterAll(async () => {
+    await new Promise<void>((resolve) => server.close(() => resolve()));
+  });
+
+  // The hostname never resolves — it exists only to prove the pinned lookup,
+  // not the OS resolver, decides where the socket goes. A ".invalid" name that
+  // reached real DNS would NXDOMAIN.
+  const pinnedUrl = (path = "/") => `http://pinned.invalid:${port}${path}`;
+
+  it("completes a request through a pinned-IP Agent", async () => {
+    const agent = buildPinnedAgent("127.0.0.1", 4);
+    try {
+      const res = await httpFetch(pinnedUrl(), {
+        headers: { "User-Agent": "PinchyBot/1.0" },
+        redirect: "manual",
+        dispatcher: agent,
+      } as RequestInit);
+
+      expect(res.status).toBe(200);
+      await expect(res.text()).resolves.toContain("pinned ok");
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it("routes to the pinned address rather than the URL's hostname", async () => {
+    const agent = buildPinnedAgent("127.0.0.1", 4);
+    try {
+      // Reaching a 200 at all proves the socket went to 127.0.0.1: no resolver
+      // would ever map "pinned.invalid" there.
+      const res = await httpFetch(pinnedUrl(), { dispatcher: agent } as RequestInit);
+      expect(res.status).toBe(200);
+      await res.text();
+    } finally {
+      await agent.close();
+    }
+  });
+
+  it("surfaces a real HTTP status instead of an opaque transport failure", async () => {
+    // The regression made every response — including redirects webFetch must
+    // read `location` off — collapse into "fetch failed" before any status was
+    // available. Assert a status survives the dispatcher.
+    const agent = buildPinnedAgent("127.0.0.1", 4);
+    try {
+      const res = await httpFetch(pinnedUrl("/redirect"), {
+        redirect: "manual",
+        dispatcher: agent,
+      } as RequestInit);
+
+      expect(res.status).toBe(302);
+      expect(res.headers.get("location")).toBe("/");
+      await res.text();
+    } finally {
+      await agent.close();
+    }
+  });
+});

--- a/packages/plugins/pinchy-web/web-fetch.test.ts
+++ b/packages/plugins/pinchy-web/web-fetch.test.ts
@@ -9,9 +9,23 @@ vi.mock("node:dns/promises", () => ({
   },
 }));
 
+// webFetch dispatches through undici's own fetch, never the global one: the
+// Agent it pins comes from the undici npm package, and Node's global fetch is
+// backed by a different, bundled undici that rejects it (see
+// web-fetch-dispatcher.test.ts). So mock the module, not the global — a
+// vi.stubGlobal("fetch", …) here would intercept nothing and every assertion
+// below would silently drift onto the real network.
+vi.mock("undici", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("undici")>();
+  // Keep the real Agent: webFetch constructs one per request, and these tests
+  // assert it gets attached as `init.dispatcher`.
+  return { ...actual, fetch: vi.fn() };
+});
+
 // Import after mock setup
 const { webFetch, pinnedLookup, readBodyCapped, extractReadableContent, visibleTextFromHtml } =
   await import("./web-fetch.js");
+const { fetch: undiciFetchMock } = await import("undici");
 
 // Build a Response whose body streams the given byte chunks, to exercise
 // readBodyCapped's streaming cap path (the text() fallback is used elsewhere).
@@ -50,15 +64,14 @@ describe("webFetch", () => {
   const resolve6Mock = dns.resolve6 as ReturnType<typeof vi.fn>;
 
   beforeEach(() => {
-    fetchMock = vi.fn();
-    vi.stubGlobal("fetch", fetchMock);
+    fetchMock = undiciFetchMock as unknown as ReturnType<typeof vi.fn>;
+    fetchMock.mockReset();
     // Default: resolve to public IPs
     resolve4Mock.mockResolvedValue(["93.184.216.34"]);
     resolve6Mock.mockResolvedValue(["2606:2800:220:1:248:1893:25c8:1946"]);
   });
 
   afterEach(() => {
-    vi.unstubAllGlobals();
     vi.restoreAllMocks();
   });
 
@@ -496,6 +509,44 @@ describe("webFetch", () => {
 
       expect(result.isError).toBe(true);
       expect(result.content).toContain("fetch failed");
+    });
+
+    // undici collapses every transport failure — DNS, TCP, TLS, a dispatcher it
+    // won't accept — into a bare `TypeError: fetch failed` and hangs the real
+    // reason off `.cause`. Reporting only `.message` is what made the undici
+    // handler-contract bug (web-fetch-dispatcher.test.ts) indistinguishable from
+    // an unreachable website: the agent, and its user, had nothing to act on.
+    it("surfaces the cause behind an opaque 'fetch failed'", async () => {
+      const cause = Object.assign(new Error("getaddrinfo ENOTFOUND example.com"), {
+        code: "ENOTFOUND",
+      });
+      fetchMock.mockRejectedValue(new TypeError("fetch failed", { cause }));
+
+      const result = await webFetch("https://example.com/dns-dead");
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("ENOTFOUND");
+      expect(result.content).toContain("getaddrinfo ENOTFOUND example.com");
+    });
+
+    it("falls back to the cause's message when it carries no errno code", async () => {
+      fetchMock.mockRejectedValue(
+        new TypeError("fetch failed", { cause: new Error("Client network socket disconnected") }),
+      );
+
+      const result = await webFetch("https://example.com/tls-dead");
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toContain("Client network socket disconnected");
+    });
+
+    it("reports plainly when there is no cause to unwrap", async () => {
+      fetchMock.mockRejectedValue(new Error("boom"));
+
+      const result = await webFetch("https://example.com/plain");
+
+      expect(result.isError).toBe(true);
+      expect(result.content).toBe("Failed to fetch URL: boom");
     });
 
     it("handles non-HTML content gracefully (returns raw text)", async () => {

--- a/packages/plugins/pinchy-web/web-fetch.ts
+++ b/packages/plugins/pinchy-web/web-fetch.ts
@@ -2,7 +2,7 @@ import { Readability } from "@mozilla/readability";
 import { parseHTML } from "linkedom";
 import dns from "node:dns/promises";
 import net from "node:net";
-import { Agent } from "undici";
+import { Agent, fetch as undiciFetch } from "undici";
 
 export interface WebFetchConfig {
   allowedDomains?: string[];
@@ -83,28 +83,54 @@ async function resolveHost(hostname: string): Promise<ResolvedHost> {
 // Custom undici lookup hook that returns the pre-resolved address. This
 // closes the DNS-rebinding TOCTOU window between the SSRF guard's resolve
 // and fetch's own connect-time resolve — both now use the same IP.
+type LookupAddress = { address: string; family: number };
 type LookupCallback = (
   err: Error | null,
-  address: string,
-  family: number,
+  address: string | LookupAddress[],
+  family?: number,
 ) => void;
+type LookupOptions = { all?: boolean };
 type LookupFunction = (
   hostname: string,
-  options: object,
+  options: LookupOptions,
   callback: LookupCallback,
 ) => void;
 
 export function pinnedLookup(address: string, family: 4 | 6): LookupFunction {
-  return (_hostname, _options, callback) => {
-    callback(null, address, family);
+  return (_hostname, options, callback) => {
+    // Honour both halves of Node's dns.lookup contract. With `all: true` the
+    // callback takes an array of {address, family}; otherwise the flat
+    // (address, family) form. undici's connector asks for `all`, and answering
+    // it in the flat form leaves it reading `undefined` as the address —
+    // ERR_INVALID_IP_ADDRESS, surfaced only as an opaque "fetch failed".
+    if (options?.all) callback(null, [{ address, family }]);
+    else callback(null, address, family);
   };
 }
 
-function buildPinnedAgent(address: string, family: 4 | 6): Agent {
+export function buildPinnedAgent(address: string, family: 4 | 6): Agent {
   return new Agent({
     connect: { lookup: pinnedLookup(address, family) },
   });
 }
+
+// MUST come from the same undici as `Agent` above. Node's global fetch is backed
+// by Node's own bundled undici, whose request handlers fail the npm package's
+// `assertRequestHandler` — handing it an Agent from here dies with
+// UND_ERR_INVALID_ARG on every dispatch, reported only as `TypeError: fetch
+// failed`. Do not "simplify" this back to the global fetch.
+//
+// The cast keeps this module on the DOM lib's fetch types: undici's fetch is the
+// same WHATWG implementation Node re-exports, and every member used here
+// (status, statusText, ok, headers.get, body.getReader, text) is identical on
+// both — only the nominal declarations differ.
+//
+// Exported so web-fetch-dispatcher.test.ts can drive this pair against a real
+// server; the mocked-fetch suite cannot see whether undici accepts the Agent.
+export const httpFetch = undiciFetch as unknown as (
+  url: string,
+  init: RequestInit,
+) => Promise<Response>;
 
 // Normalize a hostname so our allow/deny comparison is case-insensitive and
 // tolerates the trailing dot that DNS uses for fully-qualified names. Node's
@@ -137,6 +163,19 @@ function checkDomainAllowed(
     }
   }
   return null;
+}
+
+// undici collapses every transport-level failure into a bare `TypeError: fetch
+// failed` and hangs the actual reason off `.cause` — the DNS/TCP/TLS errno, or an
+// InvalidArgumentError when it rejects the dispatcher. Without the cause an agent
+// cannot tell "this site is unreachable" from "our HTTP client is broken", so
+// both reach the user as the same dead end.
+function describeFetchError(err: unknown): string {
+  if (!(err instanceof Error)) return String(err);
+  const cause = err.cause;
+  if (!(cause instanceof Error)) return err.message;
+  const code = (cause as NodeJS.ErrnoException).code;
+  return `${err.message} (${code ? `${code}: ${cause.message}` : cause.message})`;
 }
 
 // Read a response body but stop once `maxBytes` have been read, so a huge or
@@ -302,7 +341,7 @@ export async function webFetch(
     let res: Response | undefined;
 
     for (let i = 0; i <= MAX_REDIRECT_HOPS; i++) {
-      res = await fetch(currentUrl, {
+      res = await httpFetch(currentUrl, {
         headers: { "User-Agent": "PinchyBot/1.0" },
         signal: AbortSignal.timeout(30000),
         redirect: "manual",
@@ -378,8 +417,7 @@ export async function webFetch(
 
     return extractReadableContent(text, contentType, maxChars);
   } catch (err) {
-    const message = err instanceof Error ? err.message : String(err);
-    return { content: `Failed to fetch URL: ${message}`, isError: true };
+    return { content: `Failed to fetch URL: ${describeFetchError(err)}`, isError: true };
   } finally {
     dispatcher?.close().catch(() => {});
   }


### PR DESCRIPTION
## What broke

`pinchy_web_fetch` failed on **every resolvable public domain** with the opaque `Failed to fetch URL: fetch failed`. Not intermittent, not site-specific — the tool was fully non-functional. It surfaced via a bug report from an agent that couldn't reach two unrelated sites; both return HTTP 200 from outside.

`pinchy_web_search` kept working, which made it look like a network or bot-blocking problem. It isn't: `brave-search.ts` uses bare global `fetch` with no dispatcher and never touched the broken path.

## Root cause

Three bugs stacked.

**1. Two undici copies.** `web-fetch.ts` imported `Agent` from the undici npm package (8.7.0) but called Node's **global** `fetch`, which is backed by Node's own bundled undici. The two ship incompatible request-handler contracts, so `assertRequestHandler` rejected every dispatch:

```
InvalidArgumentError: invalid onRequestStart method   (UND_ERR_INVALID_ARG)
```

Introduced by 7d4ba0193, which added the pinned-IP `Agent` to close the DNS-rebinding TOCTOU window. The SSRF hardening took the tool offline.

**2. `pinnedLookup` used the wrong callback form.** undici's connector asks with `all: true` and expects `[{address, family}]`; the flat `(address, family)` form left it reading `undefined` as the address (`ERR_INVALID_IP_ADDRESS`). Fully masked by bug 1 — it only surfaced once 1 was fixed.

**3. `err.cause` was discarded.** undici collapses every transport failure into `TypeError: fetch failed` and hangs the real reason off `.cause`. The catch reported only `err.message`, so an unreachable site and a broken HTTP client produced the identical dead end. This is why 1 and 2 stayed invisible for so long.

## Why no test caught it

`web-fetch.test.ts` does `vi.stubGlobal("fetch", fetchMock)` — it replaces fetch wholesale, so the Agent is never handed to real undici. The existing assertion only checks that `init.dispatcher` **is defined**, never that it works. The suite is structurally blind to this class of bug.

`web-fetch-dispatcher.test.ts` (new) closes the gap: real `node:http` server, real Agent, no mocks. Verified by mutation — reverting the fix turns all 3 red with `UND_ERR_INVALID_ARG`.

The mock seam in `web-fetch.test.ts` moves from the global to the undici module, since `webFetch` no longer calls global fetch. No tests removed; 82 → 88.

## Verification

Real `webFetch()` against the reporting agent's actual URLs, no mocks:

```
OK     | https://clemenshelm.com
         Software-Engineer · Wien  Software, die hält. Seit über 20 Jahren baue ich Software…

FEHLER | https://www.toptal.com/resume/clemens-helm
         HTTP error 403:
```

Toptal 403s on the `PinchyBot/1.0` user agent (bot protection) — unrelated to this bug, but now reported truthfully instead of as `fetch failed`.

Gates: `pnpm test` 8279 ✓ · `test:plugins` ✓ · `typecheck:plugins` ✓ · `typecheck web` ✓ · ESLint 0 errors · `smoke-load:plugins` ✓

## Not in scope

- **Toptal's 403** needs a user-agent/fetch-strategy decision, not a bug fix.
- **The reporting agent's memory is separately broken**: a dangling `MEMORY.md` symlink (`pinchy_write` → "escapes the sandbox via a symlink", `pinchy_read` → `ENOENT`), no `memory/` dir, and a dead index (`index metadata is missing`) — while the sandbox allowlist advertises both paths. Worth its own issue.