### PR TITLE
fix(ci): stop docs-only PRs blocking on checks that can never report

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,28 +1,21 @@
 name: CI
 
+# NOTE: deliberately NO `paths-ignore:` here. This workflow hosts main's
+# required status checks, and a workflow that never starts never reports a
+# status — so a docs-only PR would sit forever on "Expected — Waiting for status
+# to be reported", unmergeable with nothing actually broken. The same path
+# filter now lives at the JOB level: the `changes` job below works out whether
+# real code changed, and every expensive job is gated on it. The required checks
+# themselves are never gated, so they always report.
 on:
   push:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - "PERSONALITY.md"
-      - "sample-data/**"
-      - "screenshots/**"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "docs/**"
-      - "**/*.md"
-      - ".github/ISSUE_TEMPLATE/**"
-      - "PERSONALITY.md"
-      - "sample-data/**"
-      - "screenshots/**"
   # Manual trigger: lets a maintainer re-run the full CI (incl. osv-scan) on a
-  # ref on demand. Needed because docs-only / *.md changes are paths-ignored
-  # above, so a docs-lockfile security bump (osv-scan reads docs/pnpm-lock.yaml)
-  # cannot otherwise produce a fresh green run on main to clear a stale red one.
+  # ref on demand — e.g. to clear a stale red main after a docs-lockfile
+  # security bump (osv-scan reads docs/pnpm-lock.yaml), which the `changes`
+  # gate classifies as docs-only.
   workflow_dispatch:
 
 # Cancel in-progress runs on the same PR/branch when a new commit is pushed.
@@ -32,8 +25,55 @@ concurrency:
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
+  # Replaces the workflow-level `paths-ignore` this file used to carry (see the
+  # note above `on:`). Every expensive job gates on `code`; the required checks
+  # (quality, vitest-integration, e2e) deliberately do NOT, so they report on
+  # every PR instead of relying on GitHub's "a skipped job counts as success"
+  # behaviour for the one thing protecting main.
+  #
+  # Decision logic + the drift guards keeping this wiring honest live in
+  # scripts/lib/ci-path-filter.mjs and its test (run by `pnpm test:scripts`).
+  changes:
+    name: Detect changed paths
+    runs-on: ubuntu-latest
+    outputs:
+      code: ${{ steps.filter.outputs.code }}
+    steps:
+      - uses: actions/checkout@v7
+        with:
+          # Enough history for a merge-base against the target branch. The
+          # filter falls back to "run everything" if a base can't be resolved,
+          # so a too-shallow clone costs CI minutes, never coverage.
+          fetch-depth: 0
+
+      - id: filter
+        env:
+          BASE_REF: ${{ github.base_ref }}
+          BEFORE: ${{ github.event.before }}
+        run: |
+          if [ "${{ github.event_name }}" = "pull_request" ]; then
+            BASE="origin/$BASE_REF"
+          elif [ "${{ github.event_name }}" = "push" ]; then
+            BASE="$BEFORE"
+          else
+            # workflow_dispatch: an explicit manual run always means "run it all".
+            echo "Manual run — full matrix."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # An unresolvable base (first push to a branch, force push, grafted
+          # history) yields an empty diff, which the filter reads as "unknown"
+          # and answers with the full matrix.
+          if ! git rev-parse --verify --quiet "$BASE^{commit}" >/dev/null; then
+            echo "Base '$BASE' not resolvable — full matrix."
+            echo "code=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          git diff --name-only "$BASE...HEAD" | node scripts/detect-code-changes.mjs
+
   build-image:
     name: Build Pinchy + OpenClaw images
+    needs: changes
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -41,7 +81,9 @@ jobs:
     # Skip on fork PRs: GITHUB_TOKEN is read-only for forks and cannot push
     # to GHCR. Non-PR pushes (main) and same-repo PRs always run.
     # Downstream jobs fall back to per-job local build when this is skipped.
-    if: github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true
+    if: >-
+      needs.changes.outputs.code == 'true' &&
+      (github.event_name != 'pull_request' || github.event.pull_request.head.repo.fork != true)
     outputs:
       pinchy-image: ${{ steps.tags.outputs.pinchy }}
       openclaw-image: ${{ steps.tags.outputs.openclaw }}
@@ -239,6 +281,8 @@ jobs:
 
   license-keypair:
     name: Verify License Keypair
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
@@ -347,10 +391,14 @@ jobs:
 
   docker-smoke:
     name: Docker smoke test
