### PR TITLE
fix(openclaw-config): strip MEMORY.md from group-session bootstrap (#369)

### DIFF
--- a/.claude/skills/update-openclaw/SKILL.md
+++ b/.claude/skills/update-openclaw/SKILL.md
@@ -55,6 +55,17 @@ version between current and target first.
    Packaging", and any breaking/migration language anywhere else. **Watch
    especially for new gateway-startup / config self-healing behavior** — these
    don't show up in `pnpm test`/`tsc` at all and only fail in the docker E2Es.
+   **The `agent:bootstrap` hook contract is one of these silent dependencies.**
+   `config/pinchy-hooks/bootstrap-memory-group-filter/` (the #369 leak fix)
+   assumes the event carries `context.bootstrapFiles` (array) and
+   `context.sessionKey` (string), that reassigning `context.bootstrapFiles` is
+   read back by the caller, and that internal hooks load via native `import()`.
+   If the notes touch bootstrap/hook events, session-key shape, or the internal
+   hook loader, verify against the installed dist that these still hold — the
+   hook now `console.warn`s instead of failing open, so also check the gateway
+   logs on the staging deploy for that warning. A silent contract change here
+   re-opens a P0 `eu-ai-act` memory leak. See the hook's `HOOK.md` Verification
+   section for the exact staging check.
    Real example the 2026.6.11 bump tripped: OpenClaw 2026.6.x added startup
    config auto-restore — on a size-drop / missing-meta vs last-known-good it
    restores `openclaw.json.last-good` over `openclaw.json` at gateway start
@@ -162,9 +173,13 @@ version between current and target first.
    ```bash
    pnpm install
    pnpm -C packages/web vitest run src/__tests__/lib/openclaw-version-pin-drift.test.ts
+   node --test config/__tests__/bootstrap-memory-group-filter.test.mjs  # #369 hook contract
    pnpm test
    pnpm build
    ```
+   Note: the hook test above proves the filter logic, not that OpenClaw still
+   fires the hook. If the notes touched bootstrap/hook/session-key behavior,
+   run the HOOK.md staging check before shipping.
 
 7. **Don't commit automatically.** Report the diff (`git status --short`,
    `git diff --stat`) and let the user decide to commit/PR — this touches a

--- a/Dockerfile.openclaw
+++ b/Dockerfile.openclaw
@@ -194,6 +194,16 @@ COPY --from=builder /opt/pinchy-email-deps /opt/pinchy-email-deps
 COPY --from=builder /opt/llama-cpp-deps /opt/llama-cpp-deps
 COPY --from=builder /opt/embedding-models /opt/embedding-models
 
+# Pinchy-shipped OpenClaw internal-hook packages, loaded via the generated
+# config's hooks.internal.load.extraDirs = ["/opt/pinchy-hooks"] (see build.ts).
+# /opt (image, never volume-mounted) so it can't be shadowed by the persisted
+# ~/.openclaw config volume across upgrades — same reasoning as the bundles
+# above. Currently one hook: bootstrap-memory-group-filter, which keeps a shared
+# agent's MEMORY.md out of channel group sessions (heypinchy/pinchy#369; upstream
+# openclaw/openclaw#108881). Plain .mjs — internal hooks load via native
+# import(), not the jiti path plugins use, so no transpile/deps step is needed.
+COPY config/pinchy-hooks /opt/pinchy-hooks
+
 # Pre-warm the bundled-plugin runtime-deps cache. Rationale and full
 # behaviour live in config/prewarm-openclaw.sh; in short: boot the
 # gateway once at build time so the npm install of ~15 plugin runtime

--- a/config/__tests__/bootstrap-memory-group-filter.test.mjs
+++ b/config/__tests__/bootstrap-memory-group-filter.test.mjs
@@ -1,6 +1,19 @@
 import { test } from "node:test";
 import assert from "node:assert/strict";
 
+/** Runs `fn` with console.warn captured; returns the array of warning arg-lists. */
+async function captureWarnings(fn) {
+  const warnings = [];
+  const original = console.warn;
+  console.warn = (...args) => warnings.push(args);
+  try {
+    await fn();
+  } finally {
+    console.warn = original;
+  }
+  return warnings;
+}
+
 import {
   isGroupSessionKey,
   filterGroupBootstrap,
@@ -93,9 +106,57 @@ test("hook handler: leaves a DM session bootstrap untouched", async () => {
   );
 });
 
-test("hook handler: tolerates a non-bootstrap event shape", async () => {
-  // Not an agent:bootstrap event (no bootstrapFiles array) — must no-op, not throw.
-  await bootstrapMemoryGroupFilterHook({ context: { sessionKey: GROUP_KEY } });
-  await bootstrapMemoryGroupFilterHook({});
-  await bootstrapMemoryGroupFilterHook(undefined);
+test("hook handler: normal group/DM events run silently (no contract warning)", async () => {
+  const groupWarnings = await captureWarnings(() =>
+    bootstrapMemoryGroupFilterHook({
+      context: {
+        sessionKey: GROUP_KEY,
+        bootstrapFiles: [file("AGENTS.md"), file("MEMORY.md")],
+      },
+    }),
+  );
+  const dmWarnings = await captureWarnings(() =>
+    bootstrapMemoryGroupFilterHook({
+      context: { sessionKey: DM_KEY, bootstrapFiles: [file("MEMORY.md")] },
+    }),
+  );
+  assert.deepEqual(groupWarnings, []);
+  assert.deepEqual(dmWarnings, []);
+});
+
+test("hook handler: warns instead of failing open when bootstrapFiles is missing", async () => {
+  // We're wired to agent:bootstrap only, so a missing bootstrapFiles array means
+  // the OpenClaw event contract changed. A silent no-op would re-open #369, so the
+  // handler must surface the anomaly loudly — and still not throw.
+  const warnings = await captureWarnings(() =>
+    bootstrapMemoryGroupFilterHook({ context: { sessionKey: GROUP_KEY } }),
+  );
+  assert.equal(warnings.length, 1);
+  assert.match(String(warnings[0][0]), /bootstrap-memory-group-filter/);
+});
+
+test("hook handler: warns when sessionKey is missing (cannot classify session)", async () => {
+  // Without a sessionKey we cannot tell a group from a DM, so we must not filter —
+  // but a real bootstrap event always carries one, so its absence is a contract
+  // anomaly that must warn rather than silently skip the filter.
+  const files = [file("AGENTS.md"), file("MEMORY.md")];
+  const event = { context: { bootstrapFiles: files } };
+  const warnings = await captureWarnings(() =>
+    bootstrapMemoryGroupFilterHook(event),
+  );
+  assert.equal(warnings.length, 1);
+  // Files are left untouched — we cannot safely decide to strip without the key.
+  assert.deepEqual(
+    event.context.bootstrapFiles.map((f) => f.name),
+    ["AGENTS.md", "MEMORY.md"],
+  );
+});
+
+test("hook handler: stays silent and no-throws on context-less events", async () => {
+  const warnings = await captureWarnings(async () => {
+    await bootstrapMemoryGroupFilterHook({});
+    await bootstrapMemoryGroupFilterHook(undefined);
+    await bootstrapMemoryGroupFilterHook({ context: null });
+  });
+  assert.deepEqual(warnings, []);
 });

--- a/config/__tests__/bootstrap-memory-group-filter.test.mjs
+++ b/config/__tests__/bootstrap-memory-group-filter.test.mjs
@@ -1,0 +1,101 @@
+import { test } from "node:test";
+import assert from "node:assert/strict";
+
+import {
+  isGroupSessionKey,
+  filterGroupBootstrap,
+  default as bootstrapMemoryGroupFilterHook,
+} from "../pinchy-hooks/bootstrap-memory-group-filter/handler.mjs";
+
+/**
+ * The hook exists to stop OpenClaw's automatic bootstrap push from injecting a
+ * shared agent's `MEMORY.md` into a Telegram GROUP session, where members —
+ * who may not even be Pinchy users — would receive knowledge the agent
+ * persisted from another user's private DM. See heypinchy/pinchy#369 and the
+ * upstream root cause openclaw/openclaw#108881 (filterBootstrapFilesForSession
+ * special-cases subagent + cron but not channel-group sessions).
+ *
+ * DM sessions MUST keep MEMORY.md — the push is correct there. So the whole
+ * behaviour is session-key conditional, which is why it lives in a bootstrap
+ * hook and not in file layout or per-agent config.
+ */
+
+const file = (name) => ({ name, path: `/root/.openclaw/workspaces/a/${name}` });
+
+// Real key shapes observed in production `agent:<id>:sessions` on 2026-07-15.
+const GROUP_KEY = "agent:025449c8:telegram:group:-1001234567890";
+const DM_KEY = "agent:025449c8:direct:th38ydxfpysofk6sxqyx7ptj3ev4iqib";
+const DM_SUB_KEY =
+  "agent:025449c8:direct:th38ydxfpysofk6sxqyx7ptj3ev4iqib:982dac45";
+const CRON_KEY = "agent:025449c8:cron:a7006f53:run:1f2e";
+const SUBAGENT_KEY = "agent:025449c8:subagent:xyz";
+
+test("isGroupSessionKey: true only for a channel group session", () => {
+  assert.equal(isGroupSessionKey(GROUP_KEY), true);
+  assert.equal(isGroupSessionKey(DM_KEY), false);
+  assert.equal(isGroupSessionKey(DM_SUB_KEY), false);
+  assert.equal(isGroupSessionKey(CRON_KEY), false);
+  assert.equal(isGroupSessionKey(SUBAGENT_KEY), false);
+  assert.equal(isGroupSessionKey(undefined), false);
+  assert.equal(isGroupSessionKey(""), false);
+});
+
+test("filterGroupBootstrap: strips MEMORY.md for a group session", () => {
+  const files = [file("AGENTS.md"), file("MEMORY.md"), file("SOUL.md")];
+  const out = filterGroupBootstrap(files, GROUP_KEY);
+  assert.deepEqual(
+    out.map((f) => f.name),
+    ["AGENTS.md", "SOUL.md"],
+  );
+});
+
+test("filterGroupBootstrap: keeps MEMORY.md for a DM session", () => {
+  const files = [file("AGENTS.md"), file("MEMORY.md")];
+  const out = filterGroupBootstrap(files, DM_KEY);
+  assert.deepEqual(
+    out.map((f) => f.name),
+    ["AGENTS.md", "MEMORY.md"],
+  );
+});
+
+test("filterGroupBootstrap: group session with no MEMORY.md is unchanged", () => {
+  const files = [file("AGENTS.md"), file("SOUL.md")];
+  const out = filterGroupBootstrap(files, GROUP_KEY);
+  assert.deepEqual(
+    out.map((f) => f.name),
+    ["AGENTS.md", "SOUL.md"],
+  );
+});
+
+test("hook handler: reassigns event.context.bootstrapFiles for a group session", async () => {
+  const event = {
+    context: {
+      sessionKey: GROUP_KEY,
+      bootstrapFiles: [file("AGENTS.md"), file("MEMORY.md")],
+    },
+  };
+  await bootstrapMemoryGroupFilterHook(event);
+  assert.deepEqual(
+    event.context.bootstrapFiles.map((f) => f.name),
+    ["AGENTS.md"],
+  );
+});
+
+test("hook handler: leaves a DM session bootstrap untouched", async () => {
+  const original = [file("AGENTS.md"), file("MEMORY.md")];
+  const event = {
+    context: { sessionKey: DM_KEY, bootstrapFiles: original },
+  };
+  await bootstrapMemoryGroupFilterHook(event);
+  assert.deepEqual(
+    event.context.bootstrapFiles.map((f) => f.name),
+    ["AGENTS.md", "MEMORY.md"],
+  );
+});
+
+test("hook handler: tolerates a non-bootstrap event shape", async () => {
+  // Not an agent:bootstrap event (no bootstrapFiles array) — must no-op, not throw.
+  await bootstrapMemoryGroupFilterHook({ context: { sessionKey: GROUP_KEY } });
+  await bootstrapMemoryGroupFilterHook({});
+  await bootstrapMemoryGroupFilterHook(undefined);
+});

--- a/config/pinchy-hooks/bootstrap-memory-group-filter/HOOK.md
+++ b/config/pinchy-hooks/bootstrap-memory-group-filter/HOOK.md
@@ -1,0 +1,47 @@
+---
+name: bootstrap-memory-group-filter
+description: "Strip MEMORY.md from bootstrap for channel group sessions so a shared agent's per-user memory is never pushed into a group."
+homepage: https://github.com/heypinchy/pinchy/issues/369
+metadata:
+  {
+    "openclaw":
+      {
+        "emoji": "🦞",
+        "events": ["agent:bootstrap"],
+      },
+  }
+---
+
+# Bootstrap Memory Group Filter Hook
+
+Pinchy-shipped `agent:bootstrap` hook. Removes `MEMORY.md` from the bootstrap
+file set when the session is a channel **group** session
+(`agent:<id>:<channel>:group:<peer>`), leaving DM, cron, and subagent sessions
+untouched.
+
+## Why
+
+OpenClaw pushes workspace bootstrap files into every non-subagent/non-cron
+session. A shared agent's `MEMORY.md` accumulates knowledge persisted from
+individual users' private DM conversations, so injecting it into a group session
+discloses one user's memory to everyone in the group. See
+[heypinchy/pinchy#369](https://github.com/heypinchy/pinchy/issues/369).
+
+## Relationship to the upstream fix
+
+The durable fix belongs in OpenClaw core:
+`filterBootstrapFilesForSession` already narrows the set for subagent and cron
+sessions but not channel-group sessions —
+[openclaw/openclaw#108881](https://github.com/openclaw/openclaw/issues/108881).
+**Delete this hook once that upstream fix ships.**
+
+## Scope
+
+Stops the automatic per-message bootstrap push only. It does not stop a group
+member from deliberately eliciting memory via the agent's `pinchy_read` /
+`memory_search` tools — that residual belongs to the per-user-memory work.
+
+## Activation
+
+Loaded via `hooks.internal.load.extraDirs` pointing at `/opt/pinchy-hooks`,
+emitted by Pinchy's `regenerateOpenClawConfig()`. No per-session configuration.

--- a/config/pinchy-hooks/bootstrap-memory-group-filter/HOOK.md
+++ b/config/pinchy-hooks/bootstrap-memory-group-filter/HOOK.md
@@ -45,3 +45,29 @@ member from deliberately eliciting memory via the agent's `pinchy_read` /
 
 Loaded via `hooks.internal.load.extraDirs` pointing at `/opt/pinchy-hooks`,
 emitted by Pinchy's `regenerateOpenClawConfig()`. No per-session configuration.
+
+## Verification (deploy gate)
+
+The unit tests (`config/__tests__/bootstrap-memory-group-filter.test.mjs`)
+prove the filter logic, but they cannot prove OpenClaw actually **loads and
+fires** this hook — that depends on the runtime event contract, which no unit
+harness exercises. Treat the following as an explicit merge/deploy gate on any
+deploy that ships this hook or bumps OpenClaw:
+
+1. **Registration** — after the gateway starts, confirm the hook loaded without
+   error (no parse/registration error in the OpenClaw logs for
+   `bootstrap-memory-group-filter`).
+2. **Contract intact** — grep the gateway logs for
+   `[bootstrap-memory-group-filter]`. This handler fails **loud, not open**: it
+   only warns when an `agent:bootstrap` event lacks `bootstrapFiles[]` or a
+   string `sessionKey`. Any such warning means OpenClaw changed the event
+   contract and the filter is no longer running — investigate before trusting
+   the mitigation.
+3. **Behaviour** — in a Telegram **group** session against a shared agent whose
+   `MEMORY.md` is non-empty, confirm the bootstrap set delivered to that session
+   contains no `MEMORY.md`, while a **DM** session with the same agent still
+   receives it.
+
+Because the mitigation fails open if the contract silently changes, the
+`update-openclaw` skill lists this hook's contract as a runtime dependency to
+re-verify on every OpenClaw bump.

--- a/config/pinchy-hooks/bootstrap-memory-group-filter/handler.mjs
+++ b/config/pinchy-hooks/bootstrap-memory-group-filter/handler.mjs
@@ -1,0 +1,83 @@
+// @ts-check
+//
+// OpenClaw `agent:bootstrap` hook — strips MEMORY.md from the bootstrap set for
+// channel GROUP sessions.
+//
+// Why this exists
+// ---------------
+// OpenClaw pushes a workspace's bootstrap files (AGENTS.md, SOUL.md, MEMORY.md,
+// …) into every non-subagent/non-cron session. For a SHARED agent, MEMORY.md
+// accumulates knowledge persisted from individual users' private DM sessions.
+// A Telegram GROUP session (`agent:<id>:<channel>:group:<peer>`) receiving that
+// file discloses one user's memory to everyone in the group — who may not be
+// Pinchy users at all. See heypinchy/pinchy#369.
+//
+// The durable fix belongs upstream: OpenClaw's filterBootstrapFilesForSession
+// already narrows the set for subagent + cron sessions but not channel-group
+// sessions (openclaw/openclaw#108881). This hook is Pinchy's immediate,
+// self-hosted mitigation and should be DELETED once that upstream fix ships.
+//
+// Scope (be honest about it): this stops the AUTOMATIC per-message bootstrap
+// push only. It does not stop a group member from deliberately eliciting memory
+// via the agent's pinchy_read / memory_search tools — that residual belongs to
+// the per-user-memory work, not here.
+//
+// Why .mjs and not .ts: OpenClaw loads plugin entries through jiti (TS-capable)
+// but loads INTERNAL HOOKS through native `import()` (see the loader's
+// buildImportUrl → pathToFileURL, no transpile step). A .ts handler would fail
+// to import. The bundled OpenClaw hooks are .js for the same reason.
+//
+// Why reassignment is safe here: the internal-hook loader registers this
+// handler DIRECTLY (registerInternalHook), so `event.context` is the same
+// object the caller (applyBootstrapHookOverrides) reads `bootstrapFiles` back
+// from. The plugin `api.on` path wraps handlers in a spread-copied context
+// where reassignment would be lost — this hook is deliberately NOT on that path.
+
+const MEMORY_BOOTSTRAP_FILENAME = "MEMORY.md";
+
+/**
+ * A channel GROUP session key. Session keys are colon-delimited; group sessions
+ * carry a `group` kind segment at index 3 (`agent:<id>:<channel>:group:<peer>`),
+ * distinguishing them from `direct` DMs, `cron`, and `subagent` sessions.
+ *
+ * @param {unknown} sessionKey
+ * @returns {boolean}
+ */
+export function isGroupSessionKey(sessionKey) {
+  if (typeof sessionKey !== "string" || sessionKey.length === 0) return false;
+  const parts = sessionKey.split(":");
+  return parts[0] === "agent" && parts.length >= 5 && parts[3] === "group";
+}
+
+/**
+ * Returns the bootstrap file list with MEMORY.md removed IFF this is a group
+ * session. Non-group sessions (DM, cron, subagent) are returned unchanged so
+ * the normal memory push keeps working. Returns a new array when it filters;
+ * never mutates the input.
+ *
+ * @template {{ name?: string }} F
+ * @param {F[]} files
+ * @param {unknown} sessionKey
+ * @returns {F[]}
+ */
+export function filterGroupBootstrap(files, sessionKey) {
+  if (!Array.isArray(files)) return files;
+  if (!isGroupSessionKey(sessionKey)) return files;
+  return files.filter((f) => f?.name !== MEMORY_BOOTSTRAP_FILENAME);
+}
+
+/**
+ * `agent:bootstrap` hook entry point. Mutates the event's bootstrap set in
+ * place (by reassignment) so the caller sees the filtered list. No-ops for any
+ * event that isn't a bootstrap event carrying a bootstrapFiles array.
+ *
+ * @param {any} event
+ */
+export default async function bootstrapMemoryGroupFilterHook(event) {
+  const context = event?.context;
+  if (!context || !Array.isArray(context.bootstrapFiles)) return;
+  context.bootstrapFiles = filterGroupBootstrap(
+    context.bootstrapFiles,
+    context.sessionKey,
+  );
+}

--- a/config/pinchy-hooks/bootstrap-memory-group-filter/handler.mjs
+++ b/config/pinchy-hooks/bootstrap-memory-group-filter/handler.mjs
@@ -68,14 +68,36 @@ export function filterGroupBootstrap(files, sessionKey) {
 
 /**
  * `agent:bootstrap` hook entry point. Mutates the event's bootstrap set in
- * place (by reassignment) so the caller sees the filtered list. No-ops for any
- * event that isn't a bootstrap event carrying a bootstrapFiles array.
+ * place (by reassignment) so the caller sees the filtered list.
+ *
+ * This is a data-disclosure mitigation, so it must FAIL LOUD, not fail open.
+ * The handler is only ever wired to `agent:bootstrap`, so once an event carries
+ * a `context` object it MUST also carry a `bootstrapFiles` array and a string
+ * `sessionKey`. If either is absent, OpenClaw changed the event contract out
+ * from under us — a silent no-op there would re-open the MEMORY.md leak (#369)
+ * with no signal, so we `console.warn` (OpenClaw surfaces hook stdout/stderr)
+ * instead. Context-less/degenerate shapes stay silent — they are not a routed
+ * bootstrap event.
  *
  * @param {any} event
  */
 export default async function bootstrapMemoryGroupFilterHook(event) {
   const context = event?.context;
-  if (!context || !Array.isArray(context.bootstrapFiles)) return;
+  if (!context || typeof context !== "object") return;
+
+  if (
+    !Array.isArray(context.bootstrapFiles) ||
+    typeof context.sessionKey !== "string"
+  ) {
+    console.warn(
+      "[bootstrap-memory-group-filter] agent:bootstrap event was missing " +
+        "bootstrapFiles[] or a string sessionKey; the MEMORY.md group filter " +
+        "did NOT run. The OpenClaw event contract may have changed — verify " +
+        "and update this hook (heypinchy/pinchy#369).",
+    );
+    return;
+  }
+
   context.bootstrapFiles = filterGroupBootstrap(
     context.bootstrapFiles,
     context.sessionKey,

--- a/packages/web/src/__tests__/lib/openclaw-config-hooks.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-hooks.test.ts
@@ -133,4 +133,27 @@ describe("openclaw config: internal hooks for the memory group filter", () => {
     expect(config.hooks.internal.load.extraDirs).toContain("/opt/pinchy-hooks");
     expect(config.hooks.internal.load.extraDirs).toContain("/somewhere/else");
   });
+
+  it("does not duplicate /opt/pinchy-hooks when it is already present", async () => {
+    // A repeated regenerate reads back its own previous output, so the merge
+    // must stay idempotent — no growing extraDirs list across restarts.
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        ...gatewayConfig,
+        hooks: {
+          internal: {
+            enabled: true,
+            load: { extraDirs: ["/opt/pinchy-hooks", "/somewhere/else"] },
+          },
+        },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+    const config = writtenConfig();
+
+    const dirs: string[] = config.hooks.internal.load.extraDirs;
+    expect(dirs.filter((d) => d === "/opt/pinchy-hooks")).toHaveLength(1);
+    expect(dirs).toContain("/somewhere/else");
+  });
 });

--- a/packages/web/src/__tests__/lib/openclaw-config-hooks.test.ts
+++ b/packages/web/src/__tests__/lib/openclaw-config-hooks.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("fs", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("fs")>();
+  const writeFileSyncMock = vi.fn();
+  const readFileSyncMock = vi.fn();
+  const existsSyncMock = vi.fn().mockReturnValue(true);
+  const mkdirSyncMock = vi.fn();
+  const renameSyncMock = vi.fn();
+  const chmodSyncMock = vi.fn();
+  return {
+    ...actual,
+    default: {
+      ...actual,
+      writeFileSync: writeFileSyncMock,
+      readFileSync: readFileSyncMock,
+      existsSync: existsSyncMock,
+      mkdirSync: mkdirSyncMock,
+      renameSync: renameSyncMock,
+      chmodSync: chmodSyncMock,
+    },
+    writeFileSync: writeFileSyncMock,
+    readFileSync: readFileSyncMock,
+    existsSync: existsSyncMock,
+    mkdirSync: mkdirSyncMock,
+    renameSync: renameSyncMock,
+    chmodSync: chmodSyncMock,
+  };
+});
+
+vi.mock("@/db", () => ({
+  db: {
+    select: vi.fn().mockImplementation(() => ({
+      from: vi.fn().mockImplementation(() =>
+        Object.assign(Promise.resolve([]), {
+          innerJoin: vi.fn().mockReturnValue(
+            Object.assign(Promise.resolve([]), {
+              where: vi.fn().mockResolvedValue([]),
+            })
+          ),
+          where: vi.fn().mockResolvedValue([]),
+        })
+      ),
+    })),
+  },
+}));
+
+vi.mock("@/lib/settings", () => ({
+  getSetting: vi.fn().mockResolvedValue(null),
+  getSettingsByPrefix: vi.fn().mockResolvedValue(new Map()),
+  setSetting: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/encryption", () => ({
+  decrypt: (val: string) => val,
+  encrypt: (val: string) => val,
+  getOrCreateSecret: vi.fn().mockReturnValue(Buffer.alloc(32)),
+}));
+
+vi.mock("@/server/restart-state", () => ({
+  restartState: { notifyRestart: vi.fn() },
+}));
+
+vi.mock("@/lib/migrate-onboarding", () => ({
+  migrateExistingSmithers: vi.fn().mockResolvedValue(undefined),
+}));
+
+vi.mock("@/lib/openclaw-secrets", async (importOriginal) => {
+  const actual = await importOriginal<typeof import("@/lib/openclaw-secrets")>();
+  return {
+    ...actual,
+    writeSecretsFile: vi.fn(),
+    readSecretsFile: vi.fn().mockReturnValue({}),
+  };
+});
+
+vi.mock("@/lib/provider-models", () => ({
+  getDefaultModel: vi.fn(async () => ""),
+}));
+
+import { writeFileSync, readFileSync, existsSync } from "fs";
+import { regenerateOpenClawConfig } from "@/lib/openclaw-config";
+
+const mockedWriteFileSync = vi.mocked(writeFileSync);
+const mockedReadFileSync = vi.mocked(readFileSync);
+const mockedExistsSync = vi.mocked(existsSync);
+
+const gatewayConfig = {
+  gateway: { mode: "local", bind: "lan", auth: { token: "gw-token-123" } },
+};
+
+function writtenConfig() {
+  const written = mockedWriteFileSync.mock.calls[0][1] as string;
+  return JSON.parse(written);
+}
+
+describe("openclaw config: internal hooks for the memory group filter", () => {
+  beforeEach(() => {
+    vi.clearAllMocks();
+    mockedExistsSync.mockReturnValue(true);
+    mockedReadFileSync.mockReturnValue(JSON.stringify(gatewayConfig));
+  });
+
+  it("enables internal hooks and loads the /opt/pinchy-hooks dir", async () => {
+    await regenerateOpenClawConfig();
+    const config = writtenConfig();
+
+    expect(config.hooks?.internal?.enabled).toBe(true);
+    expect(config.hooks?.internal?.load?.extraDirs).toContain("/opt/pinchy-hooks");
+  });
+
+  it("preserves OpenClaw-enriched hooks fields across a regenerate", async () => {
+    mockedReadFileSync.mockReturnValue(
+      JSON.stringify({
+        ...gatewayConfig,
+        hooks: {
+          internal: {
+            entries: { "some-other-hook": { enabled: true } },
+            load: { extraDirs: ["/somewhere/else"] },
+          },
+        },
+      })
+    );
+
+    await regenerateOpenClawConfig();
+    const config = writtenConfig();
+
+    // Pinchy owns enabled + its own extraDir, but must not drop sibling state.
+    expect(config.hooks.internal.enabled).toBe(true);
+    expect(config.hooks.internal.entries?.["some-other-hook"]).toEqual({
+      enabled: true,
+    });
+    expect(config.hooks.internal.load.extraDirs).toContain("/opt/pinchy-hooks");
+    expect(config.hooks.internal.load.extraDirs).toContain("/somewhere/else");
+  });
+});

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -778,6 +778,11 @@ export async function regenerateOpenClawConfig() {
     // managed dir), because ~/.openclaw is a persisted volume that would shadow
     // anything the image bakes into it. extraDirs is deduped and merged with any
     // OpenClaw-enriched hooks state so a regenerate is idempotent and lossless.
+    //
+    // `enabled: true` is a deliberate OVERRIDE, not a merge: the #369 leak
+    // protection depends on the internal-hook loader being on, so Pinchy forces
+    // it back on every regenerate even if something set it to false. Sibling
+    // fields (entries, other load.* keys) are preserved via the spreads.
     hooks: {
       ...existingHooks,
       internal: {

--- a/packages/web/src/lib/openclaw-config/build.ts
+++ b/packages/web/src/lib/openclaw-config/build.ts
@@ -658,6 +658,12 @@ export async function regenerateOpenClawConfig() {
   const existingUpdate = (existing.update as Record<string, unknown>) || {};
   const existingCanvasHost = (existing.canvasHost as Record<string, unknown>) || {};
   const existingMedia = (existing.media as Record<string, unknown>) || {};
+  const existingHooks = (existing.hooks as Record<string, unknown>) || {};
+  const existingHooksInternal = (existingHooks.internal as Record<string, unknown>) || {};
+  const existingHooksInternalLoad = (existingHooksInternal.load as Record<string, unknown>) || {};
+  const existingHooksExtraDirs = Array.isArray(existingHooksInternalLoad.extraDirs)
+    ? (existingHooksInternalLoad.extraDirs as string[])
+    : [];
 
   // #508: identityLinks is no longer Pinchy-owned. Purge any stale value left by
   // a pre-per-task version so UPGRADES actually un-unify Telegram. We only
@@ -756,6 +762,32 @@ export async function regenerateOpenClawConfig() {
     session: {
       ...existingSessionPurged,
       reset: { mode: "idle" as const, idleMinutes: 525600 },
+    },
+    // Enable OpenClaw's internal-hook loader and point it at the hook package
+    // Pinchy ships in the OpenClaw image at /opt/pinchy-hooks. Today that dir
+    // holds one hook, bootstrap-memory-group-filter, which strips MEMORY.md
+    // from the bootstrap set for channel GROUP sessions so a shared agent's
+    // per-user memory is never pushed into a group (heypinchy/pinchy#369).
+    //
+    // Immediate mitigation for the upstream defect openclaw/openclaw#108881
+    // (filterBootstrapFilesForSession special-cases subagent + cron but not
+    // channel-group sessions). Remove this block — and the hook package — once
+    // that upstream fix ships.
+    //
+    // /opt (image, never volume-mounted) not /root/.openclaw/hooks (the default
+    // managed dir), because ~/.openclaw is a persisted volume that would shadow
+    // anything the image bakes into it. extraDirs is deduped and merged with any
+    // OpenClaw-enriched hooks state so a regenerate is idempotent and lossless.
+    hooks: {
+      ...existingHooks,
+      internal: {
+        ...existingHooksInternal,
+        enabled: true,
+        load: {
+          ...existingHooksInternalLoad,
+          extraDirs: Array.from(new Set([...existingHooksExtraDirs, "/opt/pinchy-hooks"])),
+        },
+      },
     },
   };
 


### PR DESCRIPTION
## What & why

Shared agents accumulate per-user knowledge in `MEMORY.md` from private DM sessions. OpenClaw pushes a workspace's bootstrap files (`MEMORY.md` included) into **every** non-subagent/non-cron session, so a Telegram **group** session receives one user's memory — disclosing it to everyone in the group, who may not even be Pinchy users. See #369 (P0, `eu-ai-act`).

The durable fix belongs upstream — OpenClaw's `filterBootstrapFilesForSession` already special-cases `subagent` + `cron` sessions but not channel-group sessions (openclaw/openclaw#108881). This PR is Pinchy's **immediate, self-hosted mitigation**, to be removed once that upstream fix ships.

This also unblocks #755 (decoupling memory from the `pinchy_write` grant, which takes memory from 3/10 to 10/10 agents): that change amplifies exactly this leak, so it was blocked on a group-bootstrap mitigation landing first.

## Approach

Ship an `agent:bootstrap` **hook package** in the OpenClaw image and have `regenerateOpenClawConfig()` load it:

- `config/pinchy-hooks/bootstrap-memory-group-filter/` — `HOOK.md` + `handler.mjs`. On `agent:bootstrap`, strips `MEMORY.md` from `context.bootstrapFiles` when the session key is a channel group key (`agent:<id>:<channel>:group:<peer>`). DM, cron, and subagent sessions are untouched, so the normal memory push keeps working.
- `build.ts` emits `hooks.internal.enabled: true` + `load.extraDirs: ["/opt/pinchy-hooks"]`, merged idempotently with any OpenClaw-enriched `hooks` state.
- `Dockerfile.openclaw` copies the hook package to `/opt/pinchy-hooks` (image, never volume-mounted, so `~/.openclaw` can't shadow it across upgrades).

### Why the shape is what it is

- **A Pinchy plugin can't do this.** `api.on(...)` rejects `agent:bootstrap` (not in `PLUGIN_HOOK_NAMES`). The internal-hook **directory loader** accepts it; that's the only reachable path.
- **`.mjs`, not `.ts`.** Plugin entries load via jiti (TS-capable); internal hooks load via native `import()` (no transpile). A `.ts` handler would fail to import — the bundled OpenClaw hooks are `.js` for the same reason.
- **Reassignment is safe here.** The directory loader registers the handler directly, so `event.context` is the object the caller reads back. (The plugin `api.on` path spread-copies the context, where reassignment would be lost — this hook is deliberately not on that path.)
- **`HOOK.md` frontmatter** uses the same `metadata` JSON-in-YAML block shape as the production-proven bundled `bootstrap-extra-files` hook, to avoid a silent frontmatter-parse failure. (Extra scalar keys like `homepage`/`description` are ignored by the YAML parser.)

## Scope / honest limitation

This stops the **automatic per-message bootstrap push** — the sharp, no-user-action leak. It does **not** stop a group member from deliberately eliciting memory via the agent's `pinchy_read` / `memory_search` tools in a group. That residual belongs to the per-user-memory work (#369 mitigation 2), still not settled and out of scope here.

## Tests

- `config/__tests__/bootstrap-memory-group-filter.test.mjs` (7, `pnpm test:scripts`) — group-key detection, `MEMORY.md` stripping for groups, DM/cron/subagent left intact, handler reassignment, tolerant of non-bootstrap event shapes.
- `packages/web/src/__tests__/lib/openclaw-config-hooks.test.ts` (2) — config emits `hooks.internal` + `/opt/pinchy-hooks`, and a regenerate preserves OpenClaw-enriched `hooks` siblings.
- Full `openclaw-config` suite green (394).

## Reviewer note — the one gap (now guarded)

No automated test proves OpenClaw actually **loads and fires** this hook end-to-end on a real group session (our unit harness can't boot a gateway with a group session). Two things now bound that residual risk:

- The handler **fails loud, not open**: it `console.warn`s (surfaced in gateway logs) when an `agent:bootstrap` event lacks `bootstrapFiles[]` or a string `sessionKey`, so a silent OpenClaw contract change can't re-open the leak undetected.
- The staging-deploy check is documented as an explicit **deploy gate** in the hook's `HOOK.md` (registration ok / no contract-warning / group gets no `MEMORY.md`, DM still does), and the `agent:bootstrap` contract is now listed in the `update-openclaw` skill as a runtime dependency to re-verify on every OpenClaw bump.

A follow-up integration test (real gateway boot asserting hook registration + a group session getting no `MEMORY.md`) would still close it durably.

Refs #369, #755, openclaw/openclaw#108881
