### PR TITLE
[DO NOT MERGE] Verify: docs-only PR reports its required checks

### DIFF
--- a/docs/src/content/docs/glossary/what-is-openclaw.mdx
+++ b/docs/src/content/docs/glossary/what-is-openclaw.mdx
@@ -1,6 +1,6 @@
 ---
 title: What is OpenClaw?
-description: OpenClaw is an open-source AI agent runtime — the engine that connects a language model to tools, memory, and channels so an agent can actually do things. Pinchy builds the enterprise layer on top of it.
+description: OpenClaw is an open-source AI agent runtime — the engine that connects a language model to tools, memory, and channels so an agent can actually do things. Pinchy builds the enterprise layer on top of it, adding permissions, audit trails, and user management.
 head:
   - tag: script
     attrs:


### PR DESCRIPTION
**Throwaway PR — will be closed, not merged.**

#764 moved CI's path filter from workflow level to job level so docs-only PRs stop hanging on required checks that can never report. That fix could not be tested before merging: for `pull_request` events GitHub reads the workflow from the merge ref, so a docs PR branched from the old main would still carry the old `paths-ignore` and reproduce the bug rather than the fix.

Now that #764 is on main, this is the missing evidence. Expected:

- **`Detect changed paths`** → `code=false`
- **Required checks report** — `Lint, Test & Build`, `E2E Tests`, `Vitest Integration Tests (real DB)` all run and go green, so the PR reaches MERGEABLE instead of "Expected — Waiting for status to be reported"
- **`Check links` runs** — ungated on purpose, since it guards the `**/*.md` a docs PR consists of
- **16 jobs skip** — no Docker build, no E2E matrix

The diff is a one-line description tweak, chosen only because it is unambiguously docs-only.