-    needs: build-image
-    # Run even when build-image is skipped (fork PRs) or on push events
+    needs: [changes, build-image]
+    # Run even when build-image is skipped: on fork PRs that's by design and we
+    # fall back to a local build below. But build-image is ALSO skipped on a
+    # docs-only PR — where we must not build anything at all — so the changes
+    # gate has to be explicit rather than inferred from build-image's result.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     runs-on: ubuntu-latest
@@ -814,9 +862,13 @@ jobs:
 
   end-user-install:
     name: End-user install simulation
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke: build-image is skipped both on fork PRs (fall back to a
+    # local build) and on docs-only PRs (build nothing) — only the changes gate
+    # tells those two apart.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -960,9 +1012,13 @@ jobs:
 
   end-user-upgrade:
     name: End-user upgrade simulation
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke: build-image is skipped both on fork PRs (fall back to a
+    # local build) and on docs-only PRs (build nothing) — only the changes gate
+    # tells those two apart.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1200,9 +1256,12 @@ jobs:
   odoo-e2e:
     name: Odoo E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1332,9 +1391,12 @@ jobs:
   web-e2e:
     name: Web Search E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1455,9 +1517,12 @@ jobs:
     # email-microsoft.spec.ts against gmail-mock + graph-mock.
     name: Email E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1582,9 +1647,12 @@ jobs:
     # GreenMail server (SMTP+IMAP) fronted by the imap-mock control sidecar.
     name: IMAP E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1706,9 +1774,12 @@ jobs:
   setup-wizard-e2e:
     name: Setup Wizard E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -1829,9 +1900,12 @@ jobs:
   telegram-e2e:
     name: Telegram E2E Tests
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -2004,9 +2078,12 @@ jobs:
   integration:
     name: Integration Tests (OpenClaw + Fake Ollama)
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -2172,9 +2249,12 @@ jobs:
     # (stochastic + paid); see #669 for the on-demand/scheduled follow-ups.
     name: Eval Harness Self-Test
     runs-on: ubuntu-latest
-    needs: build-image
+    needs: [changes, build-image]
+    # See docker-smoke on why the changes gate is explicit rather than inferred
+    # from build-image being skipped.
     if: >-
       always() &&
+      needs.changes.outputs.code == 'true' &&
       (needs.build-image.result == 'success' ||
        needs.build-image.result == 'skipped')
     permissions:
@@ -2300,6 +2380,8 @@ jobs:
 
   ollama-integration:
     name: Ollama integration tests
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -2346,6 +2428,8 @@ jobs:
 
   links:
     name: Check links
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:
@@ -2380,6 +2464,8 @@ jobs:
   # depend on npm's legacy audit API.
   vuln-scan:
     name: Security audit
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     uses: "google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@v2.3.8"
     with:
       scan-args: |-
@@ -2393,6 +2479,8 @@ jobs:
 
   repo-hygiene:
     name: Repo hygiene
+    needs: changes
+    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -47,13 +47,18 @@ jobs:
           fetch-depth: 0
 
       - id: filter
+        # Every github.* value reaches the script through env, never through
+        # `${{ }}` interpolation into the shell — event_name is a closed enum and
+        # harmless, but a half-interpolated script invites the next edit to add a
+        # branch name or PR title, which are attacker-controlled.
         env:
+          EVENT_NAME: ${{ github.event_name }}
           BASE_REF: ${{ github.base_ref }}
           BEFORE: ${{ github.event.before }}
         run: |
-          if [ "${{ github.event_name }}" = "pull_request" ]; then
+          if [ "$EVENT_NAME" = "pull_request" ]; then
             BASE="origin/$BASE_REF"
-          elif [ "${{ github.event_name }}" = "push" ]; then
+          elif [ "$EVENT_NAME" = "push" ]; then
             BASE="$BEFORE"
           else
             # workflow_dispatch: an explicit manual run always means "run it all".
@@ -2426,10 +2431,12 @@ jobs:
         env:
           OLLAMA_URL: http://localhost:11434
 
+  # Deliberately NOT gated on `changes`: this job checks `**/*.md` / `**/*.mdx`,
+  # i.e. exactly the files a "docs-only" PR consists of. Gating it would skip the
+  # link check on precisely the PRs that edit links. It is cheap (checkout + one
+  # lychee run), so it runs on every PR.
   links:
     name: Check links
-    needs: changes
-    if: needs.changes.outputs.code == 'true'
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/docs-format.yml
+++ b/.github/workflows/docs-format.yml
@@ -1,17 +1,17 @@
 # Prettier check for docs & workflow files.
 #
-# The main CI workflow (`ci.yml`) is deliberately `paths-ignore: [docs/**,
-# **/*.md, ...]` so its heavy build/test/e2e matrix does not run on docs-only
-# changes. But that also meant its "Format check (docs & workflows)" step never
-# ran on the docs PRs it exists to guard — it only fired as collateral on
-# unrelated code PRs, where a pre-existing docs-formatting slip surfaced as a
-# confusing failure attributed to unrelated code (observed: an unformatted
-# .mdx merged via a docs-only PR, then reddened a plugin PR's CI).
+# `ci.yml` skips its heavy build/test/e2e matrix on docs-only changes (its
+# `changes` job gates every expensive job). Its old "Format check (docs &
+# workflows)" step therefore never ran on the docs PRs it existed to guard —
+# it only fired as collateral on unrelated code PRs, where a pre-existing
+# docs-formatting slip surfaced as a confusing failure attributed to unrelated
+# code (observed: an unformatted .mdx merged via a docs-only PR, then reddened
+# a plugin PR's CI).
 #
 # This dedicated workflow closes that gap: it runs the exact same prettier
-# check, but triggers on the docs/workflow paths themselves (the inverse of
-# ci.yml's ignore), so docs formatting is validated on the PR that changes it.
-# It is intentionally lightweight (checkout + setup + one prettier run).
+# check, but triggers on the docs/workflow paths themselves, so docs formatting
+# is validated on the PR that changes it. It is intentionally lightweight
+# (checkout + setup + one prettier run).
 name: Docs & Workflow Format
 
 on:

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -93,6 +93,20 @@ Concretely:
 - **Simulate the pre-existing state:** let the new path capture/write, then delete those rows for the entity, then assert the feature still works (it must fall back or have been backfilled). See `deleteCapturedTelegramMessages` + the "listed ⟹ readable" test in `packages/web/e2e/telegram/chats.spec.ts`, and the deterministic route-level equivalent in `packages/web/src/__tests__/api/agent-telegram-chat.test.ts`.
 - **Assert the cross-route invariant**, not just one route in isolation: if an item appears in a list, opening it must show content (or a defined, honest empty state). List and detail are often changed independently.
 
+## CI Path Filtering Is Job-Level, Never Workflow-Level
+
+`.github/workflows/ci.yml` must **never** carry `paths-ignore:` (or `paths:`) on its triggers. It hosts main's required status checks, and a workflow that never starts never reports a status — so a docs-only PR would sit forever on "Expected — Waiting for status to be reported": unmergeable, with nothing actually broken. This is exactly what the old `paths-ignore: [docs/**, "**/*.md", ...]` did once those checks became required.
+
+The filter now lives one level down:
+
+- The **`changes` job** diffs the PR against its base and outputs `code=true|false` via `scripts/detect-code-changes.mjs`. Pure logic is in `scripts/lib/ci-path-filter.mjs` (`hasCodeChanges`), covered by `scripts/lib/ci-path-filter.test.mjs` (`pnpm test:scripts`).
+- **Required-check jobs** (`quality`, `vitest-integration`, `e2e` — the names in branch protection, listed as `ALWAYS_RUN_JOBS`) are **never gated**. They run and report on every PR, so no required check depends on GitHub's subtle "a skipped job counts as success" behaviour.
+- **Every other job** carries `needs: changes` + `if: needs.changes.outputs.code == 'true'`, which is where the CI-minute saving comes from. A gated job is genuinely skipped on a docs-only PR.
+
+Two mistakes the drift guards in `ci-path-filter.test.mjs` exist to catch: re-adding `paths-ignore` (the original bug), and adding a new job without the gate (it would silently run the full Docker/E2E matrix on every README typo).
+
+An unresolvable base or empty diff deliberately answers **`code=true`**: wasting CI minutes is recoverable, skipping the matrix on a real code change is not. When adding a job that depends on `build-image`, note that `build-image` is skipped both on fork PRs (fall back to a local build) and on docs-only PRs (build nothing) — only the explicit `changes` gate tells those two apart.
+
 ## Web Test Files Are Type-Checked
 
 `packages/web` test files (`*.test.ts(x)`, `*.integration.test.ts`, `*.test-d.ts`) are type-checked in CI by the `quality` job's "Typecheck web (incl. tests)" step: `pnpm -C packages/web typecheck` → `tsc --noEmit -p packages/web/tsconfig.typecheck.json`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -100,10 +100,14 @@ Concretely:
 The filter now lives one level down:
 
 - The **`changes` job** diffs the PR against its base and outputs `code=true|false` via `scripts/detect-code-changes.mjs`. Pure logic is in `scripts/lib/ci-path-filter.mjs` (`hasCodeChanges`), covered by `scripts/lib/ci-path-filter.test.mjs` (`pnpm test:scripts`).
-- **Required-check jobs** (`quality`, `vitest-integration`, `e2e` — the names in branch protection, listed as `ALWAYS_RUN_JOBS`) are **never gated**. They run and report on every PR, so no required check depends on GitHub's subtle "a skipped job counts as success" behaviour.
+- **Ungated jobs** are listed in `UNGATED_JOBS` with the reason each one carries no gate. Two distinct reasons — don't conflate them:
+  - `required` (`quality`, `vitest-integration`, `e2e` — the names in branch protection, exposed as `REQUIRED_JOBS`): they must report on every PR, so no required check depends on GitHub's subtle "a skipped job counts as success" behaviour.
+  - `docs-relevant` (`links`): the job guards exactly the files a docs-only PR consists of (`**/*.md`), so gating it would skip the check on precisely the PRs that need it. Only worth it for cheap jobs.
 - **Every other job** carries `needs: changes` + `if: needs.changes.outputs.code == 'true'`, which is where the CI-minute saving comes from. A gated job is genuinely skipped on a docs-only PR.
 
-Two mistakes the drift guards in `ci-path-filter.test.mjs` exist to catch: re-adding `paths-ignore` (the original bug), and adding a new job without the gate (it would silently run the full Docker/E2E matrix on every README typo).
+Mistakes the drift guards in `ci-path-filter.test.mjs` exist to catch: re-adding `paths-ignore` (the original bug); adding a new job without the gate (it would silently run the full Docker/E2E matrix on every README typo); an `UNGATED_JOBS` entry that is actually gated in `ci.yml` (a list that lies); and a lockfile `vuln-scan` reads that the filter treats as docs.
+
+**Ignoring a path is a claim that no gated job reads it.** `docs/**` is prose with one carve-out: `docs/pnpm-lock.yaml` counts as **code**, because `vuln-scan` scans it — classifying a docs-lockfile security bump as docs-only would skip the very scan that proves the fix and leave main red until someone hand-ran `workflow_dispatch`. Before adding an ignore rule, check which gated job reads those files.
 
 An unresolvable base or empty diff deliberately answers **`code=true`**: wasting CI minutes is recoverable, skipping the matrix on a real code change is not. When adding a job that depends on `build-image`, note that `build-image` is skipped both on fork PRs (fall back to a local build) and on docs-only PRs (build nothing) — only the explicit `changes` gate tells those two apart.
 

--- a/scripts/detect-code-changes.mjs
+++ b/scripts/detect-code-changes.mjs
@@ -1,0 +1,35 @@
+#!/usr/bin/env node
+/**
+ * Reads changed file paths on stdin (one per line, as `git diff --name-only`
+ * emits them) and writes `code=true|false` to $GITHUB_OUTPUT for ci.yml's
+ * `changes` job to gate the expensive job matrix on.
+ *
+ * Pure decision logic lives in lib/ci-path-filter.mjs and is unit-tested; this
+ * wrapper only does the I/O.
+ */
+
+import { appendFileSync } from "node:fs";
+import { hasCodeChanges } from "./lib/ci-path-filter.mjs";
+
+async function readStdin() {
+  const chunks = [];
+  for await (const chunk of process.stdin) chunks.push(chunk);
+  return Buffer.concat(chunks).toString("utf8");
+}
+
+const paths = (await readStdin()).split("\n");
+const code = hasCodeChanges(paths);
+
+const listed = paths.map((p) => p.trim()).filter(Boolean);
+console.log(`Changed files (${listed.length}):`);
+for (const p of listed) console.log(`  ${p}`);
+console.log(
+  code
+    ? "→ code=true: running the full CI matrix."
+    : "→ code=false: docs-only change, skipping the build/E2E matrix. " +
+        "Required checks still run and report."
+);
+
+if (process.env.GITHUB_OUTPUT) {
+  appendFileSync(process.env.GITHUB_OUTPUT, `code=${code}\n`);
+}

--- a/scripts/lib/ci-path-filter.mjs
+++ b/scripts/lib/ci-path-filter.mjs
@@ -1,0 +1,63 @@
+/**
+ * Decides whether a set of changed files justifies CI's expensive job matrix.
+ *
+ * This replaces the `paths-ignore:` that ci.yml used to carry. That filter
+ * worked at the WORKFLOW level, which is exactly why it had to go: ci.yml hosts
+ * main's required status checks, and a workflow that never starts never reports
+ * a status — so a docs-only PR sat forever on "Expected — Waiting for status to
+ * be reported" and could not be merged, with nothing actually broken.
+ *
+ * The fix keeps the workflow always starting, and moves the same path filter
+ * down to the JOB level:
+ *   - the required checks (ALWAYS_RUN_JOBS) run on every PR and always report;
+ *   - every other job is gated on the `changes` job and is simply skipped when
+ *     only docs changed, which is where the CI-minute saving actually came from.
+ *
+ * The drift guards in ci-path-filter.test.mjs keep that wiring honest.
+ */
+
+/**
+ * Paths that never need the Docker/E2E matrix, as predicates rather than globs
+ * — the set is small and fixed, so a glob engine would be more machinery than
+ * the job needs. Each mirrors the glob ci.yml used to ignore.
+ *
+ * `PERSONALITY.md` is covered by the `**\/*.md` rule and needs no entry.
+ */
+const IGNORED_PATHS = [
+  { glob: "docs/**", matches: (p) => p.startsWith("docs/") },
+  { glob: "**/*.md", matches: (p) => p.endsWith(".md") },
+  {
+    glob: ".github/ISSUE_TEMPLATE/**",
+    matches: (p) => p.startsWith(".github/ISSUE_TEMPLATE/"),
+  },
+  { glob: "sample-data/**", matches: (p) => p.startsWith("sample-data/") },
+  { glob: "screenshots/**", matches: (p) => p.startsWith("screenshots/") },
+];
+
+/** ci.yml jobs that must run on every PR because branch protection requires them. */
+export const ALWAYS_RUN_JOBS = ["quality", "vitest-integration", "e2e"];
+
+/** The `if:` condition every other ci.yml job must carry. */
+export const GATE_EXPRESSION = "needs.changes.outputs.code == 'true'";
+
+/**
+ * @param {string} path repo-relative path of a changed file
+ * @returns {boolean} true when the path cannot affect build/test outcomes
+ */
+export function isIgnoredPath(path) {
+  return IGNORED_PATHS.some((rule) => rule.matches(path));
+}
+
+/**
+ * @param {string[]} paths repo-relative paths of every changed file
+ * @returns {boolean} true when the expensive job matrix must run
+ */
+export function hasCodeChanges(paths) {
+  const changed = paths.map((p) => p.trim()).filter((p) => p.length > 0);
+  // An empty list means we could not determine what changed (shallow clone,
+  // force push, unresolvable base) — not that nothing did. Run everything:
+  // wasting CI minutes is recoverable, skipping the matrix on a real code
+  // change is not.
+  if (changed.length === 0) return true;
+  return changed.some((p) => !isIgnoredPath(p));
+}

--- a/scripts/lib/ci-path-filter.mjs
+++ b/scripts/lib/ci-path-filter.mjs
@@ -9,12 +9,21 @@
  *
  * The fix keeps the workflow always starting, and moves the same path filter
  * down to the JOB level:
- *   - the required checks (ALWAYS_RUN_JOBS) run on every PR and always report;
+ *   - the UNGATED_JOBS run on every PR and always report;
  *   - every other job is gated on the `changes` job and is simply skipped when
  *     only docs changed, which is where the CI-minute saving actually came from.
  *
  * The drift guards in ci-path-filter.test.mjs keep that wiring honest.
  */
+
+/**
+ * docs/ is prose — except its dependency manifest. vuln-scan explicitly scans
+ * `./docs/pnpm-lock.yaml`, so treating a docs-lockfile security bump as
+ * "docs-only" would skip the very scan that proves the fix, and main would stay
+ * red until someone hand-ran workflow_dispatch. The lockfile guard in the test
+ * pins this to vuln-scan's real arguments rather than to this comment.
+ */
+const DOCS_LOCKFILE = "docs/pnpm-lock.yaml";
 
 /**
  * Paths that never need the Docker/E2E matrix, as predicates rather than globs
@@ -24,7 +33,7 @@
  * `PERSONALITY.md` is covered by the `**\/*.md` rule and needs no entry.
  */
 const IGNORED_PATHS = [
-  { glob: "docs/**", matches: (p) => p.startsWith("docs/") },
+  { glob: "docs/**", matches: (p) => p.startsWith("docs/") && p !== DOCS_LOCKFILE },
   { glob: "**/*.md", matches: (p) => p.endsWith(".md") },
   {
     glob: ".github/ISSUE_TEMPLATE/**",
@@ -34,8 +43,28 @@ const IGNORED_PATHS = [
   { glob: "screenshots/**", matches: (p) => p.startsWith("screenshots/") },
 ];
 
-/** ci.yml jobs that must run on every PR because branch protection requires them. */
-export const ALWAYS_RUN_JOBS = ["quality", "vitest-integration", "e2e"];
+/**
+ * ci.yml jobs that deliberately carry no `changes` gate, and why. The two
+ * reasons are distinct, and an earlier single "always run" list conflated them:
+ *
+ *   - `required` — named in main's branch protection. A required check must
+ *     report on EVERY pull request, so gating it would rest main's protection on
+ *     GitHub's subtle "a skipped job counts as success" behaviour.
+ *   - `docs-relevant` — cheap, and guards exactly the files a docs-only PR
+ *     changes. `links` checks `**\/*.md`, so gating it would skip the link check
+ *     on precisely the PRs that edit links.
+ */
+export const UNGATED_JOBS = {
+  quality: "required",
+  "vitest-integration": "required",
+  e2e: "required",
+  links: "docs-relevant",
+};
+
+/** The UNGATED_JOBS subset that branch protection requires. */
+export const REQUIRED_JOBS = Object.entries(UNGATED_JOBS)
+  .filter(([, reason]) => reason === "required")
+  .map(([name]) => name);
 
 /** The `if:` condition every other ci.yml job must carry. */
 export const GATE_EXPRESSION = "needs.changes.outputs.code == 'true'";

--- a/scripts/lib/ci-path-filter.test.mjs
+++ b/scripts/lib/ci-path-filter.test.mjs
@@ -1,0 +1,108 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { join, dirname, resolve } from "node:path";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { splitWorkflowIntoJobs } from "./workflow-jobs.mjs";
+import { hasCodeChanges, ALWAYS_RUN_JOBS, GATE_EXPRESSION } from "./ci-path-filter.mjs";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const CI_WORKFLOW = join(ROOT, ".github", "workflows", "ci.yml");
+
+// ---------------------------------------------------------------------------
+// hasCodeChanges: which changed files justify the expensive CI matrix
+// ---------------------------------------------------------------------------
+
+test("a source change is a code change", () => {
+  assert.equal(hasCodeChanges(["packages/web/src/lib/auth.ts"]), true);
+});
+
+test("docs-only, markdown-only and sample-data-only changes are not code changes", () => {
+  assert.equal(hasCodeChanges(["docs/src/content/docs/guides/agents.mdx"]), false);
+  assert.equal(hasCodeChanges(["README.md"]), false);
+  assert.equal(hasCodeChanges(["PERSONALITY.md"]), false);
+  assert.equal(hasCodeChanges(["packages/web/README.md"]), false);
+  assert.equal(hasCodeChanges([".github/ISSUE_TEMPLATE/bug.yml"]), false);
+  assert.equal(hasCodeChanges(["sample-data/handbook.txt"]), false);
+  assert.equal(hasCodeChanges(["screenshots/chat.png"]), false);
+});
+
+test("one code file among many docs files still makes it a code change", () => {
+  assert.equal(hasCodeChanges(["docs/a.mdx", "README.md", "packages/web/src/x.ts"]), true);
+});
+
+// A workflow edit changes CI itself — it must never skip the matrix that would
+// prove the edit works. `.github/ISSUE_TEMPLATE/**` is the deliberate exception.
+test("a workflow change is a code change", () => {
+  assert.equal(hasCodeChanges([".github/workflows/ci.yml"]), true);
+});
+
+// An .mdx outside docs/ is matched by neither `docs/**` nor `**/*.md`. Treating
+// it as code is the safe direction: it may be a component fixture, not prose.
+test("an mdx file outside docs/ is a code change", () => {
+  assert.equal(hasCodeChanges(["packages/web/src/content/note.mdx"]), true);
+});
+
+// An empty diff means we failed to work out what changed (shallow clone, force
+// push, unresolvable base). Guessing "docs only" there would silently skip the
+// whole matrix on a real code change, so an unknown diff must run everything.
+test("an empty or unknown file list runs the full matrix", () => {
+  assert.equal(hasCodeChanges([]), true);
+});
+
+test("blank lines from a git diff are ignored, not treated as code", () => {
+  assert.equal(hasCodeChanges(["README.md", "", "  "]), false);
+});
+
+// ---------------------------------------------------------------------------
+// Drift guards: the wiring that makes the filter safe
+// ---------------------------------------------------------------------------
+
+// The bug this whole mechanism replaces: ci.yml was `paths-ignore`d for docs,
+// so a docs-only PR never STARTED the workflow — and a required check that
+// never runs never reports, leaving the PR permanently stuck on "Expected —
+// Waiting for status to be reported". Job-level gating (below) is the fix
+// precisely because the workflow still starts and still reports.
+test("ci.yml has no paths-ignore — it must always start so required checks report", () => {
+  const yaml = readFileSync(CI_WORKFLOW, "utf8");
+  const uncommented = yaml
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+  assert.ok(
+    !/paths-ignore:/.test(uncommented),
+    "ci.yml must not use paths-ignore: it hosts required status checks, and a workflow that never starts blocks the PR forever. Gate individual jobs on the `changes` job instead."
+  );
+});
+
+// These are the jobs named in main's branch protection. A required check must
+// report on EVERY pull request, so it must not be gated — not even behind the
+// changes job, which would make it depend on GitHub's subtle "a skipped job
+// counts as success" behaviour for the one thing protecting main.
+test("required-check jobs are never gated", () => {
+  const jobs = splitWorkflowIntoJobs(CI_WORKFLOW);
+  for (const name of ALWAYS_RUN_JOBS) {
+    const job = jobs.find((j) => j.jobName === name);
+    assert.ok(job, `ci.yml must define the required-check job "${name}"`);
+    assert.ok(
+      !job.body.includes("needs.changes"),
+      `"${name}" is a required status check and must run on every PR, so it must not be gated on the changes job`
+    );
+  }
+});
+
+// Without this, a newly added job silently runs the full Docker/E2E matrix on
+// every README typo — the cost the removed paths-ignore used to avoid.
+test("every other job is gated on the changes job", () => {
+  const exempt = new Set([...ALWAYS_RUN_JOBS, "changes"]);
+  const offenders = splitWorkflowIntoJobs(CI_WORKFLOW)
+    .filter((job) => !exempt.has(job.jobName))
+    .filter((job) => !job.body.includes(GATE_EXPRESSION))
+    .map((job) => job.jobName);
+
+  assert.deepEqual(
+    offenders,
+    [],
+    `these ci.yml jobs must be skipped on docs-only PRs — add \`needs: changes\` and \`if: ${GATE_EXPRESSION}\`: ${offenders.join(", ")}`
+  );
+});

--- a/scripts/lib/ci-path-filter.test.mjs
+++ b/scripts/lib/ci-path-filter.test.mjs
@@ -4,7 +4,12 @@ import { join, dirname, resolve } from "node:path";
 import { readFileSync } from "node:fs";
 import { fileURLToPath } from "node:url";
 import { splitWorkflowIntoJobs } from "./workflow-jobs.mjs";
-import { hasCodeChanges, ALWAYS_RUN_JOBS, GATE_EXPRESSION } from "./ci-path-filter.mjs";
+import {
+  hasCodeChanges,
+  UNGATED_JOBS,
+  REQUIRED_JOBS,
+  GATE_EXPRESSION,
+} from "./ci-path-filter.mjs";
 
 const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..", "..");
 const CI_WORKFLOW = join(ROOT, ".github", "workflows", "ci.yml");
@@ -35,6 +40,18 @@ test("one code file among many docs files still makes it a code change", () => {
 // prove the edit works. `.github/ISSUE_TEMPLATE/**` is the deliberate exception.
 test("a workflow change is a code change", () => {
   assert.equal(hasCodeChanges([".github/workflows/ci.yml"]), true);
+});
+
+// docs/ is prose, but its lockfile is a dependency manifest that vuln-scan
+// actually reads. Classifying a docs-lockfile security bump as "docs-only"
+// would skip the very scan that proves the fix, leaving main red until someone
+// hand-ran workflow_dispatch. The guard below pins this to vuln-scan's config.
+test("the docs lockfile is a code change even though it lives under docs/", () => {
+  assert.equal(hasCodeChanges(["docs/pnpm-lock.yaml"]), true);
+});
+
+test("docs prose next to the lockfile is still not a code change", () => {
+  assert.equal(hasCodeChanges(["docs/src/content/docs/index.mdx"]), false);
 });
 
 // An .mdx outside docs/ is matched by neither `docs/**` nor `**/*.md`. Treating
@@ -75,26 +92,33 @@ test("ci.yml has no paths-ignore — it must always start so required checks rep
   );
 });
 
-// These are the jobs named in main's branch protection. A required check must
-// report on EVERY pull request, so it must not be gated — not even behind the
-// changes job, which would make it depend on GitHub's subtle "a skipped job
-// counts as success" behaviour for the one thing protecting main.
-test("required-check jobs are never gated", () => {
+// A required check must report on EVERY pull request, so it must not be gated —
+// not even behind the changes job, which would make it depend on GitHub's subtle
+// "a skipped job counts as success" behaviour for the one thing protecting main.
+// The other UNGATED_JOBS are ungated for a weaker reason (see the list), but the
+// list still has to describe ci.yml or it is just a comment that lies.
+test("every job listed as ungated really is ungated", () => {
   const jobs = splitWorkflowIntoJobs(CI_WORKFLOW);
-  for (const name of ALWAYS_RUN_JOBS) {
+  for (const [name, reason] of Object.entries(UNGATED_JOBS)) {
     const job = jobs.find((j) => j.jobName === name);
-    assert.ok(job, `ci.yml must define the required-check job "${name}"`);
+    assert.ok(job, `ci.yml must define the job "${name}" listed in UNGATED_JOBS`);
     assert.ok(
       !job.body.includes("needs.changes"),
-      `"${name}" is a required status check and must run on every PR, so it must not be gated on the changes job`
+      `"${name}" is listed in UNGATED_JOBS (${reason}) but is gated on the changes job in ci.yml — either drop the gate or drop the listing`
     );
+  }
+});
+
+test("REQUIRED_JOBS is the branch-protection subset of UNGATED_JOBS", () => {
+  for (const name of REQUIRED_JOBS) {
+    assert.equal(UNGATED_JOBS[name], "required", `"${name}" must be listed as required in UNGATED_JOBS`);
   }
 });
 
 // Without this, a newly added job silently runs the full Docker/E2E matrix on
 // every README typo — the cost the removed paths-ignore used to avoid.
 test("every other job is gated on the changes job", () => {
-  const exempt = new Set([...ALWAYS_RUN_JOBS, "changes"]);
+  const exempt = new Set([...Object.keys(UNGATED_JOBS), "changes"]);
   const offenders = splitWorkflowIntoJobs(CI_WORKFLOW)
     .filter((job) => !exempt.has(job.jobName))
     .filter((job) => !job.body.includes(GATE_EXPRESSION))
@@ -104,5 +128,25 @@ test("every other job is gated on the changes job", () => {
     offenders,
     [],
     `these ci.yml jobs must be skipped on docs-only PRs — add \`needs: changes\` and \`if: ${GATE_EXPRESSION}\`: ${offenders.join(", ")}`
+  );
+});
+
+// Ties the filter to what the scanner actually reads. vuln-scan is gated, so a
+// lockfile it scans must count as code — otherwise the PR that bumps that
+// lockfile to fix a vulnerability skips the scan that would prove the fix. This
+// fires if someone adds a --lockfile under an ignored path (e.g. a second docs
+// site) without teaching the filter about it.
+test("every lockfile vuln-scan reads counts as a code change", () => {
+  const vulnScan = splitWorkflowIntoJobs(CI_WORKFLOW).find((j) => j.jobName === "vuln-scan");
+  assert.ok(vulnScan, "ci.yml must define the vuln-scan job");
+
+  const lockfiles = [...vulnScan.body.matchAll(/--lockfile=\.\/(\S+)/g)].map((m) => m[1]);
+  assert.ok(lockfiles.length > 0, "expected vuln-scan to scan at least one lockfile");
+
+  const invisible = lockfiles.filter((path) => !hasCodeChanges([path]));
+  assert.deepEqual(
+    invisible,
+    [],
+    `vuln-scan reads these lockfiles, but the filter treats them as docs — a security bump there would skip the scan: ${invisible.join(", ")}`
   );
 });


### PR DESCRIPTION
## The bug

`ci.yml` carried `paths-ignore: [docs/**, "**/*.md", ".github/ISSUE_TEMPLATE/**", "PERSONALITY.md", "sample-data/**", "screenshots/**"]` on both triggers.

That was a harmless CI-minute saving right up until branch protection started requiring **Lint, Test & Build**, **E2E Tests** and **Vitest Integration Tests (real DB)** — all three of which live in this workflow.

A docs-only PR never starts the workflow. A workflow that never starts never reports a status. GitHub waits for a result that cannot come:

> Expected — Waiting for status to be reported

The PR is permanently unmergeable, nothing is actually broken, and no error explains why. Every future docs/README PR would have hit this.

## The fix

Move the same path filter from the **workflow** level down to the **job** level, where a skip is a reported outcome rather than silence.

- **`changes` job** — diffs against the PR base, outputs `code=true|false`.
- **Required checks are never gated.** `quality`, `vitest-integration` and `e2e` run and report on every PR. Deliberate: gating them would make the only thing protecting `main` depend on GitHub's subtle "a skipped job counts as success" rule.
- **The other 17 jobs gate on `changes`** — that's where the CI-minute saving actually came from. A docs-only PR runs 4 jobs instead of 21.

| | docs-only PR | code PR |
|---|---|---|
| Before | 0 jobs — **PR blocked forever** | 20 jobs |
| After | 5 jobs — required checks report ✅ | 21 jobs |

### Decisions worth reviewing

- **Unknown diff ⇒ run everything.** An unresolvable base (shallow clone, force push) yields an empty diff, which answers `code=true`. Wasted CI minutes are recoverable; a skipped matrix on a real code change is not.
- **`build-image` dependants gate explicitly.** It's now skipped both on fork PRs (fall back to a local build) *and* on docs-only PRs (build nothing). Their existing `if` allowed `result == 'skipped'`, so without an explicit gate they would have started on exactly the PRs we want quiet.
- **Workflow edits count as code**, so a CI change can never skip the matrix that proves it works.
- **Bonus:** docs PRs now get the astro build + docs lint from `quality`, plus the `links` check — all of which the workflow-level ignore had been skipping entirely, so a broken MDX or a dead link in a docs PR was caught by nothing.
- **Ignoring a path claims no gated job reads it.** Reviewing that claim caught two jobs the filter was blinding (fixed in the second commit): `vuln-scan` scans `docs/pnpm-lock.yaml`, so that file counts as **code** — otherwise a security bump skips the scan proving the fix. And `links` checks `**/*.md`, exactly what a docs-only PR is, so it is **ungated**. Note in-page anchors within `docs/` remain unchecked by anything: `links` excludes `--exclude-path docs`. Pre-existing, out of scope here.

## Tests

`scripts/lib/ci-path-filter.mjs` holds the pure decision logic; `ci-path-filter.test.mjs` (14 tests, `pnpm test:scripts`) covers it plus three drift guards that fail if:

1. `paths-ignore` ever returns to `ci.yml` (the original bug),
2. a job listed in `UNGATED_JOBS` is actually gated in `ci.yml` (a list that lies),
3. a new job forgets the gate (it would silently run the full Docker/E2E matrix on every README typo),
4. a lockfile `vuln-scan` reads is treated as docs — the guard parses vuln-scan's real `--lockfile` arguments, so it is pinned to the scanner's config rather than to a comment.

Gates run locally: `pnpm test:scripts` 285 pass / 0 fail; prettier docs+workflow gate clean. `ci.yml` verified through a real YAML parser, and job selection simulated for both branches of the filter (table above).

## Follow-up for a human

Consider adding **`Detect changed paths`** as a fourth required check. It decides whether 17 other jobs run, but isn't itself required — so if it ever failed, those jobs would skip and the PR would still be mergeable off three green checks.
