### PR TITLE
fix(diagnostics): stop the export form spilling out of its dialog

### DIFF
--- a/docs/src/content/docs/guides/reporting-issues.mdx
+++ b/docs/src/content/docs/guides/reporting-issues.mdx
@@ -22,9 +22,9 @@ Secrets are filtered out before the file is generated. API keys, Bearer tokens, 
 
 ## Choosing which chat to export
 
-If you have more than one conversation with an agent, the dialog lets you pick which one to export. The selector lists all of your own chats with that agent — including named chats and read-only Telegram conversations linked to your account. You can only export your own chats.
+If you have more than one conversation with an agent, you can pick which one to export. The selector lists all of your own chats with that agent — including named chats and read-only Telegram conversations linked to your account. You can only export your own chats.
 
-When you open the dialog from a specific conversation, that chat is preselected; from Settings, the agent's default chat is preselected. If a chat's transcript is no longer on disk, we still produce a valid file from the audit-log entries alone and flag it (`scope.trajectoryMissing`), so support can tell an absent transcript apart from an empty one.
+When you start from a specific conversation, that chat is preselected; from Settings, the agent's default chat is preselected. If a chat's transcript is no longer on disk, we still produce a valid file from the audit-log entries alone and flag it (`scope.trajectoryMissing`), so support can tell an absent transcript apart from an empty one.
 
 For Telegram chats the export includes the conversation transcript, but the audit-log section is currently limited — audit entries are attributed to your web account, so a Telegram chat's file may ship without them. The transcript is still the primary signal for debugging.
 
@@ -45,10 +45,10 @@ The dialog opens with that message as the anchor. In this first version, the exp
 If the issue isn't tied to one reply — say the agent feels generally slow, or a tool keeps failing — start from the agent's Settings:
 
 1. Open the agent, then go to its **Settings → Diagnostics** tab.
-2. Click **Generate diagnostics export**.
-3. Choose the chat to export in the dialog (the default chat is preselected).
+2. Choose the chat to export (the default chat is preselected).
+3. Click **Generate diagnostics export**.
 
-The export is per-agent, so the agent is already in context here — there's no agent to pick. The same dialog appears as the per-message flow.
+The form sits right in the tab, so there's nothing to open first. The export is per-agent, so the agent is already in context here — there's no agent to pick.
 
 (Looking under general **Settings → Support**? It now just points you here.)
 

--- a/packages/web/e2e/20-diagnostics-export-dialog-overflow.spec.ts
+++ b/packages/web/e2e/20-diagnostics-export-dialog-overflow.spec.ts
@@ -1,0 +1,175 @@
+// packages/web/e2e/20-diagnostics-export-dialog-overflow.spec.ts
+//
+// Real-browser regression guard for the diagnostics export dialog overflowing
+// on a long chat title: the chat picker and the textarea below it spilled out
+// past the dialog's right edge, over the page behind it.
+//
+// Root cause: shadcn's SelectTrigger is `w-fit` + `whitespace-nowrap`, so it
+// sizes to the selected chat's title. DialogContent is a `grid`, and a grid
+// column's `auto` track sizes to its items' min-content — which the nowrap
+// trigger makes as wide as the whole title. The dialog box itself stayed at
+// `sm:max-w-md` while its contents grew past it. The fix is `w-full min-w-0` on
+// the trigger, making it shrinkable and letting the title clamp instead.
+//
+// This spec is authoritative and jsdom cannot replace it: the bug IS layout,
+// and jsdom has no layout engine — every element there reports width 0. The
+// unit test in diagnostics-export-dialog.test.tsx can only assert the classes
+// are present, which stays green if the trigger's defaults or the dialog's
+// display mode ever change. Only a real browser measures the actual spill.
+//
+// Note the inline Settings → Diagnostics surface cannot catch this: its
+// container is a block element, where `w-fit` resolves against the available
+// width and can never overflow. The grid inside the dialog is the only place
+// the bug lives.
+//
+// The WebSocket is fully mocked client-side so the conversation is
+// deterministic and no OpenClaw stack is needed (same technique as
+// 19-message-hover-layout-shift.spec.ts), and the chats API is stubbed so the
+// long title doesn't depend on a live model turn.
+import { test, expect } from "@playwright/test";
+import { seedProviderConfig } from "./helpers";
+
+const HISTORY_MESSAGES = [
+  { role: "user", content: "export turn one", timestamp: "2026-07-15T09:39:00.000Z" },
+  { role: "assistant", content: "reply alpha", timestamp: "2026-07-15T09:39:01.000Z" },
+];
+
+// The title that triggered the original report — long enough to blow past the
+// dialog's `sm:max-w-md` several times over.
+const LONG_TITLE =
+  "Sind jetzt alle gebuchten Rechnungen mit Bankbuchungen abgeglichen und verbucht?";
+
+const CHATS = [
+  {
+    chatId: null,
+    sessionId: "s-default",
+    origin: "web",
+    writable: true,
+    title: LONG_TITLE,
+    lastInteractionAt: 1000,
+  },
+];
+
+const mockHistorySocket = (historyMessages: typeof HISTORY_MESSAGES) => {
+  type ClientMessage = { type?: string };
+  const RealWebSocket = window.WebSocket;
+
+  class MockWebSocket {
+    static CONNECTING = 0;
+    static OPEN = 1;
+    static CLOSING = 2;
+    static CLOSED = 3;
+    CONNECTING = 0;
+    OPEN = 1;
+    CLOSING = 2;
+    CLOSED = 3;
+    onopen: (() => void) | null = null;
+    onmessage: ((event: { data: string }) => void) | null = null;
+    onclose: (() => void) | null = null;
+    onerror: (() => void) | null = null;
+    readyState = 1;
+    binaryType = "blob";
+    constructor(url: string) {
+      if (url.includes("/_next/")) {
+        return new RealWebSocket(url) as unknown as MockWebSocket;
+      }
+      queueMicrotask(() => this.onopen?.());
+    }
+    addEventListener() {}
+    removeEventListener() {}
+    send(raw: string) {
+      const message = JSON.parse(raw) as ClientMessage;
+      if (message.type === "history") {
+        setTimeout(() => {
+          this.onmessage?.({
+            data: JSON.stringify({ type: "history", messages: historyMessages }),
+          });
+        }, 0);
+      }
+    }
+    close() {
+      this.readyState = 3;
+      this.onclose?.();
+    }
+  }
+
+  Object.defineProperty(window, "WebSocket", {
+    configurable: true,
+    writable: true,
+    value: MockWebSocket,
+  });
+};
+
+test.describe("diagnostics export dialog overflow", () => {
+  test.beforeEach(async ({ page, request }) => {
+    const setupResponse = await request.post("/api/setup", {
+      data: { name: "Test Admin", email: "admin@test.local", password: "test-password-123" },
+    });
+    expect([201, 403]).toContain(setupResponse.status());
+
+    await seedProviderConfig();
+    await page.addInitScript(mockHistorySocket, HISTORY_MESSAGES);
+
+    // Force the long-title case: the real title comes from the session's first
+    // message, which would need a live model turn.
+    await page.route("**/api/agents/*/chats", (route) =>
+      route.fulfill({
+        status: 200,
+        contentType: "application/json",
+        body: JSON.stringify({ chats: CHATS }),
+      })
+    );
+
+    // Sign in via the auth API rather than the login form — the form's onSubmit
+    // races hydration on a cold server's first compile (see the same note in
+    // 19-message-hover-layout-shift.spec.ts).
+    const signIn = await page.request.post("/api/auth/sign-in/email", {
+      data: { email: "admin@test.local", password: "test-password-123" },
+      headers: { "Content-Type": "application/json" },
+    });
+    expect(signIn.ok()).toBeTruthy();
+    const agents = (await (await page.request.get("/api/agents")).json()) as { id: string }[];
+    expect(agents.length).toBeGreaterThan(0);
+    await page.goto(`/chat/${agents[0]!.id}`);
+    await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
+    await expect(page.locator('[data-role="assistant"]')).toHaveCount(1, { timeout: 15000 });
+  });
+
+  test("a long chat title must not push the picker out of the dialog", async ({ page }) => {
+    const lastAssistant = page.locator('[data-role="assistant"]').last();
+    await lastAssistant.hover();
+    await page.getByTestId("assistant-action-bar-more-trigger").last().click();
+    await page.getByTestId("report-issue-menu-item").click();
+
+    const dialog = page.getByRole("dialog");
+    await expect(dialog).toBeVisible();
+    const picker = dialog.getByRole("combobox", { name: /chat to export/i });
+    await expect(picker).toBeVisible({ timeout: 10000 });
+
+    // Assert the title is actually the long one — otherwise a green result
+    // would only prove the stub never applied.
+    await expect(picker).toContainText("Sind jetzt alle gebuchten Rechnungen");
+
+    const dialogBox = (await dialog.boundingBox())!;
+    const pickerBox = (await picker.boundingBox())!;
+    const textarea = dialog.getByPlaceholder(/what went wrong/i);
+    const textareaBox = (await textarea.boundingBox())!;
+
+    // Before the fix the trigger measured ~600px against a ~448px dialog and
+    // hung out over the page behind it; the textarea stretched to the same
+    // over-wide grid column.
+    expect(
+      pickerBox.x + pickerBox.width,
+      `chat picker spills past the dialog: picker ends at ${Math.round(pickerBox.x + pickerBox.width)}px, dialog at ${Math.round(dialogBox.x + dialogBox.width)}px`
+    ).toBeLessThanOrEqual(dialogBox.x + dialogBox.width);
+    expect(
+      textareaBox.x + textareaBox.width,
+      `description field spills past the dialog: field ends at ${Math.round(textareaBox.x + textareaBox.width)}px, dialog at ${Math.round(dialogBox.x + dialogBox.width)}px`
+    ).toBeLessThanOrEqual(dialogBox.x + dialogBox.width);
+
+    // The dialog must not have been stretched instead — the box itself is
+    // capped, but pin it so a future `max-w` removal can't turn a spilling
+    // picker into a full-width dialog and still pass the assertions above.
+    expect(dialogBox.width).toBeLessThanOrEqual(500);
+  });
+});

