### PR TITLE
test(models): catch nested-argument mangling in the ollama-cloud tool probe

### DIFF
--- a/scripts/lib/ollama-cloud-tool-probe.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.mjs
@@ -130,6 +130,8 @@ const NESTED_PROBE_PROMPT =
 
 const NESTED_REQUIRED_ARGS = ["model", "filters", "fields"];
 
+const NESTED_TOOL_NAME = "search_records";
+
 // Keys a model wraps a collapsed array in instead of emitting the array.
 const ITEM_WRAPPER_KEYS = ["item", "items"];
 
@@ -140,13 +142,16 @@ const ITEM_WRAPPER_KEYS = ["item", "items"];
 export function buildNestedToolProbeRequest(id) {
   return {
     model: id,
-    max_tokens: 256,
+    // Roomier than the flat probe's 128: a thinking model spends budget before
+    // it emits the call, and a truncated call would read as a defect it hasn't
+    // got. The payload itself is ~40 tokens, so the headroom is nearly free.
+    max_tokens: 512,
     tool_choice: "auto",
     tools: [
       {
         type: "function",
         function: {
-          name: "search_records",
+          name: NESTED_TOOL_NAME,
           description: "Search business records with a filter domain.",
           parameters: {
             type: "object",
@@ -216,8 +221,45 @@ function arrayDefect(value, path) {
   }
   return fail(
     "wrong-shape",
-    `${path} arrived as ${Array.isArray(value) ? "array" : typeof value}, expected an array`,
+    `${path} arrived as ${typeof value}, expected an array`,
   );
+}
+
+// Why `value` is not the scalar a domain triplet holds, or null if it is one.
+// A triplet's third member may legitimately be a list — ["state", "in",
+// ["posted", "draft"]] is a valid domain — so lists are checked, not rejected.
+function scalarDefect(value, path) {
+  if (looksStringified(value)) {
+    return fail(
+      "stringified-array",
+      `${path} arrived as a stringified array: ${value}`,
+    );
+  }
+  if (value === null || typeof value !== "object") return null;
+  const wrapper = itemWrapperKey(value);
+  if (wrapper) {
+    return fail(
+      "item-wrapper",
+      `${path} collapsed into a {"${wrapper}": …} wrapper object`,
+    );
+  }
+  if (!Array.isArray(value)) {
+    return fail(
+      "wrong-shape",
+      `${path} arrived as an object, expected a scalar`,
+    );
+  }
+  for (const [i, member] of value.entries()) {
+    const defect = scalarDefect(member, `${path}[${i}]`);
+    if (defect) return defect;
+    if (Array.isArray(member)) {
+      return fail(
+        "wrong-shape",
+        `${path}[${i}] arrived as a nested array, expected a scalar`,
+      );
+    }
+  }
+  return null;
 }
 
 /**
@@ -232,6 +274,17 @@ export function classifyNestedToolResponse(parsed) {
   const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
   if (toolCalls.length === 0) {
     return fail("no-tool-call", "no structured tool_calls on the nested probe");
+  }
+
+  // A call to a tool that was never offered says nothing about nesting. Naming
+  // it plainly beats reporting it as mangled arguments — the defect class is
+  // the only thing this probe produces, so it must not lie about it.
+  const called = toolCalls[0]?.function?.name;
+  if (called !== NESTED_TOOL_NAME) {
+    return fail(
+      "wrong-tool",
+      `the model called "${called}" instead of ${NESTED_TOOL_NAME}`,
+    );
   }
 
   const raw = toolCalls[0]?.function?.arguments;
@@ -289,24 +342,8 @@ export function classifyNestedToolResponse(parsed) {
     const defect = arrayDefect(triplet, `filters[${i}]`);
     if (defect) return defect;
     for (const [j, member] of triplet.entries()) {
-      if (looksStringified(member)) {
-        return fail(
-          "stringified-array",
-          `filters[${i}][${j}] arrived as a stringified array: ${member}`,
-        );
-      }
-      if (member !== null && typeof member === "object") {
-        const wrapper = itemWrapperKey(member);
-        return wrapper
-          ? fail(
-              "item-wrapper",
-              `filters[${i}][${j}] collapsed into a {"${wrapper}": …} wrapper object`,
-            )
-          : fail(
-              "wrong-shape",
-              `filters[${i}][${j}] arrived as ${Array.isArray(member) ? "a nested array" : "an object"}, expected a scalar`,
-            );
-      }
+      const memberDefect = scalarDefect(member, `filters[${i}][${j}]`);
+      if (memberDefect) return memberDefect;
     }
   }
 
@@ -314,18 +351,24 @@ export function classifyNestedToolResponse(parsed) {
   if (fieldsDefect) return fieldsDefect;
 
   for (const [i, field] of args.fields.entries()) {
-    if (typeof field !== "string") {
-      const defect = arrayDefect(field, `fields[${i}]`);
-      // A non-string field is only an array defect if it looks like one;
-      // anything else is simply the wrong shape.
-      return defect ?? fail("wrong-shape", `fields[${i}] is not a string`);
-    }
     if (looksStringified(field)) {
       return fail(
         "stringified-array",
         `fields[${i}] arrived as a stringified array: ${field}`,
       );
     }
+    if (typeof field === "string") continue;
+    const wrapper = itemWrapperKey(field);
+    if (wrapper) {
+      return fail(
+        "item-wrapper",
+        `fields[${i}] collapsed into a {"${wrapper}": …} wrapper object`,
+      );
+    }
+    return fail(
+      "wrong-shape",
+      `fields[${i}] arrived as ${Array.isArray(field) ? "an array" : typeof field}, expected a string`,
+    );
   }
 
   return {

--- a/scripts/lib/ollama-cloud-tool-probe.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.mjs
@@ -4,12 +4,15 @@
 // https://ollama.com/v1/chat/completions for each curated model and checks the
 // reply. Every model in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS is, by definition,
 // expected to emit a *structured* tool_call — a model that silently skips the
-// call (qwen3-next's empty-content failure) or leaks the call as plain text
-// (gemini-3-flash-preview's `default_api` signature) must not be surfaced as
+// call (qwen3-next's empty-content failure), leaks the call as plain text
+// (gemini-3-flash-preview's `default_api` signature), or emits a structurally
+// valid call with mangled nested arguments (minimax-m3) must not be surfaced as
 // tool-capable, because every Pinchy agent relies on tools (files/context/docs).
 //
-// These two functions are the request shape and the response classifier, kept
-// pure so the network wrapper stays thin and this logic is unit-tested.
+// These functions are the request shapes and the response classifiers, kept
+// pure so the network wrapper stays thin and this logic is unit-tested. There
+// are two probes: a flat one (get_weather) and a nested one (search_records),
+// and they catch different defect classes — keep both.
 
 // Signatures of a tool call that a model rendered into plain text instead of
 // returning a structured `tool_calls` array. `get_weather` is the probe's own
@@ -105,6 +108,230 @@ export function buildToolFollowupRequest(id, assistantMessage) {
         content: "It is 22°C and sunny in Paris.",
       },
     ],
+  };
+}
+
+// --- Round 3: nested arguments -------------------------------------------
+//
+// The flat get_weather probe above only proves a model can fill in one string.
+// minimax-m3 passes it cleanly and still mangles NESTED arrays: they collapse
+// into {"item": …} objects, and some arrive stringified ("[10, 20]"). On
+// 2026-07-15 that broke the production agent "Penny" against Odoo — domain
+// filters died with "unhashable type: 'dict'" and account.move
+// invoice_line_ids/tax_ids command triplets were rejected (20 of 60 tool calls
+// mangled, vs 0/112 on kimi-k2.6 and 0/68 on deepseek-v4-pro). Pinchy's Odoo
+// tools are array-of-arrays all the way down, so this round asks for exactly
+// that shape and insists the arguments parse back to genuine arrays.
+
+const NESTED_PROBE_PROMPT =
+  "Find the posted invoices worth more than 10 EUR. Use the search_records " +
+  'tool on the "account.move" model with the filters state = posted and ' +
+  "amount > 10, and return the name and amount fields.";
+
+const NESTED_REQUIRED_ARGS = ["model", "filters", "fields"];
+
+// Keys a model wraps a collapsed array in instead of emitting the array.
+const ITEM_WRAPPER_KEYS = ["item", "items"];
+
+/**
+ * Build the nested-argument probe request for a model id.
+ * @param {string} id
+ */
+export function buildNestedToolProbeRequest(id) {
+  return {
+    model: id,
+    max_tokens: 256,
+    tool_choice: "auto",
+    tools: [
+      {
+        type: "function",
+        function: {
+          name: "search_records",
+          description: "Search business records with a filter domain.",
+          parameters: {
+            type: "object",
+            properties: {
+              model: {
+                type: "string",
+                description: 'Model name, e.g. "account.move"',
+              },
+              filters: {
+                type: "array",
+                description:
+                  'A filter domain: a list of [field, operator, value] triplets, e.g. [["state", "=", "posted"], ["amount", ">", 10]].',
+                items: {
+                  type: "array",
+                  description:
+                    'One [field, operator, value] triplet, e.g. ["state", "=", "posted"].',
+                  items: {},
+                },
+              },
+              fields: {
+                type: "array",
+                description: 'Field names to return, e.g. ["name", "amount"].',
+                items: { type: "string" },
+              },
+            },
+            required: NESTED_REQUIRED_ARGS,
+          },
+        },
+      },
+    ],
+    messages: [{ role: "user", content: NESTED_PROBE_PROMPT }],
+  };
+}
+
+const fail = (failure, detail) => ({ nestedOk: false, failure, detail });
+
+// A scalar the model rendered as "[…]" — the array survived the model's head
+// but left it as text, so the tool receives a string where a list belongs.
+function looksStringified(value) {
+  if (typeof value !== "string") return false;
+  const trimmed = value.trim();
+  return trimmed.startsWith("[") && trimmed.endsWith("]");
+}
+
+function itemWrapperKey(value) {
+  if (!value || typeof value !== "object" || Array.isArray(value)) return null;
+  return ITEM_WRAPPER_KEYS.find((k) =>
+    Object.prototype.hasOwnProperty.call(value, k),
+  );
+}
+
+// Why `value` is not the array it was asked to be, or null if it is one.
+function arrayDefect(value, path) {
+  if (Array.isArray(value)) return null;
+  if (looksStringified(value)) {
+    return fail(
+      "stringified-array",
+      `${path} arrived as a stringified array: ${JSON.stringify(value)}`,
+    );
+  }
+  const wrapper = itemWrapperKey(value);
+  if (wrapper) {
+    return fail(
+      "item-wrapper",
+      `${path} collapsed into a {"${wrapper}": …} wrapper object instead of an array`,
+    );
+  }
+  return fail(
+    "wrong-shape",
+    `${path} arrived as ${Array.isArray(value) ? "array" : typeof value}, expected an array`,
+  );
+}
+
+/**
+ * Classify the nested-argument probe response: the tool_call must carry named
+ * arguments whose `filters` is a genuine array of arrays and whose `fields` is
+ * a genuine array of strings — no {"item": …} wrappers, no stringified arrays.
+ * @param {any} parsed - the JSON-parsed response body
+ * @returns {{ nestedOk: boolean, failure: string|null, detail: string }}
+ */
+export function classifyNestedToolResponse(parsed) {
+  const message = parsed?.choices?.[0]?.message ?? {};
+  const toolCalls = Array.isArray(message.tool_calls) ? message.tool_calls : [];
+  if (toolCalls.length === 0) {
+    return fail("no-tool-call", "no structured tool_calls on the nested probe");
+  }
+
+  const raw = toolCalls[0]?.function?.arguments;
+  let args = raw;
+  if (typeof raw === "string") {
+    try {
+      args = JSON.parse(raw);
+    } catch {
+      return fail(
+        "unparseable-arguments",
+        `arguments are not valid JSON: ${JSON.stringify(raw.slice(0, 120))}`,
+      );
+    }
+  }
+
+  // Positional arguments: a bare array, or an object keyed "0"/"1"/"2". Pinchy's
+  // plugins dispatch on names, so position-only args land in the wrong fields.
+  if (Array.isArray(args)) {
+    return fail(
+      "positional-arguments",
+      "arguments arrived as a positional array, not a named object",
+    );
+  }
+  if (!args || typeof args !== "object") {
+    return fail(
+      "unparseable-arguments",
+      `arguments parsed to ${typeof args}, expected an object`,
+    );
+  }
+  const keys = Object.keys(args);
+  if (keys.length > 0 && keys.every((k) => /^\d+$/.test(k))) {
+    return fail(
+      "positional-arguments",
+      `arguments are keyed positionally (${keys.join(", ")}), not by name`,
+    );
+  }
+
+  for (const name of NESTED_REQUIRED_ARGS) {
+    if (!(name in args)) {
+      return fail("wrong-shape", `missing named argument "${name}"`);
+    }
+  }
+  if (typeof args.model !== "string") {
+    return fail("wrong-shape", `model arrived as ${typeof args.model}`);
+  }
+
+  const filtersDefect = arrayDefect(args.filters, "filters");
+  if (filtersDefect) return filtersDefect;
+
+  if (args.filters.length === 0) {
+    return fail("wrong-shape", "filters is empty — the domain was dropped");
+  }
+
+  for (const [i, triplet] of args.filters.entries()) {
+    const defect = arrayDefect(triplet, `filters[${i}]`);
+    if (defect) return defect;
+    for (const [j, member] of triplet.entries()) {
+      if (looksStringified(member)) {
+        return fail(
+          "stringified-array",
+          `filters[${i}][${j}] arrived as a stringified array: ${member}`,
+        );
+      }
+      if (member !== null && typeof member === "object") {
+        const wrapper = itemWrapperKey(member);
+        return wrapper
+          ? fail(
+              "item-wrapper",
+              `filters[${i}][${j}] collapsed into a {"${wrapper}": …} wrapper object`,
+            )
+          : fail(
+              "wrong-shape",
+              `filters[${i}][${j}] arrived as ${Array.isArray(member) ? "a nested array" : "an object"}, expected a scalar`,
+            );
+      }
+    }
+  }
+
+  const fieldsDefect = arrayDefect(args.fields, "fields");
+  if (fieldsDefect) return fieldsDefect;
+
+  for (const [i, field] of args.fields.entries()) {
+    if (typeof field !== "string") {
+      const defect = arrayDefect(field, `fields[${i}]`);
+      // A non-string field is only an array defect if it looks like one;
+      // anything else is simply the wrong shape.
+      return defect ?? fail("wrong-shape", `fields[${i}] is not a string`);
+    }
+    if (looksStringified(field)) {
+      return fail(
+        "stringified-array",
+        `fields[${i}] arrived as a stringified array: ${field}`,
+      );
+    }
+  }
+
+  return {
+    nestedOk: true,
+    failure: null,
+    detail: `nested arguments intact (${args.filters.length} domain triplet(s), ${args.fields.length} field(s))`,
   };
 }
 

--- a/scripts/lib/ollama-cloud-tool-probe.test.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.test.mjs
@@ -11,7 +11,7 @@ import {
 } from "./ollama-cloud-tool-probe.mjs";
 
 // Helper: wrap `arguments` the way the API does — a JSON *string*.
-function nestedResponse(args) {
+function nestedResponse(args, name = "search_records") {
   return {
     choices: [
       {
@@ -22,7 +22,7 @@ function nestedResponse(args) {
               id: "call_1",
               type: "function",
               function: {
-                name: "search_records",
+                name,
                 arguments:
                   typeof args === "string" ? args : JSON.stringify(args),
               },
@@ -192,9 +192,12 @@ test("buildNestedToolProbeRequest declares a tool whose schema requires an array
   assert.deepEqual(fn.parameters.required, ["model", "filters", "fields"]);
 
   // A user turn concrete enough to pin the expected domain, and bounded cost.
+  // The ceiling is deliberately roomier than the flat probe's: a thinking model
+  // spends budget before it ever emits the call, and a truncated call would be
+  // reported as a capability defect it doesn't have.
   assert.equal(body.messages.at(-1).role, "user");
   assert.match(body.messages.at(-1).content, /posted/i);
-  assert.ok(body.max_tokens > 0 && body.max_tokens <= 256);
+  assert.ok(body.max_tokens >= 512 && body.max_tokens <= 1024);
 });
 
 test("genuine nested arrays with named arguments pass the nested probe", () => {
@@ -316,6 +319,95 @@ test("a flat filters array (strings, not triplets) fails the nested probe", () =
   );
   assert.equal(result.nestedOk, false);
   assert.equal(result.failure, "wrong-shape");
+});
+
+test("a list value inside a triplet is legitimate nesting, not a defect", () => {
+  // ["state", "in", ["posted", "draft"]] is a perfectly valid Odoo domain: the
+  // deepest correct nesting a model can produce. Rejecting it would fail the
+  // very models this probe exists to keep.
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [["state", "in", ["posted", "draft"]]],
+    }),
+  );
+  assert.equal(result.nestedOk, true);
+  assert.equal(result.failure, null);
+});
+
+test("a stringified array inside a triplet's list value still fails", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [["amount", "in", ["[10, 20]"]]],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "stringified-array");
+  assert.match(result.detail, /filters\[0\]\[2\]\[0\]/);
+});
+
+test("an item wrapper inside a triplet's list value still fails", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [["state", "in", [{ item: "posted" }]]],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "item-wrapper");
+});
+
+test("a triplet member nested deeper than a list value is the wrong shape", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [["state", "in", [["posted"]]]],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-shape");
+});
+
+test('an {"items": …} wrapper is caught like the {"item": …} one', () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: { items: [["state", "=", "posted"]] },
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "item-wrapper");
+  assert.match(result.detail, /items/);
+});
+
+test("calling a tool the probe never offered is reported as such, not as bad arguments", () => {
+  // Misattributing this as wrong-shape would make the probe lie about the
+  // defect class, which is the one thing it produces.
+  const result = classifyNestedToolResponse(
+    nestedResponse({ city: "Paris" }, "get_weather"),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-tool");
+  assert.match(result.detail, /get_weather/);
+});
+
+test("a non-string field reports that a string was expected, not an array", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({ ...CLEAN_NESTED_ARGS, fields: ["name", 42] }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-shape");
+  assert.match(result.detail, /fields\[1\].*expected a string/);
+});
+
+test("a field that is an array reports the wrong shape against a string", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({ ...CLEAN_NESTED_ARGS, fields: [["name"]] }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-shape");
+  assert.match(result.detail, /expected a string/);
 });
 
 test("arguments already parsed into an object (not a JSON string) are accepted", () => {

--- a/scripts/lib/ollama-cloud-tool-probe.test.mjs
+++ b/scripts/lib/ollama-cloud-tool-probe.test.mjs
@@ -4,9 +4,44 @@ import assert from "node:assert/strict";
 import {
   buildToolProbeRequest,
   buildToolFollowupRequest,
+  buildNestedToolProbeRequest,
   classifyToolResponse,
+  classifyNestedToolResponse,
   isTransientStatus,
 } from "./ollama-cloud-tool-probe.mjs";
+
+// Helper: wrap `arguments` the way the API does — a JSON *string*.
+function nestedResponse(args) {
+  return {
+    choices: [
+      {
+        message: {
+          content: "",
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "search_records",
+                arguments:
+                  typeof args === "string" ? args : JSON.stringify(args),
+              },
+            },
+          ],
+        },
+      },
+    ],
+  };
+}
+
+const CLEAN_NESTED_ARGS = {
+  model: "account.move",
+  filters: [
+    ["state", "=", "posted"],
+    ["amount", ">", 10],
+  ],
+  fields: ["name", "amount"],
+};
 
 test("isTransientStatus flags retriable infra errors, not capability verdicts", () => {
   // 429/5xx are infra noise → retry, never report as "model lost tools".
@@ -123,4 +158,185 @@ test("a plain prose answer with no call and no leak is just not tool-capable her
   });
   assert.equal(result.supportsTools, false);
   assert.equal(result.leakedAsText, false);
+});
+
+// ---------------------------------------------------------------------------
+// Round 3: the nested-argument probe.
+//
+// minimax-m3 passes the flat get_weather probe cleanly but mangles NESTED
+// arrays: they collapse into {"item": …} objects and some arrive stringified
+// ("[10, 20]"). In production (2026-07-15, agent "Penny") that broke Odoo
+// domain filters ("unhashable type: 'dict'") and account.move command
+// triplets — 20 of 60 tool calls mangled, vs 0/112 on kimi-k2.6 and 0/68 on
+// deepseek-v4-pro. A flat schema cannot see this defect class at all.
+// ---------------------------------------------------------------------------
+
+test("buildNestedToolProbeRequest declares a tool whose schema requires an array of arrays", () => {
+  const body = buildNestedToolProbeRequest("minimax-m3");
+  assert.equal(body.model, "minimax-m3");
+  assert.ok(Array.isArray(body.tools) && body.tools.length === 1);
+
+  const fn = body.tools[0].function;
+  assert.equal(body.tools[0].type, "function");
+  assert.equal(fn.name, "search_records");
+
+  const props = fn.parameters.properties;
+  assert.equal(props.model.type, "string");
+  // The load-bearing bit: filters is array-of-arrays, shaped like an Odoo
+  // domain. If this ever flattens to a plain array of strings, the probe stops
+  // testing the thing it exists to test.
+  assert.equal(props.filters.type, "array");
+  assert.equal(props.filters.items.type, "array");
+  assert.equal(props.fields.type, "array");
+  assert.equal(props.fields.items.type, "string");
+  assert.deepEqual(fn.parameters.required, ["model", "filters", "fields"]);
+
+  // A user turn concrete enough to pin the expected domain, and bounded cost.
+  assert.equal(body.messages.at(-1).role, "user");
+  assert.match(body.messages.at(-1).content, /posted/i);
+  assert.ok(body.max_tokens > 0 && body.max_tokens <= 256);
+});
+
+test("genuine nested arrays with named arguments pass the nested probe", () => {
+  const result = classifyNestedToolResponse(nestedResponse(CLEAN_NESTED_ARGS));
+  assert.equal(result.nestedOk, true);
+  assert.equal(result.failure, null);
+});
+
+test("no tool_call at all fails the nested probe", () => {
+  const result = classifyNestedToolResponse({
+    choices: [
+      { message: { content: "Sure, I'll look that up.", tool_calls: [] } },
+    ],
+  });
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "no-tool-call");
+});
+
+test("arguments that are not valid JSON fail the nested probe", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse("{model: account.move,"),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "unparseable-arguments");
+});
+
+test('an {"item": …} wrapper around the filters array is the minimax-m3 defect', () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: { item: [["state", "=", "posted"]] },
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "item-wrapper");
+  assert.match(result.detail, /filters/);
+});
+
+test('an {"item": …} wrapper around an inner domain triplet is caught too', () => {
+  // The outer array survives, each triplet collapses into a dict — this is the
+  // exact shape behind Odoo's "unhashable type: 'dict'".
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [
+        { item: ["state", "=", "posted"] },
+        { item: ["amount", ">", 10] },
+      ],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "item-wrapper");
+  assert.match(result.detail, /filters\[0\]/);
+});
+
+test("a stringified filters array fails even though it parses back to an array", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: '[["state", "=", "posted"]]',
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "stringified-array");
+});
+
+test('a stringified array nested inside a domain triplet fails (the "[10, 20]" defect)', () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      ...CLEAN_NESTED_ARGS,
+      filters: [["amount", "in", "[10, 20]"]],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "stringified-array");
+  assert.match(result.detail, /\[10, 20\]/);
+});
+
+test("a stringified fields array fails", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({ ...CLEAN_NESTED_ARGS, fields: '["name", "amount"]' }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "stringified-array");
+  assert.match(result.detail, /fields/);
+});
+
+test("positional arguments fail even when the nesting itself is intact", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse(["account.move", [["state", "=", "posted"]], ["name"]]),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "positional-arguments");
+});
+
+test("named arguments faked with numeric keys are still positional", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({
+      0: "account.move",
+      1: [["state", "=", "posted"]],
+      2: ["name"],
+    }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "positional-arguments");
+});
+
+test("a missing required argument fails the nested probe", () => {
+  const { filters: _dropped, ...withoutFilters } = CLEAN_NESTED_ARGS;
+  const result = classifyNestedToolResponse(nestedResponse(withoutFilters));
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-shape");
+  assert.match(result.detail, /filters/);
+});
+
+test("a flat filters array (strings, not triplets) fails the nested probe", () => {
+  const result = classifyNestedToolResponse(
+    nestedResponse({ ...CLEAN_NESTED_ARGS, filters: ["state", "=", "posted"] }),
+  );
+  assert.equal(result.nestedOk, false);
+  assert.equal(result.failure, "wrong-shape");
+});
+
+test("arguments already parsed into an object (not a JSON string) are accepted", () => {
+  // Some gateways hand back `arguments` pre-parsed; that is not a defect.
+  const result = classifyNestedToolResponse({
+    choices: [
+      {
+        message: {
+          tool_calls: [
+            {
+              id: "call_1",
+              type: "function",
+              function: {
+                name: "search_records",
+                arguments: CLEAN_NESTED_ARGS,
+              },
+            },
+          ],
+        },
+      },
+    ],
+  });
+  assert.equal(result.nestedOk, true);
 });

