### PR TITLE
fix(scripts): guard AGENTS.md's documented commands against drift

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -175,6 +175,8 @@ cd docs && pnpm install && pnpm dev
 cd docs && pnpm build
 ```
 
+`scripts/lib/agents-md-commands.test.mjs` (run by `pnpm test:scripts`) keeps these blocks honest: it walks every `pnpm` command in this file, resolves each to the package it runs in — handling `-C`/`--dir`/`--filter`, `cd x && pnpm y` chains, `pnpm run <script>`, and pnpm builtins like `install` — and fails if the script isn't declared there. That drift is how `pnpm lint`, `pnpm format` and `pnpm db:generate` sat here for months as root commands that never existed. Nothing else in CI reads this file.
+
 Important: do not run the app with plain `pnpm dev` as the primary development path unless a task explicitly requires it. Direct local app startup can miss Docker-managed infrastructure and migrations.
 
 ## API Routes And Audit Trail

--- a/scripts/lib/agents-md-commands.mjs
+++ b/scripts/lib/agents-md-commands.mjs
@@ -1,0 +1,242 @@
+/**
+ * Drift guard for the commands documented in AGENTS.md.
+ *
+ * AGENTS.md is the first file every coding agent reads, so a command that no
+ * longer exists costs time in every future session — and nothing else in CI
+ * reads it. That is how `pnpm lint`, `pnpm format` and `pnpm db:generate` came
+ * to sit in the "Commands" section for months without any of them resolving to
+ * a script.
+ *
+ * This walks every ```bash block in AGENTS.md, works out which package each
+ * `pnpm <script>` invocation would run in, and fails if the script isn't
+ * declared there. Read-side sibling of the no-untracked-skips /
+ * no-test-deletion / plugin-typecheck / web-typecheck guards.
+ *
+ * Scope: it proves the package a command targets declares the script — e.g.
+ * that `pnpm -C packages/web lint` names a real web script. It does NOT follow
+ * a root proxy through to the script behind it: were the root to proxy `lint`
+ * on to `@pinchy/web`, renaming the web script would break the proxy without
+ * tripping this guard. CI runs the web scripts directly, so that drift surfaces
+ * there instead.
+ */
+
+import { readFileSync, readdirSync } from "node:fs";
+import { join } from "node:path";
+
+// pnpm's own subcommands: `pnpm install` is not a claim that an "install"
+// script exists. `run` is absent deliberately — it is handled before this set
+// is consulted, because its argument IS a script name.
+const BUILTINS = new Set([
+  "install",
+  "i",
+  "add",
+  "remove",
+  "rm",
+  "update",
+  "up",
+  "exec",
+  "dlx",
+  "why",
+  "outdated",
+  "audit",
+  "publish",
+  "pack",
+  "link",
+  "list",
+  "ls",
+  "store",
+  "licenses",
+  "import",
+  "prune",
+  "rebuild",
+  "setup",
+  "config",
+]);
+
+// Flags that swallow the following token, mapped to what they select.
+const TARGET_FLAGS = { "-C": "dir", "--dir": "dir", "--filter": "filter" };
+
+const FENCED_BASH = /^```bash\n([\s\S]*?)^```/gm;
+const ENV_ASSIGNMENT = /^[A-Z_][A-Z0-9_]*=\S*$/;
+
+/**
+ * Parse the tokens after `pnpm` into the script it would run, if any.
+ *
+ * @param {string[]} tokens
+ * @param {string} cwd directory the command runs in, relative to the repo root
+ * @returns {{ target: { type: "dir" | "filter", value: string }, script: string } | null}
+ */
+function parsePnpmTokens(tokens, cwd) {
+  let target = { type: "dir", value: cwd };
+  let i = 0;
+  while (i < tokens.length) {
+    const token = tokens[i];
+    const swallows = TARGET_FLAGS[token];
+    if (swallows) {
+      target = { type: swallows, value: tokens[i + 1] };
+      i += 2;
+      continue;
+    }
+    const inline = token.match(/^(--filter|--dir)=(.+)$/);
+    if (inline) {
+      target = { type: inline[1] === "--filter" ? "filter" : "dir", value: inline[2] };
+      i += 1;
+      continue;
+    }
+    if (token.startsWith("-")) {
+      i += 1;
+      continue;
+    }
+    break;
+  }
+
+  const first = tokens[i];
+  if (first === undefined) return null;
+  if (first === "run") {
+    const script = tokens[i + 1];
+    return script === undefined ? null : { target, script };
+  }
+  if (BUILTINS.has(first)) return null;
+  return { target, script: first };
+}
+
+/**
+ * Every `pnpm <script>` invocation documented in the markdown's bash blocks.
+ *
+ * @param {string} markdown
+ * @returns {Array<{ line: string, target: { type: "dir" | "filter", value: string }, script: string }>}
+ */
+export function extractPnpmInvocations(markdown) {
+  const invocations = [];
+  for (const [, block] of markdown.matchAll(FENCED_BASH)) {
+    for (const rawLine of block.split("\n")) {
+      const line = rawLine.trim();
+      if (line === "" || line.startsWith("#")) continue;
+
+      // A `cd` earlier in the chain decides where a later `pnpm` runs.
+      let cwd = ".";
+      for (const segment of line.split("&&")) {
+        const tokens = segment.trim().split(/\s+/).filter(Boolean);
+        while (tokens.length > 0 && ENV_ASSIGNMENT.test(tokens[0])) tokens.shift();
+        const [command, ...rest] = tokens;
+        if (command === "cd") {
+          cwd = rest[0] ?? ".";
+        } else if (command === "pnpm") {
+          const parsed = parsePnpmTokens(rest, cwd);
+          if (parsed) invocations.push({ line, ...parsed });
+        }
+      }
+    }
+  }
+  return invocations;
+}
+
+/** "./docs/" and "docs" name the same package; "" and "./" name the root. */
+function normalizeDir(value) {
+  if (typeof value !== "string") return null;
+  const trimmed = value.replace(/^\.\//, "").replace(/\/+$/, "");
+  return trimmed === "" || trimmed === "." ? "." : trimmed;
+}
+
+/** pnpm filters allow `*`, e.g. `--filter "./packages/plugins/*"`. */
+function matchesGlob(pattern, value) {
+  if (typeof value !== "string") return false;
+  const source = pattern.replace(/[.*+?^${}()|[\]\\]/g, (c) => (c === "*" ? "[^/]*" : `\\${c}`));
+  return new RegExp(`^${source}$`).test(value);
+}
+
+function readPackage(repoRoot, dir) {
+  try {
+    const pkg = JSON.parse(readFileSync(join(repoRoot, dir, "package.json"), "utf8"));
+    return {
+      dir,
+      name: typeof pkg.name === "string" ? pkg.name : null,
+      scripts: Object.keys(pkg.scripts ?? {}),
+    };
+  } catch {
+    // No package.json here (e.g. packages/plugins itself), or it is unreadable.
+    return null;
+  }
+}
+
+/** Every directory that could hold a package: the root, the workspace globs, and docs/. */
+function packageDirs(repoRoot) {
+  const dirs = ["."];
+  let yaml = "";
+  try {
+    yaml = readFileSync(join(repoRoot, "pnpm-workspace.yaml"), "utf8");
+  } catch {
+    yaml = "";
+  }
+  for (const line of yaml.split("\n")) {
+    const glob = line.match(/^\s*-\s*["']?([^"'\s]+)["']?\s*$/)?.[1];
+    if (!glob?.endsWith("/*")) continue;
+    const parent = glob.slice(0, -2);
+    try {
+      for (const entry of readdirSync(join(repoRoot, parent), { withFileTypes: true })) {
+        if (entry.isDirectory()) dirs.push(`${parent}/${entry.name}`);
+      }
+    } catch {
+      // Glob points at a directory that does not exist; nothing to contribute.
+    }
+  }
+  // docs/ is standalone (own lockfile, not a workspace member) but AGENTS.md
+  // documents `cd docs && pnpm build`, so the guard has to resolve it too.
+  dirs.push("docs");
+  return dirs;
+}
+
+/**
+ * Resolve a documented pnpm target against the packages that actually exist.
+ *
+ * Derived from the filesystem rather than a hand-written list: an enumeration
+ * would itself be a drift source, and would fail a correctly documented
+ * command for any package it had not been taught about.
+ *
+ * @param {string} repoRoot
+ * @returns {(target: { type: "dir" | "filter", value: string }) => string[] | null}
+ */
+export function createWorkspaceResolver(repoRoot) {
+  const packages = packageDirs(repoRoot)
+    .map((dir) => readPackage(repoRoot, dir))
+    .filter((pkg) => pkg !== null);
+
+  return (target) => {
+    const matches = packages.filter((pkg) =>
+      target.type === "dir"
+        ? normalizeDir(target.value) === pkg.dir
+        : matchesGlob(target.value, pkg.name) ||
+          matchesGlob(normalizeDir(target.value) ?? "\0", pkg.dir),
+    );
+    // A glob filter runs the script in every match, so any of them declaring it
+    // means the documented command does something.
+    return matches.length === 0 ? null : [...new Set(matches.flatMap((pkg) => pkg.scripts))];
+  };
+}
+
+/**
+ * @param {string} markdown contents of AGENTS.md
+ * @param {(target: { type: "dir" | "filter", value: string }) => string[] | null} resolveScripts
+ *   the script names declared by the targeted package, or null if no such package
+ * @returns {string[]} problems (empty = ok)
+ */
+export function checkAgentsMdCommands(markdown, resolveScripts) {
+  const problems = [];
+  for (const { line, target, script } of extractPnpmInvocations(markdown)) {
+    const scripts = resolveScripts(target);
+    if (scripts === null) {
+      problems.push(
+        `\`${line}\` targets ${target.type} "${target.value}", which is not a package in this workspace`,
+      );
+      continue;
+    }
+    if (!scripts.includes(script)) {
+      const where = target.type === "dir" ? `"${target.value}"` : `package "${target.value}"`;
+      const rootHint = target.type === "dir" && target.value === "." ? " (root package.json)" : "";
+      problems.push(
+        `\`${line}\` runs script "${script}" in ${where}${rootHint}, which declares no such script`,
+      );
+    }
+  }
+  return problems;
+}

--- a/scripts/lib/agents-md-commands.test.mjs
+++ b/scripts/lib/agents-md-commands.test.mjs
@@ -1,0 +1,137 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+import { readFileSync } from "node:fs";
+import { fileURLToPath } from "node:url";
+import { dirname, join, resolve } from "node:path";
+import {
+  extractPnpmInvocations,
+  checkAgentsMdCommands,
+  createWorkspaceResolver,
+} from "./agents-md-commands.mjs";
+
+const REPO_ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "../..");
+
+// A resolver over a hand-built workspace, so the pure logic is tested without
+// touching the real package.json files.
+function fakeResolver(workspace) {
+  return (target) => {
+    const entry =
+      target.type === "dir"
+        ? workspace.byDir[target.value]
+        : Object.values(workspace.byDir).find((p) => p.name === target.value);
+    return entry ? entry.scripts : null;
+  };
+}
+
+const WORKSPACE = {
+  byDir: {
+    ".": { name: "pinchy", scripts: ["test", "build"] },
+    "packages/web": { name: "@pinchy/web", scripts: ["test", "lint", "format", "db:generate"] },
+    docs: { name: "docs", scripts: ["dev", "build"] },
+  },
+};
+
+test("extractPnpmInvocations reads plain root scripts out of bash blocks", () => {
+  const md = ["```bash", "pnpm test", "pnpm build", "```"].join("\n");
+  assert.deepEqual(
+    extractPnpmInvocations(md).map((i) => ({ dir: i.target.value, script: i.script })),
+    [
+      { dir: ".", script: "test" },
+      { dir: ".", script: "build" },
+    ],
+  );
+});
+
+test("extractPnpmInvocations ignores non-pnpm lines", () => {
+  const md = ["```bash", "docker compose up --build", "PINCHY_KEY=x docker compose pull", "```"].join(
+    "\n",
+  );
+  assert.deepEqual(extractPnpmInvocations(md), []);
+});
+
+test("extractPnpmInvocations resolves -C into a directory target", () => {
+  const md = ["```bash", "pnpm -C packages/web test:db", "```"].join("\n");
+  const [inv] = extractPnpmInvocations(md);
+  assert.deepEqual(inv.target, { type: "dir", value: "packages/web" });
+  assert.equal(inv.script, "test:db");
+});
+
+test("extractPnpmInvocations resolves --filter into a package-name target", () => {
+  const md = ["```bash", "pnpm --filter @pinchy/web format:check", "```"].join("\n");
+  const [inv] = extractPnpmInvocations(md);
+  assert.deepEqual(inv.target, { type: "filter", value: "@pinchy/web" });
+  assert.equal(inv.script, "format:check");
+});
+
+test("extractPnpmInvocations follows `cd` across a && chain", () => {
+  const md = ["```bash", "cd docs && pnpm install && pnpm dev", "```"].join("\n");
+  const invocations = extractPnpmInvocations(md);
+  // `pnpm install` is a builtin, not a script, so only `pnpm dev` is a claim
+  // about a script existing.
+  assert.deepEqual(
+    invocations.map((i) => ({ dir: i.target.value, script: i.script })),
+    [{ dir: "docs", script: "dev" }],
+  );
+});
+
+test("extractPnpmInvocations unwraps `pnpm run <script>`", () => {
+  const md = ["```bash", "pnpm run test:scripts", "```"].join("\n");
+  assert.equal(extractPnpmInvocations(md)[0].script, "test:scripts");
+});
+
+test("checkAgentsMdCommands passes when every documented script exists", () => {
+  const md = [
+    "```bash",
+    "pnpm test",
+    "pnpm -C packages/web db:generate",
+    "cd docs && pnpm build",
+    "```",
+  ].join("\n");
+  assert.deepEqual(checkAgentsMdCommands(md, fakeResolver(WORKSPACE)), []);
+});
+
+test("checkAgentsMdCommands flags a documented script that does not exist", () => {
+  // The exact rot this guard exists to catch: AGENTS.md told agents to run
+  // `pnpm lint` from the repo root, but only packages/web has that script.
+  const md = ["```bash", "pnpm lint", "```"].join("\n");
+  const problems = checkAgentsMdCommands(md, fakeResolver(WORKSPACE));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /pnpm lint/);
+  assert.match(problems[0], /root package\.json|"\."/);
+});
+
+test("checkAgentsMdCommands flags a --filter naming an unknown package", () => {
+  const md = ["```bash", "pnpm --filter @pinchy/nope test", "```"].join("\n");
+  const problems = checkAgentsMdCommands(md, fakeResolver(WORKSPACE));
+  assert.equal(problems.length, 1);
+  assert.match(problems[0], /@pinchy\/nope/);
+});
+
+test("createWorkspaceResolver finds every package, not just the root and web", () => {
+  const resolver = createWorkspaceResolver(REPO_ROOT);
+  // A plugin reached by name — the case the hand-written map used to miss,
+  // turning a correctly documented command into a bogus "not a package".
+  assert.ok(resolver({ type: "filter", value: "@pinchy/pinchy-odoo" })?.includes("test"));
+  assert.ok(resolver({ type: "filter", value: "@pinchy/web" })?.includes("lint"));
+  assert.ok(resolver({ type: "dir", value: "." })?.includes("test:scripts"));
+  // docs/ is standalone rather than a workspace member, but AGENTS.md
+  // documents it, so the guard has to know it.
+  assert.ok(resolver({ type: "dir", value: "docs" })?.includes("build"));
+});
+
+test("createWorkspaceResolver resolves a glob filter to the union of its matches", () => {
+  const resolver = createWorkspaceResolver(REPO_ROOT);
+  assert.ok(resolver({ type: "filter", value: "./packages/plugins/*" })?.includes("test"));
+  assert.ok(resolver({ type: "filter", value: "@pinchy/*" })?.includes("lint"));
+});
+
+test("createWorkspaceResolver still returns null for a package that does not exist", () => {
+  const resolver = createWorkspaceResolver(REPO_ROOT);
+  assert.equal(resolver({ type: "filter", value: "@pinchy/nope" }), null);
+  assert.equal(resolver({ type: "dir", value: "packages/nope" }), null);
+});
+
+test("every pnpm command in the real AGENTS.md resolves to a real script", () => {
+  const markdown = readFileSync(join(REPO_ROOT, "AGENTS.md"), "utf8");
+  assert.deepEqual(checkAgentsMdCommands(markdown, createWorkspaceResolver(REPO_ROOT)), []);
+});


