### PR TITLE
fix(ci): retry the embedding-model download on transient HuggingFace errors

### DIFF
--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -82,8 +82,17 @@ RUN openclaw plugins install @openclaw/llama-cpp-provider \
 # LOUD instead of silently shipping in the image. Bump the revision + digest
 # together when updating the model (the memory-embedding-pin-drift unit test
 # enforces that both stay present).
+#
+# --retry-all-errors + --retry: a single HuggingFace 504 must not turn an
+# unrelated PR red. This is a ~300 MB uncached blob, so curl's retry is the only
+# thing between a passing build and a flaky one (PR #768 fell over twice on a
+# transient HF hiccup, 2026-07-16). Plain --retry only retries connection-level
+# errors; --retry-all-errors is what covers the 5xx *responses* HF serves under
+# load. Integrity is still enforced by the sha256sum -c below — a truncated or
+# tampered download fails the build regardless of how many retries it took.
 RUN mkdir -p /opt/embedding-models \
-    && curl -fsSL -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
+    && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
+       -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \
        https://huggingface.co/ggml-org/embeddinggemma-300m-qat-q8_0-GGUF/resolve/66f974f8cd48cc3b9c41c516b95508e75b4bee64/embeddinggemma-300m-qat-Q8_0.gguf \
     && echo "6fa0c02a9c302be6f977521d399b4de3a46310a4f2621ee0063747881b673f67  /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf" | sha256sum -c -
 

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -83,13 +83,15 @@ RUN openclaw plugins install @openclaw/llama-cpp-provider \
 # together when updating the model (the memory-embedding-pin-drift unit test
 # enforces that both stay present).
 #
-# --retry-all-errors + --retry: a single HuggingFace 504 must not turn an
+# --retry + --retry-all-errors: a single HuggingFace 504 must not turn an
 # unrelated PR red. This is a ~300 MB uncached blob, so curl's retry is the only
 # thing between a passing build and a flaky one (PR #768 fell over twice on a
-# transient HF hiccup, 2026-07-16). Plain --retry only retries connection-level
-# errors; --retry-all-errors is what covers the 5xx *responses* HF serves under
-# load. Integrity is still enforced by the sha256sum -c below — a truncated or
-# tampered download fails the build regardless of how many retries it took.
+# transient HF hiccup, 2026-07-16). --retry already covers the transient HTTP
+# codes (408, 429, 500, 502, 503, 504) — the 504 that hit #768 is in that set;
+# --retry-all-errors widens it to 4xx and non-HTTP errors too, as a safety net
+# for whatever HF returns under load. Integrity is still enforced by the
+# sha256sum -c below — a truncated or tampered download fails the build
+# regardless of how many retries it took.
 RUN mkdir -p /opt/embedding-models \
     && curl -fsSL --retry 5 --retry-all-errors --retry-delay 5 \
        -o /opt/embedding-models/embeddinggemma-300m-qat-Q8_0.gguf \

--- a/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
@@ -60,6 +60,20 @@ describe("memory embedding pin drift guard", () => {
     expect(DOCKERFILE_OPENCLAW).toMatch(/[0-9a-f]{64}\s+\S+\.gguf/);
   });
 
