### PR TITLE
fix(usage): make per-turn accounting tell the truth about cost and context

### DIFF
--- a/packages/web/drizzle/0053_flaky_iron_monger.sql
+++ b/packages/web/drizzle/0053_flaky_iron_monger.sql
@@ -1,0 +1,1 @@
+ALTER TABLE "usage_records" ADD COLUMN "context_tokens" integer;

--- a/packages/web/drizzle/meta/0053_snapshot.json
+++ b/packages/web/drizzle/meta/0053_snapshot.json
@@ -1,0 +1,3023 @@
+{
+  "id": "e88a4cb1-1f60-44b9-9b82-766520a6f377",
+  "prevId": "5f2fc04c-be8d-4166-b7d0-1d3be0794008",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.account": {
+      "name": "account",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_id": {
+          "name": "account_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_id": {
+          "name": "provider_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "access_token_expires_at": {
+          "name": "access_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "scope": {
+          "name": "scope",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "id_token": {
+          "name": "id_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "password": {
+          "name": "password",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "accounts_user_id_idx": {
+          "name": "accounts_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "account_user_id_user_id_fk": {
+          "name": "account_user_id_user_id_fk",
+          "tableFrom": "account",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_connection_permissions": {
+      "name": "agent_connection_permissions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "operation": {
+          "name": "operation",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "uq_agent_conn_model_op": {
+          "name": "uq_agent_conn_model_op",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "operation",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_agent": {
+          "name": "idx_agent_conn_perms_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_agent_conn_perms_conn": {
+          "name": "idx_agent_conn_perms_conn",
+          "columns": [
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_connection_permissions_agent_id_agents_id_fk": {
+          "name": "agent_connection_permissions_agent_id_agents_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_connection_permissions_connection_id_integration_connections_id_fk": {
+          "name": "agent_connection_permissions_connection_id_integration_connections_id_fk",
+          "tableFrom": "agent_connection_permissions",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agent_groups": {
+      "name": "agent_groups",
+      "schema": "",
+      "columns": {
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "agent_groups_group_id_idx": {
+          "name": "agent_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agent_groups_agent_id_agents_id_fk": {
+          "name": "agent_groups_agent_id_agents_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "agent_groups_group_id_groups_id_fk": {
+          "name": "agent_groups_group_id_groups_id_fk",
+          "tableFrom": "agent_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "agent_groups_agent_id_group_id_pk": {
+          "name": "agent_groups_agent_id_group_id_pk",
+          "columns": ["agent_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.agents": {
+      "name": "agents",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "agents_owner_id_idx": {
+          "name": "agents_owner_id_idx",
+          "columns": [
+            {
+              "expression": "owner_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "agents_owner_id_user_id_fk": {
+          "name": "agents_owner_id_user_id_fk",
+          "tableFrom": "agents",
+          "tableTo": "user",
+          "columnsFrom": ["owner_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "agents_visibility_check": {
+          "name": "agents_visibility_check",
+          "value": "\"agents\".\"visibility\" IN ('restricted', 'all')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_log": {
+      "name": "audit_log",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "actor_type": {
+          "name": "actor_type",
+          "type": "actor_type",
+          "typeSchema": "public",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "actor_id": {
+          "name": "actor_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "resource": {
+          "name": "resource",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "detail": {
+          "name": "detail",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "version": {
+          "name": "version",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 1
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error": {
+          "name": "error",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "row_hmac": {
+          "name": "row_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "prev_hmac": {
+          "name": "prev_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_audit_timestamp": {
+          "name": "idx_audit_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_actor": {
+          "name": "idx_audit_actor",
+          "columns": [
+            {
+              "expression": "actor_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_event": {
+          "name": "idx_audit_event",
+          "columns": [
+            {
+              "expression": "event_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_outcome": {
+          "name": "idx_audit_outcome",
+          "columns": [
+            {
+              "expression": "outcome",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_audit_resource_timestamp": {
+          "name": "idx_audit_resource_timestamp",
+          "columns": [
+            {
+              "expression": "resource",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "audit_log_v2_outcome_required": {
+          "name": "audit_log_v2_outcome_required",
+          "value": "\"audit_log\".\"version\" = 1 OR \"audit_log\".\"outcome\" IS NOT NULL"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.audit_verify_state": {
+      "name": "audit_verify_state",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "last_verified_id": {
+          "name": "last_verified_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "last_verified_hmac": {
+          "name": "last_verified_hmac",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_status": {
+          "name": "last_status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_links": {
+      "name": "channel_links",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_user_id": {
+          "name": "channel_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "linked_at": {
+          "name": "linked_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_links_user_id_idx": {
+          "name": "channel_links_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_user_channel_uniq": {
+          "name": "channel_links_user_channel_uniq",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_links_channel_user_id_uniq": {
+          "name": "channel_links_channel_user_id_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_links_user_id_user_id_fk": {
+          "name": "channel_links_user_id_user_id_fk",
+          "tableFrom": "channel_links",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.channel_messages": {
+      "name": "channel_messages",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel": {
+          "name": "channel",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "peer_id": {
+          "name": "peer_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "direction": {
+          "name": "direction",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "external_id": {
+          "name": "external_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "sent_at": {
+          "name": "sent_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "recorded_at": {
+          "name": "recorded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "channel_messages_agent_channel_peer_idx": {
+          "name": "channel_messages_agent_channel_peer_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "sent_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "channel_messages_dedup_uniq": {
+          "name": "channel_messages_dedup_uniq",
+          "columns": [
+            {
+              "expression": "channel",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "peer_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "direction",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "external_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "channel_messages_agent_id_agents_id_fk": {
+          "name": "channel_messages_agent_id_agents_id_fk",
+          "tableFrom": "channel_messages",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.chat_session_errors": {
+      "name": "chat_session_errors",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "client_message_id": {
+          "name": "client_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "error_class": {
+          "name": "error_class",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "transient_reason": {
+          "name": "transient_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "provider_error": {
+          "name": "provider_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "side_effects": {
+          "name": "side_effects",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "superseded_at": {
+          "name": "superseded_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "dismissed_at": {
+          "name": "dismissed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_chat_session_errors_session": {
+          "name": "idx_chat_session_errors_session",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_chat_session_errors_gc": {
+          "name": "idx_chat_session_errors_gc",
+          "columns": [
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "chat_session_errors_user_id_user_id_fk": {
+          "name": "chat_session_errors_user_id_user_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "chat_session_errors_agent_id_agents_id_fk": {
+          "name": "chat_session_errors_agent_id_agents_id_fk",
+          "tableFrom": "chat_session_errors",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_connection_cursors": {
+      "name": "email_connection_cursors",
+      "schema": "",
+      "columns": {
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "cursor": {
+          "name": "cursor",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_connection_cursors_connection_id_integration_connections_id_fk": {
+          "name": "email_connection_cursors_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_connection_cursors",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflow_connections": {
+      "name": "email_workflow_connections",
+      "schema": "",
+      "columns": {
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "since_ts": {
+          "name": "since_ts",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "email_workflow_connections_workflow_id_email_workflows_id_fk": {
+          "name": "email_workflow_connections_workflow_id_email_workflows_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflow_connections_connection_id_integration_connections_id_fk": {
+          "name": "email_workflow_connections_connection_id_integration_connections_id_fk",
+          "tableFrom": "email_workflow_connections",
+          "tableTo": "integration_connections",
+          "columnsFrom": ["connection_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "email_workflow_connections_workflow_id_connection_id_pk": {
+          "name": "email_workflow_connections_workflow_id_connection_id_pk",
+          "columns": ["workflow_id", "connection_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.email_workflows": {
+      "name": "email_workflows",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filter": {
+          "name": "filter",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "action": {
+          "name": "action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "poll_every": {
+          "name": "poll_every",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'5m'"
+        },
+        "sweep_window_days": {
+          "name": "sweep_window_days",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 14
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "openclaw_job_id": {
+          "name": "openclaw_job_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "email_workflows_agent_idx": {
+          "name": "email_workflows_agent_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "email_workflows_enabled_idx": {
+          "name": "email_workflows_enabled_idx",
+          "columns": [
+            {
+              "expression": "enabled",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "where": "\"email_workflows\".\"enabled\"",
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "email_workflows_agent_id_agents_id_fk": {
+          "name": "email_workflows_agent_id_agents_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "email_workflows_created_by_user_id_fk": {
+          "name": "email_workflows_created_by_user_id_fk",
+          "tableFrom": "email_workflows",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "no action",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "email_workflows_status_check": {
+          "name": "email_workflows_status_check",
+          "value": "\"email_workflows\".\"status\" IN ('pending', 'active', 'error')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.groups": {
+      "name": "groups",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.integration_connections": {
+      "name": "integration_connections",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "description": {
+          "name": "description",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "''"
+        },
+        "credentials": {
+          "name": "credentials",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "data": {
+          "name": "data",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'active'"
+        },
+        "last_error": {
+          "name": "last_error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_error_at": {
+          "name": "last_error_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "integration_connections_type_check": {
+          "name": "integration_connections_type_check",
+          "value": "\"integration_connections\".\"type\" IN ('odoo', 'web-search', 'google', 'microsoft', 'imap')"
+        },
+        "integration_connections_status_check": {
+          "name": "integration_connections_status_check",
+          "value": "\"integration_connections\".\"status\" IN ('active', 'pending', 'auth_failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.invite_groups": {
+      "name": "invite_groups",
+      "schema": "",
+      "columns": {
+        "invite_id": {
+          "name": "invite_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {
+        "invite_groups_invite_id_invites_id_fk": {
+          "name": "invite_groups_invite_id_invites_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "invites",
+          "columnsFrom": ["invite_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invite_groups_group_id_groups_id_fk": {
+          "name": "invite_groups_group_id_groups_id_fk",
+          "tableFrom": "invite_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "invite_groups_invite_id_group_id_pk": {
+          "name": "invite_groups_invite_id_group_id_pk",
+          "columns": ["invite_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.invites": {
+      "name": "invites",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "token_hash": {
+          "name": "token_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "type": {
+          "name": "type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'invite'"
+        },
+        "created_by": {
+          "name": "created_by",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_by_user_id": {
+          "name": "claimed_by_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "invites_created_by_idx": {
+          "name": "invites_created_by_idx",
+          "columns": [
+            {
+              "expression": "created_by",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_claimed_by_user_id_idx": {
+          "name": "invites_claimed_by_user_id_idx",
+          "columns": [
+            {
+              "expression": "claimed_by_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "invites_email_expires_at_idx": {
+          "name": "invites_email_expires_at_idx",
+          "columns": [
+            {
+              "expression": "email",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "invites_created_by_user_id_fk": {
+          "name": "invites_created_by_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["created_by"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "invites_claimed_by_user_id_user_id_fk": {
+          "name": "invites_claimed_by_user_id_user_id_fk",
+          "tableFrom": "invites",
+          "tableTo": "user",
+          "columnsFrom": ["claimed_by_user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "invites_token_hash_unique": {
+          "name": "invites_token_hash_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token_hash"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "invites_role_check": {
+          "name": "invites_role_check",
+          "value": "\"invites\".\"role\" IN ('admin', 'member')"
+        },
+        "invites_type_check": {
+          "name": "invites_type_check",
+          "value": "\"invites\".\"type\" IN ('invite', 'reset')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.models": {
+      "name": "models",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "provider": {
+          "name": "provider",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model_id": {
+          "name": "model_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "display_name": {
+          "name": "display_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "vision": {
+          "name": "vision",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "long_context": {
+          "name": "long_context",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "tools": {
+          "name": "tools",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source": {
+          "name": "source",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "uq_models_provider_modelid": {
+          "name": "uq_models_provider_modelid",
+          "columns": [
+            {
+              "expression": "provider",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "model_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notification_recipients": {
+      "name": "notification_recipients",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "notification_id": {
+          "name": "notification_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "read_at": {
+          "name": "read_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "notification_recipients_user_unread_idx": {
+          "name": "notification_recipients_user_unread_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "read_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notification_recipients_user_id_user_id_fk": {
+          "name": "notification_recipients_user_id_user_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "notification_recipients_notification_id_notifications_id_fk": {
+          "name": "notification_recipients_notification_id_notifications_id_fk",
+          "tableFrom": "notification_recipients",
+          "tableTo": "notifications",
+          "columnsFrom": ["notification_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "notification_recipients_user_id_notification_id_pk": {
+          "name": "notification_recipients_user_id_notification_id_pk",
+          "columns": ["user_id", "notification_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.notifications": {
+      "name": "notifications",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "source_type": {
+          "name": "source_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "source_id": {
+          "name": "source_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "title": {
+          "name": "title",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content": {
+          "name": "content",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "error_message": {
+          "name": "error_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "notifications_agent_created_idx": {
+          "name": "notifications_agent_created_idx",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "created_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "notifications_agent_id_agents_id_fk": {
+          "name": "notifications_agent_id_agents_id_fk",
+          "tableFrom": "notifications",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "notifications_status_check": {
+          "name": "notifications_status_check",
+          "value": "\"notifications\".\"status\" IN ('success', 'failure')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.processed_emails": {
+      "name": "processed_emails",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "uuid",
+          "primaryKey": true,
+          "notNull": true,
+          "default": "gen_random_uuid()"
+        },
+        "workflow_id": {
+          "name": "workflow_id",
+          "type": "uuid",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "connection_id": {
+          "name": "connection_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "provider_message_id": {
+          "name": "provider_message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "message_id_header": {
+          "name": "message_id_header",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'processing'"
+        },
+        "outcome": {
+          "name": "outcome",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "claimed_at": {
+          "name": "claimed_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "finalized_at": {
+          "name": "finalized_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "processed_emails_claim_uniq": {
+          "name": "processed_emails_claim_uniq",
+          "columns": [
+            {
+              "expression": "workflow_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "connection_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "provider_message_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "processed_emails_status_idx": {
+          "name": "processed_emails_status_idx",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "processed_emails_workflow_id_email_workflows_id_fk": {
+          "name": "processed_emails_workflow_id_email_workflows_id_fk",
+          "tableFrom": "processed_emails",
+          "tableTo": "email_workflows",
+          "columnsFrom": ["workflow_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "processed_emails_status_check": {
+          "name": "processed_emails_status_check",
+          "value": "\"processed_emails\".\"status\" IN ('processing', 'done', 'no_action', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.session": {
+      "name": "session",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token": {
+          "name": "token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "ip_address": {
+          "name": "ip_address",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "user_agent": {
+          "name": "user_agent",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {
+        "sessions_user_id_idx": {
+          "name": "sessions_user_id_idx",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "session_user_id_user_id_fk": {
+          "name": "session_user_id_user_id_fk",
+          "tableFrom": "session",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "session_token_unique": {
+          "name": "session_token_unique",
+          "nullsNotDistinct": false,
+          "columns": ["token"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.settings": {
+      "name": "settings",
+      "schema": "",
+      "columns": {
+        "key": {
+          "name": "key",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "encrypted": {
+          "name": "encrypted",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.uploaded_files": {
+      "name": "uploaded_files",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "draft_id": {
+          "name": "draft_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "filename": {
+          "name": "filename",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "mime_type": {
+          "name": "mime_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "size_bytes": {
+          "name": "size_bytes",
+          "type": "bigint",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "content_hash": {
+          "name": "content_hash",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "staging_path": {
+          "name": "staging_path",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "message_id": {
+          "name": "message_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "attached_at": {
+          "name": "attached_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_uploaded_files_gc": {
+          "name": "idx_uploaded_files_gc",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_uploaded_files_user_agent_draft": {
+          "name": "idx_uploaded_files_user_agent_draft",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "draft_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "uploaded_files_user_id_user_id_fk": {
+          "name": "uploaded_files_user_id_user_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "uploaded_files_agent_id_agents_id_fk": {
+          "name": "uploaded_files_agent_id_agents_id_fk",
+          "tableFrom": "uploaded_files",
+          "tableTo": "agents",
+          "columnsFrom": ["agent_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.usage_records": {
+      "name": "usage_records",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "timestamp": {
+          "name": "timestamp",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_id": {
+          "name": "agent_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "agent_name": {
+          "name": "agent_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "session_key": {
+          "name": "session_key",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "input_tokens": {
+          "name": "input_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "output_tokens": {
+          "name": "output_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "cache_read_tokens": {
+          "name": "cache_read_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "cache_write_tokens": {
+          "name": "cache_write_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        },
+        "estimated_cost_usd": {
+          "name": "estimated_cost_usd",
+          "type": "numeric(10, 6)",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "run_id": {
+          "name": "run_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "seq": {
+          "name": "seq",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context_tokens": {
+          "name": "context_tokens",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "indexes": {
+        "idx_usage_timestamp": {
+          "name": "idx_usage_timestamp",
+          "columns": [
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user": {
+          "name": "idx_usage_user",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent": {
+          "name": "idx_usage_agent",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_session_key": {
+          "name": "idx_usage_session_key",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_user_timestamp": {
+          "name": "idx_usage_user_timestamp",
+          "columns": [
+            {
+              "expression": "user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_usage_agent_timestamp": {
+          "name": "idx_usage_agent_timestamp",
+          "columns": [
+            {
+              "expression": "agent_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "timestamp",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "uq_usage_session_run": {
+          "name": "uq_usage_session_run",
+          "columns": [
+            {
+              "expression": "session_key",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "run_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user_groups": {
+      "name": "user_groups",
+      "schema": "",
+      "columns": {
+        "user_id": {
+          "name": "user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "group_id": {
+          "name": "group_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "user_groups_group_id_idx": {
+          "name": "user_groups_group_id_idx",
+          "columns": [
+            {
+              "expression": "group_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "user_groups_user_id_user_id_fk": {
+          "name": "user_groups_user_id_user_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "user",
+          "columnsFrom": ["user_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "user_groups_group_id_groups_id_fk": {
+          "name": "user_groups_group_id_groups_id_fk",
+          "tableFrom": "user_groups",
+          "tableTo": "groups",
+          "columnsFrom": ["group_id"],
+          "columnsTo": ["id"],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "user_groups_user_id_group_id_pk": {
+          "name": "user_groups_user_id_group_id_pk",
+          "columns": ["user_id", "group_id"]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.user": {
+      "name": "user",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email": {
+          "name": "email",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "email_verified": {
+          "name": "email_verified",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "image": {
+          "name": "image",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "role": {
+          "name": "role",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'member'"
+        },
+        "banned": {
+          "name": "banned",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": false,
+          "default": false
+        },
+        "ban_reason": {
+          "name": "ban_reason",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "ban_expires": {
+          "name": "ban_expires",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "context": {
+          "name": "context",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "audit_pseudonym": {
+          "name": "audit_pseudonym",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "gen_random_uuid()::text"
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {
+        "user_email_unique": {
+          "name": "user_email_unique",
+          "nullsNotDistinct": false,
+          "columns": ["email"]
+        },
+        "user_audit_pseudonym_unique": {
+          "name": "user_audit_pseudonym_unique",
+          "nullsNotDistinct": false,
+          "columns": ["audit_pseudonym"]
+        }
+      },
+      "policies": {},
+      "checkConstraints": {
+        "users_role_check": {
+          "name": "users_role_check",
+          "value": "\"user\".\"role\" IN ('admin', 'member')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.verification": {
+      "name": "verification",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "identifier": {
+          "name": "identifier",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "value": {
+          "name": "value",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {
+    "public.actor_type": {
+      "name": "actor_type",
+      "schema": "public",
+      "values": ["user", "agent", "system"]
+    }
+  },
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {
+    "public.active_agents": {
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "name": {
+          "name": "name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'Smithers'"
+        },
+        "model": {
+          "name": "model",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "template_id": {
+          "name": "template_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "plugin_config": {
+          "name": "plugin_config",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "allowed_tools": {
+          "name": "allowed_tools",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "skills": {
+          "name": "skills",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "owner_id": {
+          "name": "owner_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "is_personal": {
+          "name": "is_personal",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": false
+        },
+        "visibility": {
+          "name": "visibility",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'restricted'"
+        },
+        "greeting_message": {
+          "name": "greeting_message",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "tagline": {
+          "name": "tagline",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "starter_prompts": {
+          "name": "starter_prompts",
+          "type": "jsonb",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'[]'::jsonb"
+        },
+        "avatar_seed": {
+          "name": "avatar_seed",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "personality_preset_id": {
+          "name": "personality_preset_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "now()"
+        },
+        "deleted_at": {
+          "name": "deleted_at",
+          "type": "timestamp",
+          "primaryKey": false,
+          "notNull": false
+        }
+      },
+      "definition": "select \"id\", \"name\", \"model\", \"template_id\", \"plugin_config\", \"allowed_tools\", \"skills\", \"owner_id\", \"is_personal\", \"visibility\", \"greeting_message\", \"tagline\", \"starter_prompts\", \"avatar_seed\", \"personality_preset_id\", \"created_at\", \"deleted_at\" from \"agents\" where \"agents\".\"deleted_at\" is null",
+      "name": "active_agents",
+      "schema": "public",
+      "isExisting": false,
+      "materialized": false
+    }
+  },
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/packages/web/drizzle/meta/_journal.json
+++ b/packages/web/drizzle/meta/_journal.json
@@ -372,6 +372,13 @@
       "when": 1783913628844,
       "tag": "0052_eager_nightmare",
       "breakpoints": true
+    },
+    {
+      "idx": 53,
+      "version": "7",
+      "when": 1784141245727,
+      "tag": "0053_flaky_iron_monger",
+      "breakpoints": true
     }
   ]
 }

--- a/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
+++ b/packages/web/src/__tests__/integration/usage-per-turn.integration.test.ts
@@ -42,6 +42,7 @@ function row(over: Partial<InsertableUsageRow>): InsertableUsageRow {
     estimatedCostUsd: null,
     runId: "run-1",
     seq: 5,
+    contextTokens: null,
     ...over,
   };
 }
@@ -139,8 +140,13 @@ describe("per-turn usage accounting (#483) — real Postgres", () => {
           config: {
             models: {
               providers: {
+                // Bare id, exactly as openclaw-config/build.ts emits it. This
+                // fixture used to say "anthropic/claude-sonnet-4-6" — a shape
+                // the real config never produces — which made the pricing
+                // lookup match for the wrong reason and hid the fact that the
+                // per-turn path asks with a qualified id.
                 anthropic: {
-                  models: [{ id: "anthropic/claude-sonnet-4-6", cost: { input: 3, output: 15 } }],
+                  models: [{ id: "claude-sonnet-4-6", cost: { input: 3, output: 15 } }],
                 },
               },
             },

--- a/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
+++ b/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
@@ -147,11 +147,54 @@ describe("extractPerTurnUsage context size", () => {
     expect(row.contextTokens).toBe(100000);
   });
 
+  it("counts freshly cached prompt tokens toward the context size", () => {
+    // cacheWrite is the same argument as cacheRead, one call earlier: tokens
+    // being written to the cache are prompt tokens the model reads on THIS
+    // call — they are just billed at the write rate. The four classes are
+    // disjoint, which `data.usage` proves arithmetically: the fixture's
+    // 5 + 630 + 32336 + 16956 is exactly its `total` of 49927. So the prompt
+    // is input + cacheRead + cacheWrite.
+    //
+    // Omitting cacheWrite under-reports precisely where the column earns its
+    // keep: on the turn where the context GROWS, the new tail is cacheWrite.
+    // A cold turn (nothing cached yet) would report ~0 context — the same
+    // "reads as 0% utilization" failure the null-vs-0 rule exists to prevent.
+    const [row] = extractPerTurnUsage([
+      modelCompleted({
+        data: {
+          usage: { input: 5, output: 630, cacheRead: 0, cacheWrite: 150000, total: 150635 },
+          promptCache: {
+            lastCallUsage: { input: 4000, output: 630, cacheRead: 0, cacheWrite: 96000 },
+          },
+        },
+      }),
+    ]);
+
+    expect(row.contextTokens).toBe(100000);
+  });
+
   it("reports a null context size when the event carries no promptCache", () => {
     // Null, not 0 — "we don't know" must never render as "the context is empty",
     // which would silently read as 0% utilization.
     const [row] = extractPerTurnUsage([
       modelCompleted({ data: { usage: { input: 100, output: 20, total: 120 } } }),
+    ]);
+
+    expect(row.contextTokens).toBeNull();
+  });
+
+  it("reports null, not 0, when lastCallUsage carries no prompt token classes", () => {
+    // Hanging the "unknown" signal on the mere PRESENCE of the block leaks a 0
+    // through whenever the shape is empty or unrecognized — and 0 is a lie the
+    // dashboard cannot detect, because "context was empty" is a legal reading.
+    // No prompt classes we understand ⇒ we do not know the context size.
+    const [row] = extractPerTurnUsage([
+      modelCompleted({
+        data: {
+          usage: { input: 100, output: 20, total: 120 },
+          promptCache: { lastCallUsage: { output: 20 } },
+        },
+      }),
     ]);
 
     expect(row.contextTokens).toBeNull();

--- a/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
+++ b/packages/web/src/__tests__/lib/usage-from-trajectory.test.ts
@@ -34,6 +34,7 @@ describe("extractPerTurnUsage", () => {
         outputTokens: 630,
         cacheReadTokens: 32336,
         cacheWriteTokens: 16956,
+        contextTokens: null,
       },
     ]);
   });
@@ -90,5 +91,69 @@ describe("extractPerTurnUsage", () => {
 
   it("returns [] for empty input", () => {
     expect(extractPerTurnUsage([])).toEqual([]);
+  });
+});
+
+// Context size is NOT `data.usage.input`. A single turn drives a whole tool
+// loop — roughly 11 LLM calls for the production turns below — and
+// `data.usage` SUMS every one of them. The context that actually hit the
+// model's window is the size of the LAST call, in
+// `data.promptCache.lastCallUsage`. Confirmed on production 2026-07-15
+// (agent "Piper", deepseek-v4-pro):
+//
+//   ts        data.usage.input   lastCallUsage.input
+//   12:51:21         1,856,700               169,592
+//   12:55:22         2,212,441               171,097
+//   13:01:15         2,038,006               170,306
+//
+// Reading `data.usage.input` as the context would over-report by ~11x and
+// make every utilization figure meaningless. The two are kept separate on
+// purpose: `inputTokens` is what gets BILLED (every call counts),
+// `contextTokens` is what gets sent (only the last call).
+describe("extractPerTurnUsage context size", () => {
+  it("reads the context size from promptCache.lastCallUsage, not the summed data.usage", () => {
+    const [row] = extractPerTurnUsage([
+      modelCompleted({
+        provider: "ollama-cloud",
+        modelId: "deepseek-v4-pro",
+        data: {
+          usage: { input: 1856700, output: 4047, total: 1860747 },
+          promptCache: {
+            lastCallUsage: { input: 169592, output: 2073, cacheRead: 0, cacheWrite: 0 },
+          },
+        },
+      }),
+    ]);
+
+    expect(row.inputTokens).toBe(1856700);
+    expect(row.contextTokens).toBe(169592);
+  });
+
+  it("counts cached prompt tokens toward the context size", () => {
+    // On a caching provider the cached prefix is still part of the prompt the
+    // model sees — it's only billed differently. Excluding it would under-report
+    // utilization on exactly the providers that run the longest contexts.
+    const [row] = extractPerTurnUsage([
+      modelCompleted({
+        data: {
+          usage: { input: 5, output: 630, cacheRead: 32336, cacheWrite: 16956, total: 49927 },
+          promptCache: {
+            lastCallUsage: { input: 4000, output: 630, cacheRead: 96000, cacheWrite: 0 },
+          },
+        },
+      }),
+    ]);
+
+    expect(row.contextTokens).toBe(100000);
+  });
+
+  it("reports a null context size when the event carries no promptCache", () => {
+    // Null, not 0 — "we don't know" must never render as "the context is empty",
+    // which would silently read as 0% utilization.
+    const [row] = extractPerTurnUsage([
+      modelCompleted({ data: { usage: { input: 100, output: 20, total: 120 } } }),
+    ]);
+
+    expect(row.contextTokens).toBeNull();
   });
 });

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -62,6 +62,7 @@ describe("buildUsageRows", () => {
         estimatedCostUsd: "0.082751",
         runId: "run-1",
         seq: 5,
+        contextTokens: null,
       },
     ]);
   });

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -1,5 +1,24 @@
-import { describe, it, expect } from "vitest";
-import { buildUsageRows } from "@/lib/usage-per-turn";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+const mockValues = vi.fn();
+const mockResolveSessionId = vi.fn();
+const mockReadTrajectoryJsonl = vi.fn();
+
+vi.mock("@/db", () => ({
+  db: { insert: () => ({ values: mockValues }) },
+}));
+
+vi.mock("@/db/schema", () => ({
+  usageRecords: { _table: "usage_records", sessionKey: "session_key", runId: "run_id" },
+}));
+
+vi.mock("@/lib/diagnostics/jsonl-reader", () => ({
+  resolveSessionId: (...args: unknown[]) => mockResolveSessionId(...args),
+  readTrajectoryJsonl: (...args: unknown[]) => mockReadTrajectoryJsonl(...args),
+}));
+
+import { buildUsageRows, recordSessionTurnsUsage } from "@/lib/usage-per-turn";
+import { _resetPricingCacheForTest } from "@/lib/usage";
 import type { PerTurnUsage } from "@/lib/usage-from-trajectory";
 
 const ctx = {
@@ -78,5 +97,100 @@ describe("buildUsageRows", () => {
   it("uses the context sessionKey (normalized), not the raw event one", () => {
     const rows = buildUsageRows([turn({ sessionKey: "AGENT:A1:DIRECT:U1" })], ctx, () => null);
     expect(rows[0].sessionKey).toBe("agent:a1:direct:u1");
+  });
+});
+
+// Seam test. `buildUsageRows` above is pure and takes an INJECTED `priceFor`,
+// so all of its cost assertions pass regardless of whether the real lookup
+// works — which is exactly how the 2026-07-15 gap survived: every chat turn
+// recorded a null cost in production while these tests stayed green. This
+// test deliberately does NOT mock `getModelPricing`; it drives the real
+// trajectory → model-id → config-pricing chain end to end.
+describe("recordSessionTurnsUsage cost wiring", () => {
+  // One `model.completed` event in OpenClaw's real shape: `provider` and
+  // `modelId` are separate fields, which extractPerTurnUsage joins into the
+  // qualified "ollama-cloud/deepseek-v4-pro" the pricing lookup must resolve.
+  const trajectory = JSON.stringify({
+    type: "model.completed",
+    runId: "run-1",
+    seq: 1,
+    sessionId: "sess-1",
+    sessionKey: "agent:a1:direct:u1",
+    provider: "ollama-cloud",
+    modelId: "deepseek-v4-pro",
+    data: { usage: { input: 1000, output: 500, total: 1500 } },
+  });
+
+  // Pinchy emits models keyed by their bare id — see openclaw-config/build.ts.
+  const config = {
+    config: {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            models: [{ id: "deepseek-v4-pro", cost: { input: 3, output: 15 } }],
+          },
+        },
+      },
+    },
+  };
+
+  function client() {
+    return {
+      config: { get: vi.fn().mockResolvedValue(config) },
+    } as unknown as Parameters<typeof recordSessionTurnsUsage>[0]["openclawClient"];
+  }
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    _resetPricingCacheForTest();
+    mockResolveSessionId.mockResolvedValue("sess-1");
+    mockReadTrajectoryJsonl.mockResolvedValue(trajectory);
+    mockValues.mockImplementation((rows: unknown[]) => ({
+      onConflictDoNothing: () => ({
+        returning: () => Promise.resolve(rows.map((_, i) => ({ id: String(i) }))),
+      }),
+    }));
+  });
+
+  it("attaches a cost to a chat turn whose trajectory model is fully qualified", async () => {
+    const recorded = await recordSessionTurnsUsage({
+      openclawClient: client(),
+      agentId: "a1",
+      userId: "u1",
+      agentName: "Ada",
+      sessionKey: "agent:a1:direct:u1",
+    });
+
+    expect(recorded).toBe(1);
+    const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(rows[0].model).toBe("ollama-cloud/deepseek-v4-pro");
+    expect(rows[0].estimatedCostUsd).not.toBeNull();
+  });
+
+  it("still records the turn with a null cost when the model is unpriced", async () => {
+    mockReadTrajectoryJsonl.mockResolvedValue(
+      JSON.stringify({
+        type: "model.completed",
+        runId: "run-2",
+        seq: 1,
+        sessionId: "sess-1",
+        sessionKey: "agent:a1:direct:u1",
+        provider: "ollama-local",
+        modelId: "llama-unknown",
+        data: { usage: { input: 10, output: 5, total: 15 } },
+      })
+    );
+
+    const recorded = await recordSessionTurnsUsage({
+      openclawClient: client(),
+      agentId: "a1",
+      userId: "u1",
+      agentName: "Ada",
+      sessionKey: "agent:a1:direct:u1",
+    });
+
+    expect(recorded).toBe(1);
+    const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(rows[0].estimatedCostUsd).toBeNull();
   });
 });

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -172,21 +172,21 @@ describe("recordSessionTurnsUsage cost wiring", () => {
     expect(rows[0].estimatedCostUsd).not.toBeNull();
   });
 
-  it("records the turn's context size, distinct from the billed input tokens", () => {
+  it("records the turn's context size, distinct from the billed input tokens", async () => {
     // Guards the whole trajectory → DB-row path: the row must bill the summed
     // 1000 while reporting the last call's 400 as context pressure. Collapsing
     // the two is the mistake this column exists to prevent.
-    return recordSessionTurnsUsage({
+    await recordSessionTurnsUsage({
       openclawClient: client(),
       agentId: "a1",
       userId: "u1",
       agentName: "Ada",
       sessionKey: "agent:a1:direct:u1",
-    }).then(() => {
-      const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
-      expect(rows[0].inputTokens).toBe(1000);
-      expect(rows[0].contextTokens).toBe(400);
     });
+
+    const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
+    expect(rows[0].inputTokens).toBe(1000);
+    expect(rows[0].contextTokens).toBe(400);
   });
 
   it("still records the turn with a null cost when the model is unpriced", async () => {

--- a/packages/web/src/__tests__/lib/usage-per-turn.test.ts
+++ b/packages/web/src/__tests__/lib/usage-per-turn.test.ts
@@ -39,6 +39,7 @@ function turn(over: Partial<PerTurnUsage> = {}): PerTurnUsage {
     outputTokens: 630,
     cacheReadTokens: 32336,
     cacheWriteTokens: 16956,
+    contextTokens: null,
     ...over,
   };
 }
@@ -118,7 +119,10 @@ describe("recordSessionTurnsUsage cost wiring", () => {
     sessionKey: "agent:a1:direct:u1",
     provider: "ollama-cloud",
     modelId: "deepseek-v4-pro",
-    data: { usage: { input: 1000, output: 500, total: 1500 } },
+    data: {
+      usage: { input: 1000, output: 500, total: 1500 },
+      promptCache: { lastCallUsage: { input: 400, output: 500, cacheRead: 0, cacheWrite: 0 } },
+    },
   });
 
   // Pinchy emits models keyed by their bare id — see openclaw-config/build.ts.
@@ -167,6 +171,23 @@ describe("recordSessionTurnsUsage cost wiring", () => {
     expect(rows[0].estimatedCostUsd).not.toBeNull();
   });
 
+  it("records the turn's context size, distinct from the billed input tokens", () => {
+    // Guards the whole trajectory → DB-row path: the row must bill the summed
+    // 1000 while reporting the last call's 400 as context pressure. Collapsing
+    // the two is the mistake this column exists to prevent.
+    return recordSessionTurnsUsage({
+      openclawClient: client(),
+      agentId: "a1",
+      userId: "u1",
+      agentName: "Ada",
+      sessionKey: "agent:a1:direct:u1",
+    }).then(() => {
+      const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
+      expect(rows[0].inputTokens).toBe(1000);
+      expect(rows[0].contextTokens).toBe(400);
+    });
+  });
+
   it("still records the turn with a null cost when the model is unpriced", async () => {
     mockReadTrajectoryJsonl.mockResolvedValue(
       JSON.stringify({
@@ -192,5 +213,17 @@ describe("recordSessionTurnsUsage cost wiring", () => {
     expect(recorded).toBe(1);
     const rows = mockValues.mock.calls[0][0] as Array<Record<string, unknown>>;
     expect(rows[0].estimatedCostUsd).toBeNull();
+  });
+});
+
+describe("buildUsageRows context size", () => {
+  it("carries the turn's context size onto the row", () => {
+    const rows = buildUsageRows([turn({ contextTokens: 169592 })], ctx, () => null);
+    expect(rows[0].contextTokens).toBe(169592);
+  });
+
+  it("passes an unknown context size through as null, not 0", () => {
+    const rows = buildUsageRows([turn({ contextTokens: null })], ctx, () => null);
+    expect(rows[0].contextTokens).toBeNull();
   });
 });

--- a/packages/web/src/__tests__/lib/usage.test.ts
+++ b/packages/web/src/__tests__/lib/usage.test.ts
@@ -52,6 +52,7 @@ vi.mock("drizzle-orm", () => ({
 
 import {
   recordUsage,
+  getModelPricing,
   _resetPricingCacheForTest,
   _resetPendingSessionsForTest,
   _resetUsageWatermarksForTest,
@@ -593,5 +594,69 @@ describe("recordUsage", () => {
     await recordUsage({ openclawClient: client, ...baseParams });
 
     expect(client.config.get).toHaveBeenCalledTimes(1);
+  });
+});
+
+// Regression guard for a silent, production-confirmed pricing gap (2026-07-15).
+//
+// Pinchy emits every model into the OpenClaw config keyed by its BARE id
+// (openclaw-config/build.ts: `id: m.id`), but the two usage paths ask with
+// different shapes:
+//
+//   - gauge path (recordUsage, system sessions) passes `session.model` from
+//     sessions.list() — a bare id like "kimi-k2.6".
+//   - per-turn path (usage-per-turn.ts, chat sessions) passes the trajectory's
+//     fully-qualified `<provider>/<modelId>` ("ollama-cloud/kimi-k2.6"),
+//     because `model.completed` events carry a separate `provider` field.
+//
+// Only the bare form ever matched, so EVERY chat turn silently recorded
+// `estimated_cost_usd = NULL`. Production bore this out exactly: 330/330
+// per-turn rows had no cost, while 400/400 gauge rows had one. It stayed
+// invisible because Ollama Cloud is subscription-priced (cost 0), but on a
+// per-token provider it would under-report chat spend as zero.
+//
+// It slipped through because `buildUsageRows` — the only tested unit — takes an
+// INJECTED `priceFor`, so the real lookup was never exercised.
+describe("getModelPricing model-id resolution", () => {
+  const configWithPricing = {
+    config: {
+      models: {
+        providers: {
+          "ollama-cloud": {
+            models: [{ id: "deepseek-v4-pro", cost: { input: 1, output: 2 } }],
+          },
+        },
+      },
+    },
+  };
+
+  beforeEach(() => {
+    _resetPricingCacheForTest();
+  });
+
+  it("resolves a bare model id (gauge path)", async () => {
+    const client = makeOpenClawClient([], configWithPricing);
+    await expect(getModelPricing(client, "deepseek-v4-pro")).resolves.toEqual({
+      input: 1,
+      output: 2,
+    });
+  });
+
+  it("resolves a fully-qualified <provider>/<modelId> (per-turn path)", async () => {
+    const client = makeOpenClawClient([], configWithPricing);
+    await expect(getModelPricing(client, "ollama-cloud/deepseek-v4-pro")).resolves.toEqual({
+      input: 1,
+      output: 2,
+    });
+  });
+
+  it("returns null for a known provider but unknown model", async () => {
+    const client = makeOpenClawClient([], configWithPricing);
+    await expect(getModelPricing(client, "ollama-cloud/no-such-model")).resolves.toBeNull();
+  });
+
+  it("does not resolve a model attributed to the wrong provider", async () => {
+    const client = makeOpenClawClient([], configWithPricing);
+    await expect(getModelPricing(client, "anthropic/deepseek-v4-pro")).resolves.toBeNull();
   });
 });

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -693,9 +693,13 @@ export const usageRecords = pgTable(
     // and input_tokens sums every call in it (~11x larger in practice), so it
     // says nothing about context pressure.
     //
+    // Counts every prompt class of that call — input + cacheRead + cacheWrite,
+    // which the usage payload shows to be disjoint — since all three are tokens
+    // the model read, differing only in how they are billed.
+    //
     // Nullable: only the per-turn trajectory path can know it. The gauge poller
     // and the /api/internal/usage/record sink leave it NULL, as do events with
-    // no promptCache block — NULL means "unknown", never "empty".
+    // no usable promptCache — NULL means "unknown", never "empty".
     //
     // This is the read-side of the 2026-07-15 "Piper" incident: the agent ran at
     // ~170k context with compaction never firing (its window was configured at

--- a/packages/web/src/db/schema.ts
+++ b/packages/web/src/db/schema.ts
@@ -687,6 +687,24 @@ export const usageRecords = pgTable(
     // sink (plugin vision tokens) keep inserting without a run id.
     runId: text("run_id"),
     seq: integer("seq"),
+    // How full the model's context window got on this turn — the size of the
+    // prompt on the turn's LAST call, which is what the window has to hold.
+    // Deliberately distinct from input_tokens: a turn drives a whole tool loop
+    // and input_tokens sums every call in it (~11x larger in practice), so it
+    // says nothing about context pressure.
+    //
+    // Nullable: only the per-turn trajectory path can know it. The gauge poller
+    // and the /api/internal/usage/record sink leave it NULL, as do events with
+    // no promptCache block — NULL means "unknown", never "empty".
+    //
+    // This is the read-side of the 2026-07-15 "Piper" incident: the agent ran at
+    // ~170k context with compaction never firing (its window was configured at
+    // 1M, so OpenClaw's shouldCompact threshold sat at ~1.03M) and started
+    // fabricating tool results. Recovering those numbers meant SSHing into prod
+    // and parsing trajectory JSONL by hand; with this column it is one query.
+    // A drop between consecutive turns of a session is also how compaction
+    // becomes visible — OpenClaw emits no compaction trajectory event.
+    contextTokens: integer("context_tokens"),
   },
   (table) => [
     index("idx_usage_timestamp").on(table.timestamp),

--- a/packages/web/src/lib/usage-from-trajectory.ts
+++ b/packages/web/src/lib/usage-from-trajectory.ts
@@ -33,8 +33,12 @@ export interface PerTurnUsage {
    * context by roughly that factor. `data.promptCache.lastCallUsage` carries
    * the final call on its own.
    *
-   * `null` when the event has no `promptCache` block — "unknown", which must
-   * not be conflated with 0 ("empty context", i.e. 0% utilization).
+   * Counts every prompt class of that call — `input + cacheRead + cacheWrite`
+   * — because all three are tokens the model read; they only differ in billing.
+   *
+   * `null` when the event carries no usable `promptCache.lastCallUsage` —
+   * "unknown", which must not be conflated with 0 ("empty context", i.e. 0%
+   * utilization).
    */
   contextTokens: number | null;
 }
@@ -61,16 +65,30 @@ function qualifiedModel(provider: unknown, modelId: unknown): string | null {
 
 /**
  * Size of the prompt on the turn's last call, from `data.promptCache
- * .lastCallUsage`. The cached prefix counts: it is still part of the prompt the
- * model sees, only billed differently — excluding it would under-report
- * utilization on exactly the caching providers that run the longest contexts.
- * Returns null when the block is absent, so callers can tell "unknown" apart
- * from "empty".
+ * .lastCallUsage` — the sum of its three PROMPT classes.
+ *
+ * `input`, `cacheRead` and `cacheWrite` are disjoint, which the usage payload
+ * proves arithmetically: a live event reporting 5 / 630 / 32336 / 16956 carries
+ * `total: 49927` — the plain sum, no class counted twice. So the prompt the
+ * model read is `input + cacheRead + cacheWrite`; only `output` is not part of
+ * it. Cached tokens are still tokens the model sees, they are merely billed at
+ * a different rate (see estimateTurnCostUsd), and that holds for the freshly
+ * written ones too: on the turn where the context GROWS, the new tail arrives
+ * as `cacheWrite`. Dropping either cache class would under-report utilization
+ * on exactly the caching providers that run the longest contexts.
+ *
+ * Returns null when the block is missing, or when it carries none of the three
+ * classes, so callers can tell "unknown" apart from "empty" — a 0 here would
+ * read as 0% utilization, which is undetectable downstream.
  */
 function contextTokensOf(data: Record<string, unknown> | undefined): number | null {
   const lastCall = asRecord(asRecord(data?.promptCache)?.lastCallUsage);
   if (!lastCall) return null;
-  return asTokenCount(lastCall.input) + asTokenCount(lastCall.cacheRead);
+  const promptTokens =
+    asTokenCount(lastCall.input) +
+    asTokenCount(lastCall.cacheRead) +
+    asTokenCount(lastCall.cacheWrite);
+  return promptTokens > 0 ? promptTokens : null;
 }
 
 /**

--- a/packages/web/src/lib/usage-from-trajectory.ts
+++ b/packages/web/src/lib/usage-from-trajectory.ts
@@ -25,6 +25,18 @@ export interface PerTurnUsage {
   outputTokens: number;
   cacheReadTokens: number;
   cacheWriteTokens: number;
+  /**
+   * Size of the prompt the model actually saw on this turn's LAST call —
+   * i.e. how full its context window got. Deliberately NOT `inputTokens`:
+   * one turn drives a whole tool loop (~11 LLM calls in the production
+   * samples), and `data.usage` sums all of them, so it over-reports the
+   * context by roughly that factor. `data.promptCache.lastCallUsage` carries
+   * the final call on its own.
+   *
+   * `null` when the event has no `promptCache` block — "unknown", which must
+   * not be conflated with 0 ("empty context", i.e. 0% utilization).
+   */
+  contextTokens: number | null;
 }
 
 function asRecord(value: unknown): Record<string, unknown> | undefined {
@@ -45,6 +57,20 @@ function qualifiedModel(provider: unknown, modelId: unknown): string | null {
   const p = asString(provider);
   const m = asString(modelId);
   return p && m ? `${p}/${m}` : (m ?? null);
+}
+
+/**
+ * Size of the prompt on the turn's last call, from `data.promptCache
+ * .lastCallUsage`. The cached prefix counts: it is still part of the prompt the
+ * model sees, only billed differently — excluding it would under-report
+ * utilization on exactly the caching providers that run the longest contexts.
+ * Returns null when the block is absent, so callers can tell "unknown" apart
+ * from "empty".
+ */
+function contextTokensOf(data: Record<string, unknown> | undefined): number | null {
+  const lastCall = asRecord(asRecord(data?.promptCache)?.lastCallUsage);
+  if (!lastCall) return null;
+  return asTokenCount(lastCall.input) + asTokenCount(lastCall.cacheRead);
 }
 
 /**
@@ -74,6 +100,7 @@ export function extractPerTurnUsage(events: JsonlEvent[]): PerTurnUsage[] {
       outputTokens: asTokenCount(usage.output),
       cacheReadTokens: asTokenCount(usage.cacheRead),
       cacheWriteTokens: asTokenCount(usage.cacheWrite),
+      contextTokens: contextTokensOf(data),
     });
   }
   return rows;

--- a/packages/web/src/lib/usage-per-turn.ts
+++ b/packages/web/src/lib/usage-per-turn.ts
@@ -32,6 +32,8 @@ export interface InsertableUsageRow {
   estimatedCostUsd: string | null;
   runId: string;
   seq: number;
+  /** Context-window pressure for this turn — see PerTurnUsage.contextTokens. */
+  contextTokens: number | null;
 }
 
 export interface UsageRowContext {
@@ -78,6 +80,7 @@ export function buildUsageRows(
         : null,
       runId: t.runId,
       seq: t.seq,
+      contextTokens: t.contextTokens,
     };
   });
 }

--- a/packages/web/src/lib/usage.ts
+++ b/packages/web/src/lib/usage.ts
@@ -95,12 +95,20 @@ export async function getModelPricing(
   };
   const providers = result?.config?.models?.providers ?? {};
 
+  // Key every model under BOTH shapes its callers ask with. The config itself
+  // only carries the bare id, but the per-turn recorder asks with the
+  // trajectory's `<provider>/<modelId>` (model.completed events keep provider
+  // and modelId in separate fields). Keying bare-only silently priced every
+  // chat turn at null. Where two providers share a bare id, the last one wins —
+  // unchanged from before; the qualified key disambiguates those callers that
+  // supply it.
   const pricingMap = new Map<string, { input: number; output: number }>();
-  for (const provider of Object.values(providers) as Array<{
-    models?: Array<{ id: string; cost?: { input: number; output: number } }>;
-  }>) {
+  for (const [providerName, provider] of Object.entries(providers) as Array<
+    [string, { models?: Array<{ id: string; cost?: { input: number; output: number } }> }]
+  >) {
     for (const model of provider.models ?? []) {
       if (model.cost) {
+        pricingMap.set(`${providerName}/${model.id}`, model.cost);
         pricingMap.set(model.id, model.cost);
       }
     }


### PR DESCRIPTION
Two related defects in per-turn usage accounting, both surfaced by the 2026-07-15 "Piper" incident, both in the same module and the same data source (`model.completed` trajectory events). They share a test file, so splitting them would mean stacking PRs.

## 1. Chat turns never get a cost (fix)

Pinchy emits models into the OpenClaw config keyed by their **bare** id (`openclaw-config/build.ts:1187`). The two usage paths ask for pricing with different shapes:

| Path | Asks with | Example |
|---|---|---|
| gauge (`recordUsage`, system sessions) | bare id from `sessions.list()` | `kimi-k2.6` |
| per-turn (`usage-per-turn.ts`, chat sessions) | qualified, from the trajectory | `ollama-cloud/kimi-k2.6` |

The per-turn form is qualified because `model.completed` keeps `provider` and `modelId` in separate fields. Only the bare form matched, so the per-turn lookup always returned `null`. Production, same table, same day:

| Path | Model key | Rows | With cost |
|---|---|---|---|
| gauge | `gemini-3-flash-preview` | 339 | **339** |
| gauge | `kimi-k2.6` | 38 | **38** |
| per-turn | `ollama-cloud/kimi-k2.6` | 176 | **0** |
| per-turn | `ollama-cloud/deepseek-v4-pro` | 56 | **0** |

330 of 330 per-turn rows have no cost; 400 of 400 gauge rows have one. Invisible so far because Ollama Cloud is subscription-priced (cost 0) — on Anthropic/OpenAI it would report **all chat spend as zero**, the exact "dashboard lies about spend" failure the comment in `ollama-cloud-models.ts` was written to prevent.

**Fix:** key each model under both shapes its callers use. Bare-id collisions between providers resolve last-wins, unchanged; callers passing the qualified key now disambiguate.

## 2. Nothing could see the context window filling up (feat)

Piper ran at ~170k context with compaction never firing (window configured at 1M ⇒ OpenClaw's `shouldCompact` threshold at ~1.03M) and began fabricating tool results — reporting an Odoo outage while every Odoo call in the window succeeded. Recovering those numbers meant SSHing into production and parsing trajectory JSONL by hand. New `usage_records.context_tokens` makes it one query.

**The subtle part is which number to read.** Context size is *not* `data.usage.input`: a turn drives a whole tool loop and `data.usage` sums every LLM call in it. The production samples run ~11x apart:

| ts | `data.usage.input` | `lastCallUsage.input` |
|---|---|---|
| 12:51:21 | 1,856,700 | **169,592** |
| 12:55:22 | 2,212,441 | **171,097** |
| 13:01:15 | 2,038,006 | **170,306** |

What must fit in the window is the prompt on the turn's **last** call, which OpenClaw reports separately in `data.promptCache.lastCallUsage`. So `inputTokens` (billed: every call) and `contextTokens` (sent: last call) stay distinct. Cached prompt tokens count toward context — the cached prefix is still part of the prompt, just billed differently.

Nullable, and **null means "unknown", never "empty"** — only the per-turn path can know it; zero would read as 0% utilization.

This also makes compaction observable at all: OpenClaw emits **no** compaction trajectory event (verified — the only types are `prompt.submitted`, `model.completed`, `trace.artifacts`, `trace.metadata`, `context.compiled`, `session.started`, `session.ended`). A drop in `context_tokens` between consecutive turns is the signal.

## Why the tests missed the pricing bug

Worth reading, because it's the same pattern as the incident itself — a test staying green by mocking out the broken part:

- `buildUsageRows` is pure and takes an **injected** `priceFor`, so its cost assertions pass whether or not the real lookup resolves. Its fixture even used the qualified `"anthropic/claude-sonnet-4-6"` — the exact broken input — and stayed green.
- `getModelPricing` had **no tests at all**.
- The real-Postgres integration test built its config fixture as `id: "anthropic/claude-sonnet-4-6"` — **a shape the real config never emits** — so the lookup matched for the wrong reason.

Fixed the fixture to the bare id it really is, and verified the integration test now fails against the old keying and passes with the fix. Added unit tests for the resolver and a seam test that drives trajectory → model-id → config-pricing with `getModelPricing` *not* mocked.

## Gates

`pnpm test` (8291 passed) · `pnpm test:scripts` (271, 0 fail) · `pnpm -C packages/web test:db` (222 passed, incl. new migration) · `typecheck` · `lint` (0 errors) · `format:check` — all green.

Migration `0053_flaky_iron_monger.sql` is additive and nullable. Independent of #765 and #768 — no file overlap.