### PR DESCRIPTION
## What this does

Adds a CI-run drift guard for the commands documented in **AGENTS.md** — the first file every coding agent reads. Nothing in CI checked that the commands it advertises actually exist, which is how `pnpm lint`, `pnpm format` and `pnpm db:generate` sat in the root-commands block for months as commands that error out. Two subagents on 2026-07-15 both hit it and both had to work out the real commands themselves.

## Direction change — the docs fix already landed on main

This branch originally *added* the three as root `package.json` proxies. While it was open, the repo owner fixed the same rot on `main` the other way — [`3eac971a7`](https://github.com/heypinchy/pinchy/commit/3eac971a7) moves the three into the `pnpm -C packages/web` block — with a deliberate, documented rationale:

> `pnpm format` at the root would be a genuine change, not a convenience. lint-staged only covers `packages/web/**`, `docs/src/**` and `.github/**/*.yml` — `scripts/*.mjs` and `config/*.mjs` have never been prettier-managed… The per-package form keeps the scope honest.

That's an explicit owner decision, so I dropped the root-scripts approach and rebased the branch to **add only the guard on top of `main`'s per-package form**. The guard now validates that form (`pnpm -C packages/web lint`, etc.) rather than the convention I'd proposed.

## The guard

`scripts/lib/agents-md-commands.mjs` + test walks every ` ```bash ` block in AGENTS.md, resolves each `pnpm` invocation to the package it runs in — handling `-C`/`--dir`/`--filter` (incl. glob filters like `./packages/plugins/*`), `cd x && pnpm y` chains, `pnpm run <script>`, and pnpm builtins like `install` — and fails if the script isn't declared there. The package set is derived from `pnpm-workspace.yaml` plus the filesystem, so the guard is not itself an enumeration that can drift. Picked up automatically by `pnpm test:scripts` via the `scripts/lib/*.test.mjs` glob — the established `scripts/lib` guard pattern.

**Scope, stated honestly** (module header + AGENTS.md): it checks the package a command *targets*, not a proxy chain behind it. CI runs the web scripts directly, so that drift surfaces there.

## Verification

- `pnpm test:scripts` — 298/298 (13 in the guard).
- `pnpm -C packages/web format:check` — clean.
- **Mutation check:** dropping `lint` from `packages/web/package.json` reddens `pnpm -C packages/web lint` via the real resolver; restored untouched.

Note: the two new `scripts/lib/*.mjs` files are not Prettier-formatted, matching the ~17 existing files there — `scripts/lib/` sits outside every Prettier gate, which is the very fact `main`'s docs fix relied on.