--- a/scripts/verify-ollama-cloud-tools.mjs
+++ b/scripts/verify-ollama-cloud-tools.mjs
@@ -3,14 +3,17 @@
 //
 // Every model in TOOL_CAPABLE_OLLAMA_CLOUD_MODELS is, by its name, expected to
 // be tool-capable. For each one this script POSTs a function-tool probe to
-// https://ollama.com/v1/chat/completions across TWO rounds: round 1 must carry
-// a structured `tool_calls` array, and a round-2 follow-up (the same history
-// plus a tool result) must return HTTP 200. A model is reported as drift if it
-// returns empty content (qwen3-next's failure mode), leaks the call as plain
-// text (gemini-3-flash-preview's `default_api` signature), or HTTP 500s on the
-// follow-up once the history carries a tool result (gemma3 / kimi-k2-thinking).
-// Every Pinchy agent runs multi-turn tool loops, so a model that fails any of
-// these must not be surfaced as tool-capable.
+// https://ollama.com/v1/chat/completions across THREE rounds: round 1 must
+// carry a structured `tool_calls` array, a round-2 follow-up (the same history
+// plus a tool result) must return HTTP 200, and round 3 must fill a nested
+// array-of-arrays argument without mangling it. A model is reported as drift if
+// it returns empty content (qwen3-next's failure mode), leaks the call as plain
+// text (gemini-3-flash-preview's `default_api` signature), HTTP 500s on the
+// follow-up once the history carries a tool result (gemma3 / kimi-k2-thinking),
+// or collapses nested arrays into {"item": …} objects and stringified lists
+// (minimax-m3). Every Pinchy agent runs multi-turn tool loops and the Odoo
+// tools pass array-of-arrays domains, so a model that fails any round must not
+// be surfaced as tool-capable.
 //
 // NOTE: a single passing run is a smoke test, not a reliability proof — some
 // models are intermittent (qwen3-next 3/4, gemma3 flip-flopped between days).
