### PR TITLE
feat(pinchy-odoo): add odoo_reconcile for bank/payment reconciliation

### DIFF
--- a/docs/src/content/docs/concepts/agent-permissions.mdx
+++ b/docs/src/content/docs/concepts/agent-permissions.mdx
@@ -114,6 +114,7 @@ When you connect Odoo and grant an agent access to it, Pinchy automatically enab
 | **Validate picking**      | `odoo_validate_picking`    | Validate a stock transfer (`button_validate`); hands off if Odoo needs a backorder decision                    | Read & Write          |
 | **Mark MO done**          | `odoo_mark_mo_done`        | Mark a manufacturing order done (`button_mark_done`); hands off if Odoo needs a backorder/consumption decision | Read & Write          |
 | **Set approval decision** | `odoo_set_approval`        | Approve/refuse an expense report, purchase order, leave request, or approval request via its blessed method    | Read & Write          |
+| **Reconcile payment**     | `odoo_reconcile`           | Match a posted bill/invoice against a bank transaction or payment, and verify the result on the document       | Read & Write          |
 | **Update records**        | `odoo_write`               | Modify existing records                                                                                        | Read & Write          |
 | **Attach file**           | `odoo_attach_file`         | Attach an uploaded file to an existing record as `ir.attachment`                                               | Read & Write          |
 | **Delete records**        | `odoo_delete`              | Delete records                                                                                                 | Full                  |

--- a/docs/src/content/docs/guides/connect-odoo.mdx
+++ b/docs/src/content/docs/guides/connect-odoo.mdx
@@ -86,7 +86,7 @@ Open the agent's chat and try a few queries:
 The agent uses the Odoo tools to query your data in real time. If something doesn't work, check that the Odoo user has the right permissions for the models you're querying.
 
 :::note
-Agents that attach files to Odoo records, such as saving a receipt on an invoice or bill, also need access to `ir.attachment`. Finance agents that create invoices or bills may also need supporting models such as `account.journal`, `account.account`, `account.tax`, `account.payment.term`, and `res.currency`. Grant only the models and operations the agent needs, and make sure the Odoo API user has the matching access rights in Odoo.
+Agents that attach files to Odoo records, such as saving a receipt on an invoice or bill, also need access to `ir.attachment`. Finance agents that create invoices or bills may also need supporting models such as `account.journal`, `account.account`, `account.tax`, `account.payment.term`, and `res.currency`. Agents that reconcile payments additionally need write access to `account.move.line` and `account.bank.statement.line` (the bank transactions). Grant only the models and operations the agent needs, and make sure the Odoo API user has the matching access rights in Odoo.
 :::
 
 ## Agent Templates

--- a/packages/plugins/pinchy-odoo/__tests__/reconcile.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/reconcile.test.ts
@@ -482,6 +482,39 @@ describe("odoo_reconcile — bank transaction against a posted bill", () => {
     expect(mockCallMethod).not.toHaveBeenCalled();
   });
 
