### PR TITLE
fix(models): cap deepseek-v4-pro's effective context at 128K

### DIFF
--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -184,6 +184,21 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     expect(byId("deepseek-v4-flash")?.contextTokens).toBeUndefined();
   });
 
+  it("never sets a contextTokens cap above the native contextWindow", () => {
+    // The whole point of contextTokens is a budget *below* the native window,
+    // which OpenClaw budgets compaction against. A cap above contextWindow is
+    // nonsense OpenClaw would swallow silently, so guard every current and
+    // future cap in one place — a typo on the next capped model fails here.
+    // Widen off the `as const` literals so the optional field is visible (same
+    // satisfies-based widening as byId, no cast).
+    const models: readonly OllamaCloudModel[] = TOOL_CAPABLE_OLLAMA_CLOUD_MODELS;
+    for (const m of models) {
+      if (m.contextTokens !== undefined) {
+        expect(m.contextTokens).toBeLessThanOrEqual(m.contextWindow);
+      }
+    }
+  });
+
   it("every model declares vision and carries no dead capability fields", () => {
     for (const m of TOOL_CAPABLE_OLLAMA_CLOUD_MODELS) {
       expect(typeof m.vision).toBe("boolean");

--- a/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
+++ b/packages/web/src/__tests__/lib/ollama-cloud-models.test.ts
@@ -3,6 +3,7 @@ import {
   TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
   TOOL_CAPABLE_OLLAMA_CLOUD_MODEL_IDS,
   VISION_OLLAMA_CLOUD_MODEL_IDS,
+  type OllamaCloudModel,
 } from "@/lib/ollama-cloud-models";
 
 /**
@@ -21,7 +22,8 @@ import {
  *  - Tools were probed by offering a function schema and checking for a
  *    structured `tool_calls` response.
  */
-const byId = (id: string) => TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === id);
+const byId = (id: string): OllamaCloudModel | undefined =>
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.find((m) => m.id === id);
 
 describe("Ollama Cloud model catalog — empirically verified capabilities", () => {
   it("includes minimax-m3 with vision and reasoning", () => {
@@ -165,6 +167,21 @@ describe("Ollama Cloud model catalog — empirically verified capabilities", () 
     // see ollama-cloud-models.ts.
     expect(byId("deepseek-v4-pro")?.contextWindow).toBe(524288);
     expect(byId("deepseek-v4-flash")?.contextWindow).toBe(1048576);
+  });
+
+  it("caps deepseek-v4-pro's effective runtime context at 128K while keeping the native window honest", () => {
+    // Path B (2026-07-15 Piper incident): contextWindow stays the honest native
+    // size (512K, guarded above), and a separate contextTokens field carries
+    // Pinchy's policy cap. OpenClaw budgets compaction against contextTokens
+    // (< contextWindow, resolveContextWindowInfo source "modelsConfig"), so the
+    // model's long-context quality knee (~0.92 recall @128K → ~0.66 @512K) can't
+    // cause the silent confabulation the incident traced to context bloat past
+    // ~170K with compaction never firing. Only deepseek-v4-pro is capped —
+    // flash and every other model stay uncapped (no field at all).
+    const pro = byId("deepseek-v4-pro");
+    expect(pro?.contextWindow).toBe(524288);
+    expect(pro?.contextTokens).toBe(131072);
+    expect(byId("deepseek-v4-flash")?.contextTokens).toBeUndefined();
   });
 
   it("every model declares vision and carries no dead capability fields", () => {

--- a/packages/web/src/__tests__/lib/openclaw-config.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config.test.ts
@@ -2185,6 +2185,37 @@ describe("regenerateOpenClawConfig", () => {
     expect(ctx["nemotron-3-nano:30b"]).toBe(1048576);
   });
 
+  it("emits deepseek-v4-pro's context cap as contextTokens, and nothing for uncapped models", async () => {
+    // Path B (2026-07-15 Piper incident): contextWindow stays the honest native
+    // size and a separate contextTokens carries Pinchy's policy cap. OpenClaw
+    // reads models.providers.*.models[].contextTokens and budgets compaction
+    // against it (< contextWindow), so preemptive compaction fires well before
+    // the model's long-context quality knee instead of never. The field must be
+    // absent for uncapped models so the config doesn't imply a limit that the
+    // native window doesn't have.
+    mockedGetSetting.mockImplementation(async (key: string) => {
+      if (key === "ollama_cloud_api_key") return "sk-ollama-test";
+      return null;
+    });
+
+    await regenerateOpenClawConfig();
+
+    const written = mockedWriteFileSync.mock.calls[0][1] as string;
+    const config = JSON.parse(written);
+    const models = config.models.providers["ollama-cloud"].models as Array<{
+      id: string;
+      contextWindow: number;
+      contextTokens?: number;
+    }>;
+    const byId = Object.fromEntries(models.map((m) => [m.id, m]));
+
+    expect(byId["deepseek-v4-pro"].contextWindow).toBe(524288);
+    expect(byId["deepseek-v4-pro"].contextTokens).toBe(131072);
+    // Uncapped models must not carry the field at all.
+    expect(byId["deepseek-v4-flash"].contextTokens).toBeUndefined();
+    expect("contextTokens" in byId["deepseek-v4-flash"]).toBe(false);
+  });
+
   it("writes reasoning, input (vision), and cost fields for every Ollama Cloud model", async () => {
     // OpenClaw's ModelDefinitionConfig requires `reasoning`, `input`, and
     // `cost` alongside contextWindow/maxTokens/compat. Without these the

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -48,7 +48,12 @@ export interface OllamaCloudModel {
    * `models.providers.*.models[].contextTokens`, which the runtime budgets
    * compaction against (resolveContextWindowInfo, source "modelsConfig") while
    * contextWindow stays the honest native size. Set ONLY where a model's
-   * quality degrades well before its advertised window — see deepseek-v4-pro. */
+   * quality degrades well before its advertised window — see deepseek-v4-pro.
+   *
+   * NOTE: this is a *static budget cap* (config input) and is a different
+   * concept from the per-turn `context_tokens` / `contextTokens` in
+   * usage-per-turn.ts / db/schema.ts, which is the *measured* context size of a
+   * turn (#767 observability). Same word, opposite direction — don't conflate. */
   contextTokens?: number;
   /** Pinchy's max output tokens hint. Ollama doesn't publish this, so we use
    * the output-heavy value for Gemini Flash and a conservative 8192 elsewhere. */

--- a/packages/web/src/lib/ollama-cloud-models.ts
+++ b/packages/web/src/lib/ollama-cloud-models.ts
@@ -43,6 +43,13 @@ export interface OllamaCloudModel {
    * (i.e. `/api/show`), which wins over the library page when they disagree —
    * see the source-priority note in the file header. */
   contextWindow: number;
+  /** Optional Pinchy policy cap on the *effective* runtime context budget,
+   * below the native contextWindow. Emitted as OpenClaw's
+   * `models.providers.*.models[].contextTokens`, which the runtime budgets
+   * compaction against (resolveContextWindowInfo, source "modelsConfig") while
+   * contextWindow stays the honest native size. Set ONLY where a model's
+   * quality degrades well before its advertised window — see deepseek-v4-pro. */
+  contextTokens?: number;
   /** Pinchy's max output tokens hint. Ollama doesn't publish this, so we use
    * the output-heavy value for Gemini Flash and a conservative 8192 elsewhere. */
   maxTokens: number;
@@ -99,6 +106,14 @@ export const TOOL_CAPABLE_OLLAMA_CLOUD_MODELS = [
     // all 10 Odoo calls in the window had succeeded).
     id: "deepseek-v4-pro",
     contextWindow: 524288,
+    // Pinchy caps the effective runtime context at 128K. The 512K window above
+    // is the honest native size, but DeepSeek V4 Pro's long-context quality
+    // knees well before it (~0.92 recall @128K → ~0.66 @512K), and the
+    // 2026-07-15 Piper incident traced a confabulated Odoo "outage" to context
+    // bloat past ~170K with compaction never firing. Budgeting compaction
+    // against 128K instead of 512K makes OpenClaw's preemptive compaction fire
+    // in time. Cap only this model — its knee, not a global policy.
+    contextTokens: 131072,
     maxTokens: 8192,
     reasoning: true,
     vision: false,

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -19,7 +19,11 @@ import {
   EMAIL_OPERATION_DISPLAY_ORDER,
 } from "@/lib/tool-registry";
 import type { AgentPluginConfig } from "@/db/schema";
-import { TOOL_CAPABLE_OLLAMA_CLOUD_MODELS, OLLAMA_CLOUD_COST } from "@/lib/ollama-cloud-models";
+import {
+  TOOL_CAPABLE_OLLAMA_CLOUD_MODELS,
+  OLLAMA_CLOUD_COST,
+  type OllamaCloudModel,
+} from "@/lib/ollama-cloud-models";
 import { getModelCatalogForProvider } from "@/lib/openclaw-builtin-models";
 import {
   getOpenClawWorkspacePath,
@@ -1215,10 +1219,15 @@ export async function regenerateOpenClawConfig() {
       // ModelDefinitionConfig. Cost is zero because Ollama Cloud bills by
       // subscription plan, not per token — a fabricated rate would mislead
       // users reading the Usage dashboard.
-      models: TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m) => ({
+      models: TOOL_CAPABLE_OLLAMA_CLOUD_MODELS.map((m: OllamaCloudModel) => ({
         id: m.id,
         name: m.id,
         contextWindow: m.contextWindow,
+        // Pinchy policy cap on the effective runtime context budget, emitted
+        // only where a model sets one. OpenClaw budgets compaction against
+        // contextTokens (< contextWindow) so long-context quality knees don't
+        // cause silent confabulation. See ollama-cloud-models.ts (deepseek-v4-pro).
+        ...(m.contextTokens !== undefined ? { contextTokens: m.contextTokens } : {}),
         maxTokens: m.maxTokens,
         reasoning: m.reasoning,
         input: m.vision ? ["text", "image"] : ["text"],


### PR DESCRIPTION
## Why

The 2026-07-15 **Piper incident** traced a confabulated Odoo "outage" to context bloat past ~170K on `deepseek-v4-pro`, where OpenClaw's preemptive compaction never fired. [#765](https://github.com/heypinchy/pinchy/pull/765) corrected the model's native window to its honest **512K**, but DeepSeek V4 Pro's long-context quality knees well before that (~0.92 recall @128K → ~0.66 @512K) — so 512K is the wrong budget to run compaction against.

## What (Path B — fact vs. policy, kept separate)

- `contextWindow` stays the **honest native size** (the fact #765 corrected).
- A new optional `contextTokens: 131072` carries **Pinchy's policy cap** — a distinct concept, not an overwrite of the fact.

It's emitted as OpenClaw's `models.providers.*.models[].contextTokens`, which `resolveContextWindowInfo` budgets compaction against (`source: "modelsConfig"`) while leaving `contextWindow` untouched. This is a first-class OpenClaw feature — verified against the 2026.7.1 runtime and its Zod schema (*"Use this when runtime should budget below the native contextWindow"*).

**Per-model on purpose:** the knee is DeepSeek's, not a global policy. `agents.defaults.contextTokens` would also cap Claude — the wrong lever. Only `deepseek-v4-pro` is capped; every other model stays uncapped (no field at all).

## Effect

OpenClaw now budgets compaction against 128K instead of 512K, so preemptive compaction fires in time instead of never — closing the failure mode behind the incident. Observability for verifying this in practice landed in [#767](https://github.com/heypinchy/pinchy/pull/767) (`context_tokens` per-turn column).

## Tests (TDD)

- `ollama-cloud-models.test.ts` — pins the catalog: `deepseek-v4-pro` has `contextWindow: 524288` **and** `contextTokens: 131072`; `deepseek-v4-flash` has no cap.
- `openclaw-config.test.ts` — asserts the emitted config carries `contextTokens` for `deepseek-v4-pro` and **omits the field entirely** for uncapped models.

Gates: `pnpm -C packages/web test` (full suite), `typecheck` (incl. tests), `lint` (0 errors), Prettier — all green. No DB/schema changes.