### PR TITLE
fix(models): correct deepseek-v4-pro context window to 524288

### DIFF
--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -157,27 +157,14 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("kimi-k2.7-code")).toBe(false);
   });
 
-  it("flags deepseek-v4-pro with a 512K context window despite its library page", () => {
-    // ollama.com/library/deepseek-v4-pro and its registry manifest both claim
-    // 1M (1048576), and that's the value Pinchy shipped with. But Ollama's own
-    // /api/show for this model reports 524288 (512K) — a real contradiction on
-    // Ollama's side, not a typo in this file. /api/show is the runtime truth,
-    // so it wins over the library/marketing page (see file header).
-    //
-    // This isn't cosmetic: Pinchy writes contextWindow into OpenClaw config,
-    // and OpenClaw's shouldCompact() is `contextTokens > contextWindow -
-    // reserveTokens` (reserveTokens=16384). At 1048576 compaction would only
-    // fire past 1,032,192 tokens on a model that actually tops out at 524288
-    // — i.e. never. Production incident 2026-07-15: agent "Piper" on
-    // deepseek-v4-pro ran with compactionCount:0 up to 171K context and began
-    // confabulating tool results (reported an Odoo API outage while all 10
-    // Odoo calls in the window had succeeded). Manual compaction fixed it.
-    //
-    // deepseek-v4-flash sits right above this entry with the same 1048576 —
-    // do not "fix" it to match; its value is being verified separately.
-    const m = byId("deepseek-v4-pro");
-    expect(m).toBeDefined();
-    expect(m!.contextWindow).toBe(524288);
+  it("keeps the deepseek-v4 pair's context windows split: pro 512K, flash 1M", () => {
+    // These two look like they should match — same family, and both library
+    // pages claim 1M — but `ollama show` splits them: pro reports 524288,
+    // flash 1048576. So this guards against a well-meant "fix" in either
+    // direction. Rationale and the production incident behind pro's value:
+    // see ollama-cloud-models.ts.
+    expect(byId("deepseek-v4-pro")?.contextWindow).toBe(524288);
+    expect(byId("deepseek-v4-flash")?.contextWindow).toBe(1048576);
   });
 
   it("every model declares vision and carries no dead capability fields", () => {

--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -157,6 +157,29 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     expect(VISION_OLLAMA_CLOUD_MODEL_IDS.has("kimi-k2.7-code")).toBe(false);
   });
 
+  it("flags deepseek-v4-pro with a 512K context window despite its library page", () => {
+    // ollama.com/library/deepseek-v4-pro and its registry manifest both claim
+    // 1M (1048576), and that's the value Pinchy shipped with. But Ollama's own
+    // /api/show for this model reports 524288 (512K) — a real contradiction on
+    // Ollama's side, not a typo in this file. /api/show is the runtime truth,
+    // so it wins over the library/marketing page (see file header).
+    //
+    // This isn't cosmetic: Pinchy writes contextWindow into OpenClaw config,
+    // and OpenClaw's shouldCompact() is `contextTokens > contextWindow -
+    // reserveTokens` (reserveTokens=16384). At 1048576 compaction would only
+    // fire past 1,032,192 tokens on a model that actually tops out at 524288
+    // — i.e. never. Production incident 2026-07-15: agent "Piper" on
+    // deepseek-v4-pro ran with compactionCount:0 up to 171K context and began
+    // confabulating tool results (reported an Odoo API outage while all 10
+    // Odoo calls in the window had succeeded). Manual compaction fixed it.
+    //
+    // deepseek-v4-flash sits right above this entry with the same 1048576 —
+    // do not "fix" it to match; its value is being verified separately.
+    const m = byId("deepseek-v4-pro");
+    expect(m).toBeDefined();
+    expect(m!.contextWindow).toBe(524288);
+  });
+
   it("every model declares vision and carries no dead capability fields", () => {
     for (const m of TOOL_CAPABLE_OLLAMA_CLOUD_MODELS) {
       expect(typeof m.vision).toBe("boolean");

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2174,18 +2174,15 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["qwen3.5:397b"]).toBe(262144);
     // 384K
     expect(ctx["devstral-small-2:24b"]).toBe(393216);
+    // 512K — deepseek-v4-pro belongs here, not with flash below, despite its
+    // library page claiming 1M (see ollama-cloud-models.ts)
+    expect(ctx["deepseek-v4-pro"]).toBe(524288);
     // 512K — minimax-m3's guaranteed minimum (library page: "up to 1M")
     expect(ctx["minimax-m3"]).toBe(524288);
     // 1M
     expect(ctx["deepseek-v4-flash"]).toBe(1048576);
     expect(ctx["gemini-3-flash-preview"]).toBe(1048576);
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
-    // 512K — deepseek-v4-pro's library page and registry manifest both claim
-    // 1M, but Ollama's own /api/show for this model reports 524288. That's
-    // the runtime truth OpenClaw's compaction math relies on (see
-    // ollama-cloud-models.ts), so this deliberately does NOT match the 1M
-    // group above.
-    expect(ctx["deepseek-v4-pro"]).toBe(524288);
   });
 
   it("writes reasoning, input (vision), and cost fields for every Ollama Cloud model", async () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2178,9 +2178,14 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["minimax-m3"]).toBe(524288);
     // 1M
     expect(ctx["deepseek-v4-flash"]).toBe(1048576);
-    expect(ctx["deepseek-v4-pro"]).toBe(1048576);
     expect(ctx["gemini-3-flash-preview"]).toBe(1048576);
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
+    // 512K — deepseek-v4-pro's library page and registry manifest both claim
+    // 1M, but Ollama's own /api/show for this model reports 524288. That's
+    // the runtime truth OpenClaw's compaction math relies on (see
+    // ollama-cloud-models.ts), so this deliberately does NOT match the 1M
+    // group above.
+    expect(ctx["deepseek-v4-pro"]).toBe(524288);
   });
 
   it("writes reasoning, input (vision), and cost fields for every Ollama Cloud model", async () => {

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -14,13 +14,17 @@
  * hints into the OpenClaw config so context pruning can kick in before
  * requests bump into the real provider limit.
  *
- * Source priority for contextWindow: Ollama's own `/api/show` endpoint beats
- * the ollama.com/library/<name> page and the registry manifest when they
+ * Source priority for contextWindow: Ollama's own `/api/show` beats the
+ * ollama.com/library/<name> page and the registry manifest when they
  * disagree. The library page is a marketing figure; `/api/show` is what the
- * runtime actually enforces. deepseek-v4-pro is the confirmed example — its
- * library page and manifest both say 1M, but `/api/show` says 524288, and
- * that's the value here (see the inline comment on that entry). Don't
- * "reconcile" a `/api/show`-sourced value back to the library page.
+ * runtime enforces. Check a value with:
+ *
+ *     ollama show <id>:cloud     # "context length" row
+ *
+ * deepseek-v4-pro is the confirmed example: library page and manifest both
+ * say 1M, `/api/show` says 524288, and 524288 is the value here (see the
+ * inline comment on that entry). Don't "reconcile" a `/api/show`-sourced
+ * value back to the library page — re-run the command instead.
  *
  * Cost is always zero: Ollama Cloud uses subscription pricing (Free / Pro /
  * Max plans — see ollama.com/pricing), not per-token billing. A fabricated
@@ -35,7 +39,9 @@
 export interface OllamaCloudModel {
   /** ID exactly as returned by https://ollama.com/v1/models (no ":cloud" suffix). */
   id: string;
-  /** Native context window in tokens (from ollama.com/library/<name>). */
+  /** Native context window in tokens. Source: `ollama show <name>:cloud`
+   * (i.e. `/api/show`), which wins over the library page when they disagree —
+   * see the source-priority note in the file header. */
   contextWindow: number;
   /** Pinchy's max output tokens hint. Ollama doesn't publish this, so we use
    * the output-heavy value for Gemini Flash and a conservative 8192 elsewhere. */
@@ -67,6 +73,10 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
+    // The 1M here is real, unlike deepseek-v4-pro below: `ollama show
+    // deepseek-v4-flash:cloud` reports 1048576, matching its library page
+    // (checked 2026-07-16). Same family and same claimed size as pro, so it
+    // looks like it should carry pro's correction — it must not.
     id: "deepseek-v4-flash",
     contextWindow: 1048576,
     maxTokens: 8192,
@@ -74,22 +84,19 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
-    // ollama.com/library/deepseek-v4-pro and its registry manifest both
-    // claim 1M (1048576) — same as deepseek-v4-flash above. But Ollama's own
-    // /api/show for this model reports 524288, confirmed empirically. That's
-    // a genuine contradiction on Ollama's side, not a typo here: /api/show is
-    // the runtime truth Pinchy writes into OpenClaw config, and the library
-    // page is the marketing figure. Do not "correct" this back to 1048576 by
-    // re-checking the library page.
+    // 512K, NOT the 1M its library page and registry manifest both claim:
+    // `ollama show deepseek-v4-pro:cloud` reports 524288 (checked
+    // 2026-07-16). That's a contradiction on Ollama's side, not a typo here,
+    // and /api/show is the side that binds. Do not "correct" this back to
+    // 1048576 from the library page — re-run the command instead.
     //
-    // The distinction matters because OpenClaw's shouldCompact() is
-    // `contextTokens > contextWindow - reserveTokens` (reserveTokens=16384).
-    // At 1048576, compaction would only fire past 1,032,192 tokens on a model
-    // that actually tops out at 524288 — i.e. never. Production incident
-    // 2026-07-15: agent "Piper" on deepseek-v4-pro ran with
-    // compactionCount:0 up to 171K context and began confabulating tool
-    // results (reported an Odoo API outage while all 10 Odoo calls in the
-    // window had succeeded). Manual compaction fixed it.
+    // It matters because OpenClaw's shouldCompact() is `contextTokens >
+    // contextWindow - reserveTokens` (reserveTokens=16384). At 1048576,
+    // compaction would only fire past 1,032,192 tokens on a model that tops
+    // out at 524288 — i.e. never. Production incident 2026-07-15: agent
+    // "Piper" on this model ran to 171K context with compactionCount:0 and
+    // began confabulating tool results (reported an Odoo API outage while
+    // all 10 Odoo calls in the window had succeeded).
     id: "deepseek-v4-pro",
     contextWindow: 524288,
     maxTokens: 8192,

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -14,6 +14,14 @@
  * hints into the OpenClaw config so context pruning can kick in before
  * requests bump into the real provider limit.
  *
+ * Source priority for contextWindow: Ollama's own `/api/show` endpoint beats
+ * the ollama.com/library/<name> page and the registry manifest when they
+ * disagree. The library page is a marketing figure; `/api/show` is what the
+ * runtime actually enforces. deepseek-v4-pro is the confirmed example — its
+ * library page and manifest both say 1M, but `/api/show` says 524288, and
+ * that's the value here (see the inline comment on that entry). Don't
+ * "reconcile" a `/api/show`-sourced value back to the library page.
+ *
  * Cost is always zero: Ollama Cloud uses subscription pricing (Free / Pro /
  * Max plans — see ollama.com/pricing), not per-token billing. A fabricated
  * per-token rate would make Pinchy's Usage & Costs dashboard lie about
@@ -66,8 +74,24 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     vision: false,
   },
   {
+    // ollama.com/library/deepseek-v4-pro and its registry manifest both
+    // claim 1M (1048576) — same as deepseek-v4-flash above. But Ollama's own
+    // /api/show for this model reports 524288, confirmed empirically. That's
+    // a genuine contradiction on Ollama's side, not a typo here: /api/show is
+    // the runtime truth Pinchy writes into OpenClaw config, and the library
+    // page is the marketing figure. Do not "correct" this back to 1048576 by
+    // re-checking the library page.
+    //
+    // The distinction matters because OpenClaw's shouldCompact() is
+    // `contextTokens > contextWindow - reserveTokens` (reserveTokens=16384).
+    // At 1048576, compaction would only fire past 1,032,192 tokens on a model
+    // that actually tops out at 524288 — i.e. never. Production incident
+    // 2026-07-15: agent "Piper" on deepseek-v4-pro ran with
+    // compactionCount:0 up to 171K context and began confabulating tool
+    // results (reported an Odoo API outage while all 10 Odoo calls in the
+    // window had succeeded). Manual compaction fixed it.
     id: "deepseek-v4-pro",
-    contextWindow: 1048576,
+    contextWindow: 524288,
     maxTokens: 8192,
     reasoning: true,
     vision: false,


### PR DESCRIPTION
## Summary

- `deepseek-v4-pro`'s `contextWindow` in `packages/web/src/lib/ollama-cloud-models.ts` was `1048576` (1M), matching Ollama's library page and registry manifest — but Ollama's own `/api/show` for this model reports `524288` (512K). `/api/show` is the runtime truth; the library page is the marketing figure. This is a genuine contradiction on Ollama's side, not a typo in our file, so the fix adds a comment (and a note in the file header on source priority) so a future "correction" against the library page doesn't revert it.
- `deepseek-v4-flash` sits right above this entry with the same `1048576` — verified with `ollama show deepseek-v4-flash:cloud`, which reports 1048576. Its 1M is genuine; only `pro` disagrees with its library page. The catalog test pins both so the pair can't be aligned in either direction.

## Why this matters (production incident)

Pinchy writes `contextWindow` into OpenClaw config, and OpenClaw's `shouldCompact()` is:

```js
return contextTokens > contextWindow - settings.reserveTokens; // reserveTokens = 16384
```

At `1048576`, compaction on a model that actually tops out at `524288` would only fire past 1,032,192 tokens — effectively never.

Production incident 2026-07-15: agent "Piper" (running `deepseek-v4-pro`) accumulated context up to 171K tokens with `compactionCount: 0` and began confabulating tool results — it reported an Odoo API outage even though all 10 Odoo calls in the time window had succeeded. Manual compaction fixed it.

## Test plan

- [x] Added a failing-first test in `packages/web/src/__tests__/lib/ollama-cloud-models.test.ts` pinning the `deepseek-v4` pair — `pro` at `524288`, `flash` at `1048576` — so neither can be aligned to the other. Confirmed both assertions fail before landing by breaking each value in turn.
- [x] Updated the pre-existing assertion in `packages/web/src/__tests__/lib/openclaw-config.test.ts` ("writes the correct context window for each Ollama Cloud model") that had locked in the old `1048576` value for `deepseek-v4-pro` — moved into the "512K" group alongside `minimax-m3`.
- [x] Verified both values empirically with `ollama show deepseek-v4-pro:cloud` (524288) and `ollama show deepseek-v4-flash:cloud` (1048576).
- [x] `pnpm -C packages/web test` (full suite) — 8280 passed, 15 skipped (pre-existing, unrelated).
- [x] `pnpm -C packages/web run lint` — 0 errors (pre-existing warnings only).
- [x] `pnpm -C packages/web run format:check` — clean.
- [x] `pnpm -C packages/web run typecheck` — clean.
- [x] `pnpm test:scripts` — 271 passed (drift guards included).
