### PR TITLE
test(e2e): stabilize CI-load flakes in settings/permissions E2E (API sign-in in data-setup hooks + deep-link users tab)

### DIFF
--- a/packages/web/e2e/06-user-management.spec.ts
+++ b/packages/web/e2e/06-user-management.spec.ts
@@ -8,11 +8,19 @@ test.describe("User management", () => {
   });
 
   test("admin can navigate to settings and see users section", async ({ page }) => {
-    await page.goto("/settings");
-    // Navigate to Users tab (default tab is Context)
-    await page.getByRole("tab", { name: /users/i }).click();
-    // Settings page loads and shows Invite User button (admin-only feature)
-    await expect(page.getByRole("button", { name: "Invite User" })).toBeVisible({ timeout: 5000 });
+    // Deep-link straight to the Users tab instead of clicking it. The app
+    // renders the active tab from the `?tab=` param during SSR (see
+    // `useTabParam`'s `initialTab`), so the Users panel is active on first
+    // paint. Clicking the tab trigger before hydration silently drops the
+    // switch — the panel never activates and the (fetch-gated) Invite User
+    // button never appears within the budget. That lost-click race, stacked on
+    // the users fetch, was the CI-load flake here. The tab-click path itself
+    // stays covered by the next test, which clicks through to the dialog.
+    await page.goto("/settings?tab=users");
+    // The button lives behind SettingsUsers' `loading` gate, so it renders only
+    // after the users fetch resolves. Give that single round-trip the suite's
+    // standard 10s render budget — a cold-route JIT compile can eat into 5s.
+    await expect(page.getByRole("button", { name: "Invite User" })).toBeVisible({ timeout: 10000 });
   });
 
   test("admin can invite a new user and see the invite link", async ({ page }) => {

--- a/packages/web/e2e/09-groups.spec.ts
+++ b/packages/web/e2e/09-groups.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedProviderConfig,
+  apiSignInAsAdmin,
   loginAsAdmin,
   createSecondUserViaInvite,
   SECOND_USER,
@@ -9,17 +10,23 @@ import {
 test.describe.serial("Groups CRUD", () => {
   test.beforeAll(async ({ browser }) => {
     await seedProviderConfig();
-    const page = await browser.newPage();
-    await loginAsAdmin(page);
+
+    // Pure data-setup hook — only uses the request context, never the page UI.
+    // Authenticate over the API (not the UI `loginAsAdmin`, which waits up to
+    // 15 s for hydration) so the hook — which also warms three cold routes
+    // below — stays inside its 30 s budget under CI load. See `apiSignIn`.
+    const context = await browser.newContext();
+    const request = context.request;
+    await apiSignInAsAdmin(request);
 
     // Enable enterprise mode so group routes are accessible (idempotent: only toggle if not already enabled)
-    const status = await page.request.get("/api/enterprise/status");
+    const status = await request.get("/api/enterprise/status");
     const statusJson = await status.json();
     if (!statusJson.enterprise) {
-      await page.request.post("/api/dev/enterprise-toggle");
+      await request.post("/api/dev/enterprise-toggle");
     }
 
-    await createSecondUserViaInvite(page.context().request).catch(() => {
+    await createSecondUserViaInvite(request).catch(() => {
       // Idempotent: ignore if already created by an earlier spec
     });
 
@@ -37,19 +44,19 @@ test.describe.serial("Groups CRUD", () => {
     // still warms it — and nothing is created, so no stray group leaks into the
     // table assertions below.
     const MISSING_GROUP_ID = "00000000-0000-0000-0000-000000000000";
-    await page.request.patch(`/api/groups/${MISSING_GROUP_ID}`, {
+    await request.patch(`/api/groups/${MISSING_GROUP_ID}`, {
       data: { name: "__warmup__", description: null },
     });
-    await page.request.delete(`/api/groups/${MISSING_GROUP_ID}`);
+    await request.delete(`/api/groups/${MISSING_GROUP_ID}`);
     // /api/groups/[groupId]/members is a SEPARATE route module that compiles
     // independently — creating a group with a member fires its first PUT (seen
     // at next.js: 4.8s / application-code: 53ms), blowing the same 5s
     // dialog-close assertion. Warm it too; the 404 creates no membership.
-    await page.request.put(`/api/groups/${MISSING_GROUP_ID}/members`, {
+    await request.put(`/api/groups/${MISSING_GROUP_ID}/members`, {
       data: { userIds: [] },
     });
 
-    await page.close();
+    await context.close();
   });
 
   test.beforeEach(async ({ page }) => {

--- a/packages/web/e2e/10-agent-permissions.spec.ts
+++ b/packages/web/e2e/10-agent-permissions.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedProviderConfig,
+  apiSignInAsAdmin,
   loginAsAdmin,
   loginAs,
   switchUser,
@@ -15,21 +16,27 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
 
   test.beforeAll(async ({ browser }) => {
     await seedProviderConfig();
-    const page = await browser.newPage();
-    await loginAsAdmin(page);
+
+    // This hook is pure data setup — it only ever uses the request context,
+    // never the page UI. Authenticate over the API (not the UI `loginAsAdmin`,
+    // which navigates and waits up to 15 s for hydration) so the hook stays
+    // well inside its 30 s budget under CI load. See `apiSignInAsAdmin`.
+    const context = await browser.newContext();
+    const request = context.request;
+    await apiSignInAsAdmin(request);
 
     // Enable enterprise mode (same pattern as 09-groups.spec.ts)
-    const status = await page.request.get("/api/enterprise/status");
+    const status = await request.get("/api/enterprise/status");
     const { enterprise } = await status.json();
     if (!enterprise) {
-      await page.request.post("/api/dev/enterprise-toggle");
+      await request.post("/api/dev/enterprise-toggle");
     }
 
     // Create second user (idempotent: ignore if already exists)
-    await createSecondUserViaInvite(page.context().request).catch(() => {});
+    await createSecondUserViaInvite(request).catch(() => {});
 
     // Resolve second user's ID from the users list
-    const usersRes = await page.context().request.get("/api/users");
+    const usersRes = await request.get("/api/users");
     const { users } = await usersRes.json();
     const secondUser = users.find(
       (u: { email: string; id: string }) => u.email === SECOND_USER.email
@@ -38,7 +45,7 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
     secondUserId = secondUser.id;
 
     // Create a group with no members yet
-    const groupRes = await page.context().request.post("/api/groups", {
+    const groupRes = await request.post("/api/groups", {
       data: { name: "Restricted Group", description: null },
     });
     const groupData = await groupRes.json();
@@ -49,7 +56,7 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
 
     // Create an agent using the "custom" template (no extra config required).
     // Note: the DB default for visibility is "restricted", so we explicitly PATCH to "all" below.
-    const agentRes = await page.context().request.post("/api/agents", {
+    const agentRes = await request.post("/api/agents", {
       data: {
         name: "Permissions Test Agent",
         templateId: "custom",
@@ -63,7 +70,7 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
     agentId = agentData.id;
 
     // Set initial visibility to "all" so tests 1+2 can verify non-admin access
-    const patchRes = await page.context().request.patch(`/api/agents/${agentId}`, {
+    const patchRes = await request.patch(`/api/agents/${agentId}`, {
       data: { visibility: "all" },
     });
     if (!patchRes.ok()) {
@@ -72,7 +79,7 @@ test.describe.serial("Agent permissions — restricted visibility", () => {
       );
     }
 
-    await page.close();
+    await context.close();
   });
 
   test("admin sees the agent (visibility: all)", async ({ page }) => {

--- a/packages/web/e2e/12-audit-log.spec.ts
+++ b/packages/web/e2e/12-audit-log.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedProviderConfig,
+  apiSignInAsAdmin,
   loginAsAdmin,
   loginAs,
   createSecondUserViaInvite,
@@ -13,21 +14,27 @@ const AUDIT_TEST_GROUP = `AuditTestGroup-${Date.now()}`;
 test.describe.serial("Audit log", () => {
   test.beforeAll(async ({ browser }) => {
     await seedProviderConfig();
-    const page = await browser.newPage();
-    await loginAsAdmin(page);
+
+    // Pure data-setup hook — only uses the request context, never the page UI.
+    // Authenticate over the API (not the UI `loginAsAdmin`, which waits up to
+    // 15 s for hydration) so the hook stays inside its 30 s budget under CI
+    // load. See `apiSignIn`.
+    const context = await browser.newContext();
+    const request = context.request;
+    await apiSignInAsAdmin(request);
 
     // Enable enterprise mode so group routes are accessible (idempotent)
-    const status = await page.request.get("/api/enterprise/status");
+    const status = await request.get("/api/enterprise/status");
     const statusJson = await status.json();
     if (!statusJson.enterprise) {
-      await page.request.post("/api/dev/enterprise-toggle");
+      await request.post("/api/dev/enterprise-toggle");
     }
 
-    await createSecondUserViaInvite(page.context().request).catch(() => {
+    await createSecondUserViaInvite(request).catch(() => {
       // Idempotent: ignore if already created by an earlier spec
     });
 
-    await page.close();
+    await context.close();
   });
 
   test.beforeEach(async ({ page }) => {

--- a/packages/web/e2e/13-knowledge-base.spec.ts
+++ b/packages/web/e2e/13-knowledge-base.spec.ts
@@ -1,6 +1,7 @@
 import { test, expect } from "@playwright/test";
 import {
   seedProviderConfig,
+  apiSignInAsAdmin,
   loginAsAdmin,
   switchUser,
   createSecondUserViaInvite,
@@ -24,21 +25,27 @@ test.describe.serial("Knowledge base file editing", () => {
 
   test.beforeAll(async ({ browser }) => {
     await seedProviderConfig();
-    const page = await browser.newPage();
-    await loginAsAdmin(page);
+
+    // Pure data-setup hook — only uses the request context, never the page UI.
+    // Authenticate over the API (not the UI `loginAsAdmin`, which waits up to
+    // 15 s for hydration) so the hook stays inside its 30 s budget under CI
+    // load. See `apiSignIn`.
+    const context = await browser.newContext();
+    const request = context.request;
+    await apiSignInAsAdmin(request);
 
     // Create second user idempotently — ignore errors if already exists
-    await createSecondUserViaInvite(page.context().request).catch(() => {});
+    await createSecondUserViaInvite(request).catch(() => {});
 
     // Find the Smithers agent, or create a fresh one if it doesn't exist yet
-    const agentsRes = await page.context().request.get("/api/agents");
+    const agentsRes = await request.get("/api/agents");
     const agents: Array<{ id: string; name: string }> = await agentsRes.json();
     const smithers = agents.find((a) => /smithers/i.test(a.name));
 
     if (smithers) {
       agentId = smithers.id;
     } else {
-      const createRes = await page.context().request.post("/api/agents", {
+      const createRes = await request.post("/api/agents", {
         data: {
           name: "KB Test Agent",
           templateId: "custom",
@@ -54,7 +61,7 @@ test.describe.serial("Knowledge base file editing", () => {
       agentId = created.id;
     }
 
-    await page.close();
+    await context.close();
   });
 
   test.beforeEach(async ({ page }) => {

--- a/packages/web/e2e/14-agent-visibility.spec.ts
+++ b/packages/web/e2e/14-agent-visibility.spec.ts
@@ -1,8 +1,9 @@
 import { test, expect } from "@playwright/test";
 import {
   seedProviderConfig,
+  apiSignInAsAdmin,
+  apiSignIn,
   loginAsAdmin,
-  loginAs,
   switchUser,
   ADMIN_USER,
   createSecondUserViaInvite,
@@ -30,14 +31,19 @@ test.describe.serial("Agent visibility — personal vs shared", () => {
 
   test.beforeAll(async ({ browser }) => {
     await seedProviderConfig();
-    const page = await browser.newPage();
-    await loginAsAdmin(page);
+
+    // Pure data-setup hook — only uses request contexts, never the page UI.
+    // Authenticate over the API (not the UI logins, which each wait up to 15 s
+    // for hydration) so the hook — which signs in as two different users —
+    // stays inside its 30 s budget under CI load. See `apiSignIn`.
+    const adminContext = await browser.newContext();
+    await apiSignInAsAdmin(adminContext.request);
 
     // Create second user via invite (idempotent: catch if already exists)
-    await createSecondUserViaInvite(page.context().request).catch(() => {});
+    await createSecondUserViaInvite(adminContext.request).catch(() => {});
 
     // Resolve the admin's personal Smithers ID
-    const agentsRes = await page.context().request.get("/api/agents");
+    const agentsRes = await adminContext.request.get("/api/agents");
     expect(agentsRes.ok()).toBeTruthy();
     const adminAgents = await agentsRes.json();
     const adminSmithers = (
@@ -46,12 +52,12 @@ test.describe.serial("Agent visibility — personal vs shared", () => {
     if (!adminSmithers) throw new Error("Admin's personal Smithers not found in /api/agents");
     adminSmithersId = adminSmithers.id;
 
-    await page.close();
+    await adminContext.close();
 
-    // Log in as second user to resolve their personal Smithers ID
-    const secondPage = await browser.newPage();
-    await loginAs(secondPage, SECOND_USER.email, SECOND_USER.password);
-    const secondAgentsRes = await secondPage.context().request.get("/api/agents");
+    // Sign in as second user to resolve their personal Smithers ID
+    const secondContext = await browser.newContext();
+    await apiSignIn(secondContext.request, SECOND_USER.email, SECOND_USER.password);
+    const secondAgentsRes = await secondContext.request.get("/api/agents");
     expect(secondAgentsRes.ok()).toBeTruthy();
     const secondAgents = await secondAgentsRes.json();
     const secondSmithers = (
@@ -61,7 +67,7 @@ test.describe.serial("Agent visibility — personal vs shared", () => {
       throw new Error("Second user's personal Smithers not found in /api/agents");
     secondUserSmithersId = secondSmithers.id;
 
-    await secondPage.close();
+    await secondContext.close();
   });
 
   test("admin's personal agent is not visible to a different user", async ({ page }) => {

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -31,6 +31,32 @@ export async function loginAsAdmin(page: Page) {
   await expect(page).toHaveURL(/\/chat\//, { timeout: 15000 });
 }
 
+/**
+ * Authenticate an admin session directly against the auth API, no UI.
+ *
+ * Use this in data-setup hooks (`beforeAll`) that only ever touch
+ * `context.request` and never drive the page. The UI `loginAsAdmin` navigates
+ * to `/login` and waits up to 15 s for the `/chat/` redirect + hydration; that
+ * cost is pure waste in a hook that does nothing but API calls, and under CI
+ * load it can push the whole hook past its 30 s budget — at which point
+ * Playwright tears the context down and the next `browser.newPage()` /
+ * `context.request` call fails with "Target page, context or browser has been
+ * closed." Signing in over the API removes that variable-latency UI step
+ * entirely.
+ *
+ * The returned request context carries the admin session cookie for all
+ * subsequent state-changing calls.
+ */
+export async function apiSignInAsAdmin(request: APIRequestContext): Promise<void> {
+  const res = await request.post("/api/auth/sign-in/email", {
+    data: { email: ADMIN_USER.email, password: ADMIN_USER.password },
+    headers: { "Content-Type": "application/json" },
+  });
+  if (!res.ok()) {
+    throw new Error(`Admin API sign-in failed: ${res.status()} ${await res.text()}`);
+  }
+}
+
 export const SECOND_USER = {
   name: "Second User",
   email: "second@test.local",

--- a/packages/web/e2e/helpers.ts
+++ b/packages/web/e2e/helpers.ts
@@ -32,29 +32,36 @@ export async function loginAsAdmin(page: Page) {
 }
 
 /**
- * Authenticate an admin session directly against the auth API, no UI.
+ * Authenticate a session directly against the auth API, no UI.
  *
- * Use this in data-setup hooks (`beforeAll`) that only ever touch
- * `context.request` and never drive the page. The UI `loginAsAdmin` navigates
- * to `/login` and waits up to 15 s for the `/chat/` redirect + hydration; that
- * cost is pure waste in a hook that does nothing but API calls, and under CI
- * load it can push the whole hook past its 30 s budget — at which point
- * Playwright tears the context down and the next `browser.newPage()` /
- * `context.request` call fails with "Target page, context or browser has been
- * closed." Signing in over the API removes that variable-latency UI step
- * entirely.
+ * Use this (and `apiSignInAsAdmin`) in data-setup hooks (`beforeAll`) that only
+ * ever touch `context.request` and never drive the page. The UI logins
+ * (`loginAsAdmin` / `loginAs`) navigate to `/login` and wait up to 15 s for the
+ * post-login redirect + hydration; that cost is pure waste in a hook that does
+ * nothing but API calls, and under CI load it can push the whole hook past its
+ * 30 s budget — at which point Playwright tears the context down and the next
+ * `browser.newPage()` / `context.request` call fails with "Target page, context
+ * or browser has been closed." Signing in over the API removes that
+ * variable-latency UI step entirely.
  *
- * The returned request context carries the admin session cookie for all
- * subsequent state-changing calls.
+ * The `request` context carries the session cookie for all subsequent calls.
  */
-export async function apiSignInAsAdmin(request: APIRequestContext): Promise<void> {
+export async function apiSignIn(
+  request: APIRequestContext,
+  email: string,
+  password: string
+): Promise<void> {
   const res = await request.post("/api/auth/sign-in/email", {
-    data: { email: ADMIN_USER.email, password: ADMIN_USER.password },
+    data: { email, password },
     headers: { "Content-Type": "application/json" },
   });
   if (!res.ok()) {
-    throw new Error(`Admin API sign-in failed: ${res.status()} ${await res.text()}`);
+    throw new Error(`API sign-in failed for ${email}: ${res.status()} ${await res.text()}`);
   }
+}
+
+export async function apiSignInAsAdmin(request: APIRequestContext): Promise<void> {
+  await apiSignIn(request, ADMIN_USER.email, ADMIN_USER.password);
 }
 
 export const SECOND_USER = {
@@ -140,11 +147,5 @@ export async function switchUser(page: Page, email: string, password: string): P
   // Clear existing cookies so the Set-Cookie from sign-in becomes the only
   // session cookie in the jar.
   await page.context().clearCookies();
-  const res = await page.request.post("/api/auth/sign-in/email", {
-    data: { email, password },
-    headers: { "Content-Type": "application/json" },
-  });
-  if (!res.ok()) {
-    throw new Error(`switchUser failed: ${res.status()} ${await res.text()}`);
-  }
+  await apiSignIn(page.request, email, password);
 }


### PR DESCRIPTION
## What

Stabilize the CI-load flakes in the settings/permissions E2E area by removing two root causes, applied suite-wide:

1. **Data-setup `beforeAll` hooks drove a UI login they never use.** Specs **09, 10, 12, 13, 14** each did `browser.newPage()` + `loginAsAdmin` (navigate to `/login`, wait up to **15s** for the `/chat/` redirect + hydration) and then only ever touched `context.request` — pure data setup. Now each uses `browser.newContext()` + an API sign-in.
2. **A settings tab was activated by a click that races hydration** (`06-user-management`). Now it deep-links via `?tab=`.

`helpers.ts` gains a generic `apiSignIn(request, email, password)`; `apiSignInAsAdmin` and `switchUser` delegate to it (removing three copies of the same POST).

## Why — the `beforeAll` budget (specs 09/10/12/13/14)

These hooks are pure data setup — they only use `context.request` and never drive the page. But the UI login (`loginAsAdmin`/`loginAs`) navigates to `/login` and waits up to **15s** for the post-login redirect + hydration. Under CI load that variable-latency step stacks on the hook's real work and risks the **30s default hook budget**; when a hook overruns it, Playwright tears the context down and the next browser call surfaces as `browser.newPage()` → "Target page, context or browser has been closed". Two hooks are especially exposed: **09** also warms three cold routes (~5s each on first hit), and **14** signs in as *two* different users (2×15s of UI login alone). Removing the UI login cuts the single biggest, most variable cost. Determinism fix, **not** a timeout bump.

## Why — the settings render race (spec 06)

This branch's CI run turned up a sibling flake: `admin can navigate to settings and see users section` timed out finding the **Invite User** button within 5s. Two async gates stacked against that budget: the tab-trigger click can be **swallowed if it lands before React hydration** (panel never activates), and the button is gated behind `SettingsUsers`' `loading` state (appears only **after** the users fetch resolves). Under CI load (cold-route JIT compile) that overran 5s — a flake, not a bug: E2E is green across recent `main` runs, and the very next test (same navigation) passed in the *same* run.

Fix: deep-link to `/settings?tab=users`. `useTabParam` renders the active tab from the `?tab=` param during SSR, so the Users panel is active on first paint — no click to lose to hydration. The residual single fetch gets the suite's standard 10s render budget. The tab-click path stays covered by the next test, which clicks through to the invite dialog.

## Investigation notes for reviewers

- The originally-cited flake run (`29496621757`, PR #785) **passed** — 44/44 green.
- The recurring `[WebServer] ⨯ User already exists. Use another email.` lines are **benign** — the intentionally-idempotent `createSecondUserViaInvite(...).catch(() => {})` in `beforeAll`. With `retries: 0` there are no Playwright retries; not a failure.
- **Spec 11 is intentionally left unchanged** — it does not flake.
- `beforeEach` hooks and test bodies that genuinely drive the page UI are left untouched; only pure data-setup hooks were converted.

## Verification

Full standard e2e suite against an ephemeral `pgvector/pgvector:pg17-trixie` on 5433:

- **44 passed, 3 skipped** (the `workspace-fs` plugin probes, skipped in CI too).
- `tsc --noEmit` over the e2e sources clean; `prettier --check` clean; pre-commit hook green on each commit.
