### PR TITLE
fix(odoo): stop leaking synthetic fields to Odoo, stop misdiagnosing corrupted refs

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
@@ -3,7 +3,12 @@ import { describe, expect, it, vi, beforeEach, afterEach } from "vitest";
 import { mkdtempSync, writeFileSync, rmSync, mkdirSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
-import { decodeRef, encodeRef, _resetKeyCacheForTest } from "../integration-ref";
+import {
+  decodeRef,
+  encodeRef,
+  _resetKeyCacheForTest,
+  MalformedIntegrationRefError,
+} from "../integration-ref";
 
 describe("integration refs", () => {
   it("roundtrips an opaque Odoo reference", () => {
@@ -191,6 +196,64 @@ describe("integration refs", () => {
     const tampered = ref.slice(0, idx) + flipped + ref.slice(idx + 1);
 
     expect(() => decodeRef(tampered)).toThrow(/Invalid integration reference/);
+  });
+
+  // Bug B (2026-07-15 prod incident): `decodeTargetRef` in index.ts used to
+  // swallow every decode failure behind a bare `catch {}` and always report
+  // "does not belong to this Odoo connection" — even when the real cause was
+  // a corrupted/truncated ref, not a cross-connection ref. Distinguishing
+  // the two requires a typed error rather than string-matching the generic
+  // "Invalid integration reference" message, since every decode failure
+  // shares that same text.
+  describe("MalformedIntegrationRefError", () => {
+    beforeEach(() => {
+      _resetKeyCacheForTest();
+      vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+    });
+
+    it("is thrown (not a bare Error) for a ref with the wrong prefix", () => {
+      expect(() => decodeRef("not-a-pinchy-ref-at-all")).toThrow(
+        MalformedIntegrationRefError,
+      );
+    });
+
+    it("is thrown for a truncated ref (correct prefix, corrupted payload)", () => {
+      const ref = encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "res.country",
+        id: 14,
+        label: "Austria",
+      });
+      const truncated = ref.slice(0, -8);
+
+      expect(() => decodeRef(truncated)).toThrow(MalformedIntegrationRefError);
+    });
+
+    it("is thrown for a tampered ref that fails the AES-GCM auth tag check", () => {
+      const ref = encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "res.country",
+        id: 14,
+        label: "Austria",
+      });
+      const idx = ref.length - 10;
+      const flipped = ref[idx] === "a" ? "b" : "a";
+      const tampered = ref.slice(0, idx) + flipped + ref.slice(idx + 1);
+
+      expect(() => decodeRef(tampered)).toThrow(MalformedIntegrationRefError);
+    });
+
+    it("still carries the generic, non-leaking message (no key material or ref cleartext)", () => {
+      expect.assertions(2);
+      try {
+        decodeRef("not-a-pinchy-ref-at-all");
+      } catch (err) {
+        expect(err).toBeInstanceOf(MalformedIntegrationRefError);
+        expect((err as Error).message).toBe("Invalid integration reference");
+      }
+    });
   });
 
   describe("optional company fields", () => {

--- a/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/integration-ref.test.ts
@@ -198,13 +198,10 @@ describe("integration refs", () => {
     expect(() => decodeRef(tampered)).toThrow(/Invalid integration reference/);
   });
 
-  // Bug B (2026-07-15 prod incident): `decodeTargetRef` in index.ts used to
-  // swallow every decode failure behind a bare `catch {}` and always report
-  // "does not belong to this Odoo connection" — even when the real cause was
-  // a corrupted/truncated ref, not a cross-connection ref. Distinguishing
-  // the two requires a typed error rather than string-matching the generic
-  // "Invalid integration reference" message, since every decode failure
-  // shares that same text.
+  // Every decode failure shares the same generic message text, so callers
+  // can only tell "undecodable" apart from "decoded, wrong connection" by
+  // type. That distinction is the whole point of the class — see its doc
+  // comment for the incident that motivated it.
   describe("MalformedIntegrationRefError", () => {
     beforeEach(() => {
       _resetKeyCacheForTest();
@@ -243,6 +240,26 @@ describe("integration refs", () => {
       const tampered = ref.slice(0, idx) + flipped + ref.slice(idx + 1);
 
       expect(() => decodeRef(tampered)).toThrow(MalformedIntegrationRefError);
+    });
+
+    // Key rotation lands here too: every ref minted under the old key fails
+    // the auth-tag check and is indistinguishable from a garbled one. That
+    // is why the caller-facing message must not claim to have ruled any
+    // cause out — it can only name the remedy (re-fetch), which happens to
+    // be correct for both.
+    it("is thrown for a ref minted under a different PINCHY_REF_TOKEN_KEY (rotation)", () => {
+      const ref = encodeRef({
+        integrationType: "odoo",
+        connectionId: "conn-test-1",
+        model: "res.country",
+        id: 14,
+        label: "Austria",
+      });
+
+      _resetKeyCacheForTest();
+      vi.stubEnv("PINCHY_REF_TOKEN_KEY", "b".repeat(64));
+
+      expect(() => decodeRef(ref)).toThrow(MalformedIntegrationRefError);
     });
 
     it("still carries the generic, non-leaking message (no key material or ref cleartext)", () => {

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -706,17 +706,8 @@ describe("augmentFieldsWithCompanyId", () => {
   });
 });
 
-// Bug A (2026-07-15 prod incident, agent "Piper"): `_pinchy_ref` is a
-// synthetic field the plugin invents in `odoo_read` output (wrapReadResult)
-// and the tool prompt actively teaches the model to work with it. The model
-// then asks for it back via `odoo_read({ fields: [..., "_pinchy_ref"] })`,
-// which used to go straight through `augmentFieldsWithCompanyId` to Odoo and
-// hard-error, because that field does not exist on the actual model.
-// `stripSyntheticFields` removes plugin-invented field names before a
-// model-supplied `fields`/`groupby` list reaches Odoo. It is deliberately
-// separate from `augmentFieldsWithCompanyId`, whose other caller
-// (`lookupFields`) builds its field list internally and never sees
-// model-supplied input.
+// Why the plugin has to strip its own invented field names at all:
+// SYNTHETIC_FIELD_NAMES in index.ts.
 describe("stripSyntheticFields", () => {
   it("returns undefined unchanged", () => {
     expect(stripSyntheticFields(undefined)).toBeUndefined();
@@ -1384,12 +1375,8 @@ describe("odoo_read", () => {
     );
   });
 
-  // Bug A (2026-07-15 prod incident, agent "Piper"): the tool prompt teaches
-  // the model to work with `_pinchy_ref` (a field the plugin invents in read
-  // output, see wrapReadResult), so the model asks for it back in a
-  // subsequent read. Odoo has no such column and hard-errors. The plugin
-  // must strip its own synthetic field names before forwarding the request,
-  // not teach a field it then rejects.
+  // The read side of the same trap: the tool prompt teaches `_pinchy_ref`,
+  // so the model asks for it back here first. Odoo has no such column.
   it("strips the synthetic `_pinchy_ref` field before forwarding to Odoo", async () => {
     mockSearchRead.mockResolvedValue({
       records: [{ id: 1, name: "Acme Corp" }],
@@ -2002,11 +1989,8 @@ describe("odoo_aggregate", () => {
     );
   });
 
-  // Bug A, odoo_aggregate side: `fields` and `groupby` are both
-  // model-supplied lists forwarded verbatim to `client.readGroup`, exactly
-  // like odoo_read's `fields` — so a model that thinks `_pinchy_ref` is a
-  // real field (see the odoo_read strip test above) can trip the same
-  // hard-error here, including via the `field:agg` aggregation suffix.
+  // Same trap, two more model-supplied lists — `groupby` additionally
+  // accepts the `field:agg` suffix form, which must strip by base name.
   it("strips synthetic `_pinchy_ref` entries from both `fields` and `groupby` before forwarding to Odoo", async () => {
     mockReadGroup.mockResolvedValue({ groups: [] });
 
@@ -2029,6 +2013,73 @@ describe("odoo_aggregate", () => {
       expect.any(Object),
     );
   });
+
+  // Stripping a list down to NOTHING is not the same as never asking. An
+  // empty `groupby` means "one global aggregate" to Odoo, so silently
+  // forwarding it answers a different question than the model asked —
+  // plausible, wrong, and invisible to the model. Refuse instead, and name
+  // the real column to group by.
+  it("rejects a `groupby` that consisted only of synthetic fields instead of silently aggregating globally", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-ref", {
+      model: "sale.order",
+      filters: [],
+      fields: ["amount_total:sum"],
+      groupby: ["_pinchy_ref"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("_pinchy_ref");
+    expect(result.content[0].text).toContain("groupby");
+    expect(mockReadGroup).not.toHaveBeenCalled();
+  });
+
+  it("rejects a `fields` list that consisted only of synthetic fields", async () => {
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-ref", {
+      model: "sale.order",
+      filters: [],
+      fields: ["_pinchy_ref:count_distinct"],
+      groupby: ["partner_id"],
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("_pinchy_ref");
+    expect(result.content[0].text).toContain("fields");
+    expect(mockReadGroup).not.toHaveBeenCalled();
+  });
+
+  // `params.fields`/`params.groupby` are cast to string[] but arrive as
+  // whatever the model sent. A bare string used to reach Odoo as garbage;
+  // once stripSyntheticFields runs over it, it would instead die on
+  // `.filter is not a function` — an internal TypeError the model can't act
+  // on. Same gate as the `filters` shape check.
+  it.each([
+    ["fields", { fields: "amount_total:sum", groupby: ["partner_id"] }],
+    ["groupby", { fields: ["amount_total:sum"], groupby: "partner_id" }],
+  ])(
+    "rejects a non-array `%s` with a clear error instead of an internal TypeError",
+    async (param, params) => {
+      const tools = createApi({ [agentId]: agentConfig });
+      const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+      const result = await tool.execute("call-shape", {
+        model: "sale.order",
+        filters: [],
+        ...params,
+      });
+
+      expect(result.isError).toBe(true);
+      expect(result.content[0].text).toContain(`\`${param}\``);
+      expect(result.content[0].text).toContain("array");
+      expect(result.content[0].text).not.toContain("is not a function");
+      expect(mockReadGroup).not.toHaveBeenCalled();
+    },
+  );
 
   it("denies aggregation on unpermitted model", async () => {
     const tools = createApi({ [agentId]: agentConfig });
@@ -2672,12 +2723,9 @@ describe("error handling", () => {
   // the (also invalid) targetRef "x" — still an inline validation error,
   // still surfaced via details.error, just from a different gate.
   //
-  // Bug B (2026-07-15 prod incident): "x" doesn't even start with the
-  // `pinchy_ref:v1:` prefix, so it's an UNDECODABLE ref, not one minted for a
-  // different connection. Before the fix this asserted the connection-
-  // mismatch message, which was simply wrong for this input — see the
-  // dedicated "malformed vs wrong-connection" tests in the
-  // odoo_schedule_activity suite for both causes side by side.
+  // "x" has no `pinchy_ref:v1:` prefix, so it is an UNDECODABLE ref, not one
+  // minted for a different connection — this asserted the connection-mismatch
+  // message until the 2026-07-15 fix, which was simply wrong for this input.
   it("attaches details.error on an inline validation error (odoo_attach_file invalid targetRef, after filename normalization)", async () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_attach_file", agentId)!;
@@ -4905,6 +4953,54 @@ describe("bare _pinchy_ref string for many2one fields (Layer 1)", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
+  // The m2o path shares decodeOdooRefForConnection with decodeTargetRef, so
+  // it inherits the same "which failure was it?" problem: a corrupted ref
+  // used to surface the bare "Invalid integration reference", which tells
+  // the model nothing about what to do next. Same typed error, same
+  // actionable remedy as the target-ref path.
+  it("tells the model a corrupted bare _pinchy_ref is undecodable, not just 'invalid'", async () => {
+    const journalRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "account.journal",
+      id: 17,
+      label: "Miscellaneous Operations",
+    });
+
+    mockFields.mockImplementation(async (model: string) => {
+      if (model === "account.move") {
+        return [
+          { name: "id", type: "integer", required: false, readonly: true },
+          {
+            name: "journal_id",
+            type: "many2one",
+            relation: "account.journal",
+            required: true,
+            readonly: false,
+          },
+        ];
+      }
+      return [];
+    });
+
+    const tools = createApi({
+      [agentId]: { ...agentConfig, permissions: { "account.move": ["create"] } },
+    });
+    const tool = findTool(tools, "odoo_create", agentId)!;
+    const result = await tool.execute("corrupt-m2o", {
+      model: "account.move",
+      values: { journal_id: journalRef.slice(0, -6) },
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("could not be decoded");
+    expect(result.content[0].text).toContain("journal_id");
+    expect(result.content[0].text).not.toBe(
+      "Error: Invalid integration reference",
+    );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
   it("rejects a bare _pinchy_ref from a different connection", async () => {
     const otherConnRef = encodeRef({
       integrationType: "odoo",
@@ -5538,14 +5634,11 @@ describe("odoo_schedule_activity", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  // Bug B (2026-07-15 prod incident, agent "Piper"): decodeTargetRef used to
-  // swallow every decode failure behind a bare `catch { return null; }`, so
-  // BOTH causes below reported the identical "does not belong to this Odoo
-  // connection" message. In production, that message pointed 11
-  // corrupted/truncated refs at connection config and key rotation, when the
-  // actual cause was the model garbling the ref string — a completely
-  // different, model-actionable problem. These two tests pin the messages
-  // apart so a regression that merges them back together fails loudly.
+  // Two causes, two remedies — a cross-connection ref is a config problem, a
+  // garbled one the model can fix itself by re-fetching. They shared one
+  // message until the 2026-07-15 incident (see MalformedIntegrationRefError
+  // in integration-ref.ts); these tests pin them apart so a regression that
+  // merges them back together fails loudly.
 
   it("Cause 1 — ref decodes fine but belongs to a different connection: keeps the existing, correct message", async () => {
     const tools = createApi({ [agentId]: activityConfig });
@@ -5586,6 +5679,35 @@ describe("odoo_schedule_activity", () => {
     expect(result.content[0].text).not.toContain(
       "does not belong to this Odoo connection",
     );
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // `assignee` decodes through the same shared gate but a different caller
+  // (resolveAssigneeUserId), which reported the bare "Invalid integration
+  // reference" for a corrupted ref. Named after the parameter the model
+  // actually passed, so it knows which of the two refs to re-fetch.
+  it("names `assignee` — not `target` — when it is the assignee ref that is corrupted", async () => {
+    const userRef = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-test-1",
+      model: "res.users",
+      id: 7,
+      label: "Sam Seller",
+    });
+
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+
+    const result = await tool.execute("c", {
+      target: leadRef(),
+      summary: "x",
+      dueDate: "2026-06-30",
+      assignee: userRef.slice(0, -6),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("could not be decoded");
+    expect(result.content[0].text).toContain("assignee");
     expect(mockCreate).not.toHaveBeenCalled();
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -41,6 +41,8 @@ import plugin, {
   sortFieldsByPriority,
   compactSchema,
   augmentFieldsWithCompanyId,
+  stripSyntheticFields,
+  SYNTHETIC_FIELD_NAMES,
   extractCompanyLabel,
   extractCompanyId,
   formatMultiMatchError,
@@ -704,6 +706,60 @@ describe("augmentFieldsWithCompanyId", () => {
   });
 });
 
+// Bug A (2026-07-15 prod incident, agent "Piper"): `_pinchy_ref` is a
+// synthetic field the plugin invents in `odoo_read` output (wrapReadResult)
+// and the tool prompt actively teaches the model to work with it. The model
+// then asks for it back via `odoo_read({ fields: [..., "_pinchy_ref"] })`,
+// which used to go straight through `augmentFieldsWithCompanyId` to Odoo and
+// hard-error, because that field does not exist on the actual model.
+// `stripSyntheticFields` removes plugin-invented field names before a
+// model-supplied `fields`/`groupby` list reaches Odoo. It is deliberately
+// separate from `augmentFieldsWithCompanyId`, whose other caller
+// (`lookupFields`) builds its field list internally and never sees
+// model-supplied input.
+describe("stripSyntheticFields", () => {
+  it("returns undefined unchanged", () => {
+    expect(stripSyntheticFields(undefined)).toBeUndefined();
+  });
+
+  it("treats [] as 'didn't ask' and returns it unchanged (referentially equal)", () => {
+    const requested: string[] = [];
+    expect(stripSyntheticFields(requested)).toBe(requested);
+  });
+
+  it("returns the original list (referentially equal) when nothing is synthetic", () => {
+    const requested = ["name", "amount_total"];
+    expect(stripSyntheticFields(requested)).toBe(requested);
+  });
+
+  it("strips a bare `_pinchy_ref` entry", () => {
+    const result = stripSyntheticFields([
+      "name",
+      "_pinchy_ref",
+      "amount_total",
+    ]);
+    expect(result).toEqual(["name", "amount_total"]);
+  });
+
+  it("strips `_pinchy_ref` even with an aggregation/granularity suffix (odoo_aggregate's `field:agg` syntax)", () => {
+    const result = stripSyntheticFields([
+      "partner_id",
+      "_pinchy_ref:count_distinct",
+    ]);
+    expect(result).toEqual(["partner_id"]);
+  });
+
+  it("strips every synthetic field name in SYNTHETIC_FIELD_NAMES, not just a hardcoded literal", () => {
+    for (const name of SYNTHETIC_FIELD_NAMES) {
+      expect(stripSyntheticFields(["name", name])).toEqual(["name"]);
+    }
+  });
+
+  it("can strip down to an empty array when every requested field was synthetic", () => {
+    expect(stripSyntheticFields(["_pinchy_ref"])).toEqual([]);
+  });
+});
+
 describe("extractCompanyLabel", () => {
   it("returns the string label from a [id, name] tuple", () => {
     expect(extractCompanyLabel([1, "GmbH A"])).toBe("GmbH A");
@@ -1328,6 +1384,36 @@ describe("odoo_read", () => {
     );
   });
 
+  // Bug A (2026-07-15 prod incident, agent "Piper"): the tool prompt teaches
+  // the model to work with `_pinchy_ref` (a field the plugin invents in read
+  // output, see wrapReadResult), so the model asks for it back in a
+  // subsequent read. Odoo has no such column and hard-errors. The plugin
+  // must strip its own synthetic field names before forwarding the request,
+  // not teach a field it then rejects.
+  it("strips the synthetic `_pinchy_ref` field before forwarding to Odoo", async () => {
+    mockSearchRead.mockResolvedValue({
+      records: [{ id: 1, name: "Acme Corp" }],
+      total: 1,
+      limit: 100,
+      offset: 0,
+    });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_read", agentId)!;
+
+    const result = await tool.execute("call-ref", {
+      model: "res.partner",
+      fields: ["name", "_pinchy_ref"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalledWith(
+      "res.partner",
+      [],
+      expect.objectContaining({ fields: ["name"] }),
+    );
+  });
+
   it("denies read on unpermitted model", async () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_read", agentId)!;
@@ -1913,6 +1999,34 @@ describe("odoo_aggregate", () => {
       ["partner_id", "amount_total:sum"],
       ["partner_id"],
       { limit: undefined, offset: undefined, orderby: undefined },
+    );
+  });
+
+  // Bug A, odoo_aggregate side: `fields` and `groupby` are both
+  // model-supplied lists forwarded verbatim to `client.readGroup`, exactly
+  // like odoo_read's `fields` — so a model that thinks `_pinchy_ref` is a
+  // real field (see the odoo_read strip test above) can trip the same
+  // hard-error here, including via the `field:agg` aggregation suffix.
+  it("strips synthetic `_pinchy_ref` entries from both `fields` and `groupby` before forwarding to Odoo", async () => {
+    mockReadGroup.mockResolvedValue({ groups: [] });
+
+    const tools = createApi({ [agentId]: agentConfig });
+    const tool = findTool(tools, "odoo_aggregate", agentId)!;
+
+    const result = await tool.execute("call-ref", {
+      model: "sale.order",
+      filters: [],
+      fields: ["partner_id", "_pinchy_ref:count_distinct"],
+      groupby: ["partner_id", "_pinchy_ref"],
+    });
+
+    expect(result.isError).toBeFalsy();
+    expect(mockReadGroup).toHaveBeenCalledWith(
+      "sale.order",
+      [],
+      ["partner_id"],
+      ["partner_id"],
+      expect.any(Object),
     );
   });
 
@@ -2557,6 +2671,13 @@ describe("error handling", () => {
   // this filename is now VALID ("passwd") and the request instead fails at
   // the (also invalid) targetRef "x" — still an inline validation error,
   // still surfaced via details.error, just from a different gate.
+  //
+  // Bug B (2026-07-15 prod incident): "x" doesn't even start with the
+  // `pinchy_ref:v1:` prefix, so it's an UNDECODABLE ref, not one minted for a
+  // different connection. Before the fix this asserted the connection-
+  // mismatch message, which was simply wrong for this input — see the
+  // dedicated "malformed vs wrong-connection" tests in the
+  // odoo_schedule_activity suite for both causes side by side.
   it("attaches details.error on an inline validation error (odoo_attach_file invalid targetRef, after filename normalization)", async () => {
     const tools = createApi({ [agentId]: agentConfig });
     const tool = findTool(tools, "odoo_attach_file", agentId)!;
@@ -2567,9 +2688,9 @@ describe("error handling", () => {
     });
 
     expect(result.isError).toBe(true);
-    expect((result.details as { error?: string } | undefined)?.error).toContain(
-      "does not belong to this Odoo connection",
-    );
+    const error = (result.details as { error?: string } | undefined)?.error;
+    expect(error).toContain("could not be decoded");
+    expect(error).not.toContain("does not belong to this Odoo connection");
   });
 
   it("rejects a non-array `filters` with a clear error instead of forwarding garbage to Odoo", async () => {
@@ -5417,7 +5538,16 @@ describe("odoo_schedule_activity", () => {
     expect(mockCreate).not.toHaveBeenCalled();
   });
 
-  it("rejects a target ref from a different connection", async () => {
+  // Bug B (2026-07-15 prod incident, agent "Piper"): decodeTargetRef used to
+  // swallow every decode failure behind a bare `catch { return null; }`, so
+  // BOTH causes below reported the identical "does not belong to this Odoo
+  // connection" message. In production, that message pointed 11
+  // corrupted/truncated refs at connection config and key rotation, when the
+  // actual cause was the model garbling the ref string — a completely
+  // different, model-actionable problem. These two tests pin the messages
+  // apart so a regression that merges them back together fails loudly.
+
+  it("Cause 1 — ref decodes fine but belongs to a different connection: keeps the existing, correct message", async () => {
     const tools = createApi({ [agentId]: activityConfig });
     const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
     const result = await tool.execute("c", {
@@ -5427,6 +5557,33 @@ describe("odoo_schedule_activity", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toContain(
+      "does not belong to this Odoo connection",
+    );
+    expect(result.content[0].text).not.toContain("could not be decoded");
+    expect(mockCreate).not.toHaveBeenCalled();
+  });
+
+  // Same case the legacy "rejects a target ref from a different connection"
+  // test used to cover under the wrong label.
+  it("Cause 2 — ref is corrupted/truncated and never decodes: reports a distinct, actionable message, not a connection-mismatch claim", async () => {
+    const tools = createApi({ [agentId]: activityConfig });
+    const tool = findTool(tools, "odoo_schedule_activity", agentId)!;
+
+    // A real ref for THIS connection, mangled the way a model regurgitating
+    // a long opaque token in a tool call tends to mangle it — a few trailing
+    // characters dropped. Still starts with the `pinchy_ref:v1:` prefix, so
+    // it isn't caught by earlier validation; it fails inside decodeRef's
+    // AES-GCM decrypt/auth-tag step.
+    const truncated = leadRef().slice(0, -6);
+
+    const result = await tool.execute("c", {
+      target: truncated,
+      summary: "x",
+      dueDate: "2026-06-30",
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("could not be decoded");
+    expect(result.content[0].text).not.toContain(
       "does not belong to this Odoo connection",
     );
     expect(mockCreate).not.toHaveBeenCalled();

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -551,11 +551,16 @@ export function augmentFieldsWithCompanyId(
 /**
  * Field names the plugin invents in `odoo_read` output that do not exist on
  * the underlying Odoo model — currently only `_pinchy_ref` (see
- * `wrapReadResult`). The tool prompt actively teaches the model to work with
- * `_pinchy_ref`, so a model inevitably asks for it back in a later
- * `fields`/`groupby` list. Odoo has no such column and hard-errors on it.
- * Single source of truth so the set can grow without scattering string
- * literals across every call site that strips it.
+ * `wrapReadResult`). Single source of truth so the set can grow without
+ * scattering string literals across every call site that strips it.
+ *
+ * These exist because the plugin teaches the model a vocabulary Odoo does
+ * not share: the tool prompt tells it to work with `_pinchy_ref`, so it
+ * inevitably asks for the field back in a later `fields`/`groupby` list, and
+ * Odoo hard-errors on the unknown column (2026-07-15, agent "Piper"). Any
+ * field the plugin invents on the way out has to be swallowed on the way
+ * back in — teaching a name and then rejecting it is the plugin's bug, not
+ * the model's.
  */
 export const SYNTHETIC_FIELD_NAMES: ReadonlySet<string> = new Set([
   "_pinchy_ref",
@@ -587,6 +592,40 @@ export function stripSyntheticFields<T extends string[] | undefined>(
     (entry) => !SYNTHETIC_FIELD_NAMES.has(entry.split(":")[0]),
   );
   return (filtered.length === requested.length ? requested : filtered) as T;
+}
+
+/**
+ * `odoo_aggregate` entry point for the two model-supplied lists it forwards
+ * verbatim to `readGroup`. Validates the shape (both are declared `required`
+ * in the tool schema but arrive as whatever the model sent), then strips
+ * synthetic names — and refuses a list that strips down to NOTHING.
+ *
+ * The refusal is the point: an empty `groupby` means "one global aggregate"
+ * to Odoo and an empty `fields` means "counts only", so silently forwarding
+ * either answers a different question than the model asked. A wrong answer
+ * that looks right is worse than an error the model can act on, and
+ * `_pinchy_ref` is never a legitimate thing to group by — it is per-record
+ * by construction, so `id` is what the model actually wants.
+ */
+export function prepareAggregateFields(
+  value: unknown,
+  paramName: "fields" | "groupby",
+): string[] {
+  if (!Array.isArray(value) || value.some((e) => typeof e !== "string")) {
+    throw new Error(`\`${paramName}\` must be an array of field-name strings.`);
+  }
+  const stripped = stripSyntheticFields(value as string[]);
+  if (value.length > 0 && stripped.length === 0) {
+    const synthetic = [...SYNTHETIC_FIELD_NAMES]
+      .map((name) => `\`${name}\``)
+      .join(", ");
+    throw new Error(
+      `\`${paramName}\` contained only synthetic field names (${synthetic}), ` +
+        `which do not exist on the Odoo model. Use a real column — to count ` +
+        `or group per record, use \`id\`.`,
+    );
+  }
+  return stripped;
 }
 
 function getSearchReadRecords(result: unknown): OdooRecord[] {
@@ -874,26 +913,43 @@ function decodeOdooRefForConnection(
 }
 
 /**
+ * Turn a caught decode failure into a caller-facing error, naming the
+ * parameter the model actually passed so it knows which ref to re-fetch.
+ *
+ * A {@link MalformedIntegrationRefError} means the string never decoded at
+ * all. The model garbling a long base64url token is the common cause, but a
+ * rotated `PINCHY_REF_TOKEN_KEY` is indistinguishable from here — every ref
+ * minted under the old key fails the same auth-tag check. So the message
+ * names the remedy (re-fetch, which is correct either way) and claims
+ * nothing about the cause. Anything else already carries a specific message
+ * and passes through untouched.
+ */
+function refDecodeError(err: unknown, paramName: string): Error {
+  if (err instanceof MalformedIntegrationRefError) {
+    return new Error(
+      `\`${paramName}\` ref could not be decoded — it looks corrupted or ` +
+        `truncated. Re-fetch the record with \`odoo_read\` and pass the ` +
+        `fresh \`_pinchy_ref\` exactly as returned.`,
+    );
+  }
+  return err instanceof Error ? err : new Error(String(err));
+}
+
+/**
  * Decode a `target`/`targetRef` for a tool that acts on an arbitrary target
  * model (schedule/complete/reschedule activity, record-action tools,
  * attach_file). Returns the payload on success, or throws a descriptive
  * error otherwise. No model check: these tools accept any target model and
  * gate it through the permissions map instead.
  *
- * Bug fix (2026-07-15 prod incident, agent "Piper"): this used to swallow
- * every decode failure behind a bare `catch { return null; }`, and every
- * caller reported the SAME "does not belong to this Odoo connection"
- * message regardless of cause. In production that message pointed 11
- * corrupted/truncated refs at connection config and key rotation, when the
- * real cause was the model garbling a base64url ref string — a completely
- * different, model-actionable problem. `decodeRef` (integration-ref.ts)
- * throws a typed {@link MalformedIntegrationRefError} specifically for
- * "this string doesn't decode at all" (bad prefix, corrupted payload, failed
- * auth-tag check, unparsable JSON, invalid shape); `decodeOdooRefForConnection`
- * throws a plain `Error` for "decoded fine, but wrong integration type or
- * wrong connectionId". `instanceof` on the typed error is what lets this
- * function tell the two apart without string-matching the shared generic
- * "Invalid integration reference" message.
+ * The two failure causes must stay distinguishable: `decodeRef` throws a
+ * typed {@link MalformedIntegrationRefError} for "this string doesn't decode
+ * at all", while `decodeOdooRefForConnection` throws a plain `Error` for
+ * "decoded fine, but wrong integration type or connectionId". Both share the
+ * generic "Invalid integration reference" text, so `instanceof` — not string
+ * matching — is what tells them apart. Collapsing them again sends a garbled
+ * ref down a connection-config trail; that is the 2026-07-15 prod incident
+ * the `odoo_schedule_activity` "Cause 1 / Cause 2" tests pin.
  */
 function decodeTargetRef(
   connectionId: string,
@@ -904,11 +960,7 @@ function decodeTargetRef(
     return decodeOdooRefForConnection(connectionId, refString);
   } catch (err) {
     if (err instanceof MalformedIntegrationRefError) {
-      throw new Error(
-        `\`${paramName}\` ref could not be decoded — it looks corrupted or ` +
-          `truncated, not a connection mismatch. Re-fetch the record with ` +
-          `\`odoo_read\` and pass the fresh \`_pinchy_ref\` exactly as returned.`,
-      );
+      throw refDecodeError(err, paramName);
     }
     throw new Error(
       `\`${paramName}\` ref does not belong to this Odoo connection.`,
@@ -935,7 +987,12 @@ function decodeAndValidateRef(
   field: OdooField,
   refString: string,
 ): number {
-  const ref = decodeOdooRefForConnection(connectionId, refString);
+  let ref: IntegrationRefPayload;
+  try {
+    ref = decodeOdooRefForConnection(connectionId, refString);
+  } catch (err) {
+    throw refDecodeError(err, field.name);
+  }
   if (ref.model !== field.relation) {
     throw new Error(
       `Invalid ref for ${field.name}: expected ${field.relation}, got ${ref.model}.`,
@@ -1722,7 +1779,12 @@ async function resolveAssigneeUserId(
   assignee: string,
 ): Promise<number> {
   if (isIntegrationRef(assignee)) {
-    const ref = decodeOdooRefForConnection(connectionId, assignee);
+    let ref: IntegrationRefPayload;
+    try {
+      ref = decodeOdooRefForConnection(connectionId, assignee);
+    } catch (err) {
+      throw refDecodeError(err, "assignee");
+    }
     if (ref.model !== "res.users") {
       throw new Error("`assignee` ref must point to a res.users record.");
     }
@@ -2593,12 +2655,15 @@ const plugin = {
                 return permissionDenied("read", model);
               }
 
+              const fields = prepareAggregateFields(params.fields, "fields");
+              const groupby = prepareAggregateFields(params.groupby, "groupby");
+
               const result = await withAuthRetry(agentId, config, (client) =>
                 client.readGroup(
                   model,
                   asDomain(params.filters),
-                  stripSyntheticFields(params.fields as string[]),
-                  stripSyntheticFields(params.groupby as string[]),
+                  fields,
+                  groupby,
                   {
                     limit: params.limit as number | undefined,
                     offset: params.offset as number | undefined,

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -6,6 +6,7 @@ import {
   decodeRef,
   encodeRef,
   isIntegrationRef,
+  MalformedIntegrationRefError,
   type IntegrationRefPayload,
 } from "./integration-ref";
 
@@ -547,6 +548,47 @@ export function augmentFieldsWithCompanyId(
   return [...requested, "company_id"];
 }
 
+/**
+ * Field names the plugin invents in `odoo_read` output that do not exist on
+ * the underlying Odoo model — currently only `_pinchy_ref` (see
+ * `wrapReadResult`). The tool prompt actively teaches the model to work with
+ * `_pinchy_ref`, so a model inevitably asks for it back in a later
+ * `fields`/`groupby` list. Odoo has no such column and hard-errors on it.
+ * Single source of truth so the set can grow without scattering string
+ * literals across every call site that strips it.
+ */
+export const SYNTHETIC_FIELD_NAMES: ReadonlySet<string> = new Set([
+  "_pinchy_ref",
+]);
+
+/**
+ * Remove synthetic (plugin-invented) field names from a model-supplied
+ * `fields`/`groupby` list before it reaches Odoo. Entries may carry an
+ * aggregation or date-granularity suffix (`odoo_aggregate`'s `field:agg` /
+ * `field:month` syntax) — matched by base name, not exact string, so
+ * `_pinchy_ref:count_distinct` is stripped too.
+ *
+ * Mirrors the `undefined`/`[]` "didn't ask" convention from
+ * `augmentFieldsWithCompanyId` (empty stays empty, not "return nothing").
+ * Preserves referential equality when nothing was stripped, so callers that
+ * pass the result straight into `augmentFieldsWithCompanyId` don't lose that
+ * function's own referential-equality guarantee for the common case.
+ *
+ * Deliberately separate from `augmentFieldsWithCompanyId`: that function's
+ * other caller (`lookupFields`) builds its field list internally from Odoo
+ * metadata and never sees model-supplied input, so it must not go through
+ * this stripping.
+ */
+export function stripSyntheticFields<T extends string[] | undefined>(
+  requested: T,
+): T {
+  if (!requested || requested.length === 0) return requested;
+  const filtered = requested.filter(
+    (entry) => !SYNTHETIC_FIELD_NAMES.has(entry.split(":")[0]),
+  );
+  return (filtered.length === requested.length ? requested : filtered) as T;
+}
+
 function getSearchReadRecords(result: unknown): OdooRecord[] {
   if (Array.isArray(result)) return result.filter(isRecord);
   if (isRecord(result) && Array.isArray(result.records)) {
@@ -834,20 +876,43 @@ function decodeOdooRefForConnection(
 /**
  * Decode a `target`/`targetRef` for a tool that acts on an arbitrary target
  * model (schedule/complete/reschedule activity, record-action tools,
- * attach_file). Returns the payload on success, or null when the ref is
- * malformed or belongs to a different connection — the caller surfaces a
- * consistent "does not belong to this Odoo connection" error. No model
- * check: these tools accept any target model and gate it through the
- * permissions map instead.
+ * attach_file). Returns the payload on success, or throws a descriptive
+ * error otherwise. No model check: these tools accept any target model and
+ * gate it through the permissions map instead.
+ *
+ * Bug fix (2026-07-15 prod incident, agent "Piper"): this used to swallow
+ * every decode failure behind a bare `catch { return null; }`, and every
+ * caller reported the SAME "does not belong to this Odoo connection"
+ * message regardless of cause. In production that message pointed 11
+ * corrupted/truncated refs at connection config and key rotation, when the
+ * real cause was the model garbling a base64url ref string — a completely
+ * different, model-actionable problem. `decodeRef` (integration-ref.ts)
+ * throws a typed {@link MalformedIntegrationRefError} specifically for
+ * "this string doesn't decode at all" (bad prefix, corrupted payload, failed
+ * auth-tag check, unparsable JSON, invalid shape); `decodeOdooRefForConnection`
+ * throws a plain `Error` for "decoded fine, but wrong integration type or
+ * wrong connectionId". `instanceof` on the typed error is what lets this
+ * function tell the two apart without string-matching the shared generic
+ * "Invalid integration reference" message.
  */
 function decodeTargetRef(
   connectionId: string,
   refString: string,
-): IntegrationRefPayload | null {
+  paramName = "target",
+): IntegrationRefPayload {
   try {
     return decodeOdooRefForConnection(connectionId, refString);
-  } catch {
-    return null;
+  } catch (err) {
+    if (err instanceof MalformedIntegrationRefError) {
+      throw new Error(
+        `\`${paramName}\` ref could not be decoded — it looks corrupted or ` +
+          `truncated, not a connection mismatch. Re-fetch the record with ` +
+          `\`odoo_read\` and pass the fresh \`_pinchy_ref\` exactly as returned.`,
+      );
+    }
+    throw new Error(
+      `\`${paramName}\` ref does not belong to this Odoo connection.`,
+    );
   }
 }
 
@@ -2382,7 +2447,7 @@ const plugin = {
                     await client.fields(model),
                   );
                   const effectiveFields = augmentFieldsWithCompanyId(
-                    params.fields as string[] | undefined,
+                    stripSyntheticFields(params.fields as string[] | undefined),
                     modelFields,
                   );
                   const records = await client.searchRead(
@@ -2532,8 +2597,8 @@ const plugin = {
                 client.readGroup(
                   model,
                   asDomain(params.filters),
-                  params.fields as string[],
-                  params.groupby as string[],
+                  stripSyntheticFields(params.fields as string[]),
+                  stripSyntheticFields(params.groupby as string[]),
                   {
                     limit: params.limit as number | undefined,
                     offset: params.offset as number | undefined,
@@ -2805,13 +2870,6 @@ const plugin = {
               }
 
               const decoded = decodeTargetRef(config.connectionId, target);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`target` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
               const targetModel = decoded.model;
               const targetId = decoded.id;
 
@@ -2954,13 +3012,6 @@ const plugin = {
                 );
               }
               const decoded = decodeTargetRef(config.connectionId, target);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`target` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
               if (decoded.model !== "mail.activity") {
                 return errorResult(
                   new Error(
@@ -3078,13 +3129,6 @@ const plugin = {
               }
 
               const decoded = decodeTargetRef(config.connectionId, target);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`target` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
               if (decoded.model !== "mail.activity") {
                 return errorResult(
                   new Error(
@@ -3178,13 +3222,6 @@ const plugin = {
                 );
               }
               const decoded = decodeTargetRef(config.connectionId, target);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`target` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
               if (decoded.model !== spec.model) {
                 return errorResult(
                   new Error(`\`target\` must be a ${spec.model} ref.`),
@@ -3338,13 +3375,6 @@ const plugin = {
                 );
               }
               const decoded = decodeTargetRef(config.connectionId, target);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`target` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
               const route = APPROVAL_ROUTES[decoded.model];
               if (!route) {
                 return errorResult(
@@ -3598,14 +3628,11 @@ const plugin = {
               // connection decodes validly under this deployment's single ref
               // key, so reject it before acting — same gate every other
               // ref-consuming Odoo tool applies (decodeTargetRef).
-              const decoded = decodeTargetRef(config.connectionId, targetRef);
-              if (decoded === null) {
-                return errorResult(
-                  new Error(
-                    "`targetRef` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
+              const decoded = decodeTargetRef(
+                config.connectionId,
+                targetRef,
+                "targetRef",
+              );
 
               if (
                 !checkPermission(config.permissions, "ir.attachment", "create")

--- a/packages/plugins/pinchy-odoo/integration-ref.ts
+++ b/packages/plugins/pinchy-odoo/integration-ref.ts
@@ -21,6 +21,23 @@ export interface IntegrationRefPayload {
   companyLabel?: string;
 }
 
+/**
+ * Thrown by {@link decodeRef} whenever the ref string itself cannot be
+ * decoded — bad prefix, truncated/corrupted base64url payload, a failed
+ * AES-GCM auth tag check, unparsable JSON, or a payload that fails shape
+ * validation. Distinct from "decoded fine but doesn't match this deployment"
+ * (see `decodeOdooRefForConnection` in index.ts), which throws a plain
+ * `Error` instead. Callers that need to tell a corrupted ref apart from a
+ * cross-connection ref (e.g. `decodeTargetRef`) check `instanceof` this
+ * class rather than matching on message text.
+ */
+export class MalformedIntegrationRefError extends Error {
+  constructor(message = "Invalid integration reference") {
+    super(message);
+    this.name = "MalformedIntegrationRefError";
+  }
+}
+
 let cachedKey: Buffer | null = null;
 
 /**
@@ -151,7 +168,7 @@ export function encodeRef(payload: IntegrationRefPayload): string {
 
 export function decodeRef(ref: string): IntegrationRefPayload {
   if (!ref.startsWith(PREFIX)) {
-    throw new Error("Invalid integration reference");
+    throw new MalformedIntegrationRefError();
   }
 
   try {
@@ -174,7 +191,7 @@ export function decodeRef(ref: string): IntegrationRefPayload {
     }
     return payload;
   } catch {
-    throw new Error("Invalid integration reference");
+    throw new MalformedIntegrationRefError();
   }
 }
 

--- a/packages/plugins/pinchy-odoo/integration-ref.ts
+++ b/packages/plugins/pinchy-odoo/integration-ref.ts
@@ -29,7 +29,15 @@ export interface IntegrationRefPayload {
  * (see `decodeOdooRefForConnection` in index.ts), which throws a plain
  * `Error` instead. Callers that need to tell a corrupted ref apart from a
  * cross-connection ref (e.g. `decodeTargetRef`) check `instanceof` this
- * class rather than matching on message text.
+ * class rather than matching on message text — every decode failure shares
+ * the same generic message, so type is the only signal.
+ *
+ * Why the distinction earns a class: on 2026-07-15 agent "Piper" reported
+ * all 11 of its failed calls as "ref does not belong to this Odoo
+ * connection", which sent the investigation down a connection-config and
+ * key-rotation trail. 111 other calls decoded fine against that same
+ * connectionId. The refs were simply garbled by the model — a different
+ * problem with a different, model-actionable fix.
  */
 export class MalformedIntegrationRefError extends Error {
   constructor(message = "Invalid integration reference") {


### PR DESCRIPTION
## Summary

Two related bugs observed in production on 2026-07-15 on agent "Piper":

- **`odoo_read` (and `odoo_aggregate`) forwarded `_pinchy_ref` to Odoo and hard-errored.** `_pinchy_ref` is a synthetic field the plugin invents in `odoo_read` output (`wrapReadResult`, `index.ts` ~1879/~1924) — it doesn't exist on the underlying Odoo model. The tool prompt actively teaches the model to work with `_pinchy_ref`, so the model naturally asked for it back via `odoo_read({ fields: [..., "_pinchy_ref"] })`. `augmentFieldsWithCompanyId` only ever *adds* `company_id`; it never strips anything, so the field reached `client.searchRead` and Odoo rejected it. Same exposure existed in `odoo_aggregate`'s `fields`/`groupby`, which are forwarded verbatim to `client.readGroup`.

  Fix: a new `stripSyntheticFields()` helper, backed by a single `SYNTHETIC_FIELD_NAMES` constant, applied at both the `odoo_read` and `odoo_aggregate` call sites before the field list reaches Odoo. Kept deliberately separate from `augmentFieldsWithCompanyId` — that function's other caller (`lookupFields`) builds its field list internally from Odoo metadata and never sees model-supplied input, so it must not go through this stripping.

- **`decodeTargetRef` swallowed every decode failure and always blamed "connection".** `decodeTargetRef` used a bare `catch { return null; }`, so every caller reported the identical `"...ref does not belong to this Odoo connection"` message regardless of cause. In production this sent 11 corrupted/truncated refs down a false connection-config/key-rotation trail (11 failed calls vs. 111 that decoded cleanly against the same `connectionId`) — the actual cause was the model garbling a base64url ref string, not a connection mismatch.

  Fix: `decodeRef` (`integration-ref.ts`) now throws a typed `MalformedIntegrationRefError` specifically for "this string doesn't decode at all" (bad prefix, corrupted payload, failed AES-GCM auth-tag check, unparsable JSON, invalid shape). `decodeOdooRefForConnection` still throws a plain `Error` for "decoded fine, but wrong integration type or wrong connectionId". `decodeTargetRef` now uses `instanceof` to tell the two apart and reports a distinct, actionable message for the malformed case ("re-fetch with `odoo_read` and pass the fresh `_pinchy_ref`") instead of pointing at connection config. No key material or ref cleartext is included in either message.

## Test plan

- [x] `pnpm test:plugins` — all 8 plugin packages pass (pinchy-odoo: 360/360)
- [x] `pnpm typecheck:plugins`
- [x] `pnpm test:scripts`
- [x] Formatting of touched files verified against `packages/web`'s prettier config (plugins have no config of their own)
- [x] New tests written first (red before implementation), TDD:
  - `stripSyntheticFields` unit tests (undefined/empty/no-match referential equality, bare `_pinchy_ref`, `_pinchy_ref:count_distinct` aggregation-suffix form, exhaustive over `SYNTHETIC_FIELD_NAMES`, strips-to-empty)
  - `odoo_read` behavior test: `fields: ["name", "_pinchy_ref"]` reaches Odoo as `["name"]`
  - `odoo_aggregate` behavior test: `_pinchy_ref` stripped from both `fields` (with aggregation suffix) and `groupby`
  - `MalformedIntegrationRefError` unit tests in `integration-ref.test.ts` (wrong prefix, truncated payload, tampered auth-tag, message stays generic/non-leaking)
  - Two dedicated `odoo_schedule_activity` tests pinning the *different* messages for the two `decodeTargetRef` causes side by side (wrong-connection vs. malformed/truncated)
  - Corrected a pre-existing mislabeled test (`odoo_attach_file`, `targetRef: "x"`) that asserted the connection-mismatch message for what is actually an undecodable ref

## Additional `fields`-passthrough audit

Checked every `client.searchRead`/`client.readGroup` call site for model-supplied field lists reaching Odoo directly. Only `odoo_read` and `odoo_aggregate` were affected — `odoo_describe_model`/`odoo_schema`'s `fields` filters an already-fetched local schema (`compactSchema`) and never reaches Odoo, and every other `searchRead` call site uses a hardcoded internal field list (`resolveIrModelId`, `resolveDefaultActivityTypeId`, `resolveActivityTypeByName`, `resolveAssigneeUserId`, `resolveTargetSalespersonId`, `searchRelationByName`, the `res.country` lookup, the duplicate-invoice-ref check).