+  it("refuses a statement move that carries an extra line beyond liquidity + suspense", async () => {
+    // The rewrite clears every line ([5,0,0]) and recreates only liquidity +
+    // counterpart. A third line (e.g. a split bank fee on its own account)
+    // passes the exactly-one-liquidity / exactly-one-suspense guards but would
+    // be silently dropped, so a move that isn't the plain two-line shape must
+    // be refused rather than restated.
+    const FEE_ACC = 99;
+    stubReads({
+      stMoveLines: [
+        ...ST_MOVE_LINES,
+        {
+          id: 65,
+          account_id: [FEE_ACC, "Bank Fees"],
+          debit: 1.5,
+          credit: 0,
+          amount_currency: 1.5,
+          partner_id: [PARTNER, "Gemini Furniture"],
+          name: "Fee",
+        },
+      ],
+    });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/line|Reconcile it in Odoo/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
   it("requires write on account.move.line", async () => {
     stubReads();
     const tool = findTool(
@@ -547,6 +580,18 @@ describe("odoo_reconcile — invoice against an existing payment", () => {
     expect(data.reconciled).toBe(true);
   });
 
+  it("refuses a canceled payment before writing anything", async () => {
+    stubReads({ payment: { ...PAYMENT_ROW, state: "canceled" } });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.payment", PAYMENT_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/cancel|reject/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
   it("refuses when the payment has no line on the invoice's account", async () => {
     stubReads({ paymentLines: [] });
     const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
@@ -600,5 +645,10 @@ describe("odoo_reconcile — ref validation", () => {
     });
     expect(result.isError).toBe(true);
     expect(result.content[0].text).toMatch(/connection/i);
+    // The message must name the offending parameter, not a generic default —
+    // decodeTargetRef is called with the `invoice` label, so a foreign
+    // `invoice` ref reports `invoice`, never `target`.
+    expect(result.content[0].text).toMatch(/invoice/i);
+    expect(result.content[0].text).not.toMatch(/target/i);
   });
 });

--- a/packages/plugins/pinchy-odoo/__tests__/reconcile.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/reconcile.test.ts
@@ -1,0 +1,604 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentOdooConfig } from "../index";
+
+const mockSearchRead = vi.fn();
+const mockSearchCount = vi.fn();
+const mockReadGroup = vi.fn();
+const mockCreate = vi.fn();
+const mockWrite = vi.fn();
+const mockUnlink = vi.fn();
+const mockFields = vi.fn();
+const mockCallMethod = vi.fn();
+
+vi.mock("odoo-node", () => {
+  const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {
+    this.searchRead = mockSearchRead;
+    this.searchCount = mockSearchCount;
+    this.readGroup = mockReadGroup;
+    this.create = mockCreate;
+    this.write = mockWrite;
+    this.unlink = mockUnlink;
+    this.fields = mockFields;
+    this.callMethod = mockCallMethod;
+  });
+  return { OdooClient: MockOdooClient };
+});
+
+vi.mock("../io", () => ({ readFile: vi.fn(), stat: vi.fn() }));
+
+import { encodeRef } from "../integration-ref";
+import plugin from "../index";
+
+// The plugin lazily fetches Odoo credentials from the Pinchy API (Pattern B),
+// so the tool never runs without a stubbed credentials endpoint.
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({
+    type: "odoo",
+    credentials: {
+      url: "http://odoo-test:8069",
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    },
+  }),
+}));
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+interface AgentTool {
+  name: string;
+  label: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function createApi(agentConfigs: Record<string, AgentOdooConfig> = {}) {
+  const tools: Array<{
+    factory: (ctx: { agentId?: string }) => AgentTool | null;
+    name: string;
+  }> = [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: agentConfigs,
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string },
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  plugin.register(api as never);
+  return tools;
+}
+
+function findTool(
+  tools: ReturnType<typeof createApi>,
+  name: string,
+  agentId?: string,
+): AgentTool | null {
+  const entry = tools.find((t) => t.name === name);
+  if (!entry) return null;
+  return entry.factory({ agentId });
+}
+
+const agentId = "agent-1";
+const CONN = "conn-test-1";
+
+const FULL_PERMS = {
+  "account.move": ["read", "write"],
+  "account.move.line": ["read", "write"],
+  "account.bank.statement.line": ["read", "write"],
+  "account.payment": ["read"],
+  "account.journal": ["read"],
+};
+
+function cfg(
+  permissions: Record<string, string[]> = FULL_PERMS,
+): AgentOdooConfig {
+  return { connectionId: CONN, permissions } as AgentOdooConfig;
+}
+
+function ref(model: string, id: number, label = "x"): string {
+  return encodeRef({
+    integrationType: "odoo",
+    connectionId: CONN,
+    model,
+    id,
+    label,
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Fixture mirroring the real Odoo 19 shape verified on the demo instance:
+// statement line 5 (-622.27) against posted bill 9 (residual 622.27).
+//   liquidity line: Bank (47)              credit 622.27
+//   suspense line:  Bank Suspense (48)     debit  622.27
+//   bill line:      Account Payable (15)   credit 622.27
+// ---------------------------------------------------------------------------
+const INVOICE_ID = 9;
+const ST_LINE_ID = 5;
+const ST_MOVE_ID = 23;
+const JOURNAL_ID = 6;
+const BANK_ACC = 47;
+const SUSPENSE_ACC = 48;
+const PAYABLE_ACC = 15;
+const PARTNER = 10;
+
+const INVOICE_ROW = {
+  id: INVOICE_ID,
+  state: "posted",
+  payment_state: "not_paid",
+  amount_residual: 622.27,
+  company_id: [1, "Crabon Bikes"],
+  partner_id: [PARTNER, "Gemini Furniture"],
+  name: "BILL/2026/04/0001",
+};
+const INVOICE_LINE_ROW = {
+  id: 47,
+  account_id: [PAYABLE_ACC, "Account Payable"],
+  debit: 0,
+  credit: 622.27,
+  amount_currency: -622.27,
+  reconciled: false,
+};
+const ST_LINE_ROW = {
+  id: ST_LINE_ID,
+  move_id: [ST_MOVE_ID, "BNK1/2026/00005"],
+  journal_id: [JOURNAL_ID, "Bank"],
+  is_reconciled: false,
+  company_id: [1, "Crabon Bikes"],
+  partner_id: [PARTNER, "Gemini Furniture"],
+  payment_ref: "BILL/2024/01/0001",
+  amount: -622.27,
+};
+const JOURNAL_ROW = {
+  id: JOURNAL_ID,
+  default_account_id: [BANK_ACC, "Bank"],
+  suspense_account_id: [SUSPENSE_ACC, "Bank Suspense Account"],
+};
+const ST_MOVE_LINES = [
+  {
+    id: 63,
+    account_id: [BANK_ACC, "Bank"],
+    debit: 0,
+    credit: 622.27,
+    amount_currency: -622.27,
+    partner_id: [PARTNER, "Gemini Furniture"],
+    name: "BILL/2024/01/0001",
+  },
+  {
+    id: 64,
+    account_id: [SUSPENSE_ACC, "Bank Suspense Account"],
+    debit: 622.27,
+    credit: 0,
+    amount_currency: 622.27,
+    partner_id: [PARTNER, "Gemini Furniture"],
+    name: "BILL/2024/01/0001",
+  },
+];
+
+/** Pulls the value of a `[field, "=", value]` leaf out of an Odoo domain. */
+function domainValue(domain: unknown, field: string): unknown {
+  if (!Array.isArray(domain)) return undefined;
+  for (const leaf of domain) {
+    if (Array.isArray(leaf) && leaf[0] === field && leaf[1] === "=") {
+      return leaf[2];
+    }
+  }
+  return undefined;
+}
+
+/**
+ * Routes searchRead by model and domain rather than by call order, so a test
+ * can bend one leg of the fixture without depending on how many reads the
+ * implementation happens to make. Reads issued after the first write are
+ * treated as the post-reconcile read-back.
+ */
+function stubReads(
+  overrides: {
+    invoice?: Record<string, unknown>;
+    invoiceLines?: Array<Record<string, unknown>>;
+    stLine?: Record<string, unknown>;
+    stMoveLines?: Array<Record<string, unknown>>;
+    payment?: Record<string, unknown>;
+    paymentLines?: Array<Record<string, unknown>>;
+    newCounterpartLines?: Array<Record<string, unknown>>;
+    readBackStLine?: Record<string, unknown>;
+    readBackInvoice?: Record<string, unknown>;
+  } = {},
+) {
+  const mutated = () => mockCallMethod.mock.calls.length > 0;
+
+  mockSearchRead.mockImplementation((model: string, domain: unknown) => {
+    switch (model) {
+      case "account.move":
+        return Promise.resolve({
+          records: [
+            mutated()
+              ? (overrides.readBackInvoice ?? {
+                  ...INVOICE_ROW,
+                  payment_state: "paid",
+                  amount_residual: 0,
+                })
+              : (overrides.invoice ?? INVOICE_ROW),
+          ],
+        });
+
+      case "account.move.line": {
+        const moveId = domainValue(domain, "move_id");
+        if (moveId === INVOICE_ID) {
+          return Promise.resolve({
+            records: overrides.invoiceLines ?? [INVOICE_LINE_ROW],
+          });
+        }
+        if (moveId === PAYMENT_MOVE_ID) {
+          return Promise.resolve({
+            records:
+              overrides.paymentLines ??
+              [{ id: 110, account_id: [PAYABLE_ACC, "Account Payable"] }],
+          });
+        }
+        if (moveId === ST_MOVE_ID) {
+          // Before the rewrite: the original liquidity + suspense pair.
+          // After it: the freshly created payable counterpart.
+          if (mutated()) {
+            return Promise.resolve({
+              records:
+                overrides.newCounterpartLines ??
+                [{ id: 102, account_id: [PAYABLE_ACC, "Account Payable"] }],
+            });
+          }
+          return Promise.resolve({
+            records: overrides.stMoveLines ?? ST_MOVE_LINES,
+          });
+        }
+        return Promise.resolve({ records: [] });
+      }
+
+      case "account.bank.statement.line":
+        return Promise.resolve({
+          records: [
+            mutated()
+              ? (overrides.readBackStLine ?? {
+                  ...ST_LINE_ROW,
+                  is_reconciled: true,
+                })
+              : (overrides.stLine ?? ST_LINE_ROW),
+          ],
+        });
+
+      case "account.journal":
+        return Promise.resolve({ records: [JOURNAL_ROW] });
+
+      case "account.payment":
+        return Promise.resolve({ records: [overrides.payment ?? PAYMENT_ROW] });
+
+      default:
+        return Promise.resolve({ records: [] });
+    }
+  });
+}
+
+const PAYMENT_ID = 1;
+const PAYMENT_MOVE_ID = 44;
+const PAYMENT_ROW = {
+  id: PAYMENT_ID,
+  move_id: [PAYMENT_MOVE_ID, "PBNK1/2026/00001"],
+  state: "in_process",
+  company_id: [1, "Crabon Bikes"],
+  partner_id: [PARTNER, "Gemini Furniture"],
+  amount: 622.27,
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+});
+
+describe("odoo_reconcile — registration", () => {
+  it("is registered", () => {
+    expect(createApi({ [agentId]: cfg() }).map((t) => t.name)).toContain(
+      "odoo_reconcile",
+    );
+  });
+
+  it("is not offered to an agent without an Odoo config", () => {
+    const tools = createApi({});
+    // Guard against a vacuous pass: the tool must be registered, and the
+    // factory must be what withholds it from an unconfigured agent.
+    expect(tools.map((t) => t.name)).toContain("odoo_reconcile");
+    expect(findTool(tools, "odoo_reconcile", agentId)).toBeNull();
+  });
+});
+
+describe("odoo_reconcile — bank transaction against a posted bill", () => {
+  it("replaces the suspense counterpart, reconciles, and confirms via read-back", async () => {
+    stubReads();
+    mockCallMethod.mockResolvedValue(undefined);
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBeFalsy();
+
+    // Step 1: the statement move is rewritten — suspense line cleared, a
+    // counterpart on the bill's payable account created, liquidity preserved.
+    const writeCall = mockCallMethod.mock.calls.find(
+      (c) => c[0] === "account.bank.statement.line" && c[1] === "write",
+    );
+    expect(writeCall).toBeDefined();
+    const [, , writeArgs, writeKwargs] = writeCall!;
+    expect(writeArgs[0]).toEqual([ST_LINE_ID]);
+    const commands = (writeArgs[1] as { line_ids: unknown[] }).line_ids;
+    expect(commands[0]).toEqual([5, 0, 0]);
+    const created = commands.slice(1) as Array<[number, number, Record<string, unknown>]>;
+    expect(created).toHaveLength(2);
+    const liquidity = created.find((c) => c[2].account_id === BANK_ACC)![2];
+    const counterpart = created.find((c) => c[2].account_id === PAYABLE_ACC)![2];
+    expect(liquidity).toMatchObject({ debit: 0, credit: 622.27, amount_currency: -622.27 });
+    expect(counterpart).toMatchObject({ debit: 622.27, credit: 0, amount_currency: 622.27 });
+    // The original line labels must survive the rewrite. Odoo syncs the
+    // liquidity line's name back into the statement line's `payment_ref` via
+    // `_synchronize_from_moves`, so dropping it silently destroys the raw bank
+    // text — observed for real on the demo instance.
+    expect(liquidity.name).toBe("BILL/2024/01/0001");
+    expect(counterpart.name).toBe("BILL/2024/01/0001");
+    // No line may remain on the suspense account.
+    expect(created.some((c) => c[2].account_id === SUSPENSE_ACC)).toBe(false);
+    // Odoo refuses the rewrite on a posted move without these context flags.
+    expect(writeKwargs).toMatchObject({
+      context: { force_delete: true, skip_readonly_check: true },
+    });
+
+    // Step 2: same-account reconcile of the new counterpart and the bill line.
+    const reconcileCall = mockCallMethod.mock.calls.find(
+      (c) => c[0] === "account.move.line" && c[1] === "reconcile",
+    );
+    expect(reconcileCall).toBeDefined();
+    expect(reconcileCall![2]).toEqual([[102, INVOICE_LINE_ROW.id]]);
+
+    const data = JSON.parse(result.content[0].text);
+    expect(data.reconciled).toBe(true);
+    expect(data.paymentState).toBe("paid");
+    expect(data.amountResidual).toBe(0);
+  });
+
+  it("reports failure — and rolls back — when the bill's residual did not move", async () => {
+    // The subtle trap, verified against Odoo 19: clearing the suspense line
+    // (step 1) alone already flips is_reconciled to true, while the bill stays
+    // unpaid. So is_reconciled proves nothing about the reconcile itself; only
+    // the bill's residual does. reconcile() returns None either way, so a tool
+    // trusting is_reconciled would report a success that never happened.
+    stubReads({
+      readBackStLine: { ...ST_LINE_ROW, is_reconciled: true },
+      readBackInvoice: INVOICE_ROW, // residual unchanged at 622.27
+    });
+    mockCallMethod.mockResolvedValue(undefined);
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/did not reconcile|not reconciled/i);
+    // The rewrite must not be left half-done: the statement line goes back to
+    // its suspense counterpart rather than sitting restated-but-unmatched.
+    expect(
+      mockCallMethod.mock.calls.some(
+        (c) =>
+          c[0] === "account.bank.statement.line" &&
+          c[1] === "action_undo_reconciliation",
+      ),
+    ).toBe(true);
+  });
+
+  it("refuses a draft invoice before writing anything", async () => {
+    // Odoo 19 dropped the posted check: reconcile() on a draft line raises
+    // nothing and silently does nothing. We must catch it ourselves.
+    stubReads({ invoice: { ...INVOICE_ROW, state: "draft" } });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/draft|posted/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("refuses a statement line that is already reconciled", async () => {
+    stubReads({ stLine: { ...ST_LINE_ROW, is_reconciled: true } });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/already reconciled/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("refuses a cross-company match", async () => {
+    stubReads({ stLine: { ...ST_LINE_ROW, company_id: [5, "Clemens Helm"] } });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/compan/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the invoice has no open receivable/payable line", async () => {
+    stubReads({ invoiceLines: [] });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/no open|nothing left to reconcile/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("refuses when the statement move has no suspense line to replace", async () => {
+    stubReads({ stMoveLines: [ST_MOVE_LINES[0]] });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/suspense/i);
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("requires write on account.move.line", async () => {
+    stubReads();
+    const tool = findTool(
+      createApi({
+        [agentId]: cfg({ ...FULL_PERMS, "account.move.line": ["read"] }),
+      }),
+      "odoo_reconcile",
+      agentId,
+    )!;
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+
+  it("requires write on account.bank.statement.line", async () => {
+    stubReads();
+    const tool = findTool(
+      createApi({
+        [agentId]: cfg({
+          ...FULL_PERMS,
+          "account.bank.statement.line": ["read"],
+        }),
+      }),
+      "odoo_reconcile",
+      agentId,
+    )!;
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toContain("Permission denied");
+    expect(mockCallMethod).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo_reconcile — invoice against an existing payment", () => {
+  it("assigns the payment's counterpart line and confirms via read-back", async () => {
+    stubReads({
+      paymentLines: [{ id: 110, account_id: [PAYABLE_ACC, "Account Payable"] }],
+    });
+    mockCallMethod.mockResolvedValue(undefined);
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.payment", PAYMENT_ID),
+    });
+
+    expect(result.isError).toBeFalsy();
+    const call = mockCallMethod.mock.calls.find(
+      (c) => c[1] === "js_assign_outstanding_line",
+    );
+    expect(call).toBeDefined();
+    expect(call![0]).toBe("account.move");
+    // Odoo takes a scalar line id, not a list.
+    expect(call![2]).toEqual([[INVOICE_ID], 110]);
+    const data = JSON.parse(result.content[0].text);
+    expect(data.reconciled).toBe(true);
+  });
+
+  it("refuses when the payment has no line on the invoice's account", async () => {
+    stubReads({ paymentLines: [] });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("account.payment", PAYMENT_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/no matching line|does not post to/i);
+    expect(
+      mockCallMethod.mock.calls.some((c) => c[1] === "js_assign_outstanding_line"),
+    ).toBe(false);
+  });
+});
+
+describe("odoo_reconcile — ref validation", () => {
+  it("rejects an invoice ref for the wrong model", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+    const result = await tool.execute("c", {
+      invoice: ref("res.partner", 1),
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/account\.move/);
+  });
+
+  it("rejects a counterpart ref that is neither a bank transaction nor a payment", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+    const result = await tool.execute("c", {
+      invoice: ref("account.move", INVOICE_ID),
+      counterpart: ref("res.partner", 1),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(
+      /account\.bank\.statement\.line|account\.payment/,
+    );
+  });
+
+  it("rejects a ref from another Odoo connection", async () => {
+    const foreign = encodeRef({
+      integrationType: "odoo",
+      connectionId: "conn-other",
+      model: "account.move",
+      id: INVOICE_ID,
+      label: "x",
+    });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_reconcile", agentId)!;
+    const result = await tool.execute("c", {
+      invoice: foreign,
+      counterpart: ref("account.bank.statement.line", ST_LINE_ID),
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/connection/i);
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/tools.test.ts
@@ -1093,9 +1093,9 @@ describe("odoo_list_models", () => {
 });
 
 describe("tool registration", () => {
-  it("registers all 18 tools (including the deprecated odoo_schema alias)", () => {
+  it("registers all 19 tools (including the deprecated odoo_schema alias)", () => {
     const tools = createApi({ [agentId]: agentConfig });
-    expect(tools).toHaveLength(18);
+    expect(tools).toHaveLength(19);
     const names = tools.map((t) => t.name);
     expect(names).toContain("odoo_list_models");
     expect(names).toContain("odoo_describe_model");
@@ -1112,6 +1112,7 @@ describe("tool registration", () => {
     expect(names).toContain("odoo_validate_picking");
     expect(names).toContain("odoo_mark_mo_done");
     expect(names).toContain("odoo_set_approval");
+    expect(names).toContain("odoo_reconcile");
     expect(names).toContain("odoo_write");
     expect(names).toContain("odoo_delete");
     expect(names).toContain("odoo_attach_file");

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -3622,14 +3622,15 @@ const plugin = {
                 );
               }
 
-              const inv = decodeTargetRef(config.connectionId, invoiceRef);
-              if (inv === null) {
-                return errorResult(
-                  new Error(
-                    "`invoice` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
+              // decodeTargetRef throws (never returns null) on a malformed or
+              // foreign ref; the throw is caught below and surfaced with the
+              // parameter name we pass here, so the user is told which ref was
+              // wrong rather than a generic "target".
+              const inv = decodeTargetRef(
+                config.connectionId,
+                invoiceRef,
+                "invoice",
+              );
               if (inv.model !== "account.move") {
                 return errorResult(
                   new Error(
@@ -3637,14 +3638,11 @@ const plugin = {
                   ),
                 );
               }
-              const cp = decodeTargetRef(config.connectionId, counterpartRef);
-              if (cp === null) {
-                return errorResult(
-                  new Error(
-                    "`counterpart` ref does not belong to this Odoo connection.",
-                  ),
-                );
-              }
+              const cp = decodeTargetRef(
+                config.connectionId,
+                counterpartRef,
+                "counterpart",
+              );
               if (
                 cp.model !== "account.bank.statement.line" &&
                 cp.model !== "account.payment"
@@ -3797,7 +3795,7 @@ const plugin = {
                 const payment = (
                   await withAuthRetry(agentId, config, (client) =>
                     client.searchRead("account.payment", [["id", "=", cp.id]], {
-                      fields: ["move_id", "state", "company_id", "amount"],
+                      fields: ["move_id", "state", "company_id"],
                       limit: 1,
                     }),
                   )
@@ -3805,6 +3803,16 @@ const plugin = {
                 if (!payment) {
                   return errorResult(
                     new Error(`account.payment ${cp.id} was not found in Odoo.`),
+                  );
+                }
+                // A canceled or rejected payment has no live journal entry to
+                // match against; reconcile() would silently no-op, so refuse it
+                // up front with a message the agent can act on.
+                if (payment.state === "canceled" || payment.state === "rejected") {
+                  return errorResult(
+                    new Error(
+                      `This payment is in state "${String(payment.state)}", so there is nothing to reconcile against. Use a payment that is in process or paid.`,
+                    ),
                   );
                 }
                 const paymentCompanyId = relationId(payment.company_id);
@@ -3874,8 +3882,6 @@ const plugin = {
                         "journal_id",
                         "is_reconciled",
                         "company_id",
-                        "partner_id",
-                        "amount",
                       ],
                       limit: 1,
                     },
@@ -3972,6 +3978,18 @@ const plugin = {
                 return errorResult(
                   new Error(
                     "This bank transaction has no suspense line to replace — it is probably already matched to something else. Reset it in Odoo first.",
+                  ),
+                );
+              }
+              // The rewrite below clears every line ([5,0,0]) and recreates only
+              // the liquidity + counterpart pair. A move carrying any additional
+              // line (e.g. a split bank fee on its own account) would have that
+              // line silently dropped, so refuse anything that isn't the plain
+              // two-line liquidity/suspense shape and let a human handle it.
+              if (stMoveLines.length !== 2) {
+                return errorResult(
+                  new Error(
+                    `This bank transaction's journal entry has ${stMoveLines.length} lines, not the expected two (one bank line, one suspense line). It carries an extra line this tool would drop on rewrite — reconcile it in Odoo.`,
                   ),
                 );
               }

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -1865,6 +1865,66 @@ async function ensureActivityResModelId(
   return next;
 }
 
+/** Id of an Odoo many2one value, which comes back as `[id, label]` or `false`. */
+export function relationId(value: unknown): number | null {
+  if (!Array.isArray(value)) return null;
+  const id = value[0];
+  return typeof id === "number" && Number.isInteger(id) && id > 0 ? id : null;
+}
+
+/** Label of an Odoo many2one value. */
+export function relationLabel(value: unknown): string | null {
+  if (!Array.isArray(value)) return null;
+  return typeof value[1] === "string" ? value[1] : null;
+}
+
+function asNumber(value: unknown): number | null {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+/**
+ * Accounts a bill/invoice settles against, matched via
+ * `account.move.line.account_type` (a related field on the line, so no join is
+ * needed). Reconciliation only ever happens on these: Odoo refuses lines from
+ * two different accounts outright ("Entries are not from the same account"),
+ * which is why a bank transaction sitting on the journal's *suspense* account
+ * can never be reconciled against a bill's payable line directly — the suspense
+ * line has to be replaced first.
+ */
+const SETTLEMENT_ACCOUNT_TYPES = ["asset_receivable", "liability_payable"];
+
+/**
+ * Did the reconcile actually happen?
+ *
+ * This is the crux of the tool, and it is deliberately paranoid. Verified
+ * against a real Odoo 19 instance (2026-07-16):
+ *
+ *  1. `account.move.line.reconcile()` returns `None` — on success AND on a
+ *     silent no-op. Over RPC that is `undefined`. The return value carries no
+ *     information at all.
+ *  2. Odoo 19 dropped the "you can only reconcile posted entries" guard. A
+ *     reconcile touching a draft line raises nothing, writes no
+ *     `account.partial.reconcile`, and changes nothing. Silence is not success.
+ *  3. `account.bank.statement.line.is_reconciled` is NOT a valid signal: it is
+ *     computed as "no suspense line left on the move", so merely restating the
+ *     counterpart (step 1 of the bank flow) already flips it to `true` while
+ *     the bill stays unpaid.
+ *
+ * The only trustworthy evidence is the settled document's own residual going
+ * down. That is what we check.
+ */
+export function didReconcile(
+  residualBefore: unknown,
+  residualAfter: unknown,
+): boolean {
+  const before = asNumber(residualBefore);
+  const after = asNumber(residualAfter);
+  if (before === null || after === null) return false;
+  // Residuals are signed and rounded by Odoo; compare magnitudes with a
+  // cent-level tolerance so a float artefact cannot read as progress.
+  return Math.abs(after) < Math.abs(before) - 0.005;
+}
+
 /**
  * Variant A wizard handling for record-action tools. Odoo button/action
  * methods (e.g. `stock.picking.button_validate`, `mrp.production.button_mark_done`)
@@ -3503,6 +3563,522 @@ const plugin = {
         };
       },
       { name: "odoo_set_approval" },
+    );
+
+    // 5j. odoo_reconcile. Odoo has no single "reconcile" button we could wrap,
+    // and the Enterprise bank-reconciliation widget is unusable over RPC (in
+    // Odoo 19 its model is gone entirely; in 16-18 every action on it is
+    // private and the model has no table). So this tool reproduces what the
+    // widget does, using only public methods of the free `account` module —
+    // which is also why it works on Odoo Community, not just Enterprise.
+    api.registerTool(
+      (ctx: PluginToolContext) => {
+        const agentId = ctx.agentId;
+        if (!agentId) return null;
+        const config = getAgentConfig(agentConfigs, agentId);
+        if (!config) return null;
+
+        return {
+          name: "odoo_reconcile",
+          label: "Odoo Reconcile Payment",
+          description:
+            "Reconcile a POSTED bill or invoice against the money that settled it — either a bank transaction (`account.bank.statement.line`) or an existing payment (`account.payment`). Pass the `_pinchy_ref` of the bill/invoice as `invoice` and the `_pinchy_ref` of the bank transaction or payment as `counterpart`. This is the only correct way to reconcile: do NOT try to write `full_reconcile_id` or create `account.full.reconcile` records — Odoo maintains those itself. The tool verifies the result by re-reading the bill and reports honestly if nothing was reconciled. Reconcile only after the user has confirmed the match.",
+          parameters: {
+            type: "object",
+            properties: {
+              invoice: {
+                type: "string",
+                description:
+                  "Opaque `_pinchy_ref` of the posted `account.move` (vendor bill or customer invoice) to settle.",
+              },
+              counterpart: {
+                type: "string",
+                description:
+                  "Opaque `_pinchy_ref` of the money movement that settled it: an `account.bank.statement.line` (bank transaction) or an `account.payment`.",
+              },
+            },
+            required: ["invoice", "counterpart"],
+            additionalProperties: false,
+          },
+          async execute(_toolCallId: string, params: Record<string, unknown>) {
+            try {
+              const invoiceRef = params.invoice;
+              const counterpartRef = params.counterpart;
+              if (typeof invoiceRef !== "string" || invoiceRef.length === 0) {
+                return errorResult(
+                  new Error(
+                    "`invoice` is required: pass the _pinchy_ref of the bill or invoice (account.move).",
+                  ),
+                );
+              }
+              if (
+                typeof counterpartRef !== "string" ||
+                counterpartRef.length === 0
+              ) {
+                return errorResult(
+                  new Error(
+                    "`counterpart` is required: pass the _pinchy_ref of the bank transaction (account.bank.statement.line) or payment (account.payment).",
+                  ),
+                );
+              }
+
+              const inv = decodeTargetRef(config.connectionId, invoiceRef);
+              if (inv === null) {
+                return errorResult(
+                  new Error(
+                    "`invoice` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              if (inv.model !== "account.move") {
+                return errorResult(
+                  new Error(
+                    "`invoice` must be an account.move ref (a vendor bill or customer invoice).",
+                  ),
+                );
+              }
+              const cp = decodeTargetRef(config.connectionId, counterpartRef);
+              if (cp === null) {
+                return errorResult(
+                  new Error(
+                    "`counterpart` ref does not belong to this Odoo connection.",
+                  ),
+                );
+              }
+              if (
+                cp.model !== "account.bank.statement.line" &&
+                cp.model !== "account.payment"
+              ) {
+                return errorResult(
+                  new Error(
+                    `\`counterpart\` must be an account.bank.statement.line (bank transaction) or account.payment ref, not ${cp.model}.`,
+                  ),
+                );
+              }
+
+              // Reconciling rewrites and matches journal items in every case.
+              if (
+                !checkPermission(config.permissions, "account.move.line", "write")
+              ) {
+                return permissionDenied("write", "account.move.line");
+              }
+              // The bank flow additionally restates the statement line's move.
+              if (
+                cp.model === "account.bank.statement.line" &&
+                !checkPermission(
+                  config.permissions,
+                  "account.bank.statement.line",
+                  "write",
+                )
+              ) {
+                return permissionDenied("write", "account.bank.statement.line");
+              }
+
+              const invoice = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead("account.move", [["id", "=", inv.id]], {
+                    fields: [
+                      "name",
+                      "state",
+                      "payment_state",
+                      "amount_residual",
+                      "company_id",
+                      "partner_id",
+                    ],
+                    limit: 1,
+                  }),
+                )
+              ).records[0];
+              if (!invoice) {
+                return errorResult(
+                  new Error(`account.move ${inv.id} was not found in Odoo.`),
+                );
+              }
+              const invoiceName =
+                typeof invoice.name === "string" ? invoice.name : `#${inv.id}`;
+
+              // Odoo 19 no longer refuses to reconcile a draft entry — it just
+              // silently does nothing. Catch it here or ship a false success.
+              if (invoice.state !== "posted") {
+                return errorResult(
+                  new Error(
+                    `${invoiceName} is in state "${String(invoice.state)}", not "posted". Odoo accepts a reconcile call on a draft entry but silently does nothing, so post it first (after the user confirms), then reconcile.`,
+                  ),
+                );
+              }
+
+              const invoiceLines = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead(
+                    "account.move.line",
+                    [
+                      ["move_id", "=", inv.id],
+                      ["account_type", "in", SETTLEMENT_ACCOUNT_TYPES],
+                      ["reconciled", "=", false],
+                    ],
+                    {
+                      fields: [
+                        "id",
+                        "account_id",
+                        "account_type",
+                        "debit",
+                        "credit",
+                      ],
+                    },
+                  )
+                )
+              ).records;
+              if (invoiceLines.length === 0) {
+                return errorResult(
+                  new Error(
+                    `${invoiceName} has no open receivable/payable line — there is nothing left to reconcile (it may already be paid).`,
+                  ),
+                );
+              }
+              if (invoiceLines.length > 1) {
+                return errorResult(
+                  new Error(
+                    `${invoiceName} has ${invoiceLines.length} open receivable/payable lines, so the counterpart is ambiguous. Reconcile it in Odoo.`,
+                  ),
+                );
+              }
+              const invoiceLine = invoiceLines[0];
+              const settlementAccountId = relationId(invoiceLine.account_id);
+              if (settlementAccountId === null) {
+                return errorResult(
+                  new Error(
+                    `Could not read the settlement account of ${invoiceName}.`,
+                  ),
+                );
+              }
+              const invoiceCompanyId = relationId(invoice.company_id);
+              const residualBefore = invoice.amount_residual;
+
+              /**
+               * Re-read the bill and report only what Odoo actually did. On
+               * failure the caller gets an error, never a success claim.
+               */
+              const confirm = async (
+                extra: Record<string, unknown>,
+                rollback?: () => Promise<void>,
+              ) => {
+                const after = (
+                  await withAuthRetry(agentId, config, (client) =>
+                    client.searchRead("account.move", [["id", "=", inv.id]], {
+                      fields: ["payment_state", "amount_residual"],
+                      limit: 1,
+                    }),
+                  )
+                ).records[0];
+                if (!didReconcile(residualBefore, after?.amount_residual)) {
+                  if (rollback) await rollback();
+                  return toolError(
+                    `Odoo accepted the reconcile call but ${invoiceName} did not reconcile: its open balance is still ${String(after?.amount_residual ?? residualBefore)}. Odoo reports no error in this case, so this is not a transient failure — the entries were not matched. Check in Odoo that both sides are posted and on the same account.`,
+                  );
+                }
+                return {
+                  content: [
+                    {
+                      type: "text",
+                      text: JSON.stringify({
+                        reconciled: true,
+                        invoice: { id: inv.id, name: invoiceName },
+                        paymentState: after?.payment_state,
+                        amountResidual: after?.amount_residual,
+                        ...extra,
+                      }),
+                    },
+                  ],
+                };
+              };
+
+              // ---- Counterpart is an existing payment -------------------
+              if (cp.model === "account.payment") {
+                const payment = (
+                  await withAuthRetry(agentId, config, (client) =>
+                    client.searchRead("account.payment", [["id", "=", cp.id]], {
+                      fields: ["move_id", "state", "company_id", "amount"],
+                      limit: 1,
+                    }),
+                  )
+                ).records[0];
+                if (!payment) {
+                  return errorResult(
+                    new Error(`account.payment ${cp.id} was not found in Odoo.`),
+                  );
+                }
+                const paymentCompanyId = relationId(payment.company_id);
+                if (
+                  invoiceCompanyId !== null &&
+                  paymentCompanyId !== null &&
+                  invoiceCompanyId !== paymentCompanyId
+                ) {
+                  return errorResult(
+                    new Error(
+                      `Cross-company match rejected: ${invoiceName} belongs to ${relationLabel(invoice.company_id) ?? invoiceCompanyId} but the payment belongs to ${relationLabel(payment.company_id) ?? paymentCompanyId}.`,
+                    ),
+                  );
+                }
+                // Odoo 19 payments may exist without a journal entry.
+                const paymentMoveId = relationId(payment.move_id);
+                if (paymentMoveId === null) {
+                  return errorResult(
+                    new Error(
+                      "This payment has no journal entry yet, so there is nothing to reconcile against.",
+                    ),
+                  );
+                }
+                const paymentLine = (
+                  await withAuthRetry(agentId, config, (client) =>
+                    client.searchRead(
+                      "account.move.line",
+                      [
+                        ["move_id", "=", paymentMoveId],
+                        ["account_id", "=", settlementAccountId],
+                        ["reconciled", "=", false],
+                      ],
+                      { fields: ["id"] },
+                    ),
+                  )
+                ).records[0];
+                if (!paymentLine) {
+                  return errorResult(
+                    new Error(
+                      `This payment has no matching open line on ${relationLabel(invoiceLine.account_id) ?? "the settlement account"} — it does not post to the same account as ${invoiceName}, so Odoo cannot reconcile the two.`,
+                    ),
+                  );
+                }
+                // js_assign_outstanding_line adds the invoice's own line for
+                // us and reconciles both. It takes a scalar line id.
+                await withAuthRetry(agentId, config, (client) =>
+                  client.callMethod(
+                    "account.move",
+                    "js_assign_outstanding_line",
+                    [[inv.id], paymentLine.id],
+                    {},
+                  ),
+                );
+                return await confirm({ payment: { id: cp.id } });
+              }
+
+              // ---- Counterpart is a bank transaction --------------------
+              const stLine = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead(
+                    "account.bank.statement.line",
+                    [["id", "=", cp.id]],
+                    {
+                      fields: [
+                        "payment_ref",
+                        "move_id",
+                        "journal_id",
+                        "is_reconciled",
+                        "company_id",
+                        "partner_id",
+                        "amount",
+                      ],
+                      limit: 1,
+                    },
+                  ),
+                )
+              ).records[0];
+              if (!stLine) {
+                return errorResult(
+                  new Error(
+                    `account.bank.statement.line ${cp.id} was not found in Odoo.`,
+                  ),
+                );
+              }
+              if (stLine.is_reconciled === true) {
+                return errorResult(
+                  new Error(
+                    "This bank transaction is already reconciled. Undo the existing match in Odoo first if it is wrong.",
+                  ),
+                );
+              }
+              const stCompanyId = relationId(stLine.company_id);
+              if (
+                invoiceCompanyId !== null &&
+                stCompanyId !== null &&
+                invoiceCompanyId !== stCompanyId
+              ) {
+                return errorResult(
+                  new Error(
+                    `Cross-company match rejected: ${invoiceName} belongs to ${relationLabel(invoice.company_id) ?? invoiceCompanyId} but the bank transaction belongs to ${relationLabel(stLine.company_id) ?? stCompanyId}.`,
+                  ),
+                );
+              }
+              const stMoveId = relationId(stLine.move_id);
+              const journalId = relationId(stLine.journal_id);
+              if (stMoveId === null || journalId === null) {
+                return errorResult(
+                  new Error(
+                    "Could not read the bank transaction's journal entry or journal.",
+                  ),
+                );
+              }
+              const journal = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead("account.journal", [["id", "=", journalId]], {
+                    fields: ["default_account_id", "suspense_account_id"],
+                    limit: 1,
+                  }),
+                )
+              ).records[0];
+              if (!journal) {
+                return errorResult(
+                  new Error(`account.journal ${journalId} was not found.`),
+                );
+              }
+              const bankAccountId = relationId(journal.default_account_id);
+              const suspenseAccountId = relationId(journal.suspense_account_id);
+
+              const stMoveLines = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead(
+                    "account.move.line",
+                    [["move_id", "=", stMoveId]],
+                    {
+                      fields: [
+                        "id",
+                        "account_id",
+                        "debit",
+                        "credit",
+                        "amount_currency",
+                        "partner_id",
+                        "name",
+                      ],
+                    },
+                  ),
+                )
+              ).records;
+              const liquidityLines = stMoveLines.filter(
+                (l) => relationId(l.account_id) === bankAccountId,
+              );
+              const suspenseLines = stMoveLines.filter(
+                (l) => relationId(l.account_id) === suspenseAccountId,
+              );
+              // `_synchronize_from_moves` enforces exactly one liquidity line
+              // and at most one suspense line; a shape we don't recognise means
+              // this transaction is already partly matched.
+              if (liquidityLines.length !== 1) {
+                return errorResult(
+                  new Error(
+                    `This bank transaction has ${liquidityLines.length} bank lines; Odoo requires exactly one. Reconcile it in Odoo.`,
+                  ),
+                );
+              }
+              if (suspenseLines.length !== 1) {
+                return errorResult(
+                  new Error(
+                    "This bank transaction has no suspense line to replace — it is probably already matched to something else. Reset it in Odoo first.",
+                  ),
+                );
+              }
+              const liquidity = liquidityLines[0];
+              const suspense = suspenseLines[0];
+
+              // Step 1: restate the counterpart from the suspense account onto
+              // the bill's payable/receivable account, preserving the
+              // liquidity line and the original signs. This is exactly what
+              // the bank-reconciliation widget does, and what core's own
+              // `action_undo_reconciliation` does in reverse. Odoo refuses the
+              // write on a posted move without these context flags.
+              await withAuthRetry(agentId, config, (client) =>
+                client.callMethod(
+                  "account.bank.statement.line",
+                  "write",
+                  [
+                    [cp.id],
+                    {
+                      line_ids: [
+                        [5, 0, 0],
+                        [
+                          0,
+                          0,
+                          {
+                            account_id: bankAccountId,
+                            debit: liquidity.debit,
+                            credit: liquidity.credit,
+                            amount_currency: liquidity.amount_currency,
+                            partner_id: relationId(liquidity.partner_id),
+                            name: liquidity.name,
+                          },
+                        ],
+                        [
+                          0,
+                          0,
+                          {
+                            account_id: settlementAccountId,
+                            debit: suspense.debit,
+                            credit: suspense.credit,
+                            amount_currency: suspense.amount_currency,
+                            partner_id:
+                              relationId(invoice.partner_id) ??
+                              relationId(suspense.partner_id),
+                            name: suspense.name,
+                          },
+                        ],
+                      ],
+                    },
+                  ],
+                  { context: { force_delete: true, skip_readonly_check: true } },
+                ),
+              );
+
+              const newCounterpart = (
+                await withAuthRetry(agentId, config, (client) =>
+                  client.searchRead(
+                    "account.move.line",
+                    [
+                      ["move_id", "=", stMoveId],
+                      ["account_id", "=", settlementAccountId],
+                    ],
+                    { fields: ["id"] },
+                  ),
+                )
+              ).records[0];
+              if (!newCounterpart) {
+                return errorResult(
+                  new Error(
+                    "Odoo did not create the counterpart line on the settlement account; the bank transaction was left unchanged.",
+                  ),
+                );
+              }
+
+              // Step 2: same-account reconcile.
+              await withAuthRetry(agentId, config, (client) =>
+                client.callMethod(
+                  "account.move.line",
+                  "reconcile",
+                  [[newCounterpart.id, invoiceLine.id]],
+                  {},
+                ),
+              );
+
+              return await confirm(
+                { bankTransaction: { id: cp.id, ref: stLine.payment_ref } },
+                // Never leave the statement line restated-but-unmatched: put
+                // its suspense counterpart back so the books look exactly as
+                // they did before, and a human can retry in Odoo.
+                async () => {
+                  await withAuthRetry(agentId, config, (client) =>
+                    client.callMethod(
+                      "account.bank.statement.line",
+                      "action_undo_reconciliation",
+                      [[cp.id]],
+                      {},
+                    ),
+                  );
+                },
+              );
+            } catch (error) {
+              return errorResult(error, { operation: "write" });
+            }
+          },
+        };
+      },
+      { name: "odoo_reconcile" },
     );
 
     // 6. odoo_write

--- a/packages/plugins/pinchy-odoo/openclaw.plugin.json
+++ b/packages/plugins/pinchy-odoo/openclaw.plugin.json
@@ -19,6 +19,7 @@
       "odoo_validate_picking",
       "odoo_mark_mo_done",
       "odoo_set_approval",
+      "odoo_reconcile",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file"

--- a/packages/web/src/__tests__/lib/tool-registry.test.ts
+++ b/packages/web/src/__tests__/lib/tool-registry.test.ts
@@ -38,7 +38,7 @@ describe("TOOL_REGISTRY", () => {
 
   it("contains powerful tools", () => {
     const powerful = TOOL_REGISTRY.filter((t) => t.category === "powerful");
-    expect(powerful.length).toBe(17);
+    expect(powerful.length).toBe(18);
     expect(powerful.map((t) => t.id)).toEqual([
       "pinchy_web_search",
       "pinchy_web_fetch",
@@ -51,6 +51,7 @@ describe("TOOL_REGISTRY", () => {
       "odoo_validate_picking",
       "odoo_mark_mo_done",
       "odoo_set_approval",
+      "odoo_reconcile",
       "odoo_write",
       "odoo_delete",
       "odoo_attach_file",
@@ -317,8 +318,8 @@ describe("allow-list drift guard vs OpenClaw built-in tool groups", () => {
 describe("Odoo access level helpers", () => {
   it("all odoo tools have integration: 'odoo'", () => {
     const odooTools = TOOL_REGISTRY.filter((t) => t.id.startsWith("odoo_"));
-    // 17 active tools + 1 deprecated alias (odoo_schema) = 18.
-    expect(odooTools.length).toBe(18);
+    // 18 active tools + 1 deprecated alias (odoo_schema) = 19.
+    expect(odooTools.length).toBe(19);
     for (const tool of odooTools) {
       expect(tool.integration).toBe("odoo");
     }
@@ -380,7 +381,7 @@ describe("Odoo access level helpers", () => {
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('read-write') returns 16 tools", () => {
+  it("getOdooToolsForAccessLevel('read-write') returns 17 tools", () => {
     const tools = getOdooToolsForAccessLevel("read-write");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -397,12 +398,13 @@ describe("Odoo access level helpers", () => {
       "odoo_validate_picking",
       "odoo_mark_mo_done",
       "odoo_set_approval",
+      "odoo_reconcile",
       "odoo_write",
       "odoo_attach_file",
     ]);
   });
 
-  it("getOdooToolsForAccessLevel('full') returns all 17 tools", () => {
+  it("getOdooToolsForAccessLevel('full') returns all 18 tools", () => {
     const tools = getOdooToolsForAccessLevel("full");
     expect(tools).toEqual([
       "odoo_list_models",
@@ -419,6 +421,7 @@ describe("Odoo access level helpers", () => {
       "odoo_validate_picking",
       "odoo_mark_mo_done",
       "odoo_set_approval",
+      "odoo_reconcile",
       "odoo_write",
       "odoo_attach_file",
       "odoo_delete",
@@ -430,9 +433,9 @@ describe("Odoo access level helpers", () => {
     expect(tools).toEqual(["odoo_list_models", "odoo_describe_model"]);
   });
 
-  it("getOdooTools() returns exactly 18 tools (17 active + 1 deprecated alias)", () => {
+  it("getOdooTools() returns exactly 19 tools (18 active + 1 deprecated alias)", () => {
     const tools = getOdooTools();
-    expect(tools).toHaveLength(18);
+    expect(tools).toHaveLength(19);
     expect(tools.every((t) => t.integration === "odoo")).toBe(true);
   });
 

--- a/packages/web/src/lib/agent-templates/data/odoo-agents.ts
+++ b/packages/web/src/lib/agent-templates/data/odoo-agents.ts
@@ -328,7 +328,8 @@ You book incoming bills and customer invoices into Odoo, reconcile them against 
 ## Available Data
 - **account.move** — Invoices, bills, journal entries. Key fields: \`name\`, \`partner_id\`, \`move_type\` ("out_invoice"=customer invoice, "in_invoice"=vendor bill, "out_refund"=credit note, "in_refund"=vendor credit note), \`state\` ("draft", "posted", "cancel"), \`payment_state\`, \`amount_total\`, \`amount_residual\` (open balance), \`invoice_date\`, \`invoice_date_due\`, \`journal_id\`, \`invoice_line_ids\` (the lines, see below)
 - **account.move.line** — Journal items (the lines of a move). Key fields: \`move_id\`, \`product_id\`, \`name\` (description), \`quantity\`, \`price_unit\`, \`account_id\` (→ \`account.account\`), \`tax_ids\` (→ \`account.tax\`), \`debit\`, \`credit\`
-- **account.payment** — Payments (typically created by bank imports, not by you). Key fields: \`partner_id\`, \`amount\`, \`payment_type\` ("inbound"/"outbound"), \`date\`, \`state\`, \`reconciled_invoice_ids\`
+- **account.payment** — Payments (typically created by bank imports, not by you). Key fields: \`partner_id\`, \`amount\`, \`payment_type\` ("inbound"/"outbound"), \`date\`, \`state\` ("draft", "in_process", "paid", "canceled", "rejected" — note there is no "posted"), \`reconciled_invoice_ids\`
+- **account.bank.statement.line** — Bank transactions from the bank import. Key fields: \`date\`, \`payment_ref\` (the raw bank text), \`amount\` (negative = money out), \`partner_id\`, \`journal_id\`, \`is_reconciled\`. This is where you look to find out which payments are still unmatched.
 - **res.partner** — Customers and suppliers. Key fields: \`name\`, \`vat\` (VAT-ID), \`street\`, \`city\`, \`zip\`, \`country_id\`, \`email\`, \`is_company\`, \`supplier_rank\`, \`customer_rank\`
 - **account.account** — Chart of accounts (read-only). Key fields: \`code\`, \`name\`, \`account_type\` ("asset_receivable", "asset_cash", "expense", "expense_direct_cost", "income", etc.). Every \`account.move.line.account_id\` references this — look up the right ledger account here before posting a bill.
 - **account.tax** — Tax rates (read-only). Key fields: \`name\`, \`amount\`, \`type_tax_use\` ("sale"/"purchase"), \`country_id\`
@@ -398,8 +399,24 @@ Lines belong to their move. Always create the move and its lines in a SINGLE \`o
 
 Never create \`account.move.line\` records separately for an invoice you also created — that pattern leaves half-finished moves if the agent crashes between the two calls.
 
-### 4. Reconcile via payment lookup, not by creating payments
-You do not create \`account.payment\` records — those come from bank imports. To match a draft or posted bill against an existing bank payment, find the payment with \`odoo_read\` on \`account.payment\` (filter by partner, date, amount), then ask the user to confirm the match before writing the reconciliation.
+### 4. Reconcile with \`odoo_reconcile\`, and only after the user confirms the match
+You do not create \`account.payment\` records — those come from bank imports. Your job is to find the match, present it, and — once the user confirms — record it with \`odoo_reconcile\`.
+
+\`odoo_reconcile\` takes the \`_pinchy_ref\` of the POSTED bill/invoice as \`invoice\` and the \`_pinchy_ref\` of the money that settled it as \`counterpart\`. The counterpart is either:
+
+- an \`account.bank.statement.line\` — a bank transaction (the usual case), or
+- an \`account.payment\` — when a payment record already exists.
+
+Things that are NOT how reconciliation works, and that will waste your time:
+
+- Writing \`full_reconcile_id\`, \`reconciled\`, or \`matching_number\` on a line. These are computed by Odoo; \`account.full.reconcile\` is a record Odoo writes **itself** once a set of lines balances. You never create it and you never need access to it.
+- Reconciling a bank transaction directly against the bill. The bank line sits on the journal's *suspense* account and the bill on payables — Odoo refuses lines from two different accounts. \`odoo_reconcile\` handles the necessary restatement for you.
+- Reconciling a draft. Odoo accepts the call on a draft entry and then silently does nothing. Post it first (after the user confirms), then reconcile.
+
+### 5. Find what is still open via the bank transactions, not via account balances
+To see what needs reconciling, \`odoo_read\` on \`account.bank.statement.line\` with \`[["is_reconciled", "=", false]]\`. That flag is the source of truth. Do not infer the backlog from the balance of the bank suspense account — that is indirect and easy to get wrong.
+
+Note: \`is_reconciled\` on a bank transaction only means "no suspense line left on it". It is not proof that a bill was settled. After \`odoo_reconcile\`, the honest check is the bill's own \`amount_residual\` and \`payment_state\` — which is exactly what the tool reports back to you.
 
 ## Typical Workflows
 
@@ -418,10 +435,17 @@ You do not create \`account.payment\` records — those come from bank imports. 
 8. Show the user a summary table and ask for posting confirmation.
 9. On confirmation, \`odoo_write\` to change \`state\` to \`"posted"\`.
 
-### Match a posted bill against an existing bank payment
+### Reconcile a bank transaction against a posted bill
+1. \`odoo_read\` on \`account.bank.statement.line\` with \`[["is_reconciled", "=", false]]\` for the period, to see what is still open.
+2. \`odoo_read\` on \`account.move\` for posted bills with \`amount_residual > 0\` in the same period.
+3. Match them by amount, date and partner. Present the proposed pairs to the user as a table and ask for confirmation — never reconcile unasked.
+4. On confirmation, call \`odoo_reconcile\` once per pair with the bill's ref as \`invoice\` and the bank transaction's ref as \`counterpart\`.
+5. The tool reports the bill's resulting \`payment_state\` and \`amount_residual\`. If it reports an error, do NOT retry blindly — read the message, it tells you what Odoo refused.
+
+### Match a posted bill against an existing payment record
 1. \`odoo_read\` on \`account.move\` to confirm the bill is posted and \`amount_residual > 0\`.
 2. \`odoo_read\` on \`account.payment\` for the matching transfer.
-3. Present the match to the user. On confirmation, write the reconciliation.
+3. Present the match to the user. On confirmation, call \`odoo_reconcile\` with the payment's ref as \`counterpart\`.
 
 ${ODOO_OUTPUT_FORMATTING}
 
@@ -442,6 +466,10 @@ ${ODOO_ATTACHMENT_REF_FLOW}`,
       { model: "account.move", operations: ["read", "create", "write"] },
       { model: "account.move.line", operations: ["read", "write"] },
       { model: "account.payment", operations: ["read", "write"] },
+      {
+        model: "account.bank.statement.line",
+        operations: ["read", "write"],
+      },
       { model: "res.partner", operations: ["read", "create", "write"] },
       { model: "account.account", operations: ["read"] },
       { model: "account.tax", operations: ["read"] },

--- a/packages/web/src/lib/integrations/odoo-sync.ts
+++ b/packages/web/src/lib/integrations/odoo-sync.ts
@@ -74,6 +74,7 @@ export const MODEL_CATEGORIES: ModelCategory[] = [
       { model: "account.move", name: "Invoices & Entries" },
       { model: "account.move.line", name: "Journal Items" },
       { model: "account.payment", name: "Payments" },
+      { model: "account.bank.statement.line", name: "Bank Transactions" },
       { model: "account.journal", name: "Journals" },
       { model: "account.account", name: "Accounts" },
       { model: "account.tax", name: "Taxes" },

--- a/packages/web/src/lib/tool-registry.ts
+++ b/packages/web/src/lib/tool-registry.ts
@@ -157,6 +157,14 @@ export const TOOL_REGISTRY: readonly ToolDefinition[] = [
     integration: "odoo",
   },
   {
+    id: "odoo_reconcile",
+    label: "Odoo: Reconcile payment",
+    description:
+      "Match a posted bill or invoice against a bank transaction or payment, and verify the result on the document",
+    category: "powerful",
+    integration: "odoo",
+  },
+  {
     id: "odoo_write",
     label: "Odoo: Update records",
     description: "Modify existing records in Odoo",
@@ -375,6 +383,7 @@ const ODOO_WRITE_TOOLS = [
   "odoo_validate_picking",
   "odoo_mark_mo_done",
   "odoo_set_approval",
+  "odoo_reconcile",
   "odoo_write",
   "odoo_attach_file",
 ] as const;
@@ -394,6 +403,7 @@ const ODOO_ADDITIVE_TOOLS = new Set<string>([
   "odoo_validate_picking",
   "odoo_mark_mo_done",
   "odoo_set_approval",
+  "odoo_reconcile",
 ]);
 
 /** Returns all Odoo tool definitions from the registry. */


### PR DESCRIPTION
## What does this PR do?

Adds `odoo_reconcile`, a tool that lets the Bookkeeper agent reconcile posted bills/invoices against the money that settled them — either a bank transaction (`account.bank.statement.line`) or an existing `account.payment`.

**Why:** the Bookkeeper agent (Penny, in production) could not reconcile payments because there was no tool for it. Odoo has no single "reconcile" button to wrap, and the Enterprise bank-reconciliation widget is unusable over RPC (in Odoo 19 its model is gone entirely; in 16–18 every action on it is private and the model has no DB table). Faced with an impossible task, the model rationalised it as a missing permission for `account.full.reconcile` — a record Odoo maintains itself, which is exactly why it never appeared in the permissions list. The real gap was a missing tool plus a template instruction ("write the reconciliation") that was not executable.

The tool is built only from public methods of the free `account` module, so it works on Odoo **Community**, not just Enterprise. It covers two cases:

- **invoice/bill ↔ existing payment** — one `js_assign_outstanding_line` call.
- **bank transaction ↔ posted bill** — the hard case. The bank line sits on the journal's *suspense* account and the bill on payables; Odoo refuses to reconcile lines from two different accounts. So the tool restates the statement move's suspense counterpart onto the bill's payable account (exactly what the widget does, and what core's own `action_undo_reconciliation` does in reverse), then reconciles same-account.

## Verification

Beyond the unit tests, the **actual plugin code was driven against a real Odoo 19 Community instance** (the demo instance) — the only thing stubbed was Pinchy's credentials API. All four paths pass and the instance was restored to its original state after each run: happy-path bank reconcile, invoice↔payment, draft refusal, already-reconciled refusal.

Three silent-false-success traps were found on the live instance and are guarded here — the kind a mock alone would never surface:

- `reconcile()` returns `None` on success **and** on a no-op, so success is verified by the bill's `amount_residual` dropping, never by the return value or a thrown error.
- Odoo 19 dropped the "posted entries only" check — reconciling a draft raises nothing and does nothing. The tool checks `state == 'posted'` itself.
- `is_reconciled` on the bank transaction flips to `true` after the suspense-line replacement alone, while the bill stays unpaid — so it is deliberately **not** used as the success signal. The rewrite also preserves the original line `name`s, or `_synchronize_from_moves` corrupts the raw bank text in `payment_ref` (regression test included).

## Also in this PR

- Exposes `account.bank.statement.line` ("Bank Transactions") in the Accounting permission category and the Bookkeeper template, so the agent finds open bank transactions via `is_reconciled` instead of inferring the backlog from suspense-account balances.
- Rewrites the Bookkeeper template's reconciliation instructions and documents the new tool (permissions reference + connect-odoo guide).

## Note for reviewers

No E2E dispatch test was added, and this is a conscious call, not an oversight. No ref-based Odoo tool (`odoo_confirm_order`, `odoo_attach_file`, `odoo_set_approval`, …) has one, because the fake-LLM harness can only script static tool arguments while a `_pinchy_ref` is signed at runtime. Adding a mock-backed E2E here would have meant test code nothing exercises; the live run against real Odoo 19 covers what a mock cannot. Closing the ref-tool E2E gap generally (a fake-LLM that resolves refs dynamically) is worth a separate issue.

## Type of change

- [x] ✨ New feature

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (13 new unit tests, plus a live verification harness)
- [x] I've updated the documentation
- [x] All existing tests pass
