### PR TITLE
test(web): give ref-based odoo tools real E2E dispatch coverage (#791)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -345,6 +345,14 @@ Every plugin tool must be covered at three layers:
 
 Follow the Plugin Integration Contract above, then apply the tool dispatch coverage recipe for each tool the plugin registers.
 
+#### Ref-based tools (opaque `_pinchy_ref` inputs)
+
+A static `TriggerConfig` cannot cover a tool whose primary argument is an opaque `_pinchy_ref` (pinchy-odoo's `odoo_reconcile`, `odoo_schedule_activity`, `odoo_attach_file`, the record-action tools, …). The ref is minted at runtime (per connection, per record) and is unknowable when the trigger is authored, so a hard-coded ref only ever exercises the plugin's decode-rejection path — not real dispatch.
+
+The fake-LLM instead resolves the ref **dynamically**, exactly like a real model: it first dispatches `odoo_read`, then reads the real `_pinchy_ref` back out of that tool-result message and reuses it in the ref-based tool. The reusable primitive is `buildOdooRefDispatchScript` / `extractPinchyRefFromToolResults` in `fake-ollama-server.ts` (unit-tested in `fake-ollama-ref-dispatch.test.ts`). `odoo_schedule_activity` is the worked example (`odoo-agent-chat.spec.ts` dispatch-probe block); assert `outcome=success` via `pollAuditForEvent`, not just that a row exists — a broken ref still dispatches (audited `failure`).
+
+A dedicated guard, `odoo-ref-tool-e2e-coverage.test.ts` (pinchy#791), enforces this per-tool: it auto-detects every ref-based odoo tool from the plugin source and requires each to be either E2E-covered or carry a `PENDING_E2E` exemption citing the tracking issue. A **new** ref-based odoo tool with neither fails CI. To cover the next one: script its round-2 tool call in `buildOdooRefDispatchScript` (or a sibling), add the spec assertion, then delete its `PENDING_E2E` entry (the guard fails if a covered tool stays exempted).
+
 ## Documentation
 
 - Docs live in `docs/`, use Astro Starlight, and follow the Diataxis framework.

--- a/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
+++ b/packages/web/e2e/odoo/odoo-agent-chat.spec.ts
@@ -17,6 +17,7 @@ import {
 import {
   FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_TRIGGER,
   FAKE_OLLAMA_ODOO_READ_DENIED_TRIGGER,
+  FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER,
   FAKE_OLLAMA_PORT,
   startFakeOllama,
   stopFakeOllama,
@@ -24,6 +25,7 @@ import {
 import {
   loginViaUI,
   pollAuditForTool,
+  pollAuditForEvent,
   seedDefaultProviderToOllama,
   waitForOpenClawStable,
   waitForAgentDispatchable,
@@ -329,16 +331,22 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
 
     // 6. Grant Odoo permissions → triggers regenerateOpenClawConfig() which now
     //    reads default_provider=ollama-local and emits the Ollama provider block.
+    //    sale.order read → odoo_list_models probe; crm.lead read + mail.activity
+    //    create → the ref-dispatch probe (odoo_read crm.lead → schedule_activity).
+    //    res.partner is deliberately NOT granted so the failure probe below still
+    //    hits permissionDenied on odoo_read res.partner.
     await setAgentPermissions(dispatchCookie, dispatchAgentId, dispatchConnectionId, [
       { model: "sale.order", operation: "read" },
+      { model: "crm.lead", operation: "read" },
+      { model: "mail.activity", operation: "create" },
     ]);
 
-    // 7. Allow odoo_list_models (happy-path probe) + odoo_read (failure probe:
-    //    the agent only holds sale.order read, so an odoo_read on res.partner
-    //    hits permissionDenied inside the plugin).
+    // 7. Allow odoo_list_models (happy-path probe), odoo_read (failure probe +
+    //    the read half of the ref-dispatch chain), and odoo_schedule_activity
+    //    (the ref-based tool under test, pinchy#791).
     const patchRes = await pinchyPatch(
       `/api/agents/${dispatchAgentId}`,
-      { allowedTools: ["odoo_list_models", "odoo_read"] },
+      { allowedTools: ["odoo_list_models", "odoo_read", "odoo_schedule_activity"] },
       dispatchCookie
     );
     expect(patchRes.status).toBe(200);
@@ -452,5 +460,45 @@ test.describe("Odoo dispatch probe (pinchy-odoo plugin coverage)", () => {
       await new Promise((r) => setTimeout(r, 500));
     }
     expect(foundFailure).toBe(true);
+  });
+
+  test("a ref-based tool (odoo_schedule_activity) dispatches on a runtime-minted _pinchy_ref", async ({
+    page,
+  }, testInfo) => {
+    // pinchy#791: ref-based odoo tools take an opaque `_pinchy_ref` minted at
+    // runtime, so a static tool_call can never carry a valid one. The fake-LLM
+    // resolves it dynamically — round 1 dispatches odoo_read on crm.lead, then
+    // reads the real `_pinchy_ref` back out of that tool result and reuses it in
+    // odoo_schedule_activity (round 2). This proves the whole ref chain runs
+    // end-to-end against the real plugin + Odoo mock, not just the read half.
+    testInfo.setTimeout(180_000);
+
+    await loginViaUI(page, getAdminEmail(), getAdminPassword());
+
+    await page.goto(`/chat/${dispatchAgentId}`);
+    await expect(page).toHaveURL(`/chat/${dispatchAgentId}`, { timeout: 10_000 });
+
+    // Capture the cutoff BEFORE dispatch so the poll cannot match a stale row.
+    const since = new Date().toISOString();
+
+    const input = page.getByPlaceholder(/send a message/i);
+    await expect(input).toBeVisible({ timeout: 10_000 });
+    await input.fill(
+      `${FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER}: schedule a follow-up on a lead`
+    );
+    await input.press("Enter");
+
+    // Assert the SECOND-round tool (the ref-based one) not only dispatched but
+    // SUCCEEDED. outcome=success is the whole point: it proves the runtime
+    // `_pinchy_ref` decoded, the crm.lead target was read, and mail.activity was
+    // created — the full ref chain end-to-end. A broken ref would still dispatch
+    // (audited outcome=failure), so a dispatch-only assertion could false-pass.
+    const entry = await pollAuditForEvent(page, {
+      eventType: "tool.odoo_schedule_activity",
+      predicate: (e) => e.resource === `agent:${dispatchAgentId}`,
+      since,
+      deadlineMs: 160_000,
+    });
+    expect(entry.outcome).toBe("success");
   });
 });

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -680,6 +680,116 @@ function countToolResults(messages: unknown[]): number {
   return messages.filter(hasToolRole).length;
 }
 
+// ── Dynamic ref-resolution primitive (pinchy#791) ───────────────────────────
+// Ref-based odoo tools (odoo_schedule_activity, odoo_reconcile, …) take an
+// opaque `_pinchy_ref` that is minted at RUNTIME (per connection, per record)
+// and is therefore unknowable when a static trigger is authored. Rather than
+// forge a ref, the fake-LLM does what a real model does: it first calls
+// odoo_read, then reads the real `_pinchy_ref` back out of that tool-result
+// message and reuses it in the ref-based tool. This is the reusable mechanism
+// that lets any ref-based odoo tool get genuine E2E dispatch coverage — the
+// first consumer is the odoo_schedule_activity probe below.
+const ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER = "E2E_ODOO_SCHEDULE_ACTIVITY_REF";
+const ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE = "Activity scheduled via ref: coverage probe complete.";
+
+// Wire form of an integration ref (integration-ref.ts PREFIX `pinchy_ref:v1:`
+// + base64url payload). Kept local — this server is copied into a standalone
+// container and must not import the plugin.
+const PINCHY_REF_RE = /pinchy_ref:v1:[A-Za-z0-9_-]+/;
+
+/**
+ * Extract the first `_pinchy_ref` token from the CURRENT round's tool-result
+ * messages (those after the last user message), mirroring
+ * `lastRoundHasToolResult`'s scoping so a stale ref from an earlier round in a
+ * shared session can't leak in. Returns null if none is present.
+ */
+export function extractPinchyRefFromToolResults(messages: unknown[]): string | null {
+  let lastUserIndex = -1;
+  for (let i = messages.length - 1; i >= 0; i--) {
+    if ((messages[i] as { role?: unknown })?.role === "user") {
+      lastUserIndex = i;
+      break;
+    }
+  }
+  const scope = lastUserIndex === -1 ? messages : messages.slice(lastUserIndex + 1);
+  for (const message of scope) {
+    if (!hasToolRole(message)) continue;
+    const match = messageContent(message).match(PINCHY_REF_RE);
+    if (match) return match[0];
+  }
+  return null;
+}
+
+type RefDispatchScript =
+  | { kind: "tool"; toolName: string; arguments: Record<string, unknown> }
+  | { kind: "text"; text: string };
+
+/**
+ * Drive the two-tool ref-dispatch chain for the odoo_schedule_activity probe:
+ *   round 1 → odoo_read crm.lead (its result carries a real `_pinchy_ref`)
+ *   round 2 → odoo_schedule_activity on that ref (the tool under test)
+ *   round 3 → final completion text
+ * The step is chosen by how many tool results have round-tripped so far, like
+ * the Hetzner sequence.
+ */
+export function buildOdooRefDispatchScript(messages: unknown[]): RefDispatchScript {
+  const toolResults = countToolResults(messages);
+  if (toolResults === 0) {
+    return {
+      kind: "tool",
+      toolName: "odoo_read",
+      arguments: { model: "crm.lead", filters: [], fields: ["name"] },
+    };
+  }
+  if (toolResults === 1) {
+    const ref = extractPinchyRefFromToolResults(messages);
+    if (!ref) {
+      // Surface the harness failure as text so the audit poll for
+      // tool.odoo_schedule_activity times out LOUDLY instead of false-passing.
+      return {
+        kind: "text",
+        text: "Harness error: no _pinchy_ref found in the odoo_read result.",
+      };
+    }
+    return {
+      kind: "tool",
+      toolName: "odoo_schedule_activity",
+      arguments: {
+        target: ref,
+        summary: "E2E ref-dispatch follow-up",
+        dueDate: "2030-01-01",
+      },
+    };
+  }
+  return { kind: "text", text: ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE };
+}
+
+/** Emit one assistant tool_call turn on the Ollama-native NDJSON surface. */
+function writeNdjsonToolCall(
+  res: http.ServerResponse,
+  toolName: string,
+  args: Record<string, unknown>,
+  messages: unknown[]
+) {
+  const { promptTokens, completionTokens } = getUsageTokens(countUserMessages(messages));
+  writeNdjson(res, [
+    {
+      model: MODEL_NAME,
+      created_at: new Date().toISOString(),
+      message: {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ function: { name: toolName, arguments: args } }],
+      },
+      done: true,
+      done_reason: "stop",
+      total_duration: 1000000,
+      prompt_eval_count: promptTokens,
+      eval_count: completionTokens,
+    },
+  ]);
+}
+
 // ── OpenAI-compatible SSE helpers ──────────────────────────────────────────
 // Real Ollama exposes both /api/chat (Ollama-native NDJSON) and
 // /v1/chat/completions (OpenAI-style SSE). When Pinchy emits OpenClaw's ollama
@@ -1132,6 +1242,19 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    // Ref-dispatch probe (pinchy#791): odoo_read → reuse the runtime `_pinchy_ref`
+    // → odoo_schedule_activity → final text. Multi-round, driven by
+    // countToolResults, so the trigger check must NOT be gated on !hasToolResult.
+    if (lastContent.includes(ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER)) {
+      const script = buildOdooRefDispatchScript(messages);
+      if (script.kind === "tool") {
+        writeNdjsonToolCall(res, script.toolName, script.arguments, messages);
+      } else {
+        streamTextResponse(res, script.text, countUserMessages(messages));
+      }
+      return;
+    }
+
     const isSlowStreamPrompt = lastContent.includes(SLOW_STREAM_TRIGGER);
     if (isSlowStreamPrompt && !hasToolResult) {
       await streamTextResponseSlow(res, SLOW_STREAM_RESPONSE);
@@ -1307,6 +1430,20 @@ export async function handleRequest(req: http.IncomingMessage, res: http.ServerR
       return;
     }
 
+    // Ref-dispatch probe (pinchy#791) — primary surface (pi-ai uses
+    // /v1/chat/completions). odoo_read → reuse the runtime `_pinchy_ref` →
+    // odoo_schedule_activity → final text; driven by countToolResults, so NOT
+    // gated on !hasToolResult.
+    if (lastContent.includes(ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER)) {
+      const script = buildOdooRefDispatchScript(messages);
+      if (script.kind === "tool") {
+        streamOpenAiToolCalls(res, script.toolName, script.arguments);
+      } else {
+        streamOpenAiText(res, script.text);
+      }
+      return;
+    }
+
     // Slow-stream trigger: Pinchy emits ollama as api: "openai-completions" so
     // OC's pi-ai uses /v1/chat/completions, not /api/chat. The slow-stream
     // handler must live on this path too or stream-persistence tests never
@@ -1418,6 +1555,11 @@ export const FAKE_OLLAMA_CONTEXT_SAVE_USER_TOOL_RESPONSE = CONTEXT_SAVE_USER_RES
 export const FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_TRIGGER = ODOO_LIST_MODELS_TRIGGER;
 export const FAKE_OLLAMA_ODOO_LIST_MODELS_TOOL_RESPONSE = ODOO_LIST_MODELS_RESPONSE;
 export const FAKE_OLLAMA_ODOO_READ_DENIED_TRIGGER = ODOO_READ_DENIED_TRIGGER;
+// Ref-dispatch probe (pinchy#791): drives a real runtime `_pinchy_ref` through
+// odoo_read → odoo_schedule_activity. The trigger is multi-round; the response
+// constant is the final completion text asserted after the activity is scheduled.
+export const FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER = ODOO_SCHEDULE_ACTIVITY_REF_TRIGGER;
+export const FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE = ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_TRIGGER = ODOO_CREATE_NESTED_LINES_TRIGGER;
 export const FAKE_OLLAMA_ODOO_CREATE_NESTED_LINES_RESPONSE = ODOO_CREATE_NESTED_LINES_RESPONSE;
 export const FAKE_OLLAMA_EMAIL_LIST_TOOL_TRIGGER = EMAIL_LIST_TRIGGER;

--- a/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
+++ b/packages/web/e2e/shared/fake-ollama/fake-ollama-server.ts
@@ -651,14 +651,13 @@ function hasToolRole(message: unknown): boolean {
   );
 }
 
-// Detect whether the LAST exchange in the message history is a tool result —
-// i.e. the assistant emitted a tool_call in the previous step and the runtime
-// has now sent us back the tool's output to summarise. We split on the most
-// recent user message and only look at messages AFTER it. Looking at the whole
-// history was wrong: a long-lived chat session that called a tool once would
-// then never receive another tool_call response, because `messages.some` saw
-// the stale tool message from a previous round.
-function lastRoundHasToolResult(messages: unknown[]): boolean {
+// The messages belonging to the CURRENT round — everything after the most
+// recent user message. A long-lived chat session re-sends prior rounds' tool
+// messages, so any "what step am I on" decision that looks at the whole history
+// is wrong: it would see stale tool messages from a previous round (or, in the
+// odoo dispatch-probe E2E block, from a previous test sharing the same session
+// key). Callers that must ignore that stale tail scope through this helper.
+function lastRoundMessages(messages: unknown[]): unknown[] {
   let lastUserIndex = -1;
   for (let i = messages.length - 1; i >= 0; i--) {
     if ((messages[i] as { role?: unknown })?.role === "user") {
@@ -666,16 +665,30 @@ function lastRoundHasToolResult(messages: unknown[]): boolean {
       break;
     }
   }
-  if (lastUserIndex === -1) return messages.some(hasToolRole);
-  return messages.slice(lastUserIndex + 1).some(hasToolRole);
+  return lastUserIndex === -1 ? messages : messages.slice(lastUserIndex + 1);
 }
 
-// Total count of tool-result messages (role: "tool") across the WHOLE
-// conversation. Used by multi-step handlers (e.g. the Hetzner scenario
-// triggers below) to know which step of a >2-step tool chain they are on:
+// Detect whether the LAST exchange in the message history is a tool result —
+// i.e. the assistant emitted a tool_call in the previous step and the runtime
+// has now sent us back the tool's output to summarise.
+function lastRoundHasToolResult(messages: unknown[]): boolean {
+  return lastRoundMessages(messages).some(hasToolRole);
+}
+
+// Count tool-result messages (role: "tool") in the CURRENT round only. Used by
+// multi-step handlers to know which step of a >2-step tool chain they are on:
 // `lastRoundHasToolResult` only distinguishes "was the previous turn a tool
 // result" (fine for a single tool-call-then-followup shape like
 // TOOL_THEN_RATE_LIMIT) but cannot tell step 2 of 4 from step 3 of 4.
+function countToolResultsInLastRound(messages: unknown[]): number {
+  return lastRoundMessages(messages).filter(hasToolRole).length;
+}
+
+// Total count of tool-result messages (role: "tool") across the WHOLE
+// conversation. Correct only for handlers whose session is guaranteed fresh
+// (e.g. the Hetzner eval self-test, where the trigger is always the first
+// message). Prefer `countToolResultsInLastRound` for anything that can run in a
+// shared/long-lived session.
 function countToolResults(messages: unknown[]): number {
   return messages.filter(hasToolRole).length;
 }
@@ -699,20 +712,12 @@ const PINCHY_REF_RE = /pinchy_ref:v1:[A-Za-z0-9_-]+/;
 
 /**
  * Extract the first `_pinchy_ref` token from the CURRENT round's tool-result
- * messages (those after the last user message), mirroring
- * `lastRoundHasToolResult`'s scoping so a stale ref from an earlier round in a
- * shared session can't leak in. Returns null if none is present.
+ * messages (those after the last user message, via `lastRoundMessages`) so a
+ * stale ref from an earlier round in a shared session can't leak in. Returns
+ * null if none is present.
  */
 export function extractPinchyRefFromToolResults(messages: unknown[]): string | null {
-  let lastUserIndex = -1;
-  for (let i = messages.length - 1; i >= 0; i--) {
-    if ((messages[i] as { role?: unknown })?.role === "user") {
-      lastUserIndex = i;
-      break;
-    }
-  }
-  const scope = lastUserIndex === -1 ? messages : messages.slice(lastUserIndex + 1);
-  for (const message of scope) {
+  for (const message of lastRoundMessages(messages)) {
     if (!hasToolRole(message)) continue;
     const match = messageContent(message).match(PINCHY_REF_RE);
     if (match) return match[0];
@@ -729,11 +734,14 @@ type RefDispatchScript =
  *   round 1 → odoo_read crm.lead (its result carries a real `_pinchy_ref`)
  *   round 2 → odoo_schedule_activity on that ref (the tool under test)
  *   round 3 → final completion text
- * The step is chosen by how many tool results have round-tripped so far, like
- * the Hetzner sequence.
+ * The step is chosen by how many tool results have round-tripped IN THE CURRENT
+ * round. Unlike the Hetzner sequence (fresh eval session), this probe runs in
+ * the shared odoo dispatch-probe session after odoo_list_models/odoo_read have
+ * already dispatched, so counting the whole history would start at step 3 and
+ * never dispatch the ref tool — hence `countToolResultsInLastRound`.
  */
 export function buildOdooRefDispatchScript(messages: unknown[]): RefDispatchScript {
-  const toolResults = countToolResults(messages);
+  const toolResults = countToolResultsInLastRound(messages);
   if (toolResults === 0) {
     return {
       kind: "tool",

--- a/packages/web/src/__tests__/lib/fake-ollama-ref-dispatch.test.ts
+++ b/packages/web/src/__tests__/lib/fake-ollama-ref-dispatch.test.ts
@@ -1,0 +1,117 @@
+// packages/web/src/__tests__/lib/fake-ollama-ref-dispatch.test.ts
+//
+// Unit coverage for the fake-LLM's DYNAMIC ref-resolution primitive (pinchy#791).
+//
+// A `_pinchy_ref` is an AES-GCM token minted at runtime (per connection, per
+// record), so a statically-scripted tool call can never carry a valid one. The
+// harness instead behaves like a real model: it first calls odoo_read, then
+// reads the real `_pinchy_ref` back out of that tool-result message and reuses
+// it in the ref-based tool. These two pure helpers are that logic, unit-tested
+// here so the E2E spec only has to prove the wiring, not the parsing.
+import { describe, expect, it } from "vitest";
+import {
+  extractPinchyRefFromToolResults,
+  buildOdooRefDispatchScript,
+  FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE,
+} from "../../../e2e/shared/fake-ollama/fake-ollama-server";
+
+const REF = "pinchy_ref:v1:AbCd-1234_efGH";
+
+function toolResult(records: Array<Record<string, unknown>>): Record<string, unknown> {
+  return { role: "tool", content: JSON.stringify({ records }) };
+}
+
+describe("extractPinchyRefFromToolResults", () => {
+  it("returns null when there is no tool-result message", () => {
+    expect(extractPinchyRefFromToolResults([{ role: "user", content: "hi" }])).toBeNull();
+  });
+
+  it("extracts a _pinchy_ref token from a tool-result message", () => {
+    const messages = [
+      { role: "user", content: "E2E trigger" },
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      toolResult([{ id: 5, name: "Acme Lead", _pinchy_ref: REF }]),
+    ];
+    expect(extractPinchyRefFromToolResults(messages)).toBe(REF);
+  });
+
+  it("ignores a stale ref from before the last user message (current round only)", () => {
+    const stale = "pinchy_ref:v1:STALE_from_prior_round";
+    const messages = [
+      { role: "user", content: "old turn" },
+      toolResult([{ id: 1, _pinchy_ref: stale }]),
+      { role: "user", content: "E2E trigger" }, // new round starts here
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      toolResult([{ id: 5, _pinchy_ref: REF }]),
+    ];
+    expect(extractPinchyRefFromToolResults(messages)).toBe(REF);
+  });
+
+  it("reads content delivered as an OpenAI parts array", () => {
+    const messages = [
+      { role: "user", content: "E2E trigger" },
+      {
+        role: "tool",
+        content: [{ type: "text", text: JSON.stringify({ _pinchy_ref: REF }) }],
+      },
+    ];
+    expect(extractPinchyRefFromToolResults(messages)).toBe(REF);
+  });
+});
+
+describe("buildOdooRefDispatchScript", () => {
+  const trigger = { role: "user", content: "E2E_ODOO_SCHEDULE_ACTIVITY_REF: follow up" };
+
+  it("round 1 (no tool results yet): reads crm.lead to obtain a real ref", () => {
+    const script = buildOdooRefDispatchScript([trigger]);
+    expect(script.kind).toBe("tool");
+    if (script.kind !== "tool") throw new Error("unreachable");
+    expect(script.toolName).toBe("odoo_read");
+    expect(script.arguments.model).toBe("crm.lead");
+  });
+
+  it("round 2 (one read result): schedules an activity on the returned ref", () => {
+    const messages = [
+      trigger,
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      toolResult([{ id: 5, name: "Acme Lead", _pinchy_ref: REF }]),
+    ];
+    const script = buildOdooRefDispatchScript(messages);
+    expect(script.kind).toBe("tool");
+    if (script.kind !== "tool") throw new Error("unreachable");
+    expect(script.toolName).toBe("odoo_schedule_activity");
+    expect(script.arguments.target).toBe(REF);
+    expect(typeof script.arguments.summary).toBe("string");
+    expect(script.arguments.dueDate).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  it("round 2 with no ref in the read result: surfaces the harness failure as text", () => {
+    const messages = [
+      trigger,
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      { role: "tool", content: JSON.stringify({ records: [] }) },
+    ];
+    const script = buildOdooRefDispatchScript(messages);
+    expect(script.kind).toBe("text");
+    if (script.kind !== "text") throw new Error("unreachable");
+    expect(script.text).toMatch(/_pinchy_ref/);
+  });
+
+  it("round 3 (activity scheduled): returns the final completion text", () => {
+    const messages = [
+      trigger,
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      toolResult([{ id: 5, _pinchy_ref: REF }]),
+      {
+        role: "assistant",
+        content: "",
+        tool_calls: [{ function: { name: "odoo_schedule_activity" } }],
+      },
+      { role: "tool", content: JSON.stringify({ id: 99 }) },
+    ];
+    const script = buildOdooRefDispatchScript(messages);
+    expect(script.kind).toBe("text");
+    if (script.kind !== "text") throw new Error("unreachable");
+    expect(script.text).toBe(FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE);
+  });
+});

--- a/packages/web/src/__tests__/lib/fake-ollama-ref-dispatch.test.ts
+++ b/packages/web/src/__tests__/lib/fake-ollama-ref-dispatch.test.ts
@@ -114,4 +114,52 @@ describe("buildOdooRefDispatchScript", () => {
     if (script.kind !== "text") throw new Error("unreachable");
     expect(script.text).toBe(FAKE_OLLAMA_ODOO_SCHEDULE_ACTIVITY_REF_RESPONSE);
   });
+
+  // Regression (pinchy#791): the odoo dispatch-probe E2E block shares ONE OpenClaw
+  // session (same agent + user → key `agent:<id>:direct:<userId>`) across three
+  // serially-run tests. odoo_list_models and odoo_read(denied) dispatch BEFORE
+  // this ref probe, so by the time its trigger fires the session history already
+  // carries their tool-result messages — OC re-sends prior rounds' tool messages
+  // (that is exactly why `lastRoundHasToolResult` scopes to the current round).
+  // Step selection MUST therefore count tool results in the CURRENT round only,
+  // like ref extraction does; counting the whole history skips straight to the
+  // final-text branch and the ref tool never dispatches.
+  describe("shared session with stale prior-turn tool results", () => {
+    // Two completed prior turns (list_models happy-path + read denied), each
+    // leaving a tool-result message — plus a stale ref that must NOT be reused.
+    const priorTurns = [
+      { role: "user", content: "E2E_ODOO_LIST_MODELS: list" },
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_list_models" } }] },
+      toolResult([{ model: "sale.order" }]),
+      { role: "assistant", content: "Here are the models." },
+      { role: "user", content: "E2E_ODOO_READ_DENIED: read partners" },
+      { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+      { role: "tool", content: JSON.stringify({ error: "permissionDenied" }) },
+      { role: "assistant", content: "That was denied." },
+    ];
+
+    it("round 1 still reads crm.lead despite 2 stale tool results in history", () => {
+      const script = buildOdooRefDispatchScript([...priorTurns, trigger]);
+      expect(script.kind).toBe("tool");
+      if (script.kind !== "tool") throw new Error("unreachable");
+      expect(script.toolName).toBe("odoo_read");
+      expect(script.arguments.model).toBe("crm.lead");
+    });
+
+    it("round 2 schedules on the CURRENT round's ref, ignoring stale history", () => {
+      const staleRef = "pinchy_ref:v1:STALE_prior_round_ref";
+      const messages = [
+        ...priorTurns,
+        toolResult([{ id: 1, _pinchy_ref: staleRef }]), // stale ref, before trigger
+        trigger,
+        { role: "assistant", content: "", tool_calls: [{ function: { name: "odoo_read" } }] },
+        toolResult([{ id: 5, name: "Acme Lead", _pinchy_ref: REF }]),
+      ];
+      const script = buildOdooRefDispatchScript(messages);
+      expect(script.kind).toBe("tool");
+      if (script.kind !== "tool") throw new Error("unreachable");
+      expect(script.toolName).toBe("odoo_schedule_activity");
+      expect(script.arguments.target).toBe(REF);
+    });
+  });
 });

--- a/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
@@ -1,0 +1,181 @@
+// packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
+//
+// Per-tool E2E-dispatch coverage guard for pinchy-odoo's REF-BASED tools.
+//
+// Why this exists (pinchy#791): the generic `plugin-tool-coverage` guard is
+// satisfied per PLUGIN — one covered tool clears the whole plugin. pinchy-odoo
+// passed it on its ref-FREE tools (odoo_read, odoo_create, odoo_list_models)
+// while every tool whose primary argument is an opaque runtime-signed
+// `_pinchy_ref` shipped with ZERO E2E dispatch coverage. The fake-LLM harness
+// could not drive those tools because a `_pinchy_ref` is minted at runtime
+// (per connection, per record) and is unknowable when a static trigger is
+// authored — so PR #782 (odoo_reconcile) deliberately shipped without an E2E
+// test and relied on live Odoo verification instead.
+//
+// The harness now resolves refs dynamically (the fake-LLM reads the real
+// `_pinchy_ref` back from a prior odoo_read tool-result, exactly like a real
+// model would — see fake-ollama-ref-dispatch). This guard makes the gap
+// un-reopenable: every ref-based odoo tool must be either covered by an E2E
+// dispatch test OR carry an explicit, issue-tracked exemption. A NEW ref-based
+// tool with neither fails CI here.
+import { describe, it, expect } from "vitest";
+import { readFileSync, readdirSync, statSync } from "node:fs";
+import { join } from "node:path";
+import { E2E_DIR, PLUGINS_DIR, loadManifest } from "./plugin-tool-extraction";
+
+const ODOO_INDEX = join(PLUGINS_DIR, "pinchy-odoo", "index.ts");
+
+// The authoritative list of pinchy-odoo tools whose primary input is an opaque
+// `_pinchy_ref` (target / targetRef / invoice / counterpart). Kept explicit so
+// the exemption bookkeeping below is readable; `detectRefToolNames` proves it
+// stays in sync with the plugin source in both directions.
+const REF_BASED_ODOO_TOOLS = [
+  "odoo_schedule_activity",
+  "odoo_complete_activity",
+  "odoo_reschedule_activity",
+  "odoo_confirm_order",
+  "odoo_apply_inventory",
+  "odoo_validate_picking",
+  "odoo_mark_mo_done",
+  "odoo_set_approval",
+  "odoo_reconcile",
+  "odoo_attach_file",
+] as const;
+
+// Ref-based odoo tools that do NOT yet have an E2E dispatch test, each with a
+// tracked reason. The contract mirrors AGENTS.md's skip/deletion policy: an
+// exemption is a deliberate, issue-referenced act, never a silent gap. Every
+// reason must cite pinchy#791 (the umbrella issue for closing this backlog).
+//
+// odoo_reconcile is called out specifically: covering it faithfully needs
+// `account.bank.statement.line` / `account.payment` / reconcile semantics in
+// the Odoo mock, which real Odoo 19 makes silent-no-op-prone — a mock risks a
+// false-green. It stays on live verification until the mock grows that surface.
+const PENDING_E2E: Record<string, string> = {
+  odoo_complete_activity: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_reschedule_activity: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_confirm_order: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_apply_inventory: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_validate_picking: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_mark_mo_done: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_set_approval: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+  odoo_reconcile:
+    "pinchy#791 — needs account.bank.statement.line/account.payment + reconcile " +
+    "semantics in the Odoo mock; real Odoo 19 reconcile is silent-no-op-prone, so " +
+    "a mock risks a false-green. Stays on live verification until the mock grows it.",
+  odoo_attach_file: "pinchy#791 — ref-dispatch harness exists; test not yet written.",
+};
+
+/**
+ * Derive the ref-based odoo tool names straight from the plugin source, so the
+ * explicit list above cannot silently drift when a tool is added or removed.
+ * Two shapes carry a `_pinchy_ref` input:
+ *   1. `recordActionFactory({ ... name: "odoo_x" ... })` — the shared factory
+ *      for record-action tools (confirm_order, validate_picking, …).
+ *   2. An inline schema property named target / targetRef / invoice /
+ *      counterpart, whose owning tool is the nearest following `name: "odoo_x"`.
+ */
+function detectRefToolNames(source: string): Set<string> {
+  const names = new Set<string>();
+
+  for (const m of source.matchAll(/recordActionFactory\(\{[\s\S]*?name:\s*"(odoo_[a-z_]+)"/g)) {
+    names.add(m[1]);
+  }
+
+  const refProp = /\b(?:target|targetRef|invoice|counterpart):\s*\{/g;
+  for (const m of source.matchAll(refProp)) {
+    const after = source.slice(m.index ?? 0);
+    const nameMatch = after.match(/name:\s*"(odoo_[a-z_]+)"/);
+    if (nameMatch) names.add(nameMatch[1]);
+  }
+
+  return names;
+}
+
+function walkSpecFiles(dir: string): string[] {
+  const result: string[] = [];
+  for (const entry of readdirSync(dir)) {
+    const fullPath = join(dir, entry);
+    if (statSync(fullPath).isDirectory()) {
+      result.push(...walkSpecFiles(fullPath));
+    } else if (entry.endsWith(".spec.ts")) {
+      result.push(fullPath);
+    }
+  }
+  return result;
+}
+
+function getTestedToolsFromE2E(): Set<string> {
+  const tested = new Set<string>();
+  for (const specFile of walkSpecFiles(E2E_DIR)) {
+    const content = readFileSync(specFile, "utf8");
+    // Literal audit-log query: /api/audit?eventType=tool.<name>
+    for (const match of content.matchAll(/eventType=tool\.([a-z_]+)/g)) {
+      tested.add(match[1]);
+    }
+    // pollAuditForTool(page, { toolName: "<name>", ... })
+    for (const match of content.matchAll(/pollAuditForTool\s*\([\s\S]*?toolName:\s*"([a-z_]+)"/g)) {
+      tested.add(match[1]);
+    }
+    // pollAuditForEvent(page, { eventType: "tool.<name>", ... }) — used when the
+    // assertion needs the entry itself (e.g. to check outcome=success).
+    for (const match of content.matchAll(/eventType:\s*"tool\.([a-z_]+)"/g)) {
+      tested.add(match[1]);
+    }
+  }
+  return tested;
+}
+
+describe("odoo ref-based tool E2E coverage (pinchy#791)", () => {
+  const source = readFileSync(ODOO_INDEX, "utf8");
+  const refToolSet = new Set<string>(REF_BASED_ODOO_TOOLS);
+  const manifestTools = new Set(loadManifest("pinchy-odoo").contracts?.tools ?? []);
+  const testedTools = getTestedToolsFromE2E();
+
+  it("REF_BASED_ODOO_TOOLS matches the ref tools detected in the plugin source", () => {
+    const detected = detectRefToolNames(source);
+    expect([...detected].sort()).toEqual([...refToolSet].sort());
+  });
+
+  it("every listed ref tool is a registered odoo tool (no rename/removal drift)", () => {
+    const missing = [...refToolSet].filter((t) => !manifestTools.has(t));
+    expect(missing, `ref tools absent from the manifest: ${missing.join(", ")}`).toEqual([]);
+  });
+
+  it("every ref tool is either E2E-covered or has a tracked exemption", () => {
+    const uncovered = [...refToolSet].filter((t) => !testedTools.has(t) && !(t in PENDING_E2E));
+    expect(
+      uncovered,
+      [
+        `Ref-based odoo tools without E2E dispatch coverage or a tracked exemption:`,
+        `  ${uncovered.join(", ")}`,
+        ``,
+        `Add an E2E test (drive odoo_read → reuse the returned _pinchy_ref in the`,
+        `ref tool → pollAuditForTool), or add a PENDING_E2E entry citing pinchy#791.`,
+      ].join("\n")
+    ).toEqual([]);
+  });
+
+  it("no exemption is stale (a covered ref tool must be removed from PENDING_E2E)", () => {
+    const stale = Object.keys(PENDING_E2E).filter((t) => testedTools.has(t));
+    expect(
+      stale,
+      `these tools are now E2E-covered — delete their PENDING_E2E entry: ${stale.join(", ")}`
+    ).toEqual([]);
+  });
+
+  it("every exemption references a real ref tool and cites the tracking issue", () => {
+    for (const [tool, reason] of Object.entries(PENDING_E2E)) {
+      expect(refToolSet.has(tool), `${tool} is exempted but not a known ref tool`).toBe(true);
+      expect(reason, `${tool}'s exemption must cite pinchy#791`).toMatch(/#791/);
+    }
+  });
+
+  it("at least one ref tool is genuinely E2E-covered (proves the harness works)", () => {
+    const covered = [...refToolSet].filter((t) => testedTools.has(t));
+    expect(
+      covered.length,
+      "no ref-based odoo tool has E2E dispatch coverage — the ref-dispatch harness is unproven"
+    ).toBeGreaterThan(0);
+  });
+});

--- a/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
+++ b/packages/web/src/__tests__/lib/odoo-ref-tool-e2e-coverage.test.ts
@@ -178,4 +178,28 @@ describe("odoo ref-based tool E2E coverage (pinchy#791)", () => {
       "no ref-based odoo tool has E2E dispatch coverage — the ref-dispatch harness is unproven"
     ).toBeGreaterThan(0);
   });
+
+  // The fake-LLM matches refs with a LOCAL copy of the wire prefix (it is copied
+  // into a standalone container and must not import the plugin). That duplication
+  // silently rots if the plugin ever versions the prefix (v1 → v2): the harness
+  // would stop finding refs and every ref-dispatch probe would false-fail. Pin
+  // the two together so a prefix bump forces both sides to move.
+  it("fake-ollama's ref regex tracks integration-ref's wire prefix", () => {
+    const pluginSrc = readFileSync(join(PLUGINS_DIR, "pinchy-odoo", "integration-ref.ts"), "utf8");
+    const prefixMatch = pluginSrc.match(/const PREFIX\s*=\s*"([^"]+)"/);
+    expect(prefixMatch, 'integration-ref.ts must define `const PREFIX = "…"`').not.toBeNull();
+    const prefix = prefixMatch![1];
+
+    const fakeOllamaSrc = readFileSync(
+      join(E2E_DIR, "shared", "fake-ollama", "fake-ollama-server.ts"),
+      "utf8"
+    );
+    const reMatch = fakeOllamaSrc.match(/const PINCHY_REF_RE\s*=\s*\/([^/]+)\//);
+    expect(reMatch, "fake-ollama-server.ts must define `const PINCHY_REF_RE = /…/`").not.toBeNull();
+
+    expect(
+      reMatch![1],
+      `PINCHY_REF_RE must start with integration-ref's PREFIX "${prefix}" — bump both together`
+    ).toContain(prefix);
+  });
 });


### PR DESCRIPTION
## What does this PR do?

Closes the E2E-coverage gap for **ref-based odoo tools** (pinchy#791). Tools whose primary argument is an opaque `_pinchy_ref` — `odoo_reconcile`, `odoo_schedule_activity`, `odoo_attach_file`, and the record-action family (`odoo_confirm_order`, `odoo_validate_picking`, …) — shipped with **zero** E2E dispatch coverage, and the coverage guard couldn't see the gap: `plugin-tool-coverage` is satisfied per *plugin*, so pinchy-odoo passed on its ref-free tools (`odoo_read`/`odoo_create`) while every ref tool was untested. PR #782 (`odoo_reconcile`) deliberately relied on live Odoo verification for exactly this reason.

## Why the harness couldn't cover them

A `_pinchy_ref` is an AES-GCM token minted at **runtime** (per connection, per record), so a statically-scripted fake-LLM `tool_call` can never carry a valid one — a hard-coded ref only ever exercises the plugin's decode-rejection path, not real dispatch.

## Approach

The fake-LLM resolves the ref **dynamically, like a real model would**: round 1 dispatches `odoo_read`, round 2 reads the real `_pinchy_ref` back out of that tool-result message and reuses it in the ref-based tool. No key sharing, no test-only signing hook, **no production code change**.

- **Reusable primitive** — `buildOdooRefDispatchScript` / `extractPinchyRefFromToolResults` in `fake-ollama-server.ts`, wired into both the NDJSON and OpenAI-SSE surfaces. Unit-tested (8 cases) in `fake-ollama-ref-dispatch.test.ts`.
- **Worked example** — the `odoo-agent-chat` dispatch probe now covers `odoo_schedule_activity` on a runtime-minted ref end-to-end and asserts **`outcome=success`** (a broken ref still *dispatches*, audited `failure`, so a dispatch-only assertion could false-pass).
- **Guard** — `odoo-ref-tool-e2e-coverage.test.ts` auto-detects every ref-based odoo tool from the plugin source and requires each to be either E2E-covered or carry a `PENDING_E2E` exemption citing pinchy#791. A **new** ref tool with neither fails CI; a covered tool left exempted fails too.
- **AGENTS.md** documents the pattern and the guard.

`odoo_reconcile` stays exempted (on live verification) until the Odoo mock grows `account.bank.statement.line` / `account.payment` + reconcile semantics — real Odoo 19 reconcile is silent-no-op-prone, so a faithful mock is a separate, careful piece of work and a naive one risks a false-green.

## Verification

- ✅ `fake-ollama-ref-dispatch.test.ts` (8), `odoo-ref-tool-e2e-coverage.test.ts` (6), existing `plugin-tool-coverage` / `manifest-tools-drift`, `fake-ollama` lifecycle/liveness/usage/context suites
- ✅ `pnpm -C packages/web typecheck` (incl. test files), prettier, eslint (0 errors), AGENTS.md commands drift guard
- ⏳ The end-to-end dispatch itself runs in the **`odoo-e2e`** CI job (needs the full Docker + `Dockerfile.pinchy` stack); monitoring it to green.

## Type of change

- [x] ✅ Test / infrastructure

## Checklist

- [x] Follows project style
- [x] Added tests (14 new unit/guard cases + 1 E2E dispatch test)
- [x] Updated documentation (AGENTS.md)
- [x] All local gates pass

Refs pinchy#791