@@ -39,7 +42,9 @@ import {
 import {
   buildToolProbeRequest,
   buildToolFollowupRequest,
+  buildNestedToolProbeRequest,
   classifyToolResponse,
+  classifyNestedToolResponse,
   isTransientStatus,
 } from "./lib/ollama-cloud-tool-probe.mjs";
 
@@ -120,7 +125,21 @@ async function probeModel(id, apiKey) {
     const stage = isTransientStatus(r2.status) ? "inconclusive" : "round2-fail";
     return { stage, status: r2.status, r2status: r2.status, body: r2.body };
   }
-  return { stage: "ok", detail: verdict.detail };
+
+  // Round 3: nested arguments. Rounds 1-2 only prove the model can fill in one
+  // string — minimax-m3 passes both and still mangles array-of-arrays, which is
+  // what Pinchy's Odoo tools are made of.
+  const r3 = await postChat(buildNestedToolProbeRequest(id), apiKey);
+  if (r3.status !== 200 || !r3.parsed) {
+    const stage = isTransientStatus(r3.status) ? "inconclusive" : "round3-http";
+    return { stage, status: r3.status, body: r3.body };
+  }
+  const nested = classifyNestedToolResponse(r3.parsed);
+  if (!nested.nestedOk) {
+    return { stage: "round3-verdict", nested, body: r3.body };
+  }
+
+  return { stage: "ok", detail: verdict.detail, nestedDetail: nested.detail };
 }
 
 async function main() {
@@ -158,7 +177,9 @@ async function main() {
     }
 
     if (result.stage === "ok") {
-      process.stdout.write(`OK (${result.detail} + clean multi-turn)\n`);
+      process.stdout.write(
+        `OK (${result.detail} + clean multi-turn + ${result.nestedDetail})\n`,
+      );
       continue;
     }
 
@@ -171,8 +192,9 @@ async function main() {
       continue;
     }
 
-    if (result.stage === "round1-http") {
-      process.stdout.write(`DRIFT (round 1 HTTP ${result.status})\n`);
+    if (result.stage === "round1-http" || result.stage === "round3-http") {
+      const round = result.stage === "round1-http" ? 1 : 3;
+      process.stdout.write(`DRIFT (round ${round} HTTP ${result.status})\n`);
       drift.push({
         id: model.id,
         stage: result.stage,
@@ -192,6 +214,20 @@ async function main() {
         leakedAsText: result.verdict.leakedAsText,
         detail: result.verdict.detail,
         bodySnippet: result.body.slice(0, 200),
+      });
+      continue;
+    }
+
+    if (result.stage === "round3-verdict") {
+      // Clean flat call, clean multi-turn, mangled nesting — the minimax-m3
+      // failure mode. Structurally valid tool_calls, unusable arguments.
+      process.stdout.write(`DRIFT (nested args: ${result.nested.failure})\n`);
+      drift.push({
+        id: model.id,
+        stage: result.stage,
+        failure: result.nested.failure,
+        detail: result.nested.detail,
+        bodySnippet: result.body.slice(0, 400),
       });
       continue;
     }

--- a/scripts/verify-ollama-cloud-tools.mjs
+++ b/scripts/verify-ollama-cloud-tools.mjs
@@ -90,11 +90,13 @@ async function postChat(body, apiKey, attempts = 5) {
   return last; // exhausted retries — still transient
 }
 
-// Probe a model across two rounds. A model is only OK if it emits a structured
-// tool_call AND survives the multi-turn follow-up (HTTP 200 once the history
-// carries a tool result). Single-turn alone is a false-positive trap: gemma3
-// emits a clean single-turn call but HTTP 500s on the follow-up, which is why
-// gemma3 stays out of the catalog (see ollama-cloud-models.test.ts).
+// Probe a model across three rounds. A model is only OK if it emits a
+// structured tool_call, survives the multi-turn follow-up (HTTP 200 once the
+// history carries a tool result), AND fills a nested array-of-arrays argument
+// without mangling it. Each round is a false-positive trap the others miss:
+// gemma3 emits a clean single-turn call but HTTP 500s on the follow-up, which
+// is why it stays out of the catalog (see ollama-cloud-models.test.ts), while
+// minimax-m3 passes both of those and still collapses nested arrays.
 async function probeModel(id, apiKey) {
   // Re-assert the safe-ID allowlist right at the network sink. The shared
   // parser already validates, but co-locating the barrier with the fetch keeps
@@ -221,7 +223,7 @@ async function main() {
     if (result.stage === "round3-verdict") {
       // Clean flat call, clean multi-turn, mangled nesting — the minimax-m3
       // failure mode. Structurally valid tool_calls, unusable arguments.
-      process.stdout.write(`DRIFT (nested args: ${result.nested.failure})\n`);
+      process.stdout.write(`DRIFT (nested probe: ${result.nested.failure})\n`);
       drift.push({
         id: model.id,
         stage: result.stage,


### PR DESCRIPTION
## What does this PR do?

The ollama-cloud tool probe only ever proved that a model can fill in **one string**: `buildToolProbeRequest()` offers a single `get_weather` tool with `{city: string}`. minimax-m3 passes that cleanly — and still mangles nested arrays. So `verify-ollama-cloud-tools.mjs` could not detect this defect class for *any* model.

On 2026-07-15 the production agent "Penny" was routed to `ollama-cloud/minimax-m3` as a vision fallback. It emits structurally valid `tool_calls` whose nested arrays collapse into `{"item": …}` objects, with some arrays arriving stringified (`"[10, 20]"`). That broke Odoo domain filters (`unhashable type: 'dict'`) and `account.move` `invoice_line_ids`/`tax_ids` command triplets — 20 of 60 tool calls mangled, versus 0/112 on kimi-k2.6 and 0/68 on deepseek-v4-pro. minimax-m3 is already on the tools blocklist (`bb37dbfc1`); this PR closes the *detection* gap so the next such model is caught by the probe instead of by production.

**The change:** a third probe round. `buildNestedToolProbeRequest()` offers a `search_records` tool whose schema demands a real Odoo domain — `filters` as an array of `[field, operator, value]` triplets, `fields` as an array of strings. `classifyNestedToolResponse()` then parses the returned arguments back and insists they are *genuine* nested arrays. Five defect classes:

| failure | what it catches |
| --- | --- |
| `item-wrapper` | `{"item": …}` collapse, at the `filters` level, per triplet, and inside a triplet's list value — the shape behind Odoo's `unhashable type: 'dict'` |
| `stringified-array` | `filters`, an inner `"[10, 20]"`, or `fields` arriving as text |
| `positional-arguments` | a bare array, or an object keyed `"0"/"1"/"2"` — Pinchy's plugins dispatch on names |
| `unparseable-arguments` | `arguments` that aren't valid JSON |
| `wrong-shape` | missing named argument, empty domain, flat `filters`, nesting deeper than a list value |
| `wrong-tool` | a call to a tool the probe never offered — named plainly rather than misreported as bad arguments |

A triplet's value may legitimately *be* a list: `["state", "in", ["posted", "draft"]]` is a valid domain, and the probe passes it — it faults what is actually broken inside, not the nesting itself.

The flat probe stays exactly as it was: it catches failure modes the nested round cannot see (qwen3-next's empty content, gemini-3's `default_api` plain-text leak, the gemma3 / kimi-k2-thinking follow-up 500). Both files now document that the two probes are complementary.

Conventions kept: pure logic in `scripts/lib/`, thin network wrapper in `scripts/verify-ollama-cloud-tools.mjs`, the `MODEL_ID_PATTERN` CodeQL barrier at the network sink untouched, and `isTransientStatus()` still routes 429/5xx to `inconclusive` rather than a capability verdict.

## Type of change

- [x] 🧪 Tests
- [x] 🔧 Tooling / CI

## Verification

- `pnpm test:scripts` → **307 tests, 307 pass, 0 fail** (22 new, classifier-only, no network). Written TDD-first throughout — the first batch failed with `does not provide an export named 'buildNestedToolProbeRequest'`, the review-fix batch failed on the assertions it was written for.
- Stubbed-`fetch` end-to-end drive of all four wrapper paths: a mangled response (`filters: {"item": […]}`) yields `DRIFT (nested probe: item-wrapper)` and exit 1; a call to an unoffered tool yields `DRIFT (nested probe: wrong-tool)` and exit 1; a clean response — including a legitimate `["state", "in", ["posted", "draft"]]` list value — yields `OK (… + clean multi-turn + nested arguments intact (2 domain triplet(s), 2 field(s)))` and exit 0.
- Skip path intact: without `OLLAMA_CLOUD_API_KEY` the script still exits 0.

**Not verified — worth a reviewer's attention:** there was no live run. `OLLAMA_CLOUD_API_KEY` is unset in this environment, so round 3 has never hit the real API. The proof that minimax-m3 actually fails this round (and that kimi-k2.6 / deepseek-v4-pro pass it) is still outstanding; minimax-m3 is blocklisted, so it would take a targeted `--only=minimax-m3` run with a key. And as the file header already warns for the existing rounds: a single green run is a smoke test, not a reliability proof — at a 20/60 mangling rate the round should be run several times before trusting a new model.

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style (prettier clean on all three files)
- [x] I've added tests for new functionality
- [ ] I've updated the documentation — not applicable, no user-facing behavior change
- [x] All existing tests pass