--- a/packages/web/e2e/integration/diagnostics-export.spec.ts
+++ b/packages/web/e2e/integration/diagnostics-export.spec.ts
@@ -41,18 +41,21 @@ import { FAKE_OLLAMA_RESPONSE } from "../shared/fake-ollama/fake-ollama-server";
 import { login, getSmithersAgentId, waitForOpenClawConnected } from "./helpers";
 
 /**
- * Clicks the dialog's Generate button, asserts the API returned 200, and
- * returns the download promise. Surfaces the API status + body on non-200
- * — much more informative than the default 120s "waiting for download"
- * timeout when something upstream fails.
+ * Clicks the form's submit button, asserts the API returned 200, and returns
+ * the download promise. Surfaces the API status + body on non-200 — much more
+ * informative than the default 120s "waiting for download" timeout when
+ * something upstream fails.
+ *
+ * The button's label differs per surface: the Settings tab renders the form
+ * inline with its own descriptive label, the chat flow renders it in a dialog.
  */
-async function clickDialogGenerateAndAwaitDownload(page: Page) {
+async function clickGenerateAndAwaitDownload(page: Page, name: RegExp = /^generate$/i) {
   const apiResponsePromise = page.waitForResponse(
     (r) => r.url().includes("/api/diagnostics/export") && r.request().method() === "POST",
     { timeout: 60000 }
   );
   const downloadPromise = page.waitForEvent("download", { timeout: 60000 });
-  await page.getByRole("button", { name: /^generate$/i }).click();
+  await page.getByRole("button", { name }).click();
 
   const apiResponse = await apiResponsePromise;
   if (apiResponse.status() !== 200) {
@@ -99,18 +102,17 @@ test.describe.serial("Self-service diagnostics export", () => {
     // the agent is already in context here — no agent picker. No chat-turn
     // either; the beforeAll already primed the session.
     await page.goto(`/chat/${smithersAgentId}/settings?tab=diagnostics`);
-    const openDialogButton = page.getByRole("button", { name: /generate diagnostics export/i });
-    await expect(openDialogButton).toBeVisible({ timeout: 10000 });
-    await openDialogButton.click();
 
-    // The chat picker (#639) renders once the user's chats load — at minimum the
-    // default chat the seed turn created. Waiting for it also makes the export
-    // deterministic (the default chat is preselected and its sessionId sent).
+    // The form is inline on this tab — no modal to open first. The chat picker
+    // (#639) renders once the user's chats load — at minimum the default chat
+    // the seed turn created. Waiting for it also makes the export deterministic
+    // (the default chat is preselected and its sessionId sent).
     await expect(page.getByRole("combobox", { name: /chat to export/i })).toBeVisible({
       timeout: 10000,
     });
+    expect(await page.getByRole("dialog").count()).toBe(0);
 
-    const download = await clickDialogGenerateAndAwaitDownload(page);
+    const download = await clickGenerateAndAwaitDownload(page, /generate diagnostics export/i);
     expect(download.suggestedFilename()).toMatch(/^pinchy-bugreport-.+\.json$/);
 
     const downloadPath = await download.path();
@@ -151,7 +153,7 @@ test.describe.serial("Self-service diagnostics export", () => {
     await page.getByTestId("assistant-action-bar-more-trigger").last().click();
     await page.getByTestId("report-issue-menu-item").click();
 
-    const download = await clickDialogGenerateAndAwaitDownload(page);
+    const download = await clickGenerateAndAwaitDownload(page);
     expect(download.suggestedFilename()).toMatch(/^pinchy-bugreport-.+\.json$/);
 
     const downloadPath = await download.path();

--- a/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
@@ -44,11 +44,13 @@ describe("AgentSettingsDiagnostics", () => {
   beforeEach(async () => {
     const { apiPost, apiGet } = await import("@/lib/api-client");
     const { downloadBundle } = await import("@/lib/diagnostics/download");
+    const { toast } = await import("sonner");
     vi.mocked(apiPost).mockReset();
     vi.mocked(apiPost).mockResolvedValue({ schemaVersion: "pinchy.bugreport.v1" });
     vi.mocked(apiGet).mockReset();
     vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });
     vi.mocked(downloadBundle).mockClear();
+    vi.mocked(toast.success).mockClear();
   });
 
   it("renders the export form inline, not behind a modal", async () => {
@@ -99,6 +101,23 @@ describe("AgentSettingsDiagnostics", () => {
     expect(
       screen.getByRole("button", { name: /generate diagnostics export/i })
     ).toBeInTheDocument();
+  });
+
+  // Inline there is no dialog whose closing signals success, and the download
+  // itself is silent. Without this the form just blanks its description and the
+  // user is left guessing whether anything happened.
+  it("confirms a successful export with a toast, since nothing closes inline", async () => {
+    const { toast } = await import("sonner");
+    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
+
+    await screen.findByRole("combobox", { name: /chat to export/i });
+    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
+
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Diagnostics export downloaded", {
+        description: "pinchy-bugreport-smithers-19700101-0000.json",
+      })
+    );
   });
 
   it("offers no Cancel button inline — there is nothing to cancel back to", async () => {

--- a/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
+++ b/packages/web/src/__tests__/components/agent-settings-diagnostics.test.tsx
@@ -1,60 +1,109 @@
-import { describe, it, expect, vi } from "vitest";
-import { render, screen, fireEvent } from "@testing-library/react";
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
 import "@testing-library/jest-dom";
 import { AgentSettingsDiagnostics } from "@/components/agent-settings-diagnostics";
 
-// Mirror the mock used by settings-support.test.tsx so we can assert *which*
-// agent the dialog opens for without exercising the real export flow.
-vi.mock("@/components/diagnostics-export-dialog", () => ({
-  DiagnosticsExportDialog: ({
-    open,
-    agentId,
-    agentName,
-    anchorMessageId,
-  }: {
-    open: boolean;
-    agentId: string;
-    agentName: string;
-    anchorMessageId?: string;
-    onClose: () => void;
-  }) =>
-    open ? (
-      <div role="dialog" aria-label="diagnostics-export" data-anchor={anchorMessageId ?? "none"}>
-        Export dialog for {agentName} ({agentId})
-      </div>
-    ) : null,
+// The tab renders the real export form inline (no modal), so these tests
+// exercise it end to end against mocked transport.
+vi.mock("@/lib/api-client", () => ({
+  apiPost: vi.fn(async () => ({ schemaVersion: "pinchy.bugreport.v1" })),
+  apiGet: vi.fn(async () => ({ chats: [] })),
+  ApiError: class ApiError extends Error {
+    constructor(
+      public readonly status: number,
+      message: string,
+      public readonly details?: unknown
+    ) {
+      super(message);
+      this.name = "ApiError";
+    }
+  },
 }));
 
+vi.mock("@/lib/diagnostics/download", () => ({
+  downloadBundle: vi.fn(),
+  buildBundleFilename: vi.fn(() => "pinchy-bugreport-smithers-19700101-0000.json"),
+}));
+
+vi.mock("sonner", () => ({
+  toast: { error: vi.fn(), success: vi.fn() },
+}));
+
+const CHATS = [
+  {
+    chatId: null,
+    sessionId: "s-default",
+    origin: "web" as const,
+    writable: true,
+    title: "Default chat",
+    lastInteractionAt: 1000,
+  },
+];
+
 describe("AgentSettingsDiagnostics", () => {
-  it("renders the export entry point for the in-context agent without an agent picker", () => {
+  beforeEach(async () => {
+    const { apiPost, apiGet } = await import("@/lib/api-client");
+    const { downloadBundle } = await import("@/lib/diagnostics/download");
+    vi.mocked(apiPost).mockReset();
+    vi.mocked(apiPost).mockResolvedValue({ schemaVersion: "pinchy.bugreport.v1" });
+    vi.mocked(apiGet).mockReset();
+    vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });
+    vi.mocked(downloadBundle).mockClear();
+  });
+
+  it("renders the export form inline, not behind a modal", async () => {
     render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
 
+    // The tab is already the dedicated surface for this one task — the fields
+    // must be reachable without opening anything.
+    expect(await screen.findByRole("combobox", { name: /chat to export/i })).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/what went wrong/i)).toBeInTheDocument();
     expect(
       screen.getByRole("button", { name: /generate diagnostics export/i })
     ).toBeInTheDocument();
-    // The agent is already in context here — there must be no agent picker.
-    expect(screen.queryByRole("combobox")).not.toBeInTheDocument();
+    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
   });
 
-  it("opens the export dialog for the in-context agent when Generate is clicked", () => {
+  it("exports the in-context agent's chat on submit", async () => {
+    const { apiPost, apiGet } = await import("@/lib/api-client");
     render(<AgentSettingsDiagnostics agentId="agt_42" agentName="Smithers" />);
 
-    expect(screen.queryByRole("dialog")).not.toBeInTheDocument();
+    await screen.findByRole("combobox", { name: /chat to export/i });
+    expect(apiGet).toHaveBeenCalledWith("/api/agents/agt_42/chats");
 
-    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
-
-    const dialog = screen.getByRole("dialog");
-    expect(dialog).toBeInTheDocument();
-    expect(dialog).toHaveTextContent("agt_42");
-    expect(dialog).toHaveTextContent("Smithers");
-  });
-
-  it("triggers a full-session export, not a per-message one (no anchorMessageId)", () => {
-    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
     fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
 
     // Settings-triggered exports must NOT anchor on a specific message — that
     // affordance lives on the per-message action bar in chat.
-    expect(screen.getByRole("dialog")).toHaveAttribute("data-anchor", "none");
+    await waitFor(() =>
+      expect(apiPost).toHaveBeenCalledWith("/api/diagnostics/export", {
+        agentId: "agt_42",
+        sessionId: "s-default",
+      })
+    );
+  });
+
+  it("keeps the form usable and clears the description after a successful export", async () => {
+    const { downloadBundle } = await import("@/lib/diagnostics/download");
+    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
+
+    await screen.findByRole("combobox", { name: /chat to export/i });
+    const description = screen.getByPlaceholderText(/what went wrong/i);
+    fireEvent.change(description, { target: { value: "stream stopped" } });
+    fireEvent.click(screen.getByRole("button", { name: /generate diagnostics export/i }));
+
+    await waitFor(() => expect(downloadBundle).toHaveBeenCalled());
+    // Nothing closes inline, so the form must reset itself rather than leave a
+    // stale description to be resubmitted with the next export.
+    await waitFor(() => expect(description).toHaveValue(""));
+    expect(
+      screen.getByRole("button", { name: /generate diagnostics export/i })
+    ).toBeInTheDocument();
+  });
+
+  it("offers no Cancel button inline — there is nothing to cancel back to", async () => {
+    render(<AgentSettingsDiagnostics agentId="agt_1" agentName="Smithers" />);
+    await screen.findByRole("combobox", { name: /chat to export/i });
+    expect(screen.queryByRole("button", { name: /^cancel$/i })).not.toBeInTheDocument();
   });
 });

--- a/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
@@ -155,6 +155,49 @@ describe("DiagnosticsExportDialog", () => {
     await waitFor(() => expect(onClose).toHaveBeenCalled());
   });
 
+  // The download itself is silent — the browser may drop the file straight into
+  // the downloads folder with no visible tab. Name the file we produced so the
+  // user can find it, on both surfaces (inline, nothing closes at all).
+  it("confirms the download with a toast naming the file", async () => {
+    const { toast } = await import("sonner");
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    await waitFor(() =>
+      expect(toast.success).toHaveBeenCalledWith("Diagnostics export downloaded", {
+        description: "pinchy-bugreport-smithers-19700101-0000.json",
+      })
+    );
+  });
+
+  // The whole point of the form's `onSubmittingChange` plumbing: an export in
+  // flight must not be closed out from under itself, or the download is lost
+  // with no explanation. Nothing else covers this.
+  it("refuses to close on Escape while an export is in flight", async () => {
+    const { apiPost } = await import("@/lib/api-client");
+    const onClose = vi.fn();
+    let resolveExport: (bundle: unknown) => void = () => {};
+    vi.mocked(apiPost).mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveExport = resolve;
+      })
+    );
+
+    render(<DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={onClose} />);
+    fireEvent.click(screen.getByRole("button", { name: /generate/i }));
+    // Wait for the in-flight state to reach the dialog, otherwise Escape would
+    // race the click and pass for the wrong reason.
+    await waitFor(() => expect(screen.getByRole("button", { name: /generating/i })).toBeDisabled());
+
+    fireEvent.keyDown(document, { key: "Escape" });
+    expect(onClose).not.toHaveBeenCalled();
+
+    // Once it lands, the dialog closes on its own — the guard must not be sticky.
+    resolveExport({ schemaVersion: "pinchy.bugreport.v1" });
+    await waitFor(() => expect(onClose).toHaveBeenCalled());
+  });
+
   // ── #639: chat picker + context-aware default selection ──────────────────
 
   const CHATS = [

--- a/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
+++ b/packages/web/src/__tests__/components/diagnostics-export-dialog.test.tsx
@@ -194,6 +194,24 @@ describe("DiagnosticsExportDialog", () => {
     expect(apiGet).toHaveBeenCalledWith("/api/agents/agt_1/chats");
   });
 
+  it("constrains the chat picker to the dialog width so a long title can't stretch it", async () => {
+    const { apiGet } = await import("@/lib/api-client");
+    vi.mocked(apiGet).mockResolvedValue({
+      chats: [{ ...CHATS[0], title: "Sind jetzt alle gebuchten Rechnungen mit Bankbuchungen " }],
+    });
+    render(
+      <DiagnosticsExportDialog open agentId="agt_1" agentName="Smithers" onClose={() => {}} />
+    );
+    // The shadcn trigger defaults to `w-fit` + `whitespace-nowrap`, so a long
+    // chat title used to push the trigger — and with it the dialog's grid
+    // column — far past the dialog's own max-width, spilling the picker and the
+    // textarea out of the modal. jsdom computes no layout, so guard the classes
+    // that make the trigger shrinkable.
+    const trigger = await screen.findByRole("combobox", { name: /chat/i });
+    expect(trigger).toHaveClass("w-full");
+    expect(trigger).toHaveClass("min-w-0");
+  });
+
   it("exports the default chat's sessionId when launched from Settings (no chat context)", async () => {
     const { apiGet, apiPost } = await import("@/lib/api-client");
     vi.mocked(apiGet).mockResolvedValue({ chats: CHATS });

--- a/packages/web/src/components/agent-settings-diagnostics.tsx
+++ b/packages/web/src/components/agent-settings-diagnostics.tsx
@@ -1,9 +1,6 @@
 "use client";
 
-import { useState } from "react";
-
-import { Button } from "@/components/ui/button";
-import { DiagnosticsExportDialog } from "@/components/diagnostics-export-dialog";
+import { DiagnosticsExportForm } from "@/components/diagnostics-export-form";
 
 interface AgentSettingsDiagnosticsProps {
   agentId: string;
@@ -13,33 +10,33 @@ interface AgentSettingsDiagnosticsProps {
 /**
  * Agent Settings → Diagnostics tab.
  *
+ * The form is inline: this tab is already the dedicated surface for the one
+ * task it offers, so a modal would only add a click, a focus trap, and a
+ * duplicate of the heading — while squeezing the chat picker into a width it
+ * doesn't fit. The per-message "Report issue to support" flow in chat still
+ * uses DiagnosticsExportDialog, where a modal earns its keep.
+ *
  * The export is per-agent, and here the agent is already in context, so there's
- * no agent picker — unlike the old general Settings → Support flow this replaces.
- * Chat selection (#639) is handled entirely inside DiagnosticsExportDialog: we
- * don't pass a `chatId`, so it preselects the agent's default chat.
+ * no agent picker — unlike the old general Settings → Support flow this
+ * replaces. Chat selection (#639) lives in the form: we don't pass a `chatId`,
+ * so it preselects the agent's default chat.
  */
 export function AgentSettingsDiagnostics({ agentId, agentName }: AgentSettingsDiagnosticsProps) {
-  const [dialogOpen, setDialogOpen] = useState(false);
-
   return (
-    <div className="space-y-6">
+    <div className="max-w-xl space-y-6">
       <div className="space-y-2">
         <h3 className="text-lg font-medium">Diagnostics</h3>
         <p className="text-sm text-muted-foreground">
-          Run into an issue with {agentName}? Generate a diagnostics export to share with Pinchy
-          support.
+          Run into an issue with {agentName}? Generate a file containing your recent conversation,
+          model and tool activity, and version info. Secrets and emails are automatically removed.
+          You decide if and how to share it with Pinchy support.
         </p>
       </div>
 
-      <Button type="button" onClick={() => setDialogOpen(true)}>
-        Generate diagnostics export
-      </Button>
-
-      <DiagnosticsExportDialog
-        open={dialogOpen}
+      <DiagnosticsExportForm
         agentId={agentId}
         agentName={agentName}
-        onClose={() => setDialogOpen(false)}
+        submitLabel="Generate diagnostics export"
       />
     </div>
   );

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -510,9 +510,11 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
             </TabsContent>
           )}
 
-          {/* No `keepMounted`: unlike the editing tabs, this one holds no
-              unsaved state to preserve across tab switches, and mounting it
-              lazily keeps its chat-list fetch off every Settings page load. */}
+          {/* No `keepMounted`, unlike the editing tabs: mounting lazily keeps
+              this tab's chat-list fetch off every Settings page load, including
+              the vast majority that never open Diagnostics. The trade-off is
+              real but small — a half-typed description is lost when switching
+              tabs mid-report. Worth revisiting if anyone actually hits it. */}
           <TabsContent value="diagnostics">
             <AgentSettingsDiagnostics agentId={agentId} agentName={agent.name} />
           </TabsContent>

--- a/packages/web/src/components/agent-settings-page-content.tsx
+++ b/packages/web/src/components/agent-settings-page-content.tsx
@@ -510,7 +510,10 @@ export function AgentSettingsPageContent({ initialTab }: { initialTab?: string }
             </TabsContent>
           )}
 
-          <TabsContent value="diagnostics" keepMounted>
+          {/* No `keepMounted`: unlike the editing tabs, this one holds no
+              unsaved state to preserve across tab switches, and mounting it
+              lazily keeps its chat-list fetch off every Settings page load. */}
+          <TabsContent value="diagnostics">
             <AgentSettingsDiagnostics agentId={agentId} agentName={agent.name} />
           </TabsContent>
         </Tabs>

--- a/packages/web/src/components/diagnostics-export-dialog.tsx
+++ b/packages/web/src/components/diagnostics-export-dialog.tsx
@@ -1,53 +1,16 @@
 "use client";
 
-import { useEffect, useState } from "react";
-import { Loader2, Lock, Send } from "lucide-react";
-import { toast } from "sonner";
+import { useState } from "react";
 
 import {
   Dialog,
   DialogContent,
   DialogDescription,
-  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from "@/components/ui/dialog";
-import { Button } from "@/components/ui/button";
-import { Label } from "@/components/ui/label";
-import {
-  Select,
-  SelectContent,
-  SelectItem,
-  SelectTrigger,
-  SelectValue,
-} from "@/components/ui/select";
-import { Textarea } from "@/components/ui/textarea";
 
-import { apiGet, apiPost, ApiError } from "@/lib/api-client";
-import { chatTitle } from "@/lib/chats/chat-title";
-import { buildBundleFilename, downloadBundle } from "@/lib/diagnostics/download";
-import type { DiagnosticsExportRequest } from "@/lib/schemas/diagnostics";
-import type { ChatListItem } from "@/lib/schemas/sessions";
-
-import { DiagnosticsWhatsIncluded } from "./diagnostics-whats-included";
-
-const USER_DESCRIPTION_MAX = 500;
-
-/**
- * Which listed chat should be selected by default. From chat context we match
- * the active chat by `chatId` (`null` = the default/legacy chat); from Settings
- * (`chatId` undefined) we prefer the default chat. When neither is present —
- * e.g. a user with only named chats, or an active chat not yet in the list — we
- * fall back to the most-recent listed chat (the server returns them newest
- * first) rather than leaving the picker unselected, which would silently export
- * the default chat (or 404) despite a populated dropdown. Returns `null` only
- * for an empty list. Telegram chats are never the auto-match but can be the
- * newest-first fallback and are always opt-in via the picker.
- */
-function initialSessionId(chats: ChatListItem[], chatId: string | null): string | null {
-  const match = chats.find((c) => c.origin === "web" && c.chatId === chatId);
-  return match?.sessionId ?? chats[0]?.sessionId ?? null;
-}
+import { DiagnosticsExportForm } from "./diagnostics-export-form";
 
 export interface DiagnosticsExportDialogProps {
   open: boolean;
@@ -64,6 +27,15 @@ export interface DiagnosticsExportDialogProps {
   onClose: () => void;
 }
 
+/**
+ * Modal wrapper around {@link DiagnosticsExportForm} for the per-message
+ * "Report issue to support" flow in chat, where the user must not lose their
+ * place in the conversation. Agent Settings → Diagnostics renders the form
+ * inline instead — that tab is already the dedicated surface for this task.
+ *
+ * The form owns all transient state, and Radix unmounts dialog content on
+ * close, so reopening always starts clean without an explicit reset.
+ */
 export function DiagnosticsExportDialog({
   open,
   agentId,
@@ -72,98 +44,20 @@ export function DiagnosticsExportDialog({
   chatId,
   onClose,
 }: DiagnosticsExportDialogProps) {
-  const [userDescription, setUserDescription] = useState("");
-  const [validationError, setValidationError] = useState<string | null>(null);
+  // An export in flight must not be closed out from under itself via Escape or
+  // an overlay click — the download would be lost with no explanation.
   const [submitting, setSubmitting] = useState(false);
-  const [whatsIncludedOpen, setWhatsIncludedOpen] = useState(false);
-  const [chats, setChats] = useState<ChatListItem[]>([]);
-  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
-
-  // Fetch the user's chats when the dialog opens so they can pick which chat to
-  // export (#639), preselecting the active/default one. A failed fetch degrades
-  // to no picker → the export route's default-chat path — reporting a bug is a
-  // convenience path, never blocked on the chat list.
-  useEffect(() => {
-    if (!open) return;
-    let cancelled = false;
-    apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
-      .then((res) => {
-        if (cancelled) return;
-        const list = res.chats ?? [];
-        setChats(list);
-        setSelectedSessionId(initialSessionId(list, chatId ?? null));
-      })
-      .catch(() => {
-        if (cancelled) return;
-        setChats([]);
-        setSelectedSessionId(null);
-      });
-    return () => {
-      cancelled = true;
-    };
-  }, [open, agentId, chatId]);
-
-  function handleOpenChange(next: boolean) {
-    if (!next && !submitting) {
-      // Reset transient state so reopening the dialog starts clean.
-      setUserDescription("");
-      setValidationError(null);
-      setWhatsIncludedOpen(false);
-      setChats([]);
-      setSelectedSessionId(null);
-      onClose();
-    }
-  }
-
-  async function handleGenerate() {
-    const trimmed = userDescription.trim();
-    if (trimmed.length > USER_DESCRIPTION_MAX) {
-      setValidationError(
-        `Please keep this to ${USER_DESCRIPTION_MAX} characters or fewer (currently ${trimmed.length}).`
-      );
-      return;
-    }
-    setValidationError(null);
-    setSubmitting(true);
-
-    // Build a minimal body — omit optional fields when not set so the server
-    // schema sees exactly what the caller intended (the export route uses
-    // `parseRequestBody` with the strict diagnostics schema).
-    const body: DiagnosticsExportRequest = { agentId };
-    if (anchorMessageId) {
-      body.anchorMessageId = anchorMessageId;
-    }
-    if (trimmed.length > 0) {
-      body.userDescription = trimmed;
-    }
-    // Omit sessionId when none is selected so the route takes its default-chat
-    // path (unchanged behaviour for users with no listable chats).
-    if (selectedSessionId) {
-      body.sessionId = selectedSessionId;
-    }
-
-    try {
-      const bundle = await apiPost<unknown, DiagnosticsExportRequest>(
-        "/api/diagnostics/export",
-        body
-      );
-      downloadBundle(bundle, buildBundleFilename(agentName, new Date()));
-      setSubmitting(false);
-      setUserDescription("");
-      setValidationError(null);
-      setWhatsIncludedOpen(false);
-      onClose();
-    } catch (e) {
-      setSubmitting(false);
-      const message =
-        e instanceof ApiError ? e.message : "Failed to generate diagnostics. Please try again.";
-      toast.error(message);
-    }
-  }
 
   return (
-    <Dialog open={open} onOpenChange={handleOpenChange}>
-      <DialogContent className="sm:max-w-md">
+    <Dialog
+      open={open}
+      onOpenChange={(next) => {
+        if (!next && !submitting) onClose();
+      }}
+    >
+      {/* Capped height: the "What's included" disclosure can grow the form past
+          a short viewport. */}
+      <DialogContent className="max-h-[85vh] overflow-y-auto sm:max-w-md">
         <DialogHeader>
           <DialogTitle>Export diagnostics for {agentName}</DialogTitle>
           <DialogDescription>
@@ -173,113 +67,16 @@ export function DiagnosticsExportDialog({
           </DialogDescription>
         </DialogHeader>
 
-        <div className="space-y-4">
-          {anchorMessageId && (
-            <div
-              role="note"
-              className="rounded-md border border-amber-500/40 bg-amber-50/60 px-3 py-2 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-200"
-            >
-              Per-message reporting is in beta — this export includes your last 10 turns rather than
-              a slice anchored on the specific message you clicked.
-            </div>
-          )}
-          {chats.length > 0 && (
-            <div className="space-y-2">
-              <Label htmlFor="diagnostics-chat-select">Chat to export</Label>
-              <Select
-                value={selectedSessionId ?? undefined}
-                onValueChange={(v) => setSelectedSessionId(v)}
-              >
-                <SelectTrigger id="diagnostics-chat-select" aria-label="Chat to export">
-                  <SelectValue placeholder="Select a chat" />
-                </SelectTrigger>
-                <SelectContent>
-                  {chats.map((c) => (
-                    <SelectItem key={c.sessionId} value={c.sessionId}>
-                      <span className="flex items-center gap-1.5">
-                        <span className="truncate">{chatTitle(c)}</span>
-                        {c.origin === "telegram" && (
-                          <Send className="size-3 shrink-0 opacity-70" aria-label="Telegram" />
-                        )}
-                        {!c.writable && (
-                          <Lock className="size-3 shrink-0 opacity-70" aria-label="Read-only" />
-                        )}
-                      </span>
-                    </SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-          )}
-          <div className="space-y-2">
-            <Label htmlFor="diagnostics-user-description">What went wrong? (optional)</Label>
-            <Textarea
-              id="diagnostics-user-description"
-              placeholder="What went wrong? (optional)"
-              value={userDescription}
-              onChange={(e) => {
-                setUserDescription(e.target.value);
-                if (validationError) setValidationError(null);
-              }}
-              rows={4}
-              maxLength={USER_DESCRIPTION_MAX * 2}
-              aria-invalid={validationError ? true : undefined}
-              aria-describedby={validationError ? "diagnostics-user-description-error" : undefined}
-            />
-            {validationError && (
-              <p id="diagnostics-user-description-error" className="text-sm text-destructive">
-                {validationError}
-              </p>
-            )}
-          </div>
-
-          <button
-            type="button"
-            onClick={() => setWhatsIncludedOpen(true)}
-            className="text-sm text-primary-accent underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none"
-          >
-            What&apos;s included?
-          </button>
-        </div>
-
-        <DialogFooter>
-          <Button
-            type="button"
-            variant="outline"
-            onClick={() => handleOpenChange(false)}
-            disabled={submitting}
-          >
-            Cancel
-          </Button>
-          <Button type="button" onClick={handleGenerate} disabled={submitting}>
-            {submitting ? (
-              <>
-                <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-                Generating...
-              </>
-            ) : (
-              "Generate"
-            )}
-          </Button>
-        </DialogFooter>
+        <DiagnosticsExportForm
+          agentId={agentId}
+          agentName={agentName}
+          anchorMessageId={anchorMessageId}
+          chatId={chatId}
+          onCancel={onClose}
+          onExported={onClose}
+          onSubmittingChange={setSubmitting}
+        />
       </DialogContent>
-
-      {/* Nested static-content modal — content lives in its own file per the
-          plan so the wording can be updated in isolation. */}
-      <Dialog open={whatsIncludedOpen} onOpenChange={setWhatsIncludedOpen}>
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
-            <DialogTitle>What&apos;s included</DialogTitle>
-            <DialogDescription>Everything we package into the diagnostics file.</DialogDescription>
-          </DialogHeader>
-          <DiagnosticsWhatsIncluded />
-          <DialogFooter>
-            <Button type="button" onClick={() => setWhatsIncludedOpen(false)}>
-              Close
-            </Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
     </Dialog>
   );
 }

--- a/packages/web/src/components/diagnostics-export-form.tsx
+++ b/packages/web/src/components/diagnostics-export-form.tsx
@@ -162,10 +162,16 @@ export function DiagnosticsExportForm({
         "/api/diagnostics/export",
         body
       );
-      downloadBundle(bundle, buildBundleFilename(agentName, new Date()));
+      const filename = buildBundleFilename(agentName, new Date());
+      downloadBundle(bundle, filename);
       updateSubmitting(false);
       setUserDescription("");
       setValidationError(null);
+      // The download is silent — the browser may drop the file straight into
+      // the downloads folder with nothing visible. Inline there isn't even a
+      // dialog whose closing would signal success, only a description quietly
+      // blanking itself. Name the file so it can be found.
+      toast.success("Diagnostics export downloaded", { description: filename });
       onExported?.();
     } catch (e) {
       updateSubmitting(false);

--- a/packages/web/src/components/diagnostics-export-form.tsx
+++ b/packages/web/src/components/diagnostics-export-form.tsx
@@ -1,0 +1,270 @@
+"use client";
+
+import { useEffect, useId, useState } from "react";
+import { ChevronDown, Loader2, Lock, Send } from "lucide-react";
+import { toast } from "sonner";
+
+import { Button } from "@/components/ui/button";
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from "@/components/ui/collapsible";
+import { Label } from "@/components/ui/label";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { Textarea } from "@/components/ui/textarea";
+
+import { apiGet, apiPost, ApiError } from "@/lib/api-client";
+import { chatTitle } from "@/lib/chats/chat-title";
+import { buildBundleFilename, downloadBundle } from "@/lib/diagnostics/download";
+import type { DiagnosticsExportRequest } from "@/lib/schemas/diagnostics";
+import type { ChatListItem } from "@/lib/schemas/sessions";
+import { cn } from "@/lib/utils";
+
+import { DiagnosticsWhatsIncluded } from "./diagnostics-whats-included";
+
+const USER_DESCRIPTION_MAX = 500;
+
+/**
+ * Which listed chat should be selected by default. From chat context we match
+ * the active chat by `chatId` (`null` = the default/legacy chat); from Settings
+ * (`chatId` undefined) we prefer the default chat. When neither is present —
+ * e.g. a user with only named chats, or an active chat not yet in the list — we
+ * fall back to the most-recent listed chat (the server returns them newest
+ * first) rather than leaving the picker unselected, which would silently export
+ * the default chat (or 404) despite a populated dropdown. Returns `null` only
+ * for an empty list. Telegram chats are never the auto-match but can be the
+ * newest-first fallback and are always opt-in via the picker.
+ */
+function initialSessionId(chats: ChatListItem[], chatId: string | null): string | null {
+  const match = chats.find((c) => c.origin === "web" && c.chatId === chatId);
+  return match?.sessionId ?? chats[0]?.sessionId ?? null;
+}
+
+export interface DiagnosticsExportFormProps {
+  agentId: string;
+  agentName: string;
+  /** Present for per-message exports; omitted for Settings-triggered ones. */
+  anchorMessageId?: string;
+  /**
+   * The active chat when launched from chat context (`null` = default chat).
+   * Omitted (`undefined`) when launched from Settings, where the default chat
+   * is preselected. Drives the picker's initial selection (#639).
+   */
+  chatId?: string | null;
+  submitLabel?: string;
+  /**
+   * Renders a Cancel button next to submit. Only the dialog surface has
+   * somewhere to cancel back to, so its presence also right-aligns the actions
+   * into a dialog footer row; inline they sit left under the fields.
+   */
+  onCancel?: () => void;
+  /** Called after the bundle has downloaded. */
+  onExported?: () => void;
+  /**
+   * Reports whether an export is in flight, so a surrounding surface can refuse
+   * to disappear mid-request — the dialog blocks Escape and overlay clicks.
+   */
+  onSubmittingChange?: (submitting: boolean) => void;
+  className?: string;
+}
+
+/**
+ * The diagnostics export form: pick a chat, describe the problem, download a
+ * bundle. Shared by the two surfaces that offer it — inline on Agent Settings →
+ * Diagnostics, and inside a dialog for per-message "Report issue to support" in
+ * chat, where the user must not lose their place in the conversation.
+ *
+ * Owns all transient state, so the dialog gets a clean form on every open
+ * simply by unmounting its content on close.
+ */
+export function DiagnosticsExportForm({
+  agentId,
+  agentName,
+  anchorMessageId,
+  chatId,
+  submitLabel = "Generate",
+  onCancel,
+  onExported,
+  onSubmittingChange,
+  className,
+}: DiagnosticsExportFormProps) {
+  const fieldId = useId();
+  const chatSelectId = `${fieldId}-chat`;
+  const descriptionId = `${fieldId}-description`;
+  const errorId = `${fieldId}-error`;
+
+  const [userDescription, setUserDescription] = useState("");
+  const [validationError, setValidationError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [chats, setChats] = useState<ChatListItem[]>([]);
+  const [selectedSessionId, setSelectedSessionId] = useState<string | null>(null);
+
+  // Fetch the user's chats so they can pick which one to export (#639),
+  // preselecting the active/default one. A failed fetch degrades to no picker →
+  // the export route's default-chat path — reporting a bug is a convenience
+  // path, never blocked on the chat list.
+  useEffect(() => {
+    let cancelled = false;
+    apiGet<{ chats: ChatListItem[] }>(`/api/agents/${agentId}/chats`)
+      .then((res) => {
+        if (cancelled) return;
+        const list = res.chats ?? [];
+        setChats(list);
+        setSelectedSessionId(initialSessionId(list, chatId ?? null));
+      })
+      .catch(() => {
+        if (cancelled) return;
+        setChats([]);
+        setSelectedSessionId(null);
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, [agentId, chatId]);
+
+  function updateSubmitting(next: boolean) {
+    setSubmitting(next);
+    onSubmittingChange?.(next);
+  }
+
+  async function handleGenerate() {
+    const trimmed = userDescription.trim();
+    if (trimmed.length > USER_DESCRIPTION_MAX) {
+      setValidationError(
+        `Please keep this to ${USER_DESCRIPTION_MAX} characters or fewer (currently ${trimmed.length}).`
+      );
+      return;
+    }
+    setValidationError(null);
+    updateSubmitting(true);
+
+    // Build a minimal body — omit optional fields when not set so the server
+    // schema sees exactly what the caller intended (the export route uses
+    // `parseRequestBody` with the strict diagnostics schema).
+    const body: DiagnosticsExportRequest = { agentId };
+    if (anchorMessageId) {
+      body.anchorMessageId = anchorMessageId;
+    }
+    if (trimmed.length > 0) {
+      body.userDescription = trimmed;
+    }
+    // Omit sessionId when none is selected so the route takes its default-chat
+    // path (unchanged behaviour for users with no listable chats).
+    if (selectedSessionId) {
+      body.sessionId = selectedSessionId;
+    }
+
+    try {
+      const bundle = await apiPost<unknown, DiagnosticsExportRequest>(
+        "/api/diagnostics/export",
+        body
+      );
+      downloadBundle(bundle, buildBundleFilename(agentName, new Date()));
+      updateSubmitting(false);
+      setUserDescription("");
+      setValidationError(null);
+      onExported?.();
+    } catch (e) {
+      updateSubmitting(false);
+      const message =
+        e instanceof ApiError ? e.message : "Failed to generate diagnostics. Please try again.";
+      toast.error(message);
+    }
+  }
+
+  return (
+    <div className={cn("min-w-0 space-y-4", className)}>
+      {anchorMessageId && (
+        <div
+          role="note"
+          className="rounded-md border border-amber-500/40 bg-amber-50/60 px-3 py-2 text-sm text-amber-900 dark:bg-amber-950/30 dark:text-amber-200"
+        >
+          Per-message reporting is in beta — this export includes your last 10 turns rather than a
+          slice anchored on the specific message you clicked.
+        </div>
+      )}
+
+      {chats.length > 0 && (
+        <div className="space-y-2">
+          <Label htmlFor={chatSelectId}>Chat to export</Label>
+          <Select value={selectedSessionId ?? undefined} onValueChange={setSelectedSessionId}>
+            {/* `w-full min-w-0` overrides the trigger's default `w-fit`, which
+                sizes to the chat title and would otherwise spill the picker out
+                of the dialog on a long one. */}
+            <SelectTrigger id={chatSelectId} aria-label="Chat to export" className="w-full min-w-0">
+              <SelectValue placeholder="Select a chat" />
+            </SelectTrigger>
+            <SelectContent>
+              {chats.map((c) => (
+                <SelectItem key={c.sessionId} value={c.sessionId}>
+                  <span className="flex items-center gap-1.5">
+                    <span className="truncate">{chatTitle(c)}</span>
+                    {c.origin === "telegram" && (
+                      <Send className="size-3 shrink-0 opacity-70" aria-label="Telegram" />
+                    )}
+                    {!c.writable && (
+                      <Lock className="size-3 shrink-0 opacity-70" aria-label="Read-only" />
+                    )}
+                  </span>
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </div>
+      )}
+
+      <div className="space-y-2">
+        <Label htmlFor={descriptionId}>What went wrong? (optional)</Label>
+        <Textarea
+          id={descriptionId}
+          placeholder="What went wrong? (optional)"
+          value={userDescription}
+          onChange={(e) => {
+            setUserDescription(e.target.value);
+            if (validationError) setValidationError(null);
+          }}
+          rows={4}
+          maxLength={USER_DESCRIPTION_MAX * 2}
+          aria-invalid={validationError ? true : undefined}
+          aria-describedby={validationError ? errorId : undefined}
+        />
+        {validationError && (
+          <p id={errorId} className="text-sm text-destructive">
+            {validationError}
+          </p>
+        )}
+      </div>
+
+      <Collapsible>
+        <CollapsibleTrigger className="group flex items-center gap-1 text-sm text-primary-accent underline-offset-4 hover:underline focus-visible:underline focus-visible:outline-none">
+          What&apos;s included?
+          <ChevronDown className="size-4 transition-transform group-data-[state=open]:rotate-180" />
+        </CollapsibleTrigger>
+        <CollapsibleContent className="pt-3">
+          <DiagnosticsWhatsIncluded />
+        </CollapsibleContent>
+      </Collapsible>
+
+      <div className={cn("flex flex-col-reverse gap-2 sm:flex-row", onCancel && "sm:justify-end")}>
+        {onCancel && (
+          <Button type="button" variant="outline" onClick={onCancel} disabled={submitting}>
+            Cancel
+          </Button>
+        )}
+        <Button type="button" onClick={handleGenerate} disabled={submitting}>
+          {submitting ? (
+            <>
+              <Loader2 className="mr-2 h-4 w-4 animate-spin" />
+              Generating...
+            </>
+          ) : (
+            submitLabel
+          )}
+        </Button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## What does this PR do?

A long chat title pushed the chat picker — and the textarea sharing its grid column — out past the diagnostics export dialog's right edge, over the page behind it. Reported from the Agent Settings → Diagnostics flow.

**Root cause.** shadcn's `SelectTrigger` is `w-fit` + `whitespace-nowrap`, so it sizes itself to the selected chat's title. `DialogContent` is a `grid`, and an `auto` column sizes to its items' min-content — which the nowrap trigger makes as wide as the whole title. The dialog box itself stayed at `sm:max-w-md` while its contents grew past it. That's why the picker *and* the textarea spilled by the same amount: they share the over-wide column. Measured in Chromium before the fix, the picker ended **181px** past the dialog.

The fix is `w-full min-w-0` on the trigger, making it shrinkable so the title clamps instead. Scoped to this caller — the shadcn default is untouched, so no other select's layout changes.

**Settings → Diagnostics now renders the form inline, with no modal.** That tab was already the dedicated surface for its one task, so the dialog only added a click, a focus trap, and a second copy of the heading and description — while squeezing the picker into a width it doesn't fit. Per-message *Report issue to support* in chat keeps the dialog: it starts from a context menu, and the user must not lose their place in the conversation.

Both surfaces now share a `DiagnosticsExportForm` that owns the transient state, so the dialog resets simply by unmounting on close. "What's included?" becomes an inline disclosure on both, replacing a modal nested inside a modal.

### Reviewer notes

- **The inline surface cannot catch this bug**, which is worth knowing before trusting a screenshot of it: its container is a block element, where `w-fit` resolves against the available width and can never overflow. The grid inside the dialog is the only place the bug lives — so the inline rewrite alone would have *hidden* it while leaving the chat flow broken. Hence the separate trigger fix plus a browser-level guard.
- **`e2e/20-diagnostics-export-dialog-overflow.spec.ts` is the authoritative test.** jsdom has no layout engine (everything reports width 0), so the unit test can only assert the classes are present. Verified red without the fix, failing with exactly `chat picker spills past the dialog: picker ends at 1042px, dialog at 861px`. Follows the existing `19-message-hover-layout-shift.spec.ts` pattern: WebSocket mocked client-side, chats API stubbed, no OpenClaw stack needed.
- The Diagnostics tab drops `keepMounted` — unlike the editing tabs it holds no unsaved state, and lazy mounting keeps its chat-list fetch off every Settings page load.
- The dialog still refuses to close mid-export (Escape/overlay); that guard moved from local state to an `onSubmittingChange` callback rather than being dropped.
- **Known cosmetic issue, deliberately out of scope:** the clamped title hard-cuts without an ellipsis, because `line-clamp-1` conflicts with the trigger's `whitespace-nowrap`. That affects every select in the app, not just this one.

## Type of change

- [x] 🐛 Bug fix
- [ ] ✨ New feature
- [x] 📝 Documentation
- [x] ♻️ Refactor
- [x] 🧪 Tests
- [ ] 🔧 Tooling / CI

## Checklist

- [x] I've read the [Contributing Guide](../CONTRIBUTING.md)
- [x] My code follows the project's style
- [x] I've added tests for new functionality (if applicable)
- [x] I've updated the documentation (if applicable)
- [x] All existing tests pass

Gates run locally: `pnpm test` (8291 passed), `pnpm test:scripts` (285 passed), `pnpm -C packages/web typecheck`, `lint` (0 errors), `format:check`, plus the new e2e spec and the updated integration spec. `test:db` was not run — this change touches no DB paths.

Docs: `docs/guides/reporting-issues.mdx` updated, since the Settings flow's steps and the "same dialog" wording were now wrong.