### PR TITLE
fix(pinchy-odoo): actionable tool-arg errors so the model can self-correct

### DIFF
--- a/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
@@ -1,0 +1,262 @@
+// @vitest-environment node
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import type { AgentOdooConfig } from "../index";
+
+const mockSearchRead = vi.fn();
+const mockSearchCount = vi.fn();
+const mockReadGroup = vi.fn();
+const mockCreate = vi.fn();
+const mockWrite = vi.fn();
+const mockUnlink = vi.fn();
+const mockFields = vi.fn();
+const mockCallMethod = vi.fn();
+
+vi.mock("odoo-node", () => {
+  const MockOdooClient = vi.fn(function (this: Record<string, unknown>) {
+    this.searchRead = mockSearchRead;
+    this.searchCount = mockSearchCount;
+    this.readGroup = mockReadGroup;
+    this.create = mockCreate;
+    this.write = mockWrite;
+    this.unlink = mockUnlink;
+    this.fields = mockFields;
+    this.callMethod = mockCallMethod;
+  });
+  return { OdooClient: MockOdooClient };
+});
+
+vi.mock("../io", () => ({ readFile: vi.fn(), stat: vi.fn() }));
+
+import { hasItemWrappedArray } from "../index";
+import plugin from "../index";
+
+// Pattern B: the plugin lazily fetches credentials, so a stubbed endpoint is
+// required before any tool executes.
+const fetchMock = vi.fn(async () => ({
+  ok: true,
+  status: 200,
+  statusText: "OK",
+  json: async () => ({
+    type: "odoo",
+    credentials: {
+      url: "http://odoo-test:8069",
+      db: "testdb",
+      uid: 2,
+      apiKey: "test-api-key",
+    },
+  }),
+}));
+globalThis.fetch = fetchMock as unknown as typeof fetch;
+
+interface AgentTool {
+  name: string;
+  description: string;
+  parameters: Record<string, unknown>;
+  execute: (
+    id: string,
+    params: Record<string, unknown>,
+  ) => Promise<{
+    content: Array<{ type: string; text: string }>;
+    isError?: boolean;
+  }>;
+}
+
+function createApi(agentConfigs: Record<string, AgentOdooConfig> = {}) {
+  const tools: Array<{
+    factory: (ctx: { agentId?: string }) => AgentTool | null;
+    name: string;
+  }> = [];
+  const api = {
+    pluginConfig: {
+      apiBaseUrl: "http://pinchy-test:7777",
+      gatewayToken: "test-gateway-token",
+      agents: agentConfigs,
+    },
+    registerTool: (
+      factory: (ctx: { agentId?: string }) => AgentTool | null,
+      opts?: { name?: string },
+    ) => {
+      tools.push({ factory, name: opts?.name ?? "" });
+    },
+  };
+  plugin.register(api as never);
+  return tools;
+}
+
+function findTool(
+  tools: ReturnType<typeof createApi>,
+  name: string,
+  agentId?: string,
+): AgentTool | null {
+  const entry = tools.find((t) => t.name === name);
+  if (!entry) return null;
+  return entry.factory({ agentId });
+}
+
+const agentId = "agent-1";
+const CONN = "conn-test-1";
+
+const PERMS = {
+  "account.move": ["read", "create", "write"],
+  "res.partner": ["read", "create", "write"],
+};
+
+function cfg(): AgentOdooConfig {
+  return { connectionId: CONN, permissions: PERMS } as AgentOdooConfig;
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  vi.stubEnv("PINCHY_REF_TOKEN_KEY", "a".repeat(64));
+  mockFields.mockResolvedValue([]);
+});
+
+// ---------------------------------------------------------------------------
+// Unit: the pure detector for the {item: …} array-serialization artifact.
+// Certain models (e.g. ollama-cloud/deepseek-v4-pro) emit array tool-args
+// wrapped as single-key {item: …} objects, nested for nested arrays. Verified
+// against the real production trajectory (pinchy-bugreport-penny-20260716).
+// ---------------------------------------------------------------------------
+describe("hasItemWrappedArray", () => {
+  it("detects a single {item: …} wrapper", () => {
+    expect(hasItemWrappedArray({ item: [1, 2, 3] })).toBe(true);
+  });
+
+  it("detects nested {item:{item: …}} wrapping", () => {
+    expect(
+      hasItemWrappedArray({ tax_ids: { item: { item: ["6", "0", { item: "172" }] } } }),
+    ).toBe(true);
+  });
+
+  it("detects wrapping nested inside a real array", () => {
+    expect(hasItemWrappedArray([{ item: [1] }])).toBe(true);
+  });
+
+  it("passes a well-formed one2many command list", () => {
+    expect(
+      hasItemWrappedArray({ invoice_line_ids: [[0, 0, { account_id: 5, name: "x" }]] }),
+    ).toBe(false);
+  });
+
+  it("passes a well-formed many2many command list", () => {
+    expect(hasItemWrappedArray({ tax_ids: [[6, 0, [172]]] })).toBe(false);
+  });
+
+  it("does not flag a normal record whose fields are unrelated", () => {
+    expect(hasItemWrappedArray({ name: "Acme", ref: "INV/1", amount: 10 })).toBe(false);
+  });
+
+  it("does not flag a multi-key object that merely contains an 'item' key", () => {
+    expect(hasItemWrappedArray({ item: 3, quantity: 1 })).toBe(false);
+  });
+
+  it("is safe on primitives and empties", () => {
+    expect(hasItemWrappedArray(null)).toBe(false);
+    expect(hasItemWrappedArray("item")).toBe(false);
+    expect(hasItemWrappedArray([])).toBe(false);
+    expect(hasItemWrappedArray({})).toBe(false);
+  });
+});
+
+describe("odoo_create — {item: …} array-wrapping", () => {
+  it("refuses item-wrapped values with an actionable message, before touching Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_create", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      values: {
+        move_type: "in_invoice",
+        invoice_line_ids: { item: { item: ["0", "0", { account_id: "7600 Office supplies" }] } },
+      },
+    });
+
+    expect(result.isError).toBe(true);
+    // Names the artifact and shows the correct shape so the model can retry.
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(result.content[0].text).toMatch(/\[\[0, 0,/); // the correct o2m shape
+    // Must not have forwarded the garbage to Odoo.
+    expect(mockCreate).not.toHaveBeenCalled();
+    expect(mockFields).not.toHaveBeenCalled();
+  });
+
+  it("still creates normally when arrays are well-formed", async () => {
+    mockCreate.mockResolvedValue(42);
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_create", agentId)!;
+    const result = await tool.execute("c", {
+      model: "res.partner",
+      values: { name: "Acme", category_id: [[6, 0, [1, 2]]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockCreate).toHaveBeenCalled();
+  });
+});
+
+describe("odoo_read — {item: …} array-wrapping", () => {
+  it("refuses an item-wrapped domain before querying Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: { item: { item: ["id", "in", ["757", "758"]] } },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(mockSearchRead).not.toHaveBeenCalled();
+    expect(mockFields).not.toHaveBeenCalled();
+  });
+
+  it("refuses item-wrapped fields before querying Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      fields: { item: ["id", "name"] },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(mockSearchRead).not.toHaveBeenCalled();
+  });
+
+  it("still reads normally with a well-formed domain", async () => {
+    mockSearchRead.mockResolvedValue({ records: [], length: 0 });
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: [["state", "=", "posted"]],
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockSearchRead).toHaveBeenCalled();
+  });
+});
+
+describe("relation-field name string — Postgres integer error is translated", () => {
+  it("turns a raw 'invalid input syntax for type integer' into actionable guidance", async () => {
+    mockCreate.mockRejectedValue(
+      new Error(
+        'invalid input syntax for type integer: "7600 Office supplies and printed forms"',
+      ),
+    );
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_create", agentId)!;
+    const result = await tool.execute("c", {
+      model: "res.partner",
+      values: { name: "Acme" },
+    });
+    expect(result.isError).toBe(true);
+    const text = result.content[0].text;
+    // Keeps the original signal but adds what to do about it.
+    expect(text).toMatch(/invalid input syntax for type integer/i);
+    expect(text).toMatch(/relation|odoo_read|numeric id|_pinchy_ref/i);
+  });
+});
+
+describe("tool descriptions carry a correct-shape example", () => {
+  it("odoo_create description shows the plain-array command shape and warns against {item}", () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_create", agentId)!;
+    expect(tool.description).toMatch(/\[\[0, 0,/);
+    expect(tool.description).toMatch(/item/i);
+  });
+
+  it("odoo_read filters description warns against {item} wrapping", () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_read", agentId)!;
+    const props = (tool.parameters as { properties: Record<string, { description?: string }> })
+      .properties;
+    expect(props.filters.description).toMatch(/item/i);
+  });
+});

