### PR TITLE
ci: enable merge queue (trigger on merge_group) to end the rebase treadmill

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,6 +12,18 @@ on:
     branches: [main]
   pull_request:
     branches: [main]
+  # Merge queue. GitHub tests each queued PR on a `gh-readonly-queue/main/...`
+  # merge ref (main + the PR, and speculatively + the entries ahead of it), so
+  # the required checks run against the exact post-merge state. This is what lets
+  # us drop "Require branches to be up to date" from branch protection: the queue
+  # provides the same freshness guarantee without every PR author hand-rebasing
+  # and burning a full CI run each time. Without this trigger the workflow never
+  # starts for a queued PR and the required checks never report — the queue would
+  # hang forever. The `changes` job below deliberately answers code=false for
+  # merge_group, so only the required checks (which are ungated) run on the merge
+  # ref; the heavy Docker/E2E matrix already ran on the PR and, being non-required,
+  # would not gate the queue anyway — it still runs post-merge on the main push.
+  merge_group:
   # Manual trigger: lets a maintainer re-run the full CI (incl. osv-scan) on a
   # ref on demand — e.g. to clear a stale red main after a docs-lockfile
   # security bump (osv-scan reads docs/pnpm-lock.yaml), which the `changes`
@@ -56,6 +68,19 @@ jobs:
           BASE_REF: ${{ github.base_ref }}
           BEFORE: ${{ github.event.before }}
         run: |
+          if [ "$EVENT_NAME" = "merge_group" ]; then
+            # In the merge queue, only the required checks (quality,
+            # vitest-integration, e2e) need to run on the merge ref — they are
+            # ungated and run regardless of this output. The heavy Docker/E2E
+            # matrix is gated on code, and we skip it here on purpose: it already
+            # ran on the PR, and being non-required it would not gate the queue
+            # anyway, so re-running it (×5 with speculative entries) would only
+            # burn minutes and slow the queue. It still runs post-merge on the
+            # main push. Hence code=false — "the gated matrix need not run".
+            echo "Merge queue — required checks only, skipping the gated matrix."
+            echo "code=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
           if [ "$EVENT_NAME" = "pull_request" ]; then
             BASE="origin/$BASE_REF"
           elif [ "$EVENT_NAME" = "push" ]; then

