### PR TITLE
fix(models): block minimax-m3 for tool slots, it mangles nested args

### DIFF
--- a/packages/web/src/__tests__/lib/image-fallback.test.ts
+++ b/packages/web/src/__tests__/lib/image-fallback.test.ts
@@ -46,6 +46,7 @@ describe("resolveVisionFallbackModel", () => {
     tools: true,
   };
   const MINIMAX = { id: "ollama-cloud/minimax-m3", provider: "ollama-cloud", tools: true };
+  const KIMI = { id: "ollama-cloud/kimi-k2.6", provider: "ollama-cloud", tools: true };
 
   it("skips a tools-blocked preview model when the agent uses tools and picks the next usable same-provider candidate", () => {
     // The whole bug: gemini-3-flash-preview is seeded tools:true but is on the
@@ -54,10 +55,48 @@ describe("resolveVisionFallbackModel", () => {
     const model = resolveVisionFallbackModel({
       agentModel: "ollama-cloud/glm-5.2",
       agentUsesTools: true,
-      candidates: [PREVIEW, MINIMAX],
+      candidates: [PREVIEW, KIMI],
+      globalDefault: null,
+    });
+    expect(model).toBe("ollama-cloud/kimi-k2.6");
+  });
+
+  it("skips minimax-m3 for a tool-using agent and picks the next usable same-provider candidate", () => {
+    // Regression, Penny/2026-07-15: a text-only agent model (deepseek-v4-pro)
+    // received a receipt photo, so the turn was routed to a vision fallback.
+    // minimax-m3 is seeded tools:true and won on same-provider preference, then
+    // mangled every nested array in the tool arguments — Odoo domains arrived as
+    // {'item': [...]} ("unhashable type: 'dict'") and account.move
+    // invoice_line_ids/tax_ids command triplets were rejected outright. 12 failed
+    // bookings, context blown to 24M input tokens, turn aborted. Same class of
+    // defect as the preview rule: nominal tools:true, unusable in practice.
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/deepseek-v4-pro",
+      agentUsesTools: true,
+      candidates: [MINIMAX, KIMI],
+      globalDefault: null,
+    });
+    expect(model).toBe("ollama-cloud/kimi-k2.6");
+  });
+
+  it("still allows minimax-m3 when the agent does NOT use tools — the arg mangling only bites tool calls", () => {
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/deepseek-v4-pro",
+      agentUsesTools: false,
+      candidates: [MINIMAX],
       globalDefault: null,
     });
     expect(model).toBe("ollama-cloud/minimax-m3");
+  });
+
+  it("does not fall back to minimax-m3 as global default for a tool-using agent", () => {
+    const model = resolveVisionFallbackModel({
+      agentModel: "ollama-cloud/deepseek-v4-pro",
+      agentUsesTools: true,
+      candidates: [],
+      globalDefault: "ollama-cloud/minimax-m3",
+    });
+    expect(model).toBeNull();
   });
 
   it("still allows a preview model when the agent does NOT use tools — preview is fine for pure image description", () => {

--- a/packages/web/src/__tests__/lib/ollama-cloud-image-preference-drift.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-image-preference-drift.test.ts
@@ -45,4 +45,33 @@ describe("OLLAMA_CLOUD_IMAGE_PREFERENCE drift guard (#416)", () => {
   it("preference list is non-empty (otherwise ollama-cloud-only stacks lose imageModel)", () => {
     expect(OLLAMA_CLOUD_IMAGE_PREFERENCE.length).toBeGreaterThan(0);
   });
+
+  it("ranks kimi-k2.6 ahead of gemma4:31b so a tool-using image turn never lands on gemma4", () => {
+    // Penny, 2026-07-15. This list is a RANKING, not a filter: uncurated vision
+    // models rank behind every curated one (intraProviderVisionRank), so the
+    // last curated entry is what a tool-using agent falls back to once the
+    // tools-blocked entries (gemini-3-flash-preview, minimax-m3) are skipped.
+    //
+    // gemma4:31b must not be that model: it corrupts long identifiers across
+    // turns (~150-char Graph message ID — see providers/ollama-cloud.ts), and
+    // Pinchy's opaque refs are ~230 chars. Blocking minimax-m3 without kimi-k2.6
+    // ahead of gemma4:31b just swaps mangled tool args for corrupted refs.
+    //
+    // Deliberately asserted as ORDER, not as "some entry is unblocked": gemma4
+    // is not on any blocklist (its defect is unreliability, not a hard error),
+    // so an "at least one usable entry" guard would have passed even in the
+    // broken arrangement this test exists to prevent.
+    const kimi = OLLAMA_CLOUD_IMAGE_PREFERENCE.indexOf("kimi-k2.6");
+    const gemma = OLLAMA_CLOUD_IMAGE_PREFERENCE.indexOf("gemma4:31b");
+
+    expect(kimi, "kimi-k2.6 dropped out of OLLAMA_CLOUD_IMAGE_PREFERENCE").toBeGreaterThanOrEqual(
+      0
+    );
+    if (gemma >= 0) {
+      expect(
+        kimi,
+        "gemma4:31b now outranks kimi-k2.6 in OLLAMA_CLOUD_IMAGE_PREFERENCE. A tool-using agent whose model is text-only would have its image turn routed to gemma4:31b, which corrupts the ~230-char opaque refs Pinchy passes through tool loops. Keep kimi-k2.6 first, or remove gemma4:31b."
+      ).toBeLessThan(gemma);
+    }
+  });
 });

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -4620,7 +4620,7 @@ describe("ClientRouter", () => {
       mockMaterializeAttachments.mockResolvedValue(imageAttachment());
       mockListVisionModels.mockResolvedValue([
         { provider: "ollama-cloud", modelId: "gemini-3-flash-preview", vision: true, tools: true },
-        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "gemma4:31b", vision: true, tools: true },
       ]);
       mockChat.mockReturnValue(okStream());
 
@@ -4633,13 +4633,52 @@ describe("ClientRouter", () => {
 
       const [, options] = mockChat.mock.calls[0];
       expect(options.provider).toBe("ollama-cloud");
-      expect(options.model).toBe("minimax-m3");
+      expect(options.model).toBe("gemma4:31b");
 
       const audit = mockAppendAuditLog.mock.calls
         .map((c) => c[0])
         .find((e) => e.eventType === "chat.image_model_fallback");
       expect(audit).toBeDefined();
-      expect(audit.detail.fallbackModel).toBe("ollama-cloud/minimax-m3");
+      expect(audit.detail.fallbackModel).toBe("ollama-cloud/gemma4:31b");
+    });
+
+    it("does not route a tool-using agent's image turn to minimax-m3 — picks the next usable same-provider vision model", async () => {
+      // Penny's exact shape, 2026-07-15: a text-only agent (deepseek-v4-pro)
+      // using Odoo tools received a receipt photo. minimax-m3 is seeded
+      // tools:true AND outranks gemma4:31b in OLLAMA_CLOUD_IMAGE_PREFERENCE, so
+      // it won the fallback — then mangled every nested tool argument (Odoo
+      // domains arrived as {'item': [...]}, invoice_line_ids commands rejected).
+      // It must be skipped whenever the turn needs tools, even though it is the
+      // better pure-vision model.
+      mockFindFirst.mockResolvedValue({
+        ...defaultAgent,
+        model: "ollama-cloud/deepseek-v4-pro",
+        allowedTools: ["odoo_read", "odoo_create"],
+      });
+      mockIsModelVisionCapable.mockReturnValue(false);
+      mockMaterializeAttachments.mockResolvedValue(imageAttachment());
+      mockListVisionModels.mockResolvedValue([
+        { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "gemma4:31b", vision: true, tools: true },
+      ]);
+      mockChat.mockReturnValue(okStream());
+
+      await router.handleMessage(createMockClientWs() as any, {
+        type: "message",
+        content: "Book this receipt",
+        attachmentIds: [ATTACHMENT_ID],
+        agentId: "agent-1",
+      });
+
+      const [, options] = mockChat.mock.calls[0];
+      expect(options.provider).toBe("ollama-cloud");
+      expect(options.model).toBe("gemma4:31b");
+
+      const audit = mockAppendAuditLog.mock.calls
+        .map((c) => c[0])
+        .find((e) => e.eventType === "chat.image_model_fallback");
+      expect(audit).toBeDefined();
+      expect(audit.detail.fallbackModel).toBe("ollama-cloud/gemma4:31b");
     });
 
     it("picks the highest-quality vision fallback, independent of catalog row order and alphabetical order", async () => {
@@ -4650,10 +4689,15 @@ describe("ClientRouter", () => {
       // so that both "first row" (gemma4:31b) and "alphabetically first"
       // (gemma4:31b < minimax-m3) would pick the WRONG model if quality were
       // ignored, so a minimax-m3 result proves the preference sort.
+      //
+      // The agent deliberately uses NO tools: minimax-m3 is tools-blocked (it
+      // mangles nested tool arguments), so a tool-using agent would skip it and
+      // land on gemma4:31b for the wrong reason, proving nothing about sorting.
+      // Pure image description is exactly where minimax-m3 is still preferred.
       mockFindFirst.mockResolvedValue({
         ...defaultAgent,
         model: "ollama-cloud/glm-5.2",
-        allowedTools: ["odoo_search_read"],
+        allowedTools: [],
       });
       mockIsModelVisionCapable.mockReturnValue(false);
       mockMaterializeAttachments.mockResolvedValue(imageAttachment());

--- a/packages/web/src/__tests__/server/client-router.test.ts
+++ b/packages/web/src/__tests__/server/client-router.test.ts
@@ -4642,14 +4642,23 @@ describe("ClientRouter", () => {
       expect(audit.detail.fallbackModel).toBe("ollama-cloud/gemma4:31b");
     });
 
-    it("does not route a tool-using agent's image turn to minimax-m3 — picks the next usable same-provider vision model", async () => {
+    it("routes Penny's image turn to kimi-k2.6 — skips tool-mangling minimax-m3 AND long-ref-corrupting gemma4:31b", async () => {
       // Penny's exact shape, 2026-07-15: a text-only agent (deepseek-v4-pro)
       // using Odoo tools received a receipt photo. minimax-m3 is seeded
-      // tools:true AND outranks gemma4:31b in OLLAMA_CLOUD_IMAGE_PREFERENCE, so
+      // tools:true AND outranked gemma4:31b in OLLAMA_CLOUD_IMAGE_PREFERENCE, so
       // it won the fallback — then mangled every nested tool argument (Odoo
       // domains arrived as {'item': [...]}, invoice_line_ids commands rejected).
       // It must be skipped whenever the turn needs tools, even though it is the
       // better pure-vision model.
+      //
+      // Blocking minimax alone is NOT enough: that leaves gemma4:31b as the only
+      // curated ollama-cloud vision model, and gemma4:31b corrupts long
+      // identifiers across turns (~150-char Graph message ID, balanced-tier note
+      // in providers/ollama-cloud.ts). Pinchy's opaque refs are ~230 chars, so
+      // Penny would just swap one failure mode for another. kimi-k2.6 is listed
+      // last here on purpose: before it was curated it ranked BEHIND every
+      // curated model (intraProviderVisionRank), so a kimi-k2.6 result proves it
+      // is now curated ahead of gemma4:31b rather than winning by row order.
       mockFindFirst.mockResolvedValue({
         ...defaultAgent,
         model: "ollama-cloud/deepseek-v4-pro",
@@ -4660,6 +4669,7 @@ describe("ClientRouter", () => {
       mockListVisionModels.mockResolvedValue([
         { provider: "ollama-cloud", modelId: "minimax-m3", vision: true, tools: true },
         { provider: "ollama-cloud", modelId: "gemma4:31b", vision: true, tools: true },
+        { provider: "ollama-cloud", modelId: "kimi-k2.6", vision: true, tools: true },
       ]);
       mockChat.mockReturnValue(okStream());
 
@@ -4672,13 +4682,13 @@ describe("ClientRouter", () => {
 
       const [, options] = mockChat.mock.calls[0];
       expect(options.provider).toBe("ollama-cloud");
-      expect(options.model).toBe("gemma4:31b");
+      expect(options.model).toBe("kimi-k2.6");
 
       const audit = mockAppendAuditLog.mock.calls
         .map((c) => c[0])
         .find((e) => e.eventType === "chat.image_model_fallback");
       expect(audit).toBeDefined();
-      expect(audit.detail.fallbackModel).toBe("ollama-cloud/gemma4:31b");
+      expect(audit.detail.fallbackModel).toBe("ollama-cloud/kimi-k2.6");
     });
 
     it("picks the highest-quality vision fallback, independent of catalog row order and alphabetical order", async () => {
@@ -4690,10 +4700,16 @@ describe("ClientRouter", () => {
       // (gemma4:31b < minimax-m3) would pick the WRONG model if quality were
       // ignored, so a minimax-m3 result proves the preference sort.
       //
-      // The agent deliberately uses NO tools: minimax-m3 is tools-blocked (it
-      // mangles nested tool arguments), so a tool-using agent would skip it and
-      // land on gemma4:31b for the wrong reason, proving nothing about sorting.
-      // Pure image description is exactly where minimax-m3 is still preferred.
+      // The agent deliberately has no admin-configured tools: minimax-m3 is
+      // tools-blocked (it mangles nested tool arguments), so a tool-using agent
+      // would skip it and land on a different model for the wrong reason,
+      // proving nothing about sorting. Image description with built-ins only is
+      // where minimax-m3 is still preferred.
+      //
+      // Note `allowedTools: []` means "built-ins only" (memory_search,
+      // memory_get, session_status — computeAllowedTools takes no agent), NOT
+      // "no tools at all". Those schemas are flat, which minimax-m3 handles; see
+      // the proxy caveat at the resolveImageTurnModel call site.
       mockFindFirst.mockResolvedValue({
         ...defaultAgent,
         model: "ollama-cloud/glm-5.2",

--- a/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
+++ b/packages/web/src/lib/model-resolver/__tests__/blocklist.test.ts
@@ -41,6 +41,35 @@ describe("isBlocked", () => {
     expect(isBlocked("gemini-2.5-pro", ["tools"])).toBe(false);
     expect(isBlocked("gemini-2.5-flash-lite", ["tools"])).toBe(false);
   });
+
+  it("blocks minimax-m3 when tools capability is required", () => {
+    expect(isBlocked("minimax-m3", ["tools"])).toBe(true);
+    expect(isBlocked("ollama-cloud/minimax-m3", ["tools"])).toBe(true);
+  });
+
+  it("blocks minimax-m3 when vision+tools is required — the image-fallback path", () => {
+    expect(isBlocked("ollama-cloud/minimax-m3", ["vision", "tools"])).toBe(true);
+  });
+
+  it("allows minimax-m3 without tools requirement — its vision is good, only tool args are broken", () => {
+    expect(isBlocked("ollama-cloud/minimax-m3", ["vision"])).toBe(false);
+    expect(isBlocked("ollama-cloud/minimax-m3", [])).toBe(false);
+  });
+
+  it("blocks point releases of the minimax-m3 line, which must re-earn trust via a nested-arg probe", () => {
+    // Deliberate: the pattern has no trailing boundary, and the catalog names
+    // point releases `minimax-m2.1`/`m2.5`/`m2.7`, so `minimax-m3.5` is the
+    // expected shape of a "fixed" release. It stays blocked until probed.
+    expect(isBlocked("ollama-cloud/minimax-m3.5", ["tools"])).toBe(true);
+    expect(isBlocked("ollama-cloud/minimax-m3-turbo", ["tools"])).toBe(true);
+  });
+
+  it("does not block other minimax lines — the denylist is evidence-based, not name-guessing", () => {
+    // Only minimax-m3 was measured (20 of 60 calls mangled). m2.x predates it
+    // and m4 does not exist; neither is blocked on suspicion alone.
+    expect(isBlocked("ollama-cloud/minimax-m2.7", ["tools"])).toBe(false);
+    expect(isBlocked("ollama-cloud/minimax-m4", ["tools"])).toBe(false);
+  });
 });
 
 describe("getBlockReason", () => {

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -38,6 +38,34 @@ const RULES: BlockRule[] = [
   // vision fallback for a text-only agent. Lifting this block requires a fresh
   // multi-round tool probe with NESTED-array arguments against the live endpoint.
   //
+  // CORROBORATED by the eval-v1 model sweep (pinchy#669), which predates the
+  // Penny incident by four days — the signal was already in the repo when
+  // production hit it; nothing wires eval results to this list. Per model per
+  // scenario, 12 runs (eval/data/hetzner-invoice-*-models.json, 2026-07-11):
+  //
+  //   scenario      minimax-m3   kimi-k2.6   gemma4:31b
+  //   lineitems       0 / 12      10 / 12     11 / 12
+  //   conflict        5 / 12      12 / 12     12 / 12
+  //   distractor     10 / 12      12 / 12     10 / 12
+  //   rejected       12 / 12      12 / 12     12 / 12
+  //
+  // `lineitems` is the scenario needing account.move invoice_line_ids command
+  // triplets — nested arrays — and minimax-m3 scores a clean zero there while
+  // passing `rejected` 12/12 and `distractor` 10/12, where nothing nests.
+  //
+  // Read that as OUTCOME evidence, NOT mechanism proof. The sweep scores end
+  // state and never inspects tool-call payloads; it tags these runs
+  // `wrong-field-extraction`, which is arguably a mis-tag. Its failure notes say
+  // "amount_total: expected 47.6, got 0" and "No in_invoice move found" — a move
+  // that landed with no lines, or was rejected outright, which is exactly what a
+  // mangled invoice_line_ids produces. It agrees with the session payloads
+  // above; those payloads remain the evidence for WHY.
+  //
+  // The sweep cannot gate: CI runs eval-selftest only, and `eval:models` needs a
+  // docker stack plus live API keys at ~72s/run. A cheap nested-array probe in
+  // scripts/lib/ollama-cloud-tool-probe.mjs is what would fail fast in CI, and
+  // is tracked separately — the two are complements, not substitutes.
+  //
   // The pattern has NO trailing boundary on purpose, so it also covers point
   // releases of the same line: the catalog names them `minimax-m2.1`, `m2.5`,
   // `m2.7`, so a future `minimax-m3.5` is the expected shape, and a substring

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -37,6 +37,20 @@ const RULES: BlockRule[] = [
   // preview rule it is seeded tools:true, so it would otherwise win same-provider
   // vision fallback for a text-only agent. Lifting this block requires a fresh
   // multi-round tool probe with NESTED-array arguments against the live endpoint.
+  //
+  // The pattern has NO trailing boundary on purpose, so it also covers point
+  // releases of the same line: the catalog names them `minimax-m2.1`, `m2.5`,
+  // `m2.7`, so a future `minimax-m3.5` is the expected shape, and a substring
+  // match blocks it too. That is the fail-safe direction and it is not silent —
+  // the catalog is hand-curated, so adding `minimax-m3.5` means editing
+  // ollama-cloud-models.ts and meeting this rule. A release claiming the fix
+  // still has to earn the unblock with a nested-array probe, which the current
+  // flat probe cannot give (scripts/lib/ollama-cloud-tool-probe.mjs).
+  //
+  // A new major line (`minimax-m4`) deliberately does NOT match. There is no
+  // evidence about it, and this blocklist is an evidence-based denylist — every
+  // model not named here is allowed. Blocking an unseen model by guessing at its
+  // name would be a different policy than the other two rules follow.
   {
     modelPattern: /minimax-m3/i,
     forbiddenWhen: ["tools"],

--- a/packages/web/src/lib/model-resolver/blocklist.ts
+++ b/packages/web/src/lib/model-resolver/blocklist.ts
@@ -25,6 +25,24 @@ const RULES: BlockRule[] = [
     reason:
       "Preview models (e.g. gemini-3-flash-preview) are unstable for tools+vision: silent hangs and schema-rejection errors observed in production (pinchy#344, pinchy#338)",
   },
+  // Observed in production 2026-07-15 (agent "Penny", ollama-cloud stack). The
+  // model emits structurally broken tool arguments: every NESTED array collapses
+  // into an {"item": ...} object, and some arrays arrive stringified ("[10, 20]").
+  // That destroys exactly the payloads bookkeeping needs — Odoo domain filters
+  // ("unhashable type: 'dict'") and account.move invoice_line_ids/tax_ids command
+  // triplets. It also emits positional instead of named arguments, so every field
+  // lands in the schema's first property. Measured over one session: 20 of 60
+  // minimax-m3 tool calls mangled, versus 0 of 112 on kimi-k2.6 and 0 of 68 on
+  // deepseek-v4-pro — model behavior, not a Pinchy serialization bug. Like the
+  // preview rule it is seeded tools:true, so it would otherwise win same-provider
+  // vision fallback for a text-only agent. Lifting this block requires a fresh
+  // multi-round tool probe with NESTED-array arguments against the live endpoint.
+  {
+    modelPattern: /minimax-m3/i,
+    forbiddenWhen: ["tools"],
+    reason:
+      'minimax-m3 mangles nested tool-call arguments (arrays collapse to {"item": ...}), breaking Odoo domain filters and invoice line commands (observed in production 2026-07-15)',
+  },
 ];
 
 export function isBlocked(modelId: string, requiredCapabilities: ModelCapability[]): boolean {

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -57,8 +57,12 @@ const BY_TIER_FAMILY: Record<
     // refs through a multi-turn tool loop. kimi-k2.6 is vision+tools with 256K
     // context, already trusted for the balanced tier's vision+general slots,
     // and emitted 0 malformed tool calls across 112 calls in the Penny session
-    // that minimax failed. The v0.5.3 kimi silent-500 note that previously kept
-    // the family out of this slot predates the k2.6 catalog entry.
+    // that minimax failed. The eval-v1 sweep agrees on aggregate (scorecard
+    // table in blocklist.ts): kimi beats gemma4:31b on duplicate, distractor and
+    // silent-failure, with gemma4 marginally ahead only on lineitems (11/12 vs
+    // 10/12) — an aggregate call, not a rout. The v0.5.3 kimi silent-500 note
+    // that previously kept the family out of this slot predates the k2.6
+    // catalog entry.
     //
     // Trade-off, deliberate: kimi-k2.6 is a non-thinking-preferred tool-driver,
     // so a reasoning-tier turn that ALSO needs vision loses thinking. Reliable

--- a/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
+++ b/packages/web/src/lib/model-resolver/providers/ollama-cloud.ts
@@ -42,14 +42,30 @@ const BY_TIER_FAMILY: Record<
   },
   reasoning: {
     general: "ollama-cloud/deepseek-v4-pro",
-    // reasoning+vision+tools, 512K context. qwen3.5:397b was the previous pick
-    // but only claims vision — the live endpoint hallucinates image contents
-    // (see ollama-cloud-models.ts), so it is now flagged vision:false and can
-    // no longer fill a vision slot. minimax-m3's vision was confirmed against
-    // the live API (reads a random number + circle color correctly across
-    // distinct images). gemini-3-flash-preview is still blocked by the
-    // tools-blocklist (pinchy#344); kimi family avoided (v0.5.3 silent-500).
-    vision: "ollama-cloud/minimax-m3",
+    // qwen3.5:397b was the original pick but only claims vision — the live
+    // endpoint hallucinates image contents (see ollama-cloud-models.ts), so it
+    // is flagged vision:false and can no longer fill a vision slot.
+    // minimax-m3 replaced it on confirmed vision quality, then had to go too:
+    // it is now tools-blocked for mangling nested tool arguments (Penny,
+    // 2026-07-15 — see blocklist.ts). A vision slot always resolves alongside
+    // tools here, so a tools-blocked model cannot fill it, however good its
+    // eyes are — the ollama-cloud drift-guards enforce exactly that.
+    //
+    // That leaves gemma4:31b and kimi-k2.6. gemma4:31b is rejected on the
+    // balanced-tier evidence above: it corrupted a ~150-char Graph message ID
+    // across turns, and this slot's whole job is carrying invoice numbers and
+    // refs through a multi-turn tool loop. kimi-k2.6 is vision+tools with 256K
+    // context, already trusted for the balanced tier's vision+general slots,
+    // and emitted 0 malformed tool calls across 112 calls in the Penny session
+    // that minimax failed. The v0.5.3 kimi silent-500 note that previously kept
+    // the family out of this slot predates the k2.6 catalog entry.
+    //
+    // Trade-off, deliberate: kimi-k2.6 is a non-thinking-preferred tool-driver,
+    // so a reasoning-tier turn that ALSO needs vision loses thinking. Reliable
+    // tool calls beat reasoning here — a mangled invoice_line_ids payload fails
+    // the turn outright, which is what the reasoning was meant to serve.
+    // gemini-3-flash-preview remains blocked (pinchy#344).
+    vision: "ollama-cloud/kimi-k2.6",
   },
 };
 

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -147,6 +147,13 @@ export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   // only for *tool* slots, fine for pure image description) and minimax-m3
   // (reads numbers + circle colors correctly across distinct images) lead,
   // with gemma4:31b behind them.
+  //
+  // minimax-m3 is now tools-blocked too, for the same shape of reason as the
+  // preview model: it mangles nested tool-call arguments (Penny, 2026-07-15 —
+  // see model-resolver/blocklist.ts). Both stay in THIS list on purpose. It
+  // ranks pure image-description quality, and `isBlocked` is consulted with the
+  // capabilities the slot actually needs — so a chat-only agent still gets the
+  // best eyes, while any tool-using turn skips them.
   "gemini-3-flash-preview",
   "minimax-m3",
   "gemma4:31b",

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -114,8 +114,10 @@ async function resolveVisionModelChain(preference: readonly ProviderName[]): Pro
  * claims vision — it hallucinates image contents and is now flagged
  * vision:false (see ollama-cloud-models.ts). We pin the choice to the
  * best empirically vision-verified models (`gemini-3-flash-preview` >
- * `minimax-m3` > `gemma4:31b`; qwen3-vl led this list until Ollama dropped it
- * from the cloud catalog) via the typed `OLLAMA_CLOUD_IMAGE_PREFERENCE` list.
+ * `minimax-m3` > `kimi-k2.6` > `gemma4:31b`; qwen3-vl led this list until
+ * Ollama dropped it from the cloud catalog) via the typed
+ * `OLLAMA_CLOUD_IMAGE_PREFERENCE` list. That order ranks pure image quality;
+ * it is NOT the order a tool-using turn gets — see the list's own comment.
  * The TypeScript
  * constraint on that list (must be `OllamaCloudModelId`) means an unknown
  * ID fails to compile, so a runtime fallback to
@@ -150,22 +152,42 @@ export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   //
   // minimax-m3 is now tools-blocked too, for the same shape of reason as the
   // preview model: it mangles nested tool-call arguments (Penny, 2026-07-15 —
-  // see model-resolver/blocklist.ts). Both stay in THIS list on purpose. It
-  // ranks pure image-description quality, and `isBlocked` is consulted with the
-  // capabilities the slot actually needs — so a chat-only agent still gets the
-  // best eyes, while any tool-using turn skips them.
+  // see model-resolver/blocklist.ts). Both stay in THIS list on purpose: it
+  // ranks pure image-description quality, which is not what they are bad at.
+  //
+  // TWO CONSUMERS, DIFFERENT SEMANTICS — do not reason about this list without
+  // knowing which one you mean:
+  //
+  //   1. `intraProviderVisionRank` (below) — a RANKING. It ranks uncurated
+  //      ollama-cloud vision models BEHIND every curated one. The image-turn
+  //      fallback sorts with it and then applies `isBlocked` with the
+  //      capabilities the slot actually needs, so a chat-only agent still gets
+  //      the best eyes while a tool-using turn skips the blocked entries.
+  //   2. `pickOllamaCloudImageModel` (below) — effectively a FILTER. It returns
+  //      the FIRST curated + live entry and consults NO blocklist, so it hands
+  //      out `gemini-3-flash-preview` as the default `imageModel`. That is fine
+  //      only because that slot describes images and does not drive tools. If it
+  //      ever feeds a tool loop, it needs an `isBlocked` gate of its own — the
+  //      capability-aware safety net described in (1) does not cover it.
   //
   // kimi-k2.6 was added 2026-07-15 as the tool-safe floor of this list, and it
-  // is the entry that makes blocking minimax-m3 actually help. This list is not
-  // a filter — `intraProviderVisionRank` ranks UNCURATED vision models behind
-  // every curated one, so before kimi-k2.6 was listed, a tool-using agent that
-  // skipped the two blocked models landed on gemma4:31b as the last curated
-  // candidate. gemma4:31b corrupts long identifiers across turns (~150-char
-  // Graph message ID — see providers/ollama-cloud.ts), and Pinchy's opaque refs
-  // are ~230 chars, so Penny would have swapped mangled tool args for corrupted
-  // refs. kimi-k2.6 sits below minimax-m3 on pure image quality but above
-  // gemma4:31b on the thing that decides a tool turn: it emitted 0 malformed
-  // calls across 112 calls in the session minimax failed.
+  // is the entry that makes blocking minimax-m3 actually help. Because of (1),
+  // an uncurated model can never be the fallback: before kimi-k2.6 was listed,
+  // a tool-using agent that skipped the two blocked entries landed on
+  // gemma4:31b as the last curated candidate.
+  //
+  // Why kimi-k2.6 over gemma4:31b, on the evidence we have:
+  //   - eval sweep 2026-07-11 (eval/data/hetzner-invoice-*-models.json, 12 runs
+  //     per model per scenario): kimi beats gemma4 on duplicate (5/12 vs 0/12),
+  //     distractor (12/12 vs 10/12) and silent-failure (4/12 vs 1/12); they are
+  //     level on conflict (12/12) and gemma4 is marginally ahead on lineitems
+  //     (11/12 vs 10/12). Aggregate favours kimi; it is not a rout.
+  //   - gemma4:31b corrupted a ~150-char Graph message ID across turns (see
+  //     providers/ollama-cloud.ts) and Pinchy's opaque refs are ~230 chars. That
+  //     is a long-identifier failure the invoice scenarios above do not probe,
+  //     so it is a separate risk, not one the eval scores clear it of.
+  //   - kimi emitted 0 malformed tool calls across 112 calls in the session
+  //     minimax failed.
   //
   // Ordering matters, not just membership: kimi-k2.6 must stay ahead of
   // gemma4:31b, or a tool-using image turn degrades to gemma4 again. Pinned by
@@ -204,6 +226,11 @@ async function fetchLiveOllamaCloudModelIds(): Promise<Set<string>> {
  * pinned in `openclaw.json` until the next Pinchy upgrade. Intersecting with
  * the live `/v1/models` catalog means a retired model is skipped immediately —
  * the resolver falls through to the next live preference (`minimax-m3` …).
+ *
+ * NOTE this consults no blocklist: it returns the first curated + live entry,
+ * today `gemini-3-flash-preview`, which IS tools-blocked. Acceptable only
+ * because the `imageModel` slot describes images rather than driving a tool
+ * loop. Gate it on `isBlocked` before pointing anything tool-using at it.
  */
 async function pickOllamaCloudImageModel(): Promise<string | null> {
   const liveIds = await fetchLiveOllamaCloudModelIds();
@@ -243,7 +270,7 @@ function intraProviderVisionRank(provider: string, modelId: string): number {
  *
  *   1. Native-vision providers first, in `IMAGE_MODEL_PREFERENCE` order.
  *   2. Within ollama-cloud, the curated `OLLAMA_CLOUD_IMAGE_PREFERENCE` order
- *      (e.g. `minimax-m3` ahead of `gemma4:31b`), with uncurated vision models
+ *      (e.g. `kimi-k2.6` ahead of `gemma4:31b`), with uncurated vision models
  *      ranked after the curated ones.
  *   3. Ties broken alphabetically by `provider/modelId` for determinism.
  *

--- a/packages/web/src/lib/openclaw-config/default-media-models.ts
+++ b/packages/web/src/lib/openclaw-config/default-media-models.ts
@@ -154,8 +154,25 @@ export const OLLAMA_CLOUD_IMAGE_PREFERENCE: readonly OllamaCloudModelId[] = [
   // ranks pure image-description quality, and `isBlocked` is consulted with the
   // capabilities the slot actually needs — so a chat-only agent still gets the
   // best eyes, while any tool-using turn skips them.
+  //
+  // kimi-k2.6 was added 2026-07-15 as the tool-safe floor of this list, and it
+  // is the entry that makes blocking minimax-m3 actually help. This list is not
+  // a filter — `intraProviderVisionRank` ranks UNCURATED vision models behind
+  // every curated one, so before kimi-k2.6 was listed, a tool-using agent that
+  // skipped the two blocked models landed on gemma4:31b as the last curated
+  // candidate. gemma4:31b corrupts long identifiers across turns (~150-char
+  // Graph message ID — see providers/ollama-cloud.ts), and Pinchy's opaque refs
+  // are ~230 chars, so Penny would have swapped mangled tool args for corrupted
+  // refs. kimi-k2.6 sits below minimax-m3 on pure image quality but above
+  // gemma4:31b on the thing that decides a tool turn: it emitted 0 malformed
+  // calls across 112 calls in the session minimax failed.
+  //
+  // Ordering matters, not just membership: kimi-k2.6 must stay ahead of
+  // gemma4:31b, or a tool-using image turn degrades to gemma4 again. Pinned by
+  // the ordering guard in ollama-cloud-image-preference-drift.test.ts.
   "gemini-3-flash-preview",
   "minimax-m3",
+  "kimi-k2.6",
   "gemma4:31b",
 ];
 

--- a/packages/web/src/server/client-router.ts
+++ b/packages/web/src/server/client-router.ts
@@ -430,6 +430,22 @@ export class ClientRouter {
       // the agent's model the way the old recovery dialog did.
       const turnModel = await resolveImageTurnModel({
         agentModel: agent.model,
+        // PROXY, not ground truth: this is "has admin-configured tools", which is
+        // narrower than "will make tool calls this turn". `computeAllowedTools()`
+        // takes no agent argument — every agent, including one with an empty
+        // `allowedTools`, is emitted the read-only built-ins (memory_search,
+        // memory_get, session_status). So `false` here does NOT mean the turn is
+        // tool-free; it means the turn only has built-ins.
+        //
+        // That is why the false branch may still route to a tools-blocked model
+        // (gemini-3-flash-preview, minimax-m3) and is accepted for now: those
+        // built-ins have flat, few-property schemas, which is exactly the shape
+        // both models get right — the flat tool probe in
+        // scripts/lib/ollama-cloud-tool-probe.mjs passes on minimax-m3. The
+        // defects bite nested arrays (and, for minimax, positional args in
+        // multi-property schemas). If a built-in ever gains a nested-array
+        // argument, this proxy becomes wrong and the required capabilities have
+        // to be derived from the tools actually registered for the agent.
         agentUsesTools: ((agent.allowedTools as string[] | null) ?? []).length > 0,
         attachmentMimeTypes: chatAttachments.map((a) => a.mimeType ?? ""),
         deps: {


### PR DESCRIPTION
## What happened

Production agent **Penny** (bookkeeper, Odoo tools) spent two turns failing to book restaurant receipts, then blew its context and aborted. Root cause is not the context — it is the model that ran those turns.

Penny's model is `deepseek-v4-pro`, which is **text-only**. Attaching a receipt photo triggers the per-turn vision fallback, and on an ollama-cloud stack `minimax-m3` won that pick: same provider, seeded `tools: true`, and ranked above `gemma4:31b` in `OLLAMA_CLOUD_IMAGE_PREFERENCE`. The audit trail records it:

```
2026-07-15T15:31:54  chat.image_model_fallback   outcome: success
   reason:        "text_only_model_received_image"
   agentModel:    ollama-cloud/deepseek-v4-pro
   fallbackModel: ollama-cloud/minimax-m3
```

The fallback is turn-wide by design (see the comment in `image-fallback.ts` — the `agent` RPC throws on image+text-only rather than offloading), so **all 30 tool calls** in each of those turns ran on minimax-m3.

## The defect

`minimax-m3` emits structurally valid `tool_calls`, but mangles their arguments:

- **Nested arrays collapse into `{"item": ...}` objects.** Odoo domain filters come back `unhashable type: 'dict'`; `account.move` `invoice_line_ids` / `tax_ids` command triplets are rejected outright.
- **Some arrays arrive stringified** — `could not convert string to float: '[10, 20]'`.
- **Positional instead of named arguments**, so every field lands in the schema's first property. Validation then reports the wrong cause: `model: must have required properties model` when `model` *was* sent.

That is precisely the payload shape bookkeeping needs. Penny retried 12 times, and context grew to 24M input tokens before the turn aborted.

### Evidence — session payloads (the mechanism)

Tool calls inspected across the one session, by model:

| Model | Tool calls | Mangled |
|---|---|---|
| kimi-k2.6 | 112 | **0** |
| deepseek-v4-pro | 68 | **0** |
| minimax-m3 | 60 | **20** |

180 clean calls on two other models through the same tool layer — so this is model behavior, not a Pinchy serialization bug.

### Evidence — eval scorecards (the outcome, and it was already here)

The eval-v1 sweep (#669) runs the real Hetzner/Odoo invoice workflow, 12 runs per model per scenario. The scorecards are committed at `eval/data/hetzner-invoice-*-models.json`, **generated 2026-07-11 — four days before Penny failed**:

| scenario | minimax-m3 | kimi-k2.6 | gemma4:31b |
|---|---|---|---|
| **lineitems** | **0 / 12** | 10 / 12 | 11 / 12 |
| conflict | 5 / 12 | 12 / 12 | 12 / 12 |
| distractor | 10 / 12 | 12 / 12 | 10 / 12 |
| rejected | 12 / 12 | 12 / 12 | 12 / 12 |

`lineitems` is the scenario that needs `invoice_line_ids` command triplets — nested arrays — and minimax-m3 scores a clean zero, while passing `rejected` 12/12 and `distractor` 10/12 where nothing nests.

Scoped honestly: this is **outcome** evidence, not mechanism proof. The sweep never inspects tool-call payloads and tags these runs `wrong-field-extraction`, which is arguably a mis-tag — its notes say `amount_total: expected 47.6, got 0` and `No in_invoice move found`, i.e. a move that landed with no lines or was rejected outright, which is what a mangled `invoice_line_ids` produces. It agrees with the session payloads; the payloads remain the evidence for *why*.

The uncomfortable part: **the signal was in the repo before production hit it.** Nothing wires eval results to the blocklist, so a 0/12 sat there unread. That gap is worth more than this PR.

## The fix

Two changes, both needed — either alone leaves Penny broken.

**1. A `forbiddenWhen: ["tools"]` blocklist rule for `minimax-m3`** — same mechanism and same class of defect as the existing `-preview` rule (nominal `tools: true`, unusable in practice). It **stays** in `OLLAMA_CLOUD_IMAGE_PREFERENCE` on purpose: its vision is genuinely good, and `isBlocked()` is consulted with the capabilities the slot actually needs, so a chat-only agent still gets the best eyes while any tool-using turn skips it. Identical treatment to `gemini-3-flash-preview`.

**2. `kimi-k2.6` curated into `OLLAMA_CLOUD_IMAGE_PREFERENCE`, ahead of `gemma4:31b`.** Blocking minimax alone would have *swapped one failure for another*. That list is a **ranking, not a filter** — `intraProviderVisionRank` ranks uncurated vision models behind every curated one, so before kimi-k2.6 was listed, a tool-using agent that skipped the two blocked entries landed on `gemma4:31b` as the last curated candidate. gemma4 corrupts long identifiers across turns (~150-char Graph message ID) and Pinchy's opaque refs are ~230 chars. Pinned by an **ordering** guard, not a membership one: gemma4 is on no blocklist, so an "at least one usable entry" guard would have passed in exactly the broken arrangement it was meant to catch.

## Please review this call 👀

The ollama-cloud resolver's **reasoning-tier vision slot** pointed at `minimax-m3`, which the drift-guards now (correctly) reject. I moved it to **`kimi-k2.6`**.

**Deliberate trade-off:** `kimi-k2.6` is not thinking-preferred, so a reasoning-tier turn that *also* needs vision loses thinking. I weighted reliable tool calls higher — a mangled `invoice_line_ids` payload fails the turn outright, which is what the reasoning was meant to serve. It is a one-line change if you disagree.

Second call worth a look: **kimi-over-gemma4 is an aggregate judgement, not a rout.** Eval backs it on duplicate (5/12 vs 0/12), distractor (12/12 vs 10/12) and silent-failure (4/12 vs 1/12) — but gemma4 is marginally *ahead* on lineitems (11/12 vs 10/12). The tiebreaker is the long-identifier corruption, which those scenarios do not probe.

## Known gap (filed separately)

`verify-ollama-cloud-tools.mjs` **cannot catch this defect class**: its probe schema is flat (`{city: string}`), so `minimax-m3` passes it cleanly — it only fails on nesting.

The eval sweep is not a substitute. CI runs `eval-selftest` only; `eval:models` needs a docker stack plus live API keys at ~72s/run, so it corroborates but cannot gate. A cheap nested-array probe in `scripts/lib/ollama-cloud-tool-probe.mjs` is what would fail fast in CI — the two are complements. Tracked separately.

## Verification

- Full suite green: **8289 passed | 15 skipped | 0 failed** (612 files passed, 3 skipped). The 15 skips are pre-existing; this branch adds none.
- `pnpm build` compiles.
- The two generic drift-guards in `model-resolver/__tests__/ollama-cloud.test.ts` picked up the new rule automatically and caught the stale resolver slot — no test changes needed for them.
- The ordering guard was mutation-tested: swapping the two entries turns it red with an actionable message.
- The blocklist rule originally shipped with **no direct unit tests** (only indirect coverage via image-fallback/client-router). Five were added, including the point-release (`minimax-m3.5` blocked) and evidence-boundary (`minimax-m4` not blocked) cases.