--- a/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
+++ b/packages/plugins/pinchy-odoo/__tests__/arg-robustness.test.ts
@@ -226,6 +226,64 @@ describe("odoo_read — {item: …} array-wrapping", () => {
   });
 });
 
+describe("odoo_write — {item: …} array-wrapping", () => {
+  it("refuses item-wrapped values with an actionable message, before touching Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_write", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      ids: [42],
+      values: {
+        invoice_line_ids: { item: { item: ["1", "10", { price_unit: "8.33" }] } },
+      },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(result.content[0].text).toMatch(/\[\[0, 0,/); // the correct o2m shape
+    expect(mockWrite).not.toHaveBeenCalled();
+    expect(mockFields).not.toHaveBeenCalled();
+  });
+
+  it("still writes normally when arrays are well-formed", async () => {
+    mockWrite.mockResolvedValue(true);
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_write", agentId)!;
+    const result = await tool.execute("c", {
+      model: "res.partner",
+      ids: [1],
+      values: { category_id: [[6, 0, [1, 2]]] },
+    });
+    expect(result.isError).toBeFalsy();
+    expect(mockWrite).toHaveBeenCalled();
+  });
+});
+
+describe("odoo_count — {item: …} array-wrapping", () => {
+  it("refuses an item-wrapped domain before querying Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_count", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: { item: { item: ["state", "=", "posted"] } },
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(mockSearchCount).not.toHaveBeenCalled();
+  });
+});
+
+describe("odoo_aggregate — {item: …} array-wrapping", () => {
+  it("refuses an item-wrapped domain before querying Odoo", async () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_aggregate", agentId)!;
+    const result = await tool.execute("c", {
+      model: "account.move",
+      filters: { item: { item: ["state", "=", "posted"] } },
+      fields: ["amount_total:sum"],
+      groupby: ["partner_id"],
+    });
+    expect(result.isError).toBe(true);
+    expect(result.content[0].text).toMatch(/item/i);
+    expect(mockReadGroup).not.toHaveBeenCalled();
+  });
+});
+
 describe("relation-field name string — Postgres integer error is translated", () => {
   it("turns a raw 'invalid input syntax for type integer' into actionable guidance", async () => {
     mockCreate.mockRejectedValue(
@@ -249,6 +307,12 @@ describe("relation-field name string — Postgres integer error is translated", 
 describe("tool descriptions carry a correct-shape example", () => {
   it("odoo_create description shows the plain-array command shape and warns against {item}", () => {
     const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_create", agentId)!;
+    expect(tool.description).toMatch(/\[\[0, 0,/);
+    expect(tool.description).toMatch(/item/i);
+  });
+
+  it("odoo_write description shows the plain-array command shape and warns against {item}", () => {
+    const tool = findTool(createApi({ [agentId]: cfg() }), "odoo_write", agentId)!;
     expect(tool.description).toMatch(/\[\[0, 0,/);
     expect(tool.description).toMatch(/item/i);
   });

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -2702,6 +2702,11 @@ const plugin = {
               if (!checkPermission(config.permissions, model, "read")) {
                 return permissionDenied("read", model);
               }
+              // Reject the {item: …} array-serialization artifact in the domain
+              // before querying (see hasItemWrappedArray / odoo_read).
+              if (hasItemWrappedArray(params.filters)) {
+                throw itemWrappedError("filters");
+              }
 
               const count = await withAuthRetry(agentId, config, (client) =>
                 client.searchCount(model, asDomain(params.filters)),
@@ -2774,6 +2779,12 @@ const plugin = {
               const model = params.model as string;
               if (!checkPermission(config.permissions, model, "read")) {
                 return permissionDenied("read", model);
+              }
+
+              // Reject the {item: …} array-serialization artifact in the domain
+              // before querying (see hasItemWrappedArray / odoo_read).
+              if (hasItemWrappedArray(params.filters)) {
+                throw itemWrappedError("filters");
               }
 
               const fields = prepareAggregateFields(params.fields, "fields");
@@ -4178,7 +4189,7 @@ const plugin = {
           name: "odoo_write",
           label: "Odoo Write",
           description:
-            "Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.",
+            'Update an existing record in Odoo. For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.',
           parameters: {
             type: "object",
             properties: {
@@ -4201,6 +4212,13 @@ const plugin = {
               const model = params.model as string;
               if (!checkPermission(config.permissions, model, "write")) {
                 return permissionDenied("write", model);
+              }
+              // Reject the {item: …} array-serialization artifact before any
+              // Odoo round-trip — `values` carries the same one2many/many2many
+              // command tuples as odoo_create, so it hits the identical opaque
+              // "unhashable type: 'dict'" if forwarded (see hasItemWrappedArray).
+              if (hasItemWrappedArray(params.values)) {
+                throw itemWrappedError("values");
               }
 
               const success = await withAuthRetry(

--- a/packages/plugins/pinchy-odoo/index.ts
+++ b/packages/plugins/pinchy-odoo/index.ts
@@ -268,6 +268,48 @@ function unquoteFieldKeysDeep(value: unknown): unknown {
   return out;
 }
 
+// A second, distinct model-serialization quirk (observed: ollama-cloud/
+// deepseek-v4-pro in production, pinchy-bugreport-penny-20260716): array-valued
+// tool arguments arrive wrapped as single-key `{item: …}` objects, nested for
+// nested arrays — e.g. `tax_ids: [[6, 0, [172]]]` becomes
+// `{item: {item: ["6", "0", {item: "172"}]}}`. This is the XML-style array
+// serialization certain tool-calling transports produce (documented across
+// runtimes, e.g. llama.cpp ggml-org/llama.cpp#21384), and it is upstream of us.
+//
+// Unlike the quoted-key quirk above, this one is LOSSY: single-element arrays
+// collapse to scalars and ints stringify, so it cannot be reconstructed here
+// without Odoo's schema (which command position is an id list). Silently
+// guessing would forward wrong data. So we DETECT it and return an actionable
+// error naming the artifact and the correct plain-array shape — best-practice
+// for tool robustness (typed, self-correcting error over hidden coercion) —
+// instead of letting Odoo reject it with an opaque "unhashable type: 'dict'" or
+// "Wrong value for …: {'item': …}" that the model cannot act on.
+export function hasItemWrappedArray(value: unknown, depth = 0): boolean {
+  if (depth > 8) return false;
+  if (Array.isArray(value)) {
+    return value.some((v) => hasItemWrappedArray(v, depth + 1));
+  }
+  if (isRecord(value)) {
+    const keys = Object.keys(value);
+    if (keys.length === 1 && keys[0] === "item") return true;
+    return Object.values(value).some((v) => hasItemWrappedArray(v, depth + 1));
+  }
+  return false;
+}
+
+/**
+ * Error for the `{item: …}` array-wrapping quirk, naming the artifact and
+ * showing the correct plain-array shape so the model can re-issue the call.
+ */
+function itemWrappedError(paramName: string): Error {
+  return new Error(
+    `Your \`${paramName}\` arrived with arrays wrapped as {"item": …} objects instead of plain JSON arrays — a serialization artifact from the model, not a value Odoo can accept. ` +
+      `Re-issue the call with plain arrays. For example, a one2many field is invoice_line_ids: [[0, 0, {…}]], ` +
+      `a many2many is tax_ids: [[6, 0, [<id>]]], and a domain is [["state", "=", "posted"]] — ` +
+      `never {"item": {"item": [...]}}.`,
+  );
+}
+
 function unquoteFieldKeys(
   values: Record<string, unknown>,
 ): Record<string, unknown> {
@@ -2216,6 +2258,16 @@ function errorResult(
     );
   }
   const message = error instanceof Error ? error.message : "Unknown error";
+  // A relation field (many2one) that received a display name instead of an id
+  // surfaces from Postgres as "invalid input syntax for type integer: <text>".
+  // That raw DB error is not actionable for the model, so append what to do:
+  // resolve the name to an id/ref first (production: Penny repeatedly sent
+  // account_id: "7600 Office supplies …" and got only the bare Postgres error).
+  if (/invalid input syntax for type integer:/i.test(message)) {
+    return toolError(
+      `Error: ${message.trim()}\n\nThis usually means a relation field (e.g. account_id, partner_id, journal_id) was given a display name or text instead of a numeric id. Look the record up with odoo_read to get its id, then pass that id or the _pinchy_ref it returns — never the display name.`,
+    );
+  }
   return toolError(`Error: ${message}`);
 }
 
@@ -2532,7 +2584,7 @@ const plugin = {
                     "A [field, operator, value] tuple, e.g. ['state', '=', 'sale']",
                 },
                 description:
-                  "Odoo domain filter. Array of [field, operator, value] tuples. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Optional — omit or pass [] to match all records.",
+                  'Odoo domain filter. A plain array of [field, operator, value] tuples, e.g. [["state", "=", "posted"]] — never wrap it as {"item": …}. Operators: =, !=, >, >=, <, <=, in, not in, like, ilike. Optional — omit or pass [] to match all records.',
               },
               fields: {
                 type: "array",
@@ -2559,6 +2611,15 @@ const plugin = {
               const model = params.model as string;
               if (!checkPermission(config.permissions, model, "read")) {
                 return permissionDenied("read", model);
+              }
+              // Reject the {item: …} array-serialization artifact in the domain
+              // or field list before querying — Odoo otherwise fails it with an
+              // opaque "unhashable type: 'dict'" (see hasItemWrappedArray).
+              if (hasItemWrappedArray(params.filters)) {
+                throw itemWrappedError("filters");
+              }
+              if (hasItemWrappedArray(params.fields)) {
+                throw itemWrappedError("fields");
               }
 
               const result = await withAuthRetry(
@@ -2759,7 +2820,7 @@ const plugin = {
           name: "odoo_create",
           label: "Odoo Create",
           description:
-            "Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.",
+            'Create a new record in Odoo. Returns `{id, _pinchy_ref}` — pass the `_pinchy_ref` verbatim to any tool that takes an opaque reference (e.g. `odoo_attach_file.targetRef`). For many2one fields, do not pass raw numeric IDs; use an opaque ref from odoo_read, an exact display name, or a supported lookup such as a country code. One2many and many2many fields use Odoo command tuples emitted as plain JSON arrays: a new line is invoice_line_ids: [[0, 0, {…}]] and a tag link is tax_ids: [[6, 0, [<taxId>]]] — never wrap arrays as {"item": …}. Note: in invoice/order line models (e.g. `account.move.line`, `sale.order.line`, `purchase.order.line`), `price_unit` is tax-exclusive (net); Odoo computes gross totals from `tax_ids`. Convert receipt gross amounts to net before writing.',
           parameters: {
             type: "object",
             properties: {
@@ -2777,6 +2838,12 @@ const plugin = {
               const model = params.model as string;
               if (!checkPermission(config.permissions, model, "create")) {
                 return permissionDenied("create", model);
+              }
+              // Reject the {item: …} array-serialization artifact before any
+              // Odoo round-trip — forwarding it produces opaque server errors
+              // the model cannot recover from (see hasItemWrappedArray).
+              if (hasItemWrappedArray(params.values)) {
+                throw itemWrappedError("values");
               }
 
               const id = await withAuthRetry(


### PR DESCRIPTION
## What does this PR do?

Makes the Odoo tools **teach the model how to call them** when it sends malformed arguments, instead of forwarding garbage to Odoo and returning opaque server errors the model can't act on.

**Motivation:** a production bug report (`odoo-bookkeeper` agent "Penny" on `ollama-cloud/deepseek-v4-pro`) showed 57 tool errors across 266 calls, dominated by two failure modes the model never recovered from because the feedback was raw:

- **`{item: …}` array-wrapping** (~30 errors): the model serialized nested array arguments as single-key `{item: …}` objects — an XML-style array-serialization artifact seen across runtimes (e.g. [ggml-org/llama.cpp#21384](https://github.com/ggml-org/llama.cpp/issues/21384)). `tax_ids: [[6,0,[172]]]` arrived as `{item:{item:['6','0',{item:'172'}]}}`. Odoo rejected it with `unhashable type: 'dict'` / `Wrong value for …: {'item': …}` — no hint the array was wrapped, so the model repeated it 18×/9×.
- **Relation field as display name** (`account_id: "7600 Office supplies…"`) → raw Postgres `invalid input syntax for type integer: …`, again unactionable.

## Approach

Grounded in tool-robustness best practice (Anthropic tool-use docs, Martin Fowler, LangChain/practitioner guidance): **typed, self-correcting error messages and worked examples beat hidden coercion.**

- **Detect the `{item: …}` artifact** in `odoo_create` `values` and `odoo_read` `filters`/`fields` **before any Odoo round-trip**, and return an error that names the artifact and shows the correct plain-array shape (`invoice_line_ids: [[0, 0, {…}]]`, `tax_ids: [[6, 0, [<id>]]]`, domain `[["state","=","posted"]]`). The wrapping is **lossy** (single-element arrays collapse to scalars, ints stringify), so it is deliberately **not** auto-repaired — guessing would forward wrong data.
- **Translate** the raw `invalid input syntax for type integer` into guidance to resolve the relation name to an id/`_pinchy_ref` via `odoo_read`.
- **Enrich the `odoo_create` / `odoo_read` descriptions** with correct-shape command-tuple examples (Anthropic: descriptions/examples are "by far the most important factor").

`hasItemWrappedArray` is exported and unit-tested; both tool behaviours are covered against the exact shapes from the production trajectory. This is the correct-layer fix; a model-reliability blocklist for `deepseek-v4-pro` remains a fallback only if a model proves it can't recover even with this feedback.

## Type of change

- [x] 🐛 Bug fix

## Checklist

- [x] I've read the Contributing Guide
- [x] My code follows the project's style
- [x] I've added tests for new functionality (16 new unit/behaviour tests)
- [x] I've updated the documentation (tool descriptions; user-facing docs unchanged)
- [x] All existing tests pass (pinchy-odoo: 401)
