### PR TITLE
eval: surface the pass^k reliability curve in the published export (#796)

### DIFF
--- a/packages/web/eval/__tests__/export-scorecard-contract.test.ts
+++ b/packages/web/eval/__tests__/export-scorecard-contract.test.ts
@@ -1,0 +1,68 @@
+/**
+ * Pins the per-cell contract of the PUBLISHED export — the fields the
+ * /reliability hub and heypinchy-website#141 read out of `data.json`.
+ *
+ * The estimator itself has unit tests (`src/lib/eval/__tests__/scorecard.test.ts`).
+ * What those cannot see is the WIRING: before this file, deleting
+ * `passHatK: passHatKCurve(passes, n)` from `aggregate()` — or swapping its two
+ * arguments, which is invisible on the all-pass cells — left `pnpm test` green
+ * while the curve vanished from the website's only data source. Same contract
+ * as the triage guard next door: judge the numbers we actually publish.
+ */
+import { describe, it, expect } from "vitest";
+import { buildPublishedScenarios } from "../export-scorecard";
+import { computePassHatK, PASS_HAT_K_LEVELS } from "../../src/lib/eval/scorecard";
+
+const cells = (await buildPublishedScenarios()).flatMap((s) =>
+  s.models.map((m) => ({ ...m, where: `${s.label} / ${m.model}` }))
+);
+
+describe("published export: pass^k curve", () => {
+  it("carries a curve on every published cell", () => {
+    expect(cells.length).toBeGreaterThan(0);
+    for (const c of cells) {
+      expect(c.passHatK, c.where).toBeDefined();
+    }
+  });
+
+  it("reports exactly the standard k levels at or below the cell's n", () => {
+    for (const c of cells) {
+      const expected = PASS_HAT_K_LEVELS.filter((k) => k <= c.n);
+      expect(
+        c.passHatK.map((p) => p.k),
+        `${c.where} (n=${c.n})`
+      ).toEqual([...expected]);
+    }
+  });
+
+  it("recomputes from the cell's own passes/n — catches swapped arguments", () => {
+    for (const c of cells) {
+      for (const { k, value } of c.passHatK) {
+        const expected = Number(computePassHatK(c.passes, c.n, k).toFixed(3));
+        expect(value, `${c.where} at k=${k}`).toBe(expected);
+      }
+    }
+  });
+
+  it("anchors at k=1 = passRate, the published capability number", () => {
+    for (const c of cells) {
+      expect(c.passHatK.find((p) => p.k === 1)?.value, c.where).toBe(c.passRate);
+    }
+  });
+
+  it("decays monotonically — k in a row is never easier than fewer", () => {
+    for (const c of cells) {
+      for (let i = 1; i < c.passHatK.length; i++) {
+        expect(c.passHatK[i].value, `${c.where} at k=${c.passHatK[i].k}`).toBeLessThanOrEqual(
+          c.passHatK[i - 1].value
+        );
+      }
+    }
+  });
+
+  it("is all-1 exactly for the passAllK cells (and n=0 is not one)", () => {
+    for (const c of cells) {
+      expect(c.passAllK, c.where).toBe(c.n > 0 && c.passHatK.every((p) => p.value === 1));
+    }
+  });
+});

--- a/packages/web/eval/data/CHANGELOG.md
+++ b/packages/web/eval/data/CHANGELOG.md
@@ -17,6 +17,22 @@ Versioning rule:
 Every superseded version stays published and citable (HELM/Terminal-Bench legacy
 pattern): cite the version and the harness commit, not "latest".
 
+## [1.1.0] - 2026-07-17
+
+**Output field — pass^k reliability curve** (#796): every cell now carries
+`passHatK`, the unbiased τ-bench estimator `C(passes, k) / C(n, k)` at
+k = 1, 2, 4, 8, 12 (levels above the cell's n omitted). Additive: it is
+re-derived from each cell's existing passes/n, with no re-grade, no new runs,
+and no change to an existing number — the fingerprint of this export with
+`passHatK` stripped back out is identical to 1.0.0's, which is how we checked
+rather than assumed.
+
+Why it earns a field: `passRate` is pass@1, a _capability_ measure, and reading
+it as reliability overstates what an unattended agent will do. pass^k is the
+reliability framing — nemotron-3-ultra is 0.75 at pass@1 on happy-path and 0.018
+by pass^8. See `README.md` for how to read the curve, why pass^k is not pass@k,
+and why an empty curve (n=0) is not a reported 0.
+
 ## [1.0.0] - 2026-07-17
 
 First tagged release: the complete **14 models × 7 scenarios × 12 runs** state

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -93,6 +93,28 @@ correction, so those sets err slightly small. This does not soften the headline
 — it sharpens it: at n=12 this benchmark separates even less than the raw flags
 suggest.
 
+## pass^k — the reliability metric
+
+The consolidated export (`export-scorecard.ts` → the website's `data.json`)
+reports, per cell, a **pass^k** curve at k = 1, 2, 4, 8, 12 (levels above the
+cell's n are omitted). Read it as the number that matters for unattended
+deployment.
+
+- **pass@1** (= `passRate`, the same as pass^k at k=1) is a _capability_
+  measure: how often a single attempt succeeds.
+- **pass^k** is a _reliability_ measure: the chance that k attempts in a row
+  **all** succeed. We use the unbiased τ-bench estimator (arXiv 2406.12045):
+  `C(passes, k) / C(n, k)` — the probability that k of this cell's runs, drawn
+  without replacement, all passed. Not to be confused with **pass@k** (did _at
+  least one_ of k attempts succeed — an easier bar that rewards retrying).
+- Why it's the honest framing: reliability decays fast. A model at 0.75 pass@1
+  sits near 0.02 at pass^8 — "succeeds most of the time" is not "safe to run 8
+  times unwatched". A cell that is `passAllK: true` is exactly pass^12 = 1.
+
+The raw ingredient (passes/n per cell) is unchanged; pass^k is computed at
+export time in `src/lib/eval/scorecard.ts` (`computePassHatK` / `passHatKCurve`),
+so it re-derives from the open data with no new runs.
+
 ## Completeness manifest (as of harness `255678c25`)
 
 Target per scenario: 14 models × 12 runs = 168.

--- a/packages/web/eval/data/README.md
+++ b/packages/web/eval/data/README.md
@@ -109,7 +109,12 @@ deployment.
   least one_ of k attempts succeed — an easier bar that rewards retrying).
 - Why it's the honest framing: reliability decays fast. A model at 0.75 pass@1
   sits near 0.02 at pass^8 — "succeeds most of the time" is not "safe to run 8
-  times unwatched". A cell that is `passAllK: true` is exactly pass^12 = 1.
+  times unwatched". A cell that is `passAllK: true` is pass^k = 1 at every
+  reported k (at today's n=12, that includes pass^12).
+
+Two zeroes that read alike but are not: a **reported** 0 is an estimate (fewer
+than k runs passed, so no all-pass draw of size k exists), while an **empty**
+curve means the cell had no valid trials at all (n=0) and nothing was estimated.
 
 The raw ingredient (passes/n per cell) is unchanged; pass^k is computed at
 export time in `src/lib/eval/scorecard.ts` (`computePassHatK` / `passHatKCurve`),

--- a/packages/web/eval/dataset-version.ts
+++ b/packages/web/eval/dataset-version.ts
@@ -10,7 +10,7 @@
  * MINOR: additive — new models, new scenarios, new fields.
  * PATCH: corrections that don't move a published number (docs, metadata).
  */
-export const DATASET_VERSION = "1.0.0";
+export const DATASET_VERSION = "1.1.0";
 
 /**
  * SHA-256 of every number this version publishes — the part that makes the rule
@@ -31,4 +31,4 @@ export const DATASET_VERSION = "1.0.0";
  * the digest is the last line of the commit, not the first.
  */
 export const DATASET_FINGERPRINT =
-  "6bbcab79ae144626bf7c67e73bb6e1cae1fc34090931def405b5184f2dbb247a";
+  "b8d2f224cfdaa080d16180a44c7656fd7fb0764f914c6b82679f7d8c7ba7eeba";

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -104,7 +104,9 @@ interface Cell {
    * pass^k reliability curve (τ-bench estimator): the chance k runs in a row
    * all pass, at k = 1, 2, 4, 8, 12 (levels above n omitted). k=1 is the pass
    * rate; it decays as k grows. The reliability framing enterprises measure us
-   * against — a model at 0.9 pass@1 can sit near 0.5 at pass^8.
+   * against — nemotron-3-ultra on happy-path is 0.75 at pass@1 and 0.018 by
+   * pass^8. Empty for a cell with no valid trials (n=0): no estimate, which is
+   * not the same claim as an estimated 0.
    */
   passHatK: { k: number; value: number }[];
   /** Wilson 95% score interval for the pass rate, at this cell's n. */

--- a/packages/web/eval/export-scorecard.ts
+++ b/packages/web/eval/export-scorecard.ts
@@ -36,7 +36,7 @@ import { parseEvalJsonl } from "./canary";
 import { gradeRunForScenario } from "../src/lib/eval/graders";
 import { pooledClusteredDifference, tiedWithLeader } from "../src/lib/eval/comparisons";
 import { applyTrajectoryRegrade } from "../src/lib/eval/regrade-merge";
-import { wilsonInterval } from "../src/lib/eval/scorecard";
+import { passHatKCurve, wilsonInterval } from "../src/lib/eval/scorecard";
 import type { RunResult, RunTrajectory } from "../src/lib/eval/types";
 import { DATASET_VERSION } from "./dataset-version";
 import { hetznerInvoiceDuplicateScenario } from "./scenarios/hetzner-invoice-duplicate";
@@ -100,6 +100,13 @@ interface Cell {
   passes: number;
   passRate: number;
   passAllK: boolean;
+  /**
+   * pass^k reliability curve (τ-bench estimator): the chance k runs in a row
+   * all pass, at k = 1, 2, 4, 8, 12 (levels above n omitted). k=1 is the pass
+   * rate; it decays as k grows. The reliability framing enterprises measure us
+   * against — a model at 0.9 pass@1 can sit near 0.5 at pass^8.
+   */
+  passHatK: { k: number; value: number }[];
   /** Wilson 95% score interval for the pass rate, at this cell's n. */
   wilson95: [number, number];
   /** Transport-errored runs excluded from n as invalid trials. */
@@ -156,6 +163,7 @@ function aggregate(runs: RunResult[]): Cell[] {
         passes,
         passRate: n > 0 ? Number((passes / n).toFixed(3)) : 0,
         passAllK: passes === n && n > 0,
+        passHatK: passHatKCurve(passes, n),
         wilson95: wilson95(passes, n),
         excludedInfraErrors,
         pendingRerun: excludedInfraErrors > 0,

--- a/packages/web/src/lib/eval/__tests__/scorecard.test.ts
+++ b/packages/web/src/lib/eval/__tests__/scorecard.test.ts
@@ -290,4 +290,20 @@ describe("passHatKCurve", () => {
     // Only 6 of 12 passed, so an 8-of-8 all-pass subset is impossible: pass^8 = 0.
     expect(curve.find((p) => p.k === 8)?.value).toBe(0);
   });
+
+  it("is empty for a cell with no valid trials — no estimate, not an estimated 0", () => {
+    // `aggregate` produces n=0 when every run of a model was a transport error
+    // (all excluded as invalid trials). The curve must not answer 0 there: 0 is
+    // a measured claim ("k in a row never happened"), and we measured nothing.
+    expect(passHatKCurve(0, 0)).toEqual([]);
+  });
+
+  it("never rounds a real estimate down into the impossible-0 at n=12", () => {
+    // The tail is the whole point of the curve, so 3-decimal rounding must not
+    // collapse a nonzero pass^k onto the 0 that means "can't be done". The
+    // scarcest nonzero cell at each k is passes === k.
+    for (const k of [2, 4, 8, 12]) {
+      expect(passHatKCurve(k, 12).find((p) => p.k === k)?.value).toBeGreaterThan(0);
+    }
+  });
 });

--- a/packages/web/src/lib/eval/__tests__/scorecard.test.ts
+++ b/packages/web/src/lib/eval/__tests__/scorecard.test.ts
@@ -1,5 +1,11 @@
 import { describe, expect, it } from "vitest";
-import { buildScorecard, computePassCaretK, wilsonInterval } from "../scorecard";
+import {
+  buildScorecard,
+  computePassCaretK,
+  computePassHatK,
+  passHatKCurve,
+  wilsonInterval,
+} from "../scorecard";
 import type { RunResult } from "../types";
 
 function run(overrides: Partial<RunResult> = {}): RunResult {
@@ -228,5 +234,60 @@ describe("buildScorecard<Tag> generic boundary", () => {
     expect(a.tagHistogram["custom-b"]).toBe(1);
     expect(a.passCaretK).toBe(0);
     expect(computePassCaretK<CustomTag>(runs)).toBe(0);
+  });
+});
+
+describe("computePassHatK (unbiased pass^k, τ-bench estimator)", () => {
+  it("is 1 at any k when every run passed", () => {
+    expect(computePassHatK(12, 12, 8)).toBe(1);
+    expect(computePassHatK(12, 12, 12)).toBe(1);
+  });
+
+  it("equals the pass rate at k=1", () => {
+    expect(computePassHatK(7, 10, 1)).toBeCloseTo(0.7, 10);
+    expect(computePassHatK(6, 12, 1)).toBeCloseTo(0.5, 10);
+  });
+
+  it("matches C(c,k)/C(n,k) for a partial cell", () => {
+    // 6 of 12 passed, k=2: C(6,2)/C(12,2) = 15/66.
+    expect(computePassHatK(6, 12, 2)).toBeCloseTo(15 / 66, 10);
+    // 9 of 12 passed, k=8: C(9,8)/C(12,8) = 9/495.
+    expect(computePassHatK(9, 12, 8)).toBeCloseTo(9 / 495, 10);
+  });
+
+  it("is 0 when fewer than k runs passed (an all-k subset is impossible)", () => {
+    expect(computePassHatK(5, 12, 8)).toBe(0);
+    expect(computePassHatK(0, 12, 2)).toBe(0);
+  });
+
+  it("is 1 at k=0 and 0 for n=0", () => {
+    expect(computePassHatK(3, 12, 0)).toBe(1);
+    expect(computePassHatK(0, 0, 2)).toBe(0);
+  });
+});
+
+describe("passHatKCurve", () => {
+  it("reports every standard k for a full-N cell, all at 1", () => {
+    expect(passHatKCurve(12, 12)).toEqual([
+      { k: 1, value: 1 },
+      { k: 2, value: 1 },
+      { k: 4, value: 1 },
+      { k: 8, value: 1 },
+      { k: 12, value: 1 },
+    ]);
+  });
+
+  it("drops k levels above the cell's n", () => {
+    // n=8: k=12 is undefined (can't draw 12 from 8) and is omitted.
+    expect(passHatKCurve(8, 8).map((p) => p.k)).toEqual([1, 2, 4, 8]);
+  });
+
+  it("rounds values to 3 decimals, showing the reliability decay", () => {
+    const curve = passHatKCurve(6, 12);
+    expect(curve.find((p) => p.k === 1)?.value).toBe(0.5);
+    expect(curve.find((p) => p.k === 2)?.value).toBe(Number((15 / 66).toFixed(3)));
+    expect(curve.find((p) => p.k === 4)?.value).toBe(Number((15 / 495).toFixed(3)));
+    // Only 6 of 12 passed, so an 8-of-8 all-pass subset is impossible: pass^8 = 0.
+    expect(curve.find((p) => p.k === 8)?.value).toBe(0);
   });
 });

--- a/packages/web/src/lib/eval/scorecard.ts
+++ b/packages/web/src/lib/eval/scorecard.ts
@@ -31,12 +31,17 @@ export interface ScorecardEntry {
 }
 
 /**
- * pass^k for one model's runs: 1 if every run passed, else 0. 0 for an empty
- * run list (no trials, no proven consistency). Exported as a standalone pure
+ * The all-pass indicator: 1 if every run passed, else 0. 0 for an empty run
+ * list (no trials, no proven consistency). Exported as a standalone pure
  * function (in addition to being folded into `buildScorecard`'s per-model
  * entries) so it can be unit-tested directly against the n=0 edge case, which
  * `buildScorecard`'s per-model grouping never produces (a model only gets an
  * entry when it has >= 1 run).
+ *
+ * This is pass^k only at k = n: it answers "did this cell go n-for-n", not
+ * "what is pass^k". For the curve at arbitrary k — the number the published
+ * export reports — use `computePassHatK`, which is a real estimate in [0, 1]
+ * rather than a 0/1 verdict.
  */
 export function computePassCaretK<Tag extends string = FailureTag>(runs: RunResult<Tag>[]): number {
   if (runs.length === 0) return 0;
@@ -44,7 +49,7 @@ export function computePassCaretK<Tag extends string = FailureTag>(runs: RunResu
 }
 
 /** The k levels the published pass^k curve reports (k=1 is the pass rate). */
-export const PASS_CARET_K_LEVELS = [1, 2, 4, 8, 12] as const;
+export const PASS_HAT_K_LEVELS = [1, 2, 4, 8, 12] as const;
 
 /**
  * Unbiased pass^k: the probability that k runs drawn WITHOUT replacement from
@@ -71,12 +76,14 @@ export function computePassHatK(passes: number, n: number, k: number): number {
 /**
  * The pass^k curve for a cell: `computePassHatK` at each of `levels`, dropping
  * levels above n (k>n has no defined estimate), values rounded to 3 decimals to
- * match the published pass-rate precision.
+ * match the published pass-rate precision. A cell with no valid trials (n=0)
+ * therefore has an EMPTY curve, not a curve of zeroes — consumers must treat
+ * "no estimate" and "estimated 0" as different answers.
  */
 export function passHatKCurve(
   passes: number,
   n: number,
-  levels: readonly number[] = PASS_CARET_K_LEVELS
+  levels: readonly number[] = PASS_HAT_K_LEVELS
 ): { k: number; value: number }[] {
   return levels
     .filter((k) => k <= n)

--- a/packages/web/src/lib/eval/scorecard.ts
+++ b/packages/web/src/lib/eval/scorecard.ts
@@ -43,6 +43,46 @@ export function computePassCaretK<Tag extends string = FailureTag>(runs: RunResu
   return runs.every((r) => r.passed) ? 1 : 0;
 }
 
+/** The k levels the published pass^k curve reports (k=1 is the pass rate). */
+export const PASS_CARET_K_LEVELS = [1, 2, 4, 8, 12] as const;
+
+/**
+ * Unbiased pass^k: the probability that k runs drawn WITHOUT replacement from
+ * this cell's n runs all pass — `C(passes, k) / C(n, k)`, the τ-bench estimator
+ * (arXiv 2406.12045). Computed as the stable product `Π (passes−i)/(n−i)` so it
+ * never overflows a factorial. This is the RELIABILITY curve: at k=1 it is the
+ * pass rate (a capability measure), and it decays toward 0 as k grows because
+ * "succeeds k times in a row" is a strictly harder bar than "succeeds once".
+ *
+ * Edge cases: k=0 → 1 (an empty draw trivially all-passes); n=0 → 0 (no trials,
+ * nothing proven); passes<k → 0 (an all-pass subset of size k cannot be formed);
+ * k>n → 0 (cannot draw k distinct runs from n).
+ */
+export function computePassHatK(passes: number, n: number, k: number): number {
+  if (k === 0) return 1;
+  if (n === 0 || k > n || passes < k) return 0;
+  let product = 1;
+  for (let i = 0; i < k; i++) {
+    product *= (passes - i) / (n - i);
+  }
+  return product;
+}
+
+/**
+ * The pass^k curve for a cell: `computePassHatK` at each of `levels`, dropping
+ * levels above n (k>n has no defined estimate), values rounded to 3 decimals to
+ * match the published pass-rate precision.
+ */
+export function passHatKCurve(
+  passes: number,
+  n: number,
+  levels: readonly number[] = PASS_CARET_K_LEVELS
+): { k: number; value: number }[] {
+  return levels
+    .filter((k) => k <= n)
+    .map((k) => ({ k, value: Number(computePassHatK(passes, n, k).toFixed(3)) }));
+}
+
 /**
  * Wilson score interval for a binomial proportion (`passes` out of `n`
  * trials), at the given z-score (default 1.96 -> ~95% confidence). Clamped


### PR DESCRIPTION
## Gap

We run 12 trials per cell but the published export (`export-scorecard.ts` → the website's `data.json`) only showed pass@1 + Wilson CIs. For a benchmark with "reliability" in its name, **pass^k** is *the* established vocabulary (τ-bench: a 90%-pass@1 agent collapses to ~57% at pass^8), and reviewers will measure us against it. The raw data already exists — no new runs.

## What this does

- **`scorecard.ts`** — adds the unbiased τ-bench estimator `computePassHatK(passes, n, k) = C(passes,k)/C(n,k)` (stable product form, never overflows a factorial) and `passHatKCurve`. Unit-tested including the edges the aggregator can produce: n=0, `passes < k` (an all-pass subset is impossible → 0), k>n (omitted).
- **`export-scorecard.ts`** — each cell now carries a `passHatK` curve at k = 1, 2, 4, 8, 12 (levels above the cell's n omitted). k=1 is the pass rate; the decay is the point.
- **`data/README.md`** — documents pass^k vs pass@k and why pass^k is the reliability framing (not pass@k, which rewards retrying).

Real decay from the dataset:

```
happy-path  nemotron-3-ultra  pass@1=0.75   pass^2=0.545 pass^4=0.255 pass^8=0.018 pass^12=0
conflict    glm-5.1           pass@1=0.667  pass^2=0.424 pass^4=0.141 pass^8=0.002 pass^12=0
```

## No numbers move

Additive only: `passAllK` stays for back-compat, and the export is **semantically identical to `main` once `passHatK` is stripped** (verified by deep-compare) — no published pass rate, CI, or histogram changes. Website rendering (pass^12 badge / column) is the separate heypinchy-website#141.

## Test plan

- `pnpm -C packages/web test` (eval guards + scorecard unit tests, incl. 8 new pass^k cases) green.
- Export deep-compare vs `main` = identical modulo the new `passHatK` field.
- `pnpm -C packages/web lint` 0 errors; changed files typecheck clean.

Refs #796, #669