### PR TITLE
test(e2e): stop the stop-button spec gating on another spec's reply

### DIFF
--- a/packages/web/e2e/integration/19-chat-stop-button.spec.ts
+++ b/packages/web/e2e/integration/19-chat-stop-button.spec.ts
@@ -16,15 +16,22 @@
 //   2. The SAME session is immediately reusable — a second message gets a real
 //      reply. This is the session-lane-release regression guard; if the
 //      upstream fix ever regresses, this is the assertion that goes red.
+//
+// Both the mid-stream gate and the final assertion are deliberately scoped to
+// THIS run's reply via a word list only this spec can trigger. The integration
+// suite shares one OpenClaw session, so the generic E2E_SLOW_STREAM reply is
+// already in the history from specs 15-18 — see the comment on
+// FAKE_OLLAMA_ABORT_STREAM_TRIGGER for the flake that cost us.
 import { test, expect } from "@playwright/test";
 import {
-  FAKE_OLLAMA_SLOW_STREAM_TRIGGER,
+  FAKE_OLLAMA_ABORT_STREAM_TRIGGER,
   FAKE_OLLAMA_RESPONSE,
-  FAKE_OLLAMA_SLOW_STREAM_RESPONSE,
+  FAKE_OLLAMA_ABORT_STREAM_RESPONSE,
+  FAKE_OLLAMA_SLOW_STREAM_DELAY_MS,
 } from "../shared/fake-ollama/fake-ollama-server";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
-const STREAM_WORDS = FAKE_OLLAMA_SLOW_STREAM_RESPONSE.split(" ");
+const STREAM_WORDS = FAKE_OLLAMA_ABORT_STREAM_RESPONSE.split(" ");
 const STREAM_FIRST_WORD = STREAM_WORDS[0]!;
 const STREAM_LAST_WORD = STREAM_WORDS[STREAM_WORDS.length - 1]!;
 