--- a/scripts/lib/ci-path-filter.test.mjs
+++ b/scripts/lib/ci-path-filter.test.mjs
@@ -23,7 +23,10 @@ test("a source change is a code change", () => {
 });
 
 test("docs-only, markdown-only and sample-data-only changes are not code changes", () => {
-  assert.equal(hasCodeChanges(["docs/src/content/docs/guides/agents.mdx"]), false);
+  assert.equal(
+    hasCodeChanges(["docs/src/content/docs/guides/agents.mdx"]),
+    false,
+  );
   assert.equal(hasCodeChanges(["README.md"]), false);
   assert.equal(hasCodeChanges(["PERSONALITY.md"]), false);
   assert.equal(hasCodeChanges(["packages/web/README.md"]), false);
@@ -33,7 +36,10 @@ test("docs-only, markdown-only and sample-data-only changes are not code changes
 });
 
 test("one code file among many docs files still makes it a code change", () => {
-  assert.equal(hasCodeChanges(["docs/a.mdx", "README.md", "packages/web/src/x.ts"]), true);
+  assert.equal(
+    hasCodeChanges(["docs/a.mdx", "README.md", "packages/web/src/x.ts"]),
+    true,
+  );
 });
 
 // A workflow edit changes CI itself — it must never skip the matrix that would
@@ -88,7 +94,27 @@ test("ci.yml has no paths-ignore — it must always start so required checks rep
     .join("\n");
   assert.ok(
     !/paths-ignore:/.test(uncommented),
-    "ci.yml must not use paths-ignore: it hosts required status checks, and a workflow that never starts blocks the PR forever. Gate individual jobs on the `changes` job instead."
+    "ci.yml must not use paths-ignore: it hosts required status checks, and a workflow that never starts blocks the PR forever. Gate individual jobs on the `changes` job instead.",
+  );
+});
+
+// The merge-queue counterpart of the paths-ignore guard above. main's required
+// checks live in this workflow, and the merge queue tests each entry on a
+// `gh-readonly-queue/...` merge ref via the `merge_group` event. Without that
+// trigger the workflow never starts for a queued PR, the required checks never
+// report on the merge ref, and the queue sits forever waiting for a status that
+// can't arrive — the same "stuck forever" failure mode, just one level up. If
+// the queue is ever abandoned, dropping the trigger is a deliberate act; this
+// guard makes it one.
+test("ci.yml triggers on merge_group so required checks report to the merge queue", () => {
+  const yaml = readFileSync(CI_WORKFLOW, "utf8");
+  const uncommented = yaml
+    .split("\n")
+    .map((line) => line.replace(/(^|\s)#.*$/, "$1"))
+    .join("\n");
+  assert.ok(
+    /^ {2}merge_group:/m.test(uncommented),
+    "ci.yml must list `merge_group:` under `on:` — without it the merge queue never gets a status from the required checks and every queued PR hangs indefinitely.",
   );
 });
 
@@ -101,17 +127,24 @@ test("every job listed as ungated really is ungated", () => {
   const jobs = splitWorkflowIntoJobs(CI_WORKFLOW);
   for (const [name, reason] of Object.entries(UNGATED_JOBS)) {
     const job = jobs.find((j) => j.jobName === name);
-    assert.ok(job, `ci.yml must define the job "${name}" listed in UNGATED_JOBS`);
+    assert.ok(
+      job,
+      `ci.yml must define the job "${name}" listed in UNGATED_JOBS`,
+    );
     assert.ok(
       !job.body.includes("needs.changes"),
-      `"${name}" is listed in UNGATED_JOBS (${reason}) but is gated on the changes job in ci.yml — either drop the gate or drop the listing`
+      `"${name}" is listed in UNGATED_JOBS (${reason}) but is gated on the changes job in ci.yml — either drop the gate or drop the listing`,
     );
   }
 });
 
 test("REQUIRED_JOBS is the branch-protection subset of UNGATED_JOBS", () => {
   for (const name of REQUIRED_JOBS) {
-    assert.equal(UNGATED_JOBS[name], "required", `"${name}" must be listed as required in UNGATED_JOBS`);
+    assert.equal(
+      UNGATED_JOBS[name],
+      "required",
+      `"${name}" must be listed as required in UNGATED_JOBS`,
+    );
   }
 });
 
@@ -127,7 +160,7 @@ test("every other job is gated on the changes job", () => {
   assert.deepEqual(
     offenders,
     [],
-    `these ci.yml jobs must be skipped on docs-only PRs — add \`needs: changes\` and \`if: ${GATE_EXPRESSION}\`: ${offenders.join(", ")}`
+    `these ci.yml jobs must be skipped on docs-only PRs — add \`needs: changes\` and \`if: ${GATE_EXPRESSION}\`: ${offenders.join(", ")}`,
   );
 });
 
@@ -137,16 +170,23 @@ test("every other job is gated on the changes job", () => {
 // fires if someone adds a --lockfile under an ignored path (e.g. a second docs
 // site) without teaching the filter about it.
 test("every lockfile vuln-scan reads counts as a code change", () => {
-  const vulnScan = splitWorkflowIntoJobs(CI_WORKFLOW).find((j) => j.jobName === "vuln-scan");
+  const vulnScan = splitWorkflowIntoJobs(CI_WORKFLOW).find(
+    (j) => j.jobName === "vuln-scan",
+  );
   assert.ok(vulnScan, "ci.yml must define the vuln-scan job");
 
-  const lockfiles = [...vulnScan.body.matchAll(/--lockfile=\.\/(\S+)/g)].map((m) => m[1]);
-  assert.ok(lockfiles.length > 0, "expected vuln-scan to scan at least one lockfile");
+  const lockfiles = [...vulnScan.body.matchAll(/--lockfile=\.\/(\S+)/g)].map(
+    (m) => m[1],
+  );
+  assert.ok(
+    lockfiles.length > 0,
+    "expected vuln-scan to scan at least one lockfile",
+  );
 
   const invisible = lockfiles.filter((path) => !hasCodeChanges([path]));
   assert.deepEqual(
     invisible,
     [],
-    `vuln-scan reads these lockfiles, but the filter treats them as docs — a security bump there would skip the scan: ${invisible.join(", ")}`
+    `vuln-scan reads these lockfiles, but the filter treats them as docs — a security bump there would skip the scan: ${invisible.join(", ")}`,
   );
 });


### PR DESCRIPTION
## Problem

Branch protection has `strict` ("Require branches to be up to date before merging") enabled, after a bug where CI passed on a branch that didn't have main's latest code. The side effect: every PR must be hand-rebased onto main before it can merge, each rebase triggers a full ~20-min CI run, and after the merge the next PR is stale again — an O(n²) treadmill that doesn't scale with our small-PR cadence.

## Fix: GitHub Merge Queue

The merge queue gives the same freshness guarantee `strict` did — it tests each entry on a `gh-readonly-queue/main/...` merge ref (main + the PR, and speculatively + entries ahead of it) — without any manual rebasing. Authors click "Merge when ready" once; the queue tests, merges, and re-tests the next entry automatically.

Repo-side settings (already applied out-of-band):
- Merge queue enabled for `main`, method **rebase**, strategy **ALLGREEN**, up to 5 speculative builds.
- `strict` **disabled** — the queue supersedes it.

## What this PR changes

- **`on: merge_group`** added to `ci.yml`, so the required checks report on the merge ref. Without it a queued PR hangs forever waiting for a status that never arrives.
- **`changes` job answers `code=false` for `merge_group`**, so only the required checks (`quality`, `vitest-integration`, `e2e` — all ungated) run on the merge ref. The heavy Docker/E2E matrix already ran on the PR and, being non-required, wouldn't gate the queue anyway; it still runs post-merge on the `main` push. This keeps the queue fast/cheap instead of re-running the full matrix ×5 on speculative entries.
- **Drift guard** in `ci-path-filter.test.mjs` pins the `merge_group` trigger — the merge-queue counterpart of the existing no-`paths-ignore` guard.

## Coverage story

| Stage | Checks |
|---|---|
| PR push | full matrix (unchanged) |
| Merge queue (`merge_group`) | the 3 required checks on `main + PR` — the stale-code guard |
| Post-merge (`push` to main) | full matrix on main (unchanged) |

## Note / possible follow-up

The queue only blocks on the **required** checks. If we want the heavy Docker/integration jobs to also protect the queue, the move is to add them to branch protection's required list *and* run them on `merge_group` — a deliberate cost/throughput tradeoff, out of scope here.

## Test

`pnpm test:scripts` — 286 pass, including the new merge_group drift guard.