+  it("retries the GGUF download on transient HTTP failures", () => {
+    // A single HuggingFace 504 must not turn an unrelated PR red: the download
+    // is a ~300 MB blob with no cache, so the ONLY thing between a passing build
+    // and a flaky-red one is curl's retry behaviour. `--retry-all-errors` is the
+    // load-bearing flag — plain `--retry` skips 4xx/5xx *responses* (it only
+    // retries connection-level errors), which is exactly the HF 504 class that
+    // took down PR #768 twice on 2026-07-16.
+    // The curl invocation is backslash-continued across lines, so span newlines
+    // up to the downloaded .gguf path.
+    const download = DOCKERFILE_OPENCLAW.match(/curl[\s\S]*?\.gguf/)?.[0] ?? "";
+    expect(download).toMatch(/--retry\s+\d+/);
+    expect(download).toMatch(/--retry-all-errors/);
+  });
+
   it("the CI smoke test checks the same model path", () => {
     const smokePath = VERIFY_SCRIPT.match(/MODEL_PATH="([^"]+\.gguf)"/)?.[1];
     expect(smokePath).toBe(MEMORY_EMBEDDING_MODEL_PATH);

--- a/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
+++ b/packages/web/src/__tests__/lib/memory-embedding-pin-drift.test.ts
@@ -62,14 +62,19 @@ describe("memory embedding pin drift guard", () => {
 
   it("retries the GGUF download on transient HTTP failures", () => {
     // A single HuggingFace 504 must not turn an unrelated PR red: the download
-    // is a ~300 MB blob with no cache, so the ONLY thing between a passing build
-    // and a flaky-red one is curl's retry behaviour. `--retry-all-errors` is the
-    // load-bearing flag — plain `--retry` skips 4xx/5xx *responses* (it only
-    // retries connection-level errors), which is exactly the HF 504 class that
-    // took down PR #768 twice on 2026-07-16.
-    // The curl invocation is backslash-continued across lines, so span newlines
-    // up to the downloaded .gguf path.
-    const download = DOCKERFILE_OPENCLAW.match(/curl[\s\S]*?\.gguf/)?.[0] ?? "";
+    // is a ~300 MB blob with no cache, so curl's retry is the only thing between
+    // a passing build and a flaky-red one (PR #768 fell over twice this way on
+    // 2026-07-16). --retry already covers the transient HTTP codes (incl. 504);
+    // --retry-all-errors widens that to 4xx / non-HTTP errors as a safety net.
+    //
+    // Anchor on the actual download command — `curl -fsSL … huggingface…gguf` —
+    // NOT on the first `curl` token (that's `apt-get install … curl`). Anchoring
+    // loosely would let the flag text in the *explanatory comment* above satisfy
+    // these assertions and mask a real removal of the flags from the command. The
+    // comment sits before `curl -fsSL`, so it is outside this span. The curl is
+    // backslash-continued across lines, hence [\s\S] up to the HF URL.
+    const download =
+      DOCKERFILE_OPENCLAW.match(/curl -fsSL[\s\S]*?huggingface\.co\S+\.gguf/)?.[0] ?? "";
     expect(download).toMatch(/--retry\s+\d+/);
     expect(download).toMatch(/--retry-all-errors/);
   });


### PR DESCRIPTION
## What

The OpenClaw image build (`Dockerfile.openclaw`) fetches the ~300 MB EmbeddingGemma GGUF from HuggingFace with a plain `curl -fsSL` — no retry, no cache. A single transient HF failure therefore fails the whole build.

This adds `curl --retry 5 --retry-all-errors --retry-delay 5` to the download. The `sha256sum -c` integrity check is preserved unchanged.

## Why

On 2026-07-16 PR #768 went red **twice in a row** on exactly this step, while sibling PRs #765/#767 with the identical step passed — a purely transient HuggingFace hiccup turning unrelated PRs red.

`--retry` already retries the transient HTTP codes (`408, 429, 500, 502, 503, 504`) — the `504` that hit #768 is in that set. `--retry-all-errors` widens the retry set to `4xx` and non-HTTP errors as a safety net for whatever HF returns under load. Both together plus a fixed `--retry-delay 5` give a bounded, robust download.

> Correction vs. an earlier revision of this description: plain `--retry` does **not** skip 5xx responses — it already covers 500/502/503/504. `--retry-all-errors` is a superset, not the sole thing covering the 504.

## Options weighed

- **Retry (this PR)** — simplest fix, covers the cases where the download actually runs.
- **`actions/cache` for `/opt/embedding-models`** — skipped as redundant: `build-image` already uses `cache-from/cache-to: type=gha`, so an unchanged `RUN` line restores the baked model from the Docker layer cache without re-downloading. The path lives *inside* the image, so a host-side `actions/cache` wouldn't cleanly hook the build anyway.
- **Reuse the pre-built image in docker-smoke** — already the case: `docker-smoke` pulls the pushed OpenClaw image and does not rebuild `Dockerfile.openclaw` (only the fork-PR fallback builds locally). The download runs once per non-fork CI run.

## Tests

TDD: added an assertion to the existing `memory-embedding-pin-drift` drift guard pinning **both** `--retry <n>` and `--retry-all-errors`. The regex anchors on the actual download command (`curl -fsSL … huggingface…gguf`), not on the first `curl` token or the explanatory comment, so removing the flags from the command trips the guard red instead of being masked by the comment text. Watched it fail (red) on the un-patched Dockerfile, then pass (green). `pnpm typecheck` + Prettier clean.