@@ -43,16 +50,24 @@ test.describe("Chat stop button — user-triggered abort (#550)", () => {
     // 1. Kick off a genuinely incremental reply (~500ms/word, ten words). Keep
     //    the prompt free of the response's words so the last-word assertion in
     //    step 5 can never be satisfied by the echoed user message.
-    await input.fill(`${FAKE_OLLAMA_SLOW_STREAM_TRIGGER}: please respond slowly`);
+    await input.fill(`${FAKE_OLLAMA_ABORT_STREAM_TRIGGER}: please respond slowly`);
     await input.press("Enter");
 
     // 2. The run is STARTED (not merely pending): the stop button is showing
     //    AND the first word has streamed. The openclaw#42172 bug was about
     //    started runs, so we deliberately abort one mid-stream.
+    //
+    //    Scope the reply by its first word rather than taking `.last()` of all
+    //    assistant messages: only this run can produce STREAM_FIRST_WORD, so a
+    //    match cannot be an earlier spec's reply sitting in the shared session.
+    //    `.last()` could — and did — resolve to one while this run's bubble was
+    //    not in the DOM yet, passing the gate before a single token existed.
     const stopButton = page.getByRole("button", { name: "Stop generating" });
     await expect(stopButton).toBeVisible({ timeout: 15000 });
-    const assistantMessage = page.locator('[data-role="assistant"]').last();
-    await expect(assistantMessage).toContainText(STREAM_FIRST_WORD, { timeout: 15000 });
+    const assistantMessage = page
+      .locator('[data-role="assistant"]')
+      .filter({ hasText: STREAM_FIRST_WORD });
+    await expect(assistantMessage).toBeVisible({ timeout: 15000 });
 
     // 3. Click stop.
     await stopButton.click();
@@ -62,9 +77,14 @@ test.describe("Chat stop button — user-triggered abort (#550)", () => {
     await expect(stopButton).toBeHidden({ timeout: 10000 });
 
     // 5. The stream actually stopped server-side: the final word never lands.
-    //    With the old no-op abort the reply would run to completion ("ten").
-    //    Give it well over the remaining stream time to be sure.
-    await page.waitForTimeout(4000);
+    //    With the old no-op abort the reply would run to completion.
+    //    We aborted right after word one, so the nine remaining words would
+    //    take DELAY_MS * 9 to arrive. Wait out the whole response length —
+    //    a full word longer than that — so a stream that was NOT stopped has
+    //    provably had the time to finish. (The previous fixed 4000ms was
+    //    shorter than the 4500ms it was meant to outlast, which would have let
+    //    a no-op abort slip through green.)
+    await page.waitForTimeout(FAKE_OLLAMA_SLOW_STREAM_DELAY_MS * STREAM_WORDS.length);
     await expect(assistantMessage).not.toContainText(STREAM_LAST_WORD);
 
     // 6. The abort is audited as chat.run_aborted (actor = user, success).

--- a/packages/web/e2e/integration/19-chat-stop-button.spec.ts
+++ b/packages/web/e2e/integration/19-chat-stop-button.spec.ts
@@ -27,7 +27,7 @@ import {
   FAKE_OLLAMA_ABORT_STREAM_TRIGGER,
   FAKE_OLLAMA_RESPONSE,
   FAKE_OLLAMA_ABORT_STREAM_RESPONSE,
-  FAKE_OLLAMA_SLOW_STREAM_DELAY_MS,
+  FAKE_OLLAMA_ABORT_STREAM_DELAY_MS,
 } from "../shared/fake-ollama/fake-ollama-server";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
@@ -84,7 +84,11 @@ test.describe("Chat stop button — user-triggered abort (#550)", () => {
     //    provably had the time to finish. (The previous fixed 4000ms was
     //    shorter than the 4500ms it was meant to outlast, which would have let
     //    a no-op abort slip through green.)
-    await page.waitForTimeout(FAKE_OLLAMA_SLOW_STREAM_DELAY_MS * STREAM_WORDS.length);
+    await page.waitForTimeout(FAKE_OLLAMA_ABORT_STREAM_DELAY_MS * STREAM_WORDS.length);
+    //    Re-assert presence first: `not.toContainText` is also satisfied by a
+    //    locator that matches NOTHING, so a reply that vanished from the DOM
+    //    would make the assertion below pass without proving anything.
+    await expect(assistantMessage).toBeVisible();
     await expect(assistantMessage).not.toContainText(STREAM_LAST_WORD);
 
     // 6. The abort is audited as chat.run_aborted (actor = user, success).

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -79,6 +79,19 @@ const SLOW_STREAM_TRIGGER = "E2E_SLOW_STREAM";
 const SLOW_STREAM_RESPONSE = "one two three four five six seven eight nine ten";
 const SLOW_STREAM_DELAY_MS = 500;
 
+// Same slow per-word stream as SLOW_STREAM, but with a word list no other spec
+// can produce. The integration suite shares ONE OpenClaw session, so specs
+// 15-18 leave completed "one … ten" replies in the history that spec 19 then
+// re-reads. Sharing SLOW_STREAM_RESPONSE with them let spec 19's
+// "the first word streamed" gate match a STALE reply while this run's bubble
+// had not been appended yet: the gate passed ~350ms after send (the first token
+// cannot exist before SLOW_STREAM_DELAY_MS), so it clicked stop on a zero-token
+// run and then asserted the last word's absence against the old message —
+// which of course still contained it. A private word list makes both the gate
+// and the final assertion provably about the run under test.
+const ABORT_STREAM_TRIGGER = "E2E_ABORT_STREAM";
+const ABORT_STREAM_RESPONSE = "lima mike november oscar papa quebec romeo sierra tango whiskey";
+
 // ── Chat-liveness triggers ─────────────────────────────────────────────────
 // Building blocks for the chat-liveness E2E specs (asserted in a later task).
 //
@@ -1114,6 +1127,11 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    if (lastContent.includes(ABORT_STREAM_TRIGGER) && !hasToolResult) {
+      await streamTextResponseSlow(res, ABORT_STREAM_RESPONSE);
+      return;
+    }
+
     if (lastContent.includes(LIVENESS_DYING_TRIGGER) && !hasToolResult) {
       streamTextResponseDying(res, LIVENESS_DYING_PARTIAL);
       return;
@@ -1285,6 +1303,13 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    // Abort-stream trigger: same slow per-word stream, private word list. Lives
+    // on this surface for the same reason as the slow trigger above.
+    if (lastContent.includes(ABORT_STREAM_TRIGGER) && !hasToolResult) {
+      await streamOpenAiTextSlow(res, ABORT_STREAM_RESPONSE);
+      return;
+    }
+
     // Liveness DYING: abruptly-ended stream (provider death). Checked before the
     // slow trigger because both are independent prompts; order is for clarity.
     if (lastContent.includes(LIVENESS_DYING_TRIGGER) && !hasToolResult) {
@@ -1348,6 +1373,9 @@ export const FAKE_OLLAMA_DOMAIN_LOCK_TOOL_RESPONSE = DOMAIN_LOCK_TOOL_RESPONSE;
 export const FAKE_OLLAMA_SLOW_STREAM_TRIGGER = SLOW_STREAM_TRIGGER;
 export const FAKE_OLLAMA_SLOW_STREAM_RESPONSE = SLOW_STREAM_RESPONSE;
 export const FAKE_OLLAMA_SLOW_STREAM_DELAY_MS = SLOW_STREAM_DELAY_MS;
+// Stop-button trigger (#550): slow stream with a word list private to spec 19.
+export const FAKE_OLLAMA_ABORT_STREAM_TRIGGER = ABORT_STREAM_TRIGGER;
+export const FAKE_OLLAMA_ABORT_STREAM_RESPONSE = ABORT_STREAM_RESPONSE;
 // Chat-liveness triggers (slow "taking longer" + dying provider failure).
 export const FAKE_OLLAMA_LIVENESS_SLOW_TRIGGER = LIVENESS_SLOW_TRIGGER;
 export const FAKE_OLLAMA_LIVENESS_SLOW_RESPONSE = LIVENESS_SLOW_RESPONSE;

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -84,11 +84,14 @@ const SLOW_STREAM_DELAY_MS = 500;
 // 15-18 leave completed "one … ten" replies in the history that spec 19 then
 // re-reads. Sharing SLOW_STREAM_RESPONSE with them let spec 19's
 // "the first word streamed" gate match a STALE reply while this run's bubble
-// had not been appended yet: the gate passed ~350ms after send (the first token
-// cannot exist before SLOW_STREAM_DELAY_MS), so it clicked stop on a zero-token
-// run and then asserted the last word's absence against the old message —
-// which of course still contained it. A private word list makes both the gate
-// and the final assertion provably about the run under test.
+// had not been appended yet: `.last()` resolved to a finished reply from an
+// earlier spec, so the gate never proved that THIS run had streamed anything.
+// It then clicked stop and asserted the last word's absence against that old
+// message — which of course still contained it. What pinned it down was the
+// timestamp: the message the assertion failed on was rendered 03:13 PM, a full
+// minute BEFORE this run sent its prompt at 03:14:03, so it could not have
+// belonged to the run under test. A private word list makes both the gate and
+// the final assertion provably about the run under test.
 const ABORT_STREAM_TRIGGER = "E2E_ABORT_STREAM";
 const ABORT_STREAM_RESPONSE = "lima mike november oscar papa quebec romeo sierra tango whiskey";
 
@@ -1127,6 +1130,9 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    // Abort-stream trigger: same slow per-word stream, private word list. See
+    // the ABORT_STREAM_TRIGGER declaration for why spec 19 cannot share the
+    // slow trigger above.
     if (lastContent.includes(ABORT_STREAM_TRIGGER) && !hasToolResult) {
       await streamTextResponseSlow(res, ABORT_STREAM_RESPONSE);
       return;
@@ -1374,8 +1380,14 @@ export const FAKE_OLLAMA_SLOW_STREAM_TRIGGER = SLOW_STREAM_TRIGGER;
 export const FAKE_OLLAMA_SLOW_STREAM_RESPONSE = SLOW_STREAM_RESPONSE;
 export const FAKE_OLLAMA_SLOW_STREAM_DELAY_MS = SLOW_STREAM_DELAY_MS;
 // Stop-button trigger (#550): slow stream with a word list private to spec 19.
+// The per-word delay is the slow stream's, because both surfaces dispatch this
+// trigger through the shared streamTextResponseSlow/streamOpenAiTextSlow
+// helpers. Export it under its own name so spec 19 states the timing it
+// depends on: give this trigger a dedicated delay and the constant moves with
+// it, instead of the spec's wait silently drifting off the slow stream's.
 export const FAKE_OLLAMA_ABORT_STREAM_TRIGGER = ABORT_STREAM_TRIGGER;
 export const FAKE_OLLAMA_ABORT_STREAM_RESPONSE = ABORT_STREAM_RESPONSE;
+export const FAKE_OLLAMA_ABORT_STREAM_DELAY_MS = SLOW_STREAM_DELAY_MS;
 // Chat-liveness triggers (slow "taking longer" + dying provider failure).
 export const FAKE_OLLAMA_LIVENESS_SLOW_TRIGGER = LIVENESS_SLOW_TRIGGER;
 export const FAKE_OLLAMA_LIVENESS_SLOW_RESPONSE = LIVENESS_SLOW_RESPONSE;


### PR DESCRIPTION
## What does this PR do?

Fixes the flake in `19-chat-stop-button.spec.ts` in the **Integration Tests (OpenClaw + Fake Ollama)** job.

**The suspected cause was wrong.** The theory was that under CI load the ~5s stream ran to completion before the stop click landed server-side. The trace of the red run says the opposite: `chat.abort` worked correctly (`stopReason=aborted`). The spec lied — it asserted against **another spec's reply**.

### Evidence

Pulled the `integration-failure-29426161330-1` artifact (attempt 1 of the red run on d876e46a3, PR #760) and mapped Playwright's `before`/`after` events onto wall-clock via `context-options.wallTime − monotonicTime`:

| Time | Event |
|---|---|
| 15:14:03.701 | Enter (message sent) |
| 15:14:04.055 | gate "first word streamed" passed → stop clicked |
| 15:14:04.231 | `chat.abort` ✓, OpenClaw logs `stopReason=aborted` |

The decisive evidence is the **timestamp on the message the assertion failed on: 03:13 PM** — a full minute *older* than the message this test sent at 03:14:03 PM. It cannot belong to this run. The gate had matched a reply that was already in the transcript before the test even started.

### Root cause

The integration suite shares one OpenClaw session (`workers: 1`, same user, same agent), and specs 15–18 use the same `E2E_SLOW_STREAM` trigger, leaving word-identical `"one … ten"` replies in the history. While this run's bubble was not yet in the DOM, `page.locator('[data-role="assistant"]').last()` resolved to one of those **stale** replies:

1. Gate passes against the old message — it never proves *this* run streamed.
2. Stop aborts a run that has rendered nothing (correctly — `stopReason=aborted`).
3. No new bubble renders in time, so `.last()` still points at the old ten-word message.
4. `not.toContainText("ten")` fails.

Green runs were the case where the bubble happened to be appended before the gate sampled.

### The fix

- **Private slow-stream trigger** `E2E_ABORT_STREAM` → `"lima mike … whiskey"`, exclusive to this spec. Routed through both fake-ollama surfaces (Ollama-native + OpenAI-compatible) like every other trigger. A stale match is now impossible by construction.
- **Locator scoped to this run's reply**: `filter({ hasText: STREAM_FIRST_WORD })` instead of `.last()` — strict, no `.last()`, the same pattern `15-stream-persistence.spec.ts` already uses. A polluted session now fails **loudly** (strict-mode violation) instead of silently passing the gate.
- **Presence re-asserted before the negated assertion**: `not.toContainText` is also satisfied by a locator matching *nothing*, so a reply that vanished from the DOM would have passed it without proving anything.
- **Pre-existing second bug fixed while here**: the fixed `waitForTimeout(4000)` was *shorter* than the 4500ms of remaining stream it was meant to outlast (we abort after word one → nine words × 500ms). A no-op abort could have slipped through green. Now derived from the stream constants, exported as `FAKE_OLLAMA_ABORT_STREAM_DELAY_MS` so the spec names the timing it depends on.

The test intent from #550 / openclaw#42172 is unchanged — nothing weakened, nothing skipped.

## Type of change

- [x] 🧪 Tests

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [ ] I've updated the documentation (if applicable) — no product behavior change
- [x] All existing tests pass

## Verification

- **Full integration suite on a fresh stack, real suite order**: 32 passed / 2 skipped — spec 19 green after 15–18.
- **Guard sharpness (the part that matters)**: with `chatAbort` temporarily stubbed out to reproduce openclaw#42172, the spec goes red on **exactly** the stream assertion. The guard still bites. Mutation fully reverted — `client-router.ts` is untouched in this PR.
- **Gates**: `pnpm test`, `pnpm test:plugins`, `pnpm test:scripts`, `pnpm typecheck:plugins`, `pnpm -C packages/web typecheck`, lint (0 errors), prettier — all green.

## Note for the reviewer

Re-running the integration suite **locally against a reused stack** will fail specs 15 and 19 on strict mode: the shared session accumulates in the `<project>_openclaw-config` volume, so several `"one … ten"` / `"lima"` replies pile up across runs. That's an artifact of the reused stack, not a regression — CI builds the stack fresh per run. It is also precisely the loud failure this PR wants instead of a silent false gate.
