### PR TITLE
fix(pinchy-files): stop misdiagnosing a missing write root as a symlink escape

### DIFF
--- a/packages/plugins/pinchy-files/validate.test.ts
+++ b/packages/plugins/pinchy-files/validate.test.ts
@@ -362,9 +362,12 @@ describe("assertNoSymlinkEscape (write-path symlink containment)", () => {
       mkdirSync(outside);
       symlinkSync(outside, join(sandbox, "link"));
 
+      // This is the proof the fix does not weaken the guard: a genuine
+      // symlink escape (write root exists, an ancestor symlinks outside it)
+      // must still be rejected.
       expect(() =>
         assertNoSymlinkEscape(join(sandbox, "link", "secret.txt"), [sandbox])
-      ).toThrow(/escapes the sandbox/);
+      ).toThrow(/not under any configured write path/);
     } finally {
       rmSync(base, { recursive: true, force: true });
     }
@@ -378,6 +381,48 @@ describe("assertNoSymlinkEscape (write-path symlink containment)", () => {
       const sandbox = join(base, "sandbox");
       mkdirSync(sandbox);
       expect(() => assertNoSymlinkEscape(join(sandbox, "ok.txt"), [sandbox])).not.toThrow();
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("allows write when the configured write root is itself a symlink resolving to the target's real location", () => {
+    // Explicit macOS `/var` -> `/private/var` shape: the configured root is a
+    // symlink, the requested path is already the real (non-symlinked)
+    // location. Both sides must resolve to the same place and be allowed.
+    const base = mkdtempSync(join(tmpdir(), "pinchy-escape-"));
+    try {
+      const realRoot = join(base, "real-root");
+      mkdirSync(realRoot);
+      const rootLink = join(base, "root-link");
+      symlinkSync(realRoot, rootLink);
+
+      expect(() =>
+        assertNoSymlinkEscape(join(realRoot, "file.txt"), [rootLink])
+      ).not.toThrow();
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("allows a write target under a write root that does not exist yet (missing root ≠ symlink escape)", () => {
+    // The production bug: build.ts grants write_paths like
+    // `<workspace>/memory` and `<workspace>/MEMORY.md` before
+    // ensureWorkspace creates them. realpathSync(root) then throws ENOENT,
+    // and the old `catch { return false }` made a merely-absent write root
+    // indistinguishable from a genuine symlink escape, denying every write.
+    const base = mkdtempSync(join(tmpdir(), "pinchy-escape-"));
+    try {
+      const workspace = join(base, "workspace"); // exists
+      mkdirSync(workspace);
+      const memoryRoot = join(workspace, "memory"); // configured write root, NOT created yet
+      const memoryFile = join(workspace, "MEMORY.md"); // configured write root (file), NOT created yet
+
+      expect(() =>
+        assertNoSymlinkEscape(join(memoryRoot, "2026-07-15.md"), [memoryRoot, memoryFile])
+      ).not.toThrow();
+
+      expect(() => assertNoSymlinkEscape(memoryFile, [memoryRoot, memoryFile])).not.toThrow();
     } finally {
       rmSync(base, { recursive: true, force: true });
     }

--- a/packages/plugins/pinchy-files/validate.test.ts
+++ b/packages/plugins/pinchy-files/validate.test.ts
@@ -427,4 +427,46 @@ describe("assertNoSymlinkEscape (write-path symlink containment)", () => {
       rmSync(base, { recursive: true, force: true });
     }
   });
+
+  it("allows a write under a later valid root when an earlier root cannot be resolved", () => {
+    // A root that exists but cannot be resolved (here ELOOP; EACCES on a
+    // mount behaves the same) must not decide the outcome for the OTHER
+    // roots. `some()` short-circuits in list order, so letting the error
+    // propagate would make an unrelated broken root deny a legitimate write
+    // and make the verdict depend on write_paths ordering.
+    const base = mkdtempSync(join(tmpdir(), "pinchy-escape-"));
+    try {
+      const loopRoot = join(base, "loop-a");
+      symlinkSync(join(base, "loop-b"), loopRoot);
+      symlinkSync(loopRoot, join(base, "loop-b"));
+      const sandbox = join(base, "sandbox");
+      mkdirSync(sandbox);
+
+      expect(() =>
+        assertNoSymlinkEscape(join(sandbox, "ok.txt"), [loopRoot, sandbox])
+      ).not.toThrow();
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
+
+  it("denies with the normal access message when a write root cannot be resolved", () => {
+    // An unresolvable root is skipped, not swallowed into a raw fs error:
+    // the caller still gets the actionable allow-list message it can retry
+    // against, and the write stays denied.
+    const base = mkdtempSync(join(tmpdir(), "pinchy-escape-"));
+    try {
+      const loopRoot = join(base, "loop-a");
+      symlinkSync(join(base, "loop-b"), loopRoot);
+      symlinkSync(loopRoot, join(base, "loop-b"));
+      const sandbox = join(base, "sandbox");
+      mkdirSync(sandbox);
+
+      expect(() => assertNoSymlinkEscape(join(sandbox, "ok.txt"), [loopRoot])).toThrow(
+        /not under any configured write path/
+      );
+    } finally {
+      rmSync(base, { recursive: true, force: true });
+    }
+  });
 });

--- a/packages/plugins/pinchy-files/validate.ts
+++ b/packages/plugins/pinchy-files/validate.ts
@@ -70,20 +70,31 @@ export function realpathWriteTarget(requestedPath: string): string {
  * Compares realpath-to-realpath (the target's resolved path against each
  * resolved write root) so it stays consistent on symlinked roots (e.g. macOS
  * `/var` -> `/private/var`) and only fires on a genuine escape.
+ *
+ * A configured write root may not exist on disk yet (e.g. a workspace's
+ * `memory/` directory or `MEMORY.md` file, granted by config before
+ * `ensureWorkspace` creates them). `realpathSync` throws ENOENT for those, and
+ * that is not a symlink escape — it is an ordinary not-yet-provisioned root.
+ * `realpathWriteTarget` is used for the root too (not just the target) so
+ * both sides resolve the deepest EXISTING ancestor and re-append the
+ * non-existent tail under the same rule: a merely-missing root and the
+ * target agree on where they resolve to, while a symlinked ancestor that
+ * genuinely escapes the root is still resolved and still caught.
  */
 export function assertNoSymlinkEscape(requestedPath: string, writePaths: string[]): void {
   const realTarget = realpathWriteTarget(requestedPath);
-  const contained = writePaths.some((p) => {
-    let realRoot: string;
-    try {
-      realRoot = realpathSync(p);
-    } catch {
-      return false;
-    }
-    return isUnderPath(realTarget, realRoot);
-  });
+  const contained = writePaths.some((p) => isUnderPath(realTarget, realpathWriteTarget(p)));
   if (!contained) {
-    throw new Error("Access denied: write target escapes the sandbox via a symlink");
+    // Only state what is actually known: the resolved target isn't under any
+    // configured write root. The previous message asserted "via a symlink"
+    // as the cause even when the true cause was a not-yet-existing write
+    // root, misdiagnosing a provisioning gap as an attack. Include the
+    // allow-list so an LLM agent that must retry can pick a valid path
+    // instead of guessing (#418 precedent, see validateAccess above).
+    const hint = writePaths.length > 0 ? ` (write_paths: ${writePaths.join(", ")})` : "";
+    throw new Error(
+      `Access denied: resolved write target is not under any configured write path${hint}`
+    );
   }
 }
 

--- a/packages/plugins/pinchy-files/validate.ts
+++ b/packages/plugins/pinchy-files/validate.ts
@@ -83,7 +83,21 @@ export function realpathWriteTarget(requestedPath: string): string {
  */
 export function assertNoSymlinkEscape(requestedPath: string, writePaths: string[]): void {
   const realTarget = realpathWriteTarget(requestedPath);
-  const contained = writePaths.some((p) => isUnderPath(realTarget, realpathWriteTarget(p)));
+  const contained = writePaths.some((p) => {
+    let realRoot: string;
+    try {
+      realRoot = realpathWriteTarget(p);
+    } catch {
+      // A root that exists but cannot be resolved at all (ELOOP, EACCES on a
+      // mount): it can never contain the target, so skip it. `some()`
+      // short-circuits in list order, so letting this propagate would let one
+      // broken root deny a write that a later valid root allows, and make the
+      // verdict depend on write_paths ordering. ENOENT is not handled here —
+      // realpathWriteTarget resolves a missing root rather than throwing.
+      return false;
+    }
+    return isUnderPath(realTarget, realRoot);
+  });
   if (!contained) {
     // Only state what is actually known: the resolved target isn't under any
     // configured write root. The previous message asserted "via a symlink"


### PR DESCRIPTION
## Summary

- `assertNoSymlinkEscape` in `packages/plugins/pinchy-files/validate.ts` used to `catch { return false }` when `realpathSync(writeRoot)` threw `ENOENT`. A configured write root that simply doesn't exist yet on disk was therefore indistinguishable from a genuine symlink escape, and every write to that root was rejected with a message asserting a symlink attack that never happened.
- This is a live production failure: `packages/web/src/lib/openclaw-config/build.ts` grants a write-capable agent `<workspace>/MEMORY.md` and `<workspace>/memory` as `write_paths`, but `ensureWorkspace` never creates them. Every agent memory write is denied. A production agent hit this and improvised by writing to `workbench/MEMORY.md` instead, which nothing reads. (A separate PR fixes `ensureWorkspace` to create those paths; this PR is the hardening that keeps a merely-missing root from ever again masquerading as an attack — both are needed since roots may legitimately not exist yet.)
- Fix: resolve write roots with the same `realpathWriteTarget()` rule already used for the target (realpath the deepest existing ancestor, re-append the non-existent tail), instead of `realpathSync` directly on the root. Root and target are now resolved by the same rule, so a merely-absent root agrees with the target instead of throwing.
- Also fixed the rejection message: it no longer claims "via a symlink" as the cause (the code cannot know that). It states what's actually known — the resolved write target is not under any configured write path — and includes the `write_paths` allow-list, mirroring the `validateAccess` precedent (#418) so a retrying LLM agent has something to act on.

## Security property unchanged

A genuine symlink escape (write root exists, an ancestor symlinks outside it) is still rejected. Proof: the existing test `throws when a symlinked ancestor escapes the write roots` in `validate.test.ts` stays green through this change (only its expected message text was updated to match the corrected wording — the assertion still requires rejection). A symlinked-root case (macOS `/var` -> `/private/var` shape) also stays allowed, with a new explicit test for it.

## Tests added (packages/plugins/pinchy-files/validate.test.ts)

- `allows a write target under a write root that does not exist yet (missing root ≠ symlink escape)` — the production-bug regression test. **Red** against the pre-fix code (threw the symlink-escape error); **green** after the fix.
- `allows write when the configured write root is itself a symlink resolving to the target's real location` — explicit symlinked-root regression guard (new).
- `throws when a symlinked ancestor escapes the write roots` (existing) — updated only to assert the new message text; still proves rejection of a genuine escape.

### Red output before the fix

```
FAIL  validate.test.ts > assertNoSymlinkEscape (write-path symlink containment) > throws when a symlinked ancestor escapes the write roots
AssertionError: expected [Function] to throw error matching /not under any configured write path/ but got 'Access denied: write target escapes t…'

FAIL  validate.test.ts > assertNoSymlinkEscape (write-path symlink containment) > allows a write target under a write root that does not exist yet (missing root ≠ symlink escape)
AssertionError: expected [Function] to not throw an error but 'Error: Access denied: write target es…' was thrown
```

### Green after the fix

```
Test Files  14 passed (14)
     Tests  180 passed | 2 skipped (182)
```

## Test plan

- [x] `pnpm --filter @pinchy/pinchy-files test` — 180 passed, 2 skipped (pre-existing, unrelated)
- [x] `pnpm typecheck:plugins` — all 8 plugin packages typecheck cleanly
- [x] `pnpm --filter @pinchy/web lint` — 0 errors (pre-existing warnings only, unrelated to this change)
- [x] `pnpm test:scripts` — 271 passed
- [x] `pnpm -C packages/web test` (full suite, includes plugin tests a second time per repo convention) — 8281 passed, 15 